### PR TITLE
feat(producer): narrow Refresh Contest cascade via IncludeLinkedDocumentTypes propagation

### DIFF
--- a/docs/refresh-contest-cascade-narrowing.md
+++ b/docs/refresh-contest-cascade-narrowing.md
@@ -1,0 +1,235 @@
+# Refresh Contest — narrowing the document-sourcing cascade
+
+Captured 2026-05-06 from a debugging session triggered by "Refresh Contest"
+on the Contest Overview page sourcing far more than intended (entire
+roster + per-athlete stats per team, twice). Persisted here in case the
+session context is lost before the change is implemented.
+
+## Problem
+
+User clicks "Refresh Contest" on the Contest Overview page. API calls
+Producer's `ContestUpdateProcessor.Process()`, which publishes a single
+`DocumentRequested` for `DocumentType.Event`. The intent is *contest-level
+live state* (status, score, broadcast, odds) — not roster, not athletes,
+not per-athlete stats.
+
+What actually happens: the `Event` doc is sourced, downstream processors
+spawn `EventCompetition`, which spawns two `EventCompetitionCompetitor`
+docs, each of which spawns `EventCompetitionCompetitorRoster`
+(`EventCompetitionCompetitorDocumentProcessor.cs:203`), each roster
+fans out into per-athlete docs, each athlete fans out further. Hundreds
+of ESPN fetches for a refresh that should have been a few dozen.
+
+This is not the same issue as PR #294 (the fan-out `BypassCache=true`
+fix) or the deferred "in-season but completed games bypass cache"
+concern (`memory/project_in_season_completed_cache.md`). Both of those
+are about *whether* to hit ESPN. This is about *which documents* to
+source at all.
+
+## The mechanism that's already in place
+
+`DocumentRequested` carries a nullable
+`IReadOnlyCollection<DocumentType>? IncludeLinkedDocumentTypes` field.
+`DocumentCreated` carries the same field. `ProcessDocumentCommand`
+holds it. `DocumentProcessorBase.ShouldSpawn(documentType, command)`
+consults it:
+
+```csharp
+protected bool ShouldSpawn(DocumentType documentType, ProcessDocumentCommand command)
+{
+    // null/empty → spawn all (current default behavior)
+    if (command.IncludeLinkedDocumentTypes == null || command.IncludeLinkedDocumentTypes.Count == 0)
+        return true;
+
+    return command.IncludeLinkedDocumentTypes.Contains(documentType);
+}
+```
+
+Every child-spawn site in every processor is wrapped in
+`if (isNew || ShouldSpawn(DocumentType.X, command))`, so the filter
+*could* narrow the cascade if it were populated.
+
+## The propagation gap
+
+Tracing the chain hop by hop for a `Refresh Contest` flow:
+
+1. **API → Producer.** `ContestUpdateProcessor.cs:90` builds the seed
+   `DocumentRequested` and does **not** set
+   `IncludeLinkedDocumentTypes`. It defaults to `null` →
+   `ShouldSpawn` returns `true` for everything downstream.
+2. **Producer → Provider.** `IEventBus.Publish(evt)` carries
+   `IncludeLinkedDocumentTypes` on the wire. Whatever Producer puts on
+   it survives.
+3. **Provider receive.**
+   `DocumentRequestedHandler.cs:211` (leaf path) and
+   `DocumentRequestedHandler.cs:360` (fan-out path) both correctly
+   propagate `evt.IncludeLinkedDocumentTypes` onto the
+   `ProcessResourceIndexItemCommand`.
+4. **Provider publishes `DocumentCreated`.**
+   `ResourceIndexItemProcessor` lines 363, 419, 461 (the three
+   `DocumentCreated` construction sites) all include
+   `command.IncludeLinkedDocumentTypes`. Survives.
+5. **Producer consumes `DocumentCreated`.**
+   `DocumentCreatedProcessor.cs:118` puts `evt.IncludeLinkedDocumentTypes`
+   onto the `ProcessDocumentCommand` that hits the document
+   processor. Survives.
+6. **Producer's processor decides whether to spawn children.**
+   Calls `ShouldSpawn(DocumentType.X, command)`. Filter respected. Good.
+7. **Producer's processor publishes a new `DocumentRequested` for a
+   child.** Goes through
+   `DocumentProcessorBase.PublishDocumentRequestInternal` (lines
+   358–369). **This is where the chain breaks.**
+
+```csharp
+// DocumentProcessorBase.cs:358–369 (current)
+await _publishEndpoint.Publish(new DocumentRequested(
+    Id: identity.CanonicalId.ToString(),
+    ParentId: parentId?.ToString() ?? null,
+    Uri: uri,
+    Ref: null,
+    Sport: command.Sport,
+    SeasonYear: command.SeasonYear,
+    DocumentType: documentType,
+    SourceDataProvider: command.SourceDataProvider,
+    CorrelationId: command.CorrelationId,
+    CausationId: command.MessageId
+    // IncludeLinkedDocumentTypes is NOT set — the field defaults to null.
+));
+```
+
+Even when a parent processor *did* receive a non-null
+`IncludeLinkedDocumentTypes` and *did* respect it locally via
+`ShouldSpawn`, the new child `DocumentRequested` is born with `null`.
+At the next processor in the cascade, `ShouldSpawn` defaults back to
+"spawn everything." The filter dies at the first hop.
+
+## The fix — two changes
+
+### Change 1: propagate the filter through `PublishDocumentRequestInternal`
+
+`src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs`,
+inside `PublishDocumentRequestInternal`. Add one argument to the
+`DocumentRequested` constructor call:
+
+```csharp
+await _publishEndpoint.Publish(new DocumentRequested(
+    Id: identity.CanonicalId.ToString(),
+    ParentId: parentId?.ToString() ?? null,
+    Uri: uri,
+    Ref: null,
+    Sport: command.Sport,
+    SeasonYear: command.SeasonYear,
+    DocumentType: documentType,
+    SourceDataProvider: command.SourceDataProvider,
+    CorrelationId: command.CorrelationId,
+    CausationId: command.MessageId,
+    IncludeLinkedDocumentTypes: command.IncludeLinkedDocumentTypes // ← new
+));
+```
+
+That single line is what's needed for the existing machinery to start
+working end-to-end.
+
+### Change 2: seed the filter at `ContestUpdateProcessor`
+
+`src/SportsData.Producer/Application/Contests/ContestUpdateProcessor.cs:90`.
+Replace the seed publish with one that carries a narrow filter:
+
+```csharp
+private static readonly IReadOnlyCollection<DocumentType> ContestRefreshDocumentTypes = new[]
+{
+    DocumentType.Event,
+    DocumentType.EventCompetition,
+    DocumentType.EventCompetitionStatus,
+    DocumentType.EventCompetitionSituation,
+    DocumentType.EventCompetitionBroadcast,
+    DocumentType.EventCompetitionOdds,
+    DocumentType.EventCompetitionCompetitor,
+    DocumentType.EventCompetitionCompetitorScore,
+    DocumentType.EventCompetitionCompetitorLineScore,
+    DocumentType.EventCompetitionCompetitorRecord,
+    DocumentType.EventCompetitionPlay,    // live-game tick
+    DocumentType.EventCompetitionDrive    // football only; harmless for MLB
+};
+
+var evt = new DocumentRequested(
+    Id: contestIdentity.UrlHash,
+    ParentId: null,
+    Uri: new Uri(contestIdentity.CleanUrl),
+    Ref: null,
+    Sport: command.Sport,
+    SeasonYear: contest.SeasonYear,
+    DocumentType: DocumentType.Event,
+    SourceDataProvider: command.SourceDataProvider,
+    CorrelationId: command.CorrelationId,
+    CausationId: CausationId.Producer.ContestUpdateProcessor,
+    IncludeLinkedDocumentTypes: ContestRefreshDocumentTypes.ToList()
+);
+```
+
+The exact set is a product decision — list above is a reasonable
+starting point, but worth confirming before shipping.
+
+### What gets *excluded* (and why this is the win)
+
+Anything not in the list gets skipped at every spawn site:
+
+- `EventCompetitionCompetitorRoster` — the leaf that's currently
+  triggering the cascade. Roster is sourced as part of the
+  initial-sourcing path; it shouldn't change during a re-finalize.
+- `EventCompetitionCompetitorStatistics` — same: per-team stats,
+  derived elsewhere.
+- All `Athlete*` docs the roster spawn fans into.
+
+## Caveat — the `isNew` short-circuit
+
+Every spawn site looks like:
+
+```csharp
+if (isNew || ShouldSpawn(DocumentType.X, command))
+    await PublishChildDocumentRequest(...);
+```
+
+The `isNew` guard means: "if this is the first time we're seeing this
+entity, spawn everything regardless of filter." That's intentional
+and defensible — a brand-new entity needs full hydration. For a
+"Refresh Contest" flow on a contest that already exists, `isNew=false`
+on every entity in the cascade, so the filter is respected.
+
+If a *sub*-entity happens to be new (rare on re-finalize, but possible
+if e.g. a new EventCompetitionPlay arrives mid-game), the short-circuit
+fires and the filter is bypassed for that sub-entity's children. This
+isn't a bug — it's the documented behavior — but it's worth knowing
+the filter isn't absolute.
+
+## Test coverage worth adding
+
+A unit test in `SportsData.Producer.Tests.Unit` asserting that
+`PublishChildDocumentRequest` puts `IncludeLinkedDocumentTypes` on the
+published `DocumentRequested`. Today there is none, which is how this
+gap shipped silently in the first place.
+
+## Suggested rollout
+
+Standalone PR, after #294 lands. Three changes:
+
+1. Add `IncludeLinkedDocumentTypes` to the
+   `PublishDocumentRequestInternal` publish.
+2. Add `ContestRefreshDocumentTypes` constant and pass it from
+   `ContestUpdateProcessor`.
+3. Unit test confirming propagation.
+
+Validation: trigger Refresh Contest from the UI, then in Seq filter on
+the resulting CorrelationId. Expect to see exclusively the document
+types in `ContestRefreshDocumentTypes` (plus
+`DocumentRequested received` log lines that confirm the filter is on
+the wire). No `EventCompetitionCompetitorRoster` events. No `Athlete*`.
+
+## Related
+
+- PR #294 — fan-out `BypassCache` fix and `(Cache)` /
+  `(EspnUnchanged)` log disambiguation. Different concern (whether to
+  hit ESPN), but related symptoms (excess ESPN volume on refresh).
+- `memory/project_in_season_completed_cache.md` — deferred policy
+  question about treating completed current-season games as
+  cache-eligible. Orthogonal to this work.

--- a/docs/refresh-contest-cascade-narrowing.md
+++ b/docs/refresh-contest-cascade-narrowing.md
@@ -202,28 +202,52 @@ fires and the filter is bypassed for that sub-entity's children. This
 isn't a bug — it's the documented behavior — but it's worth knowing
 the filter isn't absolute.
 
-## Test coverage worth adding
+## Implemented behavior
 
-A unit test in `SportsData.Producer.Tests.Unit` asserting that
-`PublishChildDocumentRequest` puts `IncludeLinkedDocumentTypes` on the
-published `DocumentRequested`. Today there is none, which is how this
-gap shipped silently in the first place.
+As shipped:
 
-## Suggested rollout
+1. `DocumentProcessorBase.PublishDocumentRequestInternal` now sets
+   `IncludeLinkedDocumentTypes: command.IncludeLinkedDocumentTypes?.ToList()`
+   on the published `DocumentRequested`. Both `PublishDependencyRequest`
+   and `PublishChildDocumentRequest` route through this shared helper,
+   so the filter survives every cascade hop on both paths.
+2. `ContestUpdateProcessor` defines a private
+   `ContestRefreshDocumentTypes` static list and passes it via
+   `IncludeLinkedDocumentTypes` on the seed `DocumentRequested` it
+   publishes for `DocumentType.Event`. Membership: `Event`,
+   `EventCompetition`, `EventCompetitionStatus`,
+   `EventCompetitionSituation`, `EventCompetitionBroadcast`,
+   `EventCompetitionOdds`, `EventCompetitionCompetitor`,
+   `EventCompetitionCompetitorScore`,
+   `EventCompetitionCompetitorLineScore`,
+   `EventCompetitionCompetitorRecord`, `EventCompetitionPlay`,
+   `EventCompetitionDrive`.
 
-Standalone PR, after #294 lands. Three changes:
+## Test coverage
 
-1. Add `IncludeLinkedDocumentTypes` to the
-   `PublishDocumentRequestInternal` publish.
-2. Add `ContestRefreshDocumentTypes` constant and pass it from
-   `ContestUpdateProcessor`.
-3. Unit test confirming propagation.
+Verified by `DocumentProcessorBaseTests` in
+`test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/`:
 
-Validation: trigger Refresh Contest from the UI, then in Seq filter on
-the resulting CorrelationId. Expect to see exclusively the document
-types in `ContestRefreshDocumentTypes` (plus
-`DocumentRequested received` log lines that confirm the filter is on
-the wire). No `EventCompetitionCompetitorRoster` events. No `Athlete*`.
+- `PublishDependencyRequest_Should_Propagate_IncludeLinkedDocumentTypes_To_Child_Request`
+  — asserts a non-null filter on the parent command appears verbatim
+  on the published `DocumentRequested`.
+- `PublishDependencyRequest_Should_Publish_Null_Filter_When_Command_Has_No_Filter`
+  — guards the null-filter contract so a missing filter never
+  serializes as an empty list (which would flip `ShouldSpawn`'s
+  spawn-all default).
+
+Both tests exercise `PublishDocumentRequestInternal` through the
+exposed `PublishDependencyRequestPublic` test seam; since
+`PublishChildDocumentRequest` also routes through
+`PublishDocumentRequestInternal`, the same propagation contract is
+covered for the child path.
+
+## Production validation
+
+Trigger Refresh Contest from the UI, then in Seq filter on the
+resulting CorrelationId. Expect to see exclusively the document types
+in `ContestRefreshDocumentTypes`. No `EventCompetitionCompetitorRoster`
+events. No `Athlete*`.
 
 ## Related
 

--- a/src/SportsData.Producer/Application/Contests/ContestUpdateProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestUpdateProcessor.cs
@@ -5,7 +5,6 @@ using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Producer.Infrastructure.Data.Common;
-using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Application.Contests
 {
@@ -17,6 +16,31 @@ namespace SportsData.Producer.Application.Contests
     public class ContestUpdateProcessor<TDataContext> : IUpdateContests
         where TDataContext : TeamSportDataContext
     {
+        /// <summary>
+        /// Document types to source on a "Refresh Contest" request. Anything
+        /// outside this set is filtered out at every spawn site downstream
+        /// (via DocumentProcessorBase.ShouldSpawn). Excludes roster, per-team
+        /// statistics, and athlete-level docs — those are sourced once during
+        /// initial ingestion and don't change on a contest refresh.
+        ///
+        /// See docs/refresh-contest-cascade-narrowing.md for rationale.
+        /// </summary>
+        private static readonly List<DocumentType> ContestRefreshDocumentTypes = new()
+        {
+            DocumentType.Event,
+            DocumentType.EventCompetition,
+            DocumentType.EventCompetitionStatus,
+            DocumentType.EventCompetitionSituation,
+            DocumentType.EventCompetitionBroadcast,
+            DocumentType.EventCompetitionOdds,
+            DocumentType.EventCompetitionCompetitor,
+            DocumentType.EventCompetitionCompetitorScore,
+            DocumentType.EventCompetitionCompetitorLineScore,
+            DocumentType.EventCompetitionCompetitorRecord,
+            DocumentType.EventCompetitionPlay,
+            DocumentType.EventCompetitionDrive
+        };
+
         private readonly ILogger<ContestUpdateProcessor<TDataContext>> _logger;
         private readonly TDataContext _dataContext;
         private readonly IEventBus _bus;
@@ -98,7 +122,8 @@ namespace SportsData.Producer.Application.Contests
                 DocumentType: DocumentType.Event,
                 SourceDataProvider: command.SourceDataProvider,
                 CorrelationId: command.CorrelationId,
-                CausationId: CausationId.Producer.ContestUpdateProcessor
+                CausationId: CausationId.Producer.ContestUpdateProcessor,
+                IncludeLinkedDocumentTypes: ContestRefreshDocumentTypes
             );
 
             _logger.LogInformation("Publishing with {@evt}", evt);

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -355,6 +355,12 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
             return false;
         }
 
+        // Propagate the parent's IncludeLinkedDocumentTypes filter onto the
+        // child request. Without this, a narrow filter set at the seed (e.g.
+        // ContestUpdateProcessor's "Refresh Contest" set) would die at the
+        // first hop — the next processor in the cascade would see a null
+        // filter and ShouldSpawn would default to spawning everything.
+        // See docs/refresh-contest-cascade-narrowing.md.
         await _publishEndpoint.Publish(new DocumentRequested(
             Id: identity.CanonicalId.ToString(),
             ParentId: parentId?.ToString() ?? null,
@@ -365,7 +371,8 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
             DocumentType: documentType,
             SourceDataProvider: command.SourceDataProvider,
             CorrelationId: command.CorrelationId,
-            CausationId: command.MessageId
+            CausationId: command.MessageId,
+            IncludeLinkedDocumentTypes: command.IncludeLinkedDocumentTypes?.ToList()
         ));
 
         _logger.LogInformation(

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
@@ -36,7 +36,8 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
     /// </summary>
     private static ProcessDocumentCommand CreateTestCommand(
         int attemptCount = 0,
-        DocumentType documentType = DocumentType.TeamSeason)
+        DocumentType documentType = DocumentType.TeamSeason,
+        IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null)
     {
         return new ProcessDocumentCommand(
             sourceDataProvider: SourceDataProvider.Espn,
@@ -49,7 +50,8 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
             parentId: null,
             sourceUri: new Uri("http://test.com"),
             urlHash: "test123",
-            attemptCount: attemptCount);
+            attemptCount: attemptCount,
+            includeLinkedDocumentTypes: includeLinkedDocumentTypes);
     }
 
     [Fact]
@@ -241,6 +243,65 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
             It.IsAny<CancellationToken>()), Times.Never);
 
         command.RequestedDependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PublishDependencyRequest_Should_Propagate_IncludeLinkedDocumentTypes_To_Child_Request()
+    {
+        // Arrange
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var filter = new List<DocumentType>
+        {
+            DocumentType.EventCompetition,
+            DocumentType.EventCompetitionStatus,
+            DocumentType.EventCompetitionCompetitor
+        };
+
+        var command = CreateTestCommand(
+            documentType: DocumentType.Event,
+            includeLinkedDocumentTypes: filter);
+
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401234567/competitions/401234567") };
+
+        // Act
+        await processor.PublishDependencyRequestPublic(command, hasRef, Guid.NewGuid(), DocumentType.EventCompetition);
+
+        // Assert — the published DocumentRequested must carry the same filter
+        // forward, otherwise downstream processors lose the narrowing intent.
+        busMock.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(e =>
+                e.IncludeLinkedDocumentTypes != null &&
+                e.IncludeLinkedDocumentTypes.Count == filter.Count &&
+                e.IncludeLinkedDocumentTypes.SequenceEqual(filter)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishDependencyRequest_Should_Publish_Null_Filter_When_Command_Has_No_Filter()
+    {
+        // Arrange — explicit guard that the default (null filter / spawn-all) path
+        // continues to work after the propagation change. A null filter must
+        // serialize as null on the published event, not as an empty list.
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var command = CreateTestCommand(documentType: DocumentType.Event);
+
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401234567/competitions/401234567") };
+
+        // Act
+        await processor.PublishDependencyRequestPublic(command, hasRef, Guid.NewGuid(), DocumentType.EventCompetition);
+
+        // Assert
+        busMock.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(e => e.IncludeLinkedDocumentTypes == null),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `DocumentProcessorBase.PublishDocumentRequestInternal` now propagates the parent command's `IncludeLinkedDocumentTypes` onto the child `DocumentRequested` it publishes. Without this one-line fix the filter died at the first hop and every downstream processor defaulted to "spawn everything."
- `ContestUpdateProcessor` now seeds the initial \`DocumentRequested\` with a narrow `ContestRefreshDocumentTypes` set so a "Refresh Contest" request stops fanning out into rosters and per-athlete stats.
- Two unit tests on `DocumentProcessorBase` assert filter propagation (non-null carries through verbatim) and the null-filter contract (never serialized as an empty list, which would flip `ShouldSpawn`'s spawn-all default).

## Why this matters
The Contest Overview page's "Refresh Contest" action publishes a single \`DocumentRequested\` for \`DocumentType.Event\` with no inclusion filter. That one event currently cascades into:

\`\`\`
Event
└── EventCompetition
    ├── EventCompetitionStatus / Situation / Broadcast / Odds  ← what we want
    └── EventCompetitionCompetitor (× 2)
        ├── CompetitorScore / LineScore / Record               ← what we want
        ├── CompetitorRoster                                    ← unwanted
        │   └── per-Athlete fan-out                            ← unwanted
        └── CompetitorStatistics                                ← unwanted
\`\`\`

Hundreds of ESPN fetches for a refresh that should be a few dozen. The \`ShouldSpawn\` machinery exists to narrow this — every spawn site already wraps in \`if (isNew || ShouldSpawn(DocumentType.X, command))\` — but the filter was never propagated past the seed.

## Filter set chosen
Documented in \`docs/refresh-contest-cascade-narrowing.md\`:

\`\`\`csharp
private static readonly List<DocumentType> ContestRefreshDocumentTypes = new()
{
    DocumentType.Event,
    DocumentType.EventCompetition,
    DocumentType.EventCompetitionStatus,
    DocumentType.EventCompetitionSituation,
    DocumentType.EventCompetitionBroadcast,
    DocumentType.EventCompetitionOdds,
    DocumentType.EventCompetitionCompetitor,
    DocumentType.EventCompetitionCompetitorScore,
    DocumentType.EventCompetitionCompetitorLineScore,
    DocumentType.EventCompetitionCompetitorRecord,
    DocumentType.EventCompetitionPlay,
    DocumentType.EventCompetitionDrive
};
\`\`\`

Excludes \`EventCompetitionCompetitorRoster\`, \`EventCompetitionCompetitorStatistics\`, and the \`Athlete*\` fan-out beneath them. Those are sourced once during initial ingestion and don't change on a contest refresh.

## Caveat — `isNew` short-circuit
Every spawn site reads \`if (isNew || ShouldSpawn(DocumentType.X, command))\`. For a Refresh Contest the contest entities already exist (isNew=false), so the filter is respected. If a sub-entity happens to be new (rare on re-finalize), the isNew short-circuit deliberately bypasses the filter so new entities get full hydration. This isn't a bug — it's documented behavior — but the filter isn't absolute.

## Companion to #294
Same incident lineage but different concern: PR #294 fixes whether to hit ESPN (cache-vs-bypass), this one fixes which documents to source at all. Both reduce ESPN egress on contest refresh.

## Test plan
- [x] `dotnet build src/SportsData.Producer/SportsData.Producer.csproj` — clean
- [x] `dotnet test --filter "FullyQualifiedName~DocumentProcessorBaseTests"` — 10 pass / 0 fail (8 existing + 2 new)
- [ ] Deploy to prod; trigger Refresh Contest from the UI; in Seq filter on the resulting CorrelationId, expect to see exclusively the document types in `ContestRefreshDocumentTypes`. No `EventCompetitionCompetitorRoster` events. No `Athlete*`.
- [ ] Confirm `DocumentRequested received` log line in Provider includes the filter on the wire (now logged via the new `SeasonYear` field added in #294; we may want to add the filter to that log too as a follow-up).

## Design doc
Captured at `docs/refresh-contest-cascade-narrowing.md` — full hop-by-hop trace of where the filter died, the rationale for the chosen filter set, and validation steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved excessive document cascading during contest refresh operations, improving system performance and data accuracy.

* **Documentation**
  * Added comprehensive documentation detailing contest refresh improvements, including validation guidance and implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->