### PR TITLE
chore(ci): bump azure/login to v3 for Node 24 compatibility

### DIFF
--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.ACR_CREDENTIALS }}
 


### PR DESCRIPTION
## Summary
Follow-up to #275. `azure/login@v2` turned out to still be pinned to Node 20 — the deprecation warning re-surfaced on the next deploy run. Azure published `v3.0.0` as the Node 20→24 bump:

> Upgrade nodejs from 20 to 24 and update dependencies

([release notes](https://github.com/Azure/login/releases/tag/v3.0.0))

No API changes; drop-in replacement for the service-principal JSON `creds` input our workflow uses.

## Test plan
- [ ] Next `deploy-services-prod-auto` run no longer emits the Node 20 deprecation warning and authenticates to ACR successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure configuration for improved reliability and compatibility with cloud services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->