### PR TITLE
fix: sport-aware period labels in Win Probability and Play Log

### DIFF
--- a/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
@@ -85,12 +85,12 @@ export default function ContestOverview() {
           {/* Video component above Win Probability */}
           <ContestOverviewVideo mediaItems={mediaItems} />
           {/* Win probability moved up until TeamStats is available */}
-          <ContestOverviewWinProb winProbability={winProbability} homeTeam={homeTeam} awayTeam={awayTeam} />
+          <ContestOverviewWinProb winProbability={winProbability} homeTeam={homeTeam} awayTeam={awayTeam} sport={sport} />
           <ContestOverviewMetrics homeMetrics={homeMetrics} awayMetrics={awayMetrics} homeName={homeTeam?.displayName} awayName={awayTeam?.displayName} />
           <ContestOverviewInfo info={info} />
         </div>
         <div className="contest-overview-col">
-          <ContestOverviewPlaylog playLog={playLog} />
+          <ContestOverviewPlaylog playLog={playLog} sport={sport} />
         </div>
       </div>
       {isAdmin && (

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
+import { getPeriodPrefix } from "../../utils/periodLabel";
 import "./ContestOverview.css";
 
-export default function ContestOverviewPlaylog({ playLog }) {
+export default function ContestOverviewPlaylog({ playLog, sport }) {
+  const periodPrefix = getPeriodPrefix(sport);
   const [showAll, setShowAll] = useState(false);
   if (!playLog || !playLog.plays) return null;
   const { plays, awayTeamSlug, homeTeamSlug, awayTeamLogoUrl, homeTeamLogoUrl } = playLog;
@@ -54,7 +56,7 @@ export default function ContestOverviewPlaylog({ playLog }) {
                 padding: "14px 18px"
               }}
             >
-              <div style={{ fontWeight: 700, color: '#ffc107', marginBottom: 8 }}>Q{quarter}</div>
+              <div style={{ fontWeight: 700, color: '#ffc107', marginBottom: 8 }}>{periodPrefix}{quarter}</div>
               <div className="contest-scoring-summary-list">
                 {playsByQuarter[quarter].map((play, idx) => {
                   const logoUrl = getLogoUrl(play.team);

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewWinProb.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewWinProb.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from "recharts";
+import { getPeriodPrefix } from "../../utils/periodLabel";
 import "./ContestOverview.css";
 
 // Custom tooltip for dark theme
@@ -28,7 +29,8 @@ const CustomTooltip = ({ active, payload, label }) => {
 };
 
 
-export default function ContestOverviewWinProb({ winProbability }) {
+export default function ContestOverviewWinProb({ winProbability, sport }) {
+  const periodPrefix = getPeriodPrefix(sport);
   // Use colors and slugs from winProbability DTO
   const HOME_COLOR = `#${winProbability.homeTeamColor?.replace(/^#/, '') || '000000'}`;
   const AWAY_COLOR = `#${winProbability.awayTeamColor?.replace(/^#/, '') || 'ff5f05'}`;
@@ -56,7 +58,7 @@ export default function ContestOverviewWinProb({ winProbability }) {
               <XAxis
                 dataKey="quarter"
                 ticks={uniqueQuarters}
-                tickFormatter={q => `Q${q}`}
+                tickFormatter={q => `${periodPrefix}${q}`}
                 interval={0}
               />
               <YAxis domain={[0, 100]} tickFormatter={v => `${v}%`} />

--- a/src/UI/sd-ui/src/utils/periodLabel.js
+++ b/src/UI/sd-ui/src/utils/periodLabel.js
@@ -1,0 +1,8 @@
+const PERIOD_PREFIX = {
+  baseball: 'I',  // Inning
+  football: 'Q',  // Quarter
+};
+
+export function getPeriodPrefix(sport) {
+  return PERIOD_PREFIX[sport] || 'P';
+}


### PR DESCRIPTION
## Summary
- Win Probability chart x-axis: `I{n}` for baseball (innings), `Q{n}` for football (quarters)
- Play Log group headers: same sport-aware prefix
- 3 files, 18 lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Contest overview now shows sport-specific period labels (e.g., innings for baseball, quarters for football) across charts and play-by-play headers.
* **New Features**
  * Contest overview components now respect the contest's sport context so period labels and chart tick labels adapt accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->