### PR TITLE
fix: log PostgreSQL connection string at startup

### DIFF
--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -114,9 +114,7 @@ namespace SportsData.Core.DependencyInjection
                 connString = $"{connString.TrimEnd(';')};Maximum Pool Size={maxPoolSize.Value};";
             }
 
-#if DEBUG
-            Console.WriteLine($"using: {connString}");
-#endif
+            Console.WriteLine($"PostgreSQL: {connString}");
 
             services.AddDbContext<T>((serviceProvider, options) =>
             {


### PR DESCRIPTION
## Summary
Remove `#if DEBUG` guard on PostgreSQL connection string logging so it's visible in pod logs for all environments. Diagnostic aid — connection string is only visible in kubectl pod logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified logging behavior for PostgreSQL connection string to log unconditionally rather than only during debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->