### PR TITLE
fix(provider): bypass Mongo cache for current-season DocumentRequested

### DIFF
--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -1,7 +1,10 @@
 ﻿using MassTransit;
 
+using Microsoft.Extensions.Options;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Config;
 using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn;
@@ -18,15 +21,18 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
     private readonly IProvideEspnApiData _espnApi;
     private readonly ILogger<DocumentRequestedHandler> _logger;
     private readonly IProvideBackgroundJobs _backgroundJobProvider;
+    private readonly CommonConfig _commonConfig;
 
     public DocumentRequestedHandler(
         IProvideEspnApiData espnApi,
         ILogger<DocumentRequestedHandler> logger,
-        IProvideBackgroundJobs backgroundJobProvider)
+        IProvideBackgroundJobs backgroundJobProvider,
+        IOptions<CommonConfig> commonConfig)
     {
         _espnApi = espnApi;
         _logger = logger;
         _backgroundJobProvider = backgroundJobProvider;
+        _commonConfig = commonConfig.Value;
     }
 
     public async Task Consume(ConsumeContext<DocumentRequested> context)
@@ -103,6 +109,22 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
         }
     }
 
+    /// <summary>
+    /// Mirrors <c>ResourceIndexJob.ShouldBypassCache</c>. Bypass the Mongo cache for
+    /// active/future seasons; serve historical seasons from cache.
+    /// Rules:
+    ///   currentSeason == 0  → feature disabled; always bypass (safe legacy fallback)
+    ///   seasonYear == null  → non-seasonal resource (Venue, Franchise, ...); always fetch
+    ///   seasonYear &lt; currentSeason → historical/immutable; serve from Mongo
+    ///   seasonYear &gt;= currentSeason → active/future season; bypass cache and fetch
+    /// </summary>
+    private bool ShouldBypassCache(int? seasonYear)
+    {
+        if (_commonConfig.CurrentSeason == 0) return true;   // feature disabled
+        if (!seasonYear.HasValue)             return true;   // non-seasonal resource
+        return seasonYear.Value >= _commonConfig.CurrentSeason;
+    }
+
     private static Guid ResolveCorrelationId(ConsumeContext<DocumentRequested> context, out string source)
     {
         if (context.Message.CorrelationId != Guid.Empty)
@@ -163,6 +185,15 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
     {
         var urlHash = HashProvider.GenerateHashFromUri(uri);
 
+        // Cache policy mirrors ResourceIndexJob.ShouldBypassCache:
+        //   - Current/future season → bypass Mongo, fetch fresh from ESPN. ESPN payloads
+        //     for in-season resources evolve (e.g. EventCompetition gains a `details` $ref
+        //     once the game goes live; a snapshot taken pre-game lacks it permanently in
+        //     Mongo). Re-sourcing every refresh ensures Producer's downstream cascade
+        //     always sees the current shape.
+        //   - Historical season → serve from Mongo. Immutable; nothing to gain by hitting
+        //     ESPN. (Trade-off: in-season games that finish early in the year will still
+        //     re-source until the season flips. Acceptable for now.)
         var cmd = new ProcessResourceIndexItemCommand(
             CorrelationId: evt.CorrelationId,
             CausationId: evt.CausationId,
@@ -175,7 +206,7 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
             DocumentType: evt.DocumentType,
             ParentId: evt.ParentId,
             SeasonYear: evt.SeasonYear,
-            BypassCache: false, // Check MongoDB first before calling ESPN (critical for historical sourcing)
+            BypassCache: ShouldBypassCache(evt.SeasonYear),
             IncludeLinkedDocumentTypes: evt.IncludeLinkedDocumentTypes);
 
         _logger.LogInformation(

--- a/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
+++ b/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
@@ -72,7 +72,8 @@ namespace SportsData.Provider.Application.Processors
                 ["CorrelationId"] = command.CorrelationId,
                 ["CausationId"] = command.CausationId,
                 ["DocumentType"] = command.DocumentType,
-                ["SourceUrlHash"] = command.Id
+                ["SourceUrlHash"] = command.Id,
+                ["BypassCache"] = command.BypassCache
             }))
             {
                 _logger.LogInformation(

--- a/test/unit/SportsData.Provider.Tests.Unit/ProviderTestBase.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/ProviderTestBase.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Runtime.CompilerServices;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+using SportsData.Core.Config;
 using SportsData.Provider.Infrastructure.Data;
 using SportsData.Tests.Shared;
 
@@ -14,6 +18,14 @@ namespace SportsData.Provider.Tests.Unit
         {
             DataContext = new AppDataContext(GetAppDataContextOptions());
             Mocker.Use(typeof(AppDataContext), DataContext);
+
+            // CommonConfig has many `required` members the handlers under test never read.
+            // Use GetUninitializedObject so we don't have to maintain stub values for every
+            // field as the config evolves. CurrentSeason defaults to 0, which the cache
+            // policy treats as "feature disabled, always bypass" — the safe legacy path
+            // existing tests already assume.
+            var commonConfig = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
+            Mocker.Use<IOptions<CommonConfig>>(Options.Create(commonConfig));
         }
 
         private static DbContextOptions<AppDataContext> GetAppDataContextOptions()


### PR DESCRIPTION
## Summary

Fixes the silent freezing of in-season ESPN snapshots in Provider's Mongo cache. The message-driven leaf path in \`DocumentRequestedHandler.ProcessResourceIndexItem\` hardcoded \`BypassCache: false\`, so every \`DocumentRequested\` from Producer (e.g. \`ContestUpdateProcessor\`'s recurring refresh) was served from whatever Mongo had — even when the snapshot was now stale.

### Concrete failure mode

The \`EventCompetition\` document for ESPN event \`401815038\` (a Diamondbacks vs White Sox game from 2026-04-22) was cached pre-game. ESPN's pre-game payload does not include the \`details\` \$ref (the play-by-play resource index). Producer's \`EventCompetitionDocumentProcessorBase\` deserialized \`dto.Details\` as null, \`PublishChildDocumentRequest\` short-circuited at \`hasRef?.Ref is null\`, and the \`EventCompetitionPlay\` \`DocumentRequested\` was never emitted. Result: zero plays for the game, ever, no matter how many times the contest was refreshed.

A live fetch of the same URL today returns the \`details\` \$ref, confirming ESPN updated the body once the game went live — but Producer never saw it because Provider kept serving the stale Mongo doc.

### Why the existing \`ResourceIndexJob\` path was unaffected

\`ResourceIndexJob\` already used \`ShouldBypassCache(seasonYear)\`: bypass for \`seasonYear >= CurrentSeason\`, serve historical from cache. The fix here is just bringing the message-driven leaf path into agreement with the recurring-job path — same rule, same private helper, copied into \`DocumentRequestedHandler\` with an inline reference comment.

### Trade-off

In-season games that have already finished re-source on every refresh until the season flips. Acceptable for now; the alternative (per-document \`isFinal\` heuristics) is more code than this is worth right now. Revisit if it shows up as ESPN rate-limit pain.

## Changes

- \`src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs\` — inject \`IOptions<CommonConfig>\`, add \`ShouldBypassCache(int?)\` private helper (identical rule to \`ResourceIndexJob.cs:213\`), replace \`BypassCache: false\` with \`BypassCache: ShouldBypassCache(evt.SeasonYear)\`
- \`src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs\` — add \`BypassCache\` to the per-item log scope so the applied policy is visible in Seq

## Test plan

- [x] \`dotnet build\` clean on Provider
- [ ] After deploy: refresh contest \`a38bd621-3c98-7207-3e37-9d7725517de7\` and confirm in Seq:
  - \`ESPN LIVE\` (not \`ESPN HIT\`) for the \`EventCompetition\` document
  - Mongo body now carries \`details.\$ref\`
  - \`DocumentRequested\` for \`EventCompetitionPlay\` published to RabbitMQ
  - \`BaseballEventCompetitionPlayDocumentProcessor\` finally logs activity for \`Sport='BaseballMlb'\`
- [ ] Confirm historical-season \`DocumentRequested\` (e.g. \`SeasonYear: 2024\`) still serves from cache (no live ESPN call) by spot-checking a 2024 game refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved caching logic for sports data requests. Historical seasons now properly utilize cache, while current and upcoming seasons continue to refresh appropriately for the latest data.

* **Improvements**
  * Enhanced logging to include cache bypass decisions for better visibility into data retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->