### PR TITLE
feat: sport-aware picks, league window, seasonWeeks, graceful metrics + logo fallback

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -34,6 +34,14 @@ x-common-env: &common-env
   AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
   AZURE_TENANT_ID: ${AZURE_TENANT_ID}
   CommonConfig__SqlBaseConnectionString: ${PG_CONNSTR}
+  # Seq runs on the host (port 5341 ingest, 8090 UI) — override AppConfig's
+  # localhost URI so containers send via the Docker bridge. Same pattern as
+  # the Postgres connection string above. Note: the code reads this from
+  # `CommonConfig:SeqUri`, not `CommonConfig:Logging:SeqUri` — see
+  # AppConfiguration.cs line 35.
+  CommonConfig__SeqUri: http://host.docker.internal:5341/
+  # RabbitMQ is also on the host (5672). Same bridge-hop override.
+  CommonConfig__Messaging__RabbitMq__Host: host.docker.internal
 
 # Readiness probe reused by every Producer service. Uses bash's /dev/tcp to
 # verify Kestrel is accepting connections on 8080 without needing curl or

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -42,6 +42,12 @@ x-common-env: &common-env
   CommonConfig__SeqUri: http://host.docker.internal:5341/
   # RabbitMQ is also on the host (5672). Same bridge-hop override.
   CommonConfig__Messaging__RabbitMq__Host: host.docker.internal
+  # RabbitMQ Management API is on the host too (15672). The registered
+  # "RabbitMqManagement" HttpClient and ReprocessDeadLetterQueueCommandHandler
+  # read this key directly (CommonConfigKeys.RabbitMqManagementApiBaseUrl),
+  # and AppConfig's default resolves to localhost — which from inside a
+  # container points at the container itself, not the host's RabbitMQ.
+  CommonConfig__Messaging__RabbitMq__ManagementApiBaseUrl: http://host.docker.internal:15672
 
 # Readiness probe reused by every Producer service. Uses bash's /dev/tcp to
 # verify Kestrel is accepting connections on 8080 without needing curl or

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
@@ -57,9 +57,10 @@ namespace SportsData.Api.Application.PickemGroups
                 throw new Exception("Group not found");
             }
 
-            // get the current week
-            // TODO: multi-sport — resolve sport from context instead of defaulting
-            var weekResult = await _seasonClientFactory.Resolve(Sport.FootballNcaa).GetCurrentSeasonWeek();
+            // get the current week for the league's sport (NCAA, NFL, or MLB).
+            // ESPN provides native week boundaries for all three via SeasonType, so
+            // the Producer-side GetCurrentSeasonWeek endpoint works uniformly.
+            var weekResult = await _seasonClientFactory.Resolve(group.Sport).GetCurrentSeasonWeek();
             var currentWeek = weekResult.IsSuccess ? weekResult.Value : null;
 
             if (currentWeek is null)

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -85,14 +85,31 @@ namespace SportsData.Api.Application.Processors
             // 2. are there conferences to always be included?
             var conferenceSlugs = group.Conferences.Select(x => x.ConferenceSlug).ToList();
 
-            // TODO: multi-sport
-            var matchupsResult = await _contestClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa).GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek);
+            var matchupsResult = await _contestClientFactory
+                .Resolve(group.Sport)
+                .GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek);
             if (!matchupsResult.IsSuccess)
             {
                 _logger.LogWarning("Failed to retrieve matchups for season {Year} week {Week}. Skipping.", command.SeasonYear, command.SeasonWeek);
                 return;
             }
             var allMatchups = matchupsResult.Value;
+
+            // League window filter — excludes contests whose kickoff falls outside
+            // [StartsOn, EndsOn]. Null bounds mean "no constraint" (full-season league),
+            // so this is a no-op when neither is set.
+            if (group.StartsOn.HasValue || group.EndsOn.HasValue)
+            {
+                var preCount = allMatchups.Count;
+                allMatchups = allMatchups
+                    .Where(m =>
+                        (!group.StartsOn.HasValue || m.StartDateUtc >= group.StartsOn.Value) &&
+                        (!group.EndsOn.HasValue || m.StartDateUtc <= group.EndsOn.Value))
+                    .ToList();
+                _logger.LogInformation(
+                    "League window {StartsOn}..{EndsOn} filtered {Before} -> {After} matchups for group {GroupId} week {Week}",
+                    group.StartsOn, group.EndsOn, preCount, allMatchups.Count, group.Id, command.SeasonWeek);
+            }
 
             List<Matchup> groupMatchups;
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
@@ -131,15 +131,11 @@ public class CreateBaseballMlbLeagueCommandHandler : ICreateBaseballMlbLeagueCom
         }
 
         await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}",
-            SportMode,
-            group.Id,
-            group.Name,
-            currentUserId);
-
+        // Publish BEFORE the commit: with the EF outbox, Publish enqueues the
+        // message into the DbContext tracker and only SaveChangesAsync persists
+        // both the aggregate and the outbox row atomically. Publishing AFTER
+        // SaveChangesAsync silently loses the event when the DI scope disposes.
         var evt = new PickemGroupCreated(
             group.Id,
             null,
@@ -147,9 +143,16 @@ public class CreateBaseballMlbLeagueCommandHandler : ICreateBaseballMlbLeagueCom
             seasonYear,
             Guid.NewGuid(),
             Guid.NewGuid());
-
-        _logger.LogInformation("Publishing PickemGroupCreated {@Evt}", evt);
         await _eventBus.Publish(evt, cancellationToken);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; published PickemGroupCreated",
+            SportMode,
+            group.Id,
+            group.Name,
+            currentUserId);
 
         return new Success<Guid>(group.Id);
     }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
@@ -148,7 +148,7 @@ public class CreateBaseballMlbLeagueCommandHandler : ICreateBaseballMlbLeagueCom
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; published PickemGroupCreated",
+            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; PickemGroupCreated enqueued to outbox",
             SportMode,
             group.Id,
             group.Name,

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
@@ -136,15 +136,11 @@ public class CreateFootballNcaaLeagueCommandHandler : ICreateFootballNcaaLeagueC
         }
 
         await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}",
-            SportMode,
-            group.Id,
-            group.Name,
-            currentUserId);
-
+        // Publish BEFORE the commit: with the EF outbox, Publish enqueues the
+        // message into the DbContext tracker and only SaveChangesAsync persists
+        // both the aggregate and the outbox row atomically. Publishing AFTER
+        // SaveChangesAsync silently loses the event when the DI scope disposes.
         var evt = new PickemGroupCreated(
             group.Id,
             null,
@@ -152,9 +148,16 @@ public class CreateFootballNcaaLeagueCommandHandler : ICreateFootballNcaaLeagueC
             seasonYear,
             Guid.NewGuid(),
             Guid.NewGuid());
-
-        _logger.LogInformation("Publishing PickemGroupCreated {@Evt}", evt);
         await _eventBus.Publish(evt, cancellationToken);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; published PickemGroupCreated",
+            SportMode,
+            group.Id,
+            group.Name,
+            currentUserId);
 
         return new Success<Guid>(group.Id);
     }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
@@ -153,7 +153,7 @@ public class CreateFootballNcaaLeagueCommandHandler : ICreateFootballNcaaLeagueC
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; published PickemGroupCreated",
+            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; PickemGroupCreated enqueued to outbox",
             SportMode,
             group.Id,
             group.Name,

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
@@ -148,7 +148,7 @@ public class CreateFootballNflLeagueCommandHandler : ICreateFootballNflLeagueCom
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; published PickemGroupCreated",
+            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; PickemGroupCreated enqueued to outbox",
             SportMode,
             group.Id,
             group.Name,

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
@@ -131,15 +131,11 @@ public class CreateFootballNflLeagueCommandHandler : ICreateFootballNflLeagueCom
         }
 
         await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}",
-            SportMode,
-            group.Id,
-            group.Name,
-            currentUserId);
-
+        // Publish BEFORE the commit: with the EF outbox, Publish enqueues the
+        // message into the DbContext tracker and only SaveChangesAsync persists
+        // both the aggregate and the outbox row atomically. Publishing AFTER
+        // SaveChangesAsync silently loses the event when the DI scope disposes.
         var evt = new PickemGroupCreated(
             group.Id,
             null,
@@ -147,9 +143,16 @@ public class CreateFootballNflLeagueCommandHandler : ICreateFootballNflLeagueCom
             seasonYear,
             Guid.NewGuid(),
             Guid.NewGuid());
-
-        _logger.LogInformation("Publishing PickemGroupCreated {@Evt}", evt);
         await _eventBus.Publish(evt, cancellationToken);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; published PickemGroupCreated",
+            SportMode,
+            group.Id,
+            group.Name,
+            currentUserId);
 
         return new Success<Guid>(group.Id);
     }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
@@ -47,6 +47,18 @@ public class DeleteLeagueCommandHandler : IDeleteLeagueCommandHandler
                 ResultStatus.Unauthorized,
                 [new ValidationFailure(nameof(command.UserId), $"User {command.UserId} is not the commissioner of league {command.LeagueId}.")]);
 
+        // Don't let a commissioner nuke a league that members have already started picking
+        // for — too easy to destroy real scoring data during testing. Empty leagues (no
+        // picks yet) are fair game to delete.
+        var hasPicks = await _dbContext.UserPicks
+            .AnyAsync(p => p.PickemGroupId == command.LeagueId, cancellationToken);
+
+        if (hasPicks)
+            return new Failure<Guid>(
+                default,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(command.LeagueId), "Cannot delete a league that already has user picks.")]);
+
         _logger.LogInformation(
             "Deleting league {LeagueId} by commissioner {UserId}",
             command.LeagueId,

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
@@ -37,13 +37,13 @@ public class DeleteLeagueCommandHandler : IDeleteLeagueCommandHandler
 
         if (league is null)
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.NotFound,
                 [new ValidationFailure(nameof(command.LeagueId), $"League with ID {command.LeagueId} not found.")]);
 
         if (league.CommissionerUserId != command.UserId)
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.Unauthorized,
                 [new ValidationFailure(nameof(command.UserId), $"User {command.UserId} is not the commissioner of league {command.LeagueId}.")]);
 
@@ -55,7 +55,7 @@ public class DeleteLeagueCommandHandler : IDeleteLeagueCommandHandler
 
         if (hasPicks)
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.BadRequest,
                 [new ValidationFailure(nameof(command.LeagueId), "Cannot delete a league that already has user picks.")]);
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
@@ -1,3 +1,5 @@
+using System.Data;
+
 using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
@@ -50,13 +52,22 @@ public class DeleteLeagueCommandHandler : IDeleteLeagueCommandHandler
         // Don't let a commissioner nuke a league that members have already started picking
         // for — too easy to destroy real scoring data during testing. Empty leagues (no
         // picks yet) are fair game to delete.
+        //
+        // Serializable transaction: the has-picks check and the cascade delete run in one
+        // unit so a pick inserted between the two operations can't sneak through. Without
+        // this, a race (user submits a pick mid-delete) would let us delete a league that
+        // now has picks, silently destroying real scoring data — exactly the case the
+        // guard exists to prevent.
+        await using var transaction = await _dbContext.Database
+            .BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+
         var hasPicks = await _dbContext.UserPicks
             .AnyAsync(p => p.PickemGroupId == command.LeagueId, cancellationToken);
 
         if (hasPicks)
             return new Failure<Guid>(
                 default!,
-                ResultStatus.BadRequest,
+                ResultStatus.Validation,
                 [new ValidationFailure(nameof(command.LeagueId), "Cannot delete a league that already has user picks.")]);
 
         _logger.LogInformation(
@@ -79,6 +90,7 @@ public class DeleteLeagueCommandHandler : IDeleteLeagueCommandHandler
         _dbContext.PickemGroups.Remove(league);
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
 
         _logger.LogInformation("Successfully deleted league {LeagueId}", command.LeagueId);
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/DeleteLeague/DeleteLeagueCommandHandler.cs
@@ -56,44 +56,54 @@ public class DeleteLeagueCommandHandler : IDeleteLeagueCommandHandler
         // Serializable transaction: the has-picks check and the cascade delete run in one
         // unit so a pick inserted between the two operations can't sneak through. Without
         // this, a race (user submits a pick mid-delete) would let us delete a league that
-        // now has picks, silently destroying real scoring data — exactly the case the
-        // guard exists to prevent.
-        await using var transaction = await _dbContext.Database
-            .BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+        // now has picks, silently destroying real scoring data — the PickemGroupUserPick
+        // FK is OnDelete.Cascade, so FK constraints alone won't block the race.
+        //
+        // Wrap in the DbContext execution strategy: EnableRetryOnFailure is configured
+        // globally for Npgsql (see Core/DependencyInjection/ServiceRegistration.cs),
+        // and raw BeginTransactionAsync under a retry strategy throws at runtime unless
+        // the transaction body is scoped inside strategy.ExecuteAsync so the whole unit
+        // can retry atomically on serialization failures (SQLSTATE 40001).
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync<Result<Guid>>(async () =>
+        {
+            await using var transaction = await _dbContext.Database
+                .BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
 
-        var hasPicks = await _dbContext.UserPicks
-            .AnyAsync(p => p.PickemGroupId == command.LeagueId, cancellationToken);
+            var hasPicks = await _dbContext.UserPicks
+                .AnyAsync(p => p.PickemGroupId == command.LeagueId, cancellationToken);
 
-        if (hasPicks)
-            return new Failure<Guid>(
-                default!,
-                ResultStatus.Validation,
-                [new ValidationFailure(nameof(command.LeagueId), "Cannot delete a league that already has user picks.")]);
+            if (hasPicks)
+                return new Failure<Guid>(
+                    default!,
+                    ResultStatus.Validation,
+                    [new ValidationFailure(nameof(command.LeagueId), "Cannot delete a league that already has user picks.")]);
 
-        _logger.LogInformation(
-            "Deleting league {LeagueId} by commissioner {UserId}",
-            command.LeagueId,
-            command.UserId);
+            _logger.LogInformation(
+                "Deleting league {LeagueId} by commissioner {UserId}",
+                command.LeagueId,
+                command.UserId);
 
-        // Remove all members
-        _dbContext.PickemGroupMembers.RemoveRange(league.Members);
+            // Remove all members
+            _dbContext.PickemGroupMembers.RemoveRange(league.Members);
 
-        // Remove all picks
-        _dbContext.UserPicks.RemoveRange(
-            _dbContext.UserPicks.Where(p => p.PickemGroupId == command.LeagueId));
+            // Remove all picks
+            _dbContext.UserPicks.RemoveRange(
+                _dbContext.UserPicks.Where(p => p.PickemGroupId == command.LeagueId));
 
-        // Remove all matchups
-        _dbContext.PickemGroupMatchups.RemoveRange(
-            _dbContext.PickemGroupMatchups.Where(m => m.GroupId == command.LeagueId));
+            // Remove all matchups
+            _dbContext.PickemGroupMatchups.RemoveRange(
+                _dbContext.PickemGroupMatchups.Where(m => m.GroupId == command.LeagueId));
 
-        // Remove the league itself
-        _dbContext.PickemGroups.Remove(league);
+            // Remove the league itself
+            _dbContext.PickemGroups.Remove(league);
 
-        await _dbContext.SaveChangesAsync(cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
 
-        _logger.LogInformation("Successfully deleted league {LeagueId}", command.LeagueId);
+            _logger.LogInformation("Successfully deleted league {LeagueId}", command.LeagueId);
 
-        return new Success<Guid>(command.LeagueId);
+            return new Success<Guid>(command.LeagueId);
+        });
     }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueDetailDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueDetailDto.cs
@@ -24,6 +24,12 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
 
         public bool IsPublic { get; set; }
 
+        // League window — null on either side means "open-ended in that direction"
+        // (i.e. full-season or no upper bound). Both null = full season.
+        public DateTime? StartsOn { get; set; }
+
+        public DateTime? EndsOn { get; set; }
+
         public List<LeagueMemberDto> Members { get; set; } = [];
 
         public class LeagueMemberDto

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekMatchupsDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekMatchupsDto.cs
@@ -15,6 +15,10 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
 
         public bool UseConfidencePoints { get; set; }
 
+        // Sport enum name ("FootballNcaa", "FootballNfl", "BaseballMlb").
+        // UI splits this into url segments (sport/league) via resolveSportLeague().
+        public string Sport { get; set; } = default!;
+
         public List<MatchupForPickDto> Matchups { get; set; } = [];
 
         public class MatchupForPickDto

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueById/GetLeagueByIdQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueById/GetLeagueByIdQueryHandler.cs
@@ -54,6 +54,8 @@ public class GetLeagueByIdQueryHandler : IGetLeagueByIdQueryHandler
             RankingFilter = league.RankingFilter.ToString(),
             ConferenceSlugs = league.Conferences?.Select(c => c.ConferenceSlug).ToList() ?? new(),
             IsPublic = league.IsPublic,
+            StartsOn = league.StartsOn,
+            EndsOn = league.EndsOn,
             Members = league.Members.Select(m => new LeagueDetailDto.LeagueMemberDto
             {
                 UserId = m.UserId,

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -80,8 +80,20 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 query.LeagueId,
                 query.Week);
 
-            var matchups = await _dbContext.PickemGroupMatchups
+            var groupMatchups = await _dbContext.PickemGroupMatchups
                 .Where(x => x.GroupId == query.LeagueId && x.SeasonWeek == query.Week)
+                .Select(x => new
+                {
+                    x.StartDateUtc,
+                    x.ContestId,
+                    x.AwayRank,
+                    x.HomeRank,
+                    x.Headline,
+                    x.SeasonYear
+                })
+                .ToListAsync(cancellationToken);
+
+            var matchups = groupMatchups
                 .Select(x => new LeagueWeekMatchupsDto.MatchupForPickDto
                 {
                     StartDateUtc = x.StartDateUtc,
@@ -90,7 +102,12 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                     HomeRank = x.HomeRank,
                     HeadLine = x.Headline
                 })
-                .ToListAsync(cancellationToken);
+                .ToList();
+
+            // Season year is authoritative on PickemGroupMatchup (set at generation
+            // time). DateTime.UtcNow.Year was wrong for football whenever bowl games
+            // / playoffs extend into January of the following calendar year.
+            var seasonYear = groupMatchups.FirstOrDefault()?.SeasonYear ?? DateTime.UtcNow.Year;
 
             _logger.LogInformation(
                 "Retrieved {Count} matchups from database for leagueId={LeagueId}, week={Week}",
@@ -297,8 +314,9 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
             {
                 PickType = league!.PickType,
                 UseConfidencePoints = league!.UseConfidencePoints,
-                SeasonYear = DateTime.UtcNow.Year, // Assuming current year for simplicity
+                SeasonYear = seasonYear,
                 WeekNumber = query.Week,
+                Sport = league.Sport.ToString(),
                 Matchups = matchups.OrderBy(x => x.StartDateUtc).ToList()
             };
 

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -24,15 +24,18 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
     private readonly ILogger<GetLeagueWeekMatchupsQueryHandler> _logger;
     private readonly AppDataContext _dbContext;
     private readonly IContestClientFactory _contestClientFactory;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     public GetLeagueWeekMatchupsQueryHandler(
         ILogger<GetLeagueWeekMatchupsQueryHandler> logger,
         AppDataContext dbContext,
-        IContestClientFactory contestClientFactory)
+        IContestClientFactory contestClientFactory,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dbContext = dbContext;
         _contestClientFactory = contestClientFactory;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<LeagueWeekMatchupsDto>> ExecuteAsync(
@@ -106,9 +109,10 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 .ToList();
 
             // Season year is authoritative on PickemGroupMatchup (set at generation
-            // time). DateTime.UtcNow.Year was wrong for football whenever bowl games
-            // / playoffs extend into January of the following calendar year.
-            var seasonYear = groupMatchups.FirstOrDefault()?.SeasonYear ?? DateTime.UtcNow.Year;
+            // time). Falls back to the current UTC year (via IDateTimeProvider for
+            // deterministic testing) only when a week returned zero matchups — which
+            // can't cleanly infer a year from the data itself.
+            var seasonYear = groupMatchups.FirstOrDefault()?.SeasonYear ?? _dateTimeProvider.UtcNow().Year;
 
             _logger.LogInformation(
                 "Retrieved {Count} matchups from database for leagueId={LeagueId}, week={Week}",

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -81,6 +81,7 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 query.Week);
 
             var groupMatchups = await _dbContext.PickemGroupMatchups
+                .AsNoTracking()
                 .Where(x => x.GroupId == query.LeagueId && x.SeasonWeek == query.Week)
                 .Select(x => new
                 {

--- a/src/SportsData.Api/Application/UI/TeamCard/Queries/GetTeamMetrics/GetTeamMetricsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/TeamCard/Queries/GetTeamMetrics/GetTeamMetricsQueryHandler.cs
@@ -58,6 +58,12 @@ public class GetTeamMetricsQueryHandler : IGetTeamMetricsQueryHandler
 
             return new Success<FranchiseSeasonMetricsDto>(dto);
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation must propagate so upstream request abort / shutdown
+            // semantics behave correctly. Never swallow it as "empty metrics."
+            throw;
+        }
         catch (Exception ex)
         {
             // Metrics are a non-blocking enrichment surface — a backend failure here

--- a/src/SportsData.Api/Application/UI/TeamCard/Queries/GetTeamMetrics/GetTeamMetricsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/TeamCard/Queries/GetTeamMetrics/GetTeamMetricsQueryHandler.cs
@@ -45,29 +45,32 @@ public class GetTeamMetricsQueryHandler : IGetTeamMetricsQueryHandler
 
             if (dto == null)
             {
+                // Metrics simply haven't been generated yet for this team/season.
+                // Treat as a normal empty-data case: log a warning for ops visibility
+                // and return an empty DTO so the UI can render "no metrics yet"
+                // without presenting the user an error.
                 _logger.LogWarning(
-                    "No metrics found for franchise season {FranchiseSeasonId}",
+                    "No metrics found for franchise season {FranchiseSeasonId}. Returning empty DTO.",
                     query.FranchiseSeasonId);
 
-                return new Failure<FranchiseSeasonMetricsDto>(
-                    default!,
-                    ResultStatus.NotFound,
-                    [new ValidationFailure(nameof(query.FranchiseSeasonId), "Metrics not found for this franchise season")]);
+                return new Success<FranchiseSeasonMetricsDto>(new FranchiseSeasonMetricsDto());
             }
 
             return new Success<FranchiseSeasonMetricsDto>(dto);
         }
         catch (Exception ex)
         {
+            // Metrics are a non-blocking enrichment surface — a backend failure here
+            // (network blip, sport-specific client not wired up, Producer 404, etc.)
+            // should never present the user with a hard error. Log at Error level so
+            // ops still catches real regressions, but return an empty DTO so the UI
+            // renders a friendly empty state instead of a 500.
             _logger.LogError(
                 ex,
-                "Error retrieving metrics for franchise season {FranchiseSeasonId}",
+                "Error retrieving metrics for franchise season {FranchiseSeasonId}. Returning empty DTO.",
                 query.FranchiseSeasonId);
 
-            return new Failure<FranchiseSeasonMetricsDto>(
-                default!,
-                ResultStatus.Error,
-                [new ValidationFailure(nameof(query.FranchiseSeasonId), "Error retrieving metrics. Please try again later.")]);
+            return new Success<FranchiseSeasonMetricsDto>(new FranchiseSeasonMetricsDto());
         }
     }
 }

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -31,6 +31,9 @@ public class UserDto
 
         public required string Name { get; set; }
 
-        public int? MaxSeasonWeek { get; set; }
+        // Ascending list of week numbers that exist for this league.
+        // Replaces MaxSeasonWeek — custom-window leagues (e.g. "current week only"
+        // or "weeks 5-8") need exact membership, not a 1..N upper bound.
+        public IList<int> SeasonWeeks { get; set; } = [];
     }
 }

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -31,9 +31,15 @@ public class UserDto
 
         public required string Name { get; set; }
 
-        // Ascending list of week numbers that exist for this league.
-        // Replaces MaxSeasonWeek — custom-window leagues (e.g. "current week only"
-        // or "weeks 5-8") need exact membership, not a 1..N upper bound.
+        /// <summary>
+        /// Week numbers that exist for this league, ascending with duplicates removed.
+        /// </summary>
+        /// <remarks>
+        /// The list is guaranteed to be sorted in ascending order and to contain no
+        /// duplicate week numbers. Replaces <c>MaxSeasonWeek</c> — custom-window
+        /// leagues (e.g. "current week only", or "weeks 5-8") need exact membership,
+        /// not a <c>1..N</c> upper bound. Populated by <c>GetMeQueryHandler</c>.
+        /// </remarks>
         public IList<int> SeasonWeeks { get; set; } = [];
     }
 }

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -76,6 +78,17 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                 default!,
                 ResultStatus.NotFound,
                 [new FluentValidation.Results.ValidationFailure("UserId", $"User with ID {query.UserId} not found.")]);
+        }
+
+        // Defensive invariant check. SeasonWeeks is contractually ascending + distinct
+        // (see UserDto.UserLeagueMembership.SeasonWeeks <remarks>). The EF projection
+        // above enforces it via .Distinct().OrderBy(); this assert guards against a
+        // future change to that projection silently breaking the contract.
+        foreach (var league in userDto.Leagues)
+        {
+            Debug.Assert(
+                league.SeasonWeeks.SequenceEqual(league.SeasonWeeks.Distinct().OrderBy(w => w)),
+                $"SeasonWeeks for league {league.Id} is not ascending+distinct.");
         }
 
         _logger.LogInformation("User retrieved successfully. UserId={UserId}", query.UserId);

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -39,6 +39,7 @@ public class GetMeQueryHandler : IGetMeQueryHandler
 
         var userDto = await _db.Users
             .AsNoTracking()
+            .AsSplitQuery()
             .Where(x => x.Id == query.UserId)
             .Select(user => new UserDto
             {
@@ -54,8 +55,15 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                     {
                         Id = m.Group.Id,
                         Name = m.Group.Name,
-                        MaxSeasonWeek = m.Group.Weeks
-                            .Max(w => (int?)w.SeasonWeek)
+                        // Dedupe: some leagues have multiple PickemGroupWeek rows with
+                        // the same SeasonWeek number (e.g. a preseason Week 1 alongside a
+                        // regular-season Week 1, or rows carried over across SeasonYears).
+                        // UI wants the unique set of week numbers, ascending.
+                        SeasonWeeks = m.Group.Weeks
+                            .Select(w => w.SeasonWeek)
+                            .Distinct()
+                            .OrderBy(w => w)
+                            .ToList()
                     })
                     .ToList()
             })

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -6,13 +6,15 @@ SELECT
   STRING_AGG(cb."MediaName", ' | ') AS "Broadcasts",
   v."Name" AS "Venue", v."City" AS "VenueCity", v."State" AS "VenueState",
   fAway."DisplayName" AS "Away", fAway."Abbreviation" AS "AwayShort",
-  fsAway."Id" AS "AwayFranchiseSeasonId", flAway."Uri" AS "AwayLogoUri",
+  fsAway."Id" AS "AwayFranchiseSeasonId",
+  COALESCE(fslAway."Uri", flAway."Uri") AS "AwayLogoUri",
   fAway."Slug" AS "AwaySlug", fAway."ColorCodeHex" AS "AwayColor",
   fsrdAway."Current" AS "AwayRank", gsAway."Slug" AS "AwayConferenceSlug",
   fsAway."Wins" AS "AwayWins", fsAway."Losses" AS "AwayLosses",
   fsAway."ConferenceWins" AS "AwayConferenceWins", fsAway."ConferenceLosses" AS "AwayConferenceLosses",
   fHome."DisplayName" AS "Home", fHome."Abbreviation" AS "HomeShort",
-  fsHome."Id" AS "HomeFranchiseSeasonId", flHome."Uri" AS "HomeLogoUri",
+  fsHome."Id" AS "HomeFranchiseSeasonId",
+  COALESCE(fslHome."Uri", flHome."Uri") AS "HomeLogoUri",
   fHome."Slug" AS "HomeSlug", fHome."ColorCodeHex" AS "HomeColor",
   fsrdHome."Current" AS "HomeRank", gsHome."Slug" AS "HomeConferenceSlug",
   fsHome."Wins" AS "HomeWins", fsHome."Losses" AS "HomeLosses",
@@ -45,6 +47,13 @@ LEFT JOIN LATERAL (
   WHERE fl."FranchiseId" = fAway."Id"
   ORDER BY fl."CreatedUtc" ASC LIMIT 1
 ) flAway ON TRUE
+-- FranchiseSeason-level logo is preferred; Franchise-level acts as fallback
+-- (matches LogoSelectionService.SelectWithFallback convention: season -> franchise).
+LEFT JOIN LATERAL (
+  SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
+  WHERE fsl."FranchiseSeasonId" = fsAway."Id"
+  ORDER BY fsl."CreatedUtc" ASC LIMIT 1
+) fslAway ON TRUE
 INNER JOIN public."GroupSeason" gsAway ON gsAway."Id" = fsAway."GroupSeasonId"
 LEFT JOIN LATERAL (
   SELECT fsr.* FROM public."FranchiseSeasonRanking" fsr
@@ -62,6 +71,12 @@ LEFT JOIN LATERAL (
   WHERE fl."FranchiseId" = fHome."Id"
   ORDER BY fl."CreatedUtc" ASC LIMIT 1
 ) flHome ON TRUE
+-- FranchiseSeason-level preferred, Franchise fallback — see Away comment above.
+LEFT JOIN LATERAL (
+  SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
+  WHERE fsl."FranchiseSeasonId" = fsHome."Id"
+  ORDER BY fsl."CreatedUtc" ASC LIMIT 1
+) fslHome ON TRUE
 INNER JOIN public."GroupSeason" gsHome ON gsHome."Id" = fsHome."GroupSeasonId"
 LEFT JOIN LATERAL (
   SELECT fsr.* FROM public."FranchiseSeasonRanking" fsr
@@ -76,12 +91,14 @@ WHERE c."Id" = ANY(@ContestIds)
 GROUP BY
   c."SeasonWeekId", c."Id", c."StartDateUtc", cs."StatusDescription",
   v."Name", v."City", v."State",
-  fAway."DisplayName", fAway."DisplayNameShort", fsAway."Id", flAway."Uri", fAway."Slug",
+  fAway."DisplayName", fAway."DisplayNameShort", fsAway."Id",
+  flAway."Uri", fslAway."Uri", fAway."Slug",
   fsrdAway."Current", gsAway."Slug",
   fsAway."Wins", fsAway."Losses", fsAway."ConferenceWins", fsAway."ConferenceLosses",
   fAway."Abbreviation", fAway."ColorCodeHex",
   fHome."Abbreviation", fHome."ColorCodeHex",
-  fHome."DisplayName", fHome."DisplayNameShort", fsHome."Id", flHome."Uri", fHome."Slug",
+  fHome."DisplayName", fHome."DisplayNameShort", fsHome."Id",
+  flHome."Uri", fslHome."Uri", fHome."Slug",
   fsrdHome."Current", gsHome."Slug",
   fsHome."Wins", fsHome."Losses", fsHome."ConferenceWins", fsHome."ConferenceLosses",
   co."Details", co."Spread", co."OverUnder", co."OverOdds", co."UnderOdds",

--- a/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
+++ b/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
@@ -53,16 +53,17 @@ function LeaderboardPage() {
     fetchLeaderboard();
   }, [selectedLeagueId]);
 
-  // Find the selected league and its maxSeasonWeek
+  // Find the selected league and its ascending week list
   const selectedLeague = leagues.find(l => l.id === selectedLeagueId);
-  const maxSeasonWeek = selectedLeague?.maxSeasonWeek || 1;
+  const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
+  const latestSeasonWeek = seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
 
-  // Set selectedWeek to maxSeasonWeek when league changes
+  // Snap selectedWeek to the latest week the league has when league changes
   useEffect(() => {
-    if (selectedLeagueId && maxSeasonWeek) {
-      setSelectedWeek(maxSeasonWeek);
+    if (selectedLeagueId && latestSeasonWeek) {
+      setSelectedWeek(latestSeasonWeek);
     }
-  }, [selectedLeagueId, maxSeasonWeek]);
+  }, [selectedLeagueId, latestSeasonWeek]);
 
   // Add the API call for week overview using the selectedLeagueId from context
   // Only run when selectedWeek is properly set (not null)
@@ -96,8 +97,8 @@ function LeaderboardPage() {
     fetchWeeklyScores();
   }, [selectedLeagueId]);
 
-  // Generate week options based on maxSeasonWeek
-  const weekOptions = Array.from({ length: maxSeasonWeek }, (_, i) => i + 1);
+  // Week options = the league's actual week list (custom-window leagues may skip weeks)
+  const weekOptions = seasonWeeks;
 
   // Filter functions for synthetic users
   const filterLeaderboard = (data) => {

--- a/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
+++ b/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
@@ -58,11 +58,21 @@ function LeaderboardPage() {
   const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
   const latestSeasonWeek = seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
 
-  // Snap selectedWeek only when (a) nothing is selected yet, or (b) the current
-  // selection isn't valid for the newly-selected league. Don't overwrite the
-  // user's explicit choice just because a later week became available.
+  // Reconcile selectedWeek with the currently-selected league.
+  //   (a) no league selected → nothing to reconcile; leave state alone.
+  //   (b) league has no weeks (latestSeasonWeek is null) → clear selectedWeek
+  //       explicitly, otherwise a stale value from the previous league would
+  //       carry over and getLeagueWeekOverview / the "By Week" select would
+  //       receive a week number the current league doesn't have.
+  //   (c) current selection is a week the league has → leave it alone
+  //       (don't clobber the user's explicit choice when new weeks append).
+  //   (d) current selection is missing or invalid → snap to the latest.
   useEffect(() => {
-    if (!selectedLeagueId || !latestSeasonWeek) return;
+    if (!selectedLeagueId) return;
+    if (!latestSeasonWeek) {
+      if (selectedWeek !== null) setSelectedWeek(null);
+      return;
+    }
     const isCurrentValid = selectedWeek && seasonWeeks.includes(selectedWeek);
     if (!isCurrentValid) {
       setSelectedWeek(latestSeasonWeek);

--- a/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
+++ b/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
@@ -58,11 +58,16 @@ function LeaderboardPage() {
   const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
   const latestSeasonWeek = seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
 
-  // Snap selectedWeek to the latest week the league has when league changes
+  // Snap selectedWeek only when (a) nothing is selected yet, or (b) the current
+  // selection isn't valid for the newly-selected league. Don't overwrite the
+  // user's explicit choice just because a later week became available.
   useEffect(() => {
-    if (selectedLeagueId && latestSeasonWeek) {
+    if (!selectedLeagueId || !latestSeasonWeek) return;
+    const isCurrentValid = selectedWeek && seasonWeeks.includes(selectedWeek);
+    if (!isCurrentValid) {
       setSelectedWeek(latestSeasonWeek);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedLeagueId, latestSeasonWeek]);
 
   // Add the API call for week overview using the selectedLeagueId from context

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -113,8 +113,17 @@ const LeagueCreatePage = () => {
   }, [isNcaa]);
 
   // Slugs don't overlap across sports — reset group selection on switch.
+  // NFL and MLB have small, fixed division sets; pre-select all so the
+  // typical "include every team" case is one click instead of eight.
+  // NCAA starts empty — commissioners usually cherry-pick conferences.
   useEffect(() => {
-    setTeamFilter([]);
+    if (sport === SPORT_NFL) {
+      setTeamFilter(NFL_DIVISIONS.map((d) => d.slug));
+    } else if (sport === SPORT_MLB) {
+      setTeamFilter(MLB_DIVISIONS.map((d) => d.slug));
+    } else {
+      setTeamFilter([]);
+    }
     if (!isNcaa) {
       setRankingFilter("");
     }

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
@@ -29,6 +29,20 @@
   min-width: 0;
 }
 
+/* Span the full grid width so it sits above the primary/sidebar columns. */
+.back-to-leagues {
+  grid-column: 1 / -1;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  align-self: start;
+}
+
+.back-to-leagues:hover {
+  text-decoration: underline;
+}
+
 .league-info-card {
   background-color: var(--bg-modal);
   border: 2px solid var(--accent);

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
@@ -1,10 +1,32 @@
-.page-container {
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 0 1rem;
+.league-detail-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px;
+  box-sizing: border-box;
+  width: 100%;
   color: var(--text-primary);
-  background-color: var(--bg-primary);
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  display: grid;
+  /* Single column on mobile; the breakpoint below switches to two columns.
+     Each column is its own flex stack so sidebar items pack tight
+     underneath the members card instead of hanging below an empty gap. */
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (min-width: 900px) {
+  .league-detail-container {
+    grid-template-columns: 1.2fr 1fr;
+  }
+}
+
+.league-detail-primary,
+.league-detail-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 0;
 }
 
 .league-info-card {
@@ -12,7 +34,6 @@
   border: 2px solid var(--accent);
   border-radius: 12px;
   padding: 2rem;
-  margin-bottom: 2rem;
 }
 
 .league-info-card h2 {
@@ -53,7 +74,6 @@
   border: 2px solid var(--accent);
   border-radius: 12px;
   padding: 2rem;
-  margin-bottom: 2rem;
 }
 
 .members-section h2 {
@@ -119,7 +139,6 @@
   border: 2px solid var(--error);
   border-radius: 12px;
   padding: 2rem;
-  margin-bottom: 2rem;
 }
 
 .danger-zone h2 {
@@ -199,16 +218,15 @@
 
 /* Mobile responsive */
 @media (max-width: 768px) {
-  .page-container {
-    margin: 1rem auto;
-    padding: 0 0.5rem;
+  .league-detail-container {
+    padding: 12px;
+    gap: 1rem;
   }
 
   .league-info-card,
   .members-section,
   .danger-zone {
     padding: 1.5rem;
-    margin-bottom: 1.5rem;
   }
 
   .league-info-card h2 {

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -56,9 +56,21 @@ const LeagueDetail = () => {
 
   // Render the league window as a human-readable date range, or "Full Season"
   // when both bounds are null (the league was created without a custom window).
+  //
+  // Date-only UTC-midnight strings (e.g. "2026-04-19T00:00:00Z") describe a
+  // calendar day, not an instant — constructing new Date() against them would
+  // shift the displayed date to the previous day for users west of UTC. For
+  // that shape we build a Date from local components so the label reflects
+  // the intended calendar day regardless of viewer timezone. All other ISO
+  // forms (local-midnight-as-UTC produced by the league-create form, real
+  // end-of-day timestamps, etc.) fall through to the standard UTC-aware path.
+  const DATE_ONLY_UTC_MIDNIGHT = /^(\d{4})-(\d{2})-(\d{2})T00:00:00(?:\.0+)?Z$/;
   const formatWindowBound = (iso) => {
     if (!iso) return null;
-    const d = new Date(iso);
+    const dateOnlyMatch = DATE_ONLY_UTC_MIDNIGHT.exec(iso);
+    const d = dateOnlyMatch
+      ? new Date(Number(dateOnlyMatch[1]), Number(dateOnlyMatch[2]) - 1, Number(dateOnlyMatch[3]))
+      : new Date(iso);
     return Number.isNaN(d.getTime())
       ? null
       : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
@@ -90,7 +102,11 @@ const LeagueDetail = () => {
             <li><strong>League Window:</strong> {windowLabel}</li>
             <li><strong>Visibility:</strong> {league.isPublic ? "Public" : "Private"}</li>
             <li><strong>Conferences:</strong> {
-              [...new Set(league.conferenceSlugs)]?.join(", ") || "None"
+              (() => {
+                const slugs = Array.isArray(league.conferenceSlugs) ? league.conferenceSlugs : [];
+                const deduped = [...new Set(slugs)];
+                return deduped.length > 0 ? deduped.join(", ") : "None";
+              })()
             }</li>
           </ul>
         </div>

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -5,6 +5,30 @@ import leaguesApi from "../../api/leagues/leaguesApi";
 import "./LeagueDetail.css";
 import LeagueInvitation from "./LeagueInvitation";
 
+// Render the league window as a human-readable date range, or "Full Season"
+// when both bounds are null (the league was created without a custom window).
+//
+// Date-only UTC-midnight strings (e.g. "2026-04-19T00:00:00Z") describe a
+// calendar day, not an instant — constructing new Date() against them would
+// shift the displayed date to the previous day for users west of UTC. For
+// that shape we build a Date from local components so the label reflects
+// the intended calendar day regardless of viewer timezone. All other ISO
+// forms (local-midnight-as-UTC produced by the league-create form, real
+// end-of-day timestamps, etc.) fall through to the standard UTC-aware path.
+//
+// Module-scoped so the regex and function aren't rebuilt on every render.
+const DATE_ONLY_UTC_MIDNIGHT = /^(\d{4})-(\d{2})-(\d{2})T00:00:00(?:\.0+)?Z$/;
+const formatWindowBound = (iso) => {
+  if (!iso) return null;
+  const dateOnlyMatch = DATE_ONLY_UTC_MIDNIGHT.exec(iso);
+  const d = dateOnlyMatch
+    ? new Date(Number(dateOnlyMatch[1]), Number(dateOnlyMatch[2]) - 1, Number(dateOnlyMatch[3]))
+    : new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? null
+    : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+};
+
 const LeagueDetail = () => {
   const { userDto, loading: userLoading } = useUserDto();
   const { id } = useParams();
@@ -54,27 +78,6 @@ const LeagueDetail = () => {
   const commissionerId = commissioner?.userId;
   const isCommissioner = userDto?.id === commissionerId;
 
-  // Render the league window as a human-readable date range, or "Full Season"
-  // when both bounds are null (the league was created without a custom window).
-  //
-  // Date-only UTC-midnight strings (e.g. "2026-04-19T00:00:00Z") describe a
-  // calendar day, not an instant — constructing new Date() against them would
-  // shift the displayed date to the previous day for users west of UTC. For
-  // that shape we build a Date from local components so the label reflects
-  // the intended calendar day regardless of viewer timezone. All other ISO
-  // forms (local-midnight-as-UTC produced by the league-create form, real
-  // end-of-day timestamps, etc.) fall through to the standard UTC-aware path.
-  const DATE_ONLY_UTC_MIDNIGHT = /^(\d{4})-(\d{2})-(\d{2})T00:00:00(?:\.0+)?Z$/;
-  const formatWindowBound = (iso) => {
-    if (!iso) return null;
-    const dateOnlyMatch = DATE_ONLY_UTC_MIDNIGHT.exec(iso);
-    const d = dateOnlyMatch
-      ? new Date(Number(dateOnlyMatch[1]), Number(dateOnlyMatch[2]) - 1, Number(dateOnlyMatch[3]))
-      : new Date(iso);
-    return Number.isNaN(d.getTime())
-      ? null
-      : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
-  };
   const startLabel = formatWindowBound(league.startsOn);
   const endLabel = formatWindowBound(league.endsOn);
   let windowLabel;

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useUserDto } from "../../contexts/UserContext";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import leaguesApi from "../../api/leagues/leaguesApi";
 import "./LeagueDetail.css";
 import LeagueInvitation from "./LeagueInvitation";
@@ -54,8 +54,29 @@ const LeagueDetail = () => {
   const commissionerId = commissioner?.userId;
   const isCommissioner = userDto?.id === commissionerId;
 
+  // Render the league window as a human-readable date range, or "Full Season"
+  // when both bounds are null (the league was created without a custom window).
+  const formatWindowBound = (iso) => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime())
+      ? null
+      : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  };
+  const startLabel = formatWindowBound(league.startsOn);
+  const endLabel = formatWindowBound(league.endsOn);
+  let windowLabel;
+  if (!startLabel && !endLabel) windowLabel = "Full Season";
+  else if (startLabel && endLabel) windowLabel = `${startLabel} – ${endLabel}`;
+  else if (startLabel) windowLabel = `From ${startLabel}`;
+  else windowLabel = `Through ${endLabel}`;
+
   return (
     <div className="league-detail-container">
+      <Link to="/app/league" className="back-to-leagues">
+        ← My Leagues
+      </Link>
+
       <div className="league-detail-primary">
         <div className="league-info-card">
           <h2>{league.name}</h2>
@@ -66,6 +87,7 @@ const LeagueDetail = () => {
             <li><strong>Tie Policy:</strong> {league.tiebreakerTiePolicy}</li>
             <li><strong>Confidence Points:</strong> {league.useConfidencePoints ? "Yes" : "No"}</li>
             <li><strong>Ranking Filter:</strong> {league.rankingFilter || "None"}</li>
+            <li><strong>League Window:</strong> {windowLabel}</li>
             <li><strong>Visibility:</strong> {league.isPublic ? "Public" : "Private"}</li>
             <li><strong>Conferences:</strong> {
               [...new Set(league.conferenceSlugs)]?.join(", ") || "None"

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -37,7 +37,11 @@ const LeagueDetail = () => {
       navigate("/app/league");
     } catch (err) {
       console.error("Failed to delete league:", err);
-      alert("Error deleting league. Please try again.");
+      // Surface the specific server error (e.g. "Cannot delete a league that
+      // already has user picks.") instead of a generic string so the user
+      // knows why the delete was refused.
+      const serverMessage = err?.response?.data?.errors?.[0]?.errorMessage;
+      alert(serverMessage || "Error deleting league. Please try again.");
     } finally {
       setDeleting(false);
     }
@@ -51,43 +55,46 @@ const LeagueDetail = () => {
   const isCommissioner = userDto?.id === commissionerId;
 
   return (
-    <div className="page-container">
-      <div className="league-info-card">
-        <h2>{league.name}</h2>
-        <ul className="league-details-list">
-          <li><strong>Description:</strong> {league.description}</li>
-          <li><strong>Pick Type:</strong> {league.pickType}</li>
-          <li><strong>Tiebreaker:</strong> {league.tiebreakerType}</li>
-          <li><strong>Tie Policy:</strong> {league.tiebreakerTiePolicy}</li>
-          <li><strong>Confidence Points:</strong> {league.useConfidencePoints ? "Yes" : "No"}</li>
-          <li><strong>Ranking Filter:</strong> {league.rankingFilter || "None"}</li>
-          <li><strong>Visibility:</strong> {league.isPublic ? "Public" : "Private"}</li>
-          <li><strong>Conferences:</strong> {
-            [...new Set(league.conferenceSlugs)]?.join(", ") || "None"
-          }</li>
-        </ul>
-      </div>
-
-      <div className="members-section">
-        <h2>Members</h2>
-        {league.members?.length > 0 ? (
-          <ul className="members-list">
-            {league.members.map((member) => (
-              <li key={member.userId}>
-                <span className="member-username">{member.username}</span>
-                <span className={`member-role ${member.role}`}>{member.role}</span>
-              </li>
-            ))}
+    <div className="league-detail-container">
+      <div className="league-detail-primary">
+        <div className="league-info-card">
+          <h2>{league.name}</h2>
+          <ul className="league-details-list">
+            <li><strong>Description:</strong> {league.description}</li>
+            <li><strong>Pick Type:</strong> {league.pickType}</li>
+            <li><strong>Tiebreaker:</strong> {league.tiebreakerType}</li>
+            <li><strong>Tie Policy:</strong> {league.tiebreakerTiePolicy}</li>
+            <li><strong>Confidence Points:</strong> {league.useConfidencePoints ? "Yes" : "No"}</li>
+            <li><strong>Ranking Filter:</strong> {league.rankingFilter || "None"}</li>
+            <li><strong>Visibility:</strong> {league.isPublic ? "Public" : "Private"}</li>
+            <li><strong>Conferences:</strong> {
+              [...new Set(league.conferenceSlugs)]?.join(", ") || "None"
+            }</li>
           </ul>
-        ) : (
-          <p className="no-members-message">No members yet.</p>
-        )}
+        </div>
       </div>
 
-      <LeagueInvitation leagueId={league.id} leagueName={league.name} />
+      <div className="league-detail-sidebar">
+        <div className="members-section">
+          <h2>Members</h2>
+          {league.members?.length > 0 ? (
+            <ul className="members-list">
+              {league.members.map((member) => (
+                <li key={member.userId}>
+                  <span className="member-username">{member.username}</span>
+                  <span className={`member-role ${member.role}`}>{member.role}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="no-members-message">No members yet.</p>
+          )}
+        </div>
 
-      {isCommissioner && (
-        <div className="danger-zone">
+        <LeagueInvitation leagueId={league.id} leagueName={league.name} />
+
+        {isCommissioner && (
+          <div className="danger-zone">
           <h2>Danger Zone</h2>
           {confirmingDelete ? (
             <>
@@ -108,8 +115,9 @@ const LeagueDetail = () => {
               Delete League
             </button>
           )}
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/UI/sd-ui/src/components/leagues/Leagues.css
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.css
@@ -6,6 +6,34 @@
   box-sizing: border-box;
 }
 
+.leagues-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.leagues-header h1 {
+  margin: 0;
+}
+
+.create-league-button {
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+  padding: 0.6rem 1.25rem;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: background-color 0.15s ease;
+}
+
+.create-league-button:hover {
+  background-color: var(--accent-hover);
+}
+
 .league-grid {
   display: flex;
   flex-direction: column;

--- a/src/UI/sd-ui/src/components/leagues/Leagues.css
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.css
@@ -34,6 +34,15 @@
   background-color: var(--accent-hover);
 }
 
+/* Keyboard-only focus indicator. :focus-visible (not :focus) so mouse clicks
+   don't leave a lingering outline after press. Outline + offset renders
+   outside the button so it's visible regardless of the current background. */
+.create-league-button:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.25);
+}
+
 .league-grid {
   display: flex;
   flex-direction: column;

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -1,5 +1,6 @@
 // src/components/leagues/Leagues.jsx
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import LeaguesApi from "api/leagues/leaguesApi";
 import LeagueOverviewCard from "./LeagueOverviewCard";
 import "./Leagues.css"; // for grid styling
@@ -17,9 +18,17 @@ const Leagues = () => {
 
   return (
     <div className="page-container">
-      <h1>My Leagues</h1>
+      <div className="leagues-header">
+        <h1>My Leagues</h1>
+        <Link to="/app/league/create" className="create-league-button">
+          + Create League
+        </Link>
+      </div>
       {leagues.length === 0 ? (
-        <p>You’re not part of any leagues yet.</p>
+        <p>
+          You’re not part of any leagues yet.{" "}
+          <Link to="/app/league/create">Create one</Link>.
+        </p>
       ) : (
         <div className="league-grid">
           {leagues.map((league) => (

--- a/src/UI/sd-ui/src/components/map/GameMap.jsx
+++ b/src/UI/sd-ui/src/components/map/GameMap.jsx
@@ -69,10 +69,14 @@ function GameMap() {
 
   const { getContestUpdate } = useContestUpdates();
 
-  // Find the selected league's maxSeasonWeek (same pattern as PicksPage)
+  // Selected league's week list (ascending). When no league is selected (allowAll=true),
+  // fall back to the union of all leagues' weeks so the selector still offers every week.
   const selectedLeague = leagues.find((l) => l.id === selectedLeagueId) ?? null;
-  const maxSeasonWeek = selectedLeague?.maxSeasonWeek ?? 
-    (leagues.length > 0 ? Math.max(...leagues.map(l => l.maxSeasonWeek || 1)) : null);
+  const seasonWeeks = selectedLeague?.seasonWeeks?.length
+    ? selectedLeague.seasonWeeks
+    : Array.from(
+        new Set(leagues.flatMap((l) => l.seasonWeeks ?? []))
+      ).sort((a, b) => a - b);
 
   // Fetch map data from API - on mount and when league/week changes
   useEffect(() => {
@@ -311,7 +315,7 @@ function GameMap() {
             setSelectedLeagueId={setSelectedLeagueId}
             selectedWeek={selectedWeek}
             setSelectedWeek={setSelectedWeek}
-            maxSeasonWeek={maxSeasonWeek}
+            seasonWeeks={seasonWeeks}
             allowAll={true}
           />
         )}

--- a/src/UI/sd-ui/src/components/map/GameMap.jsx
+++ b/src/UI/sd-ui/src/components/map/GameMap.jsx
@@ -78,6 +78,21 @@ function GameMap() {
         new Set(leagues.flatMap((l) => l.seasonWeeks ?? []))
       ).sort((a, b) => a - b);
 
+  // Normalize selectedWeek against the current league's valid weeks. selectedWeek=null
+  // is "All Weeks" (valid when allowAll=true), so leave it alone. If a specific week is
+  // set but no longer present in seasonWeeks (e.g. user switched from a full-season
+  // NCAAFB league at week 17 to an MLB current-week-only league with [4]), snap to the
+  // first available week — or null if the list is empty. Prevents Maps.getMap(leagueId,
+  // staleWeek) from running with a pairing that can't exist on the backend.
+  const seasonWeeksKey = seasonWeeks.join(",");
+  useEffect(() => {
+    if (selectedWeek == null) return;
+    if (!seasonWeeks.includes(selectedWeek)) {
+      setSelectedWeek(seasonWeeks[0] ?? null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedLeagueId, seasonWeeksKey]);
+
   // Fetch map data from API - on mount and when league/week changes
   useEffect(() => {
     async function fetchMapData() {

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -26,10 +26,12 @@ function MatchupCard({
   isFadingOut = false,
   useConfidencePoints,
   usedConfidencePoints = [],
-  totalGames
+  totalGames,
+  leagueSport, // Backend Sport enum name (e.g. "BaseballMlb") — drives team-link routing
+  leagueSeasonYear // From LeagueWeekMatchupsDto.SeasonYear — canonical for all matchups in this response
 }) {
   const { userDto } = useUserDto();
-  const seasonYear = matchup.seasonYear ?? 2025;
+  const seasonYear = leagueSeasonYear ?? matchup.seasonYear ?? 2025;
 
   const [showConfidencePicker, setShowConfidencePicker] = useState(false);
   const [pendingPickFranchiseId, setPendingPickFranchiseId] = useState(null);
@@ -41,7 +43,7 @@ function MatchupCard({
     comparisonData,
     handleOpenComparison,
     handleCloseComparison
-  } = useTeamComparison(matchup, seasonYear);
+  } = useTeamComparison(matchup, seasonYear, leagueSport);
 
   const { isLocked } = usePickLocking(matchup.startDateUtc, userDto?.isReadOnly);
 
@@ -56,7 +58,7 @@ function MatchupCard({
     homeLoading,
     awayError,
     homeError
-  } = useTeamSchedule(matchup.awaySlug, matchup.homeSlug, seasonYear);
+  } = useTeamSchedule(matchup.awaySlug, matchup.homeSlug, seasonYear, leagueSport);
 
   // Game details
   const gameTime = formatToEasternTime(matchup.startDateUtc);
@@ -147,6 +149,7 @@ function MatchupCard({
           confWins={matchup.awayConferenceWins}
           confLosses={matchup.awayConferenceLosses}
           seasonYear={seasonYear}
+          leagueSport={leagueSport}
           showSchedule={showAwayGames}
           onToggleSchedule={() => setShowAwayGames(v => !v)}
           schedule={awaySchedule}
@@ -165,6 +168,7 @@ function MatchupCard({
           confWins={matchup.homeConferenceWins}
           confLosses={matchup.homeConferenceLosses}
           seasonYear={seasonYear}
+          leagueSport={leagueSport}
           showSchedule={showHomeGames}
           onToggleSchedule={() => setShowHomeGames(v => !v)}
           schedule={homeSchedule}
@@ -269,15 +273,48 @@ function MatchupCard({
         </div>
       </div>
     {/* TeamComparison Dialog */}
-    {showComparison && (
-      comparisonLoading || !comparisonData || !comparisonData.teamA ||!comparisonData.teamB ||
-      !comparisonData.teamA.stats || !comparisonData.teamB.stats || !comparisonData.teamA.metrics || !comparisonData.teamB.metrics ? (
-        <div className="team-comparison-dialog-backdrop">
-          <div className="team-comparison-dialog" style={{textAlign: 'center', padding: '2rem'}}>
-            Loading team comparison...
+    {showComparison && (() => {
+      if (comparisonLoading || !comparisonData) {
+        return (
+          <div className="team-comparison-dialog-backdrop">
+            <div className="team-comparison-dialog" style={{ textAlign: 'center', padding: '2rem' }}>
+              Loading team comparison...
+            </div>
           </div>
-        </div>
-      ) : (
+        );
+      }
+
+      // If neither team has stats AND neither has metrics, show an explicit
+      // empty state instead of spinning forever. Happens early in a sport's
+      // season before stats/metrics have been generated.
+      const hasAnyData =
+        comparisonData.teamA?.stats || comparisonData.teamB?.stats ||
+        comparisonData.teamA?.metrics || comparisonData.teamB?.metrics;
+
+      if (!hasAnyData) {
+        return (
+          <div className="team-comparison-dialog-backdrop" onClick={handleCloseComparison}>
+            <div
+              className="team-comparison-dialog"
+              style={{ textAlign: 'center', padding: '2rem' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p style={{ margin: 0 }}>No team stats or metrics available yet.</p>
+              <p style={{ marginTop: 8, fontSize: '0.9em', opacity: 0.75 }}>
+                Check back once the season has a few games in the books.
+              </p>
+              <button
+                onClick={handleCloseComparison}
+                style={{ marginTop: 16, padding: '6px 16px' }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        );
+      }
+
+      return (
         <TeamComparison
           open={showComparison}
           onClose={handleCloseComparison}
@@ -286,8 +323,8 @@ function MatchupCard({
           teamAColor={matchup.awayColor}
           teamBColor={matchup.homeColor}
         />
-      )
-    )}
+      );
+    })()}
     </div>
   );
 }

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -293,9 +293,21 @@ function MatchupCard({
       // If neither team has stats AND neither has metrics, show an explicit
       // empty state instead of spinning forever. Happens early in a sport's
       // season before stats/metrics have been generated.
+      //
+      // GetTeamMetricsQueryHandler returns Success(empty FranchiseSeasonMetricsDto)
+      // for the no-data case — an object that's truthy but has gamesPlayed=0 and
+      // empty strings for every text field. A naive `?.metrics` truthy check would
+      // treat that as "has data" and render TeamComparison with meaningless zeros.
+      // hasMeaningfulMetrics keys off gamesPlayed because a team can't have valid
+      // computed metrics with zero games played.
+      //
+      // Stats takes a different path (handler still returns Failure(NotFound) for
+      // null), so a truthy check on `?.stats` is sufficient there.
+      const hasMeaningfulMetrics = (m) => Boolean(m && m.gamesPlayed && m.gamesPlayed > 0);
       const hasAnyData =
         comparisonData.teamA?.stats || comparisonData.teamB?.stats ||
-        comparisonData.teamA?.metrics || comparisonData.teamB?.metrics;
+        hasMeaningfulMetrics(comparisonData.teamA?.metrics) ||
+        hasMeaningfulMetrics(comparisonData.teamB?.metrics);
 
       if (!hasAnyData) {
         return (

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -31,7 +31,13 @@ function MatchupCard({
   leagueSeasonYear // From LeagueWeekMatchupsDto.SeasonYear — canonical for all matchups in this response
 }) {
   const { userDto } = useUserDto();
-  const seasonYear = leagueSeasonYear ?? matchup.seasonYear ?? 2025;
+  // seasonYear is authoritative from leagueSeasonYear (set by the backend
+  // handler from PickemGroupMatchup.SeasonYear); fall through to the matchup
+  // itself only if the response shape ever changes. No hardcoded year fallback
+  // — downstream hooks and link builders handle an undefined value by skipping
+  // season-specific fetches / omitting the URL segment rather than silently
+  // rendering a stale year.
+  const seasonYear = leagueSeasonYear ?? matchup.seasonYear;
 
   const [showConfidencePicker, setShowConfidencePicker] = useState(false);
   const [pendingPickFranchiseId, setPendingPickFranchiseId] = useState(null);

--- a/src/UI/sd-ui/src/components/matchups/MatchupList.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupList.jsx
@@ -15,7 +15,9 @@ function MatchupList({
   fadingOut = [],
   useConfidencePoints,
   usedConfidencePoints,
-  totalGames
+  totalGames,
+  leagueSport,
+  leagueSeasonYear
 }) {
   if (loading) {
     return (
@@ -43,6 +45,8 @@ function MatchupList({
           useConfidencePoints={useConfidencePoints}
           usedConfidencePoints={usedConfidencePoints}
           totalGames={totalGames}
+          leagueSport={leagueSport}
+          leagueSeasonYear={leagueSeasonYear}
         />
       ))}
     </div>

--- a/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
@@ -19,7 +19,9 @@ function getResultClass(game) {
 }
 
 export default function MiniSchedule({ schedule = [], seasonYear, leagueSport }) {
-  const { sport, league } = resolveSportLeague(leagueSport);
+  // Null when the backend sport enum is missing or unmapped — we then render
+  // plain-text team names instead of risking a wrong-sport route.
+  const sportLeague = resolveSportLeague(leagueSport);
   // TODO: create new endpoint that only returns completed games
   const games = schedule.slice(0, 13);
   // Drilldown state: which row is open, and its data
@@ -40,10 +42,15 @@ export default function MiniSchedule({ schedule = [], seasonYear, leagueSport })
     setDrillLoading(true);
     setDrillError(null);
     setDrillSchedule([]);
+    if (!sportLeague) {
+      setDrillError("Schedule unavailable for this sport.");
+      setDrillLoading(false);
+      return;
+    }
     try {
       // Use current seasonYear for opponent
       const res = await import("../../api/apiWrapper").then(m =>
-        m.default.TeamCard.getBySlugAndSeason(sport, league, opponentSlug, seasonYear));
+        m.default.TeamCard.getBySlugAndSeason(sportLeague.sport, sportLeague.league, opponentSlug, seasonYear));
       setDrillSchedule(Array.isArray(res.data?.schedule) ? res.data.schedule.slice(0, 13) : []);
     } catch (e) {
       setDrillError("Failed to load schedule");
@@ -68,9 +75,21 @@ export default function MiniSchedule({ schedule = [], seasonYear, leagueSport })
               <tr key={idx}>
                 <td>{formatToMonthDay(game.date)}</td>
                 <td style={{ display: 'flex', alignItems: 'center' }}>
-                  <Link to={teamLink(game.opponentSlug, seasonYear, sport, league)} className="team-link">
-                    {game.locationType === 'Away' ? `@ ${game.opponentShortName ?? game.opponent ?? 'Opponent'}` : (game.opponentShortName ?? game.opponent ?? 'Opponent')}
-                  </Link>
+                  {(() => {
+                    const opponentLabel = game.opponentShortName ?? game.opponent ?? 'Opponent';
+                    const displayLabel = game.locationType === 'Away' ? `@ ${opponentLabel}` : opponentLabel;
+                    // Only render a Link when we have a slug AND a resolvable
+                    // sport/league; otherwise fall back to a plain span with the
+                    // same class/label so the row still reads correctly without
+                    // producing /team/undefined or a wrong-sport route.
+                    return game.opponentSlug && sportLeague ? (
+                      <Link to={teamLink(game.opponentSlug, seasonYear, sportLeague.sport, sportLeague.league)} className="team-link">
+                        {displayLabel}
+                      </Link>
+                    ) : (
+                      <span className="team-link">{displayLabel}</span>
+                    );
+                  })()}
                   {game.opponentSlug && (
                     <button
                       className="mini-schedule-drill-icon-btn"
@@ -88,9 +107,9 @@ export default function MiniSchedule({ schedule = [], seasonYear, leagueSport })
                   )}
                 </td>
                 <td>
-                  {game.finalizedUtc && game.contestId ? (
+                  {game.finalizedUtc && game.contestId && sportLeague ? (
                     <Link
-                      to={contestLink(game.contestId, sport, league)}
+                      to={contestLink(game.contestId, sportLeague.sport, sportLeague.league)}
                       className={`result-link ${getResultClass(game)}`}
                     >
                       {formatGameResult(game)}

--- a/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
@@ -3,7 +3,7 @@ import { FaSearchPlus, FaSearchMinus } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { formatToMonthDay } from "../../utils/timeUtils";
 import "./MiniSchedule.css";
-import { teamLink, contestLink } from '../../utils/sportLinks';
+import { teamLink, contestLink, resolveSportLeague } from '../../utils/sportLinks';
 import "./MiniScheduleDrilldown.css";
 
 function formatGameResult(game) {
@@ -18,7 +18,8 @@ function getResultClass(game) {
   return game.wasWinner ? "result-win" : "result-loss";
 }
 
-export default function MiniSchedule({ schedule = [], seasonYear }) {
+export default function MiniSchedule({ schedule = [], seasonYear, leagueSport }) {
+  const { sport, league } = resolveSportLeague(leagueSport);
   // TODO: create new endpoint that only returns completed games
   const games = schedule.slice(0, 13);
   // Drilldown state: which row is open, and its data
@@ -41,7 +42,8 @@ export default function MiniSchedule({ schedule = [], seasonYear }) {
     setDrillSchedule([]);
     try {
       // Use current seasonYear for opponent
-      const res = await import("../../api/apiWrapper").then(m => m.default.TeamCard.getBySlugAndSeason(opponentSlug, seasonYear));
+      const res = await import("../../api/apiWrapper").then(m =>
+        m.default.TeamCard.getBySlugAndSeason(sport, league, opponentSlug, seasonYear));
       setDrillSchedule(Array.isArray(res.data?.schedule) ? res.data.schedule.slice(0, 13) : []);
     } catch (e) {
       setDrillError("Failed to load schedule");
@@ -66,7 +68,7 @@ export default function MiniSchedule({ schedule = [], seasonYear }) {
               <tr key={idx}>
                 <td>{formatToMonthDay(game.date)}</td>
                 <td style={{ display: 'flex', alignItems: 'center' }}>
-                  <Link to={teamLink(game.opponentSlug, seasonYear)} className="team-link">
+                  <Link to={teamLink(game.opponentSlug, seasonYear, sport, league)} className="team-link">
                     {game.locationType === 'Away' ? `@ ${game.opponentShortName ?? game.opponent ?? 'Opponent'}` : (game.opponentShortName ?? game.opponent ?? 'Opponent')}
                   </Link>
                   {game.opponentSlug && (
@@ -88,7 +90,7 @@ export default function MiniSchedule({ schedule = [], seasonYear }) {
                 <td>
                   {game.finalizedUtc && game.contestId ? (
                     <Link
-                      to={contestLink(game.contestId)}
+                      to={contestLink(game.contestId, sport, league)}
                       className={`result-link ${getResultClass(game)}`}
                     >
                       {formatGameResult(game)}
@@ -106,7 +108,7 @@ export default function MiniSchedule({ schedule = [], seasonYear }) {
                     ) : drillError ? (
                       <div style={{ padding: 6, color: 'red', fontSize: '0.95em' }}>{drillError}</div>
                     ) : (
-                      <MiniSchedule schedule={drillSchedule} seasonYear={seasonYear} />
+                      <MiniSchedule schedule={drillSchedule} seasonYear={seasonYear} leagueSport={leagueSport} />
                     )}
                   </td>
                 </tr>

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -38,7 +38,10 @@ function TeamRow({
   loading,
   error
 }) {
-  const { sport, league } = resolveSportLeague(leagueSport);
+  // resolveSportLeague returns null for unknown/missing enums so unsupported
+  // sports don't silently render as an NCAA football route. Fall back to a
+  // non-linked team name in that case.
+  const sportLeague = resolveSportLeague(leagueSport);
   return (
     <>
       <div className="team-row">
@@ -55,12 +58,16 @@ function TeamRow({
               {rank && (
                 <span className="team-ranking">#{rank}</span>
               )}
-              <Link
-                to={teamLink(teamSlug, seasonYear, sport, league)}
-                className="team-link"
-              >
-                {teamName}
-              </Link>
+              {sportLeague ? (
+                <Link
+                  to={teamLink(teamSlug, seasonYear, sportLeague.sport, sportLeague.league)}
+                  className="team-link"
+                >
+                  {teamName}
+                </Link>
+              ) : (
+                <span className="team-link">{teamName}</span>
+              )}
             </div>
             <div className="team-record-row">
               <div className="team-record">

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { FaSearchPlus, FaSearchMinus } from "react-icons/fa";
-import { teamLink } from '../../utils/sportLinks';
+import { teamLink, resolveSportLeague } from '../../utils/sportLinks';
 import MiniSchedule from "./MiniSchedule";
 
 /**
@@ -31,12 +31,14 @@ function TeamRow({
   confWins,
   confLosses,
   seasonYear,
+  leagueSport,
   showSchedule,
   onToggleSchedule,
   schedule,
   loading,
   error
 }) {
+  const { sport, league } = resolveSportLeague(leagueSport);
   return (
     <>
       <div className="team-row">
@@ -54,7 +56,7 @@ function TeamRow({
                 <span className="team-ranking">#{rank}</span>
               )}
               <Link
-                to={teamLink(teamSlug, seasonYear)}
+                to={teamLink(teamSlug, seasonYear, sport, league)}
                 className="team-link"
               >
                 {teamName}
@@ -88,7 +90,7 @@ function TeamRow({
         ) : error ? (
           <div style={{ padding: 4, color: 'red', fontSize: '0.95em' }}>{error}</div>
         ) : (
-          <MiniSchedule schedule={schedule} seasonYear={seasonYear} />
+          <MiniSchedule schedule={schedule} seasonYear={seasonYear} leagueSport={leagueSport} />
         )
       )}
     </>

--- a/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
+++ b/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
@@ -7,9 +7,11 @@ function LeagueWeekSelector({
   setSelectedLeagueId,
   selectedWeek,
   setSelectedWeek,
-  maxSeasonWeek = 1,
+  seasonWeeks = [],
   allowAll = false, // New prop to enable "All" option
 }) {
+  const hasWeeks = Array.isArray(seasonWeeks) && seasonWeeks.length > 0;
+
   return (
     <div className="league-week-selector">
       {/* League Select */}
@@ -29,12 +31,12 @@ function LeagueWeekSelector({
           id="weekSelect"
           value={selectedWeek ?? ""}
           onChange={(e) => setSelectedWeek(e.target.value ? Number(e.target.value) : null)}
-          disabled={!maxSeasonWeek}
+          disabled={!hasWeeks}
         >
           {allowAll && <option value="">All Weeks</option>}
-          {maxSeasonWeek && Array.from({ length: maxSeasonWeek }, (_, i) => (
-            <option key={i + 1} value={i + 1}>
-              Week {i + 1}
+          {hasWeeks && seasonWeeks.map((week) => (
+            <option key={week} value={week}>
+              Week {week}
             </option>
           ))}
         </select>

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -316,10 +316,17 @@ function PicksPage() {
   const latestSeasonWeek = seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
 
   // When selectedLeagueId or week list changes, snap selectedWeek to the latest
-  // week in the league (or clear if the league has no weeks defined).
+  // week in the league. If the league has no weeks defined (latestSeasonWeek
+  // falsy), explicitly clear selectedWeek — otherwise a stale value from the
+  // previously-selected league would carry over and the matchups fetch would
+  // issue an invalid (leagueId, week) pair.
   useEffect(() => {
     if (!selectedLeagueId) return;
-    if (latestSeasonWeek && selectedWeek !== latestSeasonWeek) {
+    if (!latestSeasonWeek) {
+      if (selectedWeek !== null) setSelectedWeek(null);
+      return;
+    }
+    if (selectedWeek !== latestSeasonWeek) {
       setSelectedWeek(latestSeasonWeek);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -31,6 +31,8 @@ function PicksPage() {
   const [matchups, setMatchups] = useState([]);
   const [pickType, setPickType] = useState(null);
   const [useConfidencePoints, setUseConfidencePoints] = useState(false);
+  const [leagueSport, setLeagueSport] = useState(null);
+  const [leagueSeasonYear, setLeagueSeasonYear] = useState(null);
   const [loadingMatchups, setLoadingMatchups] = useState(true);
 
   const [selectedLeagueId, setSelectedLeagueId] = useState(null);
@@ -134,6 +136,8 @@ function PicksPage() {
         setMatchups(response.data.matchups || []);
         setPickType(response.data.pickType);
         setUseConfidencePoints(response.data.useConfidencePoints);
+        setLeagueSport(response.data.sport);
+        setLeagueSeasonYear(response.data.seasonYear);
       } catch (error) {
         console.error("Failed to fetch matchups:", error);
       } finally {
@@ -304,17 +308,22 @@ function PicksPage() {
     }
   }
 
-  // Find the selected league's maxSeasonWeek
+  // Find the selected league's week list (ascending from /user/me)
   const selectedLeague = leagues.find((l) => l.id === selectedLeagueId) ?? null;
-  const maxSeasonWeek = selectedLeague?.maxSeasonWeek ?? null;
+  const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
+  // Default to the latest week the league has (last element of the ascending list).
+  // Custom-window leagues may only have a single entry; full-season leagues have many.
+  const latestSeasonWeek = seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
 
-  // When selectedLeagueId or maxSeasonWeek changes, default selectedWeek to maxSeasonWeek
+  // When selectedLeagueId or week list changes, snap selectedWeek to the latest
+  // week in the league (or clear if the league has no weeks defined).
   useEffect(() => {
-    if (selectedLeagueId && maxSeasonWeek && selectedWeek !== maxSeasonWeek) {
-      setSelectedWeek(maxSeasonWeek);
+    if (!selectedLeagueId) return;
+    if (latestSeasonWeek && selectedWeek !== latestSeasonWeek) {
+      setSelectedWeek(latestSeasonWeek);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedLeagueId, maxSeasonWeek, selectedLeague]);
+  }, [selectedLeagueId, latestSeasonWeek, selectedLeague]);
 
   if (userLoading) return <div>Loading user info...</div>;
 
@@ -352,7 +361,7 @@ function PicksPage() {
             setSelectedLeagueId={setSelectedLeagueId}
             selectedWeek={selectedWeek}
             setSelectedWeek={setSelectedWeek}
-            maxSeasonWeek={maxSeasonWeek}
+            seasonWeeks={seasonWeeks}
           />
           <div className="pick-status-toggle-row">
             <span className="pick-status">
@@ -389,6 +398,8 @@ function PicksPage() {
                 useConfidencePoints={useConfidencePoints}
                 usedConfidencePoints={usedConfidencePoints}
                 totalGames={enrichedMatchups.length}
+                leagueSport={leagueSport}
+                leagueSeasonYear={leagueSeasonYear}
               />
             ) : (
               <MatchupGrid

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.css
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.css
@@ -292,10 +292,23 @@
   gap: 0.5rem;
 }
 
+/*
+ * Dialog-scoped logo sizing.
+ *
+ * The global `.team-logo` rule in TeamCard.css (width: 160px; height: 160px;
+ * flex: 0 0 160px;) is intended for the standalone team-card page but can leak
+ * into this dialog depending on CSS load order. Using !important here makes
+ * the dialog's 54x54 square sizing authoritative. `object-fit: contain` plus
+ * `object-position: center` keeps non-square source images (wordmarks, tall
+ * logos, etc.) centered within the square frame instead of stretching.
+ */
+.team-comparison-dialog .team-comparison-content .team-logo,
 .team-comparison-content .team-logo {
-  width: 54px;
-  height: 54px;
+  width: 54px !important;
+  height: 54px !important;
+  flex: 0 0 54px !important;
   object-fit: contain;
+  object-position: center;
   background: #fff;
   border-radius: 8px;
   border: 1px solid var(--border-strong);

--- a/src/UI/sd-ui/src/hooks/useTeamComparison.js
+++ b/src/UI/sd-ui/src/hooks/useTeamComparison.js
@@ -1,13 +1,16 @@
 import { useState } from 'react';
 import apiWrapper from '../api/apiWrapper';
+import { resolveSportLeague } from '../utils/sportLinks';
 
 /**
  * Custom hook to manage team comparison dialog state and data fetching
  * @param {object} matchup - Matchup data object
  * @param {number} seasonYear - Season year for the comparison data
+ * @param {string} leagueSport - Backend Sport enum name (e.g. "BaseballMlb") used to
+ *   resolve the {sport, league} URL segments for the TeamCard API
  * @returns {object} { showComparison, comparisonLoading, comparisonData, handleOpenComparison, handleCloseComparison }
  */
-export const useTeamComparison = (matchup, seasonYear) => {
+export const useTeamComparison = (matchup, seasonYear, leagueSport) => {
   const [showComparison, setShowComparison] = useState(false);
   const [comparisonLoading, setComparisonLoading] = useState(false);
   const [comparisonData, setComparisonData] = useState(null);
@@ -17,25 +20,32 @@ export const useTeamComparison = (matchup, seasonYear) => {
     setShowComparison(true);
 
     try {
-      const [awayRes, homeRes, awayMetrics, homeMetrics] = await Promise.all([
-        apiWrapper.TeamCard.getStatistics(matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
-        apiWrapper.TeamCard.getStatistics(matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId),
-        apiWrapper.TeamCard.getMetrics(matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
-        apiWrapper.TeamCard.getMetrics(matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId)
+      const { sport, league } = resolveSportLeague(leagueSport);
+
+      // allSettled so a missing/failed stat block for one team doesn't kill the
+      // dialog — each slot independently resolves to its data or null.
+      const results = await Promise.allSettled([
+        apiWrapper.TeamCard.getStatistics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
+        apiWrapper.TeamCard.getStatistics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId),
+        apiWrapper.TeamCard.getMetrics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
+        apiWrapper.TeamCard.getMetrics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId)
       ]);
+
+      const valueOrNull = (r) => (r.status === 'fulfilled' ? (r.value?.data ?? null) : null);
+      const [awayStats, homeStats, awayMetrics, homeMetrics] = results.map(valueOrNull);
 
       setComparisonData({
         teamA: {
           name: matchup.away,
           logoUri: matchup.awayLogoUri,
-          stats: awayRes.data,
-          metrics: awayMetrics.data
+          stats: awayStats,
+          metrics: awayMetrics
         },
         teamB: {
           name: matchup.home,
           logoUri: matchup.homeLogoUri,
-          stats: homeRes.data,
-          metrics: homeMetrics.data
+          stats: homeStats,
+          metrics: homeMetrics
         }
       });
     } catch (e) {

--- a/src/UI/sd-ui/src/hooks/useTeamComparison.js
+++ b/src/UI/sd-ui/src/hooks/useTeamComparison.js
@@ -19,8 +19,21 @@ export const useTeamComparison = (matchup, seasonYear, leagueSport) => {
     setComparisonLoading(true);
     setShowComparison(true);
 
+    const sportLeague = resolveSportLeague(leagueSport);
+    // Without a seasonYear OR a resolvable sport/league we can't build season-
+    // specific stats/metrics URLs. Show the dialog's empty-state card rather
+    // than issuing requests with an undefined year segment or a wrong sport.
+    if (!seasonYear || !sportLeague) {
+      setComparisonData({
+        teamA: { name: matchup.away, logoUri: matchup.awayLogoUri, stats: null, metrics: null },
+        teamB: { name: matchup.home, logoUri: matchup.homeLogoUri, stats: null, metrics: null }
+      });
+      setComparisonLoading(false);
+      return;
+    }
+
     try {
-      const { sport, league } = resolveSportLeague(leagueSport);
+      const { sport, league } = sportLeague;
 
       // allSettled so a missing/failed stat block for one team doesn't kill the
       // dialog — each slot independently resolves to its data or null.

--- a/src/UI/sd-ui/src/hooks/useTeamSchedule.js
+++ b/src/UI/sd-ui/src/hooks/useTeamSchedule.js
@@ -23,10 +23,12 @@ export const useTeamSchedule = (awaySlug, homeSlug, seasonYear, leagueSport) => 
 
   // Fetch away team schedule
   useEffect(() => {
-    if (!showAwayGames) return;
+    if (!showAwayGames || !seasonYear) return;
+    const sportLeague = resolveSportLeague(leagueSport);
+    if (!sportLeague) return; // unsupported/unknown sport — don't issue a wrong-sport fetch
     setAwayLoading(true);
     setAwayError(null);
-    const { sport, league } = resolveSportLeague(leagueSport);
+    const { sport, league } = sportLeague;
     apiWrapper.TeamCard.getBySlugAndSeason(sport, league, awaySlug, seasonYear)
       .then(res => {
         setAwaySchedule(Array.isArray(res.data?.schedule) ? res.data.schedule : []);
@@ -37,10 +39,12 @@ export const useTeamSchedule = (awaySlug, homeSlug, seasonYear, leagueSport) => 
 
   // Fetch home team schedule
   useEffect(() => {
-    if (!showHomeGames) return;
+    if (!showHomeGames || !seasonYear) return;
+    const sportLeague = resolveSportLeague(leagueSport);
+    if (!sportLeague) return; // unsupported/unknown sport — don't issue a wrong-sport fetch
     setHomeLoading(true);
     setHomeError(null);
-    const { sport, league } = resolveSportLeague(leagueSport);
+    const { sport, league } = sportLeague;
     apiWrapper.TeamCard.getBySlugAndSeason(sport, league, homeSlug, seasonYear)
       .then(res => {
         setHomeSchedule(Array.isArray(res.data?.schedule) ? res.data.schedule : []);

--- a/src/UI/sd-ui/src/hooks/useTeamSchedule.js
+++ b/src/UI/sd-ui/src/hooks/useTeamSchedule.js
@@ -1,14 +1,17 @@
 import { useState, useEffect } from 'react';
 import apiWrapper from '../api/apiWrapper';
+import { resolveSportLeague } from '../utils/sportLinks';
 
 /**
  * Custom hook to fetch and manage schedule data for both teams in a matchup
  * @param {string} awaySlug - Away team slug identifier
  * @param {string} homeSlug - Home team slug identifier
  * @param {number} seasonYear - Season year
+ * @param {string} leagueSport - Backend Sport enum name (e.g. "BaseballMlb") used to
+ *   resolve the {sport, league} URL segments for the TeamCard API
  * @returns {object} Schedule state and handlers for both teams
  */
-export const useTeamSchedule = (awaySlug, homeSlug, seasonYear) => {
+export const useTeamSchedule = (awaySlug, homeSlug, seasonYear, leagueSport) => {
   const [showAwayGames, setShowAwayGames] = useState(false);
   const [showHomeGames, setShowHomeGames] = useState(false);
   const [awaySchedule, setAwaySchedule] = useState([]);
@@ -23,26 +26,28 @@ export const useTeamSchedule = (awaySlug, homeSlug, seasonYear) => {
     if (!showAwayGames) return;
     setAwayLoading(true);
     setAwayError(null);
-    apiWrapper.TeamCard.getBySlugAndSeason(awaySlug, seasonYear)
+    const { sport, league } = resolveSportLeague(leagueSport);
+    apiWrapper.TeamCard.getBySlugAndSeason(sport, league, awaySlug, seasonYear)
       .then(res => {
         setAwaySchedule(Array.isArray(res.data?.schedule) ? res.data.schedule : []);
       })
       .catch(() => setAwayError("Failed to load schedule"))
       .finally(() => setAwayLoading(false));
-  }, [showAwayGames, awaySlug, seasonYear]);
+  }, [showAwayGames, awaySlug, seasonYear, leagueSport]);
 
   // Fetch home team schedule
   useEffect(() => {
     if (!showHomeGames) return;
     setHomeLoading(true);
     setHomeError(null);
-    apiWrapper.TeamCard.getBySlugAndSeason(homeSlug, seasonYear)
+    const { sport, league } = resolveSportLeague(leagueSport);
+    apiWrapper.TeamCard.getBySlugAndSeason(sport, league, homeSlug, seasonYear)
       .then(res => {
         setHomeSchedule(Array.isArray(res.data?.schedule) ? res.data.schedule : []);
       })
       .catch(() => setHomeError("Failed to load schedule"))
       .finally(() => setHomeLoading(false));
-  }, [showHomeGames, homeSlug, seasonYear]);
+  }, [showHomeGames, homeSlug, seasonYear, leagueSport]);
 
   return {
     showAwayGames,

--- a/src/UI/sd-ui/src/utils/sportLinks.js
+++ b/src/UI/sd-ui/src/utils/sportLinks.js
@@ -1,11 +1,31 @@
 /**
  * Centralized link builders for sport-specific routes.
- * Currently defaults to football/ncaa. When multi-sport UI is added,
- * these will accept sport/league from the data or context.
+ *
+ * Backend serializes the Sport enum as PascalCase ("FootballNcaa",
+ * "FootballNfl", "BaseballMlb"); URL segments are lowercase tuples
+ * (/sport/football/ncaa, etc.). resolveSportLeague() maps between the
+ * two. Callers that still pass nothing fall back to football/ncaa for
+ * backward compatibility with legacy single-sport code paths.
  */
 
 const DEFAULT_SPORT = 'football';
 const DEFAULT_LEAGUE = 'ncaa';
+
+const SPORT_ENUM_MAP = {
+  FootballNcaa: { sport: 'football', league: 'ncaa' },
+  FootballNfl: { sport: 'football', league: 'nfl' },
+  BaseballMlb: { sport: 'baseball', league: 'mlb' },
+};
+
+/**
+ * Map a backend Sport enum name to { sport, league } URL segments.
+ * Returns defaults (football/ncaa) for null/unknown values so callers
+ * never render a broken route.
+ */
+export function resolveSportLeague(sportEnum) {
+  if (!sportEnum) return { sport: DEFAULT_SPORT, league: DEFAULT_LEAGUE };
+  return SPORT_ENUM_MAP[sportEnum] ?? { sport: DEFAULT_SPORT, league: DEFAULT_LEAGUE };
+}
 
 export function teamLink(slug, seasonYear, sport = DEFAULT_SPORT, league = DEFAULT_LEAGUE) {
   return `/app/sport/${sport}/${league}/team/${slug}${seasonYear ? `/${seasonYear}` : ''}`;

--- a/src/UI/sd-ui/src/utils/sportLinks.js
+++ b/src/UI/sd-ui/src/utils/sportLinks.js
@@ -4,8 +4,14 @@
  * Backend serializes the Sport enum as PascalCase ("FootballNcaa",
  * "FootballNfl", "BaseballMlb"); URL segments are lowercase tuples
  * (/sport/football/ncaa, etc.). resolveSportLeague() maps between the
- * two. Callers that still pass nothing fall back to football/ncaa for
- * backward compatibility with legacy single-sport code paths.
+ * two.
+ *
+ * Legacy single-sport call sites may still invoke teamLink / contestLink
+ * without passing sport/league explicitly — those fall back to
+ * DEFAULT_SPORT/DEFAULT_LEAGUE for backward compatibility. New multi-sport
+ * call paths should go through resolveSportLeague so that unsupported or
+ * missing enums surface as null instead of silently rendering a football/ncaa
+ * route for an MLB / hockey / future-sport league.
  */
 
 const DEFAULT_SPORT = 'football';
@@ -19,12 +25,17 @@ const SPORT_ENUM_MAP = {
 
 /**
  * Map a backend Sport enum name to { sport, league } URL segments.
- * Returns defaults (football/ncaa) for null/unknown values so callers
- * never render a broken route.
+ * Returns null for null/undefined input and for enum names that aren't in
+ * SPORT_ENUM_MAP — callers must handle that case (skip fetch, render an
+ * unsupported state, etc.). The previous implementation defaulted unknowns
+ * to football/ncaa, which masked bugs by producing valid-looking but wrong
+ * routes for non-football leagues.
+ *
+ * @returns {{ sport: string, league: string } | null}
  */
 export function resolveSportLeague(sportEnum) {
-  if (!sportEnum) return { sport: DEFAULT_SPORT, league: DEFAULT_LEAGUE };
-  return SPORT_ENUM_MAP[sportEnum] ?? { sport: DEFAULT_SPORT, league: DEFAULT_LEAGUE };
+  if (!sportEnum) return null;
+  return SPORT_ENUM_MAP[sportEnum] ?? null;
 }
 
 export function teamLink(slug, seasonYear, sport = DEFAULT_SPORT, league = DEFAULT_LEAGUE) {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -22,11 +22,21 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
     {
         private readonly Mock<IProvideContests> _contestClientMock = new();
 
+        // Fixed "now" for every CreatedUtc in this file. Using IDateTimeProvider
+        // (via AutoMocker) instead of DateTime.UtcNow keeps test-seeded entities
+        // deterministic per CLAUDE.md guidance and matches the pattern used in
+        // ContestEnrichmentProcessorTests and AthleteSeasonDocumentProcessorTests.
+        private static readonly DateTime FixedUtcNow = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         public MatchupScheduleProcessorTests()
         {
             Mocker.GetMock<IContestClientFactory>()
                 .Setup(x => x.Resolve(It.IsAny<Sport>()))
                 .Returns(_contestClientMock.Object);
+
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(x => x.UtcNow())
+                .Returns(FixedUtcNow);
         }
         /// <summary>
         /// Validates that when a PickemGroup does not exist for the given GroupId,
@@ -74,7 +84,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 Sport = Core.Common.Sport.FootballNcaa,
                 League = League.NCAAF,
                 CommissionerUserId = Guid.NewGuid(),
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
                 CreatedBy = Guid.Empty
             };
 
@@ -90,7 +100,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 SeasonYear = 2024,
                 SeasonWeek = 1,
                 AreMatchupsGenerated = true,
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
                 CreatedBy = Guid.Empty
             };
 
@@ -135,7 +145,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
                 .With(x => x.Conferences, new List<PickemGroupConference>
                 {
-                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = DateTime.UtcNow, CreatedBy = Guid.Empty }
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(), CreatedBy = Guid.Empty }
                 })
                 .Create();
 
@@ -607,7 +617,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 .With(x => x.EndsOn, (DateTime?)windowEnd)
                 .With(x => x.Conferences, new List<PickemGroupConference>
                 {
-                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = DateTime.UtcNow, CreatedBy = Guid.Empty }
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(), CreatedBy = Guid.Empty }
                 })
                 .Create();
 
@@ -692,7 +702,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 .With(x => x.EndsOn, (DateTime?)null)
                 .With(x => x.Conferences, new List<PickemGroupConference>
                 {
-                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = DateTime.UtcNow, CreatedBy = Guid.Empty }
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(), CreatedBy = Guid.Empty }
                 })
                 .Create();
 
@@ -786,7 +796,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 .With(x => x.EndsOn, (DateTime?)windowEnd)
                 .With(x => x.Conferences, new List<PickemGroupConference>
                 {
-                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = DateTime.UtcNow, CreatedBy = Guid.Empty }
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(), CreatedBy = Guid.Empty }
                 })
                 .Create();
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -129,6 +129,8 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var conferenceSlug = "sec";
 
             var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
                 .With(x => x.Id, groupId)
                 .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
                 .With(x => x.Conferences, new List<PickemGroupConference>
@@ -206,6 +208,8 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var seasonWeekId = Guid.NewGuid();
 
             var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
                 .With(x => x.Id, groupId)
                 .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
                 .With(x => x.NonStandardWeekGroupSeasonMapFilter, "fbs")
@@ -284,6 +288,8 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var seasonWeekId = Guid.NewGuid();
 
             var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
                 .With(x => x.Id, groupId)
                 .With(x => x.RankingFilter, () => (TeamRankingFilter?)null)
                 .With(x => x.NonStandardWeekGroupSeasonMapFilter, filter) // Use the filter parameter
@@ -342,6 +348,8 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var seasonWeekId = Guid.NewGuid();
 
             var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
                 .With(x => x.Id, groupId)
                 .With(x => x.RankingFilter, () => (TeamRankingFilter?)null)
                 .With(x => x.NonStandardWeekGroupSeasonMapFilter, "fbs|bowl") // Multiple filters
@@ -406,6 +414,8 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var seasonWeekId = Guid.NewGuid();
 
             var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
                 .With(x => x.Id, groupId)
                 .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
                 .With(x => x.Conferences, new List<PickemGroupConference>())
@@ -455,6 +465,8 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var correlationId = Guid.NewGuid();
 
             var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
                 .With(x => x.Id, groupId)
                 .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
                 .With(x => x.Conferences, new List<PickemGroupConference>())
@@ -512,6 +524,8 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var contestId = Guid.NewGuid();
 
             var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
                 .With(x => x.Id, groupId)
                 .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
                 .With(x => x.Conferences, new List<PickemGroupConference>())
@@ -566,6 +580,93 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             savedMatchup.HomeWins.Should().Be(7);
             savedMatchup.HomeLosses.Should().Be(3);
             savedMatchup.Spread.Should().Be("-3.5");
+        }
+
+        /// <summary>
+        /// Validates that when a PickemGroup defines a league window (StartsOn/EndsOn),
+        /// matchups whose kickoff falls outside the window are excluded from the
+        /// PickemGroupMatchup set — supporting partial-season leagues (e.g. "September
+        /// games only" or "Weeks 1–4"). Null bounds are the full-season default and
+        /// act as "no constraint".
+        /// </summary>
+        [Fact]
+        public async Task Process_LeagueWindow_ExcludesContestsOutsideBounds()
+        {
+            // Arrange
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+            var conferenceSlug = "sec";
+
+            var windowStart = new DateTime(2024, 9, 15, 0, 0, 0, DateTimeKind.Utc);
+            var windowEnd = new DateTime(2024, 9, 21, 23, 59, 59, DateTimeKind.Utc);
+
+            var group = Fixture.Build<PickemGroup>()
+                .With(x => x.Id, groupId)
+                .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
+                .With(x => x.StartsOn, (DateTime?)windowStart)
+                .With(x => x.EndsOn, (DateTime?)windowEnd)
+                .With(x => x.Conferences, new List<PickemGroupConference>
+                {
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = DateTime.UtcNow, CreatedBy = Guid.Empty }
+                })
+                .Create();
+
+            await DataContext.PickemGroups.AddAsync(group);
+            await DataContext.SaveChangesAsync();
+
+            // Build three SEC matchups: one before the window, one inside, one after.
+            // Without the window filter, all three would match the conference rule
+            // and land in PickemGroupMatchup.
+            var allMatchups = new List<Matchup>
+            {
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, new DateTime(2024, 9, 8, 19, 0, 0, DateTimeKind.Utc))
+                    .Create(),
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, new DateTime(2024, 9, 18, 19, 0, 0, DateTimeKind.Utc))
+                    .Create(),
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, new DateTime(2024, 9, 28, 19, 0, 0, DateTimeKind.Utc))
+                    .Create(),
+            };
+
+            _contestClientMock
+                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId,
+                seasonWeekId,
+                2024,
+                1,
+                false,
+                Guid.NewGuid());
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — only the in-window matchup survives.
+            var savedGroupWeek = DataContext.PickemGroupWeeks
+                .Include(gw => gw.Matchups)
+                .FirstOrDefault(x => x.SeasonWeekId == seasonWeekId);
+
+            savedGroupWeek.Should().NotBeNull();
+            savedGroupWeek!.Matchups.Should().ContainSingle()
+                .Which.StartDateUtc.Should().Be(new DateTime(2024, 9, 18, 19, 0, 0, DateTimeKind.Utc));
         }
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -668,5 +668,189 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             savedGroupWeek!.Matchups.Should().ContainSingle()
                 .Which.StartDateUtc.Should().Be(new DateTime(2024, 9, 18, 19, 0, 0, DateTimeKind.Utc));
         }
+
+        /// <summary>
+        /// Open-ended upper bound: StartsOn is set, EndsOn is null. Matchups
+        /// before StartsOn are excluded; matchups on/after StartsOn are included
+        /// with no upper bound constraint. Mirrors a "starts next Saturday, runs
+        /// through the rest of the season" league.
+        /// </summary>
+        [Fact]
+        public async Task Process_LeagueWindow_StartsOnOnly_ExcludesContestsBeforeStart()
+        {
+            // Arrange
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+            var conferenceSlug = "sec";
+
+            var windowStart = new DateTime(2024, 9, 15, 0, 0, 0, DateTimeKind.Utc);
+
+            var group = Fixture.Build<PickemGroup>()
+                .With(x => x.Id, groupId)
+                .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
+                .With(x => x.StartsOn, (DateTime?)windowStart)
+                .With(x => x.EndsOn, (DateTime?)null)
+                .With(x => x.Conferences, new List<PickemGroupConference>
+                {
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = DateTime.UtcNow, CreatedBy = Guid.Empty }
+                })
+                .Create();
+
+            await DataContext.PickemGroups.AddAsync(group);
+            await DataContext.SaveChangesAsync();
+
+            // Three SEC matchups: one a week before the window, one exactly on
+            // StartsOn (inclusive boundary), one well after. No EndsOn, so
+            // nothing trims from the top.
+            var allMatchups = new List<Matchup>
+            {
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, new DateTime(2024, 9, 8, 19, 0, 0, DateTimeKind.Utc))
+                    .Create(),
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, windowStart)
+                    .Create(),
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, new DateTime(2024, 12, 1, 19, 0, 0, DateTimeKind.Utc))
+                    .Create(),
+            };
+
+            _contestClientMock
+                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId,
+                seasonWeekId,
+                2024,
+                1,
+                false,
+                Guid.NewGuid());
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — matchup before window is excluded; boundary and later are included.
+            var savedGroupWeek = DataContext.PickemGroupWeeks
+                .Include(gw => gw.Matchups)
+                .FirstOrDefault(x => x.SeasonWeekId == seasonWeekId);
+
+            savedGroupWeek.Should().NotBeNull();
+            savedGroupWeek!.Matchups.Should().HaveCount(2);
+            savedGroupWeek.Matchups.Select(m => m.StartDateUtc).Should().BeEquivalentTo(new[]
+            {
+                windowStart,
+                new DateTime(2024, 12, 1, 19, 0, 0, DateTimeKind.Utc),
+            });
+        }
+
+        /// <summary>
+        /// Open-ended lower bound: StartsOn is null, EndsOn is set. Matchups
+        /// after EndsOn are excluded; matchups on/before EndsOn are included.
+        ///
+        /// Uses an end-of-day EndsOn (23:59:59 on 2024-09-21) to match what
+        /// production handlers produce via CreateLeagueRequestBase.EffectiveEndsOn
+        /// when a date-only EndsOn is submitted — so a same-day matchup at 19:00
+        /// is still inside the window.
+        /// </summary>
+        [Fact]
+        public async Task Process_LeagueWindow_EndsOnOnly_ExcludesContestsAfterEnd()
+        {
+            // Arrange
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+            var conferenceSlug = "sec";
+
+            // End-of-day normalization mirrors what EffectiveEndsOn produces
+            // for a date-only EndsOn of 2024-09-21.
+            var windowEnd = new DateTime(2024, 9, 21, 23, 59, 59, DateTimeKind.Utc);
+
+            var group = Fixture.Build<PickemGroup>()
+                .With(x => x.Id, groupId)
+                .With(x => x.RankingFilter, () => TeamRankingFilter.AP_TOP_25)
+                .With(x => x.StartsOn, (DateTime?)null)
+                .With(x => x.EndsOn, (DateTime?)windowEnd)
+                .With(x => x.Conferences, new List<PickemGroupConference>
+                {
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = conferenceSlug, PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = DateTime.UtcNow, CreatedBy = Guid.Empty }
+                })
+                .Create();
+
+            await DataContext.PickemGroups.AddAsync(group);
+            await DataContext.SaveChangesAsync();
+
+            // Three SEC matchups: one well before, one same-day at 19:00 (inside
+            // the end-of-day window), one the following week. No StartsOn, so
+            // nothing trims from the bottom.
+            var sameDayEveningKickoff = new DateTime(2024, 9, 21, 19, 0, 0, DateTimeKind.Utc);
+            var allMatchups = new List<Matchup>
+            {
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, new DateTime(2024, 9, 1, 19, 0, 0, DateTimeKind.Utc))
+                    .Create(),
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, sameDayEveningKickoff)
+                    .Create(),
+                Fixture.Build<Matchup>()
+                    .With(x => x.AwayRank, (int?)null)
+                    .With(x => x.HomeRank, (int?)null)
+                    .With(x => x.AwayConferenceSlug, conferenceSlug)
+                    .With(x => x.HomeConferenceSlug, conferenceSlug)
+                    .With(x => x.StartDateUtc, new DateTime(2024, 9, 28, 19, 0, 0, DateTimeKind.Utc))
+                    .Create(),
+            };
+
+            _contestClientMock
+                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId,
+                seasonWeekId,
+                2024,
+                1,
+                false,
+                Guid.NewGuid());
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — matchup after window is excluded; before and boundary-day are included.
+            var savedGroupWeek = DataContext.PickemGroupWeeks
+                .Include(gw => gw.Matchups)
+                .FirstOrDefault(x => x.SeasonWeekId == seasonWeekId);
+
+            savedGroupWeek.Should().NotBeNull();
+            savedGroupWeek!.Matchups.Should().HaveCount(2);
+            savedGroupWeek.Matchups.Select(m => m.StartDateUtc).Should().BeEquivalentTo(new[]
+            {
+                new DateTime(2024, 9, 1, 19, 0, 0, DateTimeKind.Utc),
+                sameDayEveningKickoff,
+            });
+        }
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/TeamCard/Queries/GetTeamMetrics/GetTeamMetricsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/TeamCard/Queries/GetTeamMetrics/GetTeamMetricsQueryHandlerTests.cs
@@ -79,9 +79,11 @@ public class GetTeamMetricsQueryHandlerTests : UnitTestBase<GetTeamMetricsQueryH
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldReturnNotFound_WhenMetricsDoNotExist()
+    public async Task ExecuteAsync_ShouldReturnEmptyDto_WhenMetricsDoNotExist()
     {
-        // Arrange
+        // Metrics are a non-blocking enrichment surface — when the producer returns
+        // null we surface that as Success(empty DTO) so the UI renders a friendly
+        // empty state rather than a 500/NotFound.
         var franchiseSeasonId = Guid.NewGuid();
         var sport = Sport.FootballNcaa;
 
@@ -92,18 +94,21 @@ public class GetTeamMetricsQueryHandlerTests : UnitTestBase<GetTeamMetricsQueryH
         var handler = Mocker.CreateInstance<GetTeamMetricsQueryHandler>();
         var query = new GetTeamMetricsQuery { FranchiseSeasonId = franchiseSeasonId, Sport = sport };
 
-        // Act
         var result = await handler.ExecuteAsync(query);
 
-        // Assert
-        result.IsSuccess.Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.NotFound);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.FranchiseName.Should().BeNullOrEmpty();
+        result.Value.GamesPlayed.Should().Be(0);
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldReturnError_WhenExceptionThrown()
+    public async Task ExecuteAsync_ShouldReturnEmptyDto_WhenNonCancellationExceptionThrown()
     {
-        // Arrange
+        // A real producer-side error (network, missing sport client, etc.) also
+        // resolves to Success(empty DTO) rather than a hard failure so the UI
+        // stays graceful. The exception is logged at Error level elsewhere for
+        // ops visibility — we only validate the API contract here.
         var franchiseSeasonId = Guid.NewGuid();
         var sport = Sport.FootballNcaa;
 
@@ -114,11 +119,29 @@ public class GetTeamMetricsQueryHandlerTests : UnitTestBase<GetTeamMetricsQueryH
         var handler = Mocker.CreateInstance<GetTeamMetricsQueryHandler>();
         var query = new GetTeamMetricsQuery { FranchiseSeasonId = franchiseSeasonId, Sport = sport };
 
-        // Act
         var result = await handler.ExecuteAsync(query);
 
-        // Assert
-        result.IsSuccess.Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.Error);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.FranchiseName.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldRethrow_WhenOperationCanceled()
+    {
+        // Cancellation must propagate — the graceful catch is for non-cancel errors.
+        var franchiseSeasonId = Guid.NewGuid();
+        var sport = Sport.FootballNcaa;
+
+        _franchiseClientMock
+            .Setup(x => x.GetFranchiseSeasonMetricsByFranchiseSeasonId(franchiseSeasonId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var handler = Mocker.CreateInstance<GetTeamMetricsQueryHandler>();
+        var query = new GetTeamMetricsQuery { FranchiseSeasonId = franchiseSeasonId, Sport = sport };
+
+        var act = async () => await handler.ExecuteAsync(query);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
@@ -163,7 +163,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldReturnSeasonWeeksAscending_WhenMultipleWeeksExist()
+    public async Task ExecuteAsync_ShouldReturnSeasonWeeksAscendingAndDistinct_WhenMultipleWeeksExist()
     {
         // Arrange
         var userId = Guid.NewGuid();
@@ -219,6 +219,21 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
             Group = group
         };
 
+        // Duplicate SeasonWeek=5 row — distinct Id / SeasonWeekId but same week
+        // number. Mirrors the real-world case where a group can have multiple
+        // PickemGroupWeek rows for the same week (e.g. preseason and regular
+        // season both numbered 1, or rows carried forward across SeasonYears).
+        // Handler must dedupe; expected output remains [3, 5, 7].
+        var week4 = new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonYear = 2024,
+            SeasonWeek = 5,
+            SeasonWeekId = Guid.NewGuid(),
+            Group = group
+        };
+
         var membership = new PickemGroupMember
         {
             Id = Guid.NewGuid(),
@@ -231,11 +246,12 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         group.Weeks.Add(week1);
         group.Weeks.Add(week2);
         group.Weeks.Add(week3);
+        group.Weeks.Add(week4);
         user.GroupMemberships.Add(membership);
 
         await DataContext.Users.AddAsync(user);
         await DataContext.PickemGroups.AddAsync(group);
-        await DataContext.PickemGroupWeeks.AddRangeAsync([week1, week2, week3]);
+        await DataContext.PickemGroupWeeks.AddRangeAsync([week1, week2, week3, week4]);
         await DataContext.PickemGroupMembers.AddAsync(membership);
         await DataContext.SaveChangesAsync();
 
@@ -245,7 +261,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         // Act
         var result = await handler.ExecuteAsync(query);
 
-        // Assert
+        // Assert — 4 input rows [3, 7, 5, 5] → 3 output items, sorted + deduped.
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
         result.Value.Leagues.Should().HaveCount(1);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
@@ -159,11 +159,11 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         result.Value.Leagues.Should().HaveCount(1);
         result.Value.Leagues.First().Id.Should().Be(groupId);
         result.Value.Leagues.First().Name.Should().Be("Test League");
-        result.Value.Leagues.First().MaxSeasonWeek.Should().Be(5);
+        result.Value.Leagues.First().SeasonWeeks.Should().Equal(5);
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldCalculateMaxSeasonWeek_WhenMultipleWeeksExist()
+    public async Task ExecuteAsync_ShouldReturnSeasonWeeksAscending_WhenMultipleWeeksExist()
     {
         // Arrange
         var userId = Guid.NewGuid();
@@ -249,7 +249,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
         result.Value.Leagues.Should().HaveCount(1);
-        result.Value.Leagues.First().MaxSeasonWeek.Should().Be(7);
+        result.Value.Leagues.First().SeasonWeeks.Should().Equal(3, 5, 7);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

End-to-end multi-sport polish landed during MLB in-season testing, plus carry-over of earlier window-aware matchup + league-delete work from the branch.

### Multi-sport picks flow (primary value)
- `LeagueWeekMatchupsDto` now carries `Sport` and an authoritative `SeasonYear` sourced from `PickemGroupMatchup` (was `DateTime.UtcNow.Year`, which misrepresents football bowl season in January).
- Threads `leagueSport` + `leagueSeasonYear` from `PicksPage` → `MatchupList` → `MatchupCard` → `TeamRow` / `MiniSchedule` and the `useTeamComparison` / `useTeamSchedule` hooks. Team links, contest links, drill-down schedules, and team-comparison stats/metrics fetches all hit the correct sport/league/year route now.
- New `resolveSportLeague()` helper maps backend enum names (`FootballNcaa`, `FootballNfl`, `BaseballMlb`) to `{sport, league}` URL segments with safe fallback.
- `TeamComparison.css` locks dialog logo to 54×54 with `!important` + explicit `flex: 0 0 54px` so the global `.team-logo` rule in `TeamCard.css` (160 × 160 + `flex: 0 0 160px`) can no longer stretch dialog logos vertically.

### MLB data integrity
- `EventDocumentProcessorBase.GetSeasonWeekId` sanity-checks the ref-resolved SeasonWeek's date range against the event date and falls back to date-based inference when ESPN's MLB event doc's `week.$ref` resolves to a SeasonTypeWeek whose window doesn't contain the event. NFL / NCAAFB unaffected — their refs are consistent. New unit test `WhenWeekRefResolvesToOutOfRangeSeasonWeek_ShouldFallBackToDateInference` models the exact MLB scenario.
- `GetMatchupsByContestIds.sql` adds `COALESCE(fslXxx."Uri", flXxx."Uri")` — FranchiseSeasonLogo-first, FranchiseLogo fallback — matching `LogoSelectionService.SelectWithFallback` precedent so teams without a Franchise-level logo still render in the UI.

### League creation + detail
- Three create command handlers (`CreateBaseballMlbLeague`, `CreateFootballNcaaLeague`, `CreateFootballNflLeague`) now `Publish(ContestCreated)` **before** `SaveChangesAsync` so the EntityFrameworkOutbox actually commits the message.
- `LeagueDetailDto` exposes `StartsOn` / `EndsOn`; `LeagueDetail.jsx` renders a "League Window" row with `Full Season`, a date range, or `From`/`Through` labels for open-ended windows.
- `PickemGroupCreatedHandler` resolves the season client via `group.Sport` instead of hardcoded `FootballNcaa`, so MLB-created groups get MLB's current week.

### `SeasonWeeks` replaces `MaxSeasonWeek`
- `UserDto.UserLeagueMembership` swaps `MaxSeasonWeek int?` for `SeasonWeeks IList<int>` (ascending, distinct). Custom-window leagues like an MLB current-week-only pool now surface exactly their week list instead of `1..N`.
- `GetMeQueryHandler` gets `.AsSplitQuery()` (avoids EF's `MultipleCollectionIncludeWarning` now that a second collection is projected) and `.Distinct().OrderBy()` to dedupe weeks that occasionally repeat.
- `LeagueWeekSelector`, `PicksPage`, `GameMap`, `LeaderboardPage` all consume `seasonWeeks` directly.

### Graceful no-data for team metrics
- `GetTeamMetricsQueryHandler` returns `Success(empty DTO)` for both null producer responses and thrown exceptions. Metrics are a non-blocking enrichment surface; the UI should never see a 500 for missing stats.
- `useTeamComparison` switches from `Promise.all` to `Promise.allSettled` so one failed side doesn't collapse the dialog; `MatchupCard` renders a friendly empty-state card when neither team has stats or metrics yet.

## How to verify

- [x] `dotnet build` on Api + Producer — zero warnings / zero errors
- [x] `dotnet test` — 323 Api + 317 Producer tests pass
- [ ] Load `/app/picks/<mlb-league-id>` — links should route to `/app/sport/baseball/mlb/...` and default to the correct week from the league's `seasonWeeks`
- [ ] Click the comparison button on any matchup — URL should be `…/teamcard/sport/<sport>/league/<league>/team/<slug>/<year>/...`, and the dialog should either render metrics or show the empty-state card with a Close button
- [ ] Toggle the "last 5 games" icon on a team row — schedule drilldown should load without malformed URLs
- [ ] Check a football bowl-season league in January — `SeasonYear` on matchup responses should reflect the league's actual season year, not `now.Year`
- [ ] `/app/league/<any-league>` detail page — "League Window" row should show either `Full Season` or a date range

Mobile app changes held back for separate review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional league start/end date windows to define custom playing periods

* **Improvements**
  * UI uses exact league week lists (supports non-contiguous weeks) and snaps selection accordingly
  * Matchup views respect league date windows and show filtered counts
  * Team comparison shows explicit empty state and tolerates partial fetch failures
  * Navigation and layout improvements across League pages; direct "Create League" and back-link added
  * Matchup/team links now include sport/league context for correct drilldowns

* **Bug Fixes**
  * Prevents deleting leagues that contain user picks

* **Style**
  * Updated layout and header styles for leagues and league detail pages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->