### PR TITLE
refactor(producer): move CompetitionDrive into FootballDataContext only

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/Commands/RefreshCompetitionDrives/RefreshCompetitionDrivesCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/RefreshCompetitionDrives/RefreshCompetitionDrivesCommandHandler.cs
@@ -7,8 +7,8 @@ using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Infrastructure.DataSources.Espn;
-using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football;
 
 namespace SportsData.Producer.Application.Competitions.Commands.RefreshCompetitionDrives;
 
@@ -19,12 +19,12 @@ public interface IRefreshCompetitionDrivesCommandHandler
 
 public class RefreshCompetitionDrivesCommandHandler : IRefreshCompetitionDrivesCommandHandler
 {
-    private readonly TeamSportDataContext _dataContext;
+    private readonly FootballDataContext _dataContext;
     private readonly IEventBus _eventBus;
     private readonly IGenerateExternalRefIdentities _externalRefIdentityGenerator;
 
     public RefreshCompetitionDrivesCommandHandler(
-        TeamSportDataContext dataContext,
+        FootballDataContext dataContext,
         IEventBus eventBus,
         IGenerateExternalRefIdentities externalRefIdentityGenerator)
     {

--- a/src/SportsData.Producer/Application/Competitions/CompetitionController.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
 using SportsData.Core.Extensions;
 using SportsData.Producer.Application.Competitions.Commands.EnqueueCompetitionMediaRefresh;
 using SportsData.Producer.Application.Competitions.Commands.EnqueueCompetitionMetricsCalculation;
@@ -28,9 +30,16 @@ public class CompetitionController : ControllerBase
     [HttpPost("metrics/generate/{seasonYear}")]
     public async Task<ActionResult<RefreshCompetitionMetricsResult>> RefreshCompetitionMetrics(
         [FromRoute] int seasonYear,
-        [FromServices] IRefreshCompetitionMetricsCommandHandler handler,
+        [FromServices] IAppMode appMode,
         CancellationToken cancellationToken)
     {
+        // Football-only handler. Resolved manually after the mode guard so
+        // non-football pods return a typed BadRequest instead of bubbling a
+        // DI resolution InvalidOperationException out of model binding.
+        if (appMode.CurrentSport is not (Sport.FootballNcaa or Sport.FootballNfl))
+            return BadRequest($"RefreshCompetitionMetrics is football-only. CurrentSport={appMode.CurrentSport}");
+
+        var handler = HttpContext.RequestServices.GetRequiredService<IRefreshCompetitionMetricsCommandHandler>();
         var command = new RefreshCompetitionMetricsCommand(seasonYear);
         var result = await handler.ExecuteAsync(command, cancellationToken);
 
@@ -40,9 +49,13 @@ public class CompetitionController : ControllerBase
     [HttpPost("{competitionId}/drives/refresh")]
     public async Task<ActionResult<Guid>> RefreshDrives(
         [FromRoute] Guid competitionId,
-        [FromServices] IRefreshCompetitionDrivesCommandHandler handler,
+        [FromServices] IAppMode appMode,
         CancellationToken cancellationToken)
     {
+        if (appMode.CurrentSport is not (Sport.FootballNcaa or Sport.FootballNfl))
+            return BadRequest($"RefreshDrives is football-only. CurrentSport={appMode.CurrentSport}");
+
+        var handler = HttpContext.RequestServices.GetRequiredService<IRefreshCompetitionDrivesCommandHandler>();
         var command = new RefreshCompetitionDrivesCommand(competitionId);
         var result = await handler.ExecuteAsync(command, cancellationToken);
 

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -235,11 +235,13 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IEnqueueSeasonWeekContestsUpdateCommandHandler, EnqueueSeasonWeekContestsUpdateCommandHandler>();
 
             // Competition Commands
-            services.AddScoped<IRefreshCompetitionDrivesCommandHandler, RefreshCompetitionDrivesCommandHandler>();
             services.AddScoped<IEnqueueCompetitionMetricsCalculationCommandHandler, EnqueueCompetitionMetricsCalculationCommandHandler>();
             if (mode is Sport.FootballNcaa or Sport.FootballNfl)
             {
-                // Both depend on FootballDataContext.
+                // Drives are football-only and the handler depends on
+                // FootballDataContext (which is only registered on football
+                // pods). Same constraint as the metrics handlers below.
+                services.AddScoped<IRefreshCompetitionDrivesCommandHandler, RefreshCompetitionDrivesCommandHandler>();
                 services.AddScoped<ICalculateCompetitionMetricsCommandHandler, CalculateCompetitionMetricsCommandHandler>();
                 services.AddScoped<IRefreshCompetitionMetricsCommandHandler, RefreshCompetitionMetricsCommandHandler>();
             }

--- a/src/SportsData.Producer/Infrastructure/Data/Common/TeamSportDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Common/TeamSportDataContext.cs
@@ -107,9 +107,6 @@ namespace SportsData.Producer.Infrastructure.Data.Common
         public DbSet<ContestBase> Contests { get; set; }
         public DbSet<ContestExternalId> ContestExternalIds { get; set; }
 
-        public DbSet<CompetitionDrive> Drives { get; set; }
-        public DbSet<CompetitionDriveExternalId> DriveExternalIds { get; set; }
-
         public DbSet<Franchise> Franchises { get; set; }
         public DbSet<FranchiseExternalId> FranchiseExternalIds { get; set; }
 
@@ -232,9 +229,6 @@ namespace SportsData.Producer.Infrastructure.Data.Common
 
             modelBuilder.ApplyConfiguration(new ContestBase.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new ContestExternalId.EntityConfiguration());
-
-            modelBuilder.ApplyConfiguration(new CompetitionDrive.EntityConfiguration());
-            modelBuilder.ApplyConfiguration(new CompetitionDriveExternalId.EntityConfiguration());
 
             modelBuilder.ApplyConfiguration(new Draft.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new DraftRound.EntityConfiguration());

--- a/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
@@ -20,6 +20,15 @@ namespace SportsData.Producer.Infrastructure.Data.Football
 
         public new DbSet<FootballCompetitionPlay> CompetitionPlays { get; set; }
 
+        // Drives are football-only (a "drive" is a contiguous offensive
+        // possession terminating in a result). Lifted off TeamSportDataContext
+        // so EF doesn't discover FootballCompetitionPlay via the
+        // CompetitionDrive.Plays navigation when building per-sport models
+        // for non-football contexts (which used to pollute MLB's CompetitionPlay
+        // table with football-only TPH columns).
+        public DbSet<CompetitionDrive> Drives { get; set; }
+        public DbSet<CompetitionDriveExternalId> DriveExternalIds { get; set; }
+
         // Sport-specific status DbSet — typed entry point for the
         // football side of the CompetitionStatus split.
         public DbSet<FootballCompetitionStatus> FootballCompetitionStatuses { get; set; }
@@ -33,6 +42,8 @@ namespace SportsData.Producer.Infrastructure.Data.Football
             modelBuilder.ApplyConfiguration(new FootballCompetition.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionPlay.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionStatus.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new CompetitionDrive.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new CompetitionDriveExternalId.EntityConfiguration());
         }
     }
 }

--- a/src/SportsData.Producer/Migrations/Baseball/20260430130423_MoveDrivesToFootballOnly.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260430130423_MoveDrivesToFootballOnly.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260430130423_MoveDrivesToFootballOnly")]
+    partial class MoveDrivesToFootballOnly
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260430130423_MoveDrivesToFootballOnly.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260430130423_MoveDrivesToFootballOnly.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class MoveDrivesToFootballOnly : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionPlay_CompetitionDrive_DriveId",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropTable(
+                name: "CompetitionDriveExternalId");
+
+            migrationBuilder.DropTable(
+                name: "CompetitionDrive");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionPlay_DriveId",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "ClockDisplayValue",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "ClockValue",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "DriveId",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "EndDistance",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "EndDown",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "EndFranchiseSeasonId",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "EndYardLine",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "EndYardsToEndzone",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "StartDistance",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "StartDown",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "StartYardLine",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "StartYardsToEndzone",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "StatYardage",
+                table: "CompetitionPlay");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ClockDisplayValue",
+                table: "CompetitionPlay",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "ClockValue",
+                table: "CompetitionPlay",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "DriveId",
+                table: "CompetitionPlay",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EndDistance",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EndDown",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "EndFranchiseSeasonId",
+                table: "CompetitionPlay",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EndYardLine",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EndYardsToEndzone",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StartDistance",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StartDown",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StartYardLine",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StartYardsToEndzone",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StatYardage",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CompetitionDrive",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CompetitionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Description = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    DisplayResult = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: true),
+                    EndClockDisplayValue = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    EndClockValue = table.Column<double>(type: "double precision", nullable: true),
+                    EndDistance = table.Column<int>(type: "integer", nullable: true),
+                    EndDown = table.Column<int>(type: "integer", nullable: true),
+                    EndDownDistanceText = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    EndFranchiseSeasonId = table.Column<Guid>(type: "uuid", nullable: true),
+                    EndPeriodNumber = table.Column<int>(type: "integer", nullable: true),
+                    EndPeriodType = table.Column<string>(type: "text", nullable: true),
+                    EndShortDownDistanceText = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    EndText = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    EndYardLine = table.Column<int>(type: "integer", nullable: true),
+                    EndYardsToEndzone = table.Column<int>(type: "integer", nullable: true),
+                    IsScore = table.Column<bool>(type: "boolean", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    OffensivePlays = table.Column<int>(type: "integer", nullable: false),
+                    Ordinal = table.Column<int>(type: "integer", nullable: false),
+                    Result = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: true),
+                    SequenceNumber = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    ShortDisplayResult = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: true),
+                    SourceDescription = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    SourceId = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    StartClockDisplayValue = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    StartClockValue = table.Column<double>(type: "double precision", nullable: true),
+                    StartDistance = table.Column<int>(type: "integer", nullable: true),
+                    StartDown = table.Column<int>(type: "integer", nullable: true),
+                    StartDownDistanceText = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    StartFranchiseSeasonId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StartPeriodNumber = table.Column<int>(type: "integer", nullable: true),
+                    StartPeriodType = table.Column<string>(type: "text", nullable: true),
+                    StartShortDownDistanceText = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    StartText = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    StartYardLine = table.Column<int>(type: "integer", nullable: true),
+                    StartYardsToEndzone = table.Column<int>(type: "integer", nullable: true),
+                    TimeElapsedDisplay = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    TimeElapsedValue = table.Column<double>(type: "double precision", nullable: true),
+                    Yards = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionDrive", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CompetitionDrive_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CompetitionDriveExternalId",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DriveId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Provider = table.Column<int>(type: "integer", nullable: false),
+                    SourceUrl = table.Column<string>(type: "text", nullable: false),
+                    SourceUrlHash = table.Column<string>(type: "text", nullable: false),
+                    Value = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionDriveExternalId", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CompetitionDriveExternalId_CompetitionDrive_DriveId",
+                        column: x => x.DriveId,
+                        principalTable: "CompetitionDrive",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionPlay_DriveId",
+                table: "CompetitionPlay",
+                column: "DriveId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionDrive_CompetitionId",
+                table: "CompetitionDrive",
+                column: "CompetitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionDriveExternalId_DriveId",
+                table: "CompetitionDriveExternalId",
+                column: "DriveId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionPlay_CompetitionDrive_DriveId",
+                table: "CompetitionPlay",
+                column: "DriveId",
+                principalTable: "CompetitionDrive",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Drives are a football-specific concept. Moving \`CompetitionDrive\` and \`CompetitionDriveExternalId\` off the shared \`TeamSportDataContext\` and into \`FootballDataContext\` only. Eliminates two side effects in the MLB database:

1. The \`CompetitionDrive\` / \`CompetitionDriveExternalId\` tables existed in baseball but were never populated.
2. EF discovered \`FootballCompetitionPlay\` via \`CompetitionDrive.Plays\` when building the baseball model and folded it into the TPH hierarchy on the shared \`CompetitionPlay\` table — leaking 13 football-only columns (StartDown/Distance/YardLine/YardsToEndzone, EndDown/Distance/YardLine/YardsToEndzone/FranchiseSeasonId, ClockValue, ClockDisplayValue, StatYardage, DriveId) into MLB's \`CompetitionPlay\`.

## What changed
- \`TeamSportDataContext.cs\` — removed the two \`CompetitionDrive\` DbSets + ApplyConfiguration calls.
- \`FootballDataContext.cs\` — added the two DbSets + ApplyConfiguration calls (with explanatory comment).
- \`RefreshCompetitionDrivesCommandHandler.cs\` — retyped \`_dataContext\` from \`TeamSportDataContext\` → \`FootballDataContext\`. It's a *Drives* handler; this prevents misresolution on non-football pods.
- \`ServiceRegistration.cs\` — gated \`IRefreshCompetitionDrivesCommandHandler\` registration to football modes only (matches the \`ICalculateCompetitionMetricsCommandHandler\` precedent right next to it).
- New baseball migration \`20260430130423_MoveDrivesToFootballOnly\` — drops:
  - FK \`FK_CompetitionPlay_CompetitionDrive_DriveId\` and index \`IX_CompetitionPlay_DriveId\`
  - Tables \`CompetitionDriveExternalId\` and \`CompetitionDrive\`
  - 13 football-only columns from \`CompetitionPlay\`
  
  \`Down\` is fully scaffolded for rollback.
- \`BaseballDataContextModelSnapshot.cs\` — 287 lines deleted (FootballCompetitionPlay, CompetitionDrive, CompetitionDriveExternalId entries).
- **No football migration**: football model is byte-identical post-move (only the C# registration source changed); \`FootballDataContextModelSnapshot\` is unchanged.

## Test plan
- [x] \`dotnet build\` Producer — 0 warnings, 0 errors.
- [x] \`dotnet test\` Producer — 344 passed, 0 failed.
- [x] Local MLB: migration applied cleanly; \`CompetitionDrive\` / \`CompetitionDriveExternalId\` tables dropped; \`CompetitionPlay\` no longer has the 13 football columns.
- [x] Local NCAAFB: no migration runs; schema unchanged.
- [x] Local NFL: no migration runs; schema unchanged.
- [ ] **Hold for merge**: MLB is currently working through the contest finalization backlog. Merge after that completes and Producer pods are stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Competition drives functionality is now football-only; drives data and handlers have been moved into the football-specific data path.
  * Service registration and controller endpoints now enforce sport-type guards so drives operations run only for football.
* **Chores / Migrations**
  * Removed drives-related persistence from the baseball schema and added corresponding football-side schema support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->