### PR TITLE
fix(outbox): publish before SaveChanges and decouple Contest handlers from abstract DbContext

### DIFF
--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -181,11 +181,12 @@ namespace SportsData.Api.Application.Processors
 
             groupWeek.AreMatchupsGenerated = true;
 
-            await _dataContext.SaveChangesAsync();
-
-            // Only publish event after successful persistence and if the week is not completed
-            // Check against groupMatchups (not allMatchups) since we only care about this group's matchups
-            // Empty groupMatchups is treated as not completed (publish the event)
+            // Publish BEFORE SaveChanges so MassTransit's bus-outbox interceptor flushes
+            // the captured message into the OutboxMessage table within the same transaction
+            // as the entity write. If the save fails, the captured publish is rolled back
+            // with it — same atomicity guarantee, correct outbox semantics.
+            // Check against groupMatchups (not allMatchups) since we only care about this group's matchups.
+            // Empty groupMatchups is treated as not completed (publish the event).
             var isWeekCompleted = groupMatchups.Count > 0 && groupMatchups.All(m => ContestStatusValues.IsCompleted(m.Status));
             if (!isWeekCompleted)
             {
@@ -204,6 +205,8 @@ namespace SportsData.Api.Application.Processors
                 _logger.LogInformation("Skipping PickemGroupWeekMatchupsGenerated event for completed week. GroupId={GroupId}, SeasonYear={SeasonYear}, SeasonWeek={SeasonWeek}",
                     group.Id, command.SeasonYear, command.SeasonWeek);
             }
+
+            await _dataContext.SaveChangesAsync();
         }
     }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/AddMatchup/AddMatchupCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/AddMatchup/AddMatchupCommandHandler.cs
@@ -137,14 +137,13 @@ public class AddMatchupCommandHandler : IAddMatchupCommandHandler
         };
 
         await _dbContext.PickemGroupMatchups.AddAsync(newMatchup, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Matchup added successfully. LeagueId={LeagueId}, ContestId={ContestId}, MatchupId={MatchupId}",
-            command.LeagueId, command.ContestId, newMatchup.Id);
-
-        // 6. Publish event for AI preview generation
-        if (!ContestStatusValues.IsCompleted(matchup.Status))
+        // 6. Publish event for AI preview generation.
+        // Publish BEFORE SaveChanges so MassTransit's bus-outbox interceptor flushes the
+        // captured message into the OutboxMessage table within the same transaction as
+        // the entity write. If the save fails, the captured publish is rolled back with it.
+        var publishEvent = !ContestStatusValues.IsCompleted(matchup.Status);
+        if (publishEvent)
         {
             await _eventBus.Publish(
                 new PickemGroupMatchupAdded(
@@ -156,7 +155,16 @@ public class AddMatchupCommandHandler : IAddMatchupCommandHandler
                     command.CorrelationId,
                     Guid.NewGuid()),
                 cancellationToken);
+        }
 
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Matchup added successfully. LeagueId={LeagueId}, ContestId={ContestId}, MatchupId={MatchupId}",
+            command.LeagueId, command.ContestId, newMatchup.Id);
+
+        if (publishEvent)
+        {
             _logger.LogInformation(
                 "Published PickemGroupMatchupAdded event. LeagueId={LeagueId}, ContestId={ContestId}, CorrelationId={CorrelationId}",
                 command.LeagueId, command.ContestId, command.CorrelationId);

--- a/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
@@ -13,16 +13,17 @@ namespace SportsData.Producer.Application.Contests
     /// Gets a list of contestIds for the current season week that need to be updated
     /// and enqueues jobs to update them.
     /// </summary>
-    public class ContestUpdateJob : IAmARecurringJob
+    public class ContestUpdateJob<TDataContext> : IAmARecurringJob
+        where TDataContext : TeamSportDataContext
     {
-        private readonly ILogger<ContestUpdateJob> _logger;
-        private readonly TeamSportDataContext _dataContext;
+        private readonly ILogger<ContestUpdateJob<TDataContext>> _logger;
+        private readonly TDataContext _dataContext;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
         private readonly IAppMode _appMode;
 
         public ContestUpdateJob(
-            ILogger<ContestUpdateJob> logger,
-            TeamSportDataContext dataContext,
+            ILogger<ContestUpdateJob<TDataContext>> logger,
+            TDataContext dataContext,
             IProvideBackgroundJobs backgroundJobProvider,
             IAppMode appMode)
         {
@@ -40,7 +41,7 @@ namespace SportsData.Producer.Application.Contests
             using (_logger.BeginScope(new Dictionary<string, object>
                    {
                        ["CorrelationId"] = correlationId,
-                       ["JobName"] = nameof(ContestUpdateJob)
+                       ["JobName"] = "ContestUpdateJob"
                    }))
             {
                 _logger.LogInformation(

--- a/src/SportsData.Producer/Application/Contests/ContestUpdateProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestUpdateProcessor.cs
@@ -14,16 +14,17 @@ namespace SportsData.Producer.Application.Contests
         Task Process(UpdateContestCommand command);
     }
 
-    public class ContestUpdateProcessor : IUpdateContests
+    public class ContestUpdateProcessor<TDataContext> : IUpdateContests
+        where TDataContext : TeamSportDataContext
     {
-        private readonly ILogger<ContestUpdateProcessor> _logger;
-        private readonly TeamSportDataContext _dataContext;
+        private readonly ILogger<ContestUpdateProcessor<TDataContext>> _logger;
+        private readonly TDataContext _dataContext;
         private readonly IEventBus _bus;
         private readonly IGenerateExternalRefIdentities _externalIdentityGenerator;
 
         public ContestUpdateProcessor(
-            ILogger<ContestUpdateProcessor> logger,
-            TeamSportDataContext dataContext,
+            ILogger<ContestUpdateProcessor<TDataContext>> logger,
+            TDataContext dataContext,
             IEventBus bus,
             IGenerateExternalRefIdentities externalIdentityGenerator)
         {

--- a/src/SportsData.Producer/Application/Franchises/Commands/EnrichFranchiseSeasonHandler.cs
+++ b/src/SportsData.Producer/Application/Franchises/Commands/EnrichFranchiseSeasonHandler.cs
@@ -75,8 +75,6 @@ namespace SportsData.Producer.Application.Franchises.Commands
             franchiseSeason.ModifiedUtc = DateTime.UtcNow;
             franchiseSeason.ModifiedBy = CausationId.Producer.FranchiseSeasonEnrichmentProcessor;
 
-            await _dataContext.SaveChangesAsync();
-
             await _eventBus.Publish(new FranchiseSeasonEnrichmentCompleted(
                 command.FranchiseSeasonId,
                 null,
@@ -84,6 +82,8 @@ namespace SportsData.Producer.Application.Franchises.Commands
                 command.SeasonYear,
                 command.CorrelationId,
                 Guid.NewGuid()));
+
+            await _dataContext.SaveChangesAsync();
         }
 
         private async Task<List<ContestBase>> GetFinalizedContestsForFranchiseSeason(Guid franchiseSeasonId)

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -205,8 +205,20 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IEnrichFranchiseSeasons, EnrichFranchiseSeasonHandler<TeamSportDataContext>>();
             services.AddScoped<FranchiseSeasonEnrichmentJob>();
 
-            services.AddScoped<IUpdateContests, ContestUpdateProcessor>();
-            services.AddScoped<ContestUpdateJob>();
+            // ContestUpdate is team-sport-only (uses SeasonWeeks/Contests on TeamSportDataContext).
+            // Golf has no team-style contests, so no registration is provided for Sport.GolfPga.
+            switch (mode)
+            {
+                case Sport.FootballNcaa:
+                case Sport.FootballNfl:
+                    services.AddScoped<IUpdateContests, ContestUpdateProcessor<FootballDataContext>>();
+                    services.AddScoped<ContestUpdateJob<FootballDataContext>>();
+                    break;
+                case Sport.BaseballMlb:
+                    services.AddScoped<IUpdateContests, ContestUpdateProcessor<BaseballDataContext>>();
+                    services.AddScoped<ContestUpdateJob<BaseballDataContext>>();
+                    break;
+            }
 
             // SeasonWeek Commands
             services.AddScoped<IEnqueueSeasonWeekContestsUpdateCommandHandler, EnqueueSeasonWeekContestsUpdateCommandHandler>();
@@ -332,10 +344,22 @@ namespace SportsData.Producer.DependencyInjection
                 job => job.ExecuteAsync(),
                 Cron.Weekly);
 
-            recurringJobManager.AddOrUpdate<ContestUpdateJob>(
-                nameof(ContestUpdateJob),
-                job => job.ExecuteAsync(),
-                Cron.Daily);
+            switch (mode)
+            {
+                case Sport.FootballNcaa:
+                case Sport.FootballNfl:
+                    recurringJobManager.AddOrUpdate<ContestUpdateJob<FootballDataContext>>(
+                        "ContestUpdateJob",
+                        job => job.ExecuteAsync(),
+                        Cron.Daily);
+                    break;
+                case Sport.BaseballMlb:
+                    recurringJobManager.AddOrUpdate<ContestUpdateJob<BaseballDataContext>>(
+                        "ContestUpdateJob",
+                        job => job.ExecuteAsync(),
+                        Cron.Daily);
+                    break;
+            }
 
             if (mode is Sport.FootballNcaa or Sport.FootballNfl)
             {


### PR DESCRIPTION
## Summary

Fixes two related EF bus-outbox bugs that were silently dropping messages in Producer (BaseballMlb) and API (Pickem flows).

### Bug 1 — Publish-after-SaveChanges anti-pattern

MassTransit's \`UseBusOutbox\` captures \`Publish\` into a per-scope buffer and flushes via the EF \`SavingChanges\` interceptor. Code ordered \`SaveChanges → Publish\` never reaches the \`OutboxMessage\` table — the captured message dies with the scope. Fixed in:

- Producer: \`EnrichFranchiseSeasonHandler\`
- API: \`AddMatchupCommandHandler\`, \`MatchupScheduleProcessor\`

Each handler now publishes **before** \`SaveChangesAsync\`, so the entity write and the outbox insert land in the same transaction. If the save fails, the captured publish is rolled back with it — same atomicity guarantee, correct outbox semantics.

### Bug 2 — Abstract \`TeamSportDataContext\` injection broke Contest update outbox flush

\`ContestUpdateProcessor\` injected the abstract \`TeamSportDataContext\`. With \`AddScoped<TeamSportDataContext, BaseballDataContext>()\`, MS.DI activates a *separate* \`BaseballDataContext\` per scope. The bus-outbox flush requires a \`SaveChanges\` with real entity changes for the interceptor to open a transaction; \`ContestUpdateProcessor\` uses \`AsNoTracking\` and has zero tracked writes, so EF short-circuits SaveChanges and the captured \`DocumentRequested\` is lost. Symptom: contest refresh in MLB never showed up in \`document-requested-handler\` (correlation id 64f3f670-8740-19ae-de01-f4fd8fe50182) and never landed in the \`OutboxMessage\` table.

Made \`ContestUpdateProcessor\` and \`ContestUpdateJob\` generic over \`TDataContext : TeamSportDataContext\` and registered the closed generic per-sport in \`ServiceRegistration\`. Now they inject the concrete sport context the outbox interceptor is bound to. The Hangfire recurring-job id stays \`"ContestUpdateJob"\` so the existing schedule is preserved.

### Sweep coverage

Two parallel \`Explore\` agents swept all of \`src/SportsData.Api\` and \`src/SportsData.Producer\` (the only services that use \`AddMessaging<TDb>\` → \`useOutbox: true\`) for the publish-after-save anti-pattern. After reconciling agent reports, the 3 fixes above are the complete set; all other Publish/SaveChanges pairs in those projects are correctly ordered.

## Test plan

- [x] \`dotnet build\` clean on \`SportsData.Producer\` and \`SportsData.Api\`
- [x] \`SportsData.Producer.Tests.Unit\`: 325 pass / 0 fail / 18 skip
- [x] \`SportsData.Api.Tests.Unit\`: 326 pass / 0 fail (one flaky randomness test \`DisplayNameGeneratorTests.Should_Generate_Unique_DisplayNames\` passes on rerun, pre-existing, unrelated)
- [ ] Manual: refresh a contest in MLB Producer, confirm row appears in \`sdProducer.BaseballMlb.OutboxMessage\` and message is delivered to RabbitMQ \`document-requested-handler\`
- [ ] Manual: trigger \`PickemGroupMatchupAdded\` and \`PickemGroupWeekMatchupsGenerated\` flows in API, confirm both events reach their consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored contest update processing to support different database contexts per sport mode, improving system flexibility and maintainability.

* **Bug Fixes**
  * Enhanced data integrity by optimizing event publishing and database persistence ordering in matchup operations, contest updates, and franchise enrichment, ensuring atomicity with improved consistency guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->