### PR TITLE
fix(producer,api): unblock competition cascade and harden Pickem matchup gen

### DIFF
--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -185,10 +185,12 @@ namespace SportsData.Api.Application.Processors
             // the captured message into the OutboxMessage table within the same transaction
             // as the entity write. If the save fails, the captured publish is rolled back
             // with it — same atomicity guarantee, correct outbox semantics.
-            // Check against groupMatchups (not allMatchups) since we only care about this group's matchups.
-            // Empty groupMatchups is treated as not completed (publish the event).
-            var isWeekCompleted = groupMatchups.Count > 0 && groupMatchups.All(m => ContestStatusValues.IsCompleted(m.Status));
-            if (!isWeekCompleted)
+            // Skip publish when groupMatchups is empty: PickemGroupWeekMatchupsGeneratedHandler
+            // throws on zero rows (treated as transient and retried), which would generate
+            // bogus retries and DLQ entries for a permanently-empty group week.
+            var hasMatchups = groupMatchups.Count > 0;
+            var isWeekCompleted = hasMatchups && groupMatchups.All(m => ContestStatusValues.IsCompleted(m.Status));
+            if (hasMatchups && !isWeekCompleted)
             {
                 await _eventBus.Publish(new PickemGroupWeekMatchupsGenerated(
                         group.Id,
@@ -199,6 +201,11 @@ namespace SportsData.Api.Application.Processors
                         command.CorrelationId,
                         Guid.NewGuid()),
                     CancellationToken.None);
+            }
+            else if (!hasMatchups)
+            {
+                _logger.LogInformation("Skipping PickemGroupWeekMatchupsGenerated event — no matchups for this group week. GroupId={GroupId}, SeasonYear={SeasonYear}, SeasonWeek={SeasonWeek}",
+                    group.Id, command.SeasonYear, command.SeasonWeek);
             }
             else
             {

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -297,9 +297,21 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
             ["ParentId"] = parentId?.ToString()
         }))
         {
-            if (hasRef?.Ref is null)
+            if (hasRef is null)
             {
-                _logger.LogDebug("⏭️ SKIP_CHILD_DOCUMENT: No reference found.");
+                _logger.LogWarning(
+                    "⏭️ SKIP_CHILD_DOCUMENT: parent DTO link is null. ChildDocumentType={ChildDocumentType}, ParentId={ParentId}",
+                    documentType,
+                    parentId?.ToString());
+                return;
+            }
+
+            if (hasRef.Ref is null)
+            {
+                _logger.LogWarning(
+                    "⏭️ SKIP_CHILD_DOCUMENT: parent DTO link present but $ref is null. ChildDocumentType={ChildDocumentType}, ParentId={ParentId}",
+                    documentType,
+                    parentId?.ToString());
                 return;
             }
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
@@ -76,10 +76,15 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
             throw new InvalidOperationException($"Contest with ID {contestId} not found.");
         }
 
+        // NOTE: Do NOT Include Competitors / Competitor ExternalIds here. Nothing in
+        // ProcessUpdate, ProcessChildDocuments, or ProcessCompetitors reads from the
+        // loaded entity's Competitors — they all use externalDto.Competitors. Loading
+        // those navigations into the change tracker triggers EF's optimistic concurrency
+        // check on rows this processor never modifies, causing false-positive
+        // DbUpdateConcurrencyExceptions when EventCompetitionCompetitorRecordDocumentProcessor
+        // (or any sibling) bumps a CompetitionCompetitor row in parallel — which in turn
+        // kills the child-document cascade (e.g. EventCompetitionPlay sourcing).
         var entity = await _dataContext.Competitions
-            .Include(c => c.Competitors)
-            .ThenInclude(c => c.ExternalIds)
-            .AsSplitQuery()
             .FirstOrDefaultAsync(x =>
                 x.ExternalIds.Any(z => z.SourceUrlHash == command.UrlHash &&
                                        z.Provider == command.SourceDataProvider));
@@ -208,10 +213,14 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
             competition.ModifiedUtc = DateTime.UtcNow;
             competition.ModifiedBy = command.CorrelationId;
 
-            await _dataContext.SaveChangesAsync();
-
+            // NOTE: SaveChanges is intentionally deferred. ProcessChildDocuments below
+            // calls SaveChangesAsync at its tail, which commits this entity update AND
+            // flushes the bus-outbox publishes captured by the child PublishChildDocumentRequest
+            // calls in a single transaction. Saving here would (a) duplicate the commit
+            // and (b) on concurrency conflict, throw before the cascade ever publishes —
+            // killing all downstream sourcing (e.g. EventCompetitionPlay).
             _logger.LogInformation(
-                "Competition updated. CompetitionId={CompetitionId}, PropertyCount={PropertyCount}",
+                "Competition update staged. CompetitionId={CompetitionId}, PropertyCount={PropertyCount}",
                 competition.Id,
                 changedProperties.Count);
         }


### PR DESCRIPTION
## Summary

Three related fixes that came out of debugging missing MLB CompetitionPlay data on contest \`a38bd621-3c98-7207-3e37-9d7725517de7\` (ESPN event \`401815038\`).

### 1. Cascade survives concurrency conflicts — \`EventCompetitionDocumentProcessorBase\`

**Root cause of missing plays.** \`ProcessUpdate\` was calling \`SaveChangesAsync\` *before* invoking \`ProcessChildDocuments\`. Any throw from that save (commonly \`DbUpdateConcurrencyException\`) bubbled up and the cascade — Status, Broadcast, Predictor, PowerIndex, **Plays**, Competitors, etc. — never published. The Hangfire job was logged as failed, but in production the symptom was \"plays never arrive.\"

The save was also redundant: \`ProcessChildDocuments\` ends with its own \`SaveChangesAsync\` that commits the staged Competition update *and* flushes the bus-outbox publishes captured by \`PublishChildDocumentRequest\` in a single atomic transaction (per the bus-outbox pattern enforced in #280).

This PR removes the line-211 save and adds a comment explaining why it must NOT come back.

### 2. False-positive concurrency check — same file

The Competition lookup was \`Include(Competitors).ThenInclude(ExternalIds).AsSplitQuery()\`. Nothing in \`ProcessUpdate\`, \`ProcessChildDocuments\`, or \`ProcessCompetitors\` actually reads from the loaded entity's \`Competitors\` — they all use \`externalDto.Competitors\` from the deserialized JSON. The Include only served to load \`CompetitionCompetitor\` and its external-ids into the change tracker, which then participated in EF's optimistic concurrency check on \`SaveChangesAsync\`.

Result: any sibling processor (notably \`EventCompetitionCompetitorRecordDocumentProcessor\`) bumping a \`CompetitionCompetitor\` row in parallel produced a false-positive \`DbUpdateConcurrencyException\` against rows this processor never modifies. Combined with bug #1, this is what was killing the play cascade.

### 3. Visibility — \`DocumentProcessorBase.PublishChildDocumentRequest\`

The \"no \$ref on the link\" early-return logged at \`LogDebug\`, invisible at default Seq levels. Diagnosing bug #1 took longer than it should have because of this. Split into two \`LogWarning\` lines (\`parent DTO link is null\` vs \`parent DTO link present but \$ref is null\`), each carrying \`{ChildDocumentType}\` and \`{ParentId}\`. The outer \`ToLogScope()\` already provides CorrelationId, Sport, MessageId, etc.

### 4. Pickem empty-matchups guard — \`MatchupScheduleProcessor\` (API)

Addresses the CodeRabbit comment on #280 that I missed during merge. \`PickemGroupWeekMatchupsGeneratedHandler\` throws on zero matchup rows (treated as transient, retried by MassTransit), so publishing the event for a permanently-empty group week generates bogus retries and DLQ entries. Now skipped with an explicit log.

## Test plan

- [x] \`dotnet build\` clean on Producer + API
- [ ] Manual: refresh contest \`a38bd621-3c98-7207-3e37-9d7725517de7\` post-deploy. Expect:
  - \`SKIP_CHILD_DOCUMENT\` warnings in Seq if \`dto.Details\` is null on the cached payload (confirms the stale-Mongo hypothesis as the next bug to chase)
  - Otherwise: \`DocumentRequested\` for \`EventCompetitionPlay\` lands in RabbitMQ \`document-requested-handler\`, and \`BaseballEventCompetitionPlayDocumentProcessor\` finally logs activity in Seq for \`Sport='BaseballMlb'\`
- [ ] Manual: trigger Pickem matchup generation for a group week with zero qualifying matchups; confirm no \`PickemGroupWeekMatchupsGenerated\` event is published and no DLQ entries follow

## Related

- Built on the bus-outbox ordering pattern from #280
- The MLB Mongo-cache staleness for ESPN event \`401815038\` (status stuck at \`STATUS_SCHEDULED\` 6 days post-game) is a separate problem not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected matchup event publishing to skip empty data sets instead of publishing incomplete information.

* **Refactor**
  * Improved error handling pathways in document processing with enhanced diagnostic logging.
  * Optimized database query operations to reduce unnecessary data loading and defer persistence operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->