### PR TITLE
feat(ui+api): MLB line score header + Finalize Contest admin button

### DIFF
--- a/src/SportsData.Api/Application/UI/Contest/Commands/FinalizeContest/FinalizeContestCommand.cs
+++ b/src/SportsData.Api/Application/UI/Contest/Commands/FinalizeContest/FinalizeContestCommand.cs
@@ -1,0 +1,9 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.UI.Contest.Commands.FinalizeContest;
+
+public class FinalizeContestCommand
+{
+    public required Guid ContestId { get; init; }
+    public required Sport Sport { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Contest/Commands/FinalizeContest/FinalizeContestCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Contest/Commands/FinalizeContest/FinalizeContestCommandHandler.cs
@@ -1,0 +1,66 @@
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.UI.Contest.Commands.FinalizeContest;
+
+public interface IFinalizeContestCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        FinalizeContestCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+public class FinalizeContestCommandHandler : IFinalizeContestCommandHandler
+{
+    private readonly ILogger<FinalizeContestCommandHandler> _logger;
+    private readonly IContestClientFactory _contestClientFactory;
+
+    public FinalizeContestCommandHandler(
+        ILogger<FinalizeContestCommandHandler> logger,
+        IContestClientFactory contestClientFactory)
+    {
+        _logger = logger;
+        _contestClientFactory = contestClientFactory;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        FinalizeContestCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var correlationId = ActivityExtensions.GetCorrelationId();
+
+        _logger.LogInformation(
+            "FinalizeContest initiated. ContestId={ContestId}, Sport={Sport}, CorrelationId={CorrelationId}",
+            command.ContestId,
+            command.Sport,
+            correlationId);
+
+        var contestClient = _contestClientFactory.Resolve(command.Sport);
+        var result = await contestClient.FinalizeContestByContestId(command.ContestId, cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            _logger.LogError(
+                "FinalizeContest failed. ContestId={ContestId}, Sport={Sport}, Status={Status}, CorrelationId={CorrelationId}",
+                command.ContestId,
+                command.Sport,
+                result.Status,
+                correlationId);
+
+            var failure = (Failure<bool>)result;
+            return new Failure<Guid>(
+                correlationId,
+                result.Status,
+                failure.Errors);
+        }
+
+        _logger.LogInformation(
+            "FinalizeContest completed. ContestId={ContestId}, Sport={Sport}, CorrelationId={CorrelationId}",
+            command.ContestId,
+            command.Sport,
+            correlationId);
+
+        return new Success<Guid>(correlationId, ResultStatus.Accepted);
+    }
+}

--- a/src/SportsData.Api/Application/UI/Contest/ContestController.cs
+++ b/src/SportsData.Api/Application/UI/Contest/ContestController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Api.Application.UI.Contest.Commands.FinalizeContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContestMedia;
 using SportsData.Api.Application.UI.Contest.Queries.GetContestOverview;
@@ -56,6 +57,21 @@ public class ContestController : ApiControllerBase
     {
         var mode = ModeMapper.ResolveMode(sport, league);
         var command = new RefreshContestMediaCommand { ContestId = id, Sport = mode };
+        var result = await handler.ExecuteAsync(command, cancellationToken);
+
+        return result.ToActionResult();
+    }
+
+    [HttpPost("{id}/finalize")]
+    public async Task<ActionResult<Guid>> FinalizeContestById(
+        [FromRoute] Guid id,
+        [FromQuery] string sport = "football",
+        [FromQuery] string league = "ncaa",
+        [FromServices] IFinalizeContestCommandHandler handler = default!,
+        CancellationToken cancellationToken = default)
+    {
+        var mode = ModeMapper.ResolveMode(sport, league);
+        var command = new FinalizeContestCommand { ContestId = id, Sport = mode };
         var result = await handler.ExecuteAsync(command, cancellationToken);
 
         return result.ToActionResult();

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -30,6 +30,7 @@ using SportsData.Api.Application.Venues.Queries.GetVenues;
 using SportsData.Api.Application.Venues.Queries.GetVenueById;
 using SportsData.Api.Application.UI.Conferences.Queries.GetConferenceNamesAndSlugs;
 using SportsData.Api.Infrastructure.Refs;
+using SportsData.Api.Application.UI.Contest.Commands.FinalizeContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContestMedia;
 using SportsData.Api.Application.UI.Contest.Commands.SubmitContestPredictions;
@@ -156,6 +157,7 @@ namespace SportsData.Api.DependencyInjection
             // Contest Commands
             services.AddScoped<IRefreshContestCommandHandler, RefreshContestCommandHandler>();
             services.AddScoped<IRefreshContestMediaCommandHandler, RefreshContestMediaCommandHandler>();
+            services.AddScoped<IFinalizeContestCommandHandler, FinalizeContestCommandHandler>();
             services.AddScoped<ISubmitContestPredictionsCommandHandler, SubmitContestPredictionsCommandHandler>();
 
             // Contest Queries

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
@@ -35,6 +35,8 @@ public interface IProvideContests : IProvideHealthChecks
 
     Task<Result<bool>> RefreshContestMediaByContestId(Guid contestId, CancellationToken cancellationToken = default);
 
+    Task<Result<bool>> FinalizeContestByContestId(Guid contestId, CancellationToken cancellationToken = default);
+
     // Matchup query endpoints (Phase 2)
     Task<Result<List<Matchup>>> GetMatchupsForCurrentWeek(CancellationToken ct = default);
     Task<Result<List<Matchup>>> GetMatchupsForSeasonWeek(int year, int week, CancellationToken ct = default);
@@ -158,6 +160,22 @@ public class ContestClient : ClientBase, IProvideContests
         return await PostWithResultAsync(
             $"contests/{contestId}/media/refresh",
             "RefreshContestMedia",
+            cancellationToken);
+    }
+
+    public async Task<Result<bool>> FinalizeContestByContestId(Guid contestId, CancellationToken cancellationToken = default)
+    {
+        if (contestId == Guid.Empty)
+        {
+            return new Failure<bool>(
+                false,
+                ResultStatus.BadRequest,
+                [new ValidationFailure("contestId", "Contest ID cannot be empty")]);
+        }
+
+        return await PostWithResultAsync(
+            $"contests/{contestId}/enrich",
+            "FinalizeContest",
             cancellationToken);
     }
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
@@ -6,7 +6,6 @@ using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn;
-using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;

--- a/src/UI/sd-ui/src/api/contestApi.js
+++ b/src/UI/sd-ui/src/api/contestApi.js
@@ -13,6 +13,10 @@ const ContestApi = {
   refreshMedia: (contestId, sport, league) =>
     apiClient.post(`/ui/contest/${contestId}/media/refresh`, null, {
       params: { sport, league }
+    }),
+  finalize: (contestId, sport, league) =>
+    apiClient.post(`/ui/contest/${contestId}/finalize`, null, {
+      params: { sport, league }
     })
 };
 

--- a/src/UI/sd-ui/src/components/contests/ContestOverview.css
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.css
@@ -124,6 +124,15 @@
   padding: 0;
 }
 
+/* Sports with more than 4 periods (e.g. MLB 9 innings) need to grow past the
+   football-tuned default so the Total column doesn't collide with the home
+   team's score on the right. */
+.contest-boxscore-table-wrapper.compact.wide {
+  min-width: 0;
+  max-width: none;
+  width: auto;
+}
+
 .contest-boxscore-table {
   border-collapse: collapse;
   background: none;
@@ -140,6 +149,19 @@
 .contest-boxscore-table td {
   padding: 0 0.5rem;
   text-align: center;
+}
+
+.contest-boxscore-table.compact.wide {
+  font-size: 0.85rem;
+}
+
+.contest-boxscore-table.compact.wide th,
+.contest-boxscore-table.compact.wide td {
+  padding: 0 0.3rem;
+}
+
+.contest-boxscore-table.compact.wide .contest-boxscore-total {
+  padding-left: 0.55rem;
 }
 
 .contest-boxscore-team-short {
@@ -636,6 +658,13 @@
   flex-direction: column;
   align-items: center;
 }
+
+.contest-boxscore-table-wrapper.compact.wide {
+  min-width: 0;
+  max-width: none;
+  width: auto;
+}
+
 @media (max-width: 900px) {
   .contest-header-flex {
     flex-direction: column;

--- a/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
@@ -24,6 +24,8 @@ export default function ContestOverview() {
   const [refreshError, setRefreshError] = useState(null);
   const [refreshingMedia, setRefreshingMedia] = useState(false);
   const [refreshMediaError, setRefreshMediaError] = useState(null);
+  const [finalizing, setFinalizing] = useState(false);
+  const [finalizeError, setFinalizeError] = useState(null);
 
   useEffect(() => {
     setLoading(true);
@@ -74,6 +76,19 @@ export default function ContestOverview() {
     setRefreshingMedia(false);
   };
 
+  const handleFinalize = async () => {
+    setFinalizing(true);
+    setFinalizeError(null);
+    try {
+      await apiWrapper.Contest.finalize(contestId, sport, league);
+      toast.success("Finalize contest request submitted.");
+    } catch (err) {
+      setFinalizeError("Failed to finalize contest.");
+      toast.error("Failed to submit finalize request.");
+    }
+    setFinalizing(false);
+  };
+
   return (
     <div className="contest-overview-container">
       <ContestOverviewHeader homeTeam={homeTeam} awayTeam={awayTeam} quarterScores={quarterScores} seasonYear={header.seasonYear} sport={sport} league={league} />
@@ -112,6 +127,15 @@ export default function ContestOverview() {
             {refreshingMedia ? "Refreshing..." : "Refresh Media"}
           </button>
           {refreshMediaError && <div style={{ color: "#d32f2f", marginTop: 8 }}>{refreshMediaError}</div>}
+
+          <button
+            onClick={handleFinalize}
+            disabled={finalizing}
+            style={{ padding: "10px 24px", fontSize: 16, fontWeight: 600, borderRadius: 6, background: "#23272f", color: "#fff", border: "none", cursor: "pointer", marginTop: 16 }}
+          >
+            {finalizing ? "Finalizing..." : "Finalize Contest"}
+          </button>
+          {finalizeError && <div style={{ color: "#d32f2f", marginTop: 8 }}>{finalizeError}</div>}
         </div>
       )}
     </div>

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
@@ -28,6 +28,10 @@ export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScore
   const normAwayBg = getMutedColor(awayTeamColor);
   const awayTotal = quarterScores.reduce((sum, q) => sum + q.awayScore, 0);
   const homeTotal = quarterScores.reduce((sum, q) => sum + q.homeScore, 0);
+  // Football has 4 quarters (or 5+ with OT); baseball has 9 innings. Anything
+  // past the football default needs a wider wrapper and tighter cell padding
+  // so the Total ("T") column doesn't collide with the home-team score.
+  const wideClass = quarterScores.length > 4 ? " wide" : "";
 
   return (
     <div className="contest-section">
@@ -44,9 +48,9 @@ export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScore
         </Link>
         <div className="contest-team-score contest-header-team-score-away">{awayTotal}</div>
         {/* Box Score Table */}
-        <div className="contest-boxscore-table-wrapper compact">
+        <div className={`contest-boxscore-table-wrapper compact${wideClass}`}>
           <div className="contest-boxscore-final">Final</div>
-          <table className="contest-boxscore-table compact">
+          <table className={`contest-boxscore-table compact${wideClass}`}>
             <thead>
               <tr>
                 <th></th>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Contest/Commands/FinalizeContest/FinalizeContestCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Contest/Commands/FinalizeContest/FinalizeContestCommandHandlerTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using FluentValidation.Results;
+
+using Moq;
+
+using SportsData.Api.Application.UI.Contest.Commands.FinalizeContest;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Contest.Commands.FinalizeContest;
+
+public class FinalizeContestCommandHandlerTests : ApiTestBase<FinalizeContestCommandHandler>
+{
+    private readonly Mock<IProvideContests> _contestClientMock;
+    private readonly Mock<IContestClientFactory> _contestClientFactoryMock;
+
+    public FinalizeContestCommandHandlerTests()
+    {
+        _contestClientMock = new Mock<IProvideContests>();
+        _contestClientFactoryMock = Mocker.GetMock<IContestClientFactory>();
+        _contestClientFactoryMock
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_contestClientMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnAccepted_WhenFinalizeSucceeds()
+    {
+        // Arrange
+        var contestId = Guid.NewGuid();
+        var sport = Sport.BaseballMlb;
+
+        _contestClientMock
+            .Setup(x => x.FinalizeContestByContestId(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<bool>(true, ResultStatus.Accepted));
+
+        var sut = Mocker.CreateInstance<FinalizeContestCommandHandler>();
+        var command = new FinalizeContestCommand { ContestId = contestId, Sport = sport };
+
+        // Act
+        var result = await sut.ExecuteAsync(command);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Status.Should().Be(ResultStatus.Accepted);
+        _contestClientFactoryMock.Verify(x => x.Resolve(sport), Times.Once);
+        _contestClientMock.Verify(
+            x => x.FinalizeContestByContestId(contestId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnFailure_WhenFinalizeFails()
+    {
+        // Arrange
+        var contestId = Guid.NewGuid();
+        var sport = Sport.BaseballMlb;
+        var validationFailures = new List<ValidationFailure>
+        {
+            new("contestId", "downstream finalize failed")
+        };
+
+        _contestClientMock
+            .Setup(x => x.FinalizeContestByContestId(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<bool>(false, ResultStatus.BadRequest, validationFailures));
+
+        var sut = Mocker.CreateInstance<FinalizeContestCommandHandler>();
+        var command = new FinalizeContestCommand { ContestId = contestId, Sport = sport };
+
+        // Act
+        var result = await sut.ExecuteAsync(command);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.BadRequest);
+    }
+}


### PR DESCRIPTION
## Summary
- Contest Overview header line score grows past the football-tuned width when a sport has more than 4 periods (MLB 9 innings) so the Total column no longer overlaps the home team's score. Football layout is pixel-identical.
- New admin-only **Finalize Contest** button on the Contest Overview page (alongside Refresh Contest / Refresh Media). UI → API → Producer wiring follows the existing two-button pattern; Producer reuses its existing \`POST /api/contests/{contestId}/enrich\` endpoint, which DI-resolves \`IEnrichContests\` per sport (\`BaseballContestEnrichmentProcessor\` for MLB).

## What changed
- \`src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx\` + \`ContestOverview.css\` — \`wide\` modifier when \`quarterScores.length > 4\`, lifts max-width and tightens cell padding.
- \`src/UI/sd-ui/src/components/contests/ContestOverview.jsx\` + \`api/contestApi.js\` — \`finalize()\` API call, \`handleFinalize\`, third admin button.
- \`src/SportsData.Api/Application/UI/Contest/Commands/FinalizeContest/\` — new \`FinalizeContestCommand\` + \`FinalizeContestCommandHandler\` (\`IContestClientFactory.Resolve(sport)\`-based).
- \`src/SportsData.Api/Application/UI/Contest/ContestController.cs\` — \`[HttpPost(\"{id}/finalize\")] FinalizeContestById\` action.
- \`src/SportsData.Api/DependencyInjection/ServiceRegistration.cs\` — DI registration for the new handler.
- \`src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs\` — \`FinalizeContestByContestId\` posts to \`contests/{contestId}/enrich\`.
- \`test/unit/SportsData.Api.Tests.Unit/.../FinalizeContestCommandHandlerTests.cs\` — 2 new tests (success → Accepted, downstream failure → BadRequest).

No Producer-side changes — the existing enrich endpoint is reused.

## Test plan
- [ ] Producer + API + Core build clean.
- [ ] \`dotnet test\` API suite — new tests pass; pre-existing unrelated DisplayNameGenerator failure is not regressed.
- [ ] sd-ui dev server: open MLB Contest Overview, confirm 9-inning line score fits without overlap.
- [ ] sd-ui dev server: as admin, click Finalize Contest, watch Producer logs for \`EnrichContest requested\` and the \`BaseballContestEnrichmentProcessor\` log line.
- [ ] Confirm football Contest Overview header is visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)