### PR TITLE
feat: deactivate flag on PickemGroup, filter /user/me to active leagues

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
@@ -27,7 +27,11 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
         CancellationToken cancellationToken = default)
     {
         var leagues = await _dbContext.PickemGroupMembers
+            .AsNoTracking()
             .Where(m => m.UserId == query.UserId)
+            // Hide deactivated leagues — matches the filter on /user/me. A future
+            // "Past Seasons" endpoint will surface the excluded rows explicitly.
+            .Where(m => m.Group.DeactivatedUtc == null)
             .Include(m => m.Group)
             .Select(m => new LeagueSummaryDto
             {

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -53,6 +53,12 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                 IsAdmin = user.IsAdmin || user.Id == _config.UserIdSystem,
                 IsReadOnly = user.IsReadOnly,
                 Leagues = user.GroupMemberships
+                    // Hide deactivated leagues (season-long leagues that ended,
+                    // short-lived leagues past their window, commissioner-closed
+                    // leagues). PickemGroup.DeactivatedUtc is stamped manually
+                    // today; a background job will automate it later. A future
+                    // "Past Seasons" endpoint can surface the excluded rows.
+                    .Where(m => m.Group.DeactivatedUtc == null)
                     .Select(m => new UserDto.UserLeagueMembership
                     {
                         Id = m.Group.Id,

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
@@ -50,6 +50,15 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         /// </summary>
         public DateTime? EndsOn { get; set; }
 
+        /// <summary>
+        /// When set, the league is inactive: season-long leagues that have completed,
+        /// short-lived leagues whose window has passed, or leagues a commissioner closed
+        /// early. Null = active. Active-only queries (e.g. /user/me) filter on this.
+        /// Populated manually today; a background job will eventually stamp it once all
+        /// contests in the league have finalized.
+        /// </summary>
+        public DateTime? DeactivatedUtc { get; set; }
+
         public Guid CommissionerUserId { get; set; }
 
         public User CommissionerUser { get; set; } = default!;

--- a/src/SportsData.Api/Migrations/20260422223831__22AprV1_PickemGroupDeactivated.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260422223831__22AprV1_PickemGroupDeactivated.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260422223831__22AprV1_PickemGroupDeactivated")]
+    partial class _22AprV1_PickemGroupDeactivated
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260422223831__22AprV1_PickemGroupDeactivated.cs
+++ b/src/SportsData.Api/Migrations/20260422223831__22AprV1_PickemGroupDeactivated.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class _22AprV1_PickemGroupDeactivated : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeactivatedUtc",
+                table: "PickemGroup",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeactivatedUtc",
+                table: "PickemGroup");
+        }
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandlerTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Leagues.Queries.GetUserLeagues;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Queries.GetUserLeagues;
+
+public class GetUserLeaguesQueryHandlerTests : ApiTestBase<GetUserLeaguesQueryHandler>
+{
+    [Fact]
+    public async Task ExecuteAsync_ShouldExcludeDeactivatedLeagues()
+    {
+        // Arrange — one active and one deactivated membership for the same user.
+        // Regression guard: without the DeactivatedUtc filter the handler would
+        // return both rows, leaking stale prior-season leagues into the UI.
+        var userId = Guid.NewGuid();
+
+        var user = new UserEntity
+        {
+            Id = userId,
+            FirebaseUid = "firebase-dead-league",
+            Email = "u@example.com",
+            DisplayName = "U",
+            SignInProvider = "password",
+            EmailVerified = true,
+            CreatedUtc = DateTime.UtcNow.AddDays(-30),
+            LastLoginUtc = DateTime.UtcNow
+        };
+
+        var activeGroup = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Active League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF
+        };
+
+        var deactivatedGroup = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Last Season",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            DeactivatedUtc = DateTime.UtcNow.AddDays(-7)
+        };
+
+        var activeMembership = new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = activeGroup.Id,
+            User = user,
+            Group = activeGroup
+        };
+
+        var deactivatedMembership = new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = deactivatedGroup.Id,
+            User = user,
+            Group = deactivatedGroup
+        };
+
+        user.GroupMemberships.Add(activeMembership);
+        user.GroupMemberships.Add(deactivatedMembership);
+
+        await DataContext.Users.AddAsync(user);
+        await DataContext.PickemGroups.AddRangeAsync(activeGroup, deactivatedGroup);
+        await DataContext.PickemGroupMembers.AddRangeAsync(activeMembership, deactivatedMembership);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetUserLeaguesQueryHandler>();
+        var query = new GetUserLeaguesQuery { UserId = userId };
+
+        // Act
+        var result = await handler.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Should().HaveCount(1);
+        result.Value.Single().Id.Should().Be(activeGroup.Id);
+        result.Value.Single().Name.Should().Be("Active League");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds nullable `PickemGroup.DeactivatedUtc` — populated = inactive league (season-long leagues that ended, short-lived leagues past their window, commissioner-closed leagues).
- `/user/me` now filters league memberships where `DeactivatedUtc IS NULL` so returning users no longer see prior-season leagues surface as "active."
- No UI-facing API shape change on `UserLeagueMembership`; mobile/web clients see only active leagues without needing knowledge of the new field.

## Why
Unblocks the mobile Tier 2 "Your Leagues" home card (incoming separate PR) — it was going to light up with stale 2025 leagues without a server-side filter. Also sets up the field a future background job will flip when all contests in a league have finalized. Design rationale discussed in session: single nullable timestamp instead of a status enum — one mechanism handles season-long, short-lived, and commissioner-closed cases.

## Out of scope (deliberately deferred)
- `?includeHistorical=true` query param + "Past Seasons" viewer — will land when we have a destination for it.
- Commissioner "end my league" UI — statuses flip manually via SQL until a deactivation job or UI lands.
- Background job that auto-stamps `DeactivatedUtc` once all contests finalize — captured as future work.

## Test plan
- [x] Migration applies cleanly to local Postgres.
- [x] `dotnet build` clean across Core + Api.
- [x] `GetMe` unit tests pass (6/6).
- [ ] Manually flip `DeactivatedUtc` on a test row in staging; confirm `/user/me` drops the league.
- [ ] Confirm mobile/web still render correctly with zero active leagues (new-user primary slot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Leagues can now be marked as deactivated and will be excluded from user profile views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->