### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-about.yml
+++ b/.github/workflows/deploy-about.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{ secrets.ACR_CREDENTIALS }}
 
@@ -117,7 +117,7 @@ jobs:
           echo "Latest Jobs Dashboard tag: $LATEST_TAG"
 
       - name: Checkout sports-data-config repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: jrandallsexton/sports-data-config
           token: ${{ secrets.GH_PAT }}
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sports-data repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/deploy-services-prod.yml
+++ b/.github/workflows/deploy-services-prod.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sports-data-config repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: jrandallsexton/sports-data-config
           token: ${{ secrets.GH_PAT }}
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sports-data repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Summary
GitHub is removing Node 20 from runners on **2026-09-16** (forced switch to Node 24 on **2026-06-02**). The warning surfaced on recent workflow runs flagged two actions still pinned to Node 20 releases:

- `actions/checkout@v4` → **`v5`** (6 occurrences across all 4 workflows)
- `azure/login@v1` → **`v2`** (1 occurrence in `deploy-services-prod-auto.yml`)

## Compatibility
- `actions/checkout@v5` — pure Node-runtime bump, no API changes.
- `azure/login@v2` — the v1→v2 breaking change was around federated identity auth-type selection. Our workflow uses the service-principal JSON pattern (`creds: ${{ secrets.ACR_CREDENTIALS }}`), which v2 still accepts unchanged. No config edits needed.

## Not flagged
`actions/setup-dotnet@v4` and `actions/setup-node@v4` appear in our workflows but aren't in the warning — those maintainers have already published Node 24-compatible builds under the v4 tag, so they continue to work.

## Test plan
- [ ] Next `deploy-services-prod-auto` run exercises both updated actions end-to-end.
- [ ] `ci-mobile` next push run exercises `checkout@v5` + `setup-node@v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions across build and deployment workflows to newer stable releases for improved reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->