### PR TITLE
fix: widen competitor statistic columns, rename baseball processors

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
@@ -16,11 +16,11 @@ using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
 
 [DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionPlay)]
-public class BaseballCompetitionPlayDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
+public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {
-    public BaseballCompetitionPlayDocumentProcessor(
-        ILogger<BaseballCompetitionPlayDocumentProcessor<TDataContext>> logger,
+    public BaseballEventCompetitionPlayDocumentProcessor(
+        ILogger<BaseballEventCompetitionPlayDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionSituationDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionSituationDocumentProcessor.cs
@@ -15,11 +15,11 @@ using SportsData.Producer.Infrastructure.Data.Entities;
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
 
 [DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionSituation)]
-public class BaseballCompetitionSituationDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
+public class BaseballEventCompetitionSituationDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {
-    public BaseballCompetitionSituationDocumentProcessor(
-        ILogger<BaseballCompetitionSituationDocumentProcessor<TDataContext>> logger,
+    public BaseballEventCompetitionSituationDocumentProcessor(
+        ILogger<BaseballEventCompetitionSituationDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorStatisticCategory.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorStatisticCategory.cs
@@ -27,9 +27,9 @@ public class CompetitionCompetitorStatisticCategory : CanonicalEntityBase<Guid>
         {
             builder.HasKey(x => x.Id);
 
-            builder.Property(x => x.Name).IsRequired().HasMaxLength(256);
-            builder.Property(x => x.DisplayName).IsRequired().HasMaxLength(256);
-            builder.Property(x => x.ShortDisplayName).IsRequired().HasMaxLength(256);
+            builder.Property(x => x.Name).IsRequired().HasMaxLength(512);
+            builder.Property(x => x.DisplayName).IsRequired().HasMaxLength(512);
+            builder.Property(x => x.ShortDisplayName).IsRequired().HasMaxLength(512);
             builder.Property(x => x.Abbreviation).IsRequired().HasMaxLength(64);
             builder.Property(x => x.Summary).HasMaxLength(1024);
 

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorStatisticStat.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorStatisticStat.cs
@@ -29,12 +29,12 @@ public class CompetitionCompetitorStatisticStat : CanonicalEntityBase<Guid>
         {
             builder.HasKey(x => x.Id);
 
-            builder.Property(x => x.Name).IsRequired().HasMaxLength(256);
-            builder.Property(x => x.DisplayName).IsRequired().HasMaxLength(256);
-            builder.Property(x => x.ShortDisplayName).IsRequired().HasMaxLength(256);
+            builder.Property(x => x.Name).IsRequired().HasMaxLength(512);
+            builder.Property(x => x.DisplayName).IsRequired().HasMaxLength(512);
+            builder.Property(x => x.ShortDisplayName).IsRequired().HasMaxLength(512);
             builder.Property(x => x.Abbreviation).IsRequired().HasMaxLength(64);
             builder.Property(x => x.Description).HasMaxLength(1024);
-            builder.Property(x => x.DisplayValue).HasMaxLength(256);
+            builder.Property(x => x.DisplayValue).HasMaxLength(1024);
             builder.Property(x => x.Value).HasPrecision(18, 6);
 
             builder.HasOne(x => x.CompetitionCompetitorStatisticCategory)

--- a/src/SportsData.Producer/Migrations/Baseball/20260411084552_WidenCompetitorStatisticColumns.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260411084552_WidenCompetitorStatisticColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260411084552_WidenCompetitorStatisticColumns")]
+    partial class WidenCompetitorStatisticColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260411084552_WidenCompetitorStatisticColumns.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260411084552_WidenCompetitorStatisticColumns.cs
@@ -1,0 +1,158 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class WidenCompetitorStatisticColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayValue",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayValue",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(1024)",
+                oldMaxLength: 1024);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/20260411084541_WidenCompetitorStatisticColumns.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260411084541_WidenCompetitorStatisticColumns.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Football;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Baseball
+namespace SportsData.Producer.Migrations.Football
 {
-    [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(FootballDataContext))]
+    [Migration("20260411084541_WidenCompetitorStatisticColumns")]
+    partial class WidenCompetitorStatisticColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,120 +415,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<bool>("Active")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("ConfigurationId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int>("Season")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SeasonType")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SplitTypeId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
-
-                    b.ToTable("AthleteSeasonHotZone", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("AtBats")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("AthleteSeasonHotZoneId")
-                        .HasColumnType("uuid");
-
-                    b.Property<double?>("BattingAvg")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("BattingAvgScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int?>("Hits")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<double?>("Slugging")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("SluggingScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("ZoneId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonHotZoneId");
-
-                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Common.Athlete", b =>
@@ -8012,17 +7901,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("SeasonWeekExternalId", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Common.Athlete");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -8033,24 +7914,16 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("ThrowsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("ThrowsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("BaseballAthlete");
+                    b.HasDiscriminator().HasValue("FootballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
+                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8083,17 +7956,6 @@ namespace SportsData.Producer.Migrations.Baseball
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
-                        .WithMany("Entries")
-                        .HasForeignKey("AthleteSeasonHotZoneId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("HotZone");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Common.Athlete", b =>
@@ -9630,7 +9492,7 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("SeasonWeek");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9646,11 +9508,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Common.Athlete", b =>

--- a/src/SportsData.Producer/Migrations/Football/20260411084541_WidenCompetitorStatisticColumns.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260411084541_WidenCompetitorStatisticColumns.cs
@@ -1,0 +1,158 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class WidenCompetitorStatisticColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayValue",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayValue",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(1024)",
+                oldMaxLength: 1024);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticStats",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorStatisticCategories",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
@@ -3115,8 +3115,8 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
 
                     b.Property<Guid?>("ModifiedBy")
                         .HasColumnType("uuid");
@@ -3126,13 +3126,13 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ShortDisplayName")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("Summary")
                         .HasMaxLength(1024)
@@ -3171,13 +3171,13 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("DisplayValue")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<Guid?>("ModifiedBy")
                         .HasColumnType("uuid");
@@ -3187,13 +3187,13 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ShortDisplayName")
                         .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
 
                     b.Property<decimal?>("Value")
                         .HasPrecision(18, 6)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessorTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
 
 [Collection("Sequential")]
-public class BaseballCompetitionPlayDocumentProcessorTests : ProducerTestBase<FootballDataContext>
+public class BaseballEventCompetitionPlayDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     private async Task<(Guid competitionId, Guid teamFranchiseSeasonId)> SetupTestDataAsync(
         ExternalRefIdentityGenerator generator,
@@ -85,7 +85,7 @@ public class BaseballCompetitionPlayDocumentProcessorTests : ProducerTestBase<Fo
         var teamRef = dto!.Team.Ref.ToString();
         var (competitionId, teamFranchiseSeasonId) = await SetupTestDataAsync(generator, teamRef);
 
-        var sut = Mocker.CreateInstance<BaseballCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
 
         var command = Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.Document, json)
@@ -137,7 +137,7 @@ public class BaseballCompetitionPlayDocumentProcessorTests : ProducerTestBase<Fo
         var teamRef = dto!.Team.Ref.ToString();
         var (competitionId, _) = await SetupTestDataAsync(generator, teamRef);
 
-        var sut = Mocker.CreateInstance<BaseballCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
 
         var command = Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.Document, json)
@@ -206,7 +206,7 @@ public class BaseballCompetitionPlayDocumentProcessorTests : ProducerTestBase<Fo
         await FootballDataContext.CompetitionPlays.AddAsync(existingPlay);
         await FootballDataContext.SaveChangesAsync();
 
-        var sut = Mocker.CreateInstance<BaseballCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
 
         var command = Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.Document, json)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionSituationDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionSituationDocumentProcessorTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
 
 [Collection("Sequential")]
-public class BaseballCompetitionSituationDocumentProcessorTests : ProducerTestBase<FootballDataContext>
+public class BaseballEventCompetitionSituationDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     private async Task<(Guid competitionId, Guid lastPlayId)> SetupTestDataAsync(
         ExternalRefIdentityGenerator generator,
@@ -82,7 +82,7 @@ public class BaseballCompetitionSituationDocumentProcessorTests : ProducerTestBa
 
         var (competitionId, lastPlayId) = await SetupTestDataAsync(generator, dto!);
 
-        var sut = Mocker.CreateInstance<BaseballCompetitionSituationDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionSituationDocumentProcessor<FootballDataContext>>();
 
         var command = Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.Document, json)
@@ -140,7 +140,7 @@ public class BaseballCompetitionSituationDocumentProcessorTests : ProducerTestBa
         });
         await FootballDataContext.SaveChangesAsync();
 
-        var sut = Mocker.CreateInstance<BaseballCompetitionSituationDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionSituationDocumentProcessor<FootballDataContext>>();
 
         var command = Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.Document, json)
@@ -183,7 +183,7 @@ public class BaseballCompetitionSituationDocumentProcessorTests : ProducerTestBa
         });
         await FootballDataContext.SaveChangesAsync();
 
-        var sut = Mocker.CreateInstance<BaseballCompetitionSituationDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionSituationDocumentProcessor<FootballDataContext>>();
 
         var command = Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.Document, json)


### PR DESCRIPTION
## Summary
- Widen `CompetitionCompetitorStatisticStat.DisplayValue` from varchar(256) to varchar(1024) — baseball box score summaries exceed 256 chars
- Proactively widen `Name`, `DisplayName`, `ShortDisplayName` from 256 to 512 on both `CompetitionCompetitorStatisticStat` and `CompetitionCompetitorStatisticCategory`
- Rename `BaseballCompetitionPlay*` to `BaseballEventCompetitionPlay*` and `BaseballCompetitionSituation*` to `BaseballEventCompetitionSituation*` to match football naming convention
- EF migrations for both Football and Baseball contexts

@coderabbitai ignore

## Test plan
- [x] All 334 unit tests pass
- [ ] Deploy and verify competitor statistics process for baseball

🤖 Generated with [Claude Code](https://claude.com/claude-code)