### PR TITLE
feat: home-page tier scaffold, sport-agnostic nav, mobile form polish

### DIFF
--- a/src/UI/sd-ui/src/components/home/HomePage.css
+++ b/src/UI/sd-ui/src/components/home/HomePage.css
@@ -246,3 +246,138 @@ h2 {
   margin-bottom: 20px;
   font-size: 1.8rem;
 }
+
+/* =====================================================================
+   Tier-based landing (docs/post-login-landing-design.md)
+   Session 1: primary tier + stubs. Layout uses three stacked sections.
+   ===================================================================== */
+
+.home-page--loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 40vh;
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+/* Push the first tier below the fixed navigation on mobile. .main-content's
+   margin-top (60px) equals the nav height, but its mobile padding drops to
+   1rem — leaving the centered hero flush enough that mobile browser chrome
+   (collapsing URL bar, etc.) can bleed it under the nav. Explicit padding
+   here gives unconditional clearance. */
+@media (max-width: 768px) {
+  .home-page {
+    padding-top: 1rem;
+  }
+}
+
+.home-tier {
+  margin-bottom: 1.5rem;
+}
+
+/* One countdown phrase per line in the headline — reads more like a
+   scoreboard than a comma-separated list, and keeps both sports visually
+   weighted equally. */
+.home-primary__headline-line {
+  display: block;
+}
+
+.home-tier--stub {
+  display: none; /* hidden until session 2/3 fill it */
+}
+
+.home-primary {
+  background-color: var(--bg-card);
+  border: 1px solid var(--accent-subtle);
+  border-radius: 14px;
+  box-shadow: var(--shadow-lg);
+  padding: 2.5rem 2rem;
+  text-align: center;
+  color: var(--text-primary);
+  max-width: 880px;
+  /* Small top bump separates the banner from the nav/top-of-page edge
+     on desktop, where .main-content's 2rem padding alone felt flush. */
+  margin: 5px auto 0 auto;
+}
+
+.home-primary__eyebrow {
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.75rem;
+}
+
+.home-primary__headline {
+  color: var(--text-primary);
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem 0;
+  line-height: 1.2;
+}
+
+.home-primary__body {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.5;
+  margin: 0 auto 1.5rem auto;
+  max-width: 600px;
+}
+
+.home-primary__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.home-primary__cta {
+  display: inline-block;
+  padding: 0.7rem 1.5rem;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  white-space: nowrap;
+  transition: background-color 0.15s ease;
+}
+
+.home-primary__cta--primary {
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.home-primary__cta--primary:hover {
+  background-color: var(--accent-hover);
+}
+
+.home-primary__cta--secondary {
+  background-color: transparent;
+  color: var(--accent);
+  border: 1.5px solid var(--accent);
+}
+
+.home-primary__cta--secondary:hover {
+  background-color: var(--accent-subtle);
+}
+
+.home-primary__cta:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .home-primary {
+    padding: 1.75rem 1.25rem;
+  }
+
+  .home-primary__headline {
+    font-size: 1.5rem;
+  }
+
+  .home-primary__body {
+    font-size: 0.95rem;
+  }
+}

--- a/src/UI/sd-ui/src/components/home/HomePage.jsx
+++ b/src/UI/sd-ui/src/components/home/HomePage.jsx
@@ -1,122 +1,57 @@
-import { useState, useEffect } from "react";
-import PickAccuracyWidget from "../widgets/PickAccuracyWidget";
-import AiAccuracyWidget from "../widgets/AiAccuracyWidget";
-import FeaturedArticleCard from "./FeaturedArticleCard";
-
-import TipWeekWidget from "../widgets/TipWeekWidget";
-import NewsWidget from "../widgets/NewsWidget";
-import LeaderboardWidget from "../widgets/LeaderboardWidget";
-import PickRecordWidget from "../widgets/PickRecordWidget";
-import AiRecordWidget from "../widgets/AiRecordWidget";
 import "./HomePage.css";
 import { useUserDto } from "../../contexts/UserContext";
-import apiWrapper from "../../api/apiWrapper.js";
-import SystemNews from "./SystemNews";
-import RankingsWidget from "../widgets/RankingsWidget";
-import LeagueMembership from "./LeagueMembership";
+import PrimarySlotNewUser from "./PrimarySlotNewUser";
+import PrimarySlotOffSeasonCountdown from "./PrimarySlotOffSeasonCountdown";
 
+/**
+ * Post-login landing — date-aware, segment-aware.
+ *
+ * Design reference: docs/post-login-landing-design.md
+ *
+ * Three tiers:
+ *   Tier 1 (primary) — the single "next action" for this user.
+ *   Tier 2 (context) — sport-specific context cards. Stubbed this session.
+ *   Tier 3 (secondary) — compact adjacent surfaces. Stubbed this session.
+ *
+ * Session 1 ships Tier 1 with two of the seven rules wired up:
+ *   - New user (no leagues)       → PrimarySlotNewUser
+ *   - Fallback (any other state)  → PrimarySlotOffSeasonCountdown
+ *
+ * Covers every real user today (April 2026: NCAAFB + NFL are off-season;
+ * MLB is dev-only, not product-facing). Remaining rules — pick deadline
+ * within 48h, new matchups available, standings delta, commissioner
+ * action pending, welcome-back fallback — land in session 2 once we
+ * have per-league deadline data plumbed through /user/me or a new
+ * dashboard endpoint.
+ */
 function HomePage() {
-  const [pickGroups, setPickGroups] = useState([]); // Array of league DTOs
-  const [syntheticDto, setSyntheticDto] = useState(null);
   const { userDto, loading: userLoading } = useUserDto();
-  const [loadingPickAccuracy, setLoadingPickAccuracy] = useState(true);
-
-  useEffect(() => {
-    async function fetchPickAccuracy() {
-      setLoadingPickAccuracy(true);
-      try {
-        const response = await apiWrapper.Picks.getAccuracyChartForUser();
-        setPickGroups(response.data || []);
-  // No need to set selectedGroup; selection is now handled in PickAccuracyWidget
-      } catch (e) {
-        setPickGroups([]);
-      } finally {
-        setLoadingPickAccuracy(false);
-      }
-    }
-    fetchPickAccuracy();
-  }, []);
-
-
-  useEffect(() => {
-    async function fetchSyntheticAccuracy() {
-      try {
-        const response = await apiWrapper.Picks.getAccuracyChartForSynthetic();
-        setSyntheticDto(response.data || null);
-      } catch (e) {
-        setSyntheticDto(null);
-      }
-    }
-    fetchSyntheticAccuracy();
-  }, []);
 
   if (userLoading) {
-    return <div>Loading your dashboard...</div>;
+    return <div className="home-page home-page--loading">Loading…</div>;
   }
 
-  console.log("userDto:", userDto);
+  const hasLeagues = Array.isArray(userDto?.leagues) && userDto.leagues.length > 0;
 
-  // Determine if user is new (no leagues joined yet)
-  const isNewUser = !userDto?.leagues || userDto.leagues.length === 0;
+  // Rule resolver for Tier 1. Add cases here as session 2 lands — pick
+  // deadlines, standings deltas, etc. — keeping the cascade top-down so
+  // the most-urgent state always wins.
+  const renderPrimary = () => {
+    if (!hasLeagues) return <PrimarySlotNewUser />;
+    return <PrimarySlotOffSeasonCountdown />;
+  };
 
   return (
     <div className="home-page">
-      <SystemNews />
-
-      {/* Show LeagueMembership at top for new users as CTA */}
-      {isNewUser && (
-        <section className="card-section">
-          <LeagueMembership />
-        </section>
-      )}
-
-      <section className="card-section">
-        <div className="card">
-          <NewsWidget />
-        </div>
+      <section className="home-tier home-tier--primary">
+        {renderPrimary()}
       </section>
 
-      <section className="card-section">
-        <div className="card">
-          <RankingsWidget />
-        </div>
-      </section>
-      {/* Leaderboard + Your Stats */}
-      <section className="card-section">
-        <LeaderboardWidget />
-        <PickRecordWidget />
-        <AiRecordWidget />
-      </section>
+      {/* Tier 2 — context cards. Stub; session 2. */}
+      <section className="home-tier home-tier--context home-tier--stub" aria-hidden="true" />
 
-      {/* Show LeagueMembership in original position for existing users */}
-      {!isNewUser && (
-        <section className="card-section">
-          <LeagueMembership />
-        </section>
-      )}
-
-      <section className="card-section">
-        {/* Tips */}
-        <div className="card">
-          <TipWeekWidget />
-        </div>
-      </section>
-
-      <section className="chart-section">
-
-        <div className="card">
-          <PickAccuracyWidget leagues={pickGroups} />
-          {loadingPickAccuracy && <div style={{color:'#ffc107',textAlign:'center'}}>Loading pick accuracy...</div>}
-        </div>
-
-        <div className="card">
-          <AiAccuracyWidget syntheticDto={syntheticDto} />
-        </div>
-      </section>
-
-      <div className="card">
-        <FeaturedArticleCard />
-      </div>
+      {/* Tier 3 — compact secondary row. Stub; session 3. */}
+      <section className="home-tier home-tier--secondary home-tier--stub" aria-hidden="true" />
     </div>
   );
 }

--- a/src/UI/sd-ui/src/components/home/PrimarySlotNewUser.jsx
+++ b/src/UI/sd-ui/src/components/home/PrimarySlotNewUser.jsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+
+/**
+ * Tier 1 primary slot — shown when the signed-in user has no league
+ * memberships yet. Single, unambiguous CTA into league creation.
+ *
+ * Part of the date-aware / segment-aware landing design in
+ * docs/post-login-landing-design.md.
+ */
+function PrimarySlotNewUser() {
+  return (
+    <div className="home-primary home-primary--new-user">
+      <div className="home-primary__eyebrow">Welcome to sportDeets</div>
+      <h1 className="home-primary__headline">Pick the 2026 season with friends</h1>
+      <p className="home-primary__body">
+        Start your own pick'em league in under a minute, or browse public leagues
+        to join one.
+      </p>
+      <div className="home-primary__actions">
+        <Link to="/app/league/create" className="home-primary__cta home-primary__cta--primary">
+          Create a league
+        </Link>
+        <Link to="/app/league/discover" className="home-primary__cta home-primary__cta--secondary">
+          Browse public leagues
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default PrimarySlotNewUser;

--- a/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
+++ b/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
@@ -1,0 +1,104 @@
+import { Link } from "react-router-dom";
+
+/**
+ * Tier 1 primary slot — fallback shown when the user has at least one
+ * league but no sport they care about is currently in-season. Surfaces
+ * per-sport countdowns so users can see how close each product-focus
+ * sport is to kickoff and spin up leagues ahead of time.
+ *
+ * Kickoff dates are hard-coded constants; revisit when ESPN publishes
+ * each sport's official schedule if the dates shift.
+ *
+ * Seasonal calendar reference: docs/post-login-landing-design.md.
+ */
+
+const SPORTS = [
+  // NCAAFB opens first weekend of September (always). `sportEnum` is the
+  // value LeagueCreatePage reads from ?sport= to preselect the sport tab.
+  {
+    key: "NCAAFB",
+    label: "NCAAFB",
+    kickoff: new Date(Date.UTC(2026, 8, 5)),
+    sportEnum: "FootballNcaa",
+  },
+  // NFL opens the Thursday after Labor Day (Kickoff Thursday).
+  {
+    key: "NFL",
+    label: "NFL",
+    kickoff: new Date(Date.UTC(2026, 8, 10)),
+    sportEnum: "FootballNfl",
+  },
+];
+
+function daysUntil(targetUtc, nowMs = Date.now()) {
+  const msPerDay = 1000 * 60 * 60 * 24;
+  return Math.ceil((targetUtc.getTime() - nowMs) / msPerDay);
+}
+
+function sportPhrase(sport, nowMs) {
+  const days = daysUntil(sport.kickoff, nowMs);
+  if (days <= 0) return { status: "live", text: `${sport.label} is underway` };
+  return { status: "upcoming", text: `${sport.label} in ${days} ${days === 1 ? "day" : "days"}` };
+}
+
+function PrimarySlotOffSeasonCountdown() {
+  const nowMs = Date.now();
+  const sportsWithPhrases = SPORTS.map((s) => ({ ...s, phrase: sportPhrase(s, nowMs) }));
+  const allLive = sportsWithPhrases.every((s) => s.phrase.status === "live");
+
+  // Headline strategy:
+  //   - All sports kicked off → "Picks are live" mode, drive users to picks.
+  //   - Any sport still upcoming → render each sport's phrase on its own
+  //     line so both countdowns carry equal visual weight and read like a
+  //     scoreboard rather than a comma-run-on.
+  const headline = allLive
+    ? "NCAAFB and NFL are underway — pick your week"
+    : sportsWithPhrases.map((s) => (
+        <span key={s.key} className="home-primary__headline-line">{s.phrase.text}</span>
+      ));
+
+  const body = allLive
+    ? "Jump into your leagues and lock in your picks before the next kickoff."
+    : "Spin up your 2026 pick'em league now so you're ready for Week 1.";
+
+  // CTAs — per-sport when any sport is still upcoming, single collapsed
+  // button when all sports are live. For a sport that's already live, the
+  // CTA routes to unified picks (no need to dedup — the picks page shows
+  // all leagues the user belongs to). For an upcoming sport, link to league
+  // creation with ?sport= so LeagueCreatePage preselects the correct tab.
+  const renderActions = () => {
+    if (allLive) {
+      return (
+        <Link to="/app/picks" className="home-primary__cta home-primary__cta--primary">
+          Go to picks
+        </Link>
+      );
+    }
+
+    return sportsWithPhrases.map((s) => {
+      const isLive = s.phrase.status === "live";
+      return (
+        <Link
+          key={s.key}
+          to={isLive ? "/app/picks" : `/app/league/create?sport=${s.sportEnum}`}
+          className="home-primary__cta home-primary__cta--primary"
+        >
+          {isLive ? `Pick ${s.label} games` : `Create ${s.label} league`}
+        </Link>
+      );
+    });
+  };
+
+  return (
+    <div className="home-primary home-primary--countdown">
+      <div className="home-primary__eyebrow">2026 Season</div>
+      <h1 className="home-primary__headline">{headline}</h1>
+      <p className="home-primary__body">{body}</p>
+      <div className="home-primary__actions">
+        {renderActions()}
+      </div>
+    </div>
+  );
+}
+
+export default PrimarySlotOffSeasonCountdown;

--- a/src/UI/sd-ui/src/components/layout/Navigation.jsx
+++ b/src/UI/sd-ui/src/components/layout/Navigation.jsx
@@ -2,7 +2,7 @@
 import { NavLink } from 'react-router-dom';
 import {
   FaHome,
-  FaFootballBall,
+  FaClipboardCheck,
   FaTrophy,
   FaComments,
   FaCog,
@@ -40,7 +40,7 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
               <span>War Room</span>
             </NavLink>
             <NavLink to="/app/picks" className="nav-link" onClick={handleNavLinkClick}>
-              <FaFootballBall className="nav-icon" />
+              <FaClipboardCheck className="nav-icon" />
               <span>Picks</span>
             </NavLink>
             <NavLink to="/app/leaderboard" className="nav-link" onClick={handleNavLinkClick}>
@@ -109,7 +109,7 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
               </td>
               <td>
                 <NavLink to="/app/picks" className="nav-link">
-                  <FaFootballBall className="nav-icon" />
+                  <FaClipboardCheck className="nav-icon" />
                   <span>Picks</span>
                 </NavLink>
               </td>

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.css
@@ -29,9 +29,89 @@
 }
 
 @media (max-width: 600px) {
+  .league-create-container {
+    /* Give the container less horizontal padding so the card itself can
+       carry the breathing room instead — more consistent look than a
+       thick outer gap with content flush-left inside the card. */
+    padding: 12px;
+  }
+
   .league-create-container .card {
-    padding-left: 0;
-    padding-right: 0;
+    /* Keep horizontal padding on mobile (was 0, which left form labels
+       and inputs sitting flush against the card border). 1rem matches
+       typical mobile form padding and stays narrower than the desktop
+       2rem so the viewport isn't too cramped. */
+    padding: 1.25rem 1rem;
+  }
+
+  .league-form {
+    /* Tight stack: minimal gap between form-groups so the 8-ish fields
+       don't force excessive scrolling on a phone viewport. */
+    gap: 0.65rem;
+  }
+
+  .form-group label {
+    /* Pull label closer to its input — 0.5rem desktop value leaves an
+       obvious air gap that isn't worth the real estate on mobile. */
+    margin-bottom: 0.15rem;
+  }
+
+  /* Shrink input padding on mobile. 0.6rem top/bottom (~9.6px each side)
+     pays off on desktop where fields are generous; on a phone stack it's
+     an extra ~20px per field that adds up fast across 8+ fields. */
+  .league-create-container input[type="text"],
+  .league-create-container textarea,
+  .league-create-container select {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.95rem;
+  }
+
+  /* Description textarea defaults to min-height: 80px site-wide —
+     shorter here since it's an optional field and users rarely need
+     3 lines of description up front. Still resizable via the corner. */
+  .league-create-container textarea {
+    min-height: 56px;
+  }
+
+  /* Compact the page header so the form starts higher up the viewport. */
+  .league-create-container h1 {
+    font-size: 1.4rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .league-create-container > p {
+    font-size: 0.9rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Tighter card — less top/bottom padding, zero bottom margin since
+     the submit button lives inside the card and nothing follows. */
+  .league-create-container .card {
+    padding: 0.85rem 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Sport selector (NCAA/NFL/MLB tabs) — shrink the gap under it so
+     the first form field sits right below. */
+  .sport-selector {
+    margin-bottom: 0.75rem;
+  }
+
+  /* Reclaim more space in the form-group stack. */
+  .league-form {
+    gap: 0.5rem;
+  }
+
+  /* Checkbox section (Teams Included) has its own inner padding that
+     stacks on top of the card's padding — thin it out so the nested
+     card doesn't double up whitespace. */
+  .checkbox-section {
+    padding: 0.5rem 0.65rem;
+    gap: 0.5rem;
+  }
+
+  .checkbox-section h4 {
+    margin: 0 0 0.25rem 0;
   }
 }
 

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import apiWrapper from "../../api/apiWrapper.js";
 import { useUserDto } from "../../contexts/UserContext";
 
@@ -70,9 +70,23 @@ const DURATION_FULL = "full";
 const DURATION_WEEKS = "weeks";
 const DURATION_DATES = "dates";
 
+// Backend Sport enum values accepted via the `?sport=` query param.
+// Anything not in this set falls back to the NCAA default.
+const VALID_SPORT_PARAMS = new Set([SPORT_NCAA, SPORT_NFL, SPORT_MLB]);
+
 const LeagueCreatePage = () => {
   const { userDto, refreshUserDto } = useUserDto();
-  const [sport, setSport] = useState(SPORT_NCAA);
+  const [searchParams] = useSearchParams();
+  // Preselect the sport tab when the landing page (or any other caller)
+  // deep-links here with ?sport=FootballNcaa / FootballNfl / BaseballMlb.
+  // MLB is currently admin-gated, but honoring it here is harmless — the
+  // segmented control below hides the MLB tab for non-admins and falls
+  // back to the default selection via the sport-change effect.
+  const initialSport = (() => {
+    const raw = searchParams.get("sport");
+    return raw && VALID_SPORT_PARAMS.has(raw) ? raw : SPORT_NCAA;
+  })();
+  const [sport, setSport] = useState(initialSport);
   const [leagueName, setLeagueName] = useState("");
   const [description, setDescription] = useState("");
   const [pickType, setPickType] = useState("");


### PR DESCRIPTION
## Summary

Three related UI changes, all frontend-only.

### Home-page tier scaffold (session 1 of a multi-session rebuild)
Replaces the static widget-soup home page (2025 NCAAFB poll, CFB bracket, 11 unconditional widgets) with a three-tier layout per [docs/post-login-landing-design.md](https://github.com/jrandallsexton/sports-data-core/blob/main/docs/post-login-landing-design.md). Session 1 wires Tier 1 with two rules that cover every real user state today (NCAAFB and NFL off-season, MLB dev-only):

- **New user (no leagues)** → `PrimarySlotNewUser` hero with "Create a league" + "Browse public leagues" CTAs.
- **Any other state (fallback)** → `PrimarySlotOffSeasonCountdown` surfacing per-sport countdowns ("NCAAFB in 136 days", "NFL in 141 days" stacked on their own lines) with sport-specific deep-link CTAs.

Tier 2 and Tier 3 are `display: none` stubs for sessions 2 and 3. The 11 legacy widget imports are stripped from `HomePage.jsx`; the widget source files themselves are untouched so nothing is irreversibly deleted.

### Sport-agnostic nav
`FaFootballBall` → `FaClipboardCheck` on the Picks nav entry (both top-nav and side-nav). Sets the pattern for future PGA/NBA/NHL onboarding. Public/marketing surfaces (`HowItWorks.jsx` et al.) stay football-scoped deliberately.

### LeagueCreatePage
- Reads `?sport=FootballNcaa` / `FootballNfl` / `BaseballMlb` from the URL and preselects the sport tab on mount (deep-link target of the new countdown CTAs). Falls back to NCAA default.
- Aggressive mobile CSS compression — the zero-horizontal-padding-on-mobile bug (pre-existing) is fixed, and vertical spacing is tightened across `form-group` gap, label margin, input padding, textarea min-height, header font-size, and checkbox-section padding. ~260px of vertical space reclaimed on a phone viewport. Desktop unchanged.

## How to verify

- [ ] `/app/` — logged-in user with leagues sees the dual-sport countdown hero with CTAs linking to `/app/league/create?sport=FootballNcaa` and `?sport=FootballNfl`. No leagues → new-user hero.
- [ ] Click "Create NFL league" → LeagueCreatePage opens with NFL tab preselected (not NCAA).
- [ ] Open `/app/league/create` on a phone viewport or Chrome DevTools mobile emulation — form fields have visible horizontal padding from the card border, reduced inter-group vertical spacing.
- [ ] Nav "Picks" entry shows a clipboard-check icon, not a football.

## Deferred (not in this PR)
- Tier 1 rules 1-5 (pick deadline, new matchups, standings delta, commissioner pending, welcome-back) — session 2.
- Tier 2 context cards + Tier 3 compact row — sessions 2-3.
- Legacy widget file deletions — session 3 once we know which widgets earn re-integration.
- Mobile app league-creation parity — separate scoped work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned post-login home page with contextual sections tailored for new and established users
  * Added sport-specific season countdowns with live pick status indicators
  * Deep-link support to preset sport selection when creating leagues

* **Improvements**
  * Enhanced mobile responsiveness on league creation page
  * Updated Picks navigation icon for improved visual clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->