### PR TITLE
fix: add AsSplitQuery to franchise season logo queries

### DIFF
--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
@@ -150,6 +150,7 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
             .ThenInclude(f => f.Logos)
             .Include(fs => fs.Logos)
             .Include(fs => fs.GroupSeason)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(fs => fs.Id == contest.HomeTeamFranchiseSeasonId, cancellationToken);
 
         var awayTeamSeason = await _dbContext.FranchiseSeasons
@@ -158,6 +159,7 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
             .ThenInclude(f => f.Logos)
             .Include(fs => fs.Logos)
             .Include(fs => fs.GroupSeason)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(fs => fs.Id == contest.AwayTeamFranchiseSeasonId, cancellationToken);
 
         var competitionIdForHeader = comp?.Id ?? Guid.Empty;


### PR DESCRIPTION
@coderabbitai ignore

Hotfix for prod error from #261. Adding `ThenInclude(f => f.Logos)` created multiple collection includes without `AsSplitQuery()`, causing `MultipleCollectionIncludeWarning` to throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)