### PR TITLE
feat: logo admin tab, centralized LogoSelectionService, consistent logos

### DIFF
--- a/src/SportsData.Api/Application/UI/TeamCard/TeamCardController.cs
+++ b/src/SportsData.Api/Application/UI/TeamCard/TeamCardController.cs
@@ -7,6 +7,7 @@ using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Mapping;
 using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Franchise;
 
 using SportsData.Api.Application.Common.Enums;
 
@@ -87,4 +88,36 @@ public class TeamCardController : ApiControllerBase
 
         return result.ToActionResult();
     }
+
+    [HttpGet("logos")]
+    public async Task<ActionResult<FranchiseLogosDto>> GetFranchiseLogos(
+        string sport,
+        string league,
+        string slug,
+        [FromServices] IFranchiseClientFactory franchiseClientFactory,
+        CancellationToken cancellationToken)
+    {
+        var mode = ModeMapper.ResolveMode(sport, league);
+        var client = franchiseClientFactory.Resolve(mode);
+        var result = await client.GetFranchiseLogos(slug, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpPatch("logos/{logoId}/dark-bg")]
+    public async Task<ActionResult<bool>> UpdateLogoDarkBg(
+        string sport,
+        string league,
+        string slug,
+        [FromRoute] Guid logoId,
+        [FromBody] UpdateLogoDarkBgRequest request,
+        [FromServices] IFranchiseClientFactory franchiseClientFactory,
+        CancellationToken cancellationToken)
+    {
+        var mode = ModeMapper.ResolveMode(sport, league);
+        var client = franchiseClientFactory.Resolve(mode);
+        var result = await client.UpdateLogoDarkBg(logoId, request.IsForDarkBg, request.LogoType, cancellationToken);
+        return result.ToActionResult();
+    }
 }
+
+public record UpdateLogoDarkBgRequest(bool IsForDarkBg, string LogoType);

--- a/src/SportsData.Core/Dtos/Canonical/FranchiseLogosDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/FranchiseLogosDto.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Core.Dtos.Canonical;
+
+public record FranchiseLogosDto
+{
+    public Guid FranchiseId { get; init; }
+    public string FranchiseName { get; init; } = string.Empty;
+    public List<LogoItemDto> FranchiseLogos { get; init; } = [];
+    public List<SeasonLogosDto> SeasonLogos { get; init; } = [];
+}
+
+public record SeasonLogosDto
+{
+    public Guid FranchiseSeasonId { get; init; }
+    public int SeasonYear { get; init; }
+    public List<LogoItemDto> Logos { get; init; } = [];
+}
+
+public record LogoItemDto
+{
+    public Guid Id { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public long? Width { get; init; }
+    public long? Height { get; init; }
+    public List<string>? Rel { get; init; }
+    public bool? IsForDarkBg { get; init; }
+}

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -332,6 +332,61 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
         }
     }
 
+    protected async Task<Result<bool>> PatchWithResultAsync<TRequest>(
+        string url,
+        TRequest request,
+        string operationName,
+        CancellationToken cancellationToken = default)
+    {
+        if (request == null)
+        {
+            return new Failure<bool>(
+                false,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(operationName, "Request cannot be null")]);
+        }
+
+        try
+        {
+            var content = new StringContent(request.ToJson(), Encoding.UTF8, "application/json");
+            using var response = await HttpClient.PatchAsync(url, content, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return new Success<bool>(true, ResultStatus.Accepted);
+            }
+
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            Failure<bool>? failure = null;
+            try
+            {
+                failure = responseContent.FromJson<Failure<bool>>();
+            }
+            catch (System.Text.Json.JsonException)
+            {
+            }
+
+            var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, ResultStatus.Error);
+            var errors = failure?.Errors ?? [new ValidationFailure(operationName, $"{operationName} failed with status {response.StatusCode}")];
+
+            return new Failure<bool>(false, status, errors);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new Failure<bool>(
+                false,
+                ResultStatus.Error,
+                [new ValidationFailure(operationName, $"{operationName} failed: {ex.Message}")]);
+        }
+        catch (TaskCanceledException ex)
+        {
+            return new Failure<bool>(
+                false,
+                ResultStatus.Error,
+                [new ValidationFailure(operationName, $"{operationName} timed out: {ex.Message}")]);
+        }
+    }
+
     public string GetProviderName() =>
         HttpClient?.BaseAddress?.Host ?? "Unknown";
 

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -33,6 +33,8 @@ public interface IProvideFranchises : IProvideHealthChecks
     Task<Dictionary<Guid, string>> GetConferenceIdsBySlugs(int seasonYear, List<string> slugs, CancellationToken cancellationToken = default);
     Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, CancellationToken cancellationToken = default);
     Task<Result<TeamRosterDto>> GetTeamRoster(string slug, int seasonYear, CancellationToken cancellationToken = default);
+    Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default);
+    Task<Result<bool>> UpdateLogoDarkBg(Guid logoId, bool isForDarkBg, string logoType, CancellationToken cancellationToken = default);
 }
 
 public class FranchiseClient : ClientBase, IProvideFranchises
@@ -209,6 +211,26 @@ public class FranchiseClient : ClientBase, IProvideFranchises
             new TeamRosterDto(),
             cancellationToken);
         return new Success<TeamRosterDto>(result);
+    }
+
+    public async Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(
+            $"franchises/{slug}/logos",
+            new FranchiseLogosDto(),
+            "FranchiseLogos",
+            ResultStatus.NotFound,
+            cancellationToken);
+    }
+
+    public async Task<Result<bool>> UpdateLogoDarkBg(Guid logoId, bool isForDarkBg, string logoType, CancellationToken cancellationToken = default)
+    {
+        var payload = new { IsForDarkBg = isForDarkBg, LogoType = logoType };
+        return await PatchWithResultAsync(
+            $"franchises/logos/{logoId}/dark-bg",
+            payload,
+            "UpdateLogoDarkBg",
+            cancellationToken);
     }
 }
 

--- a/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetCurrentPolls/GetCurrentPollsQueryHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetCurrentPolls/GetCurrentPollsQueryHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Application.Services;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 
@@ -20,13 +21,16 @@ public class GetCurrentPollsQueryHandler : IGetCurrentPollsQueryHandler
 {
     private readonly TeamSportDataContext _dataContext;
     private readonly ILogger<GetCurrentPollsQueryHandler> _logger;
+    private readonly ILogoSelectionService _logoSelectionService;
 
     public GetCurrentPollsQueryHandler(
         TeamSportDataContext dataContext,
-        ILogger<GetCurrentPollsQueryHandler> logger)
+        ILogger<GetCurrentPollsQueryHandler> logger,
+        ILogoSelectionService logoSelectionService)
     {
         _dataContext = dataContext;
         _logger = logger;
+        _logoSelectionService = logoSelectionService;
     }
 
     public async Task<Result<List<FranchiseSeasonPollDto>>> ExecuteAsync(
@@ -152,14 +156,26 @@ public class GetCurrentPollsQueryHandler : IGetCurrentPollsQueryHandler
                 pollId, 
                 seasonYear);
 
-            var pollEntries = await _dataContext.FranchiseSeasonRankings
+            var rankings = await _dataContext.FranchiseSeasonRankings
+                .AsNoTracking()
                 .Where(x => x.SeasonWeekId == mostRecentPoll.SeasonWeekId && x.Type == pollId)
                 .OrderBy(x => x.Rank.Current)
-                .Select(x => new FranchiseSeasonPollDto.FranchiseSeasonPollEntryDto()
+                .Include(x => x.Franchise)
+                    .ThenInclude(f => f.Logos)
+                .Include(x => x.FranchiseSeason)
+                    .ThenInclude(fs => fs.Logos)
+                .Include(x => x.Rank)
+                .AsSplitQuery()
+                .ToListAsync(cancellationToken);
+
+            var pollEntries = rankings.Select(x =>
+            {
+                var logoUri = _logoSelectionService.SelectWithFallback(
+                    x.FranchiseSeason?.Logos, x.Franchise.Logos);
+
+                return new FranchiseSeasonPollDto.FranchiseSeasonPollEntryDto()
                 {
-                    FranchiseLogoUrl = x.FranchiseSeason.Logos.FirstOrDefault() != null 
-                        ? x.FranchiseSeason.Logos.FirstOrDefault()!.Uri.OriginalString 
-                        : string.Empty,
+                    FranchiseLogoUrl = logoUri?.OriginalString ?? string.Empty,
                     FranchiseName = x.Franchise.DisplayNameShort,
                     FranchiseSlug = x.Franchise.Slug,
                     Rank = x.Rank.Current,
@@ -167,11 +183,11 @@ public class GetCurrentPollsQueryHandler : IGetCurrentPollsQueryHandler
                     FranchiseSeasonId = x.FranchiseSeasonId,
                     Points = (int)x.Rank.Points,
                     Trend = x.Rank.Trend,
-                    Losses = x.FranchiseSeason.Losses,
+                    Losses = x.FranchiseSeason?.Losses ?? 0,
                     PreviousRank = x.Rank.Previous,
-                    Wins = x.FranchiseSeason.Wins
-                })
-                .ToListAsync(cancellationToken);
+                    Wins = x.FranchiseSeason?.Wins ?? 0
+                };
+            }).ToList();
 
             if (pollEntries.Count == 0)
             {

--- a/src/SportsData.Producer/Application/Franchises/Commands/UpdateLogoDarkBg/UpdateLogoDarkBgCommand.cs
+++ b/src/SportsData.Producer/Application/Franchises/Commands/UpdateLogoDarkBg/UpdateLogoDarkBgCommand.cs
@@ -1,0 +1,3 @@
+namespace SportsData.Producer.Application.Franchises.Commands.UpdateLogoDarkBg;
+
+public record UpdateLogoDarkBgCommand(Guid LogoId, bool IsForDarkBg, string LogoType);

--- a/src/SportsData.Producer/Application/Franchises/Commands/UpdateLogoDarkBg/UpdateLogoDarkBgCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Franchises/Commands/UpdateLogoDarkBg/UpdateLogoDarkBgCommandHandler.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Franchises.Commands.UpdateLogoDarkBg;
+
+public interface IUpdateLogoDarkBgCommandHandler
+{
+    Task<Result<bool>> ExecuteAsync(UpdateLogoDarkBgCommand command, CancellationToken cancellationToken = default);
+}
+
+public class UpdateLogoDarkBgCommandHandler : IUpdateLogoDarkBgCommandHandler
+{
+    private readonly TeamSportDataContext _dbContext;
+
+    public UpdateLogoDarkBgCommandHandler(TeamSportDataContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Result<bool>> ExecuteAsync(UpdateLogoDarkBgCommand command, CancellationToken cancellationToken = default)
+    {
+        if (command.LogoType == "franchise")
+        {
+            var logo = await _dbContext.FranchiseLogos
+                .FirstOrDefaultAsync(l => l.Id == command.LogoId, cancellationToken);
+
+            if (logo is null)
+            {
+                return new Failure<bool>(
+                    false,
+                    ResultStatus.NotFound,
+                    [new FluentValidation.Results.ValidationFailure("LogoId", $"FranchiseLogo {command.LogoId} not found")]);
+            }
+
+            logo.IsForDarkBg = command.IsForDarkBg;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new Success<bool>(true);
+        }
+
+        if (command.LogoType == "franchiseSeason")
+        {
+            var logo = await _dbContext.FranchiseSeasonLogos
+                .FirstOrDefaultAsync(l => l.Id == command.LogoId, cancellationToken);
+
+            if (logo is null)
+            {
+                return new Failure<bool>(
+                    false,
+                    ResultStatus.NotFound,
+                    [new FluentValidation.Results.ValidationFailure("LogoId", $"FranchiseSeasonLogo {command.LogoId} not found")]);
+            }
+
+            logo.IsForDarkBg = command.IsForDarkBg;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return new Success<bool>(true);
+        }
+
+        return new Failure<bool>(
+            false,
+            ResultStatus.BadRequest,
+            [new FluentValidation.Results.ValidationFailure("LogoType", $"Invalid LogoType: {command.LogoType}. Must be 'franchise' or 'franchiseSeason'")]);
+    }
+}

--- a/src/SportsData.Producer/Application/Franchises/FranchisesController.cs
+++ b/src/SportsData.Producer/Application/Franchises/FranchisesController.cs
@@ -2,8 +2,10 @@
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.Clients.Contest.Queries;
+using SportsData.Producer.Application.Franchises.Commands.UpdateLogoDarkBg;
 using SportsData.Producer.Application.Franchises.Queries.GetAllFranchises;
 using SportsData.Producer.Application.Franchises.Queries.GetFranchiseById;
+using SportsData.Producer.Application.Franchises.Queries.GetFranchiseLogos;
 using SportsData.Producer.Application.Franchises.Queries.GetFranchiseSeasons;
 using SportsData.Producer.Application.Franchises.Queries.GetSeasonContests;
 using SportsData.Producer.Application.Franchises.Queries.GetTeamCard;
@@ -110,4 +112,31 @@ public class FranchisesController : ControllerBase
 
         return result.ToActionResult();
     }
+
+    [HttpGet("{slug}/logos")]
+    public async Task<ActionResult<FranchiseLogosDto>> GetFranchiseLogos(
+        [FromServices] IGetFranchiseLogosQueryHandler handler,
+        [FromRoute] string slug,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetFranchiseLogosQuery(slug);
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+
+        return result.ToActionResult();
+    }
+
+    [HttpPatch("logos/{logoId}/dark-bg")]
+    public async Task<ActionResult<bool>> UpdateLogoDarkBg(
+        [FromServices] IUpdateLogoDarkBgCommandHandler handler,
+        [FromRoute] Guid logoId,
+        [FromBody] UpdateLogoDarkBgRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new UpdateLogoDarkBgCommand(logoId, request.IsForDarkBg, request.LogoType);
+        var result = await handler.ExecuteAsync(command, cancellationToken);
+
+        return result.ToActionResult();
+    }
 }
+
+public record UpdateLogoDarkBgRequest(bool IsForDarkBg, string LogoType);

--- a/src/SportsData.Producer/Application/Franchises/Queries/GetFranchiseLogos/GetFranchiseLogosQuery.cs
+++ b/src/SportsData.Producer/Application/Franchises/Queries/GetFranchiseLogos/GetFranchiseLogosQuery.cs
@@ -1,0 +1,3 @@
+namespace SportsData.Producer.Application.Franchises.Queries.GetFranchiseLogos;
+
+public record GetFranchiseLogosQuery(string Slug);

--- a/src/SportsData.Producer/Application/Franchises/Queries/GetFranchiseLogos/GetFranchiseLogosQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Franchises/Queries/GetFranchiseLogos/GetFranchiseLogosQueryHandler.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Franchises.Queries.GetFranchiseLogos;
+
+public interface IGetFranchiseLogosQueryHandler
+{
+    Task<Result<FranchiseLogosDto>> ExecuteAsync(GetFranchiseLogosQuery query, CancellationToken cancellationToken = default);
+}
+
+public class GetFranchiseLogosQueryHandler : IGetFranchiseLogosQueryHandler
+{
+    private readonly TeamSportDataContext _dbContext;
+
+    public GetFranchiseLogosQueryHandler(TeamSportDataContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Result<FranchiseLogosDto>> ExecuteAsync(GetFranchiseLogosQuery query, CancellationToken cancellationToken = default)
+    {
+        var franchise = await _dbContext.Franchises
+            .AsNoTracking()
+            .Include(f => f.Logos)
+            .FirstOrDefaultAsync(f => f.Slug == query.Slug, cancellationToken);
+
+        if (franchise is null)
+        {
+            return new Failure<FranchiseLogosDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new FluentValidation.Results.ValidationFailure("Slug", $"Franchise '{query.Slug}' not found")]);
+        }
+
+        var seasonLogos = await _dbContext.FranchiseSeasons
+            .AsNoTracking()
+            .Where(fs => fs.FranchiseId == franchise.Id)
+            .Include(fs => fs.Logos)
+            .OrderByDescending(fs => fs.SeasonYear)
+            .Select(fs => new SeasonLogosDto
+            {
+                FranchiseSeasonId = fs.Id,
+                SeasonYear = fs.SeasonYear,
+                Logos = fs.Logos.Select(l => new LogoItemDto
+                {
+                    Id = l.Id,
+                    Url = l.Uri.OriginalString,
+                    Width = l.Width,
+                    Height = l.Height,
+                    Rel = l.Rel,
+                    IsForDarkBg = l.IsForDarkBg
+                }).ToList()
+            })
+            .ToListAsync(cancellationToken);
+
+        var dto = new FranchiseLogosDto
+        {
+            FranchiseId = franchise.Id,
+            FranchiseName = franchise.Name,
+            FranchiseLogos = franchise.Logos.Select(l => new LogoItemDto
+            {
+                Id = l.Id,
+                Url = l.Uri.OriginalString,
+                Width = l.Width,
+                Height = l.Height,
+                Rel = l.Rel,
+                IsForDarkBg = l.IsForDarkBg
+            }).ToList(),
+            SeasonLogos = seasonLogos
+        };
+
+        return new Success<FranchiseLogosDto>(dto);
+    }
+}

--- a/src/SportsData.Producer/Application/Franchises/Queries/GetTeamCard/GetTeamCardQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Franchises/Queries/GetTeamCard/GetTeamCardQueryHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Application.Services;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Sql;
@@ -27,34 +28,107 @@ public class GetTeamCardQueryHandler : IGetTeamCardQueryHandler
     private readonly TeamSportDataContext _dbContext;
     private readonly ProducerSqlQueryProvider _sqlProvider;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogoSelectionService _logoSelectionService;
 
     public GetTeamCardQueryHandler(
         TeamSportDataContext dbContext,
         ProducerSqlQueryProvider sqlProvider,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        ILogoSelectionService logoSelectionService)
     {
         _dbContext = dbContext;
         _sqlProvider = sqlProvider;
         _dateTimeProvider = dateTimeProvider;
+        _logoSelectionService = logoSelectionService;
     }
 
     public async Task<Result<TeamCardDto>> ExecuteAsync(
         GetTeamCardQuery query,
         CancellationToken cancellationToken = default)
     {
-        var connection = _dbContext.Database.GetDbConnection();
-        var parameters = new { query.Slug, query.SeasonYear, NowUtc = _dateTimeProvider.UtcNow() };
+        var nowUtc = _dateTimeProvider.UtcNow();
 
-        var teamCard = await connection.QueryFirstOrDefaultAsync<TeamCardDto>(
-            new CommandDefinition(_sqlProvider.GetTeamCard(), parameters, cancellationToken: cancellationToken));
+        // Load franchise season with navigations needed for the team card
+        var franchiseSeason = await _dbContext.FranchiseSeasons
+            .AsNoTracking()
+            .Include(fs => fs.Franchise)
+                .ThenInclude(f => f.Logos)
+            .Include(fs => fs.Logos)
+            .Include(fs => fs.GroupSeason)
+            .AsSplitQuery()
+            .FirstOrDefaultAsync(fs =>
+                fs.Franchise.Slug == query.Slug && fs.SeasonYear == query.SeasonYear,
+                cancellationToken);
 
-        if (teamCard is null)
+        if (franchiseSeason is null)
         {
             return new Failure<TeamCardDto>(
                 default!,
                 ResultStatus.NotFound,
                 [new ValidationFailure("TeamCard", $"Team card not found for slug '{query.Slug}' season {query.SeasonYear}")]);
         }
+
+        var franchise = franchiseSeason.Franchise;
+
+        // Get current ranking: latest week before now, default ranking, ap or cfp
+        var latestWeekId = await _dbContext.SeasonWeeks
+            .AsNoTracking()
+            .Include(sw => sw.Season)
+            .Where(sw => sw.Season!.Year == query.SeasonYear && sw.EndDate <= nowUtc)
+            .OrderByDescending(sw => sw.EndDate)
+            .Select(sw => sw.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        int? ranking = null;
+        if (latestWeekId != Guid.Empty)
+        {
+            ranking = await _dbContext.FranchiseSeasonRankings
+                .AsNoTracking()
+                .Include(r => r.Rank)
+                .Where(r =>
+                    r.FranchiseSeasonId == franchiseSeason.Id &&
+                    r.DefaultRanking &&
+                    (r.Type == "ap" || r.Type == "cfp") &&
+                    r.SeasonWeekId == latestWeekId)
+                .Select(r => (int?)r.Rank.Current)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        // Select logo through the service with franchise fallback
+        var logoUri = _logoSelectionService.SelectWithFallback(
+            franchiseSeason.Logos, franchise.Logos);
+
+        // Get venue
+        var venue = franchise.VenueId != Guid.Empty
+            ? await _dbContext.Venues
+                .AsNoTracking()
+                .FirstOrDefaultAsync(v => v.Id == franchise.VenueId, cancellationToken)
+            : null;
+
+        var teamCard = new TeamCardDto
+        {
+            FranchiseSeasonId = franchiseSeason.Id,
+            Slug = franchise.Slug!,
+            Name = franchise.DisplayName ?? franchise.Name,
+            ShortName = franchise.DisplayNameShort ?? franchise.Name,
+            Ranking = ranking,
+            ConferenceName = franchiseSeason.GroupSeason?.Name,
+            ConferenceShortName = franchiseSeason.GroupSeason?.ShortName,
+            ConferenceSlug = franchiseSeason.GroupSeason?.Slug,
+            OverallRecord = $"{franchiseSeason.Wins}-{franchiseSeason.Losses}-{franchiseSeason.Ties}",
+            ConferenceRecord = $"{franchiseSeason.ConferenceWins}-{franchiseSeason.ConferenceLosses}-{franchiseSeason.ConferenceTies}",
+            ColorPrimary = franchise.ColorCodeHex ?? string.Empty,
+            ColorSecondary = franchise.ColorCodeAltHex ?? string.Empty,
+            LogoUrl = logoUri?.OriginalString ?? string.Empty,
+            HelmetUrl = string.Empty,
+            Location = franchise.Location ?? string.Empty,
+            StadiumName = venue?.Name ?? string.Empty,
+            StadiumCapacity = venue?.Capacity ?? 0
+        };
+
+        // Keep schedule and seasons as Dapper queries (complex opponent logic)
+        var connection = _dbContext.Database.GetDbConnection();
+        var parameters = new { query.Slug, query.SeasonYear, NowUtc = nowUtc };
 
         var seasons = (await connection.QueryAsync<int>(
             new CommandDefinition(_sqlProvider.GetTeamSeasons(), new { query.Slug }, cancellationToken: cancellationToken))).ToList();

--- a/src/SportsData.Producer/Application/Services/LogoSelectionService.cs
+++ b/src/SportsData.Producer/Application/Services/LogoSelectionService.cs
@@ -11,9 +11,24 @@ public interface ILogoSelectionService
     /// Selects the best logo for display on a dark background by prioritizing manually curated logos,
     /// then falling back to Rel-based heuristics and avoiding white background variants.
     /// </summary>
-    /// <param name="logos">Collection of logos to choose from</param>
-    /// <returns>The URI of the selected logo, or null if no suitable logo exists</returns>
     Uri? SelectLogoForDarkBackground(IEnumerable<ILogo>? logos);
+
+    /// <summary>
+    /// Selects the best logo for display on a light/default background by prioritizing manually curated logos,
+    /// then falling back to Rel-based heuristics and preferring white background variants.
+    /// </summary>
+    Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos);
+
+    /// <summary>
+    /// Selects the best logo with fallback from season logos to franchise logos.
+    /// Uses dark background selection by default.
+    /// </summary>
+    Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos);
+
+    /// <summary>
+    /// Selects the best logo with fallback, for the specified background type.
+    /// </summary>
+    Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground);
 }
 
 /// <summary>
@@ -32,45 +47,95 @@ public class LogoSelectionService : ILogoSelectionService
             return null;
 
         // Priority 0: Manually curated logos marked as safe for dark backgrounds
-        // If IsForDarkBg == true, this logo has been manually verified as safe
         var curatedDarkLogo = logoList.FirstOrDefault(l => l.IsForDarkBg == true);
         if (curatedDarkLogo != null)
             return curatedDarkLogo.Uri;
 
-        // For all remaining logos (IsForDarkBg == null or false), fall back to Rel-based heuristics
-        // The flag is opt-in only; false/null logos still participate in automatic selection
-
         // Priority 1: Logos explicitly designed for black backgrounds
-        var blackLogo = logoList.FirstOrDefault(l => 
+        var blackLogo = logoList.FirstOrDefault(l =>
             l.Rel != null && l.Rel.Contains("primary_logo_on_black_color"));
         if (blackLogo != null)
             return blackLogo.Uri;
 
         // Priority 2: Logos marked as "dark"
-        var darkLogo = logoList.FirstOrDefault(l => 
+        var darkLogo = logoList.FirstOrDefault(l =>
             l.Rel != null && l.Rel.Contains("dark"));
         if (darkLogo != null)
             return darkLogo.Uri;
 
-        // Priority 3: Logos on team primary/secondary colors (usually safe)
-        var teamColorLogo = logoList.FirstOrDefault(l => 
+        // Priority 3: Logos on team primary/secondary colors (usually safe on dark)
+        var teamColorLogo = logoList.FirstOrDefault(l =>
             l.Rel != null && (l.Rel.Contains("on_primary_color") || l.Rel.Contains("on_secondary_color")));
         if (teamColorLogo != null)
             return teamColorLogo.Uri;
 
         // Priority 4: Default logo
-        var defaultLogo = logoList.FirstOrDefault(l => 
+        var defaultLogo = logoList.FirstOrDefault(l =>
             l.Rel != null && l.Rel.Contains("default"));
         if (defaultLogo != null)
             return defaultLogo.Uri;
 
         // Priority 5: First logo that's NOT designed for white background
-        var anyNonWhiteLogo = logoList.FirstOrDefault(l => 
+        var anyNonWhiteLogo = logoList.FirstOrDefault(l =>
             l.Rel == null || !l.Rel.Contains("on_white_color"));
         if (anyNonWhiteLogo != null)
             return anyNonWhiteLogo.Uri;
 
         // Absolute fallback
         return logoList.FirstOrDefault()?.Uri;
+    }
+
+    public Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos)
+    {
+        if (logos == null)
+            return null;
+
+        var logoList = logos.ToList();
+        if (logoList.Count == 0)
+            return null;
+
+        // Priority 0: Manually curated — IsForDarkBg == false means curated for light
+        var curatedLightLogo = logoList.FirstOrDefault(l => l.IsForDarkBg == false);
+        if (curatedLightLogo != null)
+            return curatedLightLogo.Uri;
+
+        // Priority 1: Logos explicitly designed for white backgrounds
+        var whiteLogo = logoList.FirstOrDefault(l =>
+            l.Rel != null && l.Rel.Contains("on_white_color"));
+        if (whiteLogo != null)
+            return whiteLogo.Uri;
+
+        // Priority 2: Default logo
+        var defaultLogo = logoList.FirstOrDefault(l =>
+            l.Rel != null && l.Rel.Contains("default"));
+        if (defaultLogo != null)
+            return defaultLogo.Uri;
+
+        // Priority 3: Logos on team colors (generally safe)
+        var teamColorLogo = logoList.FirstOrDefault(l =>
+            l.Rel != null && (l.Rel.Contains("on_primary_color") || l.Rel.Contains("on_secondary_color")));
+        if (teamColorLogo != null)
+            return teamColorLogo.Uri;
+
+        // Priority 4: First logo that's NOT designed for black background
+        var anyNonDarkLogo = logoList.FirstOrDefault(l =>
+            l.Rel == null || !l.Rel.Contains("primary_logo_on_black_color"));
+        if (anyNonDarkLogo != null)
+            return anyNonDarkLogo.Uri;
+
+        // Absolute fallback
+        return logoList.FirstOrDefault()?.Uri;
+    }
+
+    public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos)
+        => SelectWithFallback(seasonLogos, franchiseLogos, darkBackground: true);
+
+    public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground)
+    {
+        var selector = darkBackground
+            ? (Func<IEnumerable<ILogo>?, Uri?>)SelectLogoForDarkBackground
+            : SelectLogoForLightBackground;
+
+        return selector(seasonLogos) ?? selector(franchiseLogos);
     }
 }

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -35,6 +35,8 @@ using SportsData.Producer.Application.Franchises.Queries.GetFranchiseSeasons;
 using SportsData.Producer.Application.Franchises.Queries.GetSeasonContests;
 using SportsData.Producer.Application.Franchises.Queries.GetTeamCard;
 using SportsData.Producer.Application.Franchises.Queries.GetTeamRoster;
+using SportsData.Producer.Application.Franchises.Queries.GetFranchiseLogos;
+using SportsData.Producer.Application.Franchises.Commands.UpdateLogoDarkBg;
 using SportsData.Producer.Application.FranchiseSeasonRankings.Queries.GetCurrentPolls;
 using SportsData.Producer.Application.FranchiseSeasonRankings.Queries.GetPollBySeasonWeekId;
 using SportsData.Producer.Application.FranchiseSeasonRankings.Queries.GetRankingsByPollByWeek;
@@ -229,6 +231,8 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IGetSeasonContestsQueryHandler, GetSeasonContestsQueryHandler>();
             services.AddScoped<IGetTeamCardQueryHandler, GetTeamCardQueryHandler>();
             services.AddScoped<IGetTeamRosterQueryHandler, GetTeamRosterQueryHandler>();
+            services.AddScoped<IGetFranchiseLogosQueryHandler, GetFranchiseLogosQueryHandler>();
+            services.AddScoped<IUpdateLogoDarkBgCommandHandler, UpdateLogoDarkBgCommandHandler>();
 
             // FranchiseSeason Queries
             services.AddScoped<IGetFranchiseSeasonByIdQueryHandler, GetFranchiseSeasonByIdQueryHandler>();

--- a/src/UI/sd-ui/src/api/apiWrapper.js
+++ b/src/UI/sd-ui/src/api/apiWrapper.js
@@ -14,6 +14,7 @@ import Analytics from "./analyticsApi";
 import Maps from "./mapsApi";
 import Articles from "./articlesApi";
 import Season from "./seasonApi";
+import LogoAdmin from "./logoAdminApi";
 
 const apiWrapper = {
   Matchups,
@@ -31,7 +32,8 @@ const apiWrapper = {
   Analytics,
   Maps,
   Articles,
-  Season
+  Season,
+  LogoAdmin
 };
 
 export default apiWrapper;

--- a/src/UI/sd-ui/src/api/logoAdminApi.js
+++ b/src/UI/sd-ui/src/api/logoAdminApi.js
@@ -1,0 +1,14 @@
+import apiClient from "./apiClient";
+
+const LogoAdminApi = {
+  getFranchiseLogos: (sport, league, slug, seasonYear) =>
+    apiClient.get(`/ui/teamcard/sport/${sport}/league/${league}/team/${slug}/${seasonYear}/logos`),
+
+  updateLogoDarkBg: (sport, league, slug, seasonYear, logoId, isForDarkBg, logoType) =>
+    apiClient.patch(`/ui/teamcard/sport/${sport}/league/${league}/team/${slug}/${seasonYear}/logos/${logoId}/dark-bg`, {
+      isForDarkBg,
+      logoType,
+    }),
+};
+
+export default LogoAdminApi;

--- a/src/UI/sd-ui/src/components/teams/TeamCard.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamCard.jsx
@@ -7,6 +7,7 @@ import TeamSchedule from "./TeamSchedule";
 import TeamNews from "./TeamNews";
 import TeamStatistics from "./TeamStatistics";
 import TeamRoster from "./TeamRoster";
+import TeamLogos from "./TeamLogos";
 
 function TeamCard() {
   const { sport = 'football', league = 'ncaa', slug, seasonYear } = useParams();
@@ -132,6 +133,12 @@ function TeamCard() {
         >
           Statistics
         </button>
+        <button
+          className={selectedTab === "logos" ? "active" : ""}
+          onClick={() => setSelectedTab("logos")}
+        >
+          Logos
+        </button>
       </div>
 
       <div className="team-card-content">
@@ -149,6 +156,9 @@ function TeamCard() {
           ) : (
             <TeamStatistics team={team} seasonYear={resolvedSeason} stats={teamStats} />
           )
+        )}
+        {selectedTab === "logos" && (
+          <TeamLogos slug={slug} seasonYear={resolvedSeason} sport={sport} league={league} />
         )}
       </div>
       {/* <TeamScheduleMUI schedule={team.schedule} seasonYear={resolvedSeason} /> */}

--- a/src/UI/sd-ui/src/components/teams/TeamLogos.css
+++ b/src/UI/sd-ui/src/components/teams/TeamLogos.css
@@ -1,0 +1,163 @@
+.logo-admin {
+  padding: 0.5rem 0;
+}
+
+.logo-admin-section {
+  margin-bottom: 1.5rem;
+}
+
+.logo-admin-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-primary);
+  padding-bottom: 0.5rem;
+}
+
+.logo-admin-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.logo-admin-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+}
+
+.logo-admin-preview {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.logo-admin-preview-dark {
+  width: 48px;
+  height: 48px;
+  background: #111;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+}
+
+.logo-admin-preview-light {
+  width: 48px;
+  height: 48px;
+  background: #fff;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+}
+
+.logo-admin-preview img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.logo-admin-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.logo-admin-dimensions {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.logo-admin-rel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.logo-admin-tag {
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  background: var(--badge-bg);
+  color: var(--text-secondary);
+  border-radius: 4px;
+}
+
+.logo-admin-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.logo-admin-toggle-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  min-width: 50px;
+}
+
+/* Toggle switch */
+.logo-admin-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+}
+
+.logo-admin-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.logo-admin-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--border-strong);
+  transition: 0.2s;
+  border-radius: 20px;
+}
+
+.logo-admin-slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: var(--text-primary);
+  transition: 0.2s;
+  border-radius: 50%;
+}
+
+.logo-admin-switch input:checked + .logo-admin-slider {
+  background-color: var(--accent);
+}
+
+.logo-admin-switch input:checked + .logo-admin-slider:before {
+  transform: translateX(16px);
+}
+
+.logo-admin-loading,
+.logo-admin-error,
+.logo-admin-empty {
+  padding: 1rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.logo-admin-error {
+  color: var(--error);
+}

--- a/src/UI/sd-ui/src/components/teams/TeamLogos.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamLogos.jsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect } from "react";
+import apiWrapper from "../../api/apiWrapper";
+import "./TeamLogos.css";
+
+export default function TeamLogos({ slug, seasonYear, sport, league }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [saving, setSaving] = useState({});
+
+  useEffect(() => {
+    if (!slug) return;
+
+    const fetchLogos = async () => {
+      try {
+        setLoading(true);
+        const response = await apiWrapper.LogoAdmin.getFranchiseLogos(sport, league, slug, seasonYear);
+        setData(response.data);
+      } catch (err) {
+        console.error("Failed to load logos:", err);
+        setError("Failed to load logos");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchLogos();
+  }, [slug, seasonYear, sport, league]);
+
+  const handleToggle = async (logoId, currentValue, logoType) => {
+    const newValue = !currentValue;
+    setSaving((prev) => ({ ...prev, [logoId]: true }));
+
+    try {
+      await apiWrapper.LogoAdmin.updateLogoDarkBg(sport, league, slug, seasonYear, logoId, newValue, logoType);
+
+      // Update local state
+      setData((prev) => {
+        const updated = { ...prev };
+
+        if (logoType === "franchise") {
+          updated.franchiseLogos = updated.franchiseLogos.map((l) =>
+            l.id === logoId ? { ...l, isForDarkBg: newValue } : l
+          );
+        } else {
+          updated.seasonLogos = updated.seasonLogos.map((season) => ({
+            ...season,
+            logos: season.logos.map((l) =>
+              l.id === logoId ? { ...l, isForDarkBg: newValue } : l
+            ),
+          }));
+        }
+
+        return updated;
+      });
+    } catch (err) {
+      console.error("Failed to update logo:", err);
+    } finally {
+      setSaving((prev) => ({ ...prev, [logoId]: false }));
+    }
+  };
+
+  const renderLogo = (logo, logoType) => (
+    <div key={logo.id} className="logo-admin-item">
+      <div className="logo-admin-preview">
+        <div className="logo-admin-preview-dark">
+          <img src={logo.url} alt="Logo on dark" />
+        </div>
+        <div className="logo-admin-preview-light">
+          <img src={logo.url} alt="Logo on light" />
+        </div>
+      </div>
+      <div className="logo-admin-details">
+        <div className="logo-admin-dimensions">
+          {logo.width && logo.height ? `${logo.width}x${logo.height}` : "—"}
+        </div>
+        {logo.rel && logo.rel.length > 0 && (
+          <div className="logo-admin-rel">
+            {logo.rel.map((r, i) => (
+              <span key={i} className="logo-admin-tag">{r}</span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="logo-admin-toggle">
+        <label className="logo-admin-switch">
+          <input
+            type="checkbox"
+            checked={logo.isForDarkBg === true}
+            onChange={() => handleToggle(logo.id, logo.isForDarkBg, logoType)}
+            disabled={saving[logo.id]}
+          />
+          <span className="logo-admin-slider"></span>
+        </label>
+        <span className="logo-admin-toggle-label">
+          {logo.isForDarkBg ? "Dark BG" : "Not set"}
+        </span>
+      </div>
+    </div>
+  );
+
+  if (loading) return <div className="logo-admin-loading">Loading logos...</div>;
+  if (error) return <div className="logo-admin-error">{error}</div>;
+  if (!data) return null;
+
+  return (
+    <div className="logo-admin">
+      <div className="logo-admin-section">
+        <h3 className="logo-admin-section-title">Franchise Logos</h3>
+        <div className="logo-admin-grid">
+          {data.franchiseLogos.length > 0
+            ? data.franchiseLogos.map((l) => renderLogo(l, "franchise"))
+            : <div className="logo-admin-empty">No franchise logos</div>}
+        </div>
+      </div>
+
+      {data.seasonLogos.map((season) => (
+        <div key={season.franchiseSeasonId} className="logo-admin-section">
+          <h3 className="logo-admin-section-title">{season.seasonYear} Season Logos</h3>
+          <div className="logo-admin-grid">
+            {season.logos.length > 0
+              ? season.logos.map((l) => renderLogo(l, "franchiseSeason"))
+              : <div className="logo-admin-empty">No logos for this season</div>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
@coderabbitai ignore

## Summary

**Logo admin feature:**
- New Logos tab in TeamCard showing all franchise and season logos with dark/light background previews
- Toggle switch to set IsForDarkBg per logo
- Full stack: UI -> API TeamCardController -> FranchiseClient -> Producer FranchisesController
- PatchWithResultAsync added to ClientBase for PATCH verb support

**Centralized LogoSelectionService:**
- Added `SelectLogoForLightBackground` with light-optimized priority cascade
- Added `SelectWithFallback(seasonLogos, franchiseLogos, darkBackground)` convenience method
- Both methods support manual curation via IsForDarkBg flag

**Consistent logo selection:**
- `GetTeamCardQueryHandler` converted from Dapper SQL to EF Core + LogoSelectionService
- `GetCurrentPollsQueryHandler` reworked to load entities then project with service
- Rankings widget now shows same logos as MatchupCard — eliminates SQL vs LINQ ordering divergence

## Test plan

- [x] Producer, API, Core all build with zero errors
- [x] Rankings widget logos match MatchupCard logos
- [x] Logos tab renders in TeamCard with toggle functionality
- [x] React build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)