### PR TITLE
fix: theme refinements and Leaders layout rework

### DIFF
--- a/src/UI/sd-ui/src/components/contests/ContestOverview.css
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.css
@@ -163,64 +163,48 @@
   margin-bottom: 0.5rem;
 }
 
-
-.contest-leaders-row {
-  display: grid;
-  grid-template-columns: 1fr 160px 1fr;
-  gap: 0.5rem;
-  align-items: center;
-  max-width: 100%;
-  min-width: 0;
+.contest-leader-category-header {
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-align: center;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
 }
 
-.contest-leaders-team {
-  min-width: 0;
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  box-sizing: border-box;
+.contest-leaders-stacked {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 0 8px;
+  gap: 6px;
 }
+
 .contest-leader-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   min-width: 0;
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
+  padding: 4px 0;
 }
+
 .contest-leader-player {
-  display: inline-block;
-  max-width: 120px;
+  font-weight: 600;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-  vertical-align: bottom;
-}
-
-.contest-leaders-team-name {
-  font-weight: 700;
-  margin-bottom: 4px;
-}
-
-.contest-leader-item {
-  margin-bottom: 6px;
-}
-
-.contest-leader-category {
-  font-weight: 500;
-  text-align: center;
-  width: 100%;
-  min-width: 120px;
   max-width: 160px;
-  margin: 0 auto;
 }
 
 .contest-leader-statline {
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: var(--text-secondary);
+}
+
+.contest-leader-team-logo {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+  flex-shrink: 0;
 }
 
 .contest-scoring-summary-section {

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewInfo.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewInfo.jsx
@@ -59,18 +59,18 @@ export default function ContestOverviewInfo({ info }) {
               onClick={handleOpenLightbox}
             />
             <Dialog open={lightboxOpen} onClose={handleCloseLightbox} maxWidth="md" fullWidth>
-              <div style={{ position: 'relative', background: '#23272f', padding: 0 }}>
+              <div style={{ position: 'relative', background: 'var(--bg-input)', padding: 0 }}>
                 <button
                   aria-label="close"
                   onClick={handleCloseLightbox}
-                  style={{ position: 'absolute', top: 8, right: 8, color: '#fff', zIndex: 2, background: 'none', border: 'none', cursor: 'pointer', fontSize: 28 }}
+                  style={{ position: 'absolute', top: 8, right: 8, color: 'var(--text-primary)', zIndex: 2, background: 'none', border: 'none', cursor: 'pointer', fontSize: 28 }}
                 >
                   <FaTimes />
                 </button>
                 <img
                   src={info.venueImageUrl}
                   alt="Venue Large"
-                  style={{ width: '100%', height: 'auto', borderRadius: 6, objectFit: 'contain', maxHeight: '80vh', display: 'block', margin: '0 auto', background: '#23272f' }}
+                  style={{ width: '100%', height: 'auto', borderRadius: 6, objectFit: 'contain', maxHeight: '80vh', display: 'block', margin: '0 auto', background: 'var(--bg-input)' }}
                 />
               </div>
             </Dialog>

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewLeaders.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewLeaders.jsx
@@ -4,15 +4,34 @@ import "./ContestOverview.css";
 
 export default function ContestOverviewLeaders({ homeTeam, awayTeam, leaders }) {
   const categories = leaders?.categories || [];
-  // Helper to decide if statLine is 'simple' (inline) or 'complex' (break line)
-  const isSimpleStat = (statLine) => {
-    if (!statLine) return true;
-    // Consider simple if it's a number or short string without comma/space
-    if (typeof statLine === 'number') return true;
-    if (statLine.length <= 5 && !statLine.match(/[ ,]/)) return true;
-    // If statLine contains comma, multiple stats, or is long, treat as complex
-    if (statLine.length > 12 || statLine.includes(',') || statLine.match(/\d+\s+\w+/)) return false;
-    return true;
+
+  const renderPlayer = (l, team) => {
+    if (!l) return <div className="contest-leader-item">-</div>;
+    const logoUrl = team?.logoUrl;
+    return (
+      <div className="contest-leader-item" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        {logoUrl && (
+          <img
+            src={logoUrl}
+            alt={team?.displayName || ''}
+            className="contest-leader-team-logo"
+          />
+        )}
+        {l.playerHeadshotUrl && (
+          <img
+            src={l.playerHeadshotUrl}
+            alt={l.playerName}
+            style={{ width: '36px', height: '36px', borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
+          />
+        )}
+        <div style={{ minWidth: 0 }}>
+          <span className="contest-leader-player">{l.playerName}</span>
+          {l.statLine && (
+            <span className="contest-leader-statline"> - {l.statLine}</span>
+          )}
+        </div>
+      </div>
+    );
   };
 
   return (
@@ -27,83 +46,22 @@ export default function ContestOverviewLeaders({ homeTeam, awayTeam, leaders }) 
               key={cat.categoryId || idx}
               className="contest-leaders-panel"
               style={{
-                background: "#23272f",
-                border: "1px solid #343a40",
+                background: "var(--bg-input)",
+                border: "1px solid var(--border-primary)",
                 borderRadius: 10,
                 boxShadow: "0 1px 6px rgba(33,150,243,0.07)",
-                marginBottom: 16,
-                padding: "14px 18px"
+                marginBottom: 12,
+                padding: "10px 14px"
               }}
             >
-              <div className="contest-leaders-row">
-                {/* Away leaders */}
-                <div className="contest-leaders-team contest-leaders-away">
-                  {cat.away?.leaders && cat.away.leaders.length > 0 ? (
-                    cat.away.leaders.map((l, i) => (
-                      <div key={i} className="contest-leader-item" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        {l.playerHeadshotUrl && (
-                          <img 
-                            src={l.playerHeadshotUrl} 
-                            alt={l.playerName}
-                            style={{ width: '40px', height: '40px', borderRadius: '50%', objectFit: 'cover' }}
-                          />
-                        )}
-                        <div>
-                          {isSimpleStat(l.statLine) ? (
-                            <span>
-                              <span className="contest-leader-player">{l.playerName}</span>
-                              {" - "}
-                              <span className="contest-leader-statline">{l.statLine}</span>
-                            </span>
-                          ) : (
-                            <>
-                              <span className="contest-leader-player">{l.playerName}</span>
-                              <div className="contest-leader-statline">{l.statLine}</div>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="contest-leader-item">-</div>
-                  )}
-                </div>
-                {/* Category name center */}
-                <div className="contest-leader-category" style={{ minWidth: 120, textAlign: 'center', fontWeight: 600, color: '#b0b3b8' }}>
-                  {cat.categoryName}
-                </div>
-                {/* Home leaders */}
-                <div className="contest-leaders-team contest-leaders-home">
-                  {cat.home?.leaders && cat.home.leaders.length > 0 ? (
-                    cat.home.leaders.map((l, i) => (
-                      <div key={i} className="contest-leader-item" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        {l.playerHeadshotUrl && (
-                          <img 
-                            src={l.playerHeadshotUrl} 
-                            alt={l.playerName}
-                            style={{ width: '40px', height: '40px', borderRadius: '50%', objectFit: 'cover' }}
-                          />
-                        )}
-                        <div>
-                          {isSimpleStat(l.statLine) ? (
-                            <span>
-                              <span className="contest-leader-player">{l.playerName}</span>
-                              {" - "}
-                              <span className="contest-leader-statline">{l.statLine}</span>
-                            </span>
-                          ) : (
-                            <>
-                              <span className="contest-leader-player">{l.playerName}</span>
-                              <div className="contest-leader-statline">{l.statLine}</div>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="contest-leader-item">-</div>
-                  )}
-                </div>
+              <div className="contest-leader-category-header">
+                {cat.categoryName}
+              </div>
+              <div className="contest-leaders-stacked">
+                {cat.away?.leaders?.length > 0 &&
+                  cat.away.leaders.map((l, i) => <React.Fragment key={`a${i}`}>{renderPlayer(l, awayTeam)}</React.Fragment>)}
+                {cat.home?.leaders?.length > 0 &&
+                  cat.home.leaders.map((l, i) => <React.Fragment key={`h${i}`}>{renderPlayer(l, homeTeam)}</React.Fragment>)}
               </div>
             </div>
           ))

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewMetrics.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewMetrics.jsx
@@ -53,7 +53,7 @@ export default function ContestOverviewMetrics({ homeMetrics = {}, awayMetrics =
           <tbody>
             {sortedKeys.map((k) => (
               <tr key={k}>
-                <td style={{ padding: '8px 12px', color: '#b0b3b8' }}>{formatLabel(k)}</td>
+                <td style={{ padding: '8px 12px', color: 'var(--text-secondary)' }}>{formatLabel(k)}</td>
                 <td style={{ padding: '8px 12px', textAlign: 'right' }}>{formatValue(k, awayMetrics?.[k])}</td>
                 <td style={{ padding: '8px 12px', textAlign: 'right' }}>{formatValue(k, homeMetrics?.[k])}</td>
               </tr>

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
@@ -48,15 +48,15 @@ export default function ContestOverviewPlaylog({ playLog, sport }) {
               key={quarter}
               className="contest-playlog-panel"
               style={{
-                background: "#23272f",
-                border: "1px solid #343a40",
+                background: "var(--bg-input)",
+                border: "1px solid var(--border-primary)",
                 borderRadius: 10,
                 boxShadow: "0 1px 6px rgba(33,150,243,0.07)",
                 marginBottom: 16,
                 padding: "14px 18px"
               }}
             >
-              <div style={{ fontWeight: 700, color: '#ffc107', marginBottom: 8 }}>{periodPrefix}{quarter}</div>
+              <div style={{ fontWeight: 700, color: 'var(--warning)', marginBottom: 8 }}>{periodPrefix}{quarter}</div>
               <div className="contest-scoring-summary-list">
                 {playsByQuarter[quarter].map((play, idx) => {
                   const logoUrl = getLogoUrl(play.team);

--- a/src/UI/sd-ui/src/components/teams/TeamCard.css
+++ b/src/UI/sd-ui/src/components/teams/TeamCard.css
@@ -1,6 +1,6 @@
-/* Link to contest overview uses same color as team-name */
+/* Link to contest overview inherits win/loss color from parent td */
 .result-link {
-  color: var(--accent);
+  color: inherit;
   text-decoration: underline;
   font-weight: 600;
   transition: color 0.2s;


### PR DESCRIPTION
@coderabbitai ignore

## Summary

- Replace inline hardcoded colors in ContestOverview JSX components (Leaders, PlayLog, Info, Metrics) with CSS variables for light mode support
- Fix result-link in TeamCard to inherit win/loss color from parent instead of overriding with accent
- Rework Leaders component from cramped 3-column grid to single-column stacked layout with category header, small team logos, and skip empty entries

## Test plan

- [x] Dark mode unchanged
- [x] Light mode: ContestOverview Leaders, PlayLog, Info, Metrics all render correctly
- [x] Win/loss colors show in TeamCard schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)