### PR TITLE
feat(producer): MLB contest enrichment + Hangfire generic-resolve fix

### DIFF
--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -5,26 +5,20 @@ using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Extensions;
-using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 namespace SportsData.Producer.Application.Contests
 {
-    public interface IEnrichContests
+    public class BaseballContestEnrichmentProcessor : IEnrichContests
     {
-        Task Process(EnrichContestCommand command);
-    }
-
-    public class ContestEnrichmentProcessor<TDataContext> : IEnrichContests
-        where TDataContext : TeamSportDataContext
-    {
-        private readonly ILogger<ContestEnrichmentProcessor<TDataContext>> _logger;
-        protected readonly TDataContext _dataContext;
+        private readonly ILogger<BaseballContestEnrichmentProcessor> _logger;
+        private readonly BaseballDataContext _dataContext;
         private readonly IEventBus _bus;
         private readonly IDateTimeProvider _dateTimeProvider;
 
-        public ContestEnrichmentProcessor(
-            ILogger<ContestEnrichmentProcessor<TDataContext>> logger,
-            TDataContext dataContext,
+        public BaseballContestEnrichmentProcessor(
+            ILogger<BaseballContestEnrichmentProcessor> logger,
+            BaseballDataContext dataContext,
             IEventBus bus,
             IDateTimeProvider dateTimeProvider)
         {
@@ -69,16 +63,10 @@ namespace SportsData.Producer.Application.Contests
                     return;
                 }
 
-                // Status was lifted off CompetitionBase onto the
-                // sport-specific Football/Baseball subclasses. Loaded
-                // independently via the abstract base set; EF
-                // materializes whichever concrete subtype is registered
-                // in the active per-sport context.
                 var status = await _dataContext.CompetitionStatuses
                     .AsNoTracking()
                     .FirstOrDefaultAsync(s => s.CompetitionId == competition.Id);
 
-                // If canonical status is not final, data isn't ready — return cleanly
                 if (status?.StatusTypeName != "STATUS_FINAL")
                 {
                     _logger.LogInformation(
@@ -89,19 +77,35 @@ namespace SportsData.Producer.Application.Contests
 
                 var contest = competition.Contest;
 
-                var (awayScore, homeScore) = await GetFinalScoresAsync(
-                    competition.Id, awayCompetitor.Id, homeCompetitor.Id);
+                // Baseball plays don't carry a clock for tiebreak ordering. Use the
+                // canonical CompetitionCompetitorScore record as the source of final
+                // score: prefer SourceDescription = "Final", otherwise the most recent.
+                var awayFinalScore = await _dataContext.CompetitionCompetitorScores
+                    .AsNoTracking()
+                    .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
+                    .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                    .ThenByDescending(s => s.CreatedUtc)
+                    .Select(s => (double?)s.Value)
+                    .FirstOrDefaultAsync();
 
-                if (awayScore is null || homeScore is null)
+                var homeFinalScore = await _dataContext.CompetitionCompetitorScores
+                    .AsNoTracking()
+                    .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
+                    .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                    .ThenByDescending(s => s.CreatedUtc)
+                    .Select(s => (double?)s.Value)
+                    .FirstOrDefaultAsync();
+
+                if (awayFinalScore is null || homeFinalScore is null)
                 {
                     _logger.LogInformation(
-                        "Final scores not available for {ContestName}. Data not ready for enrichment.",
+                        "No competitor scores available for {ContestName}. Data not ready for enrichment.",
                         contest.Name);
                     return;
                 }
 
-                contest.AwayScore = awayScore.Value;
-                contest.HomeScore = homeScore.Value;
+                contest.AwayScore = (int)awayFinalScore.Value;
+                contest.HomeScore = (int)homeFinalScore.Value;
 
                 var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
                 var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;
@@ -118,7 +122,6 @@ namespace SportsData.Producer.Application.Contests
 
                 contest.FinalizedUtc = _dateTimeProvider.UtcNow();
 
-                // Enrich results for every odds provider
                 if (competition.Odds?.Any() == true)
                 {
                     EnrichOddsResults(
@@ -128,7 +131,6 @@ namespace SportsData.Producer.Application.Contests
                         contest.AwayScore!.Value,
                         contest.HomeScore!.Value);
 
-                    // Maintain Contest-level denormalized fields from the primary provider
                     var primaryOdds = competition.Odds
                         .FirstOrDefault(o => o.EnrichedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
                         ?? competition.Odds.FirstOrDefault(o => o.EnrichedUtc.HasValue);
@@ -152,35 +154,6 @@ namespace SportsData.Producer.Application.Contests
             }
         }
 
-        // Sport-agnostic default: use the canonical CompetitionCompetitorScore record
-        // ("Final" if present, otherwise most recent). Football overrides with a
-        // play-based primary path because score records can lag the play stream.
-        protected virtual async Task<(int? Away, int? Home)> GetFinalScoresAsync(
-            Guid competitionId,
-            Guid awayCompetitorId,
-            Guid homeCompetitorId)
-        {
-            var awayFinalScore = await _dataContext.CompetitionCompetitorScores
-                .AsNoTracking()
-                .Where(s => s.CompetitionCompetitorId == awayCompetitorId)
-                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                .ThenByDescending(s => s.CreatedUtc)
-                .Select(s => (double?)s.Value)
-                .FirstOrDefaultAsync();
-
-            var homeFinalScore = await _dataContext.CompetitionCompetitorScores
-                .AsNoTracking()
-                .Where(s => s.CompetitionCompetitorId == homeCompetitorId)
-                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                .ThenByDescending(s => s.CreatedUtc)
-                .Select(s => (double?)s.Value)
-                .FirstOrDefaultAsync();
-
-            return (
-                awayFinalScore is null ? null : (int)awayFinalScore.Value,
-                homeFinalScore is null ? null : (int)homeFinalScore.Value);
-        }
-
         internal void EnrichOddsResults(
             ICollection<CompetitionOdds> allOdds,
             Guid awayFranchiseSeasonId,
@@ -190,12 +163,10 @@ namespace SportsData.Producer.Application.Contests
         {
             foreach (var odds in allOdds)
             {
-                // Reset prior results so reruns don't retain stale values
                 odds.WinnerFranchiseSeasonId = null;
                 odds.AtsWinnerFranchiseSeasonId = null;
                 odds.OverUnderResult = OverUnderResult.None;
 
-                // Straight-up winner
                 if (awayScore != homeScore)
                 {
                     odds.WinnerFranchiseSeasonId = homeScore > awayScore
@@ -203,13 +174,11 @@ namespace SportsData.Producer.Application.Contests
                         : awayFranchiseSeasonId;
                 }
 
-                // Over/Under result
                 if (odds.OverUnder.HasValue)
                 {
                     odds.OverUnderResult = GetOverUnderResult(awayScore, homeScore, odds.OverUnder.Value);
                 }
 
-                // ATS winner
                 if (odds.Spread.HasValue)
                 {
                     odds.AtsWinnerFranchiseSeasonId = GetSpreadWinnerFranchiseSeasonId(

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentJob.cs
@@ -7,15 +7,23 @@ using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Application.Contests
 {
-    public class ContestEnrichmentJob : IAmARecurringJob
+    // Same Hangfire reflection-resolve issue that bit ContestUpdateJob — register against
+    // this non-generic interface so the recurring-job entry stores a stable type name.
+    public interface IContestEnrichmentJob
     {
-        private readonly ILogger<ContestEnrichmentJob> _logger;
-        private readonly TeamSportDataContext _dataContext;
+        Task ExecuteAsync();
+    }
+
+    public class ContestEnrichmentJob<TDataContext> : IContestEnrichmentJob, IAmARecurringJob
+        where TDataContext : TeamSportDataContext
+    {
+        private readonly ILogger<ContestEnrichmentJob<TDataContext>> _logger;
+        private readonly TDataContext _dataContext;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
 
         public ContestEnrichmentJob(
-            ILogger<ContestEnrichmentJob> logger,
-            TeamSportDataContext dataContext,
+            ILogger<ContestEnrichmentJob<TDataContext>> logger,
+            TDataContext dataContext,
             IProvideBackgroundJobs backgroundJobProvider)
         {
             _logger = logger;

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentProcessor.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Extensions;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Common;
 
 namespace SportsData.Producer.Application.Contests
 {
@@ -14,16 +14,17 @@ namespace SportsData.Producer.Application.Contests
         Task Process(EnrichContestCommand command);
     }
 
-    public class ContestEnrichmentProcessor : IEnrichContests
+    public class ContestEnrichmentProcessor<TDataContext> : IEnrichContests
+        where TDataContext : TeamSportDataContext
     {
-        private readonly ILogger<ContestEnrichmentProcessor> _logger;
-        private readonly FootballDataContext _dataContext;
+        private readonly ILogger<ContestEnrichmentProcessor<TDataContext>> _logger;
+        protected readonly TDataContext _dataContext;
         private readonly IEventBus _bus;
         private readonly IDateTimeProvider _dateTimeProvider;
 
         public ContestEnrichmentProcessor(
-            ILogger<ContestEnrichmentProcessor> logger,
-            FootballDataContext dataContext,
+            ILogger<ContestEnrichmentProcessor<TDataContext>> logger,
+            TDataContext dataContext,
             IEventBus bus,
             IDateTimeProvider dateTimeProvider)
         {
@@ -88,50 +89,19 @@ namespace SportsData.Producer.Application.Contests
 
                 var contest = competition.Contest;
 
-                // Query canonical plays to determine final score (project to DTO)
-                var lastScoringPlay = await _dataContext.CompetitionPlays
-                    .AsNoTracking()
-                    .Where(p => p.CompetitionId == competition.Id && p.ScoringPlay)
-                    .OrderByDescending(p => p.PeriodNumber)
-                    .ThenBy(p => p.ClockValue)
-                    .Select(p => new { p.AwayScore, p.HomeScore })
-                    .FirstOrDefaultAsync();
+                var (awayScore, homeScore) = await GetFinalScoresAsync(
+                    competition.Id, awayCompetitor.Id, homeCompetitor.Id);
 
-                if (lastScoringPlay != null)
+                if (awayScore is null || homeScore is null)
                 {
-                    contest.AwayScore = lastScoringPlay.AwayScore;
-                    contest.HomeScore = lastScoringPlay.HomeScore;
+                    _logger.LogInformation(
+                        "Final scores not available for {ContestName}. Data not ready for enrichment.",
+                        contest.Name);
+                    return;
                 }
-                else
-                {
-                    // No scoring plays — check competitor scores (D2 fallback, project to score value only)
-                    var awayFinalScore = await _dataContext.CompetitionCompetitorScores
-                        .AsNoTracking()
-                        .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
-                        .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                        .ThenByDescending(s => s.CreatedUtc)
-                        .Select(s => (double?)s.Value)
-                        .FirstOrDefaultAsync();
 
-                    var homeFinalScore = await _dataContext.CompetitionCompetitorScores
-                        .AsNoTracking()
-                        .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
-                        .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                        .ThenByDescending(s => s.CreatedUtc)
-                        .Select(s => (double?)s.Value)
-                        .FirstOrDefaultAsync();
-
-                    if (awayFinalScore is null || homeFinalScore is null)
-                    {
-                        _logger.LogInformation(
-                            "No plays or competitor scores available for {ContestName}. Data not ready for enrichment.",
-                            contest.Name);
-                        return;
-                    }
-
-                    contest.AwayScore = (int)awayFinalScore.Value;
-                    contest.HomeScore = (int)homeFinalScore.Value;
-                }
+                contest.AwayScore = awayScore.Value;
+                contest.HomeScore = homeScore.Value;
 
                 var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
                 var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;
@@ -180,6 +150,35 @@ namespace SportsData.Producer.Application.Contests
                         Guid.NewGuid()));
                 await _dataContext.SaveChangesAsync();
             }
+        }
+
+        // Sport-agnostic default: use the canonical CompetitionCompetitorScore record
+        // ("Final" if present, otherwise most recent). Football overrides with a
+        // play-based primary path because score records can lag the play stream.
+        protected virtual async Task<(int? Away, int? Home)> GetFinalScoresAsync(
+            Guid competitionId,
+            Guid awayCompetitorId,
+            Guid homeCompetitorId)
+        {
+            var awayFinalScore = await _dataContext.CompetitionCompetitorScores
+                .AsNoTracking()
+                .Where(s => s.CompetitionCompetitorId == awayCompetitorId)
+                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                .ThenByDescending(s => s.CreatedUtc)
+                .Select(s => (double?)s.Value)
+                .FirstOrDefaultAsync();
+
+            var homeFinalScore = await _dataContext.CompetitionCompetitorScores
+                .AsNoTracking()
+                .Where(s => s.CompetitionCompetitorId == homeCompetitorId)
+                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                .ThenByDescending(s => s.CreatedUtc)
+                .Select(s => (double?)s.Value)
+                .FirstOrDefaultAsync();
+
+            return (
+                awayFinalScore is null ? null : (int)awayFinalScore.Value,
+                homeFinalScore is null ? null : (int)homeFinalScore.Value);
         }
 
         internal void EnrichOddsResults(

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -2,43 +2,266 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Producer.Enums;
+using SportsData.Producer.Extensions;
 using SportsData.Producer.Infrastructure.Data.Football;
 
 namespace SportsData.Producer.Application.Contests
 {
-    public class FootballContestEnrichmentProcessor : ContestEnrichmentProcessor<FootballDataContext>
+    public interface IEnrichContests
     {
+        Task Process(EnrichContestCommand command);
+    }
+
+    public class FootballContestEnrichmentProcessor : IEnrichContests
+    {
+        private readonly ILogger<FootballContestEnrichmentProcessor> _logger;
+        private readonly FootballDataContext _dataContext;
+        private readonly IEventBus _bus;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
         public FootballContestEnrichmentProcessor(
-            ILogger<ContestEnrichmentProcessor<FootballDataContext>> logger,
+            ILogger<FootballContestEnrichmentProcessor> logger,
             FootballDataContext dataContext,
             IEventBus bus,
             IDateTimeProvider dateTimeProvider)
-            : base(logger, dataContext, bus, dateTimeProvider)
         {
+            _logger = logger;
+            _dataContext = dataContext;
+            _bus = bus;
+            _dateTimeProvider = dateTimeProvider;
         }
 
-        // Football-specific: prefer the last scoring play (uses ClockValue tiebreak,
-        // which only exists on FootballCompetitionPlay). Falls back to the canonical
-        // score record path when no scoring plays are present (e.g., D2 sources).
-        protected override async Task<(int? Away, int? Home)> GetFinalScoresAsync(
-            Guid competitionId,
-            Guid awayCompetitorId,
-            Guid homeCompetitorId)
+        public async Task Process(EnrichContestCommand command)
         {
-            var lastScoringPlay = await _dataContext.CompetitionPlays
-                .AsNoTracking()
-                .Where(p => p.CompetitionId == competitionId && p.ScoringPlay)
-                .OrderByDescending(p => p.PeriodNumber)
-                .ThenBy(p => p.ClockValue)
-                .Select(p => new { p.AwayScore, p.HomeScore })
-                .FirstOrDefaultAsync();
-
-            if (lastScoringPlay != null)
+            using (_logger.BeginScope(new Dictionary<string, object>
+                   {
+                       ["CorrelationId"] = command.CorrelationId
+                   }))
             {
-                return (lastScoringPlay.AwayScore, lastScoringPlay.HomeScore);
-            }
+                _logger.LogInformation("Contest enrichment job started for {@command}", command);
 
-            return await base.GetFinalScoresAsync(competitionId, awayCompetitorId, homeCompetitorId);
+                var competition = await _dataContext.Competitions
+                    .Include(c => c.Competitors)
+                    .Include(c => c.Odds)
+                    .ThenInclude(o => o.Teams)
+                    .Include(c => c.Contest)
+                    .Where(c => c.ContestId == command.ContestId)
+                    .AsSplitQuery()
+                    .FirstOrDefaultAsync();
+
+                if (competition is null)
+                {
+                    _logger.LogError("Competition could not be loaded for provided contest id. {@Command}", command);
+                    return;
+                }
+
+                var awayCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "away");
+                var homeCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "home");
+
+                if (awayCompetitor is null || homeCompetitor is null)
+                {
+                    _logger.LogError(
+                        "Competition is missing away or home competitor. ContestId={ContestId}, Away={HasAway}, Home={HasHome}",
+                        command.ContestId, awayCompetitor is not null, homeCompetitor is not null);
+                    return;
+                }
+
+                // Status was lifted off CompetitionBase onto the
+                // sport-specific Football/Baseball subclasses. Loaded
+                // independently via the abstract base set; EF
+                // materializes whichever concrete subtype is registered
+                // in the active per-sport context.
+                var status = await _dataContext.CompetitionStatuses
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.CompetitionId == competition.Id);
+
+                // If canonical status is not final, data isn't ready — return cleanly
+                if (status?.StatusTypeName != "STATUS_FINAL")
+                {
+                    _logger.LogInformation(
+                        "Contest status is not yet final for {ContestName}. Current: {Status}. Skipping enrichment.",
+                        competition.Contest.Name, status?.StatusTypeName ?? "unknown");
+                    return;
+                }
+
+                var contest = competition.Contest;
+
+                // Query canonical plays to determine final score (project to DTO)
+                var lastScoringPlay = await _dataContext.CompetitionPlays
+                    .AsNoTracking()
+                    .Where(p => p.CompetitionId == competition.Id && p.ScoringPlay)
+                    .OrderByDescending(p => p.PeriodNumber)
+                    .ThenBy(p => p.ClockValue)
+                    .Select(p => new { p.AwayScore, p.HomeScore })
+                    .FirstOrDefaultAsync();
+
+                if (lastScoringPlay != null)
+                {
+                    contest.AwayScore = lastScoringPlay.AwayScore;
+                    contest.HomeScore = lastScoringPlay.HomeScore;
+                }
+                else
+                {
+                    // No scoring plays — check competitor scores (D2 fallback, project to score value only)
+                    var awayFinalScore = await _dataContext.CompetitionCompetitorScores
+                        .AsNoTracking()
+                        .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
+                        .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                        .ThenByDescending(s => s.CreatedUtc)
+                        .Select(s => (double?)s.Value)
+                        .FirstOrDefaultAsync();
+
+                    var homeFinalScore = await _dataContext.CompetitionCompetitorScores
+                        .AsNoTracking()
+                        .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
+                        .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                        .ThenByDescending(s => s.CreatedUtc)
+                        .Select(s => (double?)s.Value)
+                        .FirstOrDefaultAsync();
+
+                    if (awayFinalScore is null || homeFinalScore is null)
+                    {
+                        _logger.LogInformation(
+                            "No plays or competitor scores available for {ContestName}. Data not ready for enrichment.",
+                            contest.Name);
+                        return;
+                    }
+
+                    contest.AwayScore = (int)awayFinalScore.Value;
+                    contest.HomeScore = (int)homeFinalScore.Value;
+                }
+
+                var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
+                var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;
+
+                if (contest.AwayScore != contest.HomeScore)
+                {
+                    var homeWasWinner = contest.AwayScore < contest.HomeScore;
+
+                    contest.WinnerFranchiseId =
+                        homeWasWinner ?
+                        homeFranchiseSeasonId :
+                        awayFranchiseSeasonId;
+                }
+
+                contest.FinalizedUtc = _dateTimeProvider.UtcNow();
+
+                // Enrich results for every odds provider
+                if (competition.Odds?.Any() == true)
+                {
+                    EnrichOddsResults(
+                        competition.Odds,
+                        awayFranchiseSeasonId,
+                        homeFranchiseSeasonId,
+                        contest.AwayScore!.Value,
+                        contest.HomeScore!.Value);
+
+                    // Maintain Contest-level denormalized fields from the primary provider
+                    var primaryOdds = competition.Odds
+                        .FirstOrDefault(o => o.EnrichedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
+                        ?? competition.Odds.FirstOrDefault(o => o.EnrichedUtc.HasValue);
+
+                    if (primaryOdds != null)
+                    {
+                        contest.OverUnder = primaryOdds.OverUnderResult;
+                        contest.SpreadWinnerFranchiseId = primaryOdds.AtsWinnerFranchiseSeasonId;
+                    }
+                }
+
+                await _bus.Publish(
+                    new ContestEnrichmentCompleted(
+                        command.ContestId,
+                        null,
+                        contest.Sport,
+                        contest.SeasonYear,
+                        command.CorrelationId,
+                        Guid.NewGuid()));
+                await _dataContext.SaveChangesAsync();
+            }
+        }
+
+        internal void EnrichOddsResults(
+            ICollection<CompetitionOdds> allOdds,
+            Guid awayFranchiseSeasonId,
+            Guid homeFranchiseSeasonId,
+            int awayScore,
+            int homeScore)
+        {
+            foreach (var odds in allOdds)
+            {
+                // Reset prior results so reruns don't retain stale values
+                odds.WinnerFranchiseSeasonId = null;
+                odds.AtsWinnerFranchiseSeasonId = null;
+                odds.OverUnderResult = OverUnderResult.None;
+
+                // Straight-up winner
+                if (awayScore != homeScore)
+                {
+                    odds.WinnerFranchiseSeasonId = homeScore > awayScore
+                        ? homeFranchiseSeasonId
+                        : awayFranchiseSeasonId;
+                }
+
+                // Over/Under result
+                if (odds.OverUnder.HasValue)
+                {
+                    odds.OverUnderResult = GetOverUnderResult(awayScore, homeScore, odds.OverUnder.Value);
+                }
+
+                // ATS winner
+                if (odds.Spread.HasValue)
+                {
+                    odds.AtsWinnerFranchiseSeasonId = GetSpreadWinnerFranchiseSeasonId(
+                        awayFranchiseSeasonId,
+                        homeFranchiseSeasonId,
+                        awayScore,
+                        homeScore,
+                        odds.Spread.Value);
+                }
+
+                odds.EnrichedUtc = _dateTimeProvider.UtcNow();
+
+                _logger.LogInformation(
+                    "Enriched CompetitionOdds {OddsId} for provider {ProviderName}. " +
+                    "Winner={WinnerId}, ATS={AtsId}, O/U={OverUnder}",
+                    odds.Id, odds.ProviderName,
+                    odds.WinnerFranchiseSeasonId,
+                    odds.AtsWinnerFranchiseSeasonId,
+                    odds.OverUnderResult);
+            }
+        }
+
+        internal OverUnderResult GetOverUnderResult(int awayScore, int homeScore, decimal overUnder)
+        {
+            var total = awayScore + homeScore;
+
+            if (total > overUnder)
+                return OverUnderResult.Over;
+
+            if (total < overUnder)
+                return OverUnderResult.Under;
+
+            return OverUnderResult.Push;
+        }
+
+        internal Guid? GetSpreadWinnerFranchiseSeasonId(
+            Guid awayFranchiseSeasonId,
+            Guid homeFranchiseSeasonId,
+            int awayScore,
+            int homeScore,
+            decimal spread)
+        {
+            var adjustedHomeScore = homeScore + spread;
+            var margin = adjustedHomeScore - awayScore;
+
+            return margin switch
+            {
+                > 0 => homeFranchiseSeasonId,
+                < 0 => awayFranchiseSeasonId,
+                _ => Guid.Empty
+            };
         }
     }
 }

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Producer.Infrastructure.Data.Football;
+
+namespace SportsData.Producer.Application.Contests
+{
+    public class FootballContestEnrichmentProcessor : ContestEnrichmentProcessor<FootballDataContext>
+    {
+        public FootballContestEnrichmentProcessor(
+            ILogger<ContestEnrichmentProcessor<FootballDataContext>> logger,
+            FootballDataContext dataContext,
+            IEventBus bus,
+            IDateTimeProvider dateTimeProvider)
+            : base(logger, dataContext, bus, dateTimeProvider)
+        {
+        }
+
+        // Football-specific: prefer the last scoring play (uses ClockValue tiebreak,
+        // which only exists on FootballCompetitionPlay). Falls back to the canonical
+        // score record path when no scoring plays are present (e.g., D2 sources).
+        protected override async Task<(int? Away, int? Home)> GetFinalScoresAsync(
+            Guid competitionId,
+            Guid awayCompetitorId,
+            Guid homeCompetitorId)
+        {
+            var lastScoringPlay = await _dataContext.CompetitionPlays
+                .AsNoTracking()
+                .Where(p => p.CompetitionId == competitionId && p.ScoringPlay)
+                .OrderByDescending(p => p.PeriodNumber)
+                .ThenBy(p => p.ClockValue)
+                .Select(p => new { p.AwayScore, p.HomeScore })
+                .FirstOrDefaultAsync();
+
+            if (lastScoringPlay != null)
+            {
+                return (lastScoringPlay.AwayScore, lastScoringPlay.HomeScore);
+            }
+
+            return await base.GetFinalScoresAsync(competitionId, awayCompetitorId, homeCompetitorId);
+        }
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -195,11 +195,14 @@ namespace SportsData.Producer.DependencyInjection
 
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
 
+            // ContestEnrichment currently uses football-only sort fields on CompetitionPlay
+            // (ClockValue) — register only for football modes until MLB-aware enrichment lands.
+            // Hangfire resolves through IContestEnrichmentJob to avoid the closed-generic
+            // type-resolution issue that previously bit ContestUpdateJob.
             if (mode is Sport.FootballNcaa or Sport.FootballNfl)
             {
-                // ContestEnrichmentProcessor depends on FootballDataContext.
                 services.AddScoped<IEnrichContests, ContestEnrichmentProcessor>();
-                services.AddScoped<ContestEnrichmentJob>();
+                services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<FootballDataContext>>();
             }
 
             services.AddScoped<IEnrichFranchiseSeasons, EnrichFranchiseSeasonHandler<TeamSportDataContext>>();
@@ -341,10 +344,13 @@ namespace SportsData.Producer.DependencyInjection
             var recurringJobManager = serviceScope.ServiceProvider
                 .GetRequiredService<IRecurringJobManager>();
 
-            recurringJobManager.AddOrUpdate<ContestEnrichmentJob>(
-                nameof(ContestEnrichmentJob),
-                job => job.ExecuteAsync(),
-                Cron.Weekly);
+            if (mode is Sport.FootballNcaa or Sport.FootballNfl)
+            {
+                recurringJobManager.AddOrUpdate<IContestEnrichmentJob>(
+                    "ContestEnrichmentJob",
+                    job => job.ExecuteAsync(),
+                    Cron.Weekly);
+            }
 
             if (mode is Sport.FootballNcaa or Sport.FootballNfl or Sport.BaseballMlb)
             {

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -195,10 +195,11 @@ namespace SportsData.Producer.DependencyInjection
 
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
 
-            // ContestEnrichment is team-sport-only. Register concrete generic per sport
-            // so DI binds the concrete TDataContext (with EF interceptors). Hangfire
-            // resolves through IContestEnrichmentJob to avoid the closed-generic
-            // type-resolution issue that previously bit ContestUpdateJob.
+            // ContestEnrichment is team-sport-only. Each sport has its own concrete
+            // processor — football uses the play-based primary path, baseball uses
+            // the canonical CompetitionCompetitorScore record. Hangfire resolves
+            // the recurring trigger through IContestEnrichmentJob to avoid the
+            // closed-generic type-resolution issue that previously bit ContestUpdateJob.
             switch (mode)
             {
                 case Sport.FootballNcaa:
@@ -207,7 +208,7 @@ namespace SportsData.Producer.DependencyInjection
                     services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<FootballDataContext>>();
                     break;
                 case Sport.BaseballMlb:
-                    services.AddScoped<IEnrichContests, ContestEnrichmentProcessor<BaseballDataContext>>();
+                    services.AddScoped<IEnrichContests, BaseballContestEnrichmentProcessor>();
                     services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<BaseballDataContext>>();
                     break;
             }

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -195,14 +195,21 @@ namespace SportsData.Producer.DependencyInjection
 
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
 
-            // ContestEnrichment currently uses football-only sort fields on CompetitionPlay
-            // (ClockValue) — register only for football modes until MLB-aware enrichment lands.
-            // Hangfire resolves through IContestEnrichmentJob to avoid the closed-generic
+            // ContestEnrichment is team-sport-only. Register concrete generic per sport
+            // so DI binds the concrete TDataContext (with EF interceptors). Hangfire
+            // resolves through IContestEnrichmentJob to avoid the closed-generic
             // type-resolution issue that previously bit ContestUpdateJob.
-            if (mode is Sport.FootballNcaa or Sport.FootballNfl)
+            switch (mode)
             {
-                services.AddScoped<IEnrichContests, ContestEnrichmentProcessor>();
-                services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<FootballDataContext>>();
+                case Sport.FootballNcaa:
+                case Sport.FootballNfl:
+                    services.AddScoped<IEnrichContests, FootballContestEnrichmentProcessor>();
+                    services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<FootballDataContext>>();
+                    break;
+                case Sport.BaseballMlb:
+                    services.AddScoped<IEnrichContests, ContestEnrichmentProcessor<BaseballDataContext>>();
+                    services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<BaseballDataContext>>();
+                    break;
             }
 
             services.AddScoped<IEnrichFranchiseSeasons, EnrichFranchiseSeasonHandler<TeamSportDataContext>>();
@@ -344,7 +351,7 @@ namespace SportsData.Producer.DependencyInjection
             var recurringJobManager = serviceScope.ServiceProvider
                 .GetRequiredService<IRecurringJobManager>();
 
-            if (mode is Sport.FootballNcaa or Sport.FootballNfl)
+            if (mode is Sport.FootballNcaa or Sport.FootballNfl or Sport.BaseballMlb)
             {
                 recurringJobManager.AddOrUpdate<IContestEnrichmentJob>(
                     "ContestEnrichmentJob",

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -1,0 +1,487 @@
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Producer.Application.Contests;
+using SportsData.Producer.Enums;
+using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests;
+
+// Parallels ContestEnrichmentProcessorTests but exercises the baseball
+// path: no CompetitionPlays primary lookup — final scores come straight
+// from CompetitionCompetitorScores. Class-local BaseballDataContext is
+// overlaid so the SUT's _dataContext sees the baseball model.
+public class BaseballContestEnrichmentProcessorTests
+    : ProducerTestBase<BaseballContestEnrichmentProcessor>
+{
+    private readonly BaseballDataContext _baseballDataContext;
+    private readonly BaseballContestEnrichmentProcessor _sut;
+
+    private static readonly Guid AwayFranchiseSeasonId = Guid.NewGuid();
+    private static readonly Guid HomeFranchiseSeasonId = Guid.NewGuid();
+
+    public BaseballContestEnrichmentProcessorTests()
+    {
+        _baseballDataContext = new BaseballDataContext(
+            new DbContextOptionsBuilder<BaseballDataContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+                .Options);
+        Mocker.Use(_baseballDataContext);
+
+        Mocker.Use(typeof(IDateTimeProvider), new Mock<IDateTimeProvider>().Object);
+        Mock.Get(Mocker.Get<IDateTimeProvider>())
+            .Setup(x => x.UtcNow())
+            .Returns(new DateTime(2026, 4, 27, 12, 0, 0, DateTimeKind.Utc));
+
+        _sut = Mocker.CreateInstance<BaseballContestEnrichmentProcessor>();
+    }
+
+    #region Process — guard clauses
+
+    [Fact]
+    public async Task Process_WhenCompetitionNotFound_ReturnsEarly()
+    {
+        var command = new EnrichContestCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        await _sut.Process(command);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestEnrichmentCompleted>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenNoCompetitors_ReturnsEarly()
+    {
+        var contestId = Guid.NewGuid();
+        var contest = CreateContest(contestId);
+        var competition = new BaseballCompetition
+        {
+            Id = Guid.NewGuid(),
+            ContestId = contestId,
+            Contest = contest,
+            Competitors = new List<CompetitionCompetitor>()
+        };
+
+        _baseballDataContext.Contests.Add(contest);
+        _baseballDataContext.Competitions.Add(competition);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+
+        await _sut.Process(command);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestEnrichmentCompleted>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenStatusNotFinal_ReturnsEarly()
+    {
+        var (contestId, _) = await SeedCompetitionWithStatus("STATUS_IN_PROGRESS");
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+
+        await _sut.Process(command);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestEnrichmentCompleted>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenStatusNull_ReturnsEarly()
+    {
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+        var contest = CreateContest(contestId);
+        var competition = new BaseballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Contest = contest,
+            Status = null,
+            Competitors = new List<CompetitionCompetitor>
+            {
+                CreateCompetitor(competitionId, AwayFranchiseSeasonId, "away"),
+                CreateCompetitor(competitionId, HomeFranchiseSeasonId, "home")
+            }
+        };
+
+        _baseballDataContext.Contests.Add(contest);
+        _baseballDataContext.Competitions.Add(competition);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+
+        await _sut.Process(command);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestEnrichmentCompleted>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
+    #region Process — scoring from competitor scores
+
+    [Fact]
+    public async Task Process_WhenFinalWithCompetitorScores_SetsScoresAndFinalizes()
+    {
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var competition = await _baseballDataContext.Competitions
+            .Include(c => c.Competitors)
+            .FirstAsync(c => c.Id == competitionId);
+
+        var away = competition.Competitors.First(c => c.HomeAway == "away");
+        var home = competition.Competitors.First(c => c.HomeAway == "home");
+
+        _baseballDataContext.CompetitionCompetitorScores.AddRange(
+            CreateScore(away.Id, value: 4, sourceDescription: "Final"),
+            CreateScore(home.Id, value: 7, sourceDescription: "Final"));
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.AwayScore.Should().Be(4);
+        contest.HomeScore.Should().Be(7);
+        contest.WinnerFranchiseId.Should().Be(HomeFranchiseSeasonId);
+        contest.FinalizedUtc.Should().NotBeNull();
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestEnrichmentCompleted>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Process_PrefersFinalScoreOverNonFinalRecords()
+    {
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var competition = await _baseballDataContext.Competitions
+            .Include(c => c.Competitors)
+            .FirstAsync(c => c.Id == competitionId);
+
+        var away = competition.Competitors.First(c => c.HomeAway == "away");
+        var home = competition.Competitors.First(c => c.HomeAway == "home");
+
+        // Mid-game ticks should be ignored in favor of the "Final" record.
+        _baseballDataContext.CompetitionCompetitorScores.AddRange(
+            CreateScore(away.Id, value: 2, sourceDescription: "Live"),
+            CreateScore(away.Id, value: 5, sourceDescription: "Final"),
+            CreateScore(home.Id, value: 3, sourceDescription: "Live"),
+            CreateScore(home.Id, value: 6, sourceDescription: "Final"));
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.AwayScore.Should().Be(5);
+        contest.HomeScore.Should().Be(6);
+    }
+
+    [Fact]
+    public async Task Process_WhenNoFinalRecord_FallsBackToMostRecent()
+    {
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var competition = await _baseballDataContext.Competitions
+            .Include(c => c.Competitors)
+            .FirstAsync(c => c.Id == competitionId);
+
+        var away = competition.Competitors.First(c => c.HomeAway == "away");
+        var home = competition.Competitors.First(c => c.HomeAway == "home");
+
+        var earlier = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc);
+        var later = new DateTime(2026, 4, 27, 13, 0, 0, DateTimeKind.Utc);
+
+        _baseballDataContext.CompetitionCompetitorScores.AddRange(
+            CreateScore(away.Id, value: 1, sourceDescription: "Live", createdUtc: earlier),
+            CreateScore(away.Id, value: 8, sourceDescription: "Live", createdUtc: later),
+            CreateScore(home.Id, value: 2, sourceDescription: "Live", createdUtc: earlier),
+            CreateScore(home.Id, value: 3, sourceDescription: "Live", createdUtc: later));
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.AwayScore.Should().Be(8);
+        contest.HomeScore.Should().Be(3);
+        contest.WinnerFranchiseId.Should().Be(AwayFranchiseSeasonId);
+    }
+
+    [Fact]
+    public async Task Process_WhenNoCompetitorScores_ReturnsEarly()
+    {
+        var (contestId, _) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc.Should().BeNull();
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestEnrichmentCompleted>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenOnlyOneTeamHasScore_ReturnsEarly()
+    {
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var competition = await _baseballDataContext.Competitions
+            .Include(c => c.Competitors)
+            .FirstAsync(c => c.Id == competitionId);
+
+        var away = competition.Competitors.First(c => c.HomeAway == "away");
+
+        _baseballDataContext.CompetitionCompetitorScores.Add(
+            CreateScore(away.Id, value: 4, sourceDescription: "Final"));
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc.Should().BeNull();
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestEnrichmentCompleted>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenTie_DoesNotSetWinner()
+    {
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var competition = await _baseballDataContext.Competitions
+            .Include(c => c.Competitors)
+            .FirstAsync(c => c.Id == competitionId);
+
+        var away = competition.Competitors.First(c => c.HomeAway == "away");
+        var home = competition.Competitors.First(c => c.HomeAway == "home");
+
+        _baseballDataContext.CompetitionCompetitorScores.AddRange(
+            CreateScore(away.Id, value: 5, sourceDescription: "Final"),
+            CreateScore(home.Id, value: 5, sourceDescription: "Final"));
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.AwayScore.Should().Be(5);
+        contest.HomeScore.Should().Be(5);
+        contest.WinnerFranchiseId.Should().BeNull();
+        contest.FinalizedUtc.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region GetOverUnderResult
+
+    [Fact]
+    public void GetOverUnderResult_WhenTotalExceedsLine_ReturnsOver()
+    {
+        _sut.GetOverUnderResult(awayScore: 5, homeScore: 7, overUnder: 8.5m)
+            .Should().Be(OverUnderResult.Over);
+    }
+
+    [Fact]
+    public void GetOverUnderResult_WhenTotalBelowLine_ReturnsUnder()
+    {
+        _sut.GetOverUnderResult(awayScore: 1, homeScore: 2, overUnder: 8.5m)
+            .Should().Be(OverUnderResult.Under);
+    }
+
+    [Fact]
+    public void GetOverUnderResult_WhenTotalEqualsLine_ReturnsPush()
+    {
+        _sut.GetOverUnderResult(awayScore: 4, homeScore: 5, overUnder: 9.0m)
+            .Should().Be(OverUnderResult.Push);
+    }
+
+    #endregion
+
+    #region GetSpreadWinnerFranchiseSeasonId
+
+    [Fact]
+    public void GetSpreadWinner_WhenHomeCoversSpread_ReturnsHomeFranchise()
+    {
+        var result = _sut.GetSpreadWinnerFranchiseSeasonId(
+            AwayFranchiseSeasonId, HomeFranchiseSeasonId,
+            awayScore: 3, homeScore: 7, spread: -1.5m);
+
+        result.Should().Be(HomeFranchiseSeasonId);
+    }
+
+    [Fact]
+    public void GetSpreadWinner_WhenAwayCoversSpread_ReturnsAwayFranchise()
+    {
+        var result = _sut.GetSpreadWinnerFranchiseSeasonId(
+            AwayFranchiseSeasonId, HomeFranchiseSeasonId,
+            awayScore: 6, homeScore: 5, spread: -1.5m);
+
+        result.Should().Be(AwayFranchiseSeasonId);
+    }
+
+    [Fact]
+    public void GetSpreadWinner_WhenAwayFavored_CalculatesCorrectly()
+    {
+        var result = _sut.GetSpreadWinnerFranchiseSeasonId(
+            AwayFranchiseSeasonId, HomeFranchiseSeasonId,
+            awayScore: 8, homeScore: 4, spread: 1.5m);
+
+        result.Should().Be(AwayFranchiseSeasonId);
+    }
+
+    #endregion
+
+    #region EnrichOddsResults
+
+    [Fact]
+    public void EnrichOddsResults_SetsWinnerForAllProviders()
+    {
+        var odds = new List<CompetitionOdds>
+        {
+            CreateOdds("provider-1", "ESPN Bet", spread: -1.5m, overUnder: 8.5m),
+            CreateOdds("provider-2", "DraftKings", spread: -1.5m, overUnder: 9.0m)
+        };
+
+        _sut.EnrichOddsResults(odds, AwayFranchiseSeasonId, HomeFranchiseSeasonId, awayScore: 3, homeScore: 7);
+
+        foreach (var o in odds)
+        {
+            o.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+            o.EnrichedUtc.Should().NotBeNull();
+        }
+    }
+
+    [Fact]
+    public void EnrichOddsResults_ComputesDifferentOverUnderResults_PerProvider()
+    {
+        var odds = new List<CompetitionOdds>
+        {
+            CreateOdds("provider-1", "ESPN Bet", spread: -1.5m, overUnder: 8.0m),
+            CreateOdds("provider-2", "DraftKings", spread: -1.5m, overUnder: 11.0m)
+        };
+
+        _sut.EnrichOddsResults(odds, AwayFranchiseSeasonId, HomeFranchiseSeasonId, awayScore: 4, homeScore: 6);
+
+        odds[0].OverUnderResult.Should().Be(OverUnderResult.Over);
+        odds[1].OverUnderResult.Should().Be(OverUnderResult.Under);
+    }
+
+    [Fact]
+    public void EnrichOddsResults_WhenTie_DoesNotSetWinner()
+    {
+        var odds = new List<CompetitionOdds>
+        {
+            CreateOdds("provider-1", "ESPN Bet", spread: -1.5m, overUnder: 9.0m)
+        };
+
+        _sut.EnrichOddsResults(odds, AwayFranchiseSeasonId, HomeFranchiseSeasonId, awayScore: 4, homeScore: 4);
+
+        odds[0].WinnerFranchiseSeasonId.Should().BeNull();
+        odds[0].OverUnderResult.Should().Be(OverUnderResult.Under);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static BaseballContest CreateContest(Guid contestId) => new()
+    {
+        Id = contestId,
+        Name = "Test Game",
+        ShortName = "TST",
+        StartDateUtc = DateTime.UtcNow,
+        Sport = Sport.BaseballMlb,
+        SeasonYear = 2026
+    };
+
+    private static CompetitionCompetitor CreateCompetitor(
+        Guid competitionId, Guid franchiseSeasonId, string homeAway) => new()
+    {
+        Id = Guid.NewGuid(),
+        CompetitionId = competitionId,
+        FranchiseSeasonId = franchiseSeasonId,
+        HomeAway = homeAway,
+        Order = homeAway == "home" ? 1 : 0
+    };
+
+    private async Task<(Guid ContestId, Guid CompetitionId)> SeedCompetitionWithStatus(string statusTypeName)
+    {
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+        var contest = CreateContest(contestId);
+        var competition = new BaseballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Contest = contest,
+            Status = new BaseballCompetitionStatus
+            {
+                Id = Guid.NewGuid(),
+                CompetitionId = competitionId,
+                StatusTypeName = statusTypeName
+            },
+            Competitors = new List<CompetitionCompetitor>
+            {
+                CreateCompetitor(competitionId, AwayFranchiseSeasonId, "away"),
+                CreateCompetitor(competitionId, HomeFranchiseSeasonId, "home")
+            }
+        };
+
+        _baseballDataContext.Contests.Add(contest);
+        _baseballDataContext.Competitions.Add(competition);
+        await _baseballDataContext.SaveChangesAsync();
+
+        return (contestId, competitionId);
+    }
+
+    private static CompetitionCompetitorScore CreateScore(
+        Guid competitionCompetitorId,
+        double value,
+        string sourceDescription,
+        DateTime? createdUtc = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        CompetitionCompetitorId = competitionCompetitorId,
+        Value = value,
+        DisplayValue = value.ToString(),
+        Winner = false,
+        SourceId = "1",
+        SourceDescription = sourceDescription,
+        CreatedUtc = createdUtc ?? DateTime.UtcNow
+    };
+
+    private static CompetitionOdds CreateOdds(
+        string providerId,
+        string providerName,
+        decimal? spread,
+        decimal? overUnder) => new()
+    {
+        Id = Guid.NewGuid(),
+        CompetitionId = Guid.NewGuid(),
+        ProviderRef = new Uri("https://example.com/odds"),
+        ProviderId = providerId,
+        ProviderName = providerName,
+        Spread = spread,
+        OverUnder = overUnder
+    };
+
+    #endregion
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
@@ -16,9 +16,9 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Contests;
 
-public class ContestEnrichmentProcessorTests : ProducerTestBase<ContestEnrichmentProcessor>
+public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestEnrichmentProcessor>
 {
-    private readonly ContestEnrichmentProcessor _sut;
+    private readonly FootballContestEnrichmentProcessor _sut;
 
     private static readonly Guid AwayFranchiseSeasonId = Guid.NewGuid();
     private static readonly Guid HomeFranchiseSeasonId = Guid.NewGuid();
@@ -30,7 +30,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<ContestEnrichmen
             .Setup(x => x.UtcNow())
             .Returns(new DateTime(2026, 3, 10, 12, 0, 0, DateTimeKind.Utc));
 
-        _sut = Mocker.CreateInstance<ContestEnrichmentProcessor>();
+        _sut = Mocker.CreateInstance<FootballContestEnrichmentProcessor>();
     }
 
     #region Process — guard clauses


### PR DESCRIPTION
## What broke
On the MLB Producer pod, kicking off the recurring `ContestEnrichmentJob` failed with:

> `System.InvalidOperationException: Instances of abstract classes cannot be created.`
> at `Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance` → `Hangfire.AspNetCore.AspNetCoreJobActivatorScope.Resolve`

Two layered problems:
1. The recurring job was registered through the closed-generic `ContestEnrichmentJob<...>`, which Hangfire's reflection resolver doesn't always round-trip cleanly (same wrinkle that bit `ContestUpdateJob` in PR #283).
2. `IEnrichContests` was only DI-registered for football — on MLB pods, the per-contest `IEnrichContests.Process(...)` job had no implementation and Hangfire fell back to activating the bare interface.

## What this PR does

### Hangfire generic-resolve fix
- Adds non-generic `IContestEnrichmentJob` interface.
- Makes `ContestEnrichmentJob<TDataContext>` generic over `TeamSportDataContext` and implement `IContestEnrichmentJob` (mirrors PR #283's `IContestUpdateJob` pattern).
- Recurring registration goes through the interface; DI binds the correct closed generic per sport.

### MLB enrichment support
- Refactors `ContestEnrichmentProcessor` into a generic `ContestEnrichmentProcessor<TDataContext>` with a `protected virtual GetFinalScoresAsync` returning `(int? Away, int? Home)`.
- The default implementation uses the canonical `CompetitionCompetitorScores` record (sport-agnostic — picks `SourceDescription == "Final"` first, falls back to most recent). MLB binds directly to this generic.
- New `FootballContestEnrichmentProcessor : ContestEnrichmentProcessor<FootballDataContext>` preserves the prior behavior: last-scoring-play primary path (ordered by `PeriodNumber` desc, `ClockValue` asc — football-only `CompetitionPlay` fields), falls back to the base score-record path when no scoring plays exist (D2 sources).
- Status check, winner determination, `FinalizedUtc` stamp, and odds enrichment (over/under, ATS, straight-up winner) all run for completed MLB contests now — driving TeamCard schedule, score displays, and pick'em result columns without join-heavy queries.

### Registrations
- Football: `IEnrichContests → FootballContestEnrichmentProcessor`, `IContestEnrichmentJob → ContestEnrichmentJob<FootballDataContext>`
- MLB: `IEnrichContests → ContestEnrichmentProcessor<BaseballDataContext>`, `IContestEnrichmentJob → ContestEnrichmentJob<BaseballDataContext>`
- Recurring `ContestEnrichmentJob` registered for both football modes and MLB.

## Test plan
- [x] `dotnet build src/SportsData.Producer/SportsData.Producer.csproj` — clean (0 warnings, 0 errors)
- [x] `dotnet test test/unit/SportsData.Producer.Tests.Unit` — 325 passed, 0 failed, 18 skipped
- [x] Existing `ContestEnrichmentProcessorTests` (23 tests) retargets `FootballContestEnrichmentProcessor` and continues to validate the football play-based path
- [ ] After deploy, Hangfire dashboard on MLB pod shows `ContestEnrichmentJob` recurring entry without resolution error
- [ ] Trigger `ContestEnrichmentJob` against MLB during in-progress backfill — verify completed contests get `AwayScore`/`HomeScore`/`WinnerFranchiseId`/`FinalizedUtc` set, and `CompetitionOdds` records get `EnrichedUtc` + result columns populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added baseball contest enrichment functionality, including automatic calculation of final scores, winner determination, and odds results enrichment (spread winners, over/under results).

* **Refactor**
  * Restructured contest enrichment system to support multiple sports through sport-specific processor implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->