### PR TITLE
feat: baseball situation processor + nullable CompetitionLeaderCategory.Name

### DIFF
--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
@@ -278,8 +278,8 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
             .Where(l => l.Competition.ContestId == contestId)
             .SelectMany(l => l.Stats.Select(s => new FlatLeaderRow
             {
-                CategoryId = l.LeaderCategory.Name,
-                CategoryName = l.LeaderCategory.DisplayName ?? l.LeaderCategory.Name,
+                CategoryId = l.LeaderCategory.Name ?? l.LeaderCategory.Id.ToString(),
+                CategoryName = l.LeaderCategory.DisplayName ?? l.LeaderCategory.Name ?? l.LeaderCategory.Abbreviation,
                 Abbr = l.LeaderCategory.Abbreviation,
                 Unit = null,
                 DisplayOrder = 0,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballCompetitionSituationDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballCompetitionSituationDocumentProcessor.cs
@@ -1,0 +1,117 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Exceptions;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+
+[DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionSituation)]
+public class BaseballCompetitionSituationDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
+    where TDataContext : TeamSportDataContext
+{
+    public BaseballCompetitionSituationDocumentProcessor(
+        ILogger<BaseballCompetitionSituationDocumentProcessor<TDataContext>> logger,
+        TDataContext dataContext,
+        IEventBus publishEndpoint,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        IGenerateResourceRefs refs)
+        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs)
+    {
+    }
+
+    protected override async Task ProcessInternal(ProcessDocumentCommand command)
+    {
+        var dto = command.Document.FromJson<EspnEventCompetitionSituationDto>();
+
+        if (dto is null)
+        {
+            _logger.LogError("Failed to deserialize EspnEventCompetitionSituationDto.");
+            return;
+        }
+
+        var competitionId = TryGetOrDeriveParentId(
+            command,
+            EspnUriMapper.CompetitionSituationRefToCompetitionRef);
+
+        if (competitionId == null)
+        {
+            _logger.LogError("Unable to determine CompetitionId from ParentId or URI");
+            return;
+        }
+
+        var competitionIdValue = competitionId.Value;
+
+        // Resolve LastPlay if available
+        Guid? lastPlayId = null;
+        if (dto.LastPlay?.Ref is not null)
+        {
+            var lastPlayIdentity = _externalRefIdentityGenerator.Generate(dto.LastPlay.Ref);
+
+            var lastPlay = await _dataContext.CompetitionPlays
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.Id == lastPlayIdentity.CanonicalId);
+
+            if (lastPlay == null)
+            {
+                await PublishChildDocumentRequest(
+                    command,
+                    dto.LastPlay,
+                    competitionIdValue,
+                    DocumentType.EventCompetitionPlay);
+
+                throw new ExternalDocumentNotSourcedException(
+                    $"Last Play {dto.LastPlay.Ref} not found. Requesting. Will retry.");
+            }
+
+            lastPlayId = lastPlay.Id;
+        }
+
+        var identity = _externalRefIdentityGenerator.Generate(dto.Ref);
+
+        var exists = await _dataContext.CompetitionSituations
+            .AsNoTracking()
+            .AnyAsync(x => x.Id == identity.CanonicalId);
+
+        if (exists)
+        {
+            _logger.LogInformation("CompetitionSituation already exists, skipping. Id={Id}", identity.CanonicalId);
+            return;
+        }
+
+        // Store baseball situation using the shared entity.
+        // Football-specific fields (Down, Distance, YardLine) set to 0.
+        // Baseball-specific data (balls, strikes, outs, runners) is not yet
+        // captured in the entity — will be addressed with sport-specific
+        // situation entities in a future refactor.
+        var entity = new CompetitionSituation
+        {
+            Id = identity.CanonicalId,
+            CompetitionId = competitionIdValue,
+            LastPlayId = lastPlayId,
+            Down = 0,
+            Distance = 0,
+            YardLine = 0,
+            IsRedZone = false,
+            AwayTimeouts = 0,
+            HomeTimeouts = 0,
+            CreatedBy = command.CorrelationId,
+            CreatedUtc = DateTime.UtcNow
+        };
+
+        await _dataContext.CompetitionSituations.AddAsync(entity);
+        await _dataContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Persisted baseball CompetitionSituation. CompetitionId={CompId}, SituationId={SituationId}",
+            competitionIdValue, entity.Id);
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionLeaderCategory.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionLeaderCategory.cs
@@ -7,7 +7,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 {
     public class CompetitionLeaderCategory : CanonicalEntityBase<int>
     {
-        public required string Name { get; set; }
+        public string? Name { get; set; }
 
         public required string DisplayName { get; set; }
 
@@ -25,7 +25,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
                 builder.ToTable("lkLeaderCategory");
 
                 builder.Property(c => c.Name)
-                    .IsRequired()
+                    .IsRequired(false)
                     .HasMaxLength(50);
 
                 builder.Property(c => c.DisplayName)

--- a/src/SportsData.Producer/Migrations/Baseball/20260410100444_LeaderCategoryNameNullable.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260410100444_LeaderCategoryNameNullable.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Football
+namespace SportsData.Producer.Migrations.Baseball
 {
-    [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(BaseballDataContext))]
+    [Migration("20260410100444_LeaderCategoryNameNullable")]
+    partial class LeaderCategoryNameNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,6 +415,120 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("ConfigurationId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("Season")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SeasonType")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SplitTypeId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
+
+                    b.ToTable("AthleteSeasonHotZone", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("AtBats")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("AthleteSeasonHotZoneId")
+                        .HasColumnType("uuid");
+
+                    b.Property<double?>("BattingAvg")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("BattingAvgScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("Hits")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<double?>("Slugging")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("SluggingScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("ZoneId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonHotZoneId");
+
+                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Common.Athlete", b =>
@@ -7898,9 +8015,17 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("SeasonWeekExternalId", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Common.Athlete");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -7911,16 +8036,24 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("ThrowsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("ThrowsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("FootballAthlete");
+                    b.HasDiscriminator().HasValue("BaseballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
+                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -7953,6 +8086,17 @@ namespace SportsData.Producer.Migrations.Football
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
+                        .WithMany("Entries")
+                        .HasForeignKey("AthleteSeasonHotZoneId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("HotZone");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Common.Athlete", b =>
@@ -9489,7 +9633,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("SeasonWeek");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9505,6 +9649,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Common.Athlete", b =>

--- a/src/SportsData.Producer/Migrations/Baseball/20260410100444_LeaderCategoryNameNullable.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260410100444_LeaderCategoryNameNullable.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class LeaderCategoryNameNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "lkLeaderCategory",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "lkLeaderCategory",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
@@ -3624,7 +3624,6 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
-                        .IsRequired()
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 

--- a/src/SportsData.Producer/Migrations/Football/20260410100434_LeaderCategoryNameNullable.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260410100434_LeaderCategoryNameNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260410100434_LeaderCategoryNameNullable")]
+    partial class LeaderCategoryNameNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260410100434_LeaderCategoryNameNullable.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260410100434_LeaderCategoryNameNullable.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class LeaderCategoryNameNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "lkLeaderCategory",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "lkLeaderCategory",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballCompetitionSituationDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballCompetitionSituationDocumentProcessorTests.cs
@@ -1,0 +1,208 @@
+#nullable enable
+
+using AutoFixture;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
+
+[Collection("Sequential")]
+public class BaseballCompetitionSituationDocumentProcessorTests : ProducerTestBase<FootballDataContext>
+{
+    private async Task<(Guid competitionId, Guid lastPlayId)> SetupTestDataAsync(
+        ExternalRefIdentityGenerator generator,
+        EspnEventCompetitionSituationDto dto)
+    {
+        var competitionId = Guid.NewGuid();
+        await FootballDataContext.Competitions.AddAsync(new Competition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = DateTime.UtcNow,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+
+        // Create the last play so the situation can resolve it
+        var lastPlayIdentity = generator.Generate(dto.LastPlay.Ref);
+        var lastPlay = new CompetitionPlay
+        {
+            Id = lastPlayIdentity.CanonicalId,
+            CompetitionId = competitionId,
+            EspnId = "4018148441704990099",
+            SequenceNumber = "590",
+            Text = "Test play",
+            TypeId = "99",
+            Type = PlayType.Unknown,
+            Modified = DateTime.UtcNow,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds = new List<CompetitionPlayExternalId>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    CompetitionPlayId = lastPlayIdentity.CanonicalId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = lastPlayIdentity.CleanUrl,
+                    SourceUrlHash = lastPlayIdentity.UrlHash,
+                    Value = lastPlayIdentity.UrlHash
+                }
+            }
+        };
+        await FootballDataContext.CompetitionPlays.AddAsync(lastPlay);
+        await FootballDataContext.SaveChangesAsync();
+
+        return (competitionId, lastPlayIdentity.CanonicalId);
+    }
+
+    [Fact]
+    public async Task WhenNewBaseballSituation_ShouldCreateWithZeroedFootballFields()
+    {
+        // arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionSituation.json");
+        var dto = json.FromJson<EspnEventCompetitionSituationDto>();
+
+        var (competitionId, lastPlayId) = await SetupTestDataAsync(generator, dto!);
+
+        var sut = Mocker.CreateInstance<BaseballCompetitionSituationDocumentProcessor<FootballDataContext>>();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.Document, json)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionSituation)
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.ParentId, competitionId.ToString())
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(command);
+
+        // assert
+        var situation = await FootballDataContext.CompetitionSituations
+            .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
+
+        situation.Should().NotBeNull();
+        situation!.CompetitionId.Should().Be(competitionId);
+        situation.LastPlayId.Should().Be(lastPlayId);
+        situation.Down.Should().Be(0, "baseball has no downs");
+        situation.Distance.Should().Be(0, "baseball has no distance");
+        situation.YardLine.Should().Be(0, "baseball has no yard lines");
+        situation.IsRedZone.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WhenSituationAlreadyExists_ShouldSkip()
+    {
+        // arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionSituation.json");
+        var dto = json.FromJson<EspnEventCompetitionSituationDto>();
+
+        var (competitionId, lastPlayId) = await SetupTestDataAsync(generator, dto!);
+
+        // Pre-create the situation
+        var identity = generator.Generate(dto!.Ref);
+        await FootballDataContext.CompetitionSituations.AddAsync(new CompetitionSituation
+        {
+            Id = identity.CanonicalId,
+            CompetitionId = competitionId,
+            LastPlayId = lastPlayId,
+            Down = 0,
+            Distance = 0,
+            YardLine = 0,
+            IsRedZone = false,
+            AwayTimeouts = 0,
+            HomeTimeouts = 0,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<BaseballCompetitionSituationDocumentProcessor<FootballDataContext>>();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.Document, json)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionSituation)
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.ParentId, competitionId.ToString())
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(command);
+
+        // assert — should still be exactly 1 record
+        var count = await FootballDataContext.CompetitionSituations
+            .CountAsync(x => x.CompetitionId == competitionId);
+
+        count.Should().Be(1, "duplicate situations should be skipped");
+    }
+
+    [Fact]
+    public async Task WhenLastPlayNotSourced_ShouldThrowExternalDocumentNotSourcedException()
+    {
+        // arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionSituation.json");
+
+        // Create competition but NOT the last play
+        var competitionId = Guid.NewGuid();
+        await FootballDataContext.Competitions.AddAsync(new Competition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = DateTime.UtcNow,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<BaseballCompetitionSituationDocumentProcessor<FootballDataContext>>();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.Document, json)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionSituation)
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.ParentId, competitionId.ToString())
+            .OmitAutoProperties()
+            .Create();
+
+        // act — ExternalDocumentNotSourcedException is caught by DocumentProcessorBase
+        // and handled as a retry, so no exception propagates
+        await sut.ProcessAsync(command);
+
+        // assert — situation should NOT be created since the dependency isn't ready
+        var count = await FootballDataContext.CompetitionSituations
+            .CountAsync(x => x.CompetitionId == competitionId);
+
+        count.Should().Be(0, "situation should not be created when last play dependency is missing");
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/EventCompetitionSituation.json
+++ b/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/EventCompetitionSituation.json
@@ -1,0 +1,68 @@
+{
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/situation?lang=en&region=us",
+    "lastPlay": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/plays/4018148441704990099?lang=en&region=us"
+    },
+    "balls": 2,
+    "strikes": 2,
+    "outs": 1,
+    "onFirst": {
+        "playerId": 41217,
+        "period": 9,
+        "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/41217?lang=en&region=us"
+        },
+        "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+        },
+        "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/roster/41217/statistics/0?lang=en&region=us"
+        }
+    },
+    "onSecond": {
+        "playerId": 41183,
+        "period": 9,
+        "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/41183?lang=en&region=us"
+        },
+        "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/2?lang=en&region=us"
+        },
+        "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/roster/41183/statistics/0?lang=en&region=us"
+        }
+    },
+    "pitcher": {
+        "playerId": 39949,
+        "period": 9,
+        "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/39949?lang=en&region=us"
+        },
+        "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7/roster/39949/statistics/0?lang=en&region=us"
+        }
+    },
+    "batter": {
+        "playerId": 41217,
+        "period": 9,
+        "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/41217?lang=en&region=us"
+        },
+        "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+        },
+        "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/roster/41217/statistics/0?lang=en&region=us"
+        }
+    },
+    "situationNotes": [
+        {
+            "type": "RISP_STATS",
+            "text": "Rocchio this year w/ RISP: 4 for 8 (.500 AVG), 0 HR, 2 SO"
+        },
+        {
+            "type": "BVP_STATS",
+            "text": "Rocchio career vs. Schreiber: 1 for 3 (.333 AVG), 0 HR, 0 SO"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- **BaseballCompetitionSituationDocumentProcessor** — handles baseball situations (balls, strikes, outs, runners). Stores CompetitionId and LastPlayId linkage; football-specific fields (Down, Distance, YardLine) zeroed. Baseball-specific entity fields deferred to sport-specific refactor.
- **CompetitionLeaderCategory.Name** — made nullable. ESPN baseball leader categories (e.g., id=43 "Batting Average") have null Name.
- **GetContestOverviewQueryHandler** — fix null reference when CategoryId/CategoryName are null.
- 3 unit tests with real ESPN baseball situation data
- EF migrations for both Football and Baseball contexts

## Test plan
- [x] All Producer unit tests pass
- [x] 3 new tests: create situation, skip duplicate, missing play dependency
- [ ] Deploy and verify situation processing for baseball

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added processing for baseball competition situation documents (includes last-play resolution and canonical situation persistence).

* **Improvements**
  * Safer leader-category handling with broader null-safe fallbacks for IDs/names/abbreviations.
  * Database schema updated to allow nullable leader category names for greater data flexibility.

* **Tests**
  * Added unit tests and a JSON fixture covering baseball competition situation scenarios (creation, duplicate skip, missing dependency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->