### PR TITLE
feat(user): user-configurable timezone (web + mobile) + mobile MLB fixes

### DIFF
--- a/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommand.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommand.cs
@@ -1,0 +1,7 @@
+namespace SportsData.Api.Application.User.Commands.UpdateUserTimezone;
+
+public class UpdateUserTimezoneCommand
+{
+    // null/empty clears the user's saved timezone (falls back to ET in the UI).
+    public string? Timezone { get; init; }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommandHandler.cs
@@ -1,0 +1,64 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.User.Commands.UpdateUserTimezone;
+
+public interface IUpdateUserTimezoneCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateUserTimezoneCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+public class UpdateUserTimezoneCommandHandler : IUpdateUserTimezoneCommandHandler
+{
+    private readonly AppDataContext _db;
+    private readonly ILogger<UpdateUserTimezoneCommandHandler> _logger;
+    private readonly IValidator<UpdateUserTimezoneCommand> _validator;
+
+    public UpdateUserTimezoneCommandHandler(
+        AppDataContext db,
+        ILogger<UpdateUserTimezoneCommandHandler> logger,
+        IValidator<UpdateUserTimezoneCommand> validator)
+    {
+        _db = db;
+        _logger = logger;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateUserTimezoneCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default, ResultStatus.BadRequest, validation.Errors);
+        }
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
+        }
+
+        var normalized = string.IsNullOrWhiteSpace(command.Timezone) ? null : command.Timezone.Trim();
+        user.Timezone = normalized;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Timezone updated. UserId={UserId}, Timezone={Timezone}", user.Id, normalized);
+
+        return new Success<Guid>(user.Id);
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommandHandler.cs
@@ -40,14 +40,14 @@ public class UpdateUserTimezoneCommandHandler : IUpdateUserTimezoneCommandHandle
         var validation = await _validator.ValidateAsync(command, cancellationToken);
         if (!validation.IsValid)
         {
-            return new Failure<Guid>(default, ResultStatus.BadRequest, validation.Errors);
+            return new Failure<Guid>(default!, ResultStatus.BadRequest, validation.Errors);
         }
 
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
         if (user is null)
         {
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.NotFound,
                 [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
         }
@@ -57,7 +57,11 @@ public class UpdateUserTimezoneCommandHandler : IUpdateUserTimezoneCommandHandle
 
         await _db.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation("Timezone updated. UserId={UserId}, Timezone={Timezone}", user.Id, normalized);
+        // Strip CRLF before logging to defeat log-forgery even though the
+        // validator's TimeZoneInfo.TryFindSystemTimeZoneById check already
+        // rejects any input containing newlines.
+        var safeForLog = normalized?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        _logger.LogInformation("Timezone updated. UserId={UserId}, Timezone={Timezone}", user.Id, safeForLog);
 
         return new Success<Guid>(user.Id);
     }

--- a/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUserTimezone/UpdateUserTimezoneCommandValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.User.Commands.UpdateUserTimezone;
+
+public class UpdateUserTimezoneCommandValidator : AbstractValidator<UpdateUserTimezoneCommand>
+{
+    public UpdateUserTimezoneCommandValidator()
+    {
+        RuleFor(x => x.Timezone)
+            .MaximumLength(100)
+            .When(x => !string.IsNullOrWhiteSpace(x.Timezone))
+            .WithMessage("Timezone must not exceed 100 characters.");
+
+        // Accept any IANA zone the runtime can resolve. .NET 8+ ships ICU/tzdata
+        // cross-platform, so "America/New_York", "Europe/London", "Asia/Tokyo"
+        // all parse on Linux and Windows.
+        RuleFor(x => x.Timezone)
+            .Must(BeAValidTimezone)
+            .When(x => !string.IsNullOrWhiteSpace(x.Timezone))
+            .WithMessage("Timezone must be a valid IANA timezone identifier.");
+    }
+
+    private static bool BeAValidTimezone(string? tz)
+    {
+        if (string.IsNullOrWhiteSpace(tz))
+            return true;
+
+        return TimeZoneInfo.TryFindSystemTimeZoneById(tz, out _);
+    }
+}

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -49,6 +49,7 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                 FirebaseUid = user.FirebaseUid,
                 Email = user.Email,
                 DisplayName = user.DisplayName,
+                Timezone = user.Timezone,
                 LastLoginUtc = user.LastLoginUtc,
                 IsAdmin = user.IsAdmin || user.Id == _config.UserIdSystem,
                 IsReadOnly = user.IsReadOnly,

--- a/src/SportsData.Api/Application/User/UserController.cs
+++ b/src/SportsData.Api/Application/User/UserController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Dtos;
 using SportsData.Api.Application.User.Queries.GetMe;
@@ -48,6 +49,18 @@ public class UserController : ApiControllerBase
         var query = new GetMeQuery { UserId = userId };
         var result = await handler.ExecuteAsync(query, cancellationToken);
 
+        return result.ToActionResult();
+    }
+
+    [HttpPatch("me/timezone")]
+    [Authorize]
+    public async Task<ActionResult<Guid>> UpdateTimezone(
+        [FromBody] UpdateUserTimezoneCommand command,
+        [FromServices] IUpdateUserTimezoneCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await handler.ExecuteAsync(userId, command, cancellationToken);
         return result.ToActionResult();
     }
 }

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -74,6 +74,7 @@ using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamCard;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamMetrics;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamStatistics;
 using SportsData.Api.Application.User;
+using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Queries.GetMe;
 using SportsData.Api.Config;
@@ -211,6 +212,7 @@ namespace SportsData.Api.DependencyInjection
 
             // User Commands
             services.AddScoped<IUpsertUserCommandHandler, UpsertUserCommandHandler>();
+            services.AddScoped<IUpdateUserTimezoneCommandHandler, UpdateUserTimezoneCommandHandler>();
             
             // User Validators
             services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -19,20 +19,12 @@ import type {
   ContestOverviewDto,
   ContestOverviewLeaderCategory,
 } from '@/src/types/models';
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
-  });
-}
+import {
+  formatToUserTime,
+  getStartLabel,
+  getZoneAbbreviation,
+} from '@/src/utils/timeUtils';
+import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 
 // ─── BoxScore ─────────────────────────────────────────────────────────────────
 
@@ -257,9 +249,16 @@ function LeadersCard({
 
 // ─── Game Info ────────────────────────────────────────────────────────────────
 
-function GameInfoCard({ info }: { info: ContestOverviewDto['info'] }) {
+function GameInfoCard({
+  info,
+  sport,
+}: {
+  info: ContestOverviewDto['info'];
+  sport: string | null | undefined;
+}) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const userTz = useUserTimeZone();
 
   if (!info) return null;
 
@@ -270,7 +269,14 @@ function GameInfoCard({ info }: { info: ContestOverviewDto['info'] }) {
   if (info.attendance)
     rows.push({ label: 'Attendance', value: Number(info.attendance).toLocaleString('en-US') });
   if (info.broadcast) rows.push({ label: 'Broadcast', value: info.broadcast });
-  if (info.startDateUtc) rows.push({ label: 'Kickoff', value: formatTime(info.startDateUtc) });
+  if (info.startDateUtc) {
+    const startLabel = getStartLabel(sport);
+    const tzAbbr = getZoneAbbreviation(userTz);
+    rows.push({
+      label: `${startLabel} (${tzAbbr})`,
+      value: formatToUserTime(info.startDateUtc, userTz),
+    });
+  }
 
   if (!rows.length) return null;
 
@@ -397,7 +403,7 @@ export default function GameDetailScreen() {
 
   const weekNumber = weekParam ? parseInt(weekParam, 10) : null;
 
-  const { data: overview, isLoading: overviewLoading, error: overviewError } = useContestOverview(id);
+  const { data: overview, isLoading: overviewLoading, error: overviewError } = useContestOverview(id, sport, league);
 
   const { data: matchupsResponse } = useMatchups(leagueId, weekNumber);
   const { data: myPicks = [] } = usePicks(leagueId, weekNumber);
@@ -479,7 +485,7 @@ export default function GameDetailScreen() {
                 homeName={overview.header.homeTeam.displayName}
               />
             ) : null}
-            <GameInfoCard info={overview.info} />
+            <GameInfoCard info={overview.info} sport={sport} />
           </>
         )}
         {leagueId && matchup ? (
@@ -587,7 +593,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     textTransform: 'uppercase',
     letterSpacing: 0.3,
-    width: 88,
+    width: 116,
     paddingTop: 1,
   },
   infoValue: { fontSize: 13, flex: 1, textAlign: 'right' },

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/team/[slug].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/team/[slug].tsx
@@ -13,19 +13,8 @@ import { getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
 import { useTeamCard } from '@/src/hooks/useTeamCard';
 import type { TeamCardScheduleGame } from '@/src/types/models';
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function formatKickoff(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
-}
+import { formatToUserTime } from '@/src/utils/timeUtils';
+import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 
 // ─── Season Selector ─────────────────────────────────────────────────────────
 
@@ -88,6 +77,7 @@ function ScheduleRow({
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
   const router = useRouter();
+  const userTz = useUserTimeZone();
 
   const isFinalized = !!game.finalizedUtc;
   const resultLabel = isFinalized
@@ -102,7 +92,7 @@ function ScheduleRow({
   return (
     <View style={[styles.gameRow, { borderBottomColor: theme.separator }]}>
       <Text style={[styles.gameDate, { color: theme.textMuted }]} numberOfLines={2}>
-        {formatKickoff(game.date)}
+        {formatToUserTime(game.date, userTz)}
       </Text>
 
       <View style={styles.gameMiddle}>

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -204,6 +204,30 @@ export default function PicksScreen() {
                   } as never,
                 );
               }}
+              onPressTeam={(side) => {
+                if (!sportLeague) {
+                  console.warn(
+                    '[PicksScreen] Could not resolve sport for team navigation. Raw sport value:',
+                    matchupsResponse?.sport ?? '(no matchups response)',
+                  );
+                  return;
+                }
+                const slug =
+                  side === 'home' ? item.matchup.homeSlug : item.matchup.awaySlug;
+                router.push(
+                  {
+                    pathname: '/sport/[sport]/[league]/team/[slug]',
+                    params: {
+                      sport: sportLeague.sport,
+                      league: sportLeague.league,
+                      slug,
+                      season: String(matchupsResponse?.seasonYear ?? ''),
+                      backTitle: 'Games',
+                      backHref: '/(tabs)/picks',
+                    },
+                  } as never,
+                );
+              }}
               onPick={(m, _choice, franchiseSeasonId) => {
                 if (!leagueId || !selectedWeek) return;
                 submitPick.mutate({

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -8,12 +8,16 @@ import {
   ScrollView,
 } from 'react-native';
 import { signOut } from 'firebase/auth';
+import { useQueryClient } from '@tanstack/react-query';
 import { useColorScheme, useThemeMode, type ThemeMode } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { auth } from '@/src/lib/firebase';
 import { useAuthStore } from '@/src/stores/authStore';
-import { useCurrentUser } from '@/src/hooks/useStandings';
+import { useCurrentUser, standingsKeys } from '@/src/hooks/useStandings';
 import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
+import { usersApi } from '@/src/services/api/usersApi';
+import { DEFAULT_TIMEZONE } from '@/src/utils/timeUtils';
+import { TimezonePickerModal } from '@/src/components/features/settings/TimezonePickerModal';
 
 // ─── Record card ──────────────────────────────────────────────────────────────
 
@@ -81,12 +85,35 @@ const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: 'system', label: 'System' },
 ];
 
+// Device default — Hermes exposes Intl.DateTimeFormat().resolvedOptions().
+// We use this to pre-populate the picker when the user hasn't picked a tz
+// yet. We do NOT auto-save the device tz; the user must explicitly confirm.
+function detectDeviceTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || DEFAULT_TIMEZONE;
+  } catch {
+    return DEFAULT_TIMEZONE;
+  }
+}
+
 export default function ProfileScreen() {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
   const { user } = useAuthStore();
   const { data: me } = useCurrentUser();
   const { mode, setMode } = useThemeMode();
+  const queryClient = useQueryClient();
+
+  const deviceTz = useMemo(() => detectDeviceTimezone(), []);
+  const [tzPickerOpen, setTzPickerOpen] = useState(false);
+  const [tzMessage, setTzMessage] = useState('');
+
+  // The zone the user has saved, or the device default if nothing saved yet.
+  // The picker uses this to highlight the current selection. The user-set
+  // value is what the API persists; the device value is purely a sensible
+  // pre-population so the picker isn't empty.
+  const effectiveTimezone = me?.timezone || deviceTz;
+  const isUserSet = !!me?.timezone;
 
   const handleSignOut = () => {
     Alert.alert('Sign Out', 'Are you sure you want to sign out?', [
@@ -97,6 +124,26 @@ export default function ProfileScreen() {
         onPress: () => signOut(auth),
       },
     ]);
+  };
+
+  const handleTimezoneSelect = async (newTz: string) => {
+    if (!newTz) return;
+    setTzMessage('');
+    try {
+      await usersApi.updateTimezone(newTz);
+      // Refresh /user/me so every consumer (useUserTimeZone, etc.) picks up
+      // the new value on its next render.
+      await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
+      setTzMessage('Saved.');
+      // Auto-close after a brief moment so the user sees the confirmation.
+      setTimeout(() => {
+        setTzPickerOpen(false);
+        setTzMessage('');
+      }, 600);
+    } catch (err) {
+      console.warn('[ProfileScreen] timezone update failed', err);
+      setTzMessage('Could not save timezone. Try again?');
+    }
   };
 
   const displayName = me?.displayName ?? user?.displayName ?? user?.email ?? '—';
@@ -161,12 +208,28 @@ export default function ProfileScreen() {
       {/* Account */}
       <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
         <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>Account</Text>
+        <SettingsRow
+          label="Timezone"
+          value={isUserSet ? effectiveTimezone : `${effectiveTimezone} (device)`}
+          onPress={() => setTzPickerOpen(true)}
+        />
         <SettingsRow label="Edit Profile" onPress={() => {}} />
         <SettingsRow label="Notifications" onPress={() => {}} />
         <SettingsRow label="Sign Out" onPress={handleSignOut} destructive />
       </View>
 
       <View style={{ height: 40 }} />
+
+      <TimezonePickerModal
+        visible={tzPickerOpen}
+        onClose={() => {
+          setTzPickerOpen(false);
+          setTzMessage('');
+        }}
+        currentTimezone={effectiveTimezone}
+        onSelect={handleTimezoneSelect}
+        message={tzMessage}
+      />
     </ScrollView>
   );
 }

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -3,19 +3,8 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { Matchup } from '@/src/types/models';
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
-}
+import { formatToUserTime } from '@/src/utils/timeUtils';
+import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
@@ -37,6 +26,7 @@ interface GameStatusProps {
 export function GameStatus({ matchup, onPressGameDetail }: GameStatusProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const userTz = useUserTimeZone();
 
   const status = matchup.status.toLowerCase();
 
@@ -45,7 +35,7 @@ export function GameStatus({ matchup, onPressGameDetail }: GameStatusProps) {
     return (
       <View style={styles.statusSection}>
         <Text style={[styles.statusTime, { color: theme.text }]}>
-          {formatTime(matchup.startDateUtc)}
+          {formatToUserTime(matchup.startDateUtc, userTz)}
         </Text>
         {matchup.broadcasts ? (
           <Text style={[styles.statusMeta, { color: theme.textMuted }]}>

--- a/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
@@ -12,6 +12,8 @@ import {
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, PreviewResponse } from '@/src/types/models';
+import { formatToUserTime } from '@/src/utils/timeUtils';
+import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -41,6 +43,7 @@ function Section({ label, children }: { label: string; children: React.ReactNode
 export function InsightModal({ visible, onClose, matchup, preview, isLoading }: InsightModalProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const userTz = useUserTimeZone();
 
   return (
     <Modal
@@ -160,9 +163,7 @@ export function InsightModal({ visible, onClose, matchup, preview, isLoading }: 
                 {/* Generated time */}
                 {!!preview.generatedUtc && (
                   <Text style={[styles.generatedText, { color: theme.textMuted }]}>
-                    Generated {new Date(preview.generatedUtc).toLocaleDateString(undefined, {
-                      month: 'short', day: 'numeric', year: 'numeric',
-                    })}
+                    Generated {formatToUserTime(preview.generatedUtc, userTz)}
                   </Text>
                 )}
               </Section>

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -11,17 +11,6 @@ import { GameStatus } from './GameStatus';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
-}
-
 function spreadLabel(spread: number | null | undefined): string {
   if (spread == null || spread === 0) return 'PK';
   return spread > 0 ? `+${spread}` : `${spread}`;
@@ -371,13 +360,16 @@ function PickButtons({
 export interface MatchupCardProps {
   matchup: Matchup;
   pick?: UserPick | null;
+  /** Tap on the spread/result area → opens the contest overview. */
   onPress?: () => void;
+  /** Tap on a team row → opens that team's page. */
+  onPressTeam?: (side: 'home' | 'away') => void;
   onPick?: (matchup: Matchup, choice: PickChoice, franchiseSeasonId: string) => void;
   /** Season year used for team stats API calls. Defaults to the game start year. */
   seasonYear?: number;
 }
 
-export function MatchupCard({ matchup, pick, onPress, onPick, seasonYear }: MatchupCardProps) {
+export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear }: MatchupCardProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
   const status = matchup.status.toLowerCase();
@@ -467,16 +459,13 @@ export function MatchupCard({ matchup, pick, onPress, onPick, seasonYear }: Matc
 
   return (
     <>
-    <TouchableOpacity
+    <View
       style={[
         styles.card,
         { backgroundColor: theme.card, borderColor: cardBorderColor },
         isFinal && hasPick && isPickCorrect === true && styles.cardCorrect,
         isFinal && (isPickCorrect === false || !hasPick) && styles.cardIncorrect,
       ]}
-      onPress={onPress}
-      activeOpacity={onPress ? 0.75 : 1}
-      disabled={!onPress}
     >
       {/* Headline banner */}
       {matchup.headLine != null && matchup.headLine !== '' && (
@@ -485,30 +474,49 @@ export function MatchupCard({ matchup, pick, onPress, onPick, seasonYear }: Matc
         </View>
       )}
 
-      {/* Away team */}
-      <TeamRow
-        matchup={matchup}
-        side="away"
-        isWinning={!homeIsWinning}
-        isPicked={pickedAway}
-        isPickCorrect={isPickCorrect}
-        isFinal={isFinal}
-      />
+      {/* Away team — taps go to the team page, not the contest overview. */}
+      <TouchableOpacity
+        onPress={onPressTeam ? () => onPressTeam('away') : undefined}
+        activeOpacity={onPressTeam ? 0.6 : 1}
+        disabled={!onPressTeam}
+      >
+        <TeamRow
+          matchup={matchup}
+          side="away"
+          isWinning={!homeIsWinning}
+          isPicked={pickedAway}
+          isPickCorrect={isPickCorrect}
+          isFinal={isFinal}
+        />
+      </TouchableOpacity>
 
       {/* Home team */}
-      <TeamRow
-        matchup={matchup}
-        side="home"
-        isWinning={homeIsWinning}
-        isPicked={pickedHome}
-        isPickCorrect={isPickCorrect}
-        isFinal={isFinal}
-      />
+      <TouchableOpacity
+        onPress={onPressTeam ? () => onPressTeam('home') : undefined}
+        activeOpacity={onPressTeam ? 0.6 : 1}
+        disabled={!onPressTeam}
+      >
+        <TeamRow
+          matchup={matchup}
+          side="home"
+          isWinning={homeIsWinning}
+          isPicked={pickedHome}
+          isPickCorrect={isPickCorrect}
+          isFinal={isFinal}
+        />
+      </TouchableOpacity>
 
-      {/* Spread & O/U */}
-      <OddsRow matchup={matchup} />
+      {/* Spread & O/U — tap goes to the contest overview. */}
+      <TouchableOpacity
+        onPress={onPress}
+        activeOpacity={onPress ? 0.75 : 1}
+        disabled={!onPress}
+      >
+        <OddsRow matchup={matchup} />
+      </TouchableOpacity>
 
-      {/* Game status — time/score/live, matches web layout order */}
+      {/* Game status — time/score/live; GameStatus owns its own touchable
+          and routes to the contest overview via onPressGameDetail. */}
       <GameStatus matchup={matchup} onPressGameDetail={onPress} />
 
       {/* Inline pick buttons */}
@@ -524,9 +532,9 @@ export function MatchupCard({ matchup, pick, onPress, onPick, seasonYear }: Matc
           onOpenPreview={handleOpenPreview}
         />
       )}
-    </TouchableOpacity>
+    </View>
 
-    {/* Modals — rendered outside TouchableOpacity so they overlay in full screen */}
+    {/* Modals — rendered outside the card so they overlay in full screen */}
     <StatsComparisonModal
       visible={showStats}
       onClose={() => setShowStats(false)}

--- a/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Modal,
   View,
@@ -67,16 +67,26 @@ export function TimezonePickerModal({
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
 
-  const [showAll, setShowAll] = useState(false);
-  const [filter, setFilter] = useState('');
-  const [saving, setSaving] = useState(false);
-
   const allZones = useMemo(() => getAllIanaZones(), []);
   const isCurated = CURATED_TIMEZONES.some((z) => z.value === currentTimezone);
 
   // Auto-flip to the full list when the user has a non-curated zone (e.g.
-  // Europe/London) so they can see and change it.
-  const expanded = showAll || (!isCurated && allZones.length > 0);
+  // Europe/London) so they can see and change it. Initial state covers the
+  // first mount (no first-frame flash); the effect below re-evaluates each
+  // time the modal becomes visible so closing + re-opening with a still-
+  // non-curated zone re-flips. Critically, expanded is just `showAll` so
+  // the footer's `setShowAll(false)` actually collapses the view.
+  const [showAll, setShowAll] = useState(() => !isCurated && allZones.length > 0);
+  const [filter, setFilter] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setShowAll(!isCurated && allZones.length > 0);
+    }
+  }, [visible, isCurated, allZones.length]);
+
+  const expanded = showAll;
 
   const filteredZones = useMemo(() => {
     if (!expanded) return [];

--- a/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
@@ -1,0 +1,349 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  FlatList,
+  TextInput,
+  ActivityIndicator,
+} from 'react-native';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { Colors, getTheme } from '@/constants/Colors';
+import { DEFAULT_TIMEZONE } from '@/src/utils/timeUtils';
+
+/**
+ * Curated short-list mirrors the web SettingsPage. Order matters: Eastern,
+ * Central, Mountain, Phoenix (no DST), Pacific, Alaska, Hawaii. Anything
+ * outside this list is reachable via the "Other…" entry which expands the
+ * full Intl.supportedValuesOf("timeZone") catalog.
+ */
+const CURATED_TIMEZONES: { value: string; label: string }[] = [
+  { value: 'America/New_York', label: 'Eastern (New York)' },
+  { value: 'America/Chicago', label: 'Central (Chicago)' },
+  { value: 'America/Denver', label: 'Mountain (Denver)' },
+  { value: 'America/Phoenix', label: 'Mountain - no DST (Phoenix)' },
+  { value: 'America/Los_Angeles', label: 'Pacific (Los Angeles)' },
+  { value: 'America/Anchorage', label: 'Alaska (Anchorage)' },
+  { value: 'Pacific/Honolulu', label: 'Hawaii (Honolulu)' },
+];
+
+const OTHER_VALUE = '__other__';
+
+function getAllIanaZones(): string[] {
+  // Intl.supportedValuesOf is available on Hermes with full ICU (Expo 55+).
+  // Fall back to the curated list if a host strips it.
+  const intl = Intl as unknown as { supportedValuesOf?: (k: string) => string[] };
+  if (typeof intl.supportedValuesOf === 'function') {
+    try {
+      return intl.supportedValuesOf('timeZone');
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+interface TimezonePickerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  /** The currently effective timezone to highlight as selected. */
+  currentTimezone: string;
+  /** Called when the user taps a zone. Returns a Promise so the modal can
+   *  show a saving state and stay open until the save resolves. */
+  onSelect: (timezone: string) => Promise<void> | void;
+  /** Optional message to surface (e.g. "Saved." or "Could not save."). */
+  message?: string;
+}
+
+export function TimezonePickerModal({
+  visible,
+  onClose,
+  currentTimezone,
+  onSelect,
+  message,
+}: TimezonePickerModalProps) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const [showAll, setShowAll] = useState(false);
+  const [filter, setFilter] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const allZones = useMemo(() => getAllIanaZones(), []);
+  const isCurated = CURATED_TIMEZONES.some((z) => z.value === currentTimezone);
+
+  // Auto-flip to the full list when the user has a non-curated zone (e.g.
+  // Europe/London) so they can see and change it.
+  const expanded = showAll || (!isCurated && allZones.length > 0);
+
+  const filteredZones = useMemo(() => {
+    if (!expanded) return [];
+    const q = filter.trim().toLowerCase();
+    if (!q) return allZones;
+    return allZones.filter((z) => z.toLowerCase().includes(q));
+  }, [expanded, allZones, filter]);
+
+  const handleSelect = async (tz: string) => {
+    if (!tz || saving) return;
+    setSaving(true);
+    try {
+      await onSelect(tz);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (saving) return;
+    setShowAll(false);
+    setFilter('');
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={handleClose}
+    >
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={[styles.header, { borderBottomColor: theme.border }]}>
+          <View style={styles.headerLeft} />
+          <Text style={[styles.headerTitle, { color: theme.text }]}>Timezone</Text>
+          <TouchableOpacity onPress={handleClose} style={styles.closeBtn} hitSlop={12}>
+            <Text style={[styles.closeText, { color: theme.textMuted }]}>✕</Text>
+          </TouchableOpacity>
+        </View>
+
+        {message ? (
+          <View style={[styles.messageBar, { backgroundColor: theme.card, borderBottomColor: theme.border }]}>
+            <Text style={[styles.messageText, { color: theme.textMuted }]}>{message}</Text>
+          </View>
+        ) : null}
+
+        {expanded ? (
+          <View style={[styles.searchRow, { borderBottomColor: theme.border }]}>
+            <TextInput
+              style={[styles.searchInput, { color: theme.text, backgroundColor: theme.card, borderColor: theme.border }]}
+              placeholder="Search timezone (e.g. Chicago, GMT)…"
+              placeholderTextColor={theme.textMuted}
+              autoCorrect={false}
+              autoCapitalize="none"
+              value={filter}
+              onChangeText={setFilter}
+              editable={!saving}
+            />
+          </View>
+        ) : null}
+
+        {expanded ? (
+          allZones.length === 0 ? (
+            <View style={styles.emptyContainer}>
+              <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+                Full timezone list isn't available on this device. Pick from the curated list instead.
+              </Text>
+              <TouchableOpacity
+                onPress={() => setShowAll(false)}
+                style={[styles.linkBtn, { borderColor: Colors.brand.navy }]}
+              >
+                <Text style={[styles.linkBtnText, { color: Colors.brand.navy }]}>Back to curated list</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <FlatList
+              data={filteredZones}
+              keyExtractor={(z) => z}
+              keyboardShouldPersistTaps="handled"
+              renderItem={({ item }) => {
+                const selected = item === currentTimezone;
+                return (
+                  <TouchableOpacity
+                    style={[
+                      styles.row,
+                      { borderBottomColor: theme.separator },
+                      selected && { backgroundColor: theme.card },
+                    ]}
+                    onPress={() => handleSelect(item)}
+                    disabled={saving}
+                    activeOpacity={0.6}
+                  >
+                    <Text
+                      style={[
+                        styles.rowLabel,
+                        { color: selected ? theme.tint : theme.text },
+                        selected && styles.rowSelected,
+                      ]}
+                    >
+                      {item}
+                    </Text>
+                    {selected ? (
+                      <Text style={[styles.checkmark, { color: theme.tint }]}>✓</Text>
+                    ) : null}
+                  </TouchableOpacity>
+                );
+              }}
+              ListFooterComponent={
+                <TouchableOpacity
+                  onPress={() => {
+                    setShowAll(false);
+                    setFilter('');
+                  }}
+                  style={styles.footerLink}
+                  disabled={saving}
+                >
+                  <Text style={[styles.footerLinkText, { color: theme.tint }]}>
+                    Back to curated list
+                  </Text>
+                </TouchableOpacity>
+              }
+            />
+          )
+        ) : (
+          <FlatList
+            data={CURATED_TIMEZONES}
+            keyExtractor={(item) => item.value}
+            renderItem={({ item }) => {
+              const selected = item.value === currentTimezone;
+              return (
+                <TouchableOpacity
+                  style={[
+                    styles.row,
+                    { borderBottomColor: theme.separator },
+                    selected && { backgroundColor: theme.card },
+                  ]}
+                  onPress={() => handleSelect(item.value)}
+                  disabled={saving}
+                  activeOpacity={0.6}
+                >
+                  <View style={{ flex: 1 }}>
+                    <Text
+                      style={[
+                        styles.rowLabel,
+                        { color: selected ? theme.tint : theme.text },
+                        selected && styles.rowSelected,
+                      ]}
+                    >
+                      {item.label}
+                    </Text>
+                    <Text style={[styles.rowSub, { color: theme.textMuted }]}>{item.value}</Text>
+                  </View>
+                  {selected ? (
+                    <Text style={[styles.checkmark, { color: theme.tint }]}>✓</Text>
+                  ) : null}
+                </TouchableOpacity>
+              );
+            }}
+            ListFooterComponent={
+              <TouchableOpacity
+                onPress={() => {
+                  if (allZones.length > 0) setShowAll(true);
+                }}
+                style={styles.footerLink}
+                disabled={saving || allZones.length === 0}
+              >
+                <Text
+                  style={[
+                    styles.footerLinkText,
+                    { color: allZones.length > 0 ? theme.tint : theme.textMuted },
+                  ]}
+                >
+                  {allZones.length > 0 ? 'Other…' : 'Other (unavailable)'}
+                </Text>
+              </TouchableOpacity>
+            }
+          />
+        )}
+
+        {saving ? (
+          <View style={[styles.savingOverlay, { backgroundColor: theme.background }]}>
+            <ActivityIndicator size="small" color={Colors.brand.navy} />
+            <Text style={[styles.savingText, { color: theme.textMuted }]}>Saving…</Text>
+          </View>
+        ) : null}
+      </View>
+    </Modal>
+  );
+}
+
+export { CURATED_TIMEZONES, OTHER_VALUE, DEFAULT_TIMEZONE };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerLeft: { width: 32 },
+  headerTitle: { fontSize: 17, fontWeight: '700' },
+  closeBtn: { width: 32, alignItems: 'flex-end' },
+  closeText: { fontSize: 17, fontWeight: '400' },
+
+  messageBar: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  messageText: { fontSize: 13 },
+
+  searchRow: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  searchInput: {
+    height: 38,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 12,
+    fontSize: 14,
+  },
+
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 10,
+  },
+  rowLabel: { fontSize: 15 },
+  rowSelected: { fontWeight: '700' },
+  rowSub: { fontSize: 11, marginTop: 2 },
+  checkmark: { fontSize: 16, fontWeight: '700' },
+
+  footerLink: { padding: 16, alignItems: 'center' },
+  footerLinkText: { fontSize: 14, fontWeight: '600' },
+
+  emptyContainer: { padding: 24, alignItems: 'center', gap: 16 },
+  emptyText: { fontSize: 14, textAlign: 'center', lineHeight: 20 },
+  linkBtn: {
+    borderWidth: 1.5,
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  linkBtnText: { fontSize: 14, fontWeight: '600' },
+
+  savingOverlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingVertical: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: 'rgba(0,0,0,0.1)',
+    opacity: 0.95,
+  },
+  savingText: { fontSize: 13, fontWeight: '500' },
+});

--- a/src/UI/sd-mobile/src/hooks/useContest.ts
+++ b/src/UI/sd-mobile/src/hooks/useContest.ts
@@ -55,21 +55,28 @@ export function useSubmitPick() {
 // ─── Contest overview ─────────────────────────────────────────────────────────
 
 export const contestKeys = {
-  overview: (contestId: string) => ['contest', 'overview', contestId] as const,
+  // sport/league are part of the cache key because the API routes by them —
+  // the same contestId in two sports would collide otherwise.
+  overview: (contestId: string, sport: string, league: string) =>
+    ['contest', 'overview', sport, league, contestId] as const,
 };
 
 /** Fetches the full contest overview for a completed or in-progress game. */
-export function useContestOverview(contestId: string | null | undefined) {
+export function useContestOverview(
+  contestId: string | null | undefined,
+  sport: string | null | undefined,
+  league: string | null | undefined,
+) {
   return useQuery<ContestOverviewDto>({
-    queryKey: contestKeys.overview(contestId ?? ''),
+    queryKey: contestKeys.overview(contestId ?? '', sport ?? '', league ?? ''),
     queryFn: () =>
-      contestOverviewApi.getOverview(contestId!).then((r) => {
+      contestOverviewApi.getOverview(contestId!, sport!, league!).then((r) => {
         // API may wrap in { data: ContestOverviewDto } or return the DTO directly
         const body = r.data as unknown;
         const wrapped = body as { data?: ContestOverviewDto };
         return wrapped.data ?? (body as ContestOverviewDto);
       }),
-    enabled: !!contestId,
+    enabled: !!contestId && !!sport && !!league,
     staleTime: 1000 * 60 * 2, // 2 min — box score data refreshes moderately
     refetchInterval: 30_000, // poll every 30 s while mounted for live contest updates
   });

--- a/src/UI/sd-mobile/src/hooks/useUserTimeZone.ts
+++ b/src/UI/sd-mobile/src/hooks/useUserTimeZone.ts
@@ -1,0 +1,16 @@
+import { useCurrentUser } from '@/src/hooks/useStandings';
+import { DEFAULT_TIMEZONE } from '@/src/utils/timeUtils';
+
+/**
+ * Returns the IANA timezone the UI should render game times in for the
+ * current user. Falls back to America/New_York (Eastern Time) when the
+ * user hasn't picked one yet, when the user DTO hasn't loaded, or when
+ * we're rendering on a route outside the auth gate where /user/me hasn't
+ * been fetched.
+ *
+ * Mirrors `src/UI/sd-ui/src/hooks/useUserTimeZone.js`.
+ */
+export function useUserTimeZone(): string {
+  const { data: me } = useCurrentUser();
+  return me?.timezone || DEFAULT_TIMEZONE;
+}

--- a/src/UI/sd-mobile/src/services/api/contestOverviewApi.ts
+++ b/src/UI/sd-mobile/src/services/api/contestOverviewApi.ts
@@ -2,6 +2,11 @@ import { apiClient } from './client';
 import type { ContestOverviewDto } from '@/src/types/models';
 
 export const contestOverviewApi = {
-  getOverview: (contestId: string) =>
-    apiClient.get<ContestOverviewDto>(`/ui/contest/${contestId}/overview`),
+  // The endpoint is sport-aware: the API uses the sport/league query params
+  // to pick which sport's data to query. Without them it defaults to
+  // football/ncaa, which is why MLB contests came back empty.
+  getOverview: (contestId: string, sport: string, league: string) =>
+    apiClient.get<ContestOverviewDto>(`/ui/contest/${contestId}/overview`, {
+      params: { sport, league },
+    }),
 };

--- a/src/UI/sd-mobile/src/services/api/usersApi.ts
+++ b/src/UI/sd-mobile/src/services/api/usersApi.ts
@@ -1,0 +1,17 @@
+import { apiClient } from './client';
+import type { UserDto } from '@/src/types/models';
+
+/**
+ * Wrapper for /user/* endpoints. Mirrors the web app's `src/api/usersApi.js`.
+ * `getMe` duplicates `standingsApi.getMe` deliberately so user-related calls
+ * have a self-describing home; both backends hit the same endpoint.
+ */
+export const usersApi = {
+  // GET /user/me → UserDto (timezone, leagues, profile bits)
+  getMe: () => apiClient.get<UserDto>('/user/me'),
+
+  // PATCH /user/me/timezone — accepts any IANA zone or null/empty to clear.
+  // Backend validates via TimeZoneInfo.TryFindSystemTimeZoneById.
+  updateTimezone: (timezone: string | null) =>
+    apiClient.patch('/user/me/timezone', { timezone }),
+};

--- a/src/UI/sd-mobile/src/utils/timeUtils.ts
+++ b/src/UI/sd-mobile/src/utils/timeUtils.ts
@@ -1,0 +1,189 @@
+/**
+ * Time/date formatting helpers for the mobile app. Mirrors the web util at
+ * `src/UI/sd-ui/src/utils/timeUtils.js` so both clients render game times
+ * identically. Uses the platform's native `Intl.DateTimeFormat` with the
+ * `timeZone` option — Hermes (Expo 55 / RN 0.83) ships full ICU support so
+ * we don't need Luxon or date-fns-tz.
+ *
+ * Backend convention: midnight (00:00) in the rendered zone means "time not
+ * yet known," and we surface that to the user as "TBD". Saturday formatting
+ * deliberately omits the day-of-week pip — Saturday is the default game day
+ * for college football and the bare date reads cleaner.
+ */
+
+export const DEFAULT_TIMEZONE = 'America/New_York';
+
+const MONTHS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+// Intl.DateTimeFormat returns weekday strings like "Mon", "Tue", etc. when
+// formatted with weekday: 'short' in en-US, which is exactly what we want.
+// The "(Day)" suffix is stripped for Saturday.
+
+interface ZonedParts {
+  year: number;
+  month: number; // 1-12
+  day: number;
+  hour: number; // 0-23
+  minute: number;
+  weekday: string; // "Mon", "Tue", …
+  hour12: number; // 1-12 for "h:mm a" rendering
+  dayPeriod: 'AM' | 'PM';
+}
+
+function zonedParts(date: Date, timeZone: string): ZonedParts | null {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      weekday: 'short',
+    });
+    const parts = formatter.formatToParts(date);
+    const get = (type: Intl.DateTimeFormatPartTypes) =>
+      parts.find((p) => p.type === type)?.value ?? '';
+
+    const year = Number(get('year'));
+    const month = Number(get('month'));
+    const day = Number(get('day'));
+    let hour = Number(get('hour'));
+    const minute = Number(get('minute'));
+    const weekday = get('weekday');
+
+    if (
+      Number.isNaN(year) ||
+      Number.isNaN(month) ||
+      Number.isNaN(day) ||
+      Number.isNaN(hour) ||
+      Number.isNaN(minute)
+    ) {
+      return null;
+    }
+
+    // Some hosts return "24" for midnight under hour12: false. Normalize.
+    if (hour === 24) hour = 0;
+
+    const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+    const dayPeriod = hour < 12 ? 'AM' : 'PM';
+
+    return { year, month, day, hour, minute, weekday, hour12, dayPeriod };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a UTC ISO datetime string as a calendar+time label in the given
+ * IANA zone. Returns "MMM d (Day) @ h:mm a" (e.g. "Sep 27 (Thu) @ 1:30 PM");
+ * the (Day) is omitted on Saturdays. Midnight in the target zone renders as
+ * "TBD" because the backend uses 00:00 to mean "time not yet known."
+ *
+ * @param dateStr  ISO 8601 datetime string (assumed UTC)
+ * @param timezone IANA zone (e.g. "America/Chicago"); defaults to ET
+ */
+export function formatToUserTime(
+  dateStr: string | null | undefined,
+  timezone: string | null | undefined = DEFAULT_TIMEZONE,
+): string {
+  if (!dateStr) return 'TBD';
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return 'TBD';
+
+  const zone = timezone || DEFAULT_TIMEZONE;
+  let parts = zonedParts(d, zone);
+  if (!parts && zone !== DEFAULT_TIMEZONE) {
+    parts = zonedParts(d, DEFAULT_TIMEZONE);
+  }
+  if (!parts) return 'TBD';
+
+  const monthLabel = MONTHS_SHORT[parts.month - 1] ?? String(parts.month);
+  const isSaturday = parts.weekday === 'Sat';
+  const dateLabel =
+    `${monthLabel} ${parts.day}` + (isSaturday ? '' : ` (${parts.weekday})`);
+
+  if (parts.hour === 0 && parts.minute === 0) {
+    return `${dateLabel} @ TBD`;
+  }
+
+  const minuteStr = String(parts.minute).padStart(2, '0');
+  const timeLabel = `${parts.hour12}:${minuteStr} ${parts.dayPeriod}`;
+  return `${dateLabel} @ ${timeLabel}`;
+}
+
+/**
+ * Sport-aware label for a game's scheduled start time. Accepts either the
+ * URL sport slug ("football", "baseball") or the backend Sport enum name
+ * ("FootballNcaa", "BaseballMlb") — match is case-insensitive substring.
+ */
+export function getStartLabel(sport: string | null | undefined): string {
+  const s = (sport ?? '').toLowerCase();
+  if (s.includes('baseball')) return 'First Pitch';
+  if (s.includes('football')) return 'Kickoff';
+  return 'Start Time';
+}
+
+/**
+ * Returns the abbreviation (e.g. "EDT", "CST", "GMT+9") for a given IANA
+ * zone at the current moment. Used to label kickoff columns/rows. Falls back
+ * to "ET" when the platform Intl can't produce a short tz name.
+ */
+export function getZoneAbbreviation(
+  timezone: string | null | undefined = DEFAULT_TIMEZONE,
+): string {
+  const zone = timezone || DEFAULT_TIMEZONE;
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: zone,
+      timeZoneName: 'short',
+    });
+    const parts = formatter.formatToParts(new Date());
+    const tz = parts.find((p) => p.type === 'timeZoneName')?.value;
+    return tz || 'ET';
+  } catch {
+    return 'ET';
+  }
+}
+
+/**
+ * Backwards-compatible alias that always renders in Eastern Time. Prefer
+ * `formatToUserTime(dateStr, useUserTimeZone())` in new code so the user's
+ * configured timezone is honored.
+ */
+export function formatToEasternTime(dateStr: string | null | undefined): string {
+  return formatToUserTime(dateStr, DEFAULT_TIMEZONE);
+}
+
+/**
+ * Formats a UTC ISO datetime string as M/D in the given IANA zone.
+ */
+export function formatToMonthDay(
+  dateStr: string | null | undefined,
+  timezone: string | null | undefined = DEFAULT_TIMEZONE,
+): string {
+  if (!dateStr) return '-';
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return '-';
+  const zone = timezone || DEFAULT_TIMEZONE;
+  let parts = zonedParts(d, zone);
+  if (!parts && zone !== DEFAULT_TIMEZONE) {
+    parts = zonedParts(d, DEFAULT_TIMEZONE);
+  }
+  if (!parts) return '-';
+  return `${parts.month}/${parts.day}`;
+}

--- a/src/UI/sd-ui/src/api/usersApi.js
+++ b/src/UI/sd-ui/src/api/usersApi.js
@@ -2,7 +2,8 @@ import apiClient from "./apiClient";
 
 const UsersApi = {
   createOrUpdateUser: (userData) => apiClient.post("/user", userData),
-  getCurrentUser: () => apiClient.get("/user/me")
+  getCurrentUser: () => apiClient.get("/user/me"),
+  updateTimezone: (timezone) => apiClient.patch("/user/me/timezone", { timezone })
 };
 
 export default UsersApi;

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewInfo.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewInfo.jsx
@@ -1,10 +1,13 @@
 import React, { useState } from "react";
 import Dialog from '@mui/material/Dialog';
 import { FaTimes } from 'react-icons/fa';
-import { formatToEasternTime } from "../../utils/timeUtils";
+import { formatToUserTime, getZoneAbbreviation } from "../../utils/timeUtils";
+import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import "./ContestOverview.css";
 
 export default function ContestOverviewInfo({ info }) {
+  const userTz = useUserTimeZone();
+  const zoneAbbrev = getZoneAbbreviation(userTz);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const handleOpenLightbox = () => setLightboxOpen(true);
   const handleCloseLightbox = () => setLightboxOpen(false);
@@ -36,8 +39,8 @@ export default function ContestOverviewInfo({ info }) {
           {/* Venue image will be shown after the list */}
           {info.startDateUtc && (
             <li className="contest-info-item">
-              <span className="contest-info-label">Start Time (ET):</span> {' '}
-              <span className="contest-info-value">{formatToEasternTime(info.startDateUtc)}</span>
+              <span className="contest-info-label">Start Time ({zoneAbbrev}):</span> {' '}
+              <span className="contest-info-value">{formatToUserTime(info.startDateUtc, userTz)}</span>
             </li>
           )}
           {info.attendance !== undefined && (

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewInfo.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewInfo.jsx
@@ -7,7 +7,9 @@ import "./ContestOverview.css";
 
 export default function ContestOverviewInfo({ info }) {
   const userTz = useUserTimeZone();
-  const zoneAbbrev = getZoneAbbreviation(userTz);
+  // Pass the game's date so the abbreviation matches its DST window
+  // (e.g. "EST" for an October NCAAFB game even when viewed in May).
+  const zoneAbbrev = getZoneAbbreviation(userTz, info?.startDateUtc);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const handleOpenLightbox = () => setLightboxOpen(true);
   const handleCloseLightbox = () => setLightboxOpen(false);

--- a/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
+++ b/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
 import "./InsightDialog.css";
 import { useUserDto } from "../../contexts/UserContext";
-import { formatToEasternTime } from "../../utils/timeUtils";
+import { formatToUserTime } from "../../utils/timeUtils";
+import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 
 function InsightDialog({
   isOpen,
@@ -14,6 +15,7 @@ function InsightDialog({
 
   const { userDto } = useUserDto();
   const { isAdmin } = userDto;
+  const userTz = useUserTimeZone();
 
   // Local state for rejection note
   const [rejectionNote, setRejectionNote] = useState("");
@@ -97,7 +99,7 @@ function InsightDialog({
                 </h3>
                 {matchup.generatedUtc && (
                   <div style={{ fontSize: '0.98em', color: '#adb5bd', marginBottom: 6 }}>
-                    <strong>Generated:</strong> {formatToEasternTime(matchup.generatedUtc)}
+                    <strong>Generated:</strong> {formatToUserTime(matchup.generatedUtc, userTz)}
                   </div>
                 )}
                 <p>{matchup.prediction || "Prediction not available."}</p>

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -20,6 +20,9 @@ import { contestLink } from '../../utils/sportLinks';
  * @param {string} props.possessionFranchiseSeasonId - Team with possession ID
  * @param {boolean} props.isScoringPlay - Whether this update is for a scoring play
  * @param {string} props.contestId - Contest ID for linking to contest overview
+ * @param {string} [props.sport] - URL sport segment (e.g. "baseball"); falls
+ *   back to football/ncaa via contestLink defaults when omitted.
+ * @param {string} [props.league] - URL league segment (e.g. "mlb").
  */
 function GameStatus({
   status,
@@ -37,7 +40,9 @@ function GameStatus({
   homeFranchiseSeasonId,
   possessionFranchiseSeasonId,
   isScoringPlay,
-  contestId
+  contestId,
+  sport,
+  league
 }) {
   if (status === 'Final') {
     const scoreContent = (
@@ -54,7 +59,7 @@ function GameStatus({
         <div className="final-score">
           {contestId ? (
             <Link
-              to={contestLink(contestId)}
+              to={contestLink(contestId, sport, league)}
               className="final-score-link"
               target="_blank"
               rel="noopener noreferrer"
@@ -96,7 +101,7 @@ function GameStatus({
         <div className="final-score">
           {contestId ? (
             <Link
-              to={contestLink(contestId)}
+              to={contestLink(contestId, sport, league)}
               className="final-score-link"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -11,6 +11,7 @@ import { usePickLocking } from "../../hooks/usePickLocking";
 import { useTeamComparison } from "../../hooks/useTeamComparison";
 import TeamRow from "./TeamRow";
 import GameStatus from "./GameStatus";
+import { resolveSportLeague } from "../../utils/sportLinks";
 import PickButton from "./PickButton";
 import { SpreadAndOverUnderDisplay } from "./BettingDisplays";
 import DeetsMeter from "./DeetsMeter";
@@ -39,6 +40,13 @@ function MatchupCard({
   // season-specific fetches / omitting the URL segment rather than silently
   // rendering a stale year.
   const seasonYear = leagueSeasonYear ?? matchup.seasonYear;
+
+  // /picks routes don't carry sport in the URL — resolve it from the matchups
+  // DTO's leagueSport so contest links, etc. point at the right sport-aware
+  // page (e.g. /sport/baseball/mlb/contest/{id}). null when leagueSport is
+  // missing or unmapped; downstream link helpers fall back to football/ncaa
+  // defaults in that case.
+  const sportLeague = resolveSportLeague(leagueSport);
 
   const [showConfidencePicker, setShowConfidencePicker] = useState(false);
   const [pendingPickFranchiseId, setPendingPickFranchiseId] = useState(null);
@@ -211,6 +219,8 @@ function MatchupCard({
           possessionFranchiseSeasonId={matchup.possessionFranchiseSeasonId}
           isScoringPlay={matchup.isScoringPlay}
           contestId={matchup.contestId}
+          sport={sportLeague?.sport}
+          league={sportLeague?.league}
         />
 
         {/* DeetsMeter - AI Prediction Meters */}

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -1,6 +1,7 @@
 import "./MatchupCard.css";
 import { FaChartLine, FaLock, FaClipboardList } from "react-icons/fa";
-import { formatToEasternTime } from "../../utils/timeUtils";
+import { formatToUserTime } from "../../utils/timeUtils";
+import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import { useState, useEffect } from "react";
 import TeamComparison from "../teams/TeamComparison";
 import { useUserDto } from "../../contexts/UserContext";
@@ -66,8 +67,10 @@ function MatchupCard({
     homeError
   } = useTeamSchedule(matchup.awaySlug, matchup.homeSlug, seasonYear, leagueSport);
 
+  const userTz = useUserTimeZone();
+
   // Game details
-  const gameTime = formatToEasternTime(matchup.startDateUtc);
+  const gameTime = formatToUserTime(matchup.startDateUtc, userTz);
   const venue = matchup.venue ?? "TBD";
   const location = `${matchup.venueCity ?? ""}, ${matchup.venueState ?? ""}`;
 

--- a/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { FaSearchPlus, FaSearchMinus } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { formatToMonthDay } from "../../utils/timeUtils";
+import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import "./MiniSchedule.css";
 import { teamLink, contestLink, resolveSportLeague } from '../../utils/sportLinks';
 import "./MiniScheduleDrilldown.css";
@@ -22,6 +23,7 @@ export default function MiniSchedule({ schedule = [], seasonYear, leagueSport })
   // Null when the backend sport enum is missing or unmapped — we then render
   // plain-text team names instead of risking a wrong-sport route.
   const sportLeague = resolveSportLeague(leagueSport);
+  const userTz = useUserTimeZone();
   // TODO: create new endpoint that only returns completed games
   const games = schedule.slice(0, 13);
   // Drilldown state: which row is open, and its data
@@ -73,7 +75,7 @@ export default function MiniSchedule({ schedule = [], seasonYear, leagueSport })
           {games.length ? (
             games.map((game, idx) => [
               <tr key={idx}>
-                <td>{formatToMonthDay(game.date)}</td>
+                <td>{formatToMonthDay(game.date, userTz)}</td>
                 <td style={{ display: 'flex', alignItems: 'center' }}>
                   {(() => {
                     const opponentLabel = game.opponentShortName ?? game.opponent ?? 'Opponent';

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -1,16 +1,55 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTheme } from "../../contexts/ThemeContext";
+import { useUserDto } from "../../contexts/UserContext";
 import apiWrapper from "../../api/apiWrapper";
+import { DEFAULT_TIMEZONE } from "../../utils/timeUtils";
 import "./SettingsPage.css";
 import BadgesPanel from "../../components/badges/BadgesPanel.tsx";
+
+const CURATED_TIMEZONES = [
+  { value: "America/New_York",    label: "Eastern (New York)" },
+  { value: "America/Chicago",     label: "Central (Chicago)" },
+  { value: "America/Denver",      label: "Mountain (Denver)" },
+  { value: "America/Phoenix",     label: "Mountain - no DST (Phoenix)" },
+  { value: "America/Los_Angeles", label: "Pacific (Los Angeles)" },
+  { value: "America/Anchorage",   label: "Alaska (Anchorage)" },
+  { value: "Pacific/Honolulu",    label: "Hawaii (Honolulu)" },
+];
+
+function getAllIanaZones() {
+  if (typeof Intl?.supportedValuesOf === "function") {
+    try {
+      return Intl.supportedValuesOf("timeZone");
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function detectBrowserTimezone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || DEFAULT_TIMEZONE;
+  } catch {
+    return DEFAULT_TIMEZONE;
+  }
+}
 
 function SettingsPage() {
   const navigate = useNavigate();
   const { theme, toggleTheme } = useTheme();
+  const { refreshUserDto } = useUserDto();
   const [user, setUser] = useState(null);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+
+  const [showAllZones, setShowAllZones] = useState(false);
+  const [tzSaving, setTzSaving] = useState(false);
+  const [tzMessage, setTzMessage] = useState("");
+
+  const allZones = useMemo(() => getAllIanaZones(), []);
+  const browserTz = useMemo(() => detectBrowserTimezone(), []);
 
   useEffect(() => {
     let isMounted = true;
@@ -26,7 +65,6 @@ function SettingsPage() {
         console.error("Failed to load user:", err);
         if (isMounted) {
           if (err.isUnauthorized) {
-            // Instead of signing out, just redirect to signup
             navigate('/signup', { replace: true });
             return;
           }
@@ -42,6 +80,26 @@ function SettingsPage() {
       isMounted = false;
     };
   }, [navigate]);
+
+  const effectiveTimezone = user?.timezone || browserTz;
+  const isCurated = CURATED_TIMEZONES.some((z) => z.value === effectiveTimezone);
+
+  const handleTimezoneChange = async (newTz) => {
+    if (!newTz) return;
+    setTzSaving(true);
+    setTzMessage("");
+    try {
+      await apiWrapper.Users.updateTimezone(newTz);
+      setUser((prev) => (prev ? { ...prev, timezone: newTz } : prev));
+      await refreshUserDto();
+      setTzMessage("Saved.");
+    } catch (err) {
+      console.error("Failed to update timezone:", err);
+      setTzMessage("Could not save timezone.");
+    } finally {
+      setTzSaving(false);
+    }
+  };
 
   if (isLoading) {
     return <div className="settings-page">Loading settings...</div>;
@@ -66,7 +124,44 @@ function SettingsPage() {
           </div>
           <div className="settings-item">
             <span className="label">Timezone:</span>
-            <span>{user?.timezone || "Not set"}</span>
+            <span>
+              {(showAllZones || !isCurated) && allZones.length > 0 ? (
+                <select
+                  value={effectiveTimezone}
+                  onChange={(e) => handleTimezoneChange(e.target.value)}
+                  disabled={tzSaving}
+                >
+                  {allZones.map((z) => (
+                    <option key={z} value={z}>{z}</option>
+                  ))}
+                </select>
+              ) : (
+                <select
+                  value={effectiveTimezone}
+                  onChange={(e) => {
+                    if (e.target.value === "__other__") {
+                      setShowAllZones(true);
+                    } else {
+                      handleTimezoneChange(e.target.value);
+                    }
+                  }}
+                  disabled={tzSaving}
+                >
+                  {CURATED_TIMEZONES.map((z) => (
+                    <option key={z.value} value={z.value}>{z.label}</option>
+                  ))}
+                  <option value="__other__">Other…</option>
+                </select>
+              )}
+              {!user?.timezone && (
+                <span style={{ marginLeft: 8, fontSize: "0.85em", opacity: 0.7 }}>
+                  (using browser default — pick one to save)
+                </span>
+              )}
+              {tzMessage && (
+                <span style={{ marginLeft: 8, fontSize: "0.85em" }}>{tzMessage}</span>
+              )}
+            </span>
           </div>
         </section>
 

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -147,6 +147,14 @@ function SettingsPage() {
                   }}
                   disabled={tzSaving}
                 >
+                  {/* Fallback option for a non-curated saved zone (e.g.
+                      Europe/London) when the host lacks Intl.supportedValuesOf —
+                      without this the <select> has no matching <option> and
+                      visually defaults to Eastern, hiding the user's real saved
+                      value. */}
+                  {!isCurated && (
+                    <option value={effectiveTimezone}>{effectiveTimezone}</option>
+                  )}
                   {CURATED_TIMEZONES.map((z) => (
                     <option key={z.value} value={z.value}>{z.label}</option>
                   ))}

--- a/src/UI/sd-ui/src/components/teams/TeamSchedule.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamSchedule.jsx
@@ -1,10 +1,14 @@
 // src/components/teams/TeamSchedule.jsx
 import { Link } from "react-router-dom";
-import { formatToEasternTime } from "../../utils/timeUtils";
+import { formatToUserTime, getZoneAbbreviation, getStartLabel } from "../../utils/timeUtils";
+import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import { teamLink, contestLink } from '../../utils/sportLinks';
 import "./TeamSchedule.css";
 
 function TeamSchedule({ schedule, seasonYear, sport = 'football', league = 'ncaa' }) {
+  const userTz = useUserTimeZone();
+  const zoneAbbrev = getZoneAbbreviation(userTz);
+  const startLabel = getStartLabel(sport);
   // Helper function to format game result
   const formatGameResult = (game) => {
     if (game.status === "Final") {
@@ -29,7 +33,7 @@ function TeamSchedule({ schedule, seasonYear, sport = 'football', league = 'ncaa
       <table>
         <thead>
           <tr>
-            <th>Kickoff (ET)</th>
+            <th>{startLabel} ({zoneAbbrev})</th>
             <th>Opponent</th>
             <th>Location</th>
             <th>Result</th>
@@ -39,7 +43,7 @@ function TeamSchedule({ schedule, seasonYear, sport = 'football', league = 'ncaa
           {schedule?.length ? (
             schedule.map((game, idx) => (
               <tr key={idx}>
-                <td>{formatToEasternTime(game.date)}</td>
+                <td>{formatToUserTime(game.date, userTz)}</td>
                 <td>
                   <Link
                     to={teamLink(game.opponentSlug, seasonYear, sport, league)}

--- a/src/UI/sd-ui/src/components/teams/TeamScheduleMUI.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamScheduleMUI.jsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import { teamLink } from '../../utils/sportLinks';
-import { formatToEasternTime } from "../../utils/timeUtils";
+import { formatToUserTime, getZoneAbbreviation, getStartLabel } from "../../utils/timeUtils";
+import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import {
   Paper,
   Table,
@@ -14,8 +15,11 @@ import {
   Chip,
 } from "@mui/material";
 
-export default function TeamScheduleMUI({ schedule = [], seasonYear }) {
+export default function TeamScheduleMUI({ schedule = [], seasonYear, sport = 'football' }) {
   const hasRows = Array.isArray(schedule) && schedule.length > 0;
+  const userTz = useUserTimeZone();
+  const zoneAbbrev = getZoneAbbreviation(userTz);
+  const startLabel = getStartLabel(sport);
 
   return (
     <TableContainer component={Paper} elevation={3} sx={{ mt: 2 }}>
@@ -36,7 +40,7 @@ export default function TeamScheduleMUI({ schedule = [], seasonYear }) {
         <TableHead>
           <TableRow sx={{ bgcolor: "grey.900" }}>
             <TableCell sx={{ color: "grey.100", fontWeight: 600 }}>
-              Kickoff (ET)
+              {startLabel} ({zoneAbbrev})
             </TableCell>
             <TableCell sx={{ color: "grey.100", fontWeight: 600 }}>
               Opponent
@@ -64,7 +68,7 @@ export default function TeamScheduleMUI({ schedule = [], seasonYear }) {
                   }}
                 >
                   <TableCell sx={{ whiteSpace: "nowrap" }}>
-                    {formatToEasternTime(game.date)}
+                    {formatToUserTime(game.date, userTz)}
                   </TableCell>
 
                   <TableCell>

--- a/src/UI/sd-ui/src/components/teams/TeamScheduleMUI.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamScheduleMUI.jsx
@@ -15,7 +15,7 @@ import {
   Chip,
 } from "@mui/material";
 
-export default function TeamScheduleMUI({ schedule = [], seasonYear, sport = 'football' }) {
+export default function TeamScheduleMUI({ schedule = [], seasonYear, sport = 'football', league = 'ncaa' }) {
   const hasRows = Array.isArray(schedule) && schedule.length > 0;
   const userTz = useUserTimeZone();
   const zoneAbbrev = getZoneAbbreviation(userTz);
@@ -73,7 +73,7 @@ export default function TeamScheduleMUI({ schedule = [], seasonYear, sport = 'fo
 
                   <TableCell>
                     <Link
-                      to={teamLink(game.opponentSlug, seasonYear)}
+                      to={teamLink(game.opponentSlug, seasonYear, sport, league)}
                       style={{
                         textDecoration: "underline",
                         fontWeight: 500,

--- a/src/UI/sd-ui/src/hooks/useUserTimeZone.js
+++ b/src/UI/sd-ui/src/hooks/useUserTimeZone.js
@@ -1,0 +1,17 @@
+import { useUserDto } from "../contexts/UserContext";
+import { DEFAULT_TIMEZONE } from "../utils/timeUtils";
+
+/**
+ * Returns the IANA timezone the UI should render game times in for the
+ * current user. Falls back to America/New_York (Eastern Time) when the
+ * user hasn't picked one yet, when the user DTO hasn't loaded, or when
+ * the user is on a marketing/auth page outside the UserProvider.
+ */
+export function useUserTimeZone() {
+  try {
+    const ctx = useUserDto();
+    return ctx?.userDto?.timezone || DEFAULT_TIMEZONE;
+  } catch {
+    return DEFAULT_TIMEZONE;
+  }
+}

--- a/src/UI/sd-ui/src/utils/timeUtils.js
+++ b/src/UI/sd-ui/src/utils/timeUtils.js
@@ -48,14 +48,20 @@ export function getStartLabel(sport) {
 }
 
 /**
- * Returns the abbreviation (e.g. "EDT", "CST", "GMT+9") for a given IANA zone
- * at the current moment. Used to label kickoff columns.
+ * Returns the abbreviation (e.g. "EDT", "CST", "GMT+9") for a given IANA zone.
+ * Pass `gameDateIso` for a per-game label so the abbreviation reflects the
+ * game's actual DST status (e.g. an October NCAAFB game viewed in May should
+ * read "EDT" if it falls before the Nov DST switch, "EST" otherwise) rather
+ * than today's. Falls back to "now" when no date is provided — appropriate
+ * for column headers spanning multiple games.
  */
-export function getZoneAbbreviation(timezone = DEFAULT_TIMEZONE) {
+export function getZoneAbbreviation(timezone = DEFAULT_TIMEZONE, gameDateIso) {
   const zone = timezone || DEFAULT_TIMEZONE;
-  const dt = DateTime.now().setZone(zone);
-  if (!dt.isValid) return "ET";
-  return dt.toFormat("ZZZZ");
+  const base = gameDateIso
+    ? DateTime.fromISO(gameDateIso, { zone: "utc" }).setZone(zone)
+    : DateTime.now().setZone(zone);
+  if (!base.isValid) return "ET";
+  return base.toFormat("ZZZZ");
 }
 
 /**

--- a/src/UI/sd-ui/src/utils/timeUtils.js
+++ b/src/UI/sd-ui/src/utils/timeUtils.js
@@ -1,41 +1,82 @@
 
 import { DateTime } from "luxon";
 
+export const DEFAULT_TIMEZONE = "America/New_York";
+
 /**
- * Formats a UTC ISO datetime string into ET.
- * Adds (Day) if not Saturday. Replaces midnight with 'TBD'.
+ * Format a UTC ISO datetime string as a calendar+time label in the given IANA zone.
+ * Returns "MMM d (Day) @ h:mm a" (e.g. "Sep 27 (Thu) @ 1:30 PM"); the (Day) is
+ * omitted on Saturdays. Midnight in the target zone renders as "TBD" because the
+ * backend uses 00:00 to mean "time not yet known."
  *
  * @param {string} dateStr - ISO 8601 date string in UTC
- * @param {string} format - Format string for normal times
- * @returns {string} - Formatted string like "Sep 27 (Thu) @ TBD"
+ * @param {string} [timezone] - IANA zone (e.g. "America/Chicago"); defaults to ET
+ * @returns {string}
  */
-export function formatToEasternTime(dateStr, format = "MMM d @ h:mm a") {
+export function formatToUserTime(dateStr, timezone = DEFAULT_TIMEZONE) {
   const dtUtc = DateTime.fromISO(dateStr, { zone: "utc" });
   if (!dtUtc.isValid) return "TBD";
 
-  const dtEt = dtUtc.setZone("America/New_York");
+  const zone = timezone || DEFAULT_TIMEZONE;
+  const dtLocal = dtUtc.setZone(zone);
+  if (!dtLocal.isValid) {
+    return formatToUserTime(dateStr, DEFAULT_TIMEZONE);
+  }
 
-  const dayAbbrev = dtEt.toFormat("ccc"); // Mon, Tue, Wed, etc.
-  const isSaturday = dtEt.weekday === 6;  // Luxon: 1 = Monday, 7 = Sunday
+  const dayAbbrev = dtLocal.toFormat("ccc");
+  const isSaturday = dtLocal.weekday === 6;
+  const dateLabel = dtLocal.toFormat("MMM d") + (isSaturday ? "" : ` (${dayAbbrev})`);
 
-  const dateLabel = dtEt.toFormat("MMM d") + (isSaturday ? "" : ` (${dayAbbrev})`);
-
-  if (dtEt.hour === 0 && dtEt.minute === 0) {
+  if (dtLocal.hour === 0 && dtLocal.minute === 0) {
     return `${dateLabel} @ TBD`;
   }
 
-  const timeLabel = dtEt.toFormat("h:mm a");
+  const timeLabel = dtLocal.toFormat("h:mm a");
   return `${dateLabel} @ ${timeLabel}`;
 }
 
 /**
- * Formats a UTC ISO datetime string as M/D (e.g., 8/30)
- * @param {string} dateStr - ISO 8601 date string in UTC
- * @returns {string} - Formatted string like "8/30"
+ * Sport-aware label for a game's scheduled start time. Accepts either the
+ * URL sport slug ("football", "baseball") or the backend Sport enum name
+ * ("FootballNcaa", "BaseballMlb") — match is case-insensitive substring.
  */
-export function formatToMonthDay(dateStr) {
+export function getStartLabel(sport) {
+  const s = (sport ?? "").toLowerCase();
+  if (s.includes("baseball")) return "First Pitch";
+  if (s.includes("football")) return "Kickoff";
+  return "Start Time";
+}
+
+/**
+ * Returns the abbreviation (e.g. "EDT", "CST", "GMT+9") for a given IANA zone
+ * at the current moment. Used to label kickoff columns.
+ */
+export function getZoneAbbreviation(timezone = DEFAULT_TIMEZONE) {
+  const zone = timezone || DEFAULT_TIMEZONE;
+  const dt = DateTime.now().setZone(zone);
+  if (!dt.isValid) return "ET";
+  return dt.toFormat("ZZZZ");
+}
+
+/**
+ * Backwards-compatible alias that always renders in Eastern Time. Prefer
+ * `formatToUserTime(dateStr, useUserTimeZone())` in new code so the user's
+ * configured timezone is honored.
+ */
+export function formatToEasternTime(dateStr) {
+  return formatToUserTime(dateStr, DEFAULT_TIMEZONE);
+}
+
+/**
+ * Formats a UTC ISO datetime string as M/D in the given IANA zone.
+ */
+export function formatToMonthDay(dateStr, timezone = DEFAULT_TIMEZONE) {
   const dtUtc = DateTime.fromISO(dateStr, { zone: "utc" });
   if (!dtUtc.isValid) return "-";
-  const dtEt = dtUtc.setZone("America/New_York");
-  return dtEt.toFormat("M/d");
+  const zone = timezone || DEFAULT_TIMEZONE;
+  const dtLocal = dtUtc.setZone(zone);
+  if (!dtLocal.isValid) {
+    return formatToMonthDay(dateStr, DEFAULT_TIMEZONE);
+  }
+  return dtLocal.toFormat("M/d");
 }


### PR DESCRIPTION
## Summary

End-to-end **Timezone** setting on the User profile, plus two adjacent mobile bug fixes uncovered while testing the parity work.

- Timezone is configurable from the Settings/Profile screen on both web and mobile, persisted to the User row, and honored everywhere a game time is rendered.
- Sport-aware label: \"Kickoff\" for football, \"First Pitch\" for baseball, generic \"Start Time\" fallback. Time labels also render the dynamic zone abbreviation (e.g. \"Kickoff (EDT)\", \"First Pitch (CT)\").
- Mobile: tapping a team on the picks screen now opens that team's page (was incorrectly going to the contest overview); MLB contest overviews now load (the API call was missing sport/league query params and was defaulting to football/ncaa).

## Backend (SportsData.Api)

- `GetMeQueryHandler.cs` — project `Timezone` onto `UserDto`. The DB column and DTO field already existed; the SELECT just omitted the field, so `/user/me` returned null and the existing read-only Timezone row in Settings always showed \"Not set\".
- New endpoint **`PATCH /user/me/timezone`**:
  - `UpdateUserTimezoneCommand` / `Handler` / `Validator` under `Application/User/Commands/UpdateUserTimezone/`.
  - Validates the IANA zone via `TimeZoneInfo.TryFindSystemTimeZoneById` — accepts any zone the runtime can resolve; null/empty clears.
  - Wired in `UserController` + `ServiceRegistration`.

## Web (sd-ui)

- `utils/timeUtils.js` — generalized formatter:
  - `formatToUserTime(dateStr, tz)`, `formatToMonthDay(dateStr, tz)`, `getZoneAbbreviation(tz)`.
  - `getStartLabel(sport)` — sport-aware label (case-insensitive substring on \"baseball\" / \"football\", tolerant of both URL slugs and backend enum names).
  - `formatToEasternTime` kept as a thin ET wrapper for back-compat.
- New `hooks/useUserTimeZone.js` — reads `UserContext`, falls back to `America/New_York`.
- `api/usersApi.js` — `updateTimezone(tz)` calling the new PATCH.
- `SettingsPage.jsx` — editable picker:
  - **Curated** US zones (Eastern, Central, Mountain, Phoenix, Pacific, Alaska, Hawaii) plus **Other…** that drops into the full IANA list via `Intl.supportedValuesOf(\"timeZone\")`.
  - Pre-populates from the browser's resolved timezone when the stored value is null, but does **not** auto-save until the user picks.
- Call sites updated: `TeamSchedule.jsx`, `TeamScheduleMUI.jsx`, `ContestOverviewInfo.jsx`, `MatchupCard.jsx`, `MiniSchedule.jsx`, `InsightDialog.jsx`.

## Mobile (sd-mobile) — feature parity

- New `utils/timeUtils.ts` mirrors the web util. Uses native `Intl.DateTimeFormat` with `timeZone` — Hermes on Expo SDK 55 ships full ICU, so **no Luxon dep added** (saves ~70 KB bundle).
- New `hooks/useUserTimeZone.ts`, `services/api/usersApi.ts` (`getMe` + `updateTimezone`), `components/features/settings/TimezonePickerModal.tsx` (curated + Other → full IANA, with a search box).
- `profile.tsx` — editable Timezone row under Account; mirrors the web UX (browser-default pre-fill, save → invalidate `useCurrentUser` cache).
- Call sites updated: `GameStatus.tsx`, `InsightModal.tsx`, `team/[slug].tsx`, `game/[id].tsx` (sport-aware label on the Game Info card).

## Mobile bug fixes (uncovered during testing)

### 1. Picks screen — wrong tap routing
`MatchupCard.tsx` had a single outer `TouchableOpacity` wrapping the entire card, so tapping a team row sent you to the contest overview instead of the team page.

- Outer touchable replaced with a plain `View` (shadow + border styling preserved).
- Each `TeamRow` now wrapped in its own touchable → new `onPressTeam('home' | 'away')` prop → pushes to `/sport/[sport]/[league]/team/[slug]`.
- `OddsRow` wrapped in its own touchable → fires the existing `onPress` (overview). `GameStatus` already owned its own touchable via `onPressGameDetail`, so it stayed as-is.
- `picks.tsx` wires `onPressTeam` to the team route with the canonical `seasonYear` from the matchups response.

### 2. MLB contest overview returned empty
Mobile was calling `/ui/contest/{id}/overview` with no `sport`/`league` query params. The API uses those to route to the right sport's data and falls back to football/ncaa otherwise — which is why NCAAFB worked and MLB didn't.

- `contestOverviewApi.getOverview(contestId, sport, league)` now sends both as query params (matches the web wrapper).
- `useContestOverview(contestId, sport, league)` accepts the args; `contestKeys.overview` includes them in the cache key so the same `contestId` across sports cannot collide.
- `game/[id].tsx` passes `sport`/`league` from `useLocalSearchParams` into the hook.

## Test plan

- [x] `dotnet build SportsData.Api.csproj` — 0 errors.
- [x] `npm run build` (sd-ui) — clean.
- [x] `npx jest` (sd-mobile) — 16/16 passing.
- [x] `npx tsc --noEmit` (sd-mobile) — only pre-existing `PickSelector` `submitPending` error on `game/[id].tsx:328`, not introduced by this PR.
- [x] Manual: Yankees team page on web — header reads \"First Pitch (EDT)\" for the Eastern user; verified.
- [x] Manual: web Settings → change to Central; team schedule + contest overview re-render in CT.
- [x] Manual: mobile picks screen — tap team → team page; tap spread / time area → contest overview.
- [x] Manual: mobile MLB contest detail loads (was empty before).
- [ ] Verify on a non-default device timezone (e.g., set device to Europe/London).
- [ ] Try the **Other…** picker on both platforms with a non-US zone (e.g., `Asia/Tokyo`) to confirm the API accepts and the UI renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now set their preferred timezone in account settings with automatic device detection
  * All game times, schedules, and event information now display in the user's selected timezone instead of Eastern Time
  * Timezone preferences persist across sessions and sync across devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->