### PR TITLE
fix: replace hardcoded Sport.FootballNcaa with IAppMode.CurrentSport

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamScheduler.cs
+++ b/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamScheduler.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Infrastructure.Data;
@@ -13,15 +14,18 @@ public class FootballCompetitionStreamScheduler
     private readonly ILogger<FootballCompetitionStreamScheduler> _logger;
     private readonly FootballDataContext _dataContext;
     private readonly IProvideBackgroundJobs _backgroundJobProvider;
+    private readonly IAppMode _appMode;
 
     public FootballCompetitionStreamScheduler(
         ILogger<FootballCompetitionStreamScheduler> logger,
         FootballDataContext dataContext,
-        IProvideBackgroundJobs backgroundJobProvider)
+        IProvideBackgroundJobs backgroundJobProvider,
+        IAppMode appMode)
     {
         _logger = logger;
         _dataContext = dataContext;
         _backgroundJobProvider = backgroundJobProvider;
+        _appMode = appMode;
     }
 
     /// <summary>
@@ -95,7 +99,7 @@ public class FootballCompetitionStreamScheduler
                 {
                     ContestId = competition.ContestId,
                     CompetitionId = competition.Id,
-                    Sport = Sport.FootballNcaa,
+                    Sport = _appMode.CurrentSport,
                     SeasonYear = contest.SeasonYear,
                     DataProvider = SourceDataProvider.Espn,
                     CorrelationId = correlationId

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
 using Dtos = SportsData.Core.Dtos;
@@ -25,15 +26,18 @@ namespace SportsData.Producer.Application.Contests
         private readonly ILogger<ContestController> _logger;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
         private readonly TeamSportDataContext _dataContext;
+        private readonly IAppMode _appMode;
 
         public ContestController(
             ILogger<ContestController> logger,
             IProvideBackgroundJobs backgroundJobProvider,
-            TeamSportDataContext dataContext)
+            TeamSportDataContext dataContext,
+            IAppMode appMode)
         {
             _logger = logger;
             _backgroundJobProvider = backgroundJobProvider;
             _dataContext = dataContext;
+            _appMode = appMode;
         }
 
         [HttpGet("{contestId}")]
@@ -62,7 +66,7 @@ namespace SportsData.Producer.Application.Contests
             var cmd = new UpdateContestCommand(
                 contestId,
                 SourceDataProvider.Espn,
-                Sport.FootballNcaa,
+                _appMode.CurrentSport,
                 correlationId);
                 
             _backgroundJobProvider.Enqueue<IUpdateContests>(p => p.Process(cmd));

--- a/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
@@ -2,6 +2,7 @@
 
 using SportsData.Core.Common;
 using SportsData.Core.Common.Jobs;
+using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -17,15 +18,18 @@ namespace SportsData.Producer.Application.Contests
         private readonly ILogger<ContestUpdateJob> _logger;
         private readonly TeamSportDataContext _dataContext;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IAppMode _appMode;
 
         public ContestUpdateJob(
             ILogger<ContestUpdateJob> logger,
             TeamSportDataContext dataContext,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IAppMode appMode)
         {
             _logger = logger;
             _dataContext = dataContext;
             _backgroundJobProvider = backgroundJobProvider;
+            _appMode = appMode;
         }
 
         public async Task ExecuteAsync()
@@ -147,7 +151,7 @@ namespace SportsData.Producer.Application.Contests
                     var cmd = new UpdateContestCommand(
                         contest.Id,
                         SourceDataProvider.Espn,
-                        Sport.FootballNcaa,
+                        _appMode.CurrentSport,
                         correlationId); // Use same correlation ID for all updates in this job run
                     
                     var jobId = _backgroundJobProvider.Enqueue<IUpdateContests>(p => p.Process(cmd));

--- a/src/SportsData.Producer/Application/Franchises/Commands/EnrichFranchiseSeasonHandler.cs
+++ b/src/SportsData.Producer/Application/Franchises/Commands/EnrichFranchiseSeasonHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Franchise;
 using SportsData.Producer.Infrastructure.Data.Common;
@@ -19,15 +20,18 @@ namespace SportsData.Producer.Application.Franchises.Commands
         private readonly ILogger<EnrichFranchiseSeasonHandler<TDataContext>> _logger;
         private readonly TDataContext _dataContext;
         private readonly IEventBus _eventBus;
+        private readonly IAppMode _appMode;
 
         public EnrichFranchiseSeasonHandler(
             ILogger<EnrichFranchiseSeasonHandler<TDataContext>> logger,
             TDataContext dataContext,
-            IEventBus eventBus)
+            IEventBus eventBus,
+            IAppMode appMode)
         {
             _logger = logger;
             _dataContext = dataContext;
             _eventBus = eventBus;
+            _appMode = appMode;
         }
 
         public async Task Process(EnrichFranchiseSeasonCommand command)
@@ -76,7 +80,7 @@ namespace SportsData.Producer.Application.Franchises.Commands
             await _eventBus.Publish(new FranchiseSeasonEnrichmentCompleted(
                 command.FranchiseSeasonId,
                 null,
-                Sport.FootballNcaa,
+                _appMode.CurrentSport,
                 command.SeasonYear,
                 command.CorrelationId,
                 Guid.NewGuid()));

--- a/src/SportsData.Producer/Controllers/OutboxTestController.cs
+++ b/src/SportsData.Producer/Controllers/OutboxTestController.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -25,15 +26,18 @@ public class OutboxTestController : ControllerBase
     private readonly FootballDataContext _footballDb;
     private readonly IEventBus _bus;
     private readonly ILogger<OutboxTestController> _logger;
+    private readonly IAppMode _appMode;
 
     public OutboxTestController(
         FootballDataContext footballDb,
         IEventBus bus,
-        ILogger<OutboxTestController> logger)
+        ILogger<OutboxTestController> logger,
+        IAppMode appMode)
     {
         _footballDb = footballDb;
         _bus = bus;
         _logger = logger;
+        _appMode = appMode;
     }
 
     /// <summary>
@@ -64,7 +68,7 @@ public class OutboxTestController : ControllerBase
             SourceRef: new Uri("http://test.com/outbox-test"),
             DocumentJson: "{}",
             SourceUrlHash: "test-hash",
-            Sport: Sport.FootballNcaa,
+            Sport: _appMode.CurrentSport,
             SeasonYear: 2024,
             DocumentType: DocumentType.OutboxTest,
             SourceDataProvider: SourceDataProvider.Espn,


### PR DESCRIPTION
## Summary

- Replace 5 hardcoded `Sport.FootballNcaa` values in Producer with `IAppMode.CurrentSport`
- Affected: ContestController.UpdateContest, ContestUpdateJob, FootballCompetitionStreamScheduler, EnrichFranchiseSeasonHandler, OutboxTestController
- Each now injects `IAppMode` and derives sport from the pod's configured mode
- API project has ~20 similar hardcoded values but those are tied to the CanonicalDataProvider elimination (separate effort)

## Test plan

- [x] Producer builds with zero errors
- [x] 320 unit tests pass, 14 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Restructured the application to dynamically determine sport configuration at runtime based on the current application mode setting, replacing previously hardcoded default values. This improves flexibility and consistency across competition scheduling, contest management, franchise enrichment, background job processing, and system testing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->