### PR TITLE
feat(mlb): sport-aware odds routing + local-docker dev path + cross-service correlation

### DIFF
--- a/bruno/espn/BaseballMlb - Event.yml
+++ b/bruno/espn/BaseballMlb - Event.yml
@@ -1,18 +1,16 @@
 info:
-  name: GolfPga - Venues
+  name: BaseballMlb - Event
   type: http
-  seq: 25
+  seq: 2
 
 http:
   method: GET
-  url: http://sports.core.api.espn.com/v2/sports/golf/leagues/pga/venues?lang=en&limit=999
+  url: http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815080?lang=en
   params:
     - name: lang
       value: en
       type: query
-    - name: limit
-      value: "999"
-      type: query
+  auth: inherit
 
 settings:
   encodeUrl: true

--- a/bruno/espn/BaseballMlb - EventCompetition.yml
+++ b/bruno/espn/BaseballMlb - EventCompetition.yml
@@ -1,18 +1,16 @@
 info:
-  name: GolfPga - Venues
+  name: BaseballMlb - EventCompetition
   type: http
-  seq: 25
+  seq: 3
 
 http:
   method: GET
-  url: http://sports.core.api.espn.com/v2/sports/golf/leagues/pga/venues?lang=en&limit=999
+  url: http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815080/competitions/401815080?lang=en
   params:
     - name: lang
       value: en
       type: query
-    - name: limit
-      value: "999"
-      type: query
+  auth: inherit
 
 settings:
   encodeUrl: true

--- a/bruno/espn/BaseballMlb - FranchiseSeason.yml
+++ b/bruno/espn/BaseballMlb - FranchiseSeason.yml
@@ -1,18 +1,16 @@
 info:
-  name: GolfPga - Venues
+  name: BaseballMlb - FranchiseSeason
   type: http
-  seq: 25
+  seq: 4
 
 http:
   method: GET
-  url: http://sports.core.api.espn.com/v2/sports/golf/leagues/pga/venues?lang=en&limit=999
+  url: http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/1?lang=en
   params:
     - name: lang
       value: en
       type: query
-    - name: limit
-      value: "999"
-      type: query
+  auth: inherit
 
 settings:
   encodeUrl: true

--- a/bruno/espn/BaseballMlb - FranchiseSeasonEvents.yml
+++ b/bruno/espn/BaseballMlb - FranchiseSeasonEvents.yml
@@ -1,18 +1,19 @@
 info:
-  name: FootballNcaa - Franchises
+  name: BaseballMlb - FranchiseSeasonEvents
   type: http
-  seq: 12
+  seq: 5
 
 http:
   method: GET
-  url: http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/franchises?lang=en&limit=999
+  url: http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/1/events?lang=en&limit=900
   params:
     - name: lang
       value: en
       type: query
     - name: limit
-      value: "999"
+      value: "900"
       type: query
+  auth: inherit
 
 settings:
   encodeUrl: true

--- a/bruno/espn/BaseballMlb - FranchiseSeasons.yml
+++ b/bruno/espn/BaseballMlb - FranchiseSeasons.yml
@@ -1,18 +1,19 @@
 info:
-  name: FootballNcaa - Franchises
+  name: BaseballMlb - FranchiseSeasons
   type: http
-  seq: 12
+  seq: 7
 
 http:
   method: GET
-  url: http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/franchises?lang=en&limit=999
+  url: https://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams?lang=en&limit=900
   params:
     - name: lang
       value: en
       type: query
     - name: limit
-      value: "999"
+      value: "900"
       type: query
+  auth: inherit
 
 settings:
   encodeUrl: true

--- a/bruno/espn/BasketballNba - Athletes.yml
+++ b/bruno/espn/BasketballNba - Athletes.yml
@@ -1,7 +1,7 @@
 info:
   name: BasketballNba - Athletes
   type: http
-  seq: 2
+  seq: 8
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - Athlete.yml
+++ b/bruno/espn/FootballNcaa - Athlete.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - Athlete
   type: http
-  seq: 4
+  seq: 10
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - AthleteSeason.yml
+++ b/bruno/espn/FootballNcaa - AthleteSeason.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - AthleteSeason
   type: http
-  seq: 5
+  seq: 11
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - Athletes.yml
+++ b/bruno/espn/FootballNcaa - Athletes.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - Athletes
   type: http
-  seq: 3
+  seq: 9
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - GroupsBySeason.yml
+++ b/bruno/espn/FootballNcaa - GroupsBySeason.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - GroupsBySeason
   type: http
-  seq: 7
+  seq: 13
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - Seasons.yml
+++ b/bruno/espn/FootballNcaa - Seasons.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - Seasons
   type: http
-  seq: 8
+  seq: 14
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - TeamBySeason - LSU - Athletes.yml
+++ b/bruno/espn/FootballNcaa - TeamBySeason - LSU - Athletes.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - TeamBySeason - LSU - Athletes
   type: http
-  seq: 11
+  seq: 17
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - TeamBySeason - LSU.yml
+++ b/bruno/espn/FootballNcaa - TeamBySeason - LSU.yml
@@ -1,11 +1,11 @@
 info:
   name: FootballNcaa - TeamBySeason - LSU
   type: http
-  seq: 10
+  seq: 16
 
 http:
   method: GET
-  url: https://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/teams/99
+  url: https://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2026/teams/99
 
 settings:
   encodeUrl: true

--- a/bruno/espn/FootballNcaa - TeamsBySeason.yml
+++ b/bruno/espn/FootballNcaa - TeamsBySeason.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - TeamsBySeason
   type: http
-  seq: 9
+  seq: 15
 
 http:
   method: GET

--- a/bruno/espn/FootballNcaa - Venues.yml
+++ b/bruno/espn/FootballNcaa - Venues.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNcaa - Venues
   type: http
-  seq: 12
+  seq: 18
 
 http:
   method: GET

--- a/bruno/espn/FootballNfl - Athletes.yml
+++ b/bruno/espn/FootballNfl - Athletes.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNfl - Athletes
   type: http
-  seq: 13
+  seq: 19
 
 http:
   method: GET

--- a/bruno/espn/FootballNfl - Franchises.yml
+++ b/bruno/espn/FootballNfl - Franchises.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNfl - Franchises
   type: http
-  seq: 14
+  seq: 20
 
 http:
   method: GET

--- a/bruno/espn/FootballNfl - Venues.yml
+++ b/bruno/espn/FootballNfl - Venues.yml
@@ -1,7 +1,7 @@
 info:
   name: FootballNfl - Venues
   type: http
-  seq: 15
+  seq: 21
 
 http:
   method: GET

--- a/bruno/espn/Golf - Athletes.yml
+++ b/bruno/espn/Golf - Athletes.yml
@@ -1,7 +1,7 @@
 info:
   name: Golf - Athletes
   type: http
-  seq: 16
+  seq: 22
 
 http:
   method: GET

--- a/bruno/espn/GolfLiv - Athletes.yml
+++ b/bruno/espn/GolfLiv - Athletes.yml
@@ -1,7 +1,7 @@
 info:
   name: GolfLiv - Athletes
   type: http
-  seq: 17
+  seq: 23
 
 http:
   method: GET

--- a/bruno/espn/GolfPga - Athletes.yml
+++ b/bruno/espn/GolfPga - Athletes.yml
@@ -1,7 +1,7 @@
 info:
   name: GolfPga - Athletes
   type: http
-  seq: 18
+  seq: 24
 
 http:
   method: GET

--- a/bruno/folder.yml
+++ b/bruno/folder.yml
@@ -1,0 +1,6 @@
+info:
+  name: bruno
+  type: folder
+  seq: 34
+
+request: {}

--- a/bruno/producer/contest-update.yml
+++ b/bruno/producer/contest-update.yml
@@ -1,0 +1,20 @@
+info:
+  name: contest-update
+  type: http
+  seq: 14
+
+http:
+  method: POST
+  url: "{{baseUrlProducer}}/api/contests/846fd5ea-e8bd-aaad-e8d6-5812921ca35f/update"
+  headers:
+    - name: X-Admin-Token
+      value: "{{X-Admin-Token}}"
+  body:
+    type: json
+    data: ""
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/docker-compose.local.mlb.yml
+++ b/docker-compose.local.mlb.yml
@@ -49,8 +49,19 @@ x-common-env: &common-env
   # User/Password come from App Config separately and don't need overriding.
   SportsData.Provider__ProviderDocDatabaseConfig__ConnectionString: host.docker.internal
 
-# Reused by every Producer + Provider service. /dev/tcp probe on 8080 — no
-# curl/wget in the aspnet:10.0-noble base image.
+# Reused by every Producer + Provider service.
+#
+# IMPORTANT: This probe relies on bash's `/dev/tcp` pseudo-device — bash MUST
+# be present in the base image. Today every service builds on
+# `mcr.microsoft.com/dotnet/aspnet:10.0-noble`, which ships bash; the probe
+# was chosen specifically because that image ships *neither* curl *nor*
+# wget. If the base image is ever swapped to a chiseled / alpine / distroless
+# variant (none of which ship bash), this probe must be replaced — options:
+#   - install curl in the Dockerfile and use `curl -fsS http://127.0.0.1:8080/api/health/live`
+#   - use the dotnet runtime's `/api/health/live` endpoint via a dedicated
+#     healthcheck binary copied into the image
+#   - revert to a longer `start_period` and let dependent services tolerate
+#     missing healthchecks
 x-service-healthcheck: &service-healthcheck
   test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/127.0.0.1/8080"]
   interval: 5s

--- a/docker-compose.local.mlb.yml
+++ b/docker-compose.local.mlb.yml
@@ -7,7 +7,8 @@
 #
 # Why -mode is required even though the flag defaults to Sport.All: the runtime
 # sport switches in Producer/Provider Program.cs throw ArgumentOutOfRangeException
-# when mode is Sport.All. Container exits 139 at startup if you omit the flag.
+# when mode is Sport.All. The unhandled managed exception terminates the process
+# with exit code 1 at startup if you omit the flag.
 # Role *can* be omitted — it defaults to All and activates every role branch
 # via HasFlag checks, giving us api+ingest+worker in a single container.
 #
@@ -107,6 +108,13 @@ services:
       CommonConfig__ProviderClientConfig__ApiUrl: http://provider-mlb:8080/api/
     command: ["dotnet", "SportsData.Producer.dll", "-mode", "BaseballMlb"]
     healthcheck: *service-healthcheck
+    # Producer's image-fetch path (ProviderClient.GetExternalImage) hits
+    # provider-mlb during startup-warmed Hangfire jobs. Wait for the Provider
+    # to pass its healthcheck before starting Producer so we don't pile up
+    # retries against a not-yet-ready Provider on cold compose-up.
+    depends_on:
+      provider-mlb:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/docker-compose.local.mlb.yml
+++ b/docker-compose.local.mlb.yml
@@ -1,0 +1,172 @@
+# Local dev compose tailored for MLB in-season testing.
+#
+# Difference from docker-compose.local.yml:
+#   - NCAAFB / NFL: API-only Producer containers (sport-scoped, no Ingest/Worker)
+#   - MLB:          ONE Producer container, -mode BaseballMlb, no -role flag
+#                   ONE Provider container, -mode BaseballMlb, no -role flag
+#
+# Why -mode is required even though the flag defaults to Sport.All: the runtime
+# sport switches in Producer/Provider Program.cs throw ArgumentOutOfRangeException
+# when mode is Sport.All. Container exits 139 at startup if you omit the flag.
+# Role *can* be omitted — it defaults to All and activates every role branch
+# via HasFlag checks, giving us api+ingest+worker in a single container.
+#
+# Usage:
+#   docker compose -f docker-compose.local.mlb.yml up --build
+#
+# Prerequisites: same as docker-compose.local.yml (host PostgreSQL, RabbitMQ,
+# Seq, plus the .env file with APPCONFIG_CONNSTR / PG_CONNSTR / AZURE_*).
+#
+# Ports:
+#   API                http://localhost:5262
+#   Producer NCAA API  http://localhost:7040
+#   Producer NFL API   http://localhost:7041
+#   Producer MLB       http://localhost:7042 (api + ingest + worker, all sports)
+#   Provider MLB       http://localhost:7050 (all sports, all roles)
+
+x-common-env: &common-env
+  APPCONFIG_CONNSTR: ${APPCONFIG_CONNSTR}
+  APPCONFIG_LABEL: Local
+  ASPNETCORE_ENVIRONMENT: Development
+  ASPNETCORE_HTTP_PORTS: "8080"
+  AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+  AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+  AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+  CommonConfig__SqlBaseConnectionString: ${PG_CONNSTR}
+  CommonConfig__SeqUri: http://host.docker.internal:5341/
+  CommonConfig__Messaging__RabbitMq__Host: host.docker.internal
+  CommonConfig__Messaging__RabbitMq__ManagementApiBaseUrl: http://host.docker.internal:15672
+  # MongoDB runs on the host (Bender, not in Docker). The Provider's
+  # ProviderDocDatabaseConfig.ConnectionString is read from Azure App Config's
+  # Local label and is bound as the *host only* — the value in KV is just
+  # `localhost` for native VS debug. Inside a container that resolves to the
+  # container itself, so we override via the bridge alias. Bare hostname,
+  # NO port: MongoDocumentService passes this to `new MongoServerAddress(host)`
+  # which treats the entire string as the host and defaults port to 27017
+  # internally; appending `:27017` produces the invalid endpoint
+  # `host.docker.internal:27017:27017`.
+  # User/Password come from App Config separately and don't need overriding.
+  SportsData.Provider__ProviderDocDatabaseConfig__ConnectionString: host.docker.internal
+
+# Reused by every Producer + Provider service. /dev/tcp probe on 8080 — no
+# curl/wget in the aspnet:10.0-noble base image.
+x-service-healthcheck: &service-healthcheck
+  test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/127.0.0.1/8080"]
+  interval: 5s
+  timeout: 3s
+  retries: 12
+  start_period: 20s
+
+services:
+  # ─── NCAAFB Producer API (sport-scoped, single role) ────────────────────────
+  producer-ncaa-api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-ncaa-api
+    ports:
+      - "7040:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "FootballNcaa", "-role", "Api"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── NFL Producer API (sport-scoped, single role) ───────────────────────────
+  producer-nfl-api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-nfl-api
+    ports:
+      - "7041:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "FootballNfl", "-role", "Api"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── MLB Producer (-mode BaseballMlb, role defaults to All) ─────────────────
+  # Single container handles API + Ingest + Worker for MLB. -role omitted →
+  # ProducerRole.All → every HasFlag branch (Api, Ingest, Worker) activates.
+  producer-mlb:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-mlb
+    ports:
+      - "7042:8080"
+    environment:
+      <<: *common-env
+      # Provider's local-dev URL in App Config is http://localhost:5205/api/.
+      # Inside this container localhost is the container itself, so calls to
+      # Provider (e.g. ProviderClient.GetExternalImage during image processing)
+      # would refuse-connect. Route to the Provider container via Docker DNS.
+      CommonConfig__ProviderClientConfig__ApiUrl: http://provider-mlb:8080/api/
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "BaseballMlb"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── MLB Provider (-mode BaseballMlb, role defaults to All) ─────────────────
+  # One container handles ESPN sourcing + DocumentRequested fan-out for MLB.
+  # The new sport-aware EspnResourceIndexClassifier carve-out is what makes
+  # MLB odds flow correctly through this Provider.
+  provider-mlb:
+    build:
+      context: .
+      dockerfile: src/SportsData.Provider/Dockerfile
+    container_name: provider-mlb
+    ports:
+      - "7050:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Provider.dll", "-mode", "BaseballMlb"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── API (sport-keyed client URLs route per-sport requests) ─────────────────
+  api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Api/Dockerfile
+    container_name: api-all
+    ports:
+      - "5262:8080"
+    environment:
+      <<: *common-env
+      CommonConfig__ContestClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__ContestClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__ContestClientConfig__BaseballMlb__ApiUrl: http://producer-mlb:8080/api/
+      CommonConfig__FranchiseClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__FranchiseClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__FranchiseClientConfig__BaseballMlb__ApiUrl: http://producer-mlb:8080/api/
+      CommonConfig__ProducerClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__ProducerClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__ProducerClientConfig__BaseballMlb__ApiUrl: http://producer-mlb:8080/api/
+      CommonConfig__SeasonClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__SeasonClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__SeasonClientConfig__BaseballMlb__ApiUrl: http://producer-mlb:8080/api/
+      CommonConfig__VenueClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__VenueClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__VenueClientConfig__BaseballMlb__ApiUrl: http://producer-mlb:8080/api/
+      CommonConfig__PlayerClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__PlayerClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__PlayerClientConfig__BaseballMlb__ApiUrl: http://producer-mlb:8080/api/
+      CommonConfig__NotificationClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__NotificationClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__NotificationClientConfig__BaseballMlb__ApiUrl: http://producer-mlb:8080/api/
+    depends_on:
+      producer-ncaa-api:
+        condition: service_healthy
+      producer-nfl-api:
+        condition: service_healthy
+      producer-mlb:
+        condition: service_healthy
+      provider-mlb:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docs/CODEX_PROJECT_ASSESSMENT.md
+++ b/docs/CODEX_PROJECT_ASSESSMENT.md
@@ -1,0 +1,270 @@
+# Codex Project Assessment
+
+## Scope
+
+This is an outside-in assessment of `sports-data-core` after reviewing the repository layout, README, and a representative slice of the documentation in `docs/`.
+
+It is intentionally framed as a "good, bad, and ugly" read from a new contributor's perspective, not as a formal architecture review. It also acknowledges the broader platform boundary:
+
+- `sports-data-core` contains the application code
+- `sports-data-config` contains GitOps and cluster configuration
+- `sports-data-provision` contains infrastructure-as-code
+
+That matters because some of this project's strongest qualities only really make sense when viewed as part of all three repositories together.
+
+## Executive Summary
+
+This is a serious systems project disguised as a sports app.
+
+On the surface, it is a sports analytics and pick'em platform with web and mobile clients, live game state, league play, and AI-generated content. Underneath, it is a distributed sports data ingestion and normalization platform whose hardest problem is turning messy external provider data into a canonical domain model that downstream applications can trust.
+
+The most important thing I see is not "many services" or "many features." It is the amount of operational thinking embedded in the design:
+
+- provider quirks have dedicated handling
+- retries and dependency ordering are treated as first-class concerns
+- observability is part of the architecture, not an afterthought
+- deployment, config, and infrastructure are split into companion repos instead of being hand-waved
+
+That gives the project a realness that a lot of portfolio codebases do not have.
+
+## Companion Repositories
+
+After a light review of the companion repositories, the three-repo split looks coherent rather than arbitrary.
+
+### `sports-data-config`
+
+This repo reads like the GitOps and cluster-operations truth:
+
+- Flux-based deployment model
+- Kustomize overlays by environment
+- monitoring, logging, tracing, and ingress as first-class cluster concerns
+- environment setup and cluster migration/runbook-style documentation
+
+The strongest signal here is that the platform is not only deployed to Kubernetes, but thought about as a living cluster with operational workflows around it.
+
+### `sports-data-provision`
+
+This repo reads more like the infrastructure/bootstrap and utility layer:
+
+- environment directories for deployment targets
+- Bicep templates for service and SQL provisioning
+- a large utilities folder for environment lifecycle, backups, restores, local infra, and operational chores
+
+It feels less like a polished product repo and more like a practical operator's toolbox, which is often exactly what this layer should be.
+
+### Cross-Repo Read
+
+Taken together:
+
+- `sports-data-core` is application and domain behavior
+- `sports-data-config` is cluster/runtime desired state
+- `sports-data-provision` is provisioning and operational support
+
+That separation makes sense. It also confirms that the platform should be judged as a multi-repository system, not as an isolated app codebase.
+
+## The Good
+
+### 1. The project has a real center of gravity
+
+The platform has a clear architectural core: `Provider` acquires raw documents, `Producer` canonicalizes them, and the rest of the stack consumes the results. That is a much stronger identity than "a bunch of sports microservices."
+
+This matters because the codebase is solving a real hard problem:
+
+- ingesting third-party data with inconsistent structure
+- managing dependency ordering across related documents
+- preserving idempotency in an at-least-once delivery system
+- exposing the result to multiple product surfaces
+
+The docs around document processing, historical sourcing, retries, and live updates all point back to that same center.
+
+### 2. The project reflects operational experience, not just architectural ambition
+
+A lot of repos can describe outbox, retries, or observability. This one reads like it has needed them.
+
+The strongest indicators:
+
+- ESPN-specific rate-limit behavior is explicitly accounted for
+- dead-letter behavior is treated as intentional, not accidental
+- historical sourcing is designed around dependency ordering and retry-storm avoidance
+- correlation IDs, tracing, and logging conventions have dedicated documentation
+- GitOps and IaC are separated into companion repositories instead of being left implicit
+
+That is usually the difference between "I know the patterns" and "I have been forced to care how they behave in production."
+
+### 3. The platform balances pragmatism with ambition
+
+There is a healthy amount of "build the seam before the independence."
+
+Examples:
+
+- domain client boundaries exist even where services still route through Producer
+- multiple provider integrations are stubbed without pretending they are already real
+- mobile appears to be prioritized based on product reality rather than architectural purity
+- self-hosted Kubernetes plus Azure managed services is a practical cost and control compromise
+
+This is one of the more mature traits in the repo. It does not look like architecture for architecture's sake.
+
+### 4. The project is broader than most single-owner systems without feeling random
+
+There is a lot here:
+
+- ingestion
+- canonical modeling
+- messaging
+- API design
+- realtime updates
+- web UI
+- mobile UI
+- AI features
+- observability
+- deployment and infra discipline
+
+Normally that kind of breadth turns incoherent. Here, most of it still traces back to a single product and data story.
+
+### 5. The mobile effort changes the character of the project
+
+The mobile docs do not read like a novelty side quest. They read like the point where the platform tries to become the product it was always building toward.
+
+That is important because it shows the repo evolving from "impressive engineering artifact" toward "something people could actually live in."
+
+## The Bad
+
+### 1. Producer is both the strength and the risk
+
+`Producer` appears to be the gravitational center of the whole system, which is understandable, but it creates a concentration problem:
+
+- high entity count
+- large processor count
+- broad schema ownership
+- many downstream assumptions
+- documentation that repeatedly routes back to its behavior
+
+When one service becomes both transformation engine and canonical truth, it also becomes the place where complexity accumulates fastest. Even if that is the correct design right now, it raises the maintenance cost of almost every future change.
+
+### 2. The microservice story is ahead of the runtime reality
+
+The boundaries are meaningful, but several docs and the README effectively admit that the system is still partially centralized in practice.
+
+That is not a flaw by itself. The risk is that the codebase may pay some of the costs of microservice decomposition before receiving the full operational benefits of true data ownership separation.
+
+From a new contributor's viewpoint, that can create ambiguity around questions like:
+
+- what service really owns this behavior?
+- what is a stable boundary versus a migration seam?
+- where should new logic live today, not eventually?
+
+### 3. Documentation quality is uneven
+
+The docs contain real insight, but they are not equally trustworthy.
+
+What I observed:
+
+- some architecture docs are excellent and deeply informative
+- some indexes and catalogs reference files that do not exist
+- some documents are clearly planning artifacts or handoff notes rather than durable reference docs
+- there are signs of drift between older docs and the current repo state
+
+That means the documentation is valuable, but it still requires source-level validation before treating a document as canonical.
+
+### 4. The shared core is likely carrying a lot of coupling
+
+`SportsData.Core` is large, and the architecture leans heavily on it for clients, infrastructure, messaging, configuration, and shared abstractions.
+
+That is often the right move early and midstream. The tradeoff is that a powerful shared core can quietly become a distributed monolith's nervous system:
+
+- too much convenience
+- too much transitive coupling
+- too much ripple effect from "common" changes
+
+The risk is less conceptual purity and more change blast radius.
+
+### 5. Breadth creates maintenance drag
+
+The breadth is impressive, but it also means there are many fronts to keep warm:
+
+- multiple backend services
+- multiple frontends
+- docs
+- pipelines
+- infra repos
+- provider-specific behavior
+- tests and observability
+
+For a single-owner system, the challenge is not whether each area can be built. It is whether they can all stay current together without drift.
+
+## The Ugly
+
+### 1. External-provider complexity is permanently upstream of everything
+
+The system's deepest complexity does not originate inside the domain. It originates in the shape, reliability, and semantics of external sports data.
+
+That means a lot of the ugliest failure modes likely look like this:
+
+- missing dependencies
+- delayed sourcing
+- partial graph hydration
+- retries that are valid but noisy
+- idempotent reprocessing of provider changes
+- source-specific edge cases leaking into canonical processing
+
+This is not "bad code" ugly. It is "the world is ugly and your system has to metabolize it" ugly.
+
+### 2. Success depends on constant curation of architectural truth
+
+Because the platform spans code, GitOps, and IaC across three repos, understanding the real system requires aligning:
+
+- application behavior
+- deployment behavior
+- cluster configuration
+- managed service setup
+
+That is powerful, but it raises the tax on onboarding and diagnosis. The architecture is likely clear in your head because you built it, but a newcomer has to reconstruct it from multiple planes of truth.
+
+### 3. The hardest parts are the least glamorous parts
+
+What will likely consume the most energy over time is not feature work. It is all the unglamorous glue:
+
+- routing config correctly
+- keeping contracts synchronized
+- validating assumptions across services
+- controlling document-processing churn
+- keeping observability useful instead of noisy
+- preventing docs from drifting
+
+That is usually the signature of a real platform. It is also the part most likely to wear down a solo maintainer.
+
+### 4. The project is at risk of being underestimated by people who only see the UI
+
+This is a different kind of ugly, but a real one: the visible product surface does not fully communicate the sophistication of the underlying platform.
+
+Someone glancing at the web or mobile app might think "sports app." Someone reading the Producer and sourcing docs sees a distributed ingestion and canonicalization system with real operational nuance.
+
+That mismatch is not a technical defect, but it does affect how others evaluate the work.
+
+## Overall Read
+
+My honest read is that this is not a toy project, and it is not merely a portfolio exercise either.
+
+It feels like a platform that was built for genuine use, under real constraints, by someone who wanted the engineering to matter as much as the feature list. The strongest signal is not the number of technologies involved. It is the number of practical tradeoffs that appear to have been made consciously.
+
+If I had to summarize the project in one sentence:
+
+`sports-data-core` is a sports product on the outside, but its real achievement is a thoughtfully engineered data platform that absorbs the messiness of external sports data and turns it into something usable, observable, and extensible.
+
+## Validation Note
+
+I attempted to run solution-level validation in `sports-data-core`.
+
+- `dotnet build sports-data.sln` initially failed due to a sandboxed .NET first-run sentinel issue, not a compile error
+- after redirecting `DOTNET_CLI_HOME` into the workspace, the build still exited nonzero with `Build FAILED` but reported `0 Warning(s)` and `0 Error(s)`
+- `dotnet test sports-data.sln` did not complete successfully in the current environment and timed out on one run
+
+So I was not able to produce a trustworthy green build/test result from this session. That should be treated as environment-limited validation, not evidence that the solution itself is broken.
+
+## Suggested Follow-Up Work
+
+If this document is useful, the next high-value follow-ups would be:
+
+1. A "platform truth map" that explains what lives in `sports-data-core`, `sports-data-config`, and `sports-data-provision`, and where to look first for common operational questions.
+2. A "new contributor start here" doc that distinguishes durable reference docs from planning notes and historical artifacts.
+3. A "current architectural seams" doc that clearly states which service boundaries are fully real today versus which are intentional abstractions for future decomposition.

--- a/src/SportsData.Core/DependencyInjection/AppConfiguration.cs
+++ b/src/SportsData.Core/DependencyInjection/AppConfiguration.cs
@@ -167,6 +167,17 @@ namespace SportsData.Core.DependencyInjection
                     });
             });
 
+            // Re-add environment variables AFTER Azure App Config so env-var
+            // overrides win, restoring the conventional ASP.NET Core
+            // precedence (env > AppConfig > appsettings). The default
+            // WebApplicationBuilder adds env vars early in the chain; without
+            // this re-add, AddAzureAppConfiguration above silently overrides
+            // anything set via env vars (e.g. docker-compose's
+            // `CommonConfig__SqlBaseConnectionString` or
+            // `SportsData.Provider__ProviderDocDatabaseConfig__ConnectionString`
+            // overrides intended to swap localhost → host.docker.internal).
+            cfg.AddEnvironmentVariables();
+
             return cfg;
         }
 

--- a/src/SportsData.Core/DependencyInjection/AppConfiguration.cs
+++ b/src/SportsData.Core/DependencyInjection/AppConfiguration.cs
@@ -167,16 +167,23 @@ namespace SportsData.Core.DependencyInjection
                     });
             });
 
-            // Re-add environment variables AFTER Azure App Config so env-var
-            // overrides win, restoring the conventional ASP.NET Core
-            // precedence (env > AppConfig > appsettings). The default
-            // WebApplicationBuilder adds env vars early in the chain; without
-            // this re-add, AddAzureAppConfiguration above silently overrides
-            // anything set via env vars (e.g. docker-compose's
-            // `CommonConfig__SqlBaseConnectionString` or
+            // Re-add environment variables AFTER Azure App Config in
+            // non-Production so env-var overrides win, restoring the
+            // conventional ASP.NET Core precedence (env > AppConfig >
+            // appsettings). The default WebApplicationBuilder adds env vars
+            // early in the chain; without this re-add, AddAzureAppConfiguration
+            // above silently overrides anything set via env vars (e.g.
+            // docker-compose's `CommonConfig__SqlBaseConnectionString` or
             // `SportsData.Provider__ProviderDocDatabaseConfig__ConnectionString`
             // overrides intended to swap localhost → host.docker.internal).
-            cfg.AddEnvironmentVariables();
+            //
+            // Gated off in Production so AppConfig remains the source of
+            // truth — a stray pod env var can never silently shadow a
+            // deliberate AppConfig value in prod.
+            if (!string.Equals(environmentName, Environments.Production, StringComparison.OrdinalIgnoreCase))
+            {
+                cfg.AddEnvironmentVariables();
+            }
 
             return cfg;
         }

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -284,6 +284,12 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
     /// <summary>
     /// Performs an HTTP POST request without a body and returns Result pattern.
     /// Use this for POST operations that only need route parameters and proper error handling without exceptions.
+    ///
+    /// Always stamps an <c>X-Correlation-Id</c> header with the current
+    /// <see cref="Extensions.ActivityExtensions.GetCorrelationId"/> value so
+    /// downstream services can log the same id even when OpenTelemetry's
+    /// <c>traceparent</c> propagation isn't active (e.g. local dev with
+    /// instrumentation gated off in App Config).
     /// </summary>
     protected async Task<Result<bool>> PostWithResultAsync(
         string url,
@@ -292,7 +298,12 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
     {
         try
         {
-            using var response = await HttpClient.PostAsync(url, null, cancellationToken);
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Headers.TryAddWithoutValidation(
+                "X-Correlation-Id",
+                ActivityExtensions.GetCorrelationId().ToString());
+
+            using var response = await HttpClient.SendAsync(request, cancellationToken);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -286,10 +286,10 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
     /// Use this for POST operations that only need route parameters and proper error handling without exceptions.
     ///
     /// Always stamps an <c>X-Correlation-Id</c> header with the current
-    /// <see cref="Extensions.ActivityExtensions.GetCorrelationId"/> value so
-    /// downstream services can log the same id even when OpenTelemetry's
-    /// <c>traceparent</c> propagation isn't active (e.g. local dev with
-    /// instrumentation gated off in App Config).
+    /// <see cref="SportsData.Core.Extensions.ActivityExtensions.GetCorrelationId"/>
+    /// value so downstream services can log the same id even when
+    /// OpenTelemetry's <c>traceparent</c> propagation isn't active (e.g. local
+    /// dev with instrumentation gated off in App Config).
     /// </summary>
     protected async Task<Result<bool>> PostWithResultAsync(
         string url,

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionOddsDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionOddsDto.cs
@@ -140,6 +140,31 @@ public class Outcome
     public string? Type { get; set; }
 }
 
+/// <summary>
+/// Wrapper shape returned by ESPN's MLB <c>.../odds</c> endpoint. Each item
+/// is a per-provider odds row that lacks its own <c>$ref</c>; the MLB-specific
+/// processor synthesizes one for identity purposes. NCAAFB/NFL never use this
+/// wrapper at the processor layer because their items each have a real
+/// <c>$ref</c> that DocumentRequestedHandler extracts upstream.
+/// </summary>
+public class EspnEventCompetitionOddsListDto
+{
+    [JsonPropertyName("count")]
+    public int? Count { get; set; }
+
+    [JsonPropertyName("pageIndex")]
+    public int? PageIndex { get; set; }
+
+    [JsonPropertyName("pageSize")]
+    public int? PageSize { get; set; }
+
+    [JsonPropertyName("pageCount")]
+    public int? PageCount { get; set; }
+
+    [JsonPropertyName("items")]
+    public List<EspnEventCompetitionOddsDto> Items { get; set; } = new();
+}
+
 public class EspnEventCompetitionOddsProvider
 {
     [JsonPropertyName("$ref")]

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnResourceIndexClassifier.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnResourceIndexClassifier.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using SportsData.Core.Common;
 
 namespace SportsData.Core.Infrastructure.DataSources.Espn
 {
@@ -19,7 +21,35 @@ namespace SportsData.Core.Infrastructure.DataSources.Espn
             "status"
         };
 
-        public static bool IsResourceIndex(Uri uri)
+        /// <summary>
+        /// Per-sport leaf overrides for endpoints whose response shape is
+        /// sport-specific. MLB's <c>.../odds</c> endpoint returns a paged
+        /// collection where items lack both <c>$ref</c> and a top-level
+        /// <c>id</c>, so the generic ResourceIndex extraction path in
+        /// <c>DocumentRequestedHandler.ProcessResourceIndex</c> can't break
+        /// items out individually the way it can for NCAAFB/NFL (where each
+        /// item carries its own <c>$ref</c>). Routing the URL as a leaf for
+        /// MLB sends the full wrapper to a sport-specific processor that
+        /// splits items downstream.
+        /// </summary>
+        private static readonly Dictionary<Sport, HashSet<string>> SportSpecificLeafSuffixes = new()
+        {
+            [Sport.BaseballMlb] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "odds"
+            }
+        };
+
+        /// <summary>
+        /// Classify a URI as a resource index (paginated collection) or a leaf
+        /// document. Sport-aware so endpoints that return collection-shaped
+        /// responses for one sport but require single-document handling for
+        /// another can be routed correctly. The default rules (numeric tail,
+        /// shared <see cref="KnownLeafSuffixes"/>) apply to every sport;
+        /// <see cref="SportSpecificLeafSuffixes"/> layers per-sport overrides
+        /// on top.
+        /// </summary>
+        public static bool IsResourceIndex(Uri uri, Sport sport)
         {
             var last = uri.Segments
                            .LastOrDefault(s => !string.IsNullOrWhiteSpace(s))
@@ -30,8 +60,13 @@ namespace SportsData.Core.Infrastructure.DataSources.Espn
             if (long.TryParse(last, out _))
                 return false;
 
-            // Case 2: Ends in one of the known leaf suffixes (even though it's alpha) → treat as leaf
+            // Case 2: Ends in one of the shared known leaf suffixes → treat as leaf
             if (KnownLeafSuffixes.Contains(last))
+                return false;
+
+            // Case 3: Sport-specific leaf override (e.g. MLB odds wrapper) → treat as leaf
+            if (SportSpecificLeafSuffixes.TryGetValue(sport, out var sportSuffixes) &&
+                sportSuffixes.Contains(last))
                 return false;
 
             // Default: assume resource index

--- a/src/SportsData.Core/SportsData.Core.csproj
+++ b/src/SportsData.Core/SportsData.Core.csproj
@@ -48,14 +48,14 @@
     <PackageReference Include="NCrontab" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.14.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="Polly.Extensions" Version="8.6.5" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.1" />

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -56,8 +56,18 @@ namespace SportsData.Producer.Application.Contests
         [Route("{contestId}/update")]
         public IActionResult UpdateContest([FromRoute] Guid contestId)
         {
-            var correlationId = ActivityExtensions.GetCorrelationId();
-            
+            // Prefer the inbound X-Correlation-Id from the calling service so
+            // the same CorrelationId is logged across API → Producer → Provider.
+            // Falls back to Activity.Current (TraceId) when the header is
+            // absent — covers direct-curl testing and any future caller that
+            // doesn't propagate the header. ClientBase.PostWithResultAsync
+            // stamps this header on every outbound POST.
+            var correlationId =
+                Request.Headers.TryGetValue("X-Correlation-Id", out var headerValue)
+                && Guid.TryParse(headerValue, out var inbound)
+                    ? inbound
+                    : ActivityExtensions.GetCorrelationId();
+
             _logger.LogInformation(
                 "UpdateContest requested. ContestId={ContestId}, CorrelationId={CorrelationId}",
                 contestId,

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -40,6 +40,24 @@ namespace SportsData.Producer.Application.Contests
             _appMode = appMode;
         }
 
+        /// <summary>
+        /// Resolves the correlation id for an inbound request. Prefers the
+        /// explicit <c>X-Correlation-Id</c> HTTP header from the calling
+        /// service so the same id is logged across API → Producer → Provider.
+        /// Falls back to deriving from <c>Activity.Current</c> (TraceId) when
+        /// the header is absent — covers direct-curl testing and any caller
+        /// that doesn't propagate the header.
+        /// <see cref="SportsData.Core.Infrastructure.Clients.ClientBase"/>
+        /// stamps this header on every outbound POST.
+        /// </summary>
+        private Guid GetCorrelationIdFromRequest()
+        {
+            return Request.Headers.TryGetValue("X-Correlation-Id", out var headerValue)
+                && Guid.TryParse(headerValue, out var inbound)
+                    ? inbound
+                    : ActivityExtensions.GetCorrelationId();
+        }
+
         [HttpGet("{contestId}")]
         public async Task<ActionResult<SeasonContestDto>> GetContestById(
             [FromServices] IGetContestByIdQueryHandler handler,
@@ -56,23 +74,13 @@ namespace SportsData.Producer.Application.Contests
         [Route("{contestId}/update")]
         public IActionResult UpdateContest([FromRoute] Guid contestId)
         {
-            // Prefer the inbound X-Correlation-Id from the calling service so
-            // the same CorrelationId is logged across API → Producer → Provider.
-            // Falls back to Activity.Current (TraceId) when the header is
-            // absent — covers direct-curl testing and any future caller that
-            // doesn't propagate the header. ClientBase.PostWithResultAsync
-            // stamps this header on every outbound POST.
-            var correlationId =
-                Request.Headers.TryGetValue("X-Correlation-Id", out var headerValue)
-                && Guid.TryParse(headerValue, out var inbound)
-                    ? inbound
-                    : ActivityExtensions.GetCorrelationId();
+            var correlationId = GetCorrelationIdFromRequest();
 
             _logger.LogInformation(
                 "UpdateContest requested. ContestId={ContestId}, CorrelationId={CorrelationId}",
                 contestId,
                 correlationId);
-                
+
             var cmd = new UpdateContestCommand(
                 contestId,
                 SourceDataProvider.Espn,
@@ -88,7 +96,7 @@ namespace SportsData.Producer.Application.Contests
         [Route("{contestId}/enrich")]
         public IActionResult EnrichContest([FromRoute] Guid contestId)
         {
-            var correlationId = ActivityExtensions.GetCorrelationId();
+            var correlationId = GetCorrelationIdFromRequest();
 
             _logger.LogInformation(
                 "EnrichContest requested. ContestId={ContestId}, CorrelationId={CorrelationId}",
@@ -109,8 +117,11 @@ namespace SportsData.Producer.Application.Contests
         public IActionResult FinalizeContestsBySeasonYear(
             [FromBody] FinalizeContestsBySeasonYearCommand command)
         {
+            // Body's CorrelationId wins when explicitly set (caller may want
+            // to thread through a known id from a saga); otherwise fall back
+            // to the request-level helper (header-or-Activity).
             var correlationId = command.CorrelationId == Guid.Empty
-                ? ActivityExtensions.GetCorrelationId()
+                ? GetCorrelationIdFromRequest()
                 : command.CorrelationId;
 
             _logger.LogInformation(
@@ -131,7 +142,7 @@ namespace SportsData.Producer.Application.Contests
         [Route("{contestId}/stream")]
         public async Task<IActionResult> StartStream([FromRoute] Guid contestId, CancellationToken cancellationToken)
         {
-            var correlationId = ActivityExtensions.GetCorrelationId();
+            var correlationId = GetCorrelationIdFromRequest();
 
             _logger.LogInformation(
                 "StartStream requested. ContestId={ContestId}, CorrelationId={CorrelationId}",
@@ -185,7 +196,7 @@ namespace SportsData.Producer.Application.Contests
         [HttpPost("{id}/media/refresh")]
         public async Task<ActionResult<Guid>> RefreshContestMediaById([FromRoute] Guid id)
         {
-            var correlationId = ActivityExtensions.GetCorrelationId();
+            var correlationId = GetCorrelationIdFromRequest();
             
             _logger.LogInformation(
                 "RefreshContestMedia requested. ContestId={ContestId}, CorrelationId={CorrelationId}",
@@ -223,7 +234,7 @@ namespace SportsData.Producer.Application.Contests
         [HttpPost("{id}/replay")]
         public IActionResult ReplayContestById([FromRoute] Guid id, CancellationToken cancellationToken)
         {
-            var correlationId = ActivityExtensions.GetCorrelationId();
+            var correlationId = GetCorrelationIdFromRequest();
             
             _logger.LogInformation(
                 "ReplayContest requested. ContestId={ContestId}, CorrelationId={CorrelationId}",
@@ -242,8 +253,8 @@ namespace SportsData.Producer.Application.Contests
             [FromRoute] int seasonWeekNumber,
             CancellationToken cancellationToken)
         {
-            var correlationId = ActivityExtensions.GetCorrelationId();
-            
+            var correlationId = GetCorrelationIdFromRequest();
+
             _logger.LogInformation(
                 "ReplaySeasonWeek requested. SeasonYear={SeasonYear}, WeekNumber={WeekNumber}, CorrelationId={CorrelationId}",
                 seasonYear,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
@@ -79,12 +79,17 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
             command,
             EspnUriMapper.CompetitionOddsRefToCompetitionRef);
 
+        // Contract violation, not a transient issue — the URI doesn't map to
+        // a Competition we can derive. Retrying won't help. Log + return so
+        // the message is acked and the DLQ stays clean.
         if (competitionId is null)
         {
             _logger.LogError("Unable to determine CompetitionId from ParentId or URI");
             return;
         }
 
+        // Same — message envelope is missing a required field. Retrying the
+        // same malformed message produces the same result.
         if (!command.SeasonYear.HasValue)
         {
             _logger.LogError("Command missing SeasonYear.");
@@ -96,10 +101,16 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
             .Include(x => x.Contest)
             .FirstOrDefaultAsync(x => x.Id == competitionId.Value);
 
+        // Transient — the parent Competition document is likely still
+        // being processed upstream. Throw so Hangfire's AutomaticRetryAttribute
+        // re-runs us with backoff (eventual consistency). InvalidOperationException
+        // is a better fit than ArgumentException here: nothing about the
+        // arguments is invalid, the expected entity simply doesn't exist yet.
         if (competition is null)
         {
             _logger.LogError("Competition not found. CompetitionId={CompetitionId}", competitionId.Value);
-            throw new ArgumentException("competition not found");
+            throw new InvalidOperationException(
+                $"Competition {competitionId.Value} not found; will retry.");
         }
 
         // --- Hash + skip-when-unchanged ---
@@ -144,10 +155,15 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
         }
 
         // --- Synthesize per-item identity + persist ---
-        // Listing URL serves as the identity base; the fragment makes each
-        // provider's identity unique and deterministic. ESPN never sees this
-        // synthesized URL — it only feeds the hash function.
-        var listingUriBase = command.SourceUri.ToString();
+        // Listing URL serves as the identity base; appending /provider/{id}
+        // to the *path* makes each provider's identity unique and stable.
+        // The provider id MUST live in the path (not query/fragment) because
+        // IGenerateExternalRefIdentities.Generate hashes against the
+        // ToCleanUrl normalization, which strips both — so query- or
+        // fragment-based synthesis would collapse every item onto the
+        // same canonical id and clobber rows on persist. ESPN never sees
+        // this synthesized URL; it's only fed to the hash function.
+        var listingUri = command.SourceUri;
 
         var addedAny = false;
         foreach (var item in wrapper.Items)
@@ -160,12 +176,32 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
                 continue;
             }
 
-            // If the listing URL already has a fragment (vanishingly unlikely
-            // but defensive), extend it with `&provider=...` rather than
-            // double-fragmenting.
-            var separator = listingUriBase.Contains('#') ? '&' : '#';
-            var syntheticRef = new Uri($"{listingUriBase}{separator}provider={item.Provider.Id}");
+            // UriBuilder preserves scheme/host/port/query; we extend the path
+            // with a /provider/{id} segment that's clearly synthetic (won't
+            // be mistaken for a fetchable ESPN URL during debugging).
+            var refBuilder = new UriBuilder(listingUri)
+            {
+                Path = listingUri.AbsolutePath.TrimEnd('/')
+                       + "/provider/"
+                       + Uri.EscapeDataString(item.Provider.Id)
+            };
+            var syntheticRef = refBuilder.Uri;
             item.Ref = syntheticRef;
+
+            // Defensive guard — Competition.Contest is loaded via .Include
+            // above and the FK should be non-nullable, but a missing parent
+            // would NRE on the franchise-season accessors below. Throw with
+            // context so the operator can investigate (data integrity issue,
+            // or a race where the Contest hasn't been persisted yet —
+            // Hangfire's retry policy will pick it up).
+            if (competition.Contest is null)
+            {
+                _logger.LogError(
+                    "Competition.Contest is null; cannot resolve franchise-season ids. CompetitionId={CompId}, CorrelationId={CorrelationId}",
+                    competition.Id, command.CorrelationId);
+                throw new InvalidOperationException(
+                    $"Competition {competition.Id} has no Contest loaded; cannot persist odds. CorrelationId={command.CorrelationId}");
+            }
 
             var entity = item.AsEntity(
                 externalRefIdentityGenerator: _externalRefIdentityGenerator,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
@@ -138,21 +138,6 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
         }
 
         var hadExisting = existing.Count > 0;
-        if (hadExisting)
-        {
-            _logger.LogInformation(
-                "Replacing MLB odds for Competition. CompetitionId={CompId}, ExistingCount={ExistingCount}",
-                competition.Id, existing.Count);
-
-            // Cascade delete on entity config removes Teams, Links, ExternalIds.
-            _dataContext.CompetitionOdds.RemoveRange(existing);
-        }
-        else
-        {
-            _logger.LogInformation(
-                "Creating MLB odds for Competition. CompetitionId={CompId}",
-                competition.Id);
-        }
 
         // --- Synthesize per-item identity + persist ---
         // Listing URL serves as the identity base; appending /provider/{id}
@@ -210,6 +195,30 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
                 awayFranchiseSeasonId: competition.Contest.AwayTeamFranchiseSeasonId,
                 correlationId: command.CorrelationId,
                 contentHash: wrapperContentHash);
+
+            // Defer the existing-row removal until we know at least one item
+            // is going to be staged. If every wrapper item is malformed (e.g.
+            // missing provider.id and the loop continues out), RemoveRange
+            // would still mark the prior rows Deleted in the change tracker
+            // and a downstream SaveChanges would wipe valid data with no
+            // replacement. Cascade delete on the entity config removes Teams,
+            // Links, and ExternalIds along with each odds row.
+            if (!addedAny)
+            {
+                if (hadExisting)
+                {
+                    _logger.LogInformation(
+                        "Replacing MLB odds for Competition. CompetitionId={CompId}, ExistingCount={ExistingCount}",
+                        competition.Id, existing.Count);
+                    _dataContext.CompetitionOdds.RemoveRange(existing);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "Creating MLB odds for Competition. CompetitionId={CompId}",
+                        competition.Id);
+                }
+            }
 
             await _dataContext.CompetitionOdds.AddAsync(entity);
             addedAny = true;

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
@@ -1,0 +1,222 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
+
+namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+
+/// <summary>
+/// MLB-specific processor for EventCompetitionOdds documents.
+///
+/// Why a separate processor: ESPN's MLB odds endpoint returns a paged
+/// collection wrapper (<see cref="EspnEventCompetitionOddsListDto"/>) where
+/// each item is a per-provider odds row that lacks its own <c>$ref</c> and
+/// has no top-level <c>id</c>. The Provider's generic resource-index path
+/// can't extract those items individually (see EspnResourceIndexClassifier
+/// for the sport-aware leaf override that routes the whole wrapper here),
+/// so this processor receives the entire document and splits it.
+///
+/// NCAAFB and NFL stay on <see cref="EventCompetitionOddsDocumentProcessor{TDataContext}"/>
+/// — their odds wrappers carry per-item <c>$ref</c>s that the generic path
+/// follows successfully, so each per-provider document arrives as a single
+/// odds object the way that processor expects.
+///
+/// Identity per item: synthesized as <c>{listingUri}#provider={item.provider.id}</c>.
+/// The fragment is never sent over the wire — it's only used as a deterministic
+/// hash input so each provider's row gets a stable canonical id.
+/// </summary>
+[DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionOdds)]
+public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
+    where TDataContext : TeamSportDataContext
+{
+    private readonly IJsonHashCalculator _jsonHash;
+
+    public BaseballEventCompetitionOddsDocumentProcessor(
+        ILogger<BaseballEventCompetitionOddsDocumentProcessor<TDataContext>> logger,
+        TDataContext dataContext,
+        IEventBus publishEndpoint,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        IGenerateResourceRefs refs,
+        IJsonHashCalculator jsonHash)
+        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs)
+    {
+        _jsonHash = jsonHash;
+    }
+
+    protected override async Task ProcessInternal(ProcessDocumentCommand command)
+    {
+        // --- Deserialize wrapper ---
+        var wrapper = command.Document.FromJson<EspnEventCompetitionOddsListDto>();
+        if (wrapper?.Items is null || wrapper.Items.Count == 0)
+        {
+            _logger.LogWarning(
+                "MLB odds document had no items. UrlHash={UrlHash}",
+                command.UrlHash);
+            return;
+        }
+
+        // ESPN paginates at 25 items per page. 25+ sportsbooks per game would
+        // be unusual; if/when it happens, the streamer needs to fetch
+        // additional pages and feed them as separate documents. Flag for now.
+        if (wrapper.PageCount is > 1)
+        {
+            _logger.LogWarning(
+                "MLB odds document is paginated; only page {PageIndex} is processed. UrlHash={UrlHash}, PageCount={PageCount}",
+                wrapper.PageIndex, command.UrlHash, wrapper.PageCount);
+        }
+
+        // --- Resolve competition ---
+        var competitionId = TryGetOrDeriveParentId(
+            command,
+            EspnUriMapper.CompetitionOddsRefToCompetitionRef);
+
+        if (competitionId is null)
+        {
+            _logger.LogError("Unable to determine CompetitionId from ParentId or URI");
+            return;
+        }
+
+        if (!command.SeasonYear.HasValue)
+        {
+            _logger.LogError("Command missing SeasonYear.");
+            return;
+        }
+
+        var competition = await _dataContext.Competitions
+            .AsNoTracking()
+            .Include(x => x.Contest)
+            .FirstOrDefaultAsync(x => x.Id == competitionId.Value);
+
+        if (competition is null)
+        {
+            _logger.LogError("Competition not found. CompetitionId={CompetitionId}", competitionId.Value);
+            throw new ArgumentException("competition not found");
+        }
+
+        // --- Hash + skip-when-unchanged ---
+        // One content hash for the entire wrapper. ESPN updates all providers
+        // together, so per-provider hashing would buy little granularity at
+        // the cost of N reserialization passes. Each persisted row carries
+        // the wrapper hash; if any existing row already has it, we know the
+        // wrapper hasn't changed since we last saved it.
+        var wrapperContentHash = _jsonHash.NormalizeAndHash(command.Document);
+
+        var existing = await _dataContext.CompetitionOdds
+            .Include(o => o.ExternalIds)
+            .Include(o => o.Teams)
+            .Include(o => o.Links)
+            .AsSplitQuery()
+            .Where(o => o.CompetitionId == competition.Id)
+            .ToListAsync();
+
+        if (existing.Any(o => string.Equals(o.ContentHash, wrapperContentHash, StringComparison.Ordinal)))
+        {
+            _logger.LogInformation(
+                "No MLB odds changes detected, skipping. CompetitionId={CompId}",
+                competition.Id);
+            return;
+        }
+
+        var hadExisting = existing.Count > 0;
+        if (hadExisting)
+        {
+            _logger.LogInformation(
+                "Replacing MLB odds for Competition. CompetitionId={CompId}, ExistingCount={ExistingCount}",
+                competition.Id, existing.Count);
+
+            // Cascade delete on entity config removes Teams, Links, ExternalIds.
+            _dataContext.CompetitionOdds.RemoveRange(existing);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Creating MLB odds for Competition. CompetitionId={CompId}",
+                competition.Id);
+        }
+
+        // --- Synthesize per-item identity + persist ---
+        // Listing URL serves as the identity base; the fragment makes each
+        // provider's identity unique and deterministic. ESPN never sees this
+        // synthesized URL — it only feeds the hash function.
+        var listingUriBase = command.SourceUri.ToString();
+
+        var addedAny = false;
+        foreach (var item in wrapper.Items)
+        {
+            if (item.Provider?.Id is null)
+            {
+                _logger.LogWarning(
+                    "MLB odds item missing provider.id, skipping item. CompetitionId={CompId}",
+                    competition.Id);
+                continue;
+            }
+
+            // If the listing URL already has a fragment (vanishingly unlikely
+            // but defensive), extend it with `&provider=...` rather than
+            // double-fragmenting.
+            var separator = listingUriBase.Contains('#') ? '&' : '#';
+            var syntheticRef = new Uri($"{listingUriBase}{separator}provider={item.Provider.Id}");
+            item.Ref = syntheticRef;
+
+            var entity = item.AsEntity(
+                externalRefIdentityGenerator: _externalRefIdentityGenerator,
+                competitionId: competition.Id,
+                homeFranchiseSeasonId: competition.Contest.HomeTeamFranchiseSeasonId,
+                awayFranchiseSeasonId: competition.Contest.AwayTeamFranchiseSeasonId,
+                correlationId: command.CorrelationId,
+                contentHash: wrapperContentHash);
+
+            await _dataContext.CompetitionOdds.AddAsync(entity);
+            addedAny = true;
+
+            _logger.LogInformation(
+                "Persisted MLB odds row. CompetitionId={CompId}, Provider={Prov}, OddsId={OddsId}",
+                competition.Id, item.Provider.Id, entity.Id);
+        }
+
+        if (!addedAny)
+        {
+            _logger.LogWarning(
+                "MLB odds wrapper produced no valid items to persist. CompetitionId={CompId}",
+                competition.Id);
+            return;
+        }
+
+        // --- Publish event ---
+        // One event per wrapper-document arrival (analogous to one event per
+        // provider-document arrival on NCAAFB/NFL). Subscribers care that the
+        // contest's odds changed; per-provider granularity isn't useful yet.
+        if (hadExisting)
+        {
+            await _publishEndpoint.Publish(new ContestOddsUpdated(
+                competition.Contest.Id,
+                "ContestOddsUpdated",
+                null,
+                command.Sport,
+                command.SeasonYear,
+                command.CorrelationId,
+                CausationId.Producer.EventDocumentProcessor));
+        }
+        else
+        {
+            await _publishEndpoint.Publish(new ContestOddsCreated(
+                competition.Contest.Id,
+                null,
+                command.Sport,
+                command.SeasonYear,
+                command.CorrelationId,
+                command.MessageId));
+        }
+
+        await _dataContext.SaveChangesAsync();
+    }
+}

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
@@ -14,9 +14,11 @@ using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 
+// MLB intentionally absent here — its odds wire shape is a paged wrapper
+// that doesn't carry per-item $refs, so it's handled by
+// BaseballMlbEventCompetitionOddsDocumentProcessor (sport-specific processor).
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.EventCompetitionOdds)]
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNfl, DocumentType.EventCompetitionOdds)]
-[DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionOdds)]
 public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
@@ -16,7 +16,8 @@ namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Co
 
 // MLB intentionally absent here — its odds wire shape is a paged wrapper
 // that doesn't carry per-item $refs, so it's handled by
-// BaseballMlbEventCompetitionOddsDocumentProcessor (sport-specific processor).
+// BaseballEventCompetitionOddsDocumentProcessor (sport-specific processor
+// under Application/Documents/Processors/Providers/Espn/Baseball/).
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.EventCompetitionOdds)]
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNfl, DocumentType.EventCompetitionOdds)]
 public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
@@ -50,6 +51,9 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
             command,
             EspnUriMapper.CompetitionOddsRefToCompetitionRef);
 
+        // Contract violation, not a transient issue — the URI doesn't map to
+        // a Competition we can derive. Retrying won't help. Log + return so
+        // the message is acked and the DLQ stays clean.
         if (competitionId == null)
         {
             _logger.LogError("Unable to determine CompetitionId from ParentId or URI");
@@ -58,6 +62,8 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
 
         var competitionIdValue = competitionId.Value;
 
+        // Same — message envelope is missing a required field. Retrying the
+        // same malformed message produces the same result.
         if (!command.SeasonYear.HasValue)
         {
             _logger.LogError("Command missing SeasonYear.");
@@ -69,10 +75,14 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
             .Include(x => x.Contest)
             .FirstOrDefaultAsync(x => x.Id == competitionIdValue);
 
+        // Transient — the parent Competition document is likely still
+        // being processed upstream. Throw so Hangfire's AutomaticRetryAttribute
+        // re-runs us with backoff (eventual consistency).
         if (competition is null)
         {
             _logger.LogError("Competition not found. CompetitionId={CompetitionId}", competitionIdValue);
-            throw new ArgumentException("competition not found");
+            throw new InvalidOperationException(
+                $"Competition {competitionIdValue} not found; will retry.");
         }
 
         // --- Identity + hash ---
@@ -105,6 +115,21 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
             _logger.LogInformation("No odds changes detected, skipping. CompetitionId={CompId}, Provider={Prov}",
                 competition.Id, dto.Provider.Id);
             return;
+        }
+
+        // Defensive guard — Competition.Contest is loaded via .Include above
+        // and the FK should be non-nullable, but a missing parent would NRE
+        // on the franchise-season accessors below. Throw with context so the
+        // operator can investigate (data integrity issue, or a race where
+        // the Contest hasn't been persisted yet — Hangfire's retry policy
+        // will pick it up).
+        if (competition.Contest is null)
+        {
+            _logger.LogError(
+                "Competition.Contest is null; cannot resolve franchise-season ids. CompetitionId={CompId}, CorrelationId={CorrelationId}",
+                competition.Id, command.CorrelationId);
+            throw new InvalidOperationException(
+                $"Competition {competition.Id} has no Contest loaded; cannot persist odds. CorrelationId={command.CorrelationId}");
         }
 
         // Build the authoritative incoming graph

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionOddsExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionOddsExtensions.cs
@@ -24,7 +24,11 @@ public static class CompetitionOddsExtensions
             Id = identity.CanonicalId, // stable per odds provider ref
             CompetitionId = competitionId,
 
-            ProviderRef = src.Provider.Ref,
+            // Fall back to the item's own ref when provider.ref is missing.
+            // MLB items don't carry a provider.ref in the wire payload — the
+            // sport-specific processor synthesizes src.Ref per provider, so
+            // it doubles as the identity URL for the provider here.
+            ProviderRef = src.Provider.Ref ?? src.Ref,
             ProviderId = src.Provider.Id,
             ProviderName = src.Provider.Name,
             ProviderPriority = src.Provider.Priority,

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -1,3 +1,6 @@
+using Hangfire;
+using Hangfire.Dashboard;
+
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
@@ -68,10 +71,16 @@ public class Program
         services.AddClients(config);
 
         // Per-role connection pool sizing — configurable via Azure App Config.
-        // Keys: {appName}:ConnectionPool:Worker, :Api, :Ingest
-        // Defaults: Worker=22, Api=5, Ingest=5
+        // Keys: {appName}:ConnectionPool:All, :Worker, :Api, :Ingest
+        // Defaults: All=60, Worker=22, Api=5, Ingest=5
+        //
+        // The All arm covers the local-dev / docker-compose case where one
+        // process runs every role concurrently and starves the Worker-sized
+        // pool. In prod K8s each role is its own pod, so this branch never
+        // matches there — strictly additive.
         var (roleName, defaultPoolSize) = role switch
         {
+            _ when role == ProducerRole.All => ("All", 60),
             _ when role.HasFlag(ProducerRole.Api) && !role.HasFlag(ProducerRole.Worker) => ("Api", 5),
             _ when role.HasFlag(ProducerRole.Ingest) && !role.HasFlag(ProducerRole.Worker) => ("Ingest", 5),
             _ when role.HasFlag(ProducerRole.Worker) => ("Worker", 22),
@@ -230,6 +239,24 @@ public class Program
         {
             app.UseAuthorization();
             app.MapControllers();
+
+            // Hangfire dashboard for non-Production environments only.
+            // Prod cluster aggregates dashboards via SportsData.JobsDashboard
+            // at jobs.sportdeets.com behind basic auth; per-pod /dashboard
+            // would just be redundant surface area.
+            //
+            // For local dev (docker-compose / VS native), pass an empty
+            // authorization filter array — Hangfire's default
+            // LocalRequestsOnlyAuthorizationFilter rejects requests from
+            // outside the container, so an empty list opens it up to the
+            // host machine. Acceptable for local-only ports (7042 here).
+            if (!app.Environment.IsProduction())
+            {
+                app.UseHangfireDashboard("/dashboard", new DashboardOptions
+                {
+                    Authorization = Array.Empty<IDashboardAuthorizationFilter>()
+                });
+            }
         }
 
         // Map Prometheus metrics endpoint only if OpenTelemetry metrics are enabled

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -37,15 +37,9 @@ public class Program
         // Add services to the container.
         var config = builder.Configuration;
         config.AddCommonConfiguration(builder.Environment.EnvironmentName, builder.Environment.ApplicationName, mode);
-        // Re-add env vars *after* AppConfig so container-level overrides (e.g. the
-        // docker-compose `CommonConfig__SqlBaseConnectionString=host.docker.internal`)
-        // beat AppConfig's host-native `localhost` value. Gated off in Production
-        // so a stray pod env var can never silently shadow a deliberate AppConfig
-        // value — AppConfig is the source of truth in prod.
-        if (!builder.Environment.IsProduction())
-        {
-            config.AddEnvironmentVariables();
-        }
+        // Note: AddCommonConfiguration handles the post-AppConfig env-var
+        // re-add for non-Production environments (gated inside the helper),
+        // so Provider/Producer/Api all share the same precedence wiring.
 
         builder.WithLoggingContext(mode, role.ToString());
         builder.UseCommon();
@@ -240,17 +234,19 @@ public class Program
             app.UseAuthorization();
             app.MapControllers();
 
-            // Hangfire dashboard for non-Production environments only.
-            // Prod cluster aggregates dashboards via SportsData.JobsDashboard
-            // at jobs.sportdeets.com behind basic auth; per-pod /dashboard
-            // would just be redundant surface area.
+            // Hangfire dashboard for the Development environment only.
+            // Tightened from !IsProduction() so Staging/QA don't inadvertently
+            // expose the dashboard. Prod cluster aggregates dashboards via
+            // SportsData.JobsDashboard at jobs.sportdeets.com behind basic
+            // auth; per-pod /dashboard would just be redundant surface area.
             //
-            // For local dev (docker-compose / VS native), pass an empty
-            // authorization filter array — Hangfire's default
-            // LocalRequestsOnlyAuthorizationFilter rejects requests from
-            // outside the container, so an empty list opens it up to the
-            // host machine. Acceptable for local-only ports (7042 here).
-            if (!app.Environment.IsProduction())
+            // The empty authorization filter array is intentional — Hangfire's
+            // default LocalRequestsOnlyAuthorizationFilter rejects requests
+            // from outside the container, which blocks docker-compose access
+            // from the host machine (the container sees host requests as
+            // remote). Safe in Development because the container's port is
+            // only bound to localhost via docker-compose `ports:` mapping.
+            if (app.Environment.IsDevelopment())
             {
                 app.UseHangfireDashboard("/dashboard", new DashboardOptions
                 {

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -92,7 +92,7 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
     {
         var uri = evt.Uri;
 
-        if (EspnResourceIndexClassifier.IsResourceIndex(uri))
+        if (EspnResourceIndexClassifier.IsResourceIndex(uri, evt.Sport))
         {
             _logger.LogInformation(
                 "Treating as resource index. Uri={Uri}, CorrelationId={CorrelationId}",

--- a/src/SportsData.Provider/Program.cs
+++ b/src/SportsData.Provider/Program.cs
@@ -153,17 +153,21 @@ namespace SportsData.Provider
                 app.UseAuthorization();
                 app.MapControllers();
 
-                // Hangfire dashboard for non-Production environments only.
-                // Prod cluster aggregates dashboards via SportsData.JobsDashboard
-                // at jobs.sportdeets.com behind basic auth; per-pod /dashboard
-                // would just be redundant surface area.
+                // Hangfire dashboard for the Development environment only.
+                // Tightened from !IsProduction() so Staging/QA don't
+                // inadvertently expose the dashboard. Prod cluster aggregates
+                // dashboards via SportsData.JobsDashboard at jobs.sportdeets.com
+                // behind basic auth; per-pod /dashboard would just be redundant
+                // surface area.
                 //
-                // For local dev (docker-compose / VS native), pass an empty
-                // authorization filter array — Hangfire's default
-                // LocalRequestsOnlyAuthorizationFilter rejects requests from
-                // outside the container, so an empty list opens it up to the
-                // host machine. Acceptable for local-only ports (7050 here).
-                if (!app.Environment.IsProduction())
+                // The empty authorization filter array is intentional —
+                // Hangfire's default LocalRequestsOnlyAuthorizationFilter
+                // rejects requests from outside the container, which blocks
+                // docker-compose access from the host machine (the container
+                // sees host requests as remote). Safe in Development because
+                // the container's port is only bound to localhost via
+                // docker-compose `ports:` mapping.
+                if (app.Environment.IsDevelopment())
                 {
                     app.UseHangfireDashboard("/dashboard", new DashboardOptions
                     {

--- a/src/SportsData.Provider/Program.cs
+++ b/src/SportsData.Provider/Program.cs
@@ -1,3 +1,6 @@
+using Hangfire;
+using Hangfire.Dashboard;
+
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
@@ -64,10 +67,16 @@ namespace SportsData.Provider
             }
 
             // Per-role connection pool sizing — configurable via Azure App Config.
-            // Keys: {appName}:ConnectionPool:Worker, :Api, :Ingest
-            // Defaults: Worker=22, Api=5, Ingest=5
+            // Keys: {appName}:ConnectionPool:All, :Worker, :Api, :Ingest
+            // Defaults: All=60, Worker=22, Api=5, Ingest=5
+            //
+            // The All arm covers the local-dev / docker-compose case where one
+            // process runs every role concurrently and starves the Worker-sized
+            // pool. In prod K8s each role is its own pod, so this branch never
+            // matches there — strictly additive.
             var (roleName, defaultPoolSize) = role switch
             {
+                _ when role == ProviderRole.All => ("All", 60),
                 _ when role.HasFlag(ProviderRole.Api) && !role.HasFlag(ProviderRole.Worker) => ("Api", 5),
                 _ when role.HasFlag(ProviderRole.Ingest) && !role.HasFlag(ProviderRole.Worker) => ("Ingest", 5),
                 _ when role.HasFlag(ProviderRole.Worker) => ("Worker", 22),
@@ -143,6 +152,24 @@ namespace SportsData.Provider
             {
                 app.UseAuthorization();
                 app.MapControllers();
+
+                // Hangfire dashboard for non-Production environments only.
+                // Prod cluster aggregates dashboards via SportsData.JobsDashboard
+                // at jobs.sportdeets.com behind basic auth; per-pod /dashboard
+                // would just be redundant surface area.
+                //
+                // For local dev (docker-compose / VS native), pass an empty
+                // authorization filter array — Hangfire's default
+                // LocalRequestsOnlyAuthorizationFilter rejects requests from
+                // outside the container, so an empty list opens it up to the
+                // host machine. Acceptable for local-only ports (7050 here).
+                if (!app.Environment.IsProduction())
+                {
+                    app.UseHangfireDashboard("/dashboard", new DashboardOptions
+                    {
+                        Authorization = Array.Empty<IDashboardAuthorizationFilter>()
+                    });
+                }
             }
 
             // Map Prometheus metrics endpoint only if OpenTelemetry metrics are enabled

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnResourceIndexClassifierTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnResourceIndexClassifierTests.cs
@@ -1,5 +1,6 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 
+using SportsData.Core.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn;
 
 using Xunit;
@@ -8,6 +9,10 @@ namespace SportsData.Core.Tests.Unit.Infrastructure.DataSources.Espn
 {
     public class EspnResourceIndexClassifierTests
     {
+        // Sport-agnostic classification rules. These must hold for every sport
+        // since they don't touch SportSpecificLeafSuffixes — verifying with
+        // FootballNcaa is sufficient. Add a sport-parameterized companion test
+        // below if any of these ever start to disagree across sports.
         [Theory]
         [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401767256/competitions/401767256/status?lang=en&region=us", false)]
         [InlineData("http://espn.com/v2/sports/football/events", true)]
@@ -20,7 +25,27 @@ namespace SportsData.Core.Tests.Unit.Infrastructure.DataSources.Espn
         public void IsResourceIndex_Should_Classify_Uris(string uriString, bool expected)
         {
             var uri = new Uri(uriString);
-            var actual = EspnResourceIndexClassifier.IsResourceIndex(uri);
+            var actual = EspnResourceIndexClassifier.IsResourceIndex(uri, Sport.FootballNcaa);
+            actual.Should().Be(expected);
+        }
+
+        // Sport-specific leaf-suffix override. MLB's `.../odds` endpoint returns
+        // a paged collection where items lack `$ref` and top-level `id`; the
+        // generic resource-index extraction path can't process those, so MLB
+        // routes odds as a leaf and a sport-specific processor splits items
+        // downstream. NCAAFB/NFL keep the original index behavior — items in
+        // their odds wrappers each have a `$ref` that the generic path follows.
+        [Theory]
+        [InlineData(Sport.BaseballMlb, false)]
+        [InlineData(Sport.FootballNcaa, true)]
+        [InlineData(Sport.FootballNfl, true)]
+        public void IsResourceIndex_OddsEndpoint_OnlyMlbIsLeaf(Sport sport, bool expected)
+        {
+            var uri = new Uri(
+                "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds?lang=en&region=us");
+
+            var actual = EspnResourceIndexClassifier.IsResourceIndex(uri, sport);
+
             actual.Should().Be(expected);
         }
     }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessorTests.cs
@@ -152,10 +152,13 @@ public class BaseballEventCompetitionOddsDocumentProcessorTests
         saved[0].ContentHash.Should().Be("content-hash-v1");
 
         // assert — synthetic ref uses the listing URL + #provider={id}
+        // The synthetic ref must place provider id in the PATH, not the
+        // query/fragment. UriExtensions.ToCleanUrl strips query+fragment,
+        // so any provider distinction outside the path collapses every
+        // item onto the same canonical id during identity generation.
         generatedUris.Should().NotBeEmpty();
         generatedUris.Should().Contain(u =>
-            u.OriginalString.StartsWith(listingUri.ToString()) &&
-            u.OriginalString.Contains("#provider=100"));
+            u.AbsolutePath.Contains("/odds/provider/100"));
 
         // assert — created event published (no prior odds existed)
         bus.Verify(x => x.Publish(It.IsAny<ContestOddsCreated>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessorTests.cs
@@ -1,0 +1,296 @@
+#nullable enable
+
+using AutoFixture;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
+
+/// <summary>
+/// Tests for BaseballEventCompetitionOddsDocumentProcessor — MLB-specific
+/// processor that handles the paged-collection wrapper ESPN serves on
+/// <c>/competitions/{id}/odds</c> for baseball.
+///
+/// Uses <see cref="FootballDataContext"/> as the concrete TDataContext —
+/// the processor is generic on TeamSportDataContext, and other Baseball
+/// processor tests follow the same pragmatic pattern until a dedicated
+/// BaseballDataContext test scaffold lands.
+/// </summary>
+[Collection("Sequential")]
+public class BaseballEventCompetitionOddsDocumentProcessorTests
+    : ProducerTestBase<BaseballEventCompetitionOddsDocumentProcessor<FootballDataContext>>
+{
+    private async Task<(ContestBase contest, CompetitionBase competition)> CreateTestContestAndCompetitionAsync(Guid competitionId)
+    {
+        var contest = new FootballContest
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Contest",
+            ShortName = "Test",
+            SeasonYear = 2026,
+            Sport = Sport.BaseballMlb,
+            StartDateUtc = DateTime.UtcNow,
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = contest.Id,
+            Date = DateTime.UtcNow,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.Competitions.AddAsync(competition);
+        await FootballDataContext.SaveChangesAsync();
+
+        return (contest, competition);
+    }
+
+    [Fact]
+    public async Task EspnEventCompetitionOddsListDto_DeserializesMlbWrapper()
+    {
+        // arrange
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionOdds.json");
+
+        // act
+        var wrapper = json.FromJson<EspnEventCompetitionOddsListDto>();
+
+        // assert — pagination metadata present
+        wrapper.Should().NotBeNull();
+        wrapper!.Count.Should().Be(1);
+        wrapper.PageIndex.Should().Be(1);
+        wrapper.PageCount.Should().Be(1);
+        wrapper.Items.Should().HaveCount(1);
+
+        // assert — items[0] populates the per-provider DTO correctly
+        var item = wrapper.Items[0];
+        item.Ref.Should().BeNull("MLB items have no $ref of their own — this is the whole reason for the sport-specific processor");
+        item.Provider.Should().NotBeNull();
+        item.Provider!.Id.Should().Be("100");
+        item.Provider.Name.Should().Be("DraftKings");
+        item.Details.Should().Be("CLE -122");
+        item.OverUnder.Should().Be(6.0m);
+        item.Spread.Should().Be(1.5m);
+        item.AwayTeamOdds.Should().NotBeNull();
+        item.AwayTeamOdds!.Favorite.Should().BeTrue();
+        item.AwayTeamOdds.MoneyLine.Should().Be(102);
+        item.HomeTeamOdds.Should().NotBeNull();
+        item.HomeTeamOdds!.MoneyLine.Should().Be(-122);
+        item.Links.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task WhenNoExistingOdds_AddsOneRowPerItem_AndPublishesCreated()
+    {
+        // arrange
+        var bus = Mocker.GetMock<IEventBus>();
+        var idGen = Mocker.GetMock<IGenerateExternalRefIdentities>();
+        var hash = Mocker.GetMock<IJsonHashCalculator>();
+
+        var compId = Guid.NewGuid();
+        await CreateTestContestAndCompetitionAsync(compId);
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionOdds.json");
+
+        // Capture every URI Generate is called with so we can assert that
+        // synthetic-$ref derivation produced the correct shape.
+        var generatedUris = new List<Uri>();
+        idGen.Setup(x => x.Generate(It.IsAny<Uri>()))
+            .Callback<Uri>(u => generatedUris.Add(u))
+            .Returns(() => new ExternalRefIdentity(Guid.NewGuid(), $"hash-{generatedUris.Count}", "http://x/clean"));
+
+        hash.Setup(x => x.NormalizeAndHash(It.IsAny<string>())).Returns("content-hash-v1");
+
+        var listingUri = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds?lang=en&region=us");
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, compId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionOdds)
+            .With(x => x.Document, json)
+            .With(x => x.SourceUri, listingUri)
+            .With(x => x.UrlHash, "url-hash")
+            .OmitAutoProperties()
+            .Create();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionOddsDocumentProcessor<FootballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — fixture has exactly 1 item; one CompetitionOdds row written.
+        var saved = await FootballDataContext.CompetitionOdds.AsNoTracking().ToListAsync();
+        saved.Should().HaveCount(1);
+        saved[0].CompetitionId.Should().Be(compId);
+        saved[0].ContentHash.Should().Be("content-hash-v1");
+
+        // assert — synthetic ref uses the listing URL + #provider={id}
+        generatedUris.Should().NotBeEmpty();
+        generatedUris.Should().Contain(u =>
+            u.OriginalString.StartsWith(listingUri.ToString()) &&
+            u.OriginalString.Contains("#provider=100"));
+
+        // assert — created event published (no prior odds existed)
+        bus.Verify(x => x.Publish(It.IsAny<ContestOddsCreated>(), It.IsAny<CancellationToken>()), Times.Once);
+        bus.Verify(x => x.Publish(It.IsAny<ContestOddsUpdated>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenContentHashUnchanged_SkipsWrite_DoesNotPublish()
+    {
+        // arrange
+        var bus = Mocker.GetMock<IEventBus>();
+        var idGen = Mocker.GetMock<IGenerateExternalRefIdentities>();
+        var hash = Mocker.GetMock<IJsonHashCalculator>();
+
+        var compId = Guid.NewGuid();
+        await CreateTestContestAndCompetitionAsync(compId);
+
+        // Pre-seed an existing CompetitionOdds row with the SAME content hash
+        // the processor will compute. The skip-when-unchanged check should
+        // bail before any new rows are added or events published.
+        var preExisting = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = compId,
+            ProviderRef = new Uri("http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds#provider=100"),
+            ProviderId = "100",
+            ProviderName = "DraftKings",
+            ProviderPriority = 1,
+            ContentHash = "content-hash-v1",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        await FootballDataContext.CompetitionOdds.AddAsync(preExisting);
+        await FootballDataContext.SaveChangesAsync();
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionOdds.json");
+
+        hash.Setup(x => x.NormalizeAndHash(It.IsAny<string>())).Returns("content-hash-v1");
+
+        var listingUri = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds?lang=en&region=us");
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, compId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionOdds)
+            .With(x => x.Document, json)
+            .With(x => x.SourceUri, listingUri)
+            .With(x => x.UrlHash, "url-hash")
+            .OmitAutoProperties()
+            .Create();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionOddsDocumentProcessor<FootballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — exactly one row remains (the pre-existing one); identity unchanged
+        var saved = await FootballDataContext.CompetitionOdds.AsNoTracking().ToListAsync();
+        saved.Should().HaveCount(1);
+        saved[0].Id.Should().Be(preExisting.Id);
+
+        // assert — no events emitted
+        bus.Verify(x => x.Publish(It.IsAny<ContestOddsCreated>(), It.IsAny<CancellationToken>()), Times.Never);
+        bus.Verify(x => x.Publish(It.IsAny<ContestOddsUpdated>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // assert — no synthetic refs were generated (we bailed before the per-item loop)
+        idGen.Verify(x => x.Generate(It.IsAny<Uri>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenContentHashChanged_ReplacesExistingRows_PublishesUpdated()
+    {
+        // arrange
+        var bus = Mocker.GetMock<IEventBus>();
+        var idGen = Mocker.GetMock<IGenerateExternalRefIdentities>();
+        var hash = Mocker.GetMock<IJsonHashCalculator>();
+
+        var compId = Guid.NewGuid();
+        await CreateTestContestAndCompetitionAsync(compId);
+
+        // Pre-seed with an OLD content hash so the wrapper-vs-existing comparison
+        // detects a change and triggers the replace path.
+        var oldRowId = Guid.NewGuid();
+        var preExisting = new CompetitionOdds
+        {
+            Id = oldRowId,
+            CompetitionId = compId,
+            ProviderRef = new Uri("http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds#provider=100"),
+            ProviderId = "100",
+            ProviderName = "DraftKings",
+            ProviderPriority = 1,
+            ContentHash = "content-hash-OLD",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        await FootballDataContext.CompetitionOdds.AddAsync(preExisting);
+        await FootballDataContext.SaveChangesAsync();
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionOdds.json");
+
+        idGen.Setup(x => x.Generate(It.IsAny<Uri>()))
+            .Returns(new ExternalRefIdentity(Guid.NewGuid(), "hash-new", "http://x/clean"));
+        hash.Setup(x => x.NormalizeAndHash(It.IsAny<string>())).Returns("content-hash-NEW");
+
+        var listingUri = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds?lang=en&region=us");
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, compId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionOdds)
+            .With(x => x.Document, json)
+            .With(x => x.SourceUri, listingUri)
+            .With(x => x.UrlHash, "url-hash")
+            .OmitAutoProperties()
+            .Create();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionOddsDocumentProcessor<FootballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — old row gone, fresh row written with the new hash
+        var saved = await FootballDataContext.CompetitionOdds.AsNoTracking().ToListAsync();
+        saved.Should().HaveCount(1);
+        saved[0].Id.Should().NotBe(oldRowId);
+        saved[0].ContentHash.Should().Be("content-hash-NEW");
+
+        // assert — Updated event (not Created) since rows existed before
+        bus.Verify(x => x.Publish(It.IsAny<ContestOddsUpdated>(), It.IsAny<CancellationToken>()), Times.Once);
+        bus.Verify(x => x.Publish(It.IsAny<ContestOddsCreated>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -398,4 +398,66 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         capturedCommands[1].InlineJson.Should().Contain("Kickoff");
         capturedCommands[2].InlineJson.Should().Contain("Rush");
     }
+
+    /// <summary>
+    /// MLB EventCompetitionOdds is now classified as a leaf (sport-aware
+    /// override in <see cref="EspnResourceIndexClassifier"/>) instead of a
+    /// resource index. Items in MLB's odds wrapper lack both <c>$ref</c> and
+    /// a top-level <c>id</c>, so the generic per-item extraction path in
+    /// <see cref="DocumentRequestedHandler.ProcessResourceIndex"/> has nothing
+    /// to work with. The leaf path enqueues the entire wrapper as a single
+    /// document; a sport-specific Producer-side processor will iterate items
+    /// and persist a CompetitionOdds row per provider.
+    ///
+    /// NCAAFB/NFL retain the original index behavior because their odds
+    /// wrapper items each have a real `$ref` the generic path can follow —
+    /// see the OddsEndpoint test in EspnResourceIndexClassifierTests.
+    /// </summary>
+    [Fact]
+    public async Task WhenMlbEventCompetitionOdds_TreatsAsLeaf_EnqueuesSingleDocument()
+    {
+        // arrange — the JSON is loaded purely so any sanity check against the
+        // mocked GetResource has realistic content; the leaf path doesn't fetch.
+        await LoadJsonTestData("EspnBaseballMlbEventCompetitionOdds.json");
+
+        var oddsListingUri = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds?lang=en&region=us");
+
+        var capturedCommands = new List<ProcessResourceIndexItemCommand>();
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        background.Setup(x => x.Enqueue<IProcessResourceIndexItems>(It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
+            .Callback<Expression<Func<IProcessResourceIndexItems, Task>>>(expr =>
+            {
+                var func = expr.Compile();
+                var mockProcessor = new Mock<IProcessResourceIndexItems>();
+                mockProcessor.Setup(p => p.Process(It.IsAny<ProcessResourceIndexItemCommand>()))
+                    .Callback<ProcessResourceIndexItemCommand>(cmd => capturedCommands.Add(cmd))
+                    .Returns(Task.CompletedTask);
+                func(mockProcessor.Object).GetAwaiter().GetResult();
+            });
+
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = Fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, oddsListingUri)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionOdds)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .OmitAutoProperties()
+            .Create();
+
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — exactly one ProcessResourceIndexItem command enqueued for
+        // the listing URL itself (the leaf path doesn't fetch upstream)
+        capturedCommands.Should().HaveCount(1);
+        capturedCommands[0].Uri.Should().Be(oddsListingUri);
+        capturedCommands[0].DocumentType.Should().Be(DocumentType.EventCompetitionOdds);
+        capturedCommands[0].Sport.Should().Be(Sport.BaseballMlb);
+        capturedCommands[0].InlineJson.Should().BeNull(
+            "leaf path defers fetch+persist to ProcessResourceIndexItem; no inline data is attached at this stage");
+    }
 }

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -416,10 +416,10 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
     [Fact]
     public async Task WhenMlbEventCompetitionOdds_TreatsAsLeaf_EnqueuesSingleDocument()
     {
-        // arrange — the JSON is loaded purely so any sanity check against the
-        // mocked GetResource has realistic content; the leaf path doesn't fetch.
-        await LoadJsonTestData("EspnBaseballMlbEventCompetitionOdds.json");
-
+        // arrange — leaf path doesn't fetch from ESPN, so no JSON setup needed.
+        // The fixture file (EspnBaseballMlbEventCompetitionOdds.json) is used
+        // by the BaseballEventCompetitionOddsDocumentProcessorTests on the
+        // Producer side where the JSON is actually deserialized.
         var oddsListingUri = new Uri(
             "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds?lang=en&region=us");
 

--- a/test/unit/SportsData.Provider.Tests.Unit/Data/EspnBaseballMlbEventCompetitionOdds.json
+++ b/test/unit/SportsData.Provider.Tests.Unit/Data/EspnBaseballMlbEventCompetitionOdds.json
@@ -1,0 +1,346 @@
+{
+    "count": 1,
+    "pageIndex": 1,
+    "pageSize": 25,
+    "pageCount": 1,
+    "items": [
+        {
+            "provider": {
+                "id": "100",
+                "name": "DraftKings",
+                "priority": 1
+            },
+            "details": "CLE -122",
+            "overUnder": 6.0,
+            "spread": 1.5,
+            "initialSpread": 0.0,
+            "initialOverUnder": 0.0,
+            "price": 0.0,
+            "overOdds": -105.0,
+            "underOdds": -115.0,
+            "awayTeamOdds": {
+                "favorite": true,
+                "underdog": false,
+                "moneyLine": 102,
+                "open": {
+                    "favorite": true,
+                    "pointSpread": {
+                        "alternateDisplayValue": "-1.5",
+                        "american": "-1.5"
+                    },
+                    "spread": {
+                        "value": 2.63,
+                        "displayValue": "163/100",
+                        "alternateDisplayValue": "+163",
+                        "decimal": 2.63,
+                        "fraction": "163/100",
+                        "american": "+163"
+                    },
+                    "moneyLine": {
+                        "value": 1.98,
+                        "displayValue": "50/51",
+                        "alternateDisplayValue": "-102",
+                        "decimal": 1.98,
+                        "fraction": "50/51",
+                        "american": "-102"
+                    }
+                },
+                "close": {
+                    "pointSpread": {
+                        "alternateDisplayValue": "-1.5",
+                        "american": "-1.5"
+                    },
+                    "spread": {
+                        "value": 2.75,
+                        "displayValue": "7/4",
+                        "alternateDisplayValue": "+175",
+                        "decimal": 2.75,
+                        "fraction": "7/4",
+                        "american": "+175"
+                    },
+                    "moneyLine": {
+                        "value": 2.02,
+                        "displayValue": "51/50",
+                        "alternateDisplayValue": "+102",
+                        "decimal": 2.02,
+                        "fraction": "51/50",
+                        "american": "+102"
+                    }
+                },
+                "current": {
+                    "pointSpread": {
+                        "alternateDisplayValue": "-1.5",
+                        "american": "-1.5"
+                    },
+                    "spread": {
+                        "value": 2.75,
+                        "displayValue": "7/4",
+                        "alternateDisplayValue": "+175",
+                        "decimal": 2.75,
+                        "fraction": "7/4",
+                        "american": "+175"
+                    },
+                    "moneyLine": {
+                        "value": 2.02,
+                        "displayValue": "51/50",
+                        "alternateDisplayValue": "+102",
+                        "decimal": 2.02,
+                        "fraction": "51/50",
+                        "american": "+102"
+                    }
+                },
+                "team": {
+                    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/7?lang=en&region=us"
+                }
+            },
+            "homeTeamOdds": {
+                "favorite": false,
+                "underdog": true,
+                "moneyLine": -122,
+                "open": {
+                    "favorite": false,
+                    "pointSpread": {
+                        "value": 0.0,
+                        "alternateDisplayValue": "+1.5",
+                        "decimal": 0.0,
+                        "american": "+1.5"
+                    },
+                    "spread": {
+                        "value": 1.5,
+                        "displayValue": "100/199",
+                        "alternateDisplayValue": "-199",
+                        "decimal": 1.5,
+                        "fraction": "100/199",
+                        "american": "-199"
+                    },
+                    "moneyLine": {
+                        "value": 1.84,
+                        "displayValue": "50/59",
+                        "alternateDisplayValue": "-118",
+                        "decimal": 1.84,
+                        "fraction": "50/59",
+                        "american": "-118"
+                    }
+                },
+                "close": {
+                    "pointSpread": {
+                        "value": 0.0,
+                        "alternateDisplayValue": "+1.5",
+                        "decimal": 0.0,
+                        "american": "+1.5"
+                    },
+                    "spread": {
+                        "value": 1.46,
+                        "displayValue": "20/43",
+                        "alternateDisplayValue": "-215",
+                        "decimal": 1.46,
+                        "fraction": "20/43",
+                        "american": "-215"
+                    },
+                    "moneyLine": {
+                        "value": 1.81,
+                        "displayValue": "50/61",
+                        "alternateDisplayValue": "-122",
+                        "decimal": 1.81,
+                        "fraction": "50/61",
+                        "american": "-122"
+                    }
+                },
+                "current": {
+                    "pointSpread": {
+                        "value": 0.0,
+                        "alternateDisplayValue": "+1.5",
+                        "decimal": 0.0,
+                        "american": "+1.5"
+                    },
+                    "spread": {
+                        "value": 1.46,
+                        "displayValue": "20/43",
+                        "alternateDisplayValue": "-215",
+                        "decimal": 1.46,
+                        "fraction": "20/43",
+                        "american": "-215"
+                    },
+                    "moneyLine": {
+                        "value": 1.81,
+                        "displayValue": "50/61",
+                        "alternateDisplayValue": "-122",
+                        "decimal": 1.81,
+                        "fraction": "50/61",
+                        "american": "-122"
+                    }
+                },
+                "team": {
+                    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/5?lang=en&region=us"
+                }
+            },
+            "links": [
+                {
+                    "language": "en-US",
+                    "rel": [
+                        "home",
+                        "desktop",
+                        "bets"
+                    ],
+                    "href": "https://sportsbook.draftkings.com/gateway?s=__s__&wpcid=__wpcid__&wpsrc=413&wpcn=ESPN&wpscn=Widget&wpcrn=BetSlipDeepLink&wpscid=__wpscid__&wpcrid=xx&preurl=https%3A%2F%2Fsportsbook.draftkings.com%2Fevent%2F33942624%3Foutcomes%3D0ML84205477_1",
+                    "text": "Home Bet",
+                    "shortText": "Home Bet",
+                    "isExternal": true,
+                    "isPremium": false
+                },
+                {
+                    "language": "en-US",
+                    "rel": [
+                        "away",
+                        "desktop",
+                        "bets"
+                    ],
+                    "href": "https://sportsbook.draftkings.com/gateway?s=__s__&wpcid=__wpcid__&wpsrc=413&wpcn=ESPN&wpscn=Widget&wpcrn=BetSlipDeepLink&wpscid=__wpscid__&wpcrid=xx&preurl=https%3A%2F%2Fsportsbook.draftkings.com%2Fevent%2F33942624%3Foutcomes%3D0ML84205477_3",
+                    "text": "Away Bet",
+                    "shortText": "Away Bet",
+                    "isExternal": true,
+                    "isPremium": false
+                },
+                {
+                    "language": "en-US",
+                    "rel": [
+                        "homeSpread",
+                        "desktop",
+                        "bets"
+                    ],
+                    "href": "https://sportsbook.draftkings.com/gateway?s=__s__&wpcid=__wpcid__&wpsrc=413&wpcn=ESPN&wpscn=Widget&wpcrn=BetSlipDeepLink&wpscid=__wpscid__&wpcrid=xx&preurl=https%3A%2F%2Fsportsbook.draftkings.com%2Fevent%2F33942624%3Foutcomes%3D0HC84205477P150_1",
+                    "text": "Home Point Spread",
+                    "shortText": "Home Point Spread",
+                    "isExternal": true,
+                    "isPremium": false
+                },
+                {
+                    "language": "en-US",
+                    "rel": [
+                        "awaySpread",
+                        "desktop",
+                        "bets"
+                    ],
+                    "href": "https://sportsbook.draftkings.com/gateway?s=__s__&wpcid=__wpcid__&wpsrc=413&wpcn=ESPN&wpscn=Widget&wpcrn=BetSlipDeepLink&wpscid=__wpscid__&wpcrid=xx&preurl=https%3A%2F%2Fsportsbook.draftkings.com%2Fevent%2F33942624%3Foutcomes%3D0HC84205477N150_3",
+                    "text": "Away Point Spread",
+                    "shortText": "Away Point Spread",
+                    "isExternal": true,
+                    "isPremium": false
+                },
+                {
+                    "language": "en-US",
+                    "rel": [
+                        "over",
+                        "desktop",
+                        "bets"
+                    ],
+                    "href": "https://sportsbook.draftkings.com/gateway?s=__s__&wpcid=__wpcid__&wpsrc=413&wpcn=ESPN&wpscn=Widget&wpcrn=BetSlipDeepLink&wpscid=__wpscid__&wpcrid=xx&preurl=https%3A%2F%2Fsportsbook.draftkings.com%2Fevent%2F33942624%3Foutcomes%3D0OU84205477O600_1",
+                    "text": "Over Odds",
+                    "shortText": "Over Odds",
+                    "isExternal": true,
+                    "isPremium": false
+                },
+                {
+                    "language": "en-US",
+                    "rel": [
+                        "under",
+                        "desktop",
+                        "bets"
+                    ],
+                    "href": "https://sportsbook.draftkings.com/gateway?s=__s__&wpcid=__wpcid__&wpsrc=413&wpcn=ESPN&wpscn=Widget&wpcrn=BetSlipDeepLink&wpscid=__wpscid__&wpcrid=xx&preurl=https%3A%2F%2Fsportsbook.draftkings.com%2Fevent%2F33942624%3Foutcomes%3D0OU84205477U600_3",
+                    "text": "Under Odds",
+                    "shortText": "Under Odds",
+                    "isExternal": true,
+                    "isPremium": false
+                },
+                {
+                    "language": "en-US",
+                    "rel": [
+                        "game",
+                        "desktop",
+                        "bets"
+                    ],
+                    "href": "https://sportsbook.draftkings.com/gateway?s=__s__&wpcid=__wpcid__&wpsrc=413&wpcn=ESPN&wpscn=Widget&wpcrn=BetSlipDeepLink&wpscid=__wpscid__&wpcrid=xx&preurl=https%3A%2F%2Fsportsbook.draftkings.com%2Fevent%2F33942624",
+                    "text": "Game",
+                    "shortText": "Game",
+                    "isExternal": true,
+                    "isPremium": false
+                }
+            ],
+            "moneylineWinner": false,
+            "spreadWinner": false,
+            "open": {
+                "over": {
+                    "value": 2.0,
+                    "displayValue": "1/1",
+                    "alternateDisplayValue": "+100",
+                    "decimal": 2.0,
+                    "fraction": "1/1",
+                    "american": "+100"
+                },
+                "under": {
+                    "value": 1.83,
+                    "displayValue": "5/6",
+                    "alternateDisplayValue": "-120",
+                    "decimal": 1.83,
+                    "fraction": "5/6",
+                    "american": "-120"
+                },
+                "total": {
+                    "value": 0.0,
+                    "alternateDisplayValue": "7",
+                    "decimal": 0.0,
+                    "american": "7"
+                }
+            },
+            "close": {
+                "over": {
+                    "value": 1.95,
+                    "displayValue": "20/21",
+                    "alternateDisplayValue": "-105",
+                    "decimal": 1.95,
+                    "fraction": "20/21",
+                    "american": "-105"
+                },
+                "under": {
+                    "value": 1.86,
+                    "displayValue": "20/23",
+                    "alternateDisplayValue": "-115",
+                    "decimal": 1.86,
+                    "fraction": "20/23",
+                    "american": "-115"
+                },
+                "total": {
+                    "value": 0.0,
+                    "alternateDisplayValue": "6",
+                    "decimal": 0.0,
+                    "american": "6"
+                }
+            },
+            "current": {
+                "over": {
+                    "value": 1.95,
+                    "displayValue": "20/21",
+                    "alternateDisplayValue": "-105",
+                    "decimal": 1.95,
+                    "fraction": "20/21",
+                    "american": "-105"
+                },
+                "under": {
+                    "value": 1.86,
+                    "displayValue": "20/23",
+                    "alternateDisplayValue": "-115",
+                    "decimal": 1.86,
+                    "fraction": "20/23",
+                    "american": "-115"
+                },
+                "total": {
+                    "value": 0.0,
+                    "alternateDisplayValue": "6",
+                    "decimal": 0.0,
+                    "american": "6"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Three loosely-related threads bundled because they all surfaced while getting MLB working end-to-end on local Docker:

### 1. Sport-aware EventCompetitionOdds path for MLB
- `EspnResourceIndexClassifier.IsResourceIndex(uri, sport)` — sport parameter added with a per-sport leaf-suffix override map. MLB's `.../odds` endpoint now classifies as a leaf (its items lack `$ref` and top-level `id`, so the generic resource-index extraction can't process them). NCAAFB/NFL behavior unchanged.
- New `EspnEventCompetitionOddsListDto` wrapper for the paged-collection shape MLB serves.
- New `BaseballEventCompetitionOddsDocumentProcessor` handles the wrapper: iterates items, synthesizes `{listingUri}#provider={item.provider.id}` per-row identity, persists one CompetitionOdds row per provider.
- Existing `EventCompetitionOddsDocumentProcessor` drops `Sport.BaseballMlb` registration (handled by the new sport-specific processor); NCAAFB + NFL unchanged.
- `CompetitionOddsExtensions.AsEntity` falls back to `src.Ref` when `Provider.Ref` is null (MLB items don't carry it).
- 4 new unit tests + new MLB fixture; existing classifier tests updated for the new signature.

### 2. Local-Docker / VS-debug parity
- `docker-compose.local.mlb.yml` — single Producer + Provider container per sport for MLB (no role split locally), keeps NCAA/NFL API-only.
- `AppConfiguration.cs` re-adds env vars *after* Azure App Config so `docker-compose` host overrides actually win. Gated to non-Production so prod App Config remains the source of truth.
- New `ProducerRole.All` / `ProviderRole.All` arms in the per-role connection-pool sizing switch (60 connections; covers the api+ingest+worker-in-one-process load that starves the Worker-sized 22). Prod K8s split-role pods unaffected.
- Hangfire dashboard registered at `/dashboard` on Producer and Provider for non-Production only, with empty authorization filter so the host can hit the local docker port. Prod surface unchanged (still served exclusively via the JobsDashboard service).
- OpenTelemetry packages bumped `1.14.0` → `1.15.x` to clear NU1902 advisory-as-error build failures.

### 3. Cross-service correlation
- `ClientBase.PostWithResultAsync` now stamps `X-Correlation-Id` on every outbound POST, derived from `ActivityExtensions.GetCorrelationId()`.
- Producer's `ContestController.UpdateContest` reads the inbound header and uses it as the CorrelationId, falling back to `Activity.Current` when absent. Same Guid now flows API → Producer → (existing publish chain via `command.CorrelationId`) → Provider.

## Out of scope (deliberately deferred)
- Broadening `X-Correlation-Id` injection to every `ClientBase` overload (only the no-body POST is covered today; a global `DelegatingHandler` via `services.ConfigureHttpClientDefaults` is the cleaner cross-cutting fix).
- Splitting Producer/Provider per-role pool sizes via App Config (works today via `ResolvePoolSize` lookup but no overrides set in manifest).
- Repointing the Producer-on-VS-native debug story so it doesn't depend on App Config's localhost values.

## Test plan
- [x] `dotnet build sports-data.sln` clean (was failing on NU1902 before the package bumps).
- [x] Unit tests: 4 new MLB processor tests pass, existing classifier tests pass under new signature, handler tests pass.
- [x] Manually verified in docker-compose: `producer-mlb` + `provider-mlb` come up after MongoDB user creation, Hangfire dashboard reachable at `localhost:7042/dashboard` and `localhost:7050/dashboard`, MLB odds documents flow into the new processor, refresh-contest CorrelationId now flows API → Producer → Provider in Seq.
- [ ] Reviewer: grep prod manifests for any expectation that env vars *don't* override App Config (none expected — but the gate is in place if someone unknowingly relied on the old order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MLB event competition odds ingestion and processing; added related sports API endpoints and local MLB test environment.
  * Request-level correlation header (X-Correlation-Id) support for improved tracing.

* **Bug Fixes**
  * Restored environment variable precedence so env vars override remote config in non-production.

* **Documentation**
  * Added project assessment guidance for external contributors.

* **Chores**
  * Bumped OpenTelemetry packages.

* **Tests**
  * Added unit tests and test fixtures for MLB odds processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->