### PR TITLE
feat(mlb): sport-specific CompetitionStatus split + cross-service correlation hardening

### DIFF
--- a/src/SportsData.Core/Eventing/EventBus.cs
+++ b/src/SportsData.Core/Eventing/EventBus.cs
@@ -84,14 +84,33 @@ namespace SportsData.Core.Eventing
         {
             var direct = _policy.Mode == DeliveryMode.Direct || !_outbox.IsActive;
 
+            // Auto-stamp X-Correlation-Id transport header from
+            // EventBase.CorrelationId. Belt-and-suspenders alongside the
+            // body field — the header survives even if a serializer
+            // change ever drops the body's positional record property.
+            // Consumers (e.g. DocumentRequestedHandler) prefer body
+            // first, header second.
+            Action<MassTransit.PublishContext<T>>? headerSetter = null;
+            if (message is EventBase eb && eb.CorrelationId != Guid.Empty)
+            {
+                var correlationIdString = eb.CorrelationId.ToString();
+                headerSetter = ctx => ctx.Headers.Set("X-Correlation-Id", correlationIdString);
+            }
+
             if (direct)
             {
                 await Task.Delay(TimeSpan.FromSeconds(1), ct); // 🚨 Dirty Hack: Give consumers time to commit
-                await _bus.Publish(message, ct);
+                if (headerSetter is null)
+                    await _bus.Publish(message, ct);
+                else
+                    await _bus.Publish(message, headerSetter, ct);
             }
             else
             {
-                await _publish.Publish(message, ct);
+                if (headerSetter is null)
+                    await _publish.Publish(message, ct);
+                else
+                    await _publish.Publish(message, headerSetter, ct);
             }
         }
 

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentProcessor.cs
@@ -47,7 +47,6 @@ namespace SportsData.Producer.Application.Contests
                     .Include(c => c.Odds)
                     .ThenInclude(o => o.Teams)
                     .Include(c => c.Contest)
-                    .Include(c => c.Status)
                     .Where(c => c.ContestId == command.ContestId)
                     .AsSplitQuery()
                     .FirstOrDefaultAsync();
@@ -69,12 +68,21 @@ namespace SportsData.Producer.Application.Contests
                     return;
                 }
 
+                // Status was lifted off CompetitionBase onto the
+                // sport-specific Football/Baseball subclasses. Loaded
+                // independently via the abstract base set; EF
+                // materializes whichever concrete subtype is registered
+                // in the active per-sport context.
+                var status = await _dataContext.CompetitionStatuses
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.CompetitionId == competition.Id);
+
                 // If canonical status is not final, data isn't ready — return cleanly
-                if (competition.Status?.StatusTypeName != "STATUS_FINAL")
+                if (status?.StatusTypeName != "STATUS_FINAL")
                 {
                     _logger.LogInformation(
                         "Contest status is not yet final for {ContestName}. Current: {Status}. Skipping enrichment.",
-                        competition.Contest.Name, competition.Status?.StatusTypeName ?? "unknown");
+                        competition.Contest.Name, status?.StatusTypeName ?? "unknown");
                     return;
                 }
 

--- a/src/SportsData.Producer/Application/Contests/ContestUpdateProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestUpdateProcessor.cs
@@ -87,7 +87,7 @@ namespace SportsData.Producer.Application.Contests
                 "Publishing DocumentRequested for Event. Uri={Uri}",
                 contestIdentity.CleanUrl);
 
-            await _bus.Publish(new DocumentRequested(
+            var evt = new DocumentRequested(
                 Id: contestIdentity.UrlHash,
                 ParentId: null,
                 Uri: new Uri(contestIdentity.CleanUrl),
@@ -98,7 +98,11 @@ namespace SportsData.Producer.Application.Contests
                 SourceDataProvider: command.SourceDataProvider,
                 CorrelationId: command.CorrelationId,
                 CausationId: CausationId.Producer.ContestUpdateProcessor
-            ));
+            );
+
+            _logger.LogInformation("Publishing with {@evt}", evt);
+
+            await _bus.Publish(evt);
 
             await _dataContext.SaveChangesAsync();
         }

--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
@@ -71,7 +71,6 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
 
         var competition = await _dbContext.Competitions
             .AsNoTracking()
-            .Include(c => c.Status)
             .FirstOrDefaultAsync(c => c.ContestId == contest.Id, cancellationToken);
 
         if (competition is null)
@@ -141,8 +140,17 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
 
         var comp = await _dbContext.Competitions
             .AsNoTracking()
-            .Include(c => c.Status)
             .FirstOrDefaultAsync(c => c.ContestId == contestId, cancellationToken);
+
+        // Status was lifted off CompetitionBase onto the sport-specific
+        // subclasses; loaded separately here. EF returns the active
+        // per-sport context's concrete subtype but the shared fields
+        // satisfy DetermineContestStatus.
+        var compStatus = comp is null
+            ? null
+            : await _dbContext.CompetitionStatuses
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.CompetitionId == comp.Id, cancellationToken);
 
         var homeTeamSeason = await _dbContext.FranchiseSeasons
             .AsNoTracking()
@@ -174,7 +182,7 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
         var header = new GameHeaderDto
         {
             ContestId = contest.Id,
-            Status = DetermineContestStatus(contest, comp?.Status),
+            Status = DetermineContestStatus(contest, compStatus),
             WeekLabel = contest.SeasonWeek?.Number.ToString(),
             SeasonWeekId = contest.SeasonWeek?.Id,
             SeasonYear = contest.SeasonYear,
@@ -225,7 +233,7 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
     /// Uses CompetitionStatus.StatusState and StatusTypeName as primary indicators,
     /// with fallback to Contest timestamps and current time.
     /// </summary>
-    private static ContestStatus DetermineContestStatus(ContestBase contest, CompetitionStatus? competitionStatus = null)
+    private static ContestStatus DetermineContestStatus(ContestBase contest, CompetitionStatusBase? competitionStatus = null)
     {
         var now = DateTime.UtcNow;
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
@@ -10,6 +10,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
@@ -65,7 +66,6 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext> : Docum
         var competitionIdValue = competitionId.Value;
 
         var competition = await _dataContext.Competitions
-            .Include(c => c.Status)
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == competitionIdValue);
 
@@ -74,6 +74,14 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext> : Docum
             _logger.LogError("Competition not found. CompetitionId={CompetitionId}", competitionIdValue);
             throw new InvalidOperationException($"Competition with ID {competitionIdValue} does not exist.");
         }
+
+        // Status was lifted off CompetitionBase onto the sport-specific
+        // BaseballCompetition in the abstract-status redesign. Loaded
+        // independently so the in-progress branch can still gate on
+        // IsCompleted.
+        var competitionStatus = await _dataContext.Set<BaseballCompetitionStatus>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.CompetitionId == competitionIdValue);
 
         // Baseball plays have team but no start/end with team refs
         Guid? teamFranchiseSeasonId = null;
@@ -96,7 +104,7 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext> : Docum
 
         if (entity is null)
         {
-            await ProcessNew(command, externalDto, competition, teamFranchiseSeasonId);
+            await ProcessNew(command, externalDto, competition, competitionStatus, teamFranchiseSeasonId);
         }
         else
         {
@@ -108,6 +116,7 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext> : Docum
         ProcessDocumentCommand command,
         EspnBaseballEventCompetitionPlayDto externalDto,
         CompetitionBase competition,
+        BaseballCompetitionStatus? competitionStatus,
         Guid? teamFranchiseSeasonId)
     {
         _logger.LogInformation(
@@ -120,7 +129,7 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext> : Docum
             competition.Id,
             teamFranchiseSeasonId);
 
-        if (competition.Status is not null && !competition.Status.IsCompleted)
+        if (competitionStatus is not null && !competitionStatus.IsCompleted)
         {
             await _publishEndpoint.Publish(new CompetitionPlayCompleted(
                 CompetitionPlayId: play.Id,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessor.cs
@@ -1,0 +1,165 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
+
+namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+
+/// <summary>
+/// MLB-specific processor for EventCompetitionStatus documents.
+///
+/// Why a separate processor: ESPN's MLB status payload includes
+/// baseball-only fields (<c>halfInning</c>, <c>periodPrefix</c>) and a
+/// <c>featuredAthletes</c> child collection (winning/losing pitcher
+/// post-game; current batter/pitcher in-game) that the generic
+/// <see cref="Common.EventCompetitionStatusDocumentProcessor{TDataContext}"/>
+/// would silently drop because it deserializes to the base DTO and
+/// constructs a base <c>CompetitionStatus</c>. This processor
+/// deserializes to <see cref="EspnBaseballEventCompetitionStatusDto"/>
+/// and constructs <see cref="BaseballCompetitionStatus"/> — the
+/// sport-specific TPH subclass — so the MLB fields and the
+/// FeaturedAthletes children persist alongside the shared status row.
+/// </summary>
+[DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionStatus)]
+public class BaseballEventCompetitionStatusDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
+    where TDataContext : TeamSportDataContext
+{
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public BaseballEventCompetitionStatusDocumentProcessor(
+        ILogger<BaseballEventCompetitionStatusDocumentProcessor<TDataContext>> logger,
+        TDataContext dataContext,
+        IEventBus publishEndpoint,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        IGenerateResourceRefs refGenerator,
+        IDateTimeProvider dateTimeProvider)
+        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refGenerator)
+    {
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    protected override async Task ProcessInternal(ProcessDocumentCommand command)
+    {
+        var publishEvent = false;
+
+        var dto = command.Document.FromJson<EspnBaseballEventCompetitionStatusDto>();
+
+        if (dto is null)
+        {
+            _logger.LogError("Failed to deserialize EspnBaseballEventCompetitionStatusDto.");
+            return; // terminal failure — don't retry
+        }
+
+        if (string.IsNullOrEmpty(dto.Ref?.ToString()))
+        {
+            _logger.LogError("EspnBaseballEventCompetitionStatusDto Ref is null or empty.");
+            return; // terminal failure — don't retry
+        }
+
+        // Type / Type.Name are dereferenced unconditionally below in the
+        // existing-status comparison and several log lines. The base
+        // mapping is null-safe via `dto.Type?.Name ?? string.Empty`, but
+        // this method's own diff path would NRE on a malformed payload.
+        // Bail with a useful log instead.
+        if (dto.Type is null || string.IsNullOrWhiteSpace(dto.Type.Name))
+        {
+            _logger.LogError(
+                "EspnBaseballEventCompetitionStatusDto Type is missing or has empty Name. Ref={Ref}",
+                dto.Ref);
+            return; // terminal failure — don't retry
+        }
+
+        var competitionId = TryGetOrDeriveParentId(
+            command,
+            EspnUriMapper.CompetitionStatusRefToCompetitionRef);
+
+        if (competitionId is null)
+        {
+            _logger.LogError("Unable to determine CompetitionId from ParentId or URI");
+            return;
+        }
+
+        var competitionIdValue = competitionId.Value;
+
+        var entity = dto.AsEntity(
+            _externalRefIdentityGenerator,
+            competitionIdValue,
+            command.CorrelationId,
+            _dateTimeProvider.UtcNow());
+
+        // Includes are scoped to the MLB subclass DbSet so we can pull
+        // FeaturedAthletes (subclass-only nav) without an OfType cast.
+        // The Competition nav was lifted off CompetitionStatus when the
+        // Status relationship moved to the sport-specific competition
+        // subclass — the FK is still on this side, but the inverse is
+        // owned by BaseballCompetition.
+        var existing = await _dataContext.Set<BaseballCompetitionStatus>()
+            .Include(x => x.ExternalIds)
+            .Include(x => x.FeaturedAthletes)
+            .AsSplitQuery()
+            .FirstOrDefaultAsync(x => x.CompetitionId == competitionIdValue);
+
+        if (existing is not null)
+        {
+            publishEvent = existing.StatusTypeName != dto.Type.Name;
+
+            _logger.LogInformation(
+                "Updating MLB CompetitionStatus (hard replace). CompetitionId={CompId}, OldStatus={OldStatus}, NewStatus={NewStatus}, FeaturedAthleteCount={FeaturedAthleteCount}",
+                competitionIdValue,
+                existing.StatusTypeName,
+                dto.Type.Name,
+                entity.FeaturedAthletes.Count);
+
+            // ExternalIds and FeaturedAthletes cascade-delete with the
+            // parent (DeleteBehavior.Cascade configured on both child
+            // configurations), so removing the parent is sufficient.
+            _dataContext.Set<BaseballCompetitionStatus>().Remove(existing);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Creating new MLB CompetitionStatus. CompetitionId={CompId}, Status={Status}, FeaturedAthleteCount={FeaturedAthleteCount}",
+                competitionIdValue,
+                dto.Type.Name,
+                entity.FeaturedAthletes.Count);
+        }
+
+        if (publishEvent)
+        {
+            _logger.LogInformation(
+                "MLB Competition status changed, publishing event. CompetitionId={CompId}, NewStatus={Status}",
+                competitionIdValue,
+                entity.StatusTypeName);
+
+            await _publishEndpoint.Publish(new CompetitionStatusChanged(
+                competitionIdValue,
+                entity.StatusTypeName,
+                _refGenerator.ForCompetition(competitionIdValue),
+                command.Sport,
+                command.SeasonYear,
+                command.CorrelationId,
+                CausationId.Producer.EventCompetitionStatusDocumentProcessor
+            ));
+        }
+
+        await _dataContext.Set<BaseballCompetitionStatus>().AddAsync(entity);
+        await _dataContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Persisted MLB CompetitionStatus. CompetitionId={CompId}, Status={Status}, HalfInning={HalfInning}, PeriodPrefix={PeriodPrefix}",
+            competitionIdValue,
+            entity.StatusTypeName,
+            entity.HalfInning,
+            entity.PeriodPrefix);
+    }
+}

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusDocumentProcessor.cs
@@ -11,12 +11,17 @@ using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 
+// MLB intentionally absent here — its status payload carries baseball-only
+// fields (halfInning, periodPrefix, featuredAthletes[]) that this
+// processor wouldn't model. Routed to
+// BaseballEventCompetitionStatusDocumentProcessor under Espn/Baseball/,
+// which constructs BaseballCompetitionStatus instead of FootballCompetitionStatus.
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.EventCompetitionStatus)]
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNfl, DocumentType.EventCompetitionStatus)]
-[DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionStatus)]
 public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {
@@ -65,40 +70,41 @@ public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentPro
             competitionIdValue,
             command.CorrelationId);
 
-        var existing = await _dataContext.CompetitionStatuses
+        // Status is queried via the typed Set so the result materializes
+        // as FootballCompetitionStatus (the only concrete subclass
+        // registered in FootballDataContext).
+        var existing = await _dataContext.Set<FootballCompetitionStatus>()
             .Include(x => x.ExternalIds)
-            .Include(x => x.Competition)
             .FirstOrDefaultAsync(x => x.CompetitionId == competitionIdValue);
 
         if (existing is not null)
         {
             publishEvent = existing.StatusTypeName != dto.Type.Name;
 
-            _logger.LogInformation("Updating CompetitionStatus (hard replace). CompetitionId={CompId}, OldStatus={OldStatus}, NewStatus={NewStatus}", 
+            _logger.LogInformation(
+                "Updating CompetitionStatus (hard replace). CompetitionId={CompId}, OldStatus={OldStatus}, NewStatus={NewStatus}",
                 competitionIdValue,
                 existing.StatusTypeName,
                 dto.Type.Name);
 
-            // Remove only the ExternalIds for the ESPN provider to avoid unique key constraint violations
-            var espnExternalIds = existing.ExternalIds
-                .Where(x => x.Provider == SourceDataProvider.Espn)
-                .ToList();
-
-            _dataContext.CompetitionStatusExternalIds.RemoveRange(espnExternalIds);
-
-            _dataContext.CompetitionStatuses.Remove(existing);
+            // ExternalIds cascade-delete with the parent (configured on
+            // CompetitionStatus.EntityConfiguration), so removing the
+            // parent is sufficient.
+            _dataContext.Set<FootballCompetitionStatus>().Remove(existing);
         }
         else
         {
-            _logger.LogInformation("Creating new CompetitionStatus. CompetitionId={CompId}, Status={Status}", 
-                competitionId,
+            _logger.LogInformation(
+                "Creating new CompetitionStatus. CompetitionId={CompId}, Status={Status}",
+                competitionIdValue,
                 dto.Type.Name);
         }
 
         if (publishEvent)
         {
-            _logger.LogInformation("Competition status changed, publishing event. CompetitionId={CompId}, NewStatus={Status}",
-                competitionId,
+            _logger.LogInformation(
+                "Competition status changed, publishing event. CompetitionId={CompId}, NewStatus={Status}",
+                competitionIdValue,
                 entity.StatusTypeName);
 
             await _publishEndpoint.Publish(new CompetitionStatusChanged(
@@ -112,11 +118,12 @@ public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentPro
             ));
         }
 
-        await _dataContext.CompetitionStatuses.AddAsync(entity);
+        await _dataContext.Set<FootballCompetitionStatus>().AddAsync(entity);
         await _dataContext.SaveChangesAsync();
 
-        _logger.LogInformation("Persisted CompetitionStatus. CompetitionId={CompId}, Status={Status}", 
-            competitionId,
+        _logger.LogInformation(
+            "Persisted CompetitionStatus. CompetitionId={CompId}, Status={Status}",
+            competitionIdValue,
             entity.StatusTypeName);
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionPlayDocumentProcessor.cs
@@ -78,7 +78,6 @@ public class EventCompetitionPlayDocumentProcessor<TDataContext> : DocumentProce
         }
 
         var competition = await _dataContext.Competitions
-            .Include(c => c.Status)
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == competitionIdValue);
 
@@ -87,6 +86,14 @@ public class EventCompetitionPlayDocumentProcessor<TDataContext> : DocumentProce
             _logger.LogError("Competition not found. CompetitionId={CompetitionId}", competitionIdValue);
             throw new InvalidOperationException($"Competition with ID {competitionIdValue} does not exist.");
         }
+
+        // Status was lifted off CompetitionBase onto the sport-specific
+        // FootballCompetition in the abstract-status redesign. Loaded
+        // independently so the live/post-game branch below can still
+        // gate on IsCompleted.
+        var competitionStatus = await _dataContext.Set<FootballCompetitionStatus>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.CompetitionId == competitionIdValue);
 
         var startFranchiseSeasonId = await _dataContext.ResolveIdAsync<
             FranchiseSeason, FranchiseSeasonExternalId>(
@@ -117,6 +124,7 @@ public class EventCompetitionPlayDocumentProcessor<TDataContext> : DocumentProce
                 command,
                 externalDto,
                 competition,
+                competitionStatus,
                 competitionDriveId,
                 startFranchiseSeasonId,
                 endFranchiseSeasonId);
@@ -138,11 +146,12 @@ public class EventCompetitionPlayDocumentProcessor<TDataContext> : DocumentProce
         ProcessDocumentCommand command,
         EspnFootballEventCompetitionPlayDto externalDto,
         CompetitionBase competition,
+        FootballCompetitionStatus? competitionStatus,
         Guid? competitionDriveId,
         Guid? startFranchiseSeasonId,
         Guid? endFranchiseSeasonId)
     {
-        _logger.LogInformation("Creating new CompetitionPlay. CompetitionId={CompId}, DriveId={DriveId}, PlayType={PlayType}", 
+        _logger.LogInformation("Creating new CompetitionPlay. CompetitionId={CompId}, DriveId={DriveId}, PlayType={PlayType}",
             competition.Id,
             competitionDriveId,
             externalDto.Type?.Text);
@@ -157,7 +166,7 @@ public class EventCompetitionPlayDocumentProcessor<TDataContext> : DocumentProce
 
         // if the competition is underway,
         // broadcast a CompetitionPlayCompleted event
-        if (competition.Status is not null && !competition.Status.IsCompleted)
+        if (competitionStatus is not null && !competitionStatus.IsCompleted)
         {
             _logger.LogInformation("Competition in progress, publishing CompetitionPlayCompleted event. CompetitionId={CompId}, PlayId={PlayId}",
                 competition.Id,

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
@@ -20,6 +20,14 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
 
         public new DbSet<BaseballCompetitionPlay> CompetitionPlays { get; set; }
 
+        // Sport-specific subclass set: the inherited DbSet<CompetitionStatus>
+        // on TeamSportDataContext can still serve plain reads via the base
+        // type, but eager-loading FeaturedAthletes / accessing HalfInning /
+        // PeriodPrefix requires this typed entry point.
+        public DbSet<BaseballCompetitionStatus> BaseballCompetitionStatuses { get; set; }
+
+        public DbSet<BaseballCompetitionStatusFeaturedAthlete> BaseballCompetitionStatusFeaturedAthletes { get; set; }
+
         public DbSet<AthleteSeasonHotZone> AthleteSeasonHotZones { get; set; }
 
         public DbSet<AthleteSeasonHotZoneEntry> AthleteSeasonHotZoneEntries { get; set; }
@@ -33,6 +41,8 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
             modelBuilder.ApplyConfiguration(new AthleteSeason.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetition.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionPlay.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new BaseballCompetitionStatus.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new BaseballCompetitionStatusFeaturedAthlete.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeasonHotZone.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeasonHotZoneEntry.EntityConfiguration());
         }

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetition.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetition.cs
@@ -9,6 +9,11 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
     {
         public ICollection<BaseballCompetitionPlay> Plays { get; set; } = [];
 
+        // Sport-specific Status nav typed to the MLB subclass so
+        // HalfInning / PeriodPrefix / FeaturedAthletes are reachable
+        // without an OfType cast.
+        public BaseballCompetitionStatus? Status { get; set; }
+
         public new class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetition>
         {
             public void Configure(EntityTypeBuilder<BaseballCompetition> builder)
@@ -21,6 +26,11 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
                 builder.HasMany(x => x.Plays)
                     .WithOne()
                     .HasForeignKey(x => x.CompetitionId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                builder.HasOne(x => x.Status)
+                    .WithOne()
+                    .HasForeignKey<BaseballCompetitionStatus>(x => x.CompetitionId)
                     .OnDelete(DeleteBehavior.Cascade);
             }
         }

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionStatus.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionStatus.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+
+// MLB-specific subclass of CompetitionStatus. Holds the baseball-only
+// fields ESPN ships in its status payload — half-inning indicator,
+// period prefix ("Top" / "Bot" / "End"), and the at-bat featured-
+// athletes collection (winning/losing pitcher post-game; current
+// batter/pitcher in-game). Football's status rows live on
+// FootballCompetitionStatus and never see these fields, mirroring
+// the FootballCompetition / BaseballCompetition split that already
+// lives next door.
+public class BaseballCompetitionStatus : CompetitionStatusBase
+{
+    // 1 = top, 2 = bottom (ESPN's encoding).
+    public int? HalfInning { get; set; }
+
+    // "Top", "Bot", "End", or null pre-game.
+    public string? PeriodPrefix { get; set; }
+
+    public ICollection<BaseballCompetitionStatusFeaturedAthlete> FeaturedAthletes { get; set; } = [];
+
+    public new class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetitionStatus>
+    {
+        public void Configure(EntityTypeBuilder<BaseballCompetitionStatus> builder)
+        {
+            builder.Property(x => x.PeriodPrefix).HasMaxLength(10);
+
+            builder.HasMany(x => x.FeaturedAthletes)
+                .WithOne(x => x.CompetitionStatus)
+                .HasForeignKey(x => x.CompetitionStatusId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionStatusFeaturedAthlete.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionStatusFeaturedAthlete.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+
+// Child of BaseballCompetitionStatus. ESPN's MLB status payload
+// carries a featuredAthletes[] array (e.g. winningPitcher /
+// losingPitcher post-game; current batter / pitcher in-game) and
+// each entry references an athlete, team, and statistics endpoint.
+// Lives in Baseball/Entities/ — the football side has no analogue
+// and no table for this.
+public class BaseballCompetitionStatusFeaturedAthlete : CanonicalEntityBase<Guid>
+{
+    public Guid CompetitionStatusId { get; set; }
+
+    public BaseballCompetitionStatus CompetitionStatus { get; set; } = null!;
+
+    // ESPN's source-document ordinal (0-based). Required so consumers
+    // can reconstruct ESPN's order — e.g. winningPitcher [0],
+    // losingPitcher [1] — without depending on row insertion order.
+    public int Ordinal { get; set; }
+
+    public int PlayerId { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? DisplayName { get; set; }
+
+    public string? ShortDisplayName { get; set; }
+
+    public string? Abbreviation { get; set; }
+
+    // ESPN $ref pointers. Resolution to canonical Player / Franchise
+    // FKs is out of scope here — stored as Uri so a downstream
+    // enrichment job can join against them later.
+    public Uri? AthleteRef { get; set; }
+
+    public Uri? TeamRef { get; set; }
+
+    public Uri? StatisticsRef { get; set; }
+
+    public class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetitionStatusFeaturedAthlete>
+    {
+        public void Configure(EntityTypeBuilder<BaseballCompetitionStatusFeaturedAthlete> builder)
+        {
+            builder.ToTable(nameof(BaseballCompetitionStatusFeaturedAthlete));
+            builder.HasKey(x => x.Id);
+
+            builder.Property(x => x.Ordinal).IsRequired();
+            builder.Property(x => x.PlayerId).IsRequired();
+            builder.Property(x => x.Name).HasMaxLength(100);
+            builder.Property(x => x.DisplayName).HasMaxLength(100);
+            builder.Property(x => x.ShortDisplayName).HasMaxLength(50);
+            builder.Property(x => x.Abbreviation).HasMaxLength(20);
+
+            builder.HasOne(x => x.CompetitionStatus)
+                .WithMany(x => x.FeaturedAthletes)
+                .HasForeignKey(x => x.CompetitionStatusId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Common/TeamSportDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Common/TeamSportDataContext.cs
@@ -100,7 +100,7 @@ namespace SportsData.Producer.Infrastructure.Data.Common
 
         public DbSet<CompetitionSituation> CompetitionSituations { get; set; }
 
-        public DbSet<CompetitionStatus> CompetitionStatuses { get; set; }
+        public DbSet<CompetitionStatusBase> CompetitionStatuses { get; set; }
 
         public DbSet<CompetitionStatusExternalId> CompetitionStatusExternalIds { get; set; }
 
@@ -225,7 +225,7 @@ namespace SportsData.Producer.Infrastructure.Data.Common
 
             modelBuilder.ApplyConfiguration(new CompetitionSituation.EntityConfiguration());
 
-            modelBuilder.ApplyConfiguration(new CompetitionStatus.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new CompetitionStatusBase.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionStatusExternalId.EntityConfiguration());
 
             modelBuilder.ApplyConfiguration(new CompetitionStream.EntityConfiguration());

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionBase.cs
@@ -91,8 +91,10 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
         public CompetitionSource? StatsSource { get; set; }
 
-        public CompetitionStatus? Status { get; set; }
-
+        // Status nav lives on the sport-specific subclasses
+        // (FootballCompetition / BaseballCompetition) typed to each
+        // sport's CompetitionStatus subclass. Lifting it off the shared
+        // base keeps sport-specific concerns out of the abstract surface.
         public Venue? Venue { get; set; }
 
         public Guid? VenueId { get; set; } // FK to Venue
@@ -207,10 +209,9 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
                     .HasForeignKey(x => x.CompetitionId)
                     .OnDelete(DeleteBehavior.Cascade);
 
-                builder.HasOne(x => x.Status)
-                    .WithOne(x => x.Competition)
-                    .HasForeignKey<CompetitionStatus>(x => x.CompetitionId)
-                    .OnDelete(DeleteBehavior.Cascade);
+                // Status FK lives on FootballCompetition / BaseballCompetition
+                // EntityConfigurations so each sport binds its own
+                // CompetitionStatus subclass.
 
                 builder.HasMany(x => x.Media)
                     .WithOne()

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionStatusBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionStatusBase.cs
@@ -1,18 +1,27 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 using SportsData.Core.Infrastructure.Data.Entities;
-using SportsData.Producer.Infrastructure.Data.Common;
-using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Contracts;
 
 namespace SportsData.Producer.Infrastructure.Data.Entities
 {
-    public class CompetitionStatus : CanonicalEntityBase<Guid>, IHasExternalIds
+    // Abstract base for sport-specific status entities. Mirrors the
+    // CompetitionBase / FootballCompetition / BaseballCompetition split:
+    // shared fields stay here; sport-specific fields and child collections
+    // live on FootballCompetitionStatus / BaseballCompetitionStatus.
+    //
+    // Naming: matches the *Base convention used elsewhere in this
+    // codebase (CompetitionBase, ContestBase, CompetitionPlayBase,
+    // AthleteBase) so the abstract role is obvious at a glance.
+    //
+    // The Status nav was previously hung off CompetitionBase, which
+    // pushed sport-specific concerns into the shared contract. It now
+    // lives on each sport's Competition subclass typed to that sport's
+    // CompetitionStatus subclass; the FK config moves with it.
+    public abstract class CompetitionStatusBase : CanonicalEntityBase<Guid>, IHasExternalIds
     {
         public Guid CompetitionId { get; set; }
-
-        public CompetitionBase Competition { get; set; } = null!;
 
         public double Clock { get; set; }
 
@@ -38,11 +47,14 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
         public IEnumerable<ExternalId> GetExternalIds() => ExternalIds;
 
-        public class EntityConfiguration : IEntityTypeConfiguration<CompetitionStatus>
+        public class EntityConfiguration : IEntityTypeConfiguration<CompetitionStatusBase>
         {
-            public void Configure(EntityTypeBuilder<CompetitionStatus> builder)
+            public void Configure(EntityTypeBuilder<CompetitionStatusBase> builder)
             {
-                builder.ToTable(nameof(CompetitionStatus));
+                // Literal table name (not nameof) preserves the existing
+                // "CompetitionStatus" schema across this rename — every
+                // prior migration references that string.
+                builder.ToTable("CompetitionStatus");
                 builder.HasKey(x => x.Id);
 
                 builder.Property(x => x.Clock).IsRequired();
@@ -58,10 +70,9 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
                 builder.Property(x => x.IsCompleted).IsRequired();
 
-                builder.HasOne(x => x.Competition)
-                    .WithOne(x => x.Status)
-                    .HasForeignKey<CompetitionStatus>(x => x.CompetitionId)
-                    .OnDelete(DeleteBehavior.Cascade);
+                // Competition <-> Status FK is configured on each sport's
+                // FootballCompetition / BaseballCompetition EntityConfiguration
+                // so the relationship is typed to that sport's subclass.
 
                 builder.HasMany(x => x.ExternalIds)
                     .WithOne(x => x.CompetitionStatus)

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionStatusExternalId.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionStatusExternalId.cs
@@ -10,7 +10,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
     {
         public Guid CompetitionStatusId { get; set; }
 
-        public CompetitionStatus CompetitionStatus { get; set; } = null!;
+        public CompetitionStatusBase CompetitionStatus { get; set; } = null!;
 
         public class EntityConfiguration : IEntityTypeConfiguration<CompetitionStatusExternalId>
         {

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionStatusExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionStatusExtensions.cs
@@ -1,12 +1,21 @@
-﻿using SportsData.Core.Common;
+using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
 {
     public static class CompetitionStatusExtensions
     {
-        public static CompetitionStatus AsEntity(
+        // Football overload. Builds the concrete FootballCompetitionStatus
+        // subclass — the abstract CompetitionStatus base can't be
+        // instantiated directly. NCAAFB and NFL share this path; if those
+        // ever diverge, split into NcaaFootballCompetitionStatus /
+        // NflFootballCompetitionStatus subclasses without changing the
+        // common processor.
+        public static FootballCompetitionStatus AsEntity(
             this EspnEventCompetitionStatusDtoBase dto,
             IGenerateExternalRefIdentities externalRefIdentityGenerator,
             Guid competitionId,
@@ -17,7 +26,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
 
             var identity = externalRefIdentityGenerator.Generate(dto.Ref);
 
-            return new CompetitionStatus
+            return new FootballCompetitionStatus
             {
                 Id = identity.CanonicalId,
                 CreatedBy = correlationId,
@@ -49,6 +58,90 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
                     }
                 }
             };
+        }
+
+        // Baseball overload. Builds BaseballCompetitionStatus so the MLB
+        // fields and FeaturedAthletes children travel with the entity.
+        // The shared mapping is duplicated rather than calling the
+        // football overload and casting — we'd get the wrong runtime
+        // type for EF and lose the discriminator. createdUtc threads in
+        // (rather than reading DateTime.UtcNow here) so the extension
+        // stays pure and unit-testable; callers pass
+        // IDateTimeProvider.UtcNow().
+        public static BaseballCompetitionStatus AsEntity(
+            this EspnBaseballEventCompetitionStatusDto dto,
+            IGenerateExternalRefIdentities externalRefIdentityGenerator,
+            Guid competitionId,
+            Guid correlationId,
+            DateTime createdUtc)
+        {
+            if (dto.Ref == null)
+                throw new ArgumentException("Status DTO is missing its $ref property.");
+
+            var identity = externalRefIdentityGenerator.Generate(dto.Ref);
+
+            var entity = new BaseballCompetitionStatus
+            {
+                Id = identity.CanonicalId,
+                CreatedBy = correlationId,
+                CreatedUtc = createdUtc,
+
+                CompetitionId = competitionId,
+
+                Clock = dto.Clock,
+                DisplayClock = dto.DisplayClock,
+                Period = dto.Period,
+
+                StatusTypeId = dto.Type?.Id ?? string.Empty,
+                StatusTypeName = dto.Type?.Name ?? string.Empty,
+                StatusState = dto.Type?.State ?? string.Empty,
+                IsCompleted = dto.Type?.Completed ?? false,
+                StatusDescription = dto.Type?.Description ?? string.Empty,
+                StatusDetail = dto.Type?.Detail ?? string.Empty,
+                StatusShortDetail = dto.Type?.ShortDetail ?? string.Empty,
+
+                HalfInning = dto.HalfInning,
+                PeriodPrefix = dto.PeriodPrefix,
+
+                ExternalIds = new List<CompetitionStatusExternalId>
+                {
+                    new()
+                    {
+                        Id = identity.CanonicalId,
+                        Provider = SourceDataProvider.Espn,
+                        Value = identity.UrlHash,
+                        SourceUrl = identity.CleanUrl,
+                        SourceUrlHash = identity.UrlHash
+                    }
+                }
+            };
+
+            if (dto.FeaturedAthletes is { Count: > 0 })
+            {
+                // Index-based Ordinal preserves ESPN's source order
+                // (winningPitcher [0], losingPitcher [1] post-game) so
+                // the sequence survives a save+reload round-trip.
+                entity.FeaturedAthletes = dto.FeaturedAthletes
+                    .Select((a, i) => new BaseballCompetitionStatusFeaturedAthlete
+                    {
+                        Id = Guid.NewGuid(),
+                        CreatedBy = correlationId,
+                        CreatedUtc = createdUtc,
+
+                        Ordinal = i,
+                        PlayerId = a.PlayerId,
+                        Name = a.Name,
+                        DisplayName = a.DisplayName,
+                        ShortDisplayName = a.ShortDisplayName,
+                        Abbreviation = a.Abbreviation,
+                        AthleteRef = a.Athlete?.Ref,
+                        TeamRef = a.Team?.Ref,
+                        StatisticsRef = a.Statistics?.Ref
+                    })
+                    .ToList();
+            }
+
+            return entity;
         }
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetition.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetition.cs
@@ -11,6 +11,10 @@ namespace SportsData.Producer.Infrastructure.Data.Football.Entities
 
         public ICollection<CompetitionDrive> Drives { get; set; } = [];
 
+        // Sport-specific Status nav. Lifted off CompetitionBase so the
+        // shared entity surface stays free of sport-specific concerns.
+        public FootballCompetitionStatus? Status { get; set; }
+
         public new class EntityConfiguration : IEntityTypeConfiguration<FootballCompetition>
         {
             public void Configure(EntityTypeBuilder<FootballCompetition> builder)
@@ -28,6 +32,11 @@ namespace SportsData.Producer.Infrastructure.Data.Football.Entities
                 builder.HasMany(x => x.Drives)
                     .WithOne()
                     .HasForeignKey(x => x.CompetitionId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                builder.HasOne(x => x.Status)
+                    .WithOne()
+                    .HasForeignKey<FootballCompetitionStatus>(x => x.CompetitionId)
                     .OnDelete(DeleteBehavior.Cascade);
             }
         }

--- a/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionStatus.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionStatus.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+// Sport-specific subclass for football status. No additional fields
+// today — exists so the type system records "this is football's
+// status" and the FootballCompetition.Status nav binds to it
+// concretely. Future football-only signals (red-zone state, etc.)
+// can land here without touching the base entity.
+public class FootballCompetitionStatus : CompetitionStatusBase
+{
+    public new class EntityConfiguration : IEntityTypeConfiguration<FootballCompetitionStatus>
+    {
+        public void Configure(EntityTypeBuilder<FootballCompetitionStatus> builder)
+        {
+            // No subclass-specific configuration yet; declared so each
+            // sport's DataContext registers a parallel hook point.
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
@@ -20,6 +20,10 @@ namespace SportsData.Producer.Infrastructure.Data.Football
 
         public new DbSet<FootballCompetitionPlay> CompetitionPlays { get; set; }
 
+        // Sport-specific status DbSet — typed entry point for the
+        // football side of the CompetitionStatus split.
+        public DbSet<FootballCompetitionStatus> FootballCompetitionStatuses { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -28,6 +32,7 @@ namespace SportsData.Producer.Infrastructure.Data.Football
             modelBuilder.ApplyConfiguration(new AthleteSeason.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetition.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionPlay.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new FootballCompetitionStatus.EntityConfiguration());
         }
     }
 }

--- a/src/SportsData.Producer/Migrations/Baseball/20260427082209_SplitCompetitionStatusBySport.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260427082209_SplitCompetitionStatusBySport.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Football
+namespace SportsData.Producer.Migrations.Baseball
 {
-    [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(BaseballDataContext))]
+    [Migration("20260427082209_SplitCompetitionStatusBySport")]
+    partial class SplitCompetitionStatusBySport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,6 +415,179 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("ConfigurationId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("Season")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SeasonType")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SplitTypeId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
+
+                    b.ToTable("AthleteSeasonHotZone", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("AtBats")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("AthleteSeasonHotZoneId")
+                        .HasColumnType("uuid");
+
+                    b.Property<double?>("BattingAvg")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("BattingAvgScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("Hits")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<double?>("Slugging")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("SluggingScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("ZoneId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonHotZoneId");
+
+                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("AthleteRef")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("CompetitionStatusId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasColumnType("text");
+
+                    b.Property<string>("TeamRef")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionStatusId");
+
+                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -4416,7 +4592,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("CompetitionSource");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -4490,7 +4666,7 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.ToTable("CompetitionStatus", (string)null);
 
-                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionStatusBase");
+                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionStatus");
 
                     b.UseTphMappingStrategy();
                 });
@@ -7889,9 +8065,17 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -7902,23 +8086,132 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("ThrowsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("ThrowsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("FootballAthlete");
+                    b.HasDiscriminator().HasValue("BaseballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
+                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetition");
+                    b.HasDiscriminator().HasValue("BaseballCompetition");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+                {
+                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
+
+                    b.Property<string>("AtBatId")
+                        .HasMaxLength(32)
+                        .HasColumnType("character varying(32)");
+
+                    b.Property<int?>("AtBatPitchNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayHits")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("BatOrder")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("HitCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("HitCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("HomeErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("HomeHits")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsDoublePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsTriplePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<double?>("PitchCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("PitchCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("PitchCountBalls")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("PitchCountStrikes")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PitchTypeAbbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<string>("PitchTypeId")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<string>("PitchTypeText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int?>("PitchVelocity")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("RbiCount")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("ResultCountBalls")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("ResultCountStrikes")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StrikeType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("SummaryType")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("Trajectory")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
@@ -7926,8 +8219,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
                     b.Property<string>("ClockDisplayValue")
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("text");
 
                     b.Property<double>("ClockValue")
                         .HasColumnType("double precision");
@@ -7970,21 +8262,28 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
-                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus");
+
+                    b.Property<int?>("HalfInning")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PeriodPrefix")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("FootballContest");
+                    b.HasDiscriminator().HasValue("BaseballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8017,6 +8316,28 @@ namespace SportsData.Producer.Migrations.Football
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
+                        .WithMany("Entries")
+                        .HasForeignKey("AthleteSeasonHotZoneId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("HotZone");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
+                        .WithMany("FeaturedAthletes")
+                        .HasForeignKey("CompetitionStatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionStatus");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8611,12 +8932,6 @@ namespace SportsData.Producer.Migrations.Football
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
-                        .WithMany("Drives")
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
                     b.Navigation("Competition");
                 });
 
@@ -8884,7 +9199,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusExternalId", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", "CompetitionStatus")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", "CompetitionStatus")
                         .WithMany("ExternalIds")
                         .HasForeignKey("CompetitionStatusId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -9541,7 +9856,7 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9550,23 +9865,26 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+                {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
                         .WithMany("Plays")
                         .HasForeignKey("DriveId")
@@ -9575,11 +9893,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9591,6 +9909,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -9782,7 +10105,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("ExternalIds");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", b =>
                 {
                     b.Navigation("ExternalIds");
                 });
@@ -9943,16 +10266,19 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.Navigation("Drives");
-
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.Navigation("FeaturedAthletes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Baseball/20260427082209_SplitCompetitionStatusBySport.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260427082209_SplitCompetitionStatusBySport.cs
@@ -11,13 +11,20 @@ namespace SportsData.Producer.Migrations.Baseball
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Default to the concrete baseball subtype so the column
+            // never carries an empty / unmapped TPH discriminator —
+            // existing rows in this DB were all written by the
+            // pre-split processor, which is now BaseballCompetitionStatus.
+            // The UPDATE backfill below is retained as a defensive
+            // idempotent step in case any row somehow predates the
+            // default being applied.
             migrationBuilder.AddColumn<string>(
                 name: "Discriminator",
                 table: "CompetitionStatus",
                 type: "character varying(34)",
                 maxLength: 34,
                 nullable: false,
-                defaultValue: "");
+                defaultValue: "BaseballCompetitionStatus");
 
             migrationBuilder.AddColumn<int>(
                 name: "HalfInning",

--- a/src/SportsData.Producer/Migrations/Baseball/20260427082209_SplitCompetitionStatusBySport.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260427082209_SplitCompetitionStatusBySport.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class SplitCompetitionStatusBySport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Discriminator",
+                table: "CompetitionStatus",
+                type: "character varying(34)",
+                maxLength: 34,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "HalfInning",
+                table: "CompetitionStatus",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PeriodPrefix",
+                table: "CompetitionStatus",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+
+            // Existing rows in the baseball DB were inserted before the
+            // sport-specific subclass split — backfill the discriminator
+            // so EF's typed queries (Set<BaseballCompetitionStatus>)
+            // match them. HalfInning / PeriodPrefix stay null on these
+            // rows (they were never captured by the previous processor).
+            migrationBuilder.Sql(
+                "UPDATE \"CompetitionStatus\" SET \"Discriminator\" = 'BaseballCompetitionStatus' WHERE \"Discriminator\" = ''");
+
+            migrationBuilder.CreateTable(
+                name: "BaseballCompetitionStatusFeaturedAthlete",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CompetitionStatusId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Ordinal = table.Column<int>(type: "integer", nullable: false),
+                    PlayerId = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    DisplayName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ShortDisplayName = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    Abbreviation = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    AthleteRef = table.Column<string>(type: "text", nullable: true),
+                    TeamRef = table.Column<string>(type: "text", nullable: true),
+                    StatisticsRef = table.Column<string>(type: "text", nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BaseballCompetitionStatusFeaturedAthlete", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BaseballCompetitionStatusFeaturedAthlete_CompetitionStatus_~",
+                        column: x => x.CompetitionStatusId,
+                        principalTable: "CompetitionStatus",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BaseballCompetitionStatusFeaturedAthlete_CompetitionStatusId",
+                table: "BaseballCompetitionStatusFeaturedAthlete",
+                column: "CompetitionStatusId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BaseballCompetitionStatusFeaturedAthlete");
+
+            migrationBuilder.DropColumn(
+                name: "Discriminator",
+                table: "CompetitionStatus");
+
+            migrationBuilder.DropColumn(
+                name: "HalfInning",
+                table: "CompetitionStatus");
+
+            migrationBuilder.DropColumn(
+                name: "PeriodPrefix",
+                table: "CompetitionStatus");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/20260427083536_RenameCompetitionStatusToBase.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260427083536_RenameCompetitionStatusToBase.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Football
+namespace SportsData.Producer.Migrations.Baseball
 {
-    [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(BaseballDataContext))]
+    [Migration("20260427083536_RenameCompetitionStatusToBase")]
+    partial class RenameCompetitionStatusToBase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,6 +415,179 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("ConfigurationId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("Season")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SeasonType")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SplitTypeId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
+
+                    b.ToTable("AthleteSeasonHotZone", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("AtBats")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("AthleteSeasonHotZoneId")
+                        .HasColumnType("uuid");
+
+                    b.Property<double?>("BattingAvg")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("BattingAvgScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("Hits")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<double?>("Slugging")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("SluggingScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("ZoneId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonHotZoneId");
+
+                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("AthleteRef")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("CompetitionStatusId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasColumnType("text");
+
+                    b.Property<string>("TeamRef")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionStatusId");
+
+                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -7889,9 +8065,17 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -7902,23 +8086,132 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("ThrowsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("ThrowsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("FootballAthlete");
+                    b.HasDiscriminator().HasValue("BaseballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
+                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetition");
+                    b.HasDiscriminator().HasValue("BaseballCompetition");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+                {
+                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
+
+                    b.Property<string>("AtBatId")
+                        .HasMaxLength(32)
+                        .HasColumnType("character varying(32)");
+
+                    b.Property<int?>("AtBatPitchNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayHits")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("BatOrder")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("HitCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("HitCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("HomeErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("HomeHits")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsDoublePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsTriplePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<double?>("PitchCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("PitchCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("PitchCountBalls")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("PitchCountStrikes")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PitchTypeAbbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<string>("PitchTypeId")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<string>("PitchTypeText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int?>("PitchVelocity")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("RbiCount")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("ResultCountBalls")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("ResultCountStrikes")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StrikeType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("SummaryType")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("Trajectory")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
@@ -7926,8 +8219,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
                     b.Property<string>("ClockDisplayValue")
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("text");
 
                     b.Property<double>("ClockValue")
                         .HasColumnType("double precision");
@@ -7970,21 +8262,28 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+
+                    b.Property<int?>("HalfInning")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PeriodPrefix")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("FootballContest");
+                    b.HasDiscriminator().HasValue("BaseballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8017,6 +8316,28 @@ namespace SportsData.Producer.Migrations.Football
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
+                        .WithMany("Entries")
+                        .HasForeignKey("AthleteSeasonHotZoneId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("HotZone");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
+                        .WithMany("FeaturedAthletes")
+                        .HasForeignKey("CompetitionStatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionStatus");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8607,12 +8928,6 @@ namespace SportsData.Producer.Migrations.Football
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
                         .WithMany()
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
-                        .WithMany("Drives")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -9541,7 +9856,7 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9550,23 +9865,26 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+                {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
                         .WithMany("Plays")
                         .HasForeignKey("DriveId")
@@ -9575,11 +9893,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9591,6 +9909,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -9943,16 +10266,19 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.Navigation("Drives");
-
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.Navigation("FeaturedAthletes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Baseball/20260427083536_RenameCompetitionStatusToBase.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260427083536_RenameCompetitionStatusToBase.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class RenameCompetitionStatusToBase : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
@@ -528,6 +528,65 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
                 });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("AthleteRef")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("CompetitionStatusId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasColumnType("text");
+
+                    b.Property<string>("TeamRef")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionStatusId");
+
+                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
+                });
+
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
                 {
                     b.Property<Guid>("Id")
@@ -4530,7 +4589,7 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("CompetitionSource");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -4547,6 +4606,11 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.Property<DateTime>("CreatedUtc")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Discriminator")
+                        .IsRequired()
+                        .HasMaxLength(34)
+                        .HasColumnType("character varying(34)");
 
                     b.Property<string>("DisplayClock")
                         .IsRequired()
@@ -4597,10 +4661,11 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasKey("Id");
 
-                    b.HasIndex("CompetitionId")
-                        .IsUnique();
-
                     b.ToTable("CompetitionStatus", (string)null);
+
+                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionStatusBase");
+
+                    b.UseTphMappingStrategy();
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusExternalId", b =>
@@ -8194,6 +8259,23 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+
+                    b.Property<int?>("HalfInning")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PeriodPrefix")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.HasIndex("CompetitionId")
+                        .IsUnique();
+
+                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
+                });
+
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
@@ -8242,6 +8324,17 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
 
                     b.Navigation("HotZone");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
+                        .WithMany("FeaturedAthletes")
+                        .HasForeignKey("CompetitionStatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionStatus");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -9101,20 +9194,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("LastPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
-                        .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", "CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Competition");
-                });
-
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusExternalId", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", "CompetitionStatus")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", "CompetitionStatus")
                         .WithMany("ExternalIds")
                         .HasForeignKey("CompetitionStatusId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -9808,6 +9890,15 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Drive");
                 });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                        .WithOne("Status")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("CompetitionOdds", b =>
                 {
                     b.Navigation("ExternalIds");
@@ -9935,8 +10026,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Probabilities");
 
                     b.Navigation("Situations");
-
-                    b.Navigation("Status");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", b =>
@@ -10013,7 +10102,7 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("ExternalIds");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", b =>
                 {
                     b.Navigation("ExternalIds");
                 });
@@ -10177,6 +10266,13 @@ namespace SportsData.Producer.Migrations.Baseball
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
                     b.Navigation("Plays");
+
+                    b.Navigation("Status");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.Navigation("FeaturedAthletes");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>

--- a/src/SportsData.Producer/Migrations/Football/20260427082151_SplitCompetitionStatusBySport.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260427082151_SplitCompetitionStatusBySport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260427082151_SplitCompetitionStatusBySport")]
+    partial class SplitCompetitionStatusBySport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -4416,7 +4419,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("CompetitionSource");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -4490,7 +4493,7 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.ToTable("CompetitionStatus", (string)null);
 
-                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionStatusBase");
+                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionStatus");
 
                     b.UseTphMappingStrategy();
                 });
@@ -7972,7 +7975,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
-                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
@@ -8884,7 +8887,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusExternalId", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", "CompetitionStatus")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", "CompetitionStatus")
                         .WithMany("ExternalIds")
                         .HasForeignKey("CompetitionStatusId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -9782,7 +9785,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("ExternalIds");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatus", b =>
                 {
                     b.Navigation("ExternalIds");
                 });

--- a/src/SportsData.Producer/Migrations/Football/20260427082151_SplitCompetitionStatusBySport.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260427082151_SplitCompetitionStatusBySport.cs
@@ -10,19 +10,21 @@ namespace SportsData.Producer.Migrations.Football
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Default to the concrete football subtype so the column
+            // never carries an empty / unmapped TPH discriminator —
+            // existing rows in this DB were all written by the
+            // pre-split processor, which is now FootballCompetitionStatus.
+            // The UPDATE backfill below is retained as a defensive
+            // idempotent step in case any row somehow predates the
+            // default being applied.
             migrationBuilder.AddColumn<string>(
                 name: "Discriminator",
                 table: "CompetitionStatus",
                 type: "character varying(34)",
                 maxLength: 34,
                 nullable: false,
-                defaultValue: "");
+                defaultValue: "FootballCompetitionStatus");
 
-            // Existing rows in the football DB are all the football
-            // subtype — backfill the discriminator so EF's typed
-            // queries (Set<FootballCompetitionStatus>) match them.
-            // Without this every pre-migration row reads as the empty
-            // default and is invisible to the new code path.
             migrationBuilder.Sql(
                 "UPDATE \"CompetitionStatus\" SET \"Discriminator\" = 'FootballCompetitionStatus' WHERE \"Discriminator\" = ''");
         }

--- a/src/SportsData.Producer/Migrations/Football/20260427082151_SplitCompetitionStatusBySport.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260427082151_SplitCompetitionStatusBySport.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class SplitCompetitionStatusBySport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Discriminator",
+                table: "CompetitionStatus",
+                type: "character varying(34)",
+                maxLength: 34,
+                nullable: false,
+                defaultValue: "");
+
+            // Existing rows in the football DB are all the football
+            // subtype — backfill the discriminator so EF's typed
+            // queries (Set<FootballCompetitionStatus>) match them.
+            // Without this every pre-migration row reads as the empty
+            // default and is invisible to the new code path.
+            migrationBuilder.Sql(
+                "UPDATE \"CompetitionStatus\" SET \"Discriminator\" = 'FootballCompetitionStatus' WHERE \"Discriminator\" = ''");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Discriminator",
+                table: "CompetitionStatus");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/20260427083508_RenameCompetitionStatusToBase.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260427083508_RenameCompetitionStatusToBase.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260427083508_RenameCompetitionStatusToBase")]
+    partial class RenameCompetitionStatusToBase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260427083508_RenameCompetitionStatusToBase.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260427083508_RenameCompetitionStatusToBase.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class RenameCompetitionStatusToBase : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -33,40 +33,55 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
     {
         var evt = context.Message;
 
-        // ✅ Validate CorrelationId - generate new one if empty
-        if (evt.CorrelationId == Guid.Empty)
-        {
-            _logger.LogWarning(
-                "DocumentRequested received with empty CorrelationId. Generating new one. Uri={Uri}, DocumentType={DocumentType}",
-                evt.Uri,
-                evt.DocumentType);
-            
-            // Generate new correlation ID from current Activity (OpenTelemetry)
-            var newCorrelationId = ActivityExtensions.GetCorrelationId();
-            
-            // Create new event with valid CorrelationId
-            evt = new DocumentRequested(
-                evt.Id,
-                evt.ParentId,
-                evt.Uri,
-                evt.Ref,
-                evt.Sport,
-                evt.SeasonYear,
-                evt.DocumentType,
-                evt.SourceDataProvider,
-                newCorrelationId,  // ✅ Use new correlation ID
-                evt.CausationId,
-                evt.PropertyBag,
-                evt.IncludeLinkedDocumentTypes);
-        }
+        // Resolve the upstream correlation id with explicit fallbacks.
+        // The previous implementation regenerated silently on
+        // Guid.Empty, which made every dropped CorrelationId look like
+        // a fresh trace in Seq and broke cross-service Producer→Provider
+        // searches. Order:
+        //   1) Body field (DocumentRequested.CorrelationId) — preferred,
+        //      set by Producer's ContestUpdateProcessor / DocumentProcessorBase.
+        //   2) Transport header X-Correlation-Id — auto-stamped by
+        //      EventBusAdapter on every EventBase publish; survives a
+        //      body-deserialization drop.
+        //   3) MassTransit ConsumeContext.CorrelationId — set when the
+        //      publisher used MT's transport-level correlation.
+        //   4) Activity.Current.TraceId — final fallback, derived from
+        //      the W3C traceparent header MT propagates via OpenTelemetry.
+        //   5) NewGuid + ERROR log so the operator can find the drop.
+        var correlationId = ResolveCorrelationId(context, out var source);
+        var bodyWasMissing = context.Message.CorrelationId == Guid.Empty;
 
         using (_logger.BeginScope(new Dictionary<string, object>
                {
-                   ["CorrelationId"] = evt.CorrelationId,
+                   ["CorrelationId"] = correlationId,
                    ["DocumentType"] = evt.DocumentType,
-                   ["Uri"] = evt.Uri.ToString()
+                   ["Uri"] = evt.Uri.ToString(),
+                   ["CorrelationIdSource"] = source
                }))
         {
+            if (bodyWasMissing)
+            {
+                // ERROR (not Warning) so this is searchable in Seq —
+                // the operator needs to be able to find every dropped
+                // CorrelationId and trace it back to the publisher.
+                _logger.LogError(
+                    "DocumentRequested arrived with empty body CorrelationId. " +
+                    "Resolved={ResolvedCorrelationId} via {ResolvedSource}. " +
+                    "TransportHeaderXCorrelationId={HeaderXCorrelationId}, " +
+                    "MassTransitContextCorrelationId={ContextCorrelationId}, " +
+                    "Uri={Uri}",
+                    correlationId,
+                    source,
+                    context.Headers.Get<string>("X-Correlation-Id") ?? "<absent>",
+                    context.CorrelationId,
+                    evt.Uri);
+
+                // Replace the event so downstream code (and the
+                // outbound DocumentCreated publish) carries the
+                // resolved id forward.
+                evt = evt with { CorrelationId = correlationId };
+            }
+
             _logger.LogInformation(
                 "DocumentRequested received. Uri={Uri}, DocumentType={DocumentType}, Sport={Sport}, Provider={Provider}",
                 evt.Uri,
@@ -77,7 +92,7 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
             try
             {
                 await ConsumeInternal(evt);
-                
+
                 _logger.LogInformation("DocumentRequested processed. Uri={Uri}", evt.Uri);
             }
             catch (Exception ex)
@@ -86,6 +101,40 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 throw;
             }
         }
+    }
+
+    private static Guid ResolveCorrelationId(ConsumeContext<DocumentRequested> context, out string source)
+    {
+        if (context.Message.CorrelationId != Guid.Empty)
+        {
+            source = "MessageBody";
+            return context.Message.CorrelationId;
+        }
+
+        var headerValue = context.Headers.Get<string>("X-Correlation-Id");
+        if (!string.IsNullOrWhiteSpace(headerValue)
+            && Guid.TryParse(headerValue, out var headerGuid)
+            && headerGuid != Guid.Empty)
+        {
+            source = "TransportHeader";
+            return headerGuid;
+        }
+
+        if (context.CorrelationId.HasValue && context.CorrelationId.Value != Guid.Empty)
+        {
+            source = "MassTransitContext";
+            return context.CorrelationId.Value;
+        }
+
+        var activityCorrelationId = ActivityExtensions.GetCorrelationId();
+        if (activityCorrelationId != Guid.Empty)
+        {
+            source = "ActivityTraceId";
+            return activityCorrelationId;
+        }
+
+        source = "NewGuid";
+        return Guid.NewGuid();
     }
 
     private async Task ConsumeInternal(DocumentRequested evt)

--- a/src/SportsData.Provider/Program.cs
+++ b/src/SportsData.Provider/Program.cs
@@ -110,6 +110,7 @@ namespace SportsData.Provider
                 }
                 else
                 {
+                    Console.WriteLine("Message consumption is ACTIVE. DocumentRequestedHandler will be registered.");
                     consumers.Add(typeof(DocumentRequestedHandler));
                 }
 
@@ -120,6 +121,7 @@ namespace SportsData.Provider
             }
             else
             {
+                Console.WriteLine("Ingestion not enabled.");
                 // Non-ingest roles still need MassTransit bus for publishing events
                 services.AddMessaging(config, consumers: null);
             }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
@@ -512,7 +512,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<ContestEnrichmen
             Id = competitionId,
             ContestId = contestId,
             Contest = contest,
-            Status = new CompetitionStatus
+            Status = new FootballCompetitionStatus
             {
                 Id = Guid.NewGuid(),
                 CompetitionId = competitionId,

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using FluentAssertions;
+
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+using SportsData.Producer.Infrastructure.Data.Football;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
+
+/// <summary>
+/// Tests for BaseballEventCompetitionStatusDocumentProcessor — the
+/// MLB-specific processor that builds <c>BaseballCompetitionStatus</c>
+/// (the sport-specific subclass) so the baseball-only fields and the
+/// FeaturedAthletes child collection persist alongside the shared
+/// status row.
+///
+/// The persistence path uses
+/// <c>_dataContext.Set&lt;BaseballCompetitionStatus&gt;()</c>, which
+/// requires the type to be in the model — only BaseballDataContext
+/// has it registered. ProducerTestBase only wires up FootballDataContext
+/// today, so the round-trip tests stay skipped behind the same
+/// "Requires BaseballDataContext test infrastructure" guard the other
+/// Baseball processor tests in this folder use. The DTO-deserialization
+/// fact runs unconditionally and is the actual schema-drift canary
+/// against ESPN's MLB status payload.
+/// </summary>
+[Collection("Sequential")]
+public class BaseballEventCompetitionStatusDocumentProcessorTests
+    : ProducerTestBase<BaseballEventCompetitionStatusDocumentProcessor<FootballDataContext>>
+{
+    [Fact]
+    public async Task EspnBaseballEventCompetitionStatusDto_DeserializesMlbFields()
+    {
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionStatus.json");
+
+        var dto = json.FromJson<EspnBaseballEventCompetitionStatusDto>();
+
+        dto.Should().NotBeNull();
+        dto!.Type.Name.Should().Be("STATUS_FINAL");
+        dto.HalfInning.Should().Be(17);
+        dto.PeriodPrefix.Should().Be("Bottom");
+        dto.FeaturedAthletes.Should().HaveCount(2);
+        dto.FeaturedAthletes![0].Name.Should().Be("winningPitcher");
+        dto.FeaturedAthletes[0].PlayerId.Should().Be(4987924);
+        dto.FeaturedAthletes[0].Athlete!.Ref.Should().NotBeNull();
+        dto.FeaturedAthletes[1].Name.Should().Be("losingPitcher");
+    }
+
+    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
+    public Task WhenNoExisting_PersistsStatus_WithMlbFieldsAndFeaturedAthletes()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
+    public Task WhenStatusTypeNameChanges_PublishesCompetitionStatusChanged()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
+    public Task WhenExistingStatusReplaced_OrdinalPreservesEspnSourceOrder()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
@@ -1,37 +1,103 @@
 #nullable enable
 
+using AutoFixture;
+
 using FluentAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
 
 using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
 
 /// <summary>
-/// Tests for BaseballEventCompetitionStatusDocumentProcessor — the
-/// MLB-specific processor that builds <c>BaseballCompetitionStatus</c>
+/// Tests for <see cref="BaseballEventCompetitionStatusDocumentProcessor{TDataContext}"/>
+/// — the MLB-specific processor that builds <c>BaseballCompetitionStatus</c>
 /// (the sport-specific subclass) so the baseball-only fields and the
 /// FeaturedAthletes child collection persist alongside the shared
 /// status row.
 ///
-/// The persistence path uses
-/// <c>_dataContext.Set&lt;BaseballCompetitionStatus&gt;()</c>, which
-/// requires the type to be in the model — only BaseballDataContext
-/// has it registered. ProducerTestBase only wires up FootballDataContext
-/// today, so the round-trip tests stay skipped behind the same
-/// "Requires BaseballDataContext test infrastructure" guard the other
-/// Baseball processor tests in this folder use. The DTO-deserialization
-/// fact runs unconditionally and is the actual schema-drift canary
-/// against ESPN's MLB status payload.
+/// Wires a class-local <see cref="BaseballDataContext"/> rather than
+/// reusing <see cref="ProducerTestBase{T}.FootballDataContext"/> so
+/// <c>BaseballCompetitionStatus</c> and
+/// <c>BaseballCompetitionStatusFeaturedAthlete</c> are in the model
+/// and the persistence path under test is real, not stubbed.
 /// </summary>
 [Collection("Sequential")]
 public class BaseballEventCompetitionStatusDocumentProcessorTests
-    : ProducerTestBase<BaseballEventCompetitionStatusDocumentProcessor<FootballDataContext>>
+    : ProducerTestBase<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>
 {
+    private static readonly DateTime FixedNow =
+        new DateTime(2026, 4, 27, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly BaseballDataContext _baseballDataContext;
+
+    public BaseballEventCompetitionStatusDocumentProcessorTests()
+    {
+        // Class-local BaseballDataContext so the SUT's
+        // _dataContext.Set<BaseballCompetitionStatus>() finds a registered
+        // subclass. The parent ProducerTestBase still wires Football for
+        // the abstract TeamSportDataContext / BaseDataContext slots used
+        // by other processors; this Use(...) overlays a concrete
+        // BaseballDataContext for direct injection by Mocker.
+        _baseballDataContext = new BaseballDataContext(
+            new DbContextOptionsBuilder<BaseballDataContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+                .Options);
+        Mocker.Use(_baseballDataContext);
+
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    private async Task<(BaseballContest contest, BaseballCompetition competition)>
+        SeedContestAndCompetitionAsync(Guid competitionId)
+    {
+        var contest = new BaseballContest
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Contest",
+            ShortName = "Test",
+            SeasonYear = 2026,
+            Sport = Sport.BaseballMlb,
+            StartDateUtc = FixedNow,
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        var competition = new BaseballCompetition
+        {
+            Id = competitionId,
+            ContestId = contest.Id,
+            Date = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        await _baseballDataContext.Contests.AddAsync(contest);
+        await _baseballDataContext.Competitions.AddAsync(competition);
+        await _baseballDataContext.SaveChangesAsync();
+
+        return (contest, competition);
+    }
+
     [Fact]
     public async Task EspnBaseballEventCompetitionStatusDto_DeserializesMlbFields()
     {
@@ -50,21 +116,173 @@ public class BaseballEventCompetitionStatusDocumentProcessorTests
         dto.FeaturedAthletes[1].Name.Should().Be("losingPitcher");
     }
 
-    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
-    public Task WhenNoExisting_PersistsStatus_WithMlbFieldsAndFeaturedAthletes()
+    [Fact]
+    public async Task WhenNoExisting_PersistsStatus_WithMlbFieldsAndFeaturedAthletes_AndDoesNotPublishStatusChanged()
     {
-        return Task.CompletedTask;
+        // arrange
+        var bus = Mocker.GetMock<IEventBus>();
+        var idGen = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(idGen);
+
+        var compId = Guid.NewGuid();
+        await SeedContestAndCompetitionAsync(compId);
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionStatus.json");
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, compId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionStatus)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash,
+                "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/status?lang=en&region=us"
+                    .UrlHash())
+            .With(x => x.CorrelationId, Guid.NewGuid())
+            .OmitAutoProperties()
+            .Create();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — persisted as the MLB subtype with all MLB fields
+        var status = await _baseballDataContext.Set<BaseballCompetitionStatus>()
+            .Include(x => x.FeaturedAthletes)
+            .Where(x => x.CompetitionId == compId)
+            .ToListAsync();
+
+        status.Should().ContainSingle();
+        var entity = status[0];
+        entity.StatusTypeName.Should().Be("STATUS_FINAL");
+        entity.IsCompleted.Should().BeTrue();
+        entity.HalfInning.Should().Be(17);
+        entity.PeriodPrefix.Should().Be("Bottom");
+
+        // FeaturedAthletes children persisted with refs preserved.
+        entity.FeaturedAthletes.Should().HaveCount(2);
+        var winning = entity.FeaturedAthletes.Single(a => a.Name == "winningPitcher");
+        winning.PlayerId.Should().Be(4987924);
+        winning.AthleteRef!.AbsoluteUri.Should().Contain("/athletes/4987924");
+        winning.TeamRef!.AbsoluteUri.Should().Contain("/teams/5");
+        winning.StatisticsRef.Should().NotBeNull();
+
+        // Initial create — no prior status to compare against, so the
+        // status-changed branch must not fire.
+        bus.Verify(
+            x => x.Publish(It.IsAny<CompetitionStatusChanged>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
-    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
-    public Task WhenStatusTypeNameChanges_PublishesCompetitionStatusChanged()
+    [Fact]
+    public async Task WhenStatusTypeNameChanges_HardReplacesRowAndPublishesCompetitionStatusChanged()
     {
-        return Task.CompletedTask;
+        // arrange — pre-seed a row with a DIFFERENT status name so the
+        // comparison detects a change.
+        var bus = Mocker.GetMock<IEventBus>();
+        var idGen = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(idGen);
+
+        var compId = Guid.NewGuid();
+        await SeedContestAndCompetitionAsync(compId);
+
+        var oldRowId = Guid.NewGuid();
+        var existing = new BaseballCompetitionStatus
+        {
+            Id = oldRowId,
+            CompetitionId = compId,
+            StatusTypeName = "STATUS_IN_PROGRESS",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        await _baseballDataContext.Set<BaseballCompetitionStatus>().AddAsync(existing);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionStatus.json");
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, compId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionStatus)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash,
+                "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/status?lang=en&region=us"
+                    .UrlHash())
+            .With(x => x.CorrelationId, Guid.NewGuid())
+            .OmitAutoProperties()
+            .Create();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — old row replaced by a new row carrying the new status.
+        var saved = await _baseballDataContext.Set<BaseballCompetitionStatus>()
+            .AsNoTracking()
+            .Where(s => s.CompetitionId == compId)
+            .ToListAsync();
+        saved.Should().ContainSingle();
+        saved[0].Id.Should().NotBe(oldRowId);
+        saved[0].StatusTypeName.Should().Be("STATUS_FINAL");
+
+        // assert — CompetitionStatusChanged published exactly once with
+        // the new status name.
+        bus.Verify(
+            x => x.Publish(
+                It.Is<CompetitionStatusChanged>(e =>
+                    e.CompetitionId == compId &&
+                    e.Status == "STATUS_FINAL"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
-    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
-    public Task WhenExistingStatusReplaced_OrdinalPreservesEspnSourceOrder()
+    [Fact]
+    public async Task FeaturedAthletes_PersistInEspnSourceOrderViaOrdinal()
     {
-        return Task.CompletedTask;
+        // arrange
+        var idGen = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(idGen);
+
+        var compId = Guid.NewGuid();
+        await SeedContestAndCompetitionAsync(compId);
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionStatus.json");
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, compId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionStatus)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash,
+                "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/status?lang=en&region=us"
+                    .UrlHash())
+            .With(x => x.CorrelationId, Guid.NewGuid())
+            .OmitAutoProperties()
+            .Create();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — Ordinal mirrors ESPN's source array index
+        // (winningPitcher [0], losingPitcher [1] from the fixture).
+        var athletes = await _baseballDataContext.Set<BaseballCompetitionStatusFeaturedAthlete>()
+            .AsNoTracking()
+            .OrderBy(a => a.Ordinal)
+            .ToListAsync();
+
+        athletes.Should().HaveCount(2);
+        athletes[0].Ordinal.Should().Be(0);
+        athletes[0].Name.Should().Be("winningPitcher");
+        athletes[1].Ordinal.Should().Be(1);
+        athletes[1].Name.Should().Be("losingPitcher");
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
@@ -34,6 +34,7 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
         Fixture.Customizations.Add(new TypeRelay(typeof(ContestBase), typeof(FootballContest)));
         Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionBase), typeof(FootballCompetition)));
         Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionPlayBase), typeof(FootballCompetitionPlay)));
+        Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionStatusBase), typeof(FootballCompetitionStatus)));
 
         // Override mapper with Producer-specific mapping profile
         var mapperConfig = new MapperConfiguration(c =>


### PR DESCRIPTION
Three logical pieces bundled because they all need to land together to enable the next prod push for MLB live testing.

## 1) CompetitionStatus inheritance split

Replaces #278 (closed) — the prior attempt added MLB-only fields directly to the shared `CompetitionStatus` entity, leaking baseball concerns into the football surface. This rev mirrors the existing `CompetitionBase / FootballCompetition / BaseballCompetition` pattern: shared fields stay on an abstract base, sport-specific fields and relationships live on per-sport subclasses registered only in the matching `DataContext`.

- `CompetitionStatus` → `CompetitionStatusBase` (abstract; renamed to match the `*Base` convention used elsewhere). Table name preserved via `builder.ToTable(""CompetitionStatus"")` so prior migrations stay valid.
- `FootballCompetitionStatus : CompetitionStatusBase` (no extra fields yet — exists for type-system parallelism and future football-only signals).
- `BaseballCompetitionStatus : CompetitionStatusBase` with `HalfInning`, `PeriodPrefix`, `FeaturedAthletes` nav.
- `BaseballCompetitionStatusFeaturedAthlete` child table (FK + cascade) with index-based `Ordinal` so ESPN's source order (`winningPitcher [0]`, `losingPitcher [1]` etc.) survives a save/reload.
- `Status` nav moved off `CompetitionBase` onto `FootballCompetition` and `BaseballCompetition` typed to each sport's subclass; FK config relocated with it.
- Four consumer call sites updated to query `CompetitionStatuses` directly by `CompetitionId` instead of via the now-absent base nav: `ContestEnrichmentProcessor`, `GetContestOverviewQueryHandler`, both Football and Baseball `EventCompetitionPlayDocumentProcessor`.
- New `BaseballEventCompetitionStatusDocumentProcessor`; the existing shared processor drops `Sport.BaseballMlb` and now constructs `FootballCompetitionStatus`.
- AutoFixture `TypeRelay` added (`CompetitionStatusBase` → `FootballCompetitionStatus`) so existing tests continue to build.

**Schema impact per sport DB:**
- **Football:** TPH discriminator added to existing `CompetitionStatus` table, backfilled to `'FootballCompetitionStatus'` for prior rows. No new columns, no new tables.
- **Baseball:** Discriminator + nullable `HalfInning` + nullable `PeriodPrefix(10)` added to `CompetitionStatus`, backfilled to `'BaseballCompetitionStatus'` for prior rows. New `BaseballCompetitionStatusFeaturedAthlete` table.
- Two migrations per context — the schema split itself, then a second no-op migration that resyncs the snapshot to the renamed CLR type after the `CompetitionStatusBase` rename.

## 2) Cross-service correlation hardening

Direct response to the symptom: hitting Refresh Contest emits an API + Producer trace under one CorrelationId, but Provider's logs for that same id come back empty. Root cause was the silent-regen path in `DocumentRequestedHandler` — when the body's `CorrelationId` arrived empty, it generated a fresh one from `Activity.Current.TraceId` and used that for the scope, so Seq filtering by the upstream id missed every Provider log line.

- `EventBusAdapter.Publish` now auto-stamps an `X-Correlation-Id` transport header from `EventBase.CorrelationId` on every publish. Belt-and-suspenders alongside the body field.
- `DocumentRequestedHandler.Consume` replaces the silent regen with `ResolveCorrelationId` — explicit fallback chain (body → `X-Correlation-Id` header → `ConsumeContext.CorrelationId` → `Activity.TraceId` → `NewGuid`). Logs an `Error` (not Warning) with the resolved value, the source it came from, the header value, and the MT context CorrelationId whenever the body arrived empty — searchable in Seq, makes the silent drop loud.

## 3) Diagnostic logging for the prod push

Temporary instrumentation so the next prod deploy makes the failure mode visible from pod logs:
- `ContestUpdateProcessor` logs the full `DocumentRequested` envelope immediately before `_bus.Publish` so the `CorrelationId` on the wire is grep-able.
- `Provider/Program.cs` prints `""Message consumption is ACTIVE. DocumentRequestedHandler will be registered.""` or `""Ingestion not enabled.""` at startup so the consumer-registration path can be confirmed via `kubectl logs`.

## Test plan
- [x] `dotnet build` clean (full solution)
- [x] `dotnet test` — 322 passing, 21 skipped (pre-existing), 0 failing
- [x] Migrations applied locally on Football + Baseball contexts via `docker compose up`
- [ ] Prod push: deploy, hit Refresh Contest on an MLB contest, confirm via `kubectl logs producer-baseball-mlb-worker | grep ""Publishing with""` that `CorrelationId` is non-empty on the wire
- [ ] Prod: `kubectl logs provider-baseball-mlb-ingest | grep -E ""ACTIVE\|not enabled""` confirms consumer is registered
- [ ] Prod: Seq search by the returned correlationId — Provider lines should appear; if they don't, the new ERROR log will name which fallback fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MLB competition status tracking and processing with support for featured athletes and inning information.

* **Improvements**
  * Enhanced correlation ID tracking across event publishing to improve message traceability.
  * Refined event logging to include correlation context details and resolution sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->