### PR TITLE
fix(producer): IContestUpdateJob interface for Hangfire generic-resolve

### DIFF
--- a/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
@@ -5,15 +5,23 @@ using SportsData.Core.Common.Jobs;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 using SportsData.Producer.Infrastructure.Data.Common;
-using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Application.Contests
 {
+    // Hangfire stores the job type by name and resolves it via reflection on each
+    // recurring trigger. Closed-generic types like ContestUpdateJob`1[BaseballDataContext]
+    // do not always round-trip through that resolver. Register and resolve through this
+    // non-generic interface instead — DI binds it per-sport to the correct closed generic.
+    public interface IContestUpdateJob
+    {
+        Task ExecuteAsync();
+    }
+
     /// <summary>
     /// Gets a list of contestIds for the current season week that need to be updated
     /// and enqueues jobs to update them.
     /// </summary>
-    public class ContestUpdateJob<TDataContext> : IAmARecurringJob
+    public class ContestUpdateJob<TDataContext> : IContestUpdateJob, IAmARecurringJob
         where TDataContext : TeamSportDataContext
     {
         private readonly ILogger<ContestUpdateJob<TDataContext>> _logger;

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -207,16 +207,18 @@ namespace SportsData.Producer.DependencyInjection
 
             // ContestUpdate is team-sport-only (uses SeasonWeeks/Contests on TeamSportDataContext).
             // Golf has no team-style contests, so no registration is provided for Sport.GolfPga.
+            // Register IContestUpdateJob (not the closed generic) so Hangfire can store and
+            // re-resolve the recurring job by a stable, non-generic type name.
             switch (mode)
             {
                 case Sport.FootballNcaa:
                 case Sport.FootballNfl:
                     services.AddScoped<IUpdateContests, ContestUpdateProcessor<FootballDataContext>>();
-                    services.AddScoped<ContestUpdateJob<FootballDataContext>>();
+                    services.AddScoped<IContestUpdateJob, ContestUpdateJob<FootballDataContext>>();
                     break;
                 case Sport.BaseballMlb:
                     services.AddScoped<IUpdateContests, ContestUpdateProcessor<BaseballDataContext>>();
-                    services.AddScoped<ContestUpdateJob<BaseballDataContext>>();
+                    services.AddScoped<IContestUpdateJob, ContestUpdateJob<BaseballDataContext>>();
                     break;
             }
 
@@ -344,21 +346,12 @@ namespace SportsData.Producer.DependencyInjection
                 job => job.ExecuteAsync(),
                 Cron.Weekly);
 
-            switch (mode)
+            if (mode is Sport.FootballNcaa or Sport.FootballNfl or Sport.BaseballMlb)
             {
-                case Sport.FootballNcaa:
-                case Sport.FootballNfl:
-                    recurringJobManager.AddOrUpdate<ContestUpdateJob<FootballDataContext>>(
-                        "ContestUpdateJob",
-                        job => job.ExecuteAsync(),
-                        Cron.Daily);
-                    break;
-                case Sport.BaseballMlb:
-                    recurringJobManager.AddOrUpdate<ContestUpdateJob<BaseballDataContext>>(
-                        "ContestUpdateJob",
-                        job => job.ExecuteAsync(),
-                        Cron.Daily);
-                    break;
+                recurringJobManager.AddOrUpdate<IContestUpdateJob>(
+                    "ContestUpdateJob",
+                    job => job.ExecuteAsync(),
+                    Cron.Daily);
             }
 
             if (mode is Sport.FootballNcaa or Sport.FootballNfl)


### PR DESCRIPTION
## Summary
- Hangfire's recurring-job dashboard was failing to schedule `ContestUpdateJob` with: `Could not resolve type 'SportsData.Producer.Application.Contests.ContestUpdateJob\`1' in assembly 'SportsData.Producer'`. Hangfire serializes the job type by name and reflects it back on each trigger; closed-generic forms (`ContestUpdateJob<BaseballDataContext>`) didn't round-trip cleanly.
- Introduce non-generic `IContestUpdateJob` interface; `ContestUpdateJob<TDataContext>` now implements it. DI registers `IContestUpdateJob` per sport, and `ConfigureHangfireJobs` schedules `recurringJobManager.AddOrUpdate<IContestUpdateJob>(...)`. Hangfire stores a stable type name; DI binds the correct closed generic at execution time.
- Folded the per-sport `switch` in `ConfigureHangfireJobs` into a single registration since both branches are now identical.

## Why generics broke Hangfire
Hangfire persists the job's CLR type as a string in its job-storage hash and resolves it through `Type.GetType(...)` on each trigger. Closed-generic type names (`Foo\`1[[Bar, Asm]]`) require fully-qualified assembly metadata that Hangfire's resolver doesn't always reconstruct correctly across pod restarts and storage reads. Registering the recurring job against an interface sidesteps the entire problem — Hangfire stores `IContestUpdateJob`, DI resolves the closed generic.

## Test plan
- [x] `dotnet build src/SportsData.Producer/SportsData.Producer.csproj` — clean (0 warnings, 0 errors)
- [x] `dotnet test test/unit/SportsData.Producer.Tests.Unit` — 325 passed, 0 failed, 18 skipped
- [ ] Deploy to cluster; confirm Hangfire dashboard shows `ContestUpdateJob` recurring entry without resolution error
- [ ] Trigger `ContestUpdateJob` manually from dashboard against MLB; confirm it executes against `BaseballDataContext` and enqueues per-contest update jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal job registration architecture for contest updates to enhance code maintainability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->