### PR TITLE
refactor: sport-specific ESPN EventCompetition DTOs

### DIFF
--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionCompetitorDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionCompetitorDto.cs
@@ -1,0 +1,37 @@
+#pragma warning disable CS8618 // Non-nullable property is uninitialized
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+
+public class EspnBaseballEventCompetitionCompetitorDto : EspnEventCompetitionCompetitorDto
+{
+    [JsonPropertyName("probables")]
+    public List<EspnBaseballProbableDto>? Probables { get; set; }
+}
+
+public class EspnBaseballProbableDto
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("shortDisplayName")]
+    public string? ShortDisplayName { get; set; }
+
+    [JsonPropertyName("abbreviation")]
+    public string? Abbreviation { get; set; }
+
+    [JsonPropertyName("playerId")]
+    public int PlayerId { get; set; }
+
+    [JsonPropertyName("athlete")]
+    public EspnLinkDto? Athlete { get; set; }
+
+    [JsonPropertyName("statistics")]
+    public EspnLinkDto? Statistics { get; set; }
+}

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionDto.cs
@@ -1,0 +1,91 @@
+#pragma warning disable CS8618 // Non-nullable property is uninitialized
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+
+public class EspnBaseballEventCompetitionDto : EspnEventCompetitionDtoBase
+{
+    [JsonPropertyName("timeOfDay")]
+    public string? TimeOfDay { get; set; }
+
+    [JsonPropertyName("duration")]
+    public EspnBaseballCompetitionDurationDto? Duration { get; set; }
+
+    [JsonPropertyName("necessary")]
+    public bool Necessary { get; set; }
+
+    [JsonPropertyName("wasSuspended")]
+    public bool WasSuspended { get; set; }
+
+    [JsonPropertyName("seriesId")]
+    public string? SeriesId { get; set; }
+
+    [JsonPropertyName("series")]
+    public List<EspnBaseballSeriesDto>? Series { get; set; }
+
+    [JsonPropertyName("officials")]
+    public EspnLinkDto? Officials { get; set; }
+
+    [JsonPropertyName("relevancy")]
+    public EspnLinkDto? Relevancy { get; set; }
+
+    [JsonPropertyName("dataFormat")]
+    public string? DataFormat { get; set; }
+}
+
+public class EspnBaseballCompetitionDurationDto
+{
+    [JsonPropertyName("displayValue")]
+    public string? DisplayValue { get; set; }
+}
+
+public class EspnBaseballSeriesDto
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("summary")]
+    public string? Summary { get; set; }
+
+    [JsonPropertyName("completed")]
+    public bool Completed { get; set; }
+
+    [JsonPropertyName("totalCompetitions")]
+    public int TotalCompetitions { get; set; }
+
+    [JsonPropertyName("competitors")]
+    public List<EspnBaseballSeriesCompetitorDto>? Competitors { get; set; }
+
+    [JsonPropertyName("events")]
+    public List<EspnLinkDto>? Events { get; set; }
+
+    [JsonPropertyName("startDate")]
+    public string? StartDate { get; set; }
+}
+
+public class EspnBaseballSeriesCompetitorDto
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("uid")]
+    public string? Uid { get; set; }
+
+    [JsonPropertyName("wins")]
+    public int Wins { get; set; }
+
+    [JsonPropertyName("ties")]
+    public int Ties { get; set; }
+
+    [JsonPropertyName("team")]
+    public EspnLinkDto? Team { get; set; }
+}

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionDtoBase.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionDtoBase.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS8618 // Non-nullable property is uninitialized
+#pragma warning disable CS8618 // Non-nullable property is uninitialized
 
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Contracts;
 
@@ -9,14 +9,10 @@ using System.Text.Json.Serialization;
 namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 
 /// <summary>
-/// Represents a competition within an ESPN event, providing detailed information about the competition's attributes, 
-/// participants, status, and related resources.
-/// http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334/competitions/401628334
+/// Base DTO for an ESPN event competition. Contains properties shared across all sports.
+/// Sport-specific subclasses add fields unique to football, baseball, etc.
 /// </summary>
-/// <remarks>This class encapsulates various properties that describe the competition, including its unique
-/// identifiers,  date, venue, competitors, and availability of features such as play-by-play, boxscore, and commentary.
-/// It also includes links to related resources such as broadcasts, odds, and leaders.</remarks>
-public class EspnEventCompetitionDto : IHasRef
+public class EspnEventCompetitionDtoBase : IHasRef
 {
     [JsonPropertyName("$ref")]
     public Uri Ref { get; set; }
@@ -41,9 +37,6 @@ public class EspnEventCompetitionDto : IHasRef
 
     [JsonPropertyName("timeValid")]
     public bool TimeValid { get; set; }
-
-    [JsonPropertyName("dateValid")]
-    public bool DateValid { get; set; }
 
     [JsonPropertyName("neutralSite")]
     public bool NeutralSite { get; set; }
@@ -170,10 +163,4 @@ public class EspnEventCompetitionDto : IHasRef
 
     [JsonPropertyName("format")]
     public EspnEventCompetitionFormatDto Format { get; set; }
-
-    [JsonPropertyName("drives")]
-    public EspnLinkDto Drives { get; set; }
-
-    [JsonPropertyName("hasDefensiveStats")]
-    public bool HasDefensiveStats { get; set; }
 }

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionPlayStartEndDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionPlayStartEndDto.cs
@@ -1,22 +1,17 @@
 ﻿using System.Text.Json.Serialization;
 
 namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
-
 #pragma warning disable CS8618
 public class EspnEventCompetitionPlayStartEndDto
 {
     [JsonPropertyName("down")]
     public int Down { get; set; }
-
     [JsonPropertyName("distance")]
     public int Distance { get; set; }
-
     [JsonPropertyName("yardLine")]
     public int YardLine { get; set; }
-
     [JsonPropertyName("yardsToEndzone")]
     public int YardsToEndzone { get; set; }
-
     [JsonPropertyName("team")]
     public EspnLinkDto Team { get; set; }
 }

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventDto.cs
@@ -50,7 +50,7 @@ namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common
         public bool TimeValid { get; set; }
 
         [JsonPropertyName("competitions")]
-        public List<EspnEventCompetitionDto> Competitions { get; set; }
+        public List<EspnEventCompetitionDtoBase> Competitions { get; set; }
 
         [JsonPropertyName("links")]
         public List<EspnLinkFullDto> Links { get; set; }

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveDto.cs
@@ -1,68 +1,48 @@
 ﻿#pragma warning disable CS8618
 
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Contracts;
-
 using System;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using System.Text.Json.Serialization;
-
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
-
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 public class EspnEventCompetitionDriveDto : IHasRef
 {
     [JsonPropertyName("$ref")]
     public Uri Ref { get; set; }
-
     [JsonPropertyName("id")]
     public string Id { get; set; }
-
     [JsonPropertyName("description")]
     public string Description { get; set; }
-
     [JsonPropertyName("sequenceNumber")]
     public string SequenceNumber { get; set; }
-
     [JsonPropertyName("team")]
     public EspnLinkDto Team { get; set; }
-
     [JsonPropertyName("endTeam")]
     public EspnLinkDto EndTeam { get; set; }
-
     /// <summary>
     /// team that is on offense for this drive
     /// </summary>
     [JsonPropertyName("start")]
     public EspnEventCompetitionDriveStartDto Start { get; set; }
-
-    /// <summary>
     /// 
-    /// </summary>
     [JsonPropertyName("end")]
     public EspnEventCompetitionDriveEndDto End { get; set; }
-
     [JsonPropertyName("timeElapsed")]
     public EspnEventCompetitionDriveTimeElapsedDto TimeElapsed { get; set; }
-
     [JsonPropertyName("yards")]
     public int Yards { get; set; }
-
     [JsonPropertyName("isScore")]
     public bool IsScore { get; set; }
-
     [JsonPropertyName("offensivePlays")]
     public int OffensivePlays { get; set; }
-
     [JsonPropertyName("result")]
     public string Result { get; set; }
-
     [JsonPropertyName("shortDisplayResult")]
     public string ShortDisplayResult { get; set; }
-
     [JsonPropertyName("displayResult")]
     public string DisplayResult { get; set; }
-
     [JsonPropertyName("source")]
     public EspnEventCompetitionDriveSourceDto Source { get; set; }
-
     [JsonPropertyName("plays")]
     public EspnEventCompetitionPlaysDto? Plays { get; set; }
 }

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveEndDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveEndDto.cs
@@ -1,41 +1,30 @@
 ﻿#pragma warning disable CS8618
 
 using System.Text.Json.Serialization;
-
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
-
-public class EspnEventCompetitionDriveStartDto
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
+public class EspnEventCompetitionDriveEndDto
 {
     [JsonPropertyName("period")]
     public EspnEventCompetitionDrivePeriodDto Period { get; set; }
-
     [JsonPropertyName("clock")]
     public EspnClockDto Clock { get; set; }
-
     [JsonPropertyName("yardLine")]
     public int YardLine { get; set; }
-
     [JsonPropertyName("text")]
     public string Text { get; set; }
-
     [JsonPropertyName("down")]
     public int? Down { get; set; }
-
     [JsonPropertyName("distance")]
     public int? Distance { get; set; }
-
     [JsonPropertyName("yardsToEndzone")]
     public int? YardsToEndzone { get; set; }
-
     [JsonPropertyName("team")]
     public EspnLinkDto? Team { get; set; }
-
     [JsonPropertyName("downDistanceText")]
     public string? DownDistanceText { get; set; }
-
     [JsonPropertyName("shortDownDistanceText")]
     public string? ShortDownDistanceText { get; set; }
-
     [JsonPropertyName("possessionText")]
     public string? PossessionText { get; set; }
 }

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveItemTypeDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveItemTypeDto.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 
 public class EspnEventCompetitionDriveItemTypeDto
 {

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveParticipantDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveParticipantDto.cs
@@ -1,28 +1,22 @@
 ﻿#pragma warning disable CS8618 // Non-nullable property is uninitialized
 
 using System.Collections.Generic;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using System.Text.Json.Serialization;
-
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
-
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 #pragma warning disable CS8618
 public class EspnEventCompetitionDriveParticipantDto
 {
     [JsonPropertyName("athlete")]
     public EspnLinkDto Athlete { get; set; }
-
     [JsonPropertyName("position")]
     public EspnLinkDto Position { get; set; }
-
     [JsonPropertyName("statistics")]
     public EspnLinkDto Statistics { get; set; }
-
     [JsonPropertyName("stats")]
     public List<EspnEventCompetitionParticipantStatDto> Stats { get; set; }
-
     [JsonPropertyName("order")]
     public int Order { get; set; }
-
     [JsonPropertyName("type")]
     public string Type { get; set; }
 }

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDrivePeriodDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDrivePeriodDto.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 
 #pragma warning disable CS8618
 public class EspnEventCompetitionDrivePeriodDto

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveSourceDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveSourceDto.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 
 #pragma warning disable CS8618
 public class EspnEventCompetitionDriveSourceDto

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveStartDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveStartDto.cs
@@ -1,41 +1,30 @@
 ﻿#pragma warning disable CS8618
 
 using System.Text.Json.Serialization;
-
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
-
-public class EspnEventCompetitionDriveEndDto
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
+public class EspnEventCompetitionDriveStartDto
 {
     [JsonPropertyName("period")]
     public EspnEventCompetitionDrivePeriodDto Period { get; set; }
-
     [JsonPropertyName("clock")]
     public EspnClockDto Clock { get; set; }
-
     [JsonPropertyName("yardLine")]
     public int YardLine { get; set; }
-
     [JsonPropertyName("text")]
     public string Text { get; set; }
-
     [JsonPropertyName("down")]
     public int? Down { get; set; }
-
     [JsonPropertyName("distance")]
     public int? Distance { get; set; }
-
     [JsonPropertyName("yardsToEndzone")]
     public int? YardsToEndzone { get; set; }
-
     [JsonPropertyName("team")]
     public EspnLinkDto? Team { get; set; }
-
     [JsonPropertyName("downDistanceText")]
     public string? DownDistanceText { get; set; }
-
     [JsonPropertyName("shortDownDistanceText")]
     public string? ShortDownDistanceText { get; set; }
-
     [JsonPropertyName("possessionText")]
     public string? PossessionText { get; set; }
 }

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveTimeElapsedDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnEventCompetitionDriveTimeElapsedDto.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 
 public class EspnEventCompetitionDriveTimeElapsedDto
 {

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnFootballEventCompetitionDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Football/EspnFootballEventCompetitionDto.cs
@@ -1,0 +1,18 @@
+#pragma warning disable CS8618 // Non-nullable property is uninitialized
+
+using System.Text.Json.Serialization;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
+
+public class EspnFootballEventCompetitionDto : EspnEventCompetitionDtoBase
+{
+    [JsonPropertyName("dateValid")]
+    public bool DateValid { get; set; }
+
+    [JsonPropertyName("drives")]
+    public EspnLinkDto Drives { get; set; }
+
+    [JsonPropertyName("hasDefensiveStats")]
+    public bool HasDefensiveStats { get; set; }
+}

--- a/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamer.cs
+++ b/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamer.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Infrastructure.Data;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -210,7 +211,7 @@ public class FootballCompetitionStreamer : IFootballCompetitionBroadcastingJob
         }
     }
 
-    private async Task<EspnEventCompetitionDto?> GetCompetitionAsync(Uri uri, CancellationToken cancellationToken)
+    private async Task<EspnFootballEventCompetitionDto?> GetCompetitionAsync(Uri uri, CancellationToken cancellationToken)
     {
         try
         {
@@ -222,7 +223,7 @@ public class FootballCompetitionStreamer : IFootballCompetitionBroadcastingJob
             }
 
             var json = await response.Content.ReadAsStringAsync(cancellationToken);
-            var result = json.FromJson<EspnEventCompetitionDto>();
+            var result = json.FromJson<EspnFootballEventCompetitionDto>();
 
             return result;
         }
@@ -304,7 +305,7 @@ public class FootballCompetitionStreamer : IFootballCompetitionBroadcastingJob
     }
 
     private void StartPollingWorkers(
-        EspnEventCompetitionDto competitionDto,
+        EspnFootballEventCompetitionDto competitionDto,
         StreamFootballCompetitionCommand command,
         CancellationToken cancellationToken)
     {

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessor.cs
@@ -1,6 +1,8 @@
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
@@ -22,8 +24,11 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
         IGenerateResourceRefs refs)
         : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
 
+    protected override EspnEventCompetitionDtoBase? DeserializeDto(string document)
+        => document.FromJson<EspnBaseballEventCompetitionDto>();
+
     protected override CompetitionBase CreateEntity(
-        EspnEventCompetitionDto dto,
+        EspnEventCompetitionDtoBase dto,
         IGenerateExternalRefIdentities identityGenerator,
         Guid contestId,
         Guid correlationId)

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventDocumentProcessor.cs
@@ -1,3 +1,4 @@
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
@@ -25,24 +25,27 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
         : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
 
     protected abstract CompetitionBase CreateEntity(
-        EspnEventCompetitionDto dto,
+        EspnEventCompetitionDtoBase dto,
         IGenerateExternalRefIdentities identityGenerator,
         Guid contestId,
         Guid correlationId);
 
+    protected virtual EspnEventCompetitionDtoBase? DeserializeDto(string document)
+        => document.FromJson<EspnEventCompetitionDtoBase>();
+
     protected override async Task ProcessInternal(ProcessDocumentCommand command)
     {
-        var externalDto = command.Document.FromJson<EspnEventCompetitionDto>();
+        var externalDto = DeserializeDto(command.Document);
 
         if (externalDto is null)
         {
-            _logger.LogError("Failed to deserialize EspnEventCompetitionDto.");
+            _logger.LogError("Failed to deserialize EspnEventCompetitionDtoBase.");
             return;
         }
 
         if (string.IsNullOrEmpty(externalDto.Ref?.ToString()))
         {
-            _logger.LogError("EspnEventCompetitionDto Ref is null.");
+            _logger.LogError("EspnEventCompetitionDtoBase Ref is null.");
             return;
         }
 
@@ -95,7 +98,7 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
 
     private async Task ProcessNewEntity(
         ProcessDocumentCommand command,
-        EspnEventCompetitionDto externalDto,
+        EspnEventCompetitionDtoBase externalDto,
         int seasonYear,
         Guid contestId)
     {
@@ -118,7 +121,7 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
 
     private async Task AddVenue(
         ProcessDocumentCommand command,
-        EspnEventCompetitionDto externalDto,
+        EspnEventCompetitionDtoBase externalDto,
         CompetitionBase competition)
     {
         var venue = externalDto.Venue;
@@ -156,7 +159,7 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
 
     private async Task ProcessUpdate(
         ProcessDocumentCommand command,
-        EspnEventCompetitionDto dto,
+        EspnEventCompetitionDtoBase dto,
         CompetitionBase competition)
     {
         var updatedEntity = CreateEntity(dto, _externalRefIdentityGenerator, competition.ContestId, command.CorrelationId);
@@ -222,7 +225,7 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
 
     private async Task ProcessChildDocuments(
         ProcessDocumentCommand command,
-        EspnEventCompetitionDto dto,
+        EspnEventCompetitionDtoBase dto,
         CompetitionBase competition,
         bool isNew)
     {
@@ -255,8 +258,7 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
         if (isNew || ShouldSpawn(DocumentType.EventCompetitionPowerIndex, command))
             await PublishChildDocumentRequest(command, dto.PowerIndexes, competition.Id, DocumentType.EventCompetitionPowerIndex);
 
-        if (isNew || ShouldSpawn(DocumentType.EventCompetitionDrive, command))
-            await PublishChildDocumentRequest(command, dto.Drives, competition.Id, DocumentType.EventCompetitionDrive);
+        await ProcessSportSpecificChildDocuments(command, dto, competition, isNew);
 
         if (isNew || ShouldSpawn(DocumentType.EventCompetitionCompetitor, command))
             await ProcessCompetitors(command, dto, competition);
@@ -266,9 +268,15 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
         _logger.LogInformation("Completed processing child documents for Competition. CompetitionId={CompId}", competition.Id);
     }
 
+    protected virtual Task ProcessSportSpecificChildDocuments(
+        ProcessDocumentCommand command,
+        EspnEventCompetitionDtoBase dto,
+        CompetitionBase competition,
+        bool isNew) => Task.CompletedTask;
+
     private async Task ProcessCompetitors(
         ProcessDocumentCommand command,
-        EspnEventCompetitionDto externalDto,
+        EspnEventCompetitionDtoBase externalDto,
         CompetitionBase competition)
     {
         _logger.LogInformation("Requesting {Count} competitors. CompetitionId={CompId}",
@@ -297,7 +305,7 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
 
     private static void ProcessNotes(
         ProcessDocumentCommand command,
-        EspnEventCompetitionDto externalDto,
+        EspnEventCompetitionDtoBase externalDto,
         CompetitionBase competition)
     {
         if (!externalDto.Notes.Any())
@@ -319,7 +327,7 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
 
     private static void ProcessLinks(
         ProcessDocumentCommand command,
-        EspnEventCompetitionDto externalDto,
+        EspnEventCompetitionDtoBase externalDto,
         CompetitionBase competition)
     {
         if (externalDto.Links?.Any() != true)

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionDocumentProcessor.cs
@@ -2,7 +2,10 @@ using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
+using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
@@ -23,12 +26,28 @@ public class EventCompetitionDocumentProcessor<TDataContext> : EventCompetitionD
         IGenerateResourceRefs refs)
         : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
 
+    protected override EspnEventCompetitionDtoBase? DeserializeDto(string document)
+        => document.FromJson<EspnFootballEventCompetitionDto>();
+
     protected override CompetitionBase CreateEntity(
-        EspnEventCompetitionDto dto,
+        EspnEventCompetitionDtoBase dto,
         IGenerateExternalRefIdentities identityGenerator,
         Guid contestId,
         Guid correlationId)
     {
         return dto.AsFootballEntity(identityGenerator, contestId, correlationId);
+    }
+
+    protected override async Task ProcessSportSpecificChildDocuments(
+        ProcessDocumentCommand command,
+        EspnEventCompetitionDtoBase dto,
+        CompetitionBase competition,
+        bool isNew)
+    {
+        if (dto is EspnFootballEventCompetitionDto footballDto)
+        {
+            if (isNew || ShouldSpawn(DocumentType.EventCompetitionDrive, command))
+                await PublishChildDocumentRequest(command, footballDto.Drives, competition.Id, DocumentType.EventCompetitionDrive);
+        }
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionDriveDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionDriveDocumentProcessor.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventDocumentProcessor.cs
@@ -1,21 +1,23 @@
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 using SportsData.Producer.Infrastructure.Data.Football;
 
-namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.Event)]
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNfl, DocumentType.Event)]
-public class EventDocumentProcessor<TDataContext> : EventDocumentProcessorBase<TDataContext>
+public class FootballEventDocumentProcessor<TDataContext> : EventDocumentProcessorBase<TDataContext>
     where TDataContext : FootballDataContext
 {
-    public EventDocumentProcessor(
-        ILogger<EventDocumentProcessor<TDataContext>> logger,
+    public FootballEventDocumentProcessor(
+        ILogger<FootballEventDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionDriveExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionDriveExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 
 namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionExtensions.cs
@@ -1,6 +1,7 @@
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
 using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
@@ -9,18 +10,25 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
     public static class CompetitionExtensions
     {
         public static FootballCompetition AsFootballEntity(
-            this EspnEventCompetitionDto dto,
+            this EspnEventCompetitionDtoBase dto,
             IGenerateExternalRefIdentities externalRefIdentityGenerator,
             Guid contestId,
             Guid correlationId)
         {
             var entity = new FootballCompetition();
             MapSharedProperties(dto, entity, externalRefIdentityGenerator, contestId, correlationId);
+
+            if (dto is EspnFootballEventCompetitionDto footballDto)
+            {
+                entity.DateValid = footballDto.DateValid;
+                entity.HasDefensiveStats = footballDto.HasDefensiveStats;
+            }
+
             return entity;
         }
 
         public static BaseballCompetition AsBaseballEntity(
-            this EspnEventCompetitionDto dto,
+            this EspnEventCompetitionDtoBase dto,
             IGenerateExternalRefIdentities externalRefIdentityGenerator,
             Guid contestId,
             Guid correlationId)
@@ -31,7 +39,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
         }
 
         private static void MapSharedProperties(
-            EspnEventCompetitionDto dto,
+            EspnEventCompetitionDtoBase dto,
             CompetitionBase entity,
             IGenerateExternalRefIdentities externalRefIdentityGenerator,
             Guid contestId,
@@ -45,7 +53,6 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
             entity.CreatedBy = correlationId;
             entity.CreatedUtc = DateTime.UtcNow;
             entity.Date = DateTime.TryParse(dto.Date, out var date) ? date.ToUniversalTime() : DateTime.MinValue.ToUniversalTime();
-            entity.DateValid = dto.DateValid;
             entity.FormatOvertimeDisplayName = dto.Format?.Overtime?.DisplayName;
             entity.FormatOvertimePeriods = dto.Format?.Overtime?.Periods;
             entity.FormatOvertimeSlug = dto.Format?.Overtime?.Slug;
@@ -53,7 +60,6 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
             entity.FormatRegulationDisplayName = dto.Format?.Regulation?.DisplayName;
             entity.FormatRegulationPeriods = dto.Format?.Regulation?.Periods;
             entity.FormatRegulationSlug = dto.Format?.Regulation?.Slug;
-            entity.HasDefensiveStats = dto.HasDefensiveStats;
             entity.IsBoxscoreAvailable = dto.BoxscoreAvailable;
             entity.IsBracketAvailable = dto.BracketAvailable;
             entity.IsCommentaryAvailable = dto.CommentaryAvailable;

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorTests.cs
@@ -13,6 +13,7 @@ using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -49,7 +50,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             var documentJson = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetition.json");
 
             // act
-            var dto = documentJson.FromJson<EspnEventCompetitionDto>();
+            var dto = documentJson.FromJson<EspnFootballEventCompetitionDto>();
 
             // assert
             dto.Should().NotBeNull();
@@ -69,7 +70,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 
             var bus = Mocker.GetMock<IEventBus>();
 
-            var dto = documentJson.FromJson<EspnEventCompetitionDto>();
+            var dto = documentJson.FromJson<EspnFootballEventCompetitionDto>();
 
             Guid homeId = Guid.Empty;
             Guid awayId = Guid.Empty;
@@ -180,7 +181,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 
             var bus = Mocker.GetMock<IEventBus>();
 
-            var dto = documentJson.FromJson<EspnEventCompetitionDto>();
+            var dto = documentJson.FromJson<EspnFootballEventCompetitionDto>();
             var competitionIdentity = generator.Generate(dto.Ref);
 
             Guid homeId = Guid.Empty;
@@ -318,7 +319,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 
             var bus = Mocker.GetMock<IEventBus>();
 
-            var dto = documentJson.FromJson<EspnEventCompetitionDto>();
+            var dto = documentJson.FromJson<EspnFootballEventCompetitionDto>();
             var competitionIdentity = generator.Generate(dto.Ref);
 
             Guid homeId = Guid.NewGuid();
@@ -555,7 +556,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 
             var bus = Mocker.GetMock<IEventBus>();
 
-            var dto = documentJson.FromJson<EspnEventCompetitionDto>();
+            var dto = documentJson.FromJson<EspnFootballEventCompetitionDto>();
             var competitionIdentity = generator.Generate(dto.Ref);
 
             Guid homeId = Guid.NewGuid();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
@@ -24,16 +24,16 @@ using SportsData.Producer.Infrastructure.Data.Football;
 using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 using Xunit;
-using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Common;
 
 /// <summary>
-/// Tests for EventDocumentProcessor.
+/// Tests for FootballEventDocumentProcessor.
 /// Optimized to eliminate AutoFixture overhead.
 /// </summary>
 [Collection("Sequential")]
-public class EventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
+public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     // Helper method to setup common test data
     private async Task SetupSeasonDataAsync(ExternalRefIdentityGenerator generator, EspnEventDto dto)
@@ -226,7 +226,7 @@ public class EventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
                 .Create());
 
         var bus = Mocker.GetMock<IEventBus>();
-        var sut = Mocker.CreateInstance<EventDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent.json");
 
@@ -304,7 +304,7 @@ public class EventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
                 .Create());
 
         var bus = Mocker.GetMock<IEventBus>();
-        var sut = Mocker.CreateInstance<EventDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent.json");
 
@@ -351,7 +351,7 @@ public class EventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
         Mocker.Use<IGenerateExternalRefIdentities>(generator);
 
         var bus = Mocker.GetMock<IEventBus>();
-        var sut = Mocker.CreateInstance<EventDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent.json");
 
@@ -422,7 +422,7 @@ public class EventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
                 .Create());
 
         var bus = Mocker.GetMock<IEventBus>();
-        var sut = Mocker.CreateInstance<EventDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnBaseballMlb/Event_SpringTraining.json");
         var dto = json.FromJson<EspnEventDto>();
@@ -513,7 +513,7 @@ public class EventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
         var generator = new ExternalRefIdentityGenerator();
         Mocker.Use<IGenerateExternalRefIdentities>(generator);
 
-        var sut = Mocker.CreateInstance<EventDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnBaseballMlb/Event_SpringTraining.json");
         var dto = json.FromJson<EspnEventDto>();
@@ -579,7 +579,7 @@ public class EventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
                 .Create());
 
         var bus = Mocker.GetMock<IEventBus>();
-        var sut = Mocker.CreateInstance<EventDocumentProcessor<FootballDataContext>>();
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent_MissingWeek.json");
 


### PR DESCRIPTION
## Summary

- Split `EspnEventCompetitionDto` into inheritance hierarchy: shared base in `Common/`, football subclass with `Drives`/`HasDefensiveStats`/`DateValid`, baseball subclass with `TimeOfDay`/`Duration`/`Series[]`/`SeriesId`/`WasSuspended`/`Necessary`/`Officials`/`Relevancy`/`DataFormat`
- Add `EspnBaseballEventCompetitionCompetitorDto` with `Probables[]` for starting pitcher data
- Move 8 Drive DTOs from `Common/` to `Football/` namespace
- Processors use virtual `DeserializeDto()` for sport-specific deserialization
- Football processor spawns drives via `ProcessSportSpecificChildDocuments` override
- Extension methods split football-only field mapping out of shared `MapSharedProperties`

## Test plan

- [x] Producer builds with zero errors
- [x] 320 unit tests pass, 14 skipped, 0 failed
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Baseball competition data now includes probable pitcher details with athlete and statistics information
  * Baseball events now include series metadata such as standings, competition counts, and schedules

* **Refactor**
  * Event competition data structures reorganized to improve sport-specific handling and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->