### PR TITLE
fix: sanity-check ESPN Week $ref against event date (MLB)

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
@@ -128,6 +128,13 @@ public abstract class EventDocumentProcessorBase<TDataContext> : DocumentProcess
         ProcessDocumentCommand command,
         EspnEventDto externalDto)
     {
+        DateTime? eventDateUtc = null;
+        if (DateTime.TryParse(externalDto.Date, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedDate))
+        {
+            eventDateUtc = parsedDate;
+        }
+
         if (externalDto.Week is not null)
         {
             var seasonWeekIdentity = _externalRefIdentityGenerator.Generate(externalDto.Week.Ref);
@@ -136,26 +143,45 @@ public abstract class EventDocumentProcessorBase<TDataContext> : DocumentProcess
                 .AsNoTracking()
                 .FirstOrDefaultAsync(sw => sw.Id == seasonWeekIdentity.CanonicalId);
 
-            if (seasonWeek is not null)
+            if (seasonWeek is null)
+            {
+                await PublishDependencyRequest<string?>(
+                    command,
+                    externalDto.Week,
+                    parentId: null,
+                    DocumentType.SeasonTypeWeek);
+
+                throw new ExternalDocumentNotSourcedException(
+                    $"SeasonWeek not found for {externalDto.Week.Ref} (Id: {seasonWeekIdentity.CanonicalId})");
+            }
+
+            // ESPN's MLB event docs can reference a week URL whose resolved
+            // SeasonTypeWeek doc has StartDate/EndDate that don't contain the
+            // event's date (e.g. an April game refs .../weeks/16 which is July
+            // 8-15). When the ref and the event date disagree, trust the date
+            // and fall through to date-based inference below.
+            if (eventDateUtc.HasValue &&
+                (eventDateUtc.Value < seasonWeek.StartDate || eventDateUtc.Value > seasonWeek.EndDate))
+            {
+                _logger.LogWarning(
+                    "Week $ref resolved to SeasonWeek whose window does not contain the event date. " +
+                    "EventDate={EventDate}, ResolvedWeek={WeekNumber} [{Start}..{End}]. " +
+                    "Falling back to date-based inference. Ref={Ref}",
+                    eventDateUtc.Value, seasonWeek.Number, seasonWeek.StartDate, seasonWeek.EndDate,
+                    externalDto.Week.Ref);
+            }
+            else
+            {
                 return seasonWeek.Id;
-
-            await PublishDependencyRequest<string?>(
-                command,
-                externalDto.Week,
-                parentId: null,
-                DocumentType.SeasonTypeWeek);
-
-            throw new ExternalDocumentNotSourcedException(
-                $"SeasonWeek not found for {externalDto.Week.Ref} (Id: {seasonWeekIdentity.CanonicalId})");
+            }
         }
 
-        if (DateTime.TryParse(externalDto.Date, CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var eventDateUtc))
+        if (eventDateUtc.HasValue)
         {
             var inferredWeek = await _dataContext.SeasonWeeks
                 .AsNoTracking()
-                .Where(sw => sw.StartDate <= eventDateUtc &&
-                             sw.EndDate >= eventDateUtc)
+                .Where(sw => sw.StartDate <= eventDateUtc.Value &&
+                             sw.EndDate >= eventDateUtc.Value)
                 .OrderBy(sw => sw.Number)
                 .FirstOrDefaultAsync();
 
@@ -163,13 +189,13 @@ public abstract class EventDocumentProcessorBase<TDataContext> : DocumentProcess
             {
                 _logger.LogWarning(
                     "Inferred SeasonWeek from event date. EventDate={EventDate}, WeekNumber={WeekNumber}, SeasonWeekId={SeasonWeekId}",
-                    eventDateUtc, inferredWeek.Number, inferredWeek.Id);
+                    eventDateUtc.Value, inferredWeek.Number, inferredWeek.Id);
                 return inferredWeek.Id;
             }
 
             _logger.LogWarning(
                 "Could not infer SeasonWeek from event date. No week covers EventDate={EventDate}",
-                eventDateUtc);
+                eventDateUtc.Value);
         }
 
         if (command.Sport is Sport.FootballNcaa or Sport.FootballNfl)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
@@ -80,13 +80,26 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
         await FootballDataContext.SaveChangesAsync();
 
         var seasonWeekIdentity = generator.Generate(dto.Week.Ref);
-        
+
+        // Parse the event's date so the SeasonWeek window actually contains it.
+        // The processor now sanity-checks StartDate/EndDate against the event
+        // date and falls back to date-based inference when they disagree, so
+        // tests must set plausible dates or the ref-resolved path is skipped.
+        var eventDate = DateTime.TryParse(dto.Date,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed
+            : DateTime.UtcNow;
+
         // OPTIMIZATION: Direct instantiation
         var seasonWeek = new SeasonWeek
         {
             Id = seasonWeekIdentity.CanonicalId,
             SeasonPhaseId = seasonPhase.Id,
             Number = 1,
+            StartDate = eventDate.AddDays(-3),
+            EndDate = eventDate.AddDays(3),
             CreatedUtc = DateTime.UtcNow,
             CreatedBy = Guid.NewGuid(),
             ExternalIds = new List<SeasonWeekExternalId>
@@ -563,6 +576,158 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
         // assert
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*Cannot determine SeasonWeek*");
+    }
+
+    [Fact]
+    public async Task WhenWeekRefResolvesToOutOfRangeSeasonWeek_ShouldFallBackToDateInference()
+    {
+        // Models ESPN's MLB early-season data: Event doc's week.$ref points at a
+        // SeasonTypeWeek URL whose StartDate/EndDate don't contain the event's
+        // date. Processor must ignore the bad ref and pick the SeasonWeek whose
+        // window actually covers the event.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        Mocker.GetMock<IProvideProviders>()
+            .Setup(s => s.GetExternalDocument(It.IsAny<GetExternalDocumentQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => Fixture.Build<GetExternalDocumentResponse>()
+                .OmitAutoProperties()
+                .Create());
+
+        var bus = Mocker.GetMock<IEventBus>();
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent.json");
+        var dto = json.FromJson<EspnEventDto>();
+
+        // Venue
+        var venueUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/venues/6501";
+        var venueHash = venueUrl.UrlHash();
+        var venueId = Guid.NewGuid();
+        await FootballDataContext.Venues.AddAsync(new Venue
+        {
+            Id = venueId,
+            Name = "Tiger Stadium",
+            Slug = "tiger-stadium",
+            City = "Baton Rouge",
+            State = "LA",
+            PostalCode = "71077",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds =
+            [
+                new VenueExternalId
+                {
+                    Id = Guid.NewGuid(),
+                    VenueId = venueId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrlHash = venueHash,
+                    Value = venueHash,
+                    SourceUrl = venueUrl
+                }
+            ]
+        });
+        await FootballDataContext.SaveChangesAsync();
+
+        // Season + phase
+        var seasonId = Guid.NewGuid();
+        var seasonTypeIdentity = generator.Generate(dto!.SeasonType.Ref);
+        await FootballDataContext.Seasons.AddAsync(new Season
+        {
+            Id = seasonId,
+            Name = "2024",
+            Year = 2024,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        var seasonPhase = new SeasonPhase
+        {
+            Id = seasonTypeIdentity.CanonicalId,
+            Name = "Regular Season",
+            Abbreviation = "reg",
+            Slug = "reg-season",
+            SeasonId = seasonId,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds = new List<SeasonPhaseExternalId>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SeasonPhaseId = seasonTypeIdentity.CanonicalId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = seasonTypeIdentity.CleanUrl,
+                    SourceUrlHash = seasonTypeIdentity.UrlHash,
+                    Value = seasonTypeIdentity.UrlHash
+                }
+            }
+        };
+        await FootballDataContext.SeasonPhases.AddAsync(seasonPhase);
+        await FootballDataContext.SaveChangesAsync();
+
+        // Event is 2024-09-01.
+        // "Bad" SeasonWeek: matches the ref hash but has a December window that
+        // doesn't contain the event date — simulating ESPN's MLB inconsistency.
+        var weekRefIdentity = generator.Generate(dto.Week.Ref);
+        var badSeasonWeek = new SeasonWeek
+        {
+            Id = weekRefIdentity.CanonicalId,
+            SeasonId = seasonId,
+            SeasonPhaseId = seasonPhase.Id,
+            Number = 99,
+            StartDate = new DateTime(2024, 12, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2024, 12, 7, 23, 59, 59, DateTimeKind.Utc),
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds = new List<SeasonWeekExternalId>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SeasonWeekId = weekRefIdentity.CanonicalId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = weekRefIdentity.CleanUrl,
+                    SourceUrlHash = weekRefIdentity.UrlHash,
+                    Value = weekRefIdentity.UrlHash
+                }
+            }
+        };
+        await FootballDataContext.SeasonWeeks.AddAsync(badSeasonWeek);
+
+        // "Good" SeasonWeek: unrelated Id, window covers the event date.
+        var expectedSeasonWeekId = Guid.NewGuid();
+        await FootballDataContext.SeasonWeeks.AddAsync(new SeasonWeek
+        {
+            Id = expectedSeasonWeekId,
+            SeasonId = seasonId,
+            SeasonPhaseId = seasonPhase.Id,
+            Number = 1,
+            StartDate = new DateTime(2024, 8, 29, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2024, 9, 4, 23, 59, 59, DateTimeKind.Utc),
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+
+        await SetupFranchiseSeasonsAsync(generator, dto!);
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.Document, json)
+            .With(x => x.DocumentType, DocumentType.Event)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .OmitAutoProperties()
+            .Create();
+
+        await sut.ProcessAsync(command);
+
+        var created = await FootballDataContext.Contests.FirstOrDefaultAsync();
+        created.Should().NotBeNull();
+        created!.SeasonWeekId.Should().Be(expectedSeasonWeekId,
+            "ref-resolved SeasonWeek's window doesn't contain event date — processor should fall back to date-based inference");
+
+        bus.Verify(x => x.Publish(It.IsAny<ContestCreated>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- When ESPN's MLB Event document references a Week \$ref whose resolved SeasonTypeWeek window doesn't contain the event's own date, fall back to date-based inference instead of writing a wrong `SeasonWeekId`.
- Root cause: ESPN serves inconsistent numbering for MLB — Event docs for an April 19, 2026 game point `week.\$ref` at `.../weeks/16`, but ESPN's own `.../weeks/16` doc describes "Week 16 = July 8–15". Both endpoints are internally consistent; they just disagree with each other.
- Effect before fix: `Contest.SeasonWeekId` for early-season MLB games was FK'd to a mid-season SeasonWeek, so `GetMatchupsForSeasonWeek(year=2026, week=4)` returned 0 rows even though the April contests existed.
- NFL / NCAAFB unaffected — their refs are consistent with their SeasonTypeWeek dates, so the sanity check is a no-op.

## How to verify

1. Check out this branch and run the Producer unit tests — new test `WhenWeekRefResolvesToOutOfRangeSeasonWeek_ShouldFallBackToDateInference` covers the MLB scenario; all 6 `FootballEventDocumentProcessorTests` pass; 317/317 pass in the full Producer unit suite.
2. Full diagnostic trail (10 SQL queries against the MLB Producer DB that pinpointed the bug) is in `docs/mlb-matchup-gen-debug.md` on a follow-up branch.

## Test plan

- [x] `dotnet build` on Producer + test project — zero errors, zero warnings
- [x] `dotnet test` on `SportsData.Producer.Tests.Unit` — all 317 pass, 0 regressions
- [ ] After merge: re-source MLB 2026 contests locally, create an MLB league for the current week, verify matchups are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of season week assignment by adding fallback logic that uses event dates when reference data conflicts with actual event timing.

* **Tests**
  * Added test coverage for season week fallback inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->