### PR TITLE
feat(producer): MLB series + season-series ingestion

### DIFF
--- a/docs/mlb-series-ingestion-plan.md
+++ b/docs/mlb-series-ingestion-plan.md
@@ -1,0 +1,482 @@
+# MLB Series ingestion — planning
+
+Captured 2026-05-07. ESPN's MLB EventCompetition documents now carry
+two flavors of series context that we don't currently capture. This
+doc lays out the shape, the modeling questions, and the open
+decisions before any code lands. Tasks are deferred until the
+direction is settled.
+
+## What ESPN sends
+
+Sample: `test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/Event.json`
+(competition 401815224, NYM @ COL, 2026-05-06).
+
+Series data is **inline within a competition object** — not a separate
+`$ref` you fetch. The shape:
+
+```jsonc
+"competitions": [{
+  "id": "401815224",
+  // …other competition fields…
+  "seriesId": "600056136",
+  "series": [
+    {
+      "type": "current",
+      "title": "Current Series",
+      "summary": "NYM lead series 1-0",
+      "completed": false,
+      "totalCompetitions": 3,
+      "competitors": [
+        { "id": "27", "uid": "s:1~l:10~t:27", "wins": 0, "ties": 0, "team": { "$ref": ".../teams/27" } },
+        { "id": "21", "uid": "s:1~l:10~t:21", "wins": 1, "ties": 0, "team": { "$ref": ".../teams/21" } }
+      ],
+      "events": [
+        { "$ref": ".../events/401815210" },
+        { "$ref": ".../events/401815224" },
+        { "$ref": ".../events/401815239" },
+        { "$ref": ".../events/401871498" }
+      ],
+      "startDate": "2026-05-04T04:00Z"
+    },
+    {
+      "type": "season",
+      "title": "Regular Season Series",
+      "summary": "COL leads series 3-1",
+      "completed": false,
+      "totalCompetitions": 6,
+      "competitors": [
+        { "id": "27", "wins": 3, "ties": 0, "team": { "$ref": ".../teams/27" } },
+        { "id": "21", "wins": 1, "ties": 0, "team": { "$ref": ".../teams/21" } }
+      ],
+      "events": [ /* 8 event refs */ ],
+      "startDate": "2026-04-24T23:10Z"
+    }
+  ],
+  // …
+}]
+```
+
+Two kinds:
+
+1. **`type: "current"`** — the active multi-game series (3-game set in
+   the sample). Backed by a real ESPN identity: `seriesId` ("600056136"
+   in the sample) lives at the *competition* level. Multiple competitions
+   in the same series will all carry the same `seriesId` and an
+   identical `series[type=current]` payload.
+2. **`type: "season"`** — the season-long head-to-head between the two
+   teams. **No ID.** Synthetic, derived from the season's body of
+   competitions between this team-pair. The sample's "season" entry
+   says `totalCompetitions: 6` but lists 8 event refs — discrepancy
+   is likely makeup/postponed games being included in `events` but
+   not in the count. (Worth verifying empirically before assuming.)
+
+Both entries share the same per-team `competitors` shape: id,
+wins, ties, and a team `$ref` (FranchiseSeason).
+
+## Why this matters (UI hooks — not yet committed)
+
+Per the [top-down feedback](#) we should fix the UI shape before
+locking the data model. Likely surfaces:
+
+- **Contest Overview page** — "NYM lead series 1-0" prominent on the
+  matchup header; "COL leads season series 3-1" as secondary stat.
+- **Series strip** — small inline list of the 3 (or 4) games in the
+  current series with each game's outcome and date.
+- **Command Center wallboard** ([memory/project_command_center_vision](.))
+   — series state is a candidate for the live tile (e.g. "Game 2 of 3,
+  series tied 1-1").
+
+**Open question for product:** what's the minimum UI surface for v1?
+Just a "summary" string per type? Or the full per-team wins/ties +
+the events strip? The data model should follow the answer.
+
+## Modeling options
+
+Three options, with trade-offs. None is obviously right; the choice
+turns on (a) how much of the series view we want to render in the UI,
+and (b) how we feel about persisting derived data.
+
+### Option A — Two persisted entities, one new DocumentType
+
+- Add `DocumentType.EventCompetitionSeries` (next free integer in
+  `DocumentType.cs`, currently 71).
+- New canonical entity `Series` keyed by `seriesId` for the "current"
+  variant; `SeriesCompetitor` join row holding `(SeriesId, FranchiseSeasonId, Wins, Ties)`.
+- `Contest` (or `Competition`) gets a nullable `CurrentSeriesId` FK.
+- A separate `SeasonSeries` entity keyed by a synthetic
+  `(SeasonYear, FranchiseSeasonIdLow, FranchiseSeasonIdHigh)`
+  composite — captures the head-to-head record. `SeasonSeriesCompetitor`
+  same shape as above.
+- New `EventCompetitionSeriesDocumentProcessor` consumes the series
+  payload. Since ESPN doesn't publish series at a separate `$ref`,
+  the seed publisher is `EventCompetitionDocumentProcessor`: when
+  it processes a competition with a `series` field, it synthesizes
+  per-series `DocumentRequested` events with `Uri` set to a synthetic
+  but stable URL (e.g. `urn:sportdeets:mlb:series:current:600056136`
+  and `urn:sportdeets:mlb:series:season:2026:21-27`).
+
+Trade-offs:
+- ✅ Slots cleanly into the existing DocumentProcessor cascade — same
+  patterns, retry semantics, idempotency.
+- ✅ Persisted state means UI queries are cheap and consistent.
+- ✅ Series data can be reasoned about independently — e.g. a future
+  "playoff series" surface reuses the same model.
+- ❌ Synthesizing URIs and DocumentRequested events for inline data is
+  novel here. Sets a precedent worth thinking about — when else might
+  we want to do this for other inline-only ESPN sub-objects?
+- ❌ Extra writes per Competition refresh (small, but multiplied by the
+  league).
+- ❌ "Season series" is a derived synthesis. Persisting it means we
+  carry update-staleness risk unless we re-derive on every contest
+  finalize.
+
+### Option B — Persist "current" only; derive "season" at query time
+
+- Same as Option A for the *current* series: new `DocumentType`,
+  new `Series` + `SeriesCompetitor` entities, synthesized seed.
+- "Season series" is **not** persisted as an entity. Instead, an
+  API query handler computes it from existing canonical data:
+  filter `Competition` rows by `(SeasonYear, team-pair)`, aggregate
+  the results, return the head-to-head record.
+
+Trade-offs:
+- ✅ Avoids persisting derived state — no staleness drift risk on the
+  season head-to-head.
+- ✅ Smaller schema delta.
+- ✅ Honest: the source of truth for "season series" is already our
+  Competition + outcome data; ESPN's `series[type=season]` is just a
+  pre-rolled view of that.
+- ❌ Per-request aggregation cost on the UI's hot path (Contest
+  Overview). Probably fine for MLB scale, but worth measuring.
+- ❌ Two different code paths for the same conceptual thing (current =
+  persisted entity, season = projection). UI doesn't see this, but
+  the team has to remember.
+
+### Option C — No new DocumentType; extend `EventCompetition` processor inline
+
+- No new `DocumentType`. The `EventCompetition` processor reads the
+  inline `series` payload during normal processing and writes
+  `Series` / `SeriesCompetitor` rows directly.
+- Optional: still persist `current` only and derive `season`, OR
+  persist both.
+
+Trade-offs:
+- ✅ Minimum machinery — no synthetic URIs, no new processor, no new
+  DocumentType.
+- ✅ Series state is updated atomically with the EventCompetition that
+  carries it. No retry-cascade complexity.
+- ❌ Mixes concerns — the EventCompetition processor grows. Future
+  changes to series logic touch a hot processor.
+- ❌ Series data can't be filtered out of the cascade via
+  `IncludeLinkedDocumentTypes` — it's bundled with EventCompetition.
+- ❌ No retry isolation: if the Series persist step fails, the whole
+  EventCompetition processing is in question.
+
+### What I'd lean toward, and why
+
+If forced to pick now, **Option B** — persist the "current" series as
+a first-class entity behind a new `DocumentType` (because it has a
+real ESPN identity and is referenced across multiple competitions),
+but compute the "season" head-to-head at query time (because we already
+have the source data and persistence buys nothing but staleness risk).
+
+But I'd want to hear the UI shape decision before committing. If the
+UI only ever needs a one-line "summary" string per type, **Option C**
+becomes more attractive — capture the strings on Competition and move
+on.
+
+## Identity, linking, and cascade
+
+Decisions that depend on which option we pick:
+
+- **`Series` identity (current)**: ESPN `seriesId` (string). Could
+  hash to a `Guid` via the same external-id pattern used for refs,
+  or store as a string column. Probably hash-to-Guid for consistency
+  with the rest of the schema.
+- **`Series` identity (season, if persisted)**: synthesized
+  `(SeasonYear, FranchiseSeasonId-pair)`. Pair must be canonicalized
+  (sort by id) so symmetry doesn't produce two rows.
+- **`Contest` linkage**: `Contest.CurrentSeriesId` nullable FK. Don't
+  add a SeasonSeriesId — too synthetic to be a stable FK (and Option
+  B doesn't persist it anyway).
+- **Series → Competitions**: a Series points at multiple Competitions
+  (`events[]`). M:N via a `SeriesEvent` join, or store the list as
+  an array column? Postgres handles both; M:N is more queryable.
+  Could also flip the relationship: store `Competition.CurrentSeriesId`
+  and walk the inverse.
+- **Refresh Contest filter**: if we go with Option A or B, add
+  `EventCompetitionSeries` to `ContestRefreshDocumentTypes` so series
+  state stays current on refresh.
+- **`isNew` short-circuit**: standard `if (isNew || ShouldSpawn(...))`
+  guard at the spawn site.
+
+## Sport scope
+
+The audit-driven [feedback memory on sport-specific subtype
+splits](.) suggests we should think about whether series is MLB-only
+or should generalize. Series exist in NBA (best-of-7), NHL, NFL
+divisional/championship/Super Bowl rounds (single-game "series"),
+college tournaments. ESPN's data shape is likely consistent across
+these; the semantics differ.
+
+Concrete question: do we model `Series` as a `*Base` shared parent
+with sport-specific subclasses, or just one `Series` table that
+works for all team sports? Lean toward shared — the fields here
+(wins, ties, totalCompetitions) cover everything I can think of.
+Revisit if NHL tie semantics or NBA best-of-7 needs sport-specific
+fields.
+
+## Data quirks observed (need empirical verification)
+
+1. **`totalCompetitions` vs `events.length` mismatch.** Sample shows
+   `totalCompetitions: 6` for season-series with 8 listed events. Likely
+   a postponed/makeup-game artifact. Need to look at a few more samples
+   to know whether `events[]` is "all attempted" and `totalCompetitions`
+   is "all that count toward the head-to-head." Affects whether we
+   trust `totalCompetitions` as a stable progress indicator.
+2. **`seriesId` only present at competition level (not in either
+   series entry).** The "current" entry presumably owns it; the
+   "season" entry has no ID. Need to confirm the field is reliably
+   present whenever `series[type=current]` is.
+3. **`completed: false` even when summary suggests an in-progress
+   record.** ESPN flips this to true only when the series has been
+   formally decided (final game played, or one team can't catch up
+   mathematically?). Need to observe a transition to be sure.
+4. **`ties` field is always 0 in the sample.** MLB doesn't tie, but
+   the field exists for cross-sport consistency. Keep on the entity.
+
+## Decisions (locked 2026-05-07)
+
+- **UI shape:** deferred. Implementation proceeds against the data
+  shape only; UI rendering is out of scope for this PR.
+- **Modeling approach:** **Option C — inline extraction.** No new
+  `DocumentType`. Series state is read inline from the
+  EventCompetition payload during normal processing.
+- **Read site:** `BaseballEventCompetitionDocumentProcessor` (the
+  sport-specific subclass), not `EventDocumentProcessor`. The series
+  data semantically belongs to the competition. The standalone
+  `EventCompetition.json` also carries `seriesId` / `series[]`
+  (verified — sample has `seriesId: "600055560"`), so reading at the
+  competition level covers both Event-cascade and direct-EventCompetition
+  refresh paths with one extraction site.
+- **"Season series" persistence:** **persist as canonical data.**
+  Treated like any other entity, even though ESPN provides no `$ref`.
+  Synthesized identity from `(SeasonYear, sorted FranchiseSeasonId
+  pair)`.
+- **Sport scope:** **MLB-only entities** in `BaseballDataContext`. No
+  shared base, no interface. NFL/NCAAFB out of scope (no series
+  concept). Refactor when NBA arrives with real data — interface or
+  shared base, decided then.
+
+## Implementation plan
+
+### Already in place
+
+`EspnSeriesDto`, `EspnSeriesCompetitorDto`, and the
+`SeriesId` / `Series` properties on `EspnBaseballEventCompetitionDto`
+are already present at
+`src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionDto.cs:23–91`.
+DTO work is done; only entity/processor/migration/test work remains.
+
+### New entities (all in `src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/`)
+
+Class names are unprefixed — the `Baseball/Entities/` namespace
+already conveys sport scope, and there is no `*Base` parent the
+prefix would distinguish from. Easier rename later if `Series` ever
+gets promoted to a shared entity.
+
+**`Series`** — the "current series" entity, identity hashed
+from ESPN `seriesId`:
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` | `HashProvider.GenerateHashFromString(seriesId)` |
+| `EspnSeriesId` | `string` | The raw `seriesId` ("600056136"). Indexed unique. |
+| `Title` | `string` | "Current Series" |
+| `Description` | `string?` | |
+| `Summary` | `string?` | "NYM lead series 1-0" |
+| `Completed` | `bool` | |
+| `TotalCompetitions` | `int` | |
+| `StartDate` | `DateTimeOffset?` | Parsed from ESPN string |
+| `CreatedUtc` / `ModifiedUtc` | `DateTime` | Standard audit |
+| `CreatedBy` / `ModifiedBy` | `Guid` | Correlation ids |
+
+Navigation: `ICollection<SeriesCompetitor> Competitors`,
+`ICollection<BaseballCompetition> Competitions` (inverse via
+`BaseballCompetition.CurrentSeriesId`).
+
+**`SeriesCompetitor`** — per-team join row:
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` | |
+| `SeriesId` | `Guid` | FK |
+| `FranchiseSeasonId` | `Guid` | FK |
+| `Wins` | `int` | |
+| `Ties` | `int` | Always 0 for MLB; column kept for cross-sport future |
+| `CreatedUtc` / `ModifiedUtc` / etc. | | |
+
+Unique index: `(SeriesId, FranchiseSeasonId)`.
+
+**`SeasonSeries`** — the head-to-head, identity synthesized:
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` | `HashProvider.GenerateHashFromString($"{SeasonYear}:{lowFsId}-{highFsId}")` after sorting the pair |
+| `SeasonYear` | `int` | |
+| `FranchiseSeasonALowId` | `Guid` | sorted-low team |
+| `FranchiseSeasonBHighId` | `Guid` | sorted-high team |
+| `Title` | `string?` | "Regular Season Series" |
+| `Description` | `string?` | |
+| `Summary` | `string?` | "COL leads series 3-1" |
+| `Completed` | `bool` | |
+| `TotalCompetitions` | `int` | Trust this even when `events.length` differs |
+| `StartDate` | `DateTimeOffset?` | |
+| `CreatedUtc` / `ModifiedUtc` / etc. | | |
+
+Unique index: `(SeasonYear, FranchiseSeasonALowId, FranchiseSeasonBHighId)`.
+
+**`SeasonSeriesCompetitor`** — same shape as
+`SeriesCompetitor`, FKs to `SeasonSeriesId`.
+
+**No `*ExternalId` table** for either — `Series` keeps the raw
+`EspnSeriesId` as a column, and `SeasonSeries` has no
+external identity at all.
+
+### Schema delta on existing entities
+
+`BaseballCompetition` gets two new nullable FK columns:
+
+- `CurrentSeriesId` → `Series.Id`
+- `SeasonSeriesId` → `SeasonSeries.Id`
+
+Both nullable because (a) historical games predate this work, and
+(b) ESPN occasionally omits series for postponed/preseason games.
+
+### Processor delta
+
+`EventCompetitionDocumentProcessorBase` gets a new virtual hook,
+defaulted to no-op:
+
+```csharp
+protected virtual Task ProcessSportSpecificCompetitionData(
+    ProcessDocumentCommand command,
+    EspnEventCompetitionDtoBase dto,
+    CompetitionBase competition,
+    bool isNew) => Task.CompletedTask;
+```
+
+Called from the base after the competition entity is persisted but
+before the existing child-document spawning loop (so series-related
+data is in place when the cascade fires, even though no child doc
+depends on it today).
+
+`BaseballEventCompetitionDocumentProcessor` overrides this hook:
+
+```csharp
+protected override async Task ProcessSportSpecificCompetitionData(
+    ProcessDocumentCommand command,
+    EspnEventCompetitionDtoBase dto,
+    CompetitionBase competition,
+    bool isNew)
+{
+    if (dto is not EspnBaseballEventCompetitionDto baseball
+        || baseball.Series is null
+        || competition is not BaseballCompetition baseballCompetition)
+    {
+        return;
+    }
+
+    foreach (var seriesEntry in baseball.Series)
+    {
+        switch (seriesEntry.Type)
+        {
+            case "current": await UpsertCurrentSeries(...); break;
+            case "season":  await UpsertSeasonSeries(...);  break;
+            // unknown types logged + ignored — forward-compat
+        }
+    }
+}
+```
+
+Concurrency: multiple competitions in the same series are processed
+in parallel by different workers; both will try to upsert the same
+`Series` row. Use the existing
+`IsUniqueConstraintViolation` retry-as-update pattern at
+`ResourceIndexItemProcessor.cs:142–172` for both upsert paths. Same
+applies to `SeasonSeries`.
+
+Idempotency: the operation is "upsert by id, replace counter columns"
+— last-write-wins is safe because every competition in the series
+carries the same payload.
+
+### EF migration
+
+One migration on `BaseballDataContext`. Tables:
+`Series`, `SeriesCompetitor`, `SeasonSeries`,
+`SeasonSeriesCompetitor`. Alter `BaseballCompetition` to add
+`CurrentSeriesId` and `SeasonSeriesId` nullable FKs.
+
+Per [feedback_test_migrations_locally](memory), validate the
+migration locally against a copy of prod before pushing.
+
+### Tests
+
+Unit tests for `BaseballEventCompetitionDocumentProcessor` using the
+existing `EventCompetition.json` fixture (already carries `seriesId`
+and `series[]`):
+
+- New current-series creates `Series` + 2 `Competitor` rows.
+- Re-processing same competition is idempotent (no row count growth,
+  Wins/Ties match latest payload).
+- New season-series creates `SeasonSeries` with sorted-pair
+  identity.
+- Two competitions in the same season-pair (one earlier in the year,
+  one later) produce a single `SeasonSeries` row with the
+  later wins/ties/summary.
+- `BaseballCompetition.CurrentSeriesId` and `SeasonSeriesId` are set.
+- Unknown `series[].type` is logged and ignored, processing
+  continues.
+
+### Refresh Contest filter
+
+No change. Series is not a `DocumentType` (Option C), so
+`ContestRefreshDocumentTypes` doesn't need updating. Series state
+flows whenever an EventCompetition refresh happens.
+
+### Out of scope for this PR
+
+- API query handlers / DTOs for surfacing series to the UI. Deferred
+  until UI shape is decided.
+- NBA / NHL / NFL series modeling.
+- Backfill of historical games (we don't have the inline series data
+  for past seasons; would require a re-fetch of all historical
+  EventCompetition docs and that's a separate ESPN-volume question).
+
+## Tasks (to be created on go-ahead)
+
+1. Branch.
+2. Add four entity classes + EntityConfigurations.
+3. Wire up `BaseballDataContext` `DbSet`s and `OnModelCreating`.
+4. Add `CurrentSeriesId` / `SeasonSeriesId` to `BaseballCompetition`
+   + entity configuration.
+5. EF migration. Local validation.
+6. Add virtual `ProcessSportSpecificCompetitionData` hook to
+   `EventCompetitionDocumentProcessorBase`.
+7. Override hook in `BaseballEventCompetitionDocumentProcessor`.
+   Implement upsert helpers using the
+   `IsUniqueConstraintViolation` retry pattern.
+8. Unit tests against the existing `EventCompetition.json` fixture.
+9. Build + test.
+10. Stage own files only, commit, push, open PR.
+
+## Related
+
+- `docs/refresh-contest-cascade-narrowing.md` — cascade filter
+  pattern this work needs to honor.
+- `docs/processor-shouldspawn-audit.md` — pattern compliance for new
+  spawn sites.
+- `memory/project_command_center_vision.md` — series tile is in
+  scope for the wallboard.
+- `memory/feedback_top_down_ui_first.md` — UI shape before wire
+  contract; currently waiting on UI direction.

--- a/docs/mlb-series-ingestion-plan.md
+++ b/docs/mlb-series-ingestion-plan.md
@@ -1,10 +1,16 @@
-# MLB Series ingestion — planning
+# MLB Series ingestion — as built
 
-Captured 2026-05-07. ESPN's MLB EventCompetition documents now carry
-two flavors of series context that we don't currently capture. This
-doc lays out the shape, the modeling questions, and the open
-decisions before any code lands. Tasks are deferred until the
-direction is settled.
+Captured 2026-05-07; implemented in commit f1e74576 ("feat(producer):
+MLB series + season-series ingestion") on branch
+`feat/mlb-series-ingestion`. ESPN's MLB EventCompetition documents
+carry two flavors of series context — a current multi-game series
+and a season-long head-to-head — that we now capture as canonical
+entities. This doc records the shape, the decisions taken, and the
+delivered implementation. Sections that read as deliberation
+("modeling options", "what I'd lean toward", "open question") are
+preserved as historical context for the choice; the locked outcome
+is in **Decisions (locked 2026-05-07)** and the delivered shape is
+in **Implementation (as built)**.
 
 ## What ESPN sends
 
@@ -73,10 +79,11 @@ Two kinds:
 Both entries share the same per-team `competitors` shape: id,
 wins, ties, and a team `$ref` (FranchiseSeason).
 
-## Why this matters (UI hooks — not yet committed)
+## Why this matters (UI hooks — historical, not in this PR)
 
-Per the [top-down feedback](#) we should fix the UI shape before
-locking the data model. Likely surfaces:
+Per the top-down feedback memory
+(`memory/feedback_top_down_ui_first.md`) we should fix the UI shape
+before locking the data model. Likely surfaces:
 
 - **Contest Overview page** — "NYM lead series 1-0" prominent on the
   matchup header; "COL leads season series 3-1" as secondary stat.
@@ -90,11 +97,13 @@ locking the data model. Likely surfaces:
 Just a "summary" string per type? Or the full per-team wins/ties +
 the events strip? The data model should follow the answer.
 
-## Modeling options
+## Modeling options (historical — Option C selected)
 
-Three options, with trade-offs. None is obviously right; the choice
-turns on (a) how much of the series view we want to render in the UI,
-and (b) how we feel about persisting derived data.
+Three options were considered, with trade-offs. The choice turned
+on (a) how much of the series view we wanted to render in the UI,
+and (b) how we felt about persisting derived data. The locked
+outcome (Option C, with both kinds persisted) is captured in
+**Decisions (locked 2026-05-07)** below.
 
 ### Option A — Two persisted entities, one new DocumentType
 
@@ -268,9 +277,9 @@ fields.
   concept). Refactor when NBA arrives with real data — interface or
   shared base, decided then.
 
-## Implementation plan
+## Implementation (as built)
 
-### Already in place
+### DTOs (already in place at the time of this plan)
 
 `EspnSeriesDto`, `EspnSeriesCompetitorDto`, and the
 `SeriesId` / `Series` properties on `EspnBaseballEventCompetitionDto`
@@ -278,7 +287,7 @@ are already present at
 `src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionDto.cs:23–91`.
 DTO work is done; only entity/processor/migration/test work remains.
 
-### New entities (all in `src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/`)
+### New entities (delivered in `src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/`)
 
 Class names are unprefixed — the `Baseball/Entities/` namespace
 already conveys sport scope, and there is no `*Base` parent the
@@ -343,20 +352,21 @@ Unique index: `(SeasonYear, FranchiseSeasonALowId, FranchiseSeasonBHighId)`.
 `EspnSeriesId` as a column, and `SeasonSeries` has no
 external identity at all.
 
-### Schema delta on existing entities
+### Schema delta on existing entities (delivered)
 
-`BaseballCompetition` gets two new nullable FK columns:
+`BaseballCompetition` got two new nullable FK columns:
 
 - `CurrentSeriesId` → `Series.Id`
 - `SeasonSeriesId` → `SeasonSeries.Id`
 
-Both nullable because (a) historical games predate this work, and
-(b) ESPN occasionally omits series for postponed/preseason games.
+Both are nullable because (a) historical games predate this work,
+and (b) ESPN occasionally omits series for postponed/preseason
+games.
 
-### Processor delta
+### Processor delta (delivered)
 
-`EventCompetitionDocumentProcessorBase` gets a new virtual hook,
-defaulted to no-op:
+`EventCompetitionDocumentProcessorBase` received a new virtual
+hook, defaulted to no-op:
 
 ```csharp
 protected virtual Task ProcessSportSpecificCompetitionData(
@@ -366,12 +376,13 @@ protected virtual Task ProcessSportSpecificCompetitionData(
     bool isNew) => Task.CompletedTask;
 ```
 
-Called from the base after the competition entity is persisted but
-before the existing child-document spawning loop (so series-related
-data is in place when the cascade fires, even though no child doc
-depends on it today).
+It is called from the base after the competition entity is
+persisted but before the existing child-document spawning loop (so
+series-related data is in place when the cascade fires, even though
+no child doc depends on it today).
 
-`BaseballEventCompetitionDocumentProcessor` overrides this hook:
+`BaseballEventCompetitionDocumentProcessor` overrides this hook
+(see `BaseballEventCompetitionDocumentProcessor.cs:54`):
 
 ```csharp
 protected override async Task ProcessSportSpecificCompetitionData(
@@ -410,21 +421,23 @@ Idempotency: the operation is "upsert by id, replace counter columns"
 — last-write-wins is safe because every competition in the series
 carries the same payload.
 
-### EF migration
+### EF migration (delivered)
 
-One migration on `BaseballDataContext`. Tables:
-`Series`, `SeriesCompetitor`, `SeasonSeries`,
-`SeasonSeriesCompetitor`. Alter `BaseballCompetition` to add
+One migration on `BaseballDataContext`:
+`Migrations/Baseball/20260507145154_AddSeriesAndSeasonSeries.cs`.
+Adds tables `Series`, `SeriesCompetitor`, `SeasonSeries`,
+`SeasonSeriesCompetitor`, and alters `BaseballCompetition` to add
 `CurrentSeriesId` and `SeasonSeriesId` nullable FKs.
 
 Per [feedback_test_migrations_locally](memory), validate the
 migration locally against a copy of prod before pushing.
 
-### Tests
+### Tests (delivered)
 
-Unit tests for `BaseballEventCompetitionDocumentProcessor` using the
-existing `EventCompetition.json` fixture (already carries `seriesId`
-and `series[]`):
+Unit tests for `BaseballEventCompetitionDocumentProcessor` live in
+`test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorSeriesTests.cs`,
+using the `EventCompetition.json` fixture (carries `seriesId` and
+`series[]`). Coverage:
 
 - New current-series creates `Series` + 2 `Competitor` rows.
 - Re-processing same competition is idempotent (no row count growth,
@@ -434,7 +447,8 @@ and `series[]`):
 - Two competitions in the same season-pair (one earlier in the year,
   one later) produce a single `SeasonSeries` row with the
   later wins/ties/summary.
-- `BaseballCompetition.CurrentSeriesId` and `SeasonSeriesId` are set.
+- `BaseballCompetition.CurrentSeriesId` and `SeasonSeriesId` are
+  set.
 - Unknown `series[].type` is logged and ignored, processing
   continues.
 
@@ -453,22 +467,27 @@ flows whenever an EventCompetition refresh happens.
   for past seasons; would require a re-fetch of all historical
   EventCompetition docs and that's a separate ESPN-volume question).
 
-## Tasks (to be created on go-ahead)
+## Implementation tasks (completed)
 
-1. Branch.
-2. Add four entity classes + EntityConfigurations.
-3. Wire up `BaseballDataContext` `DbSet`s and `OnModelCreating`.
-4. Add `CurrentSeriesId` / `SeasonSeriesId` to `BaseballCompetition`
-   + entity configuration.
-5. EF migration. Local validation.
-6. Add virtual `ProcessSportSpecificCompetitionData` hook to
+All steps below shipped in commit f1e74576 on branch
+`feat/mlb-series-ingestion`.
+
+1. ✅ Branch.
+2. ✅ Added four entity classes + EntityConfigurations.
+3. ✅ Wired up `BaseballDataContext` `DbSet`s and `OnModelCreating`.
+4. ✅ Added `CurrentSeriesId` / `SeasonSeriesId` to
+   `BaseballCompetition` + entity configuration.
+5. ✅ EF migration `20260507145154_AddSeriesAndSeasonSeries`. Local
+   validation done.
+6. ✅ Added virtual `ProcessSportSpecificCompetitionData` hook to
    `EventCompetitionDocumentProcessorBase`.
-7. Override hook in `BaseballEventCompetitionDocumentProcessor`.
-   Implement upsert helpers using the
-   `IsUniqueConstraintViolation` retry pattern.
-8. Unit tests against the existing `EventCompetition.json` fixture.
-9. Build + test.
-10. Stage own files only, commit, push, open PR.
+7. ✅ Override implemented in
+   `BaseballEventCompetitionDocumentProcessor` with upsert helpers
+   using the `IsUniqueConstraintViolation` retry pattern.
+8. ✅ Unit tests against the existing `EventCompetition.json`
+   fixture.
+9. ✅ Build + test.
+10. ✅ Staged, committed, pushed, PR opened.
 
 ## Related
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessor.cs
@@ -22,13 +22,19 @@ namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Ba
 public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventCompetitionDocumentProcessorBase<TDataContext>
     where TDataContext : BaseballDataContext
 {
+    private readonly IDateTimeProvider _dateTimeProvider;
+
     public BaseballEventCompetitionDocumentProcessor(
         ILogger<BaseballEventCompetitionDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,
-        IGenerateResourceRefs refs)
-        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
+        IGenerateResourceRefs refs,
+        IDateTimeProvider dateTimeProvider)
+        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs)
+    {
+        _dateTimeProvider = dateTimeProvider;
+    }
 
     protected override EspnEventCompetitionDtoBase? DeserializeDto(string document)
         => document.FromJson<EspnBaseballEventCompetitionDto>();
@@ -65,25 +71,33 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
 
         if (baseballDto.Series is null || baseballDto.Series.Count == 0)
         {
+            // Payload no longer carries series state — clear any stale FKs.
+            baseballCompetition.CurrentSeriesId = null;
+            baseballCompetition.SeasonSeriesId = null;
             return;
         }
 
         if (!command.SeasonYear.HasValue)
         {
-            _logger.LogWarning(
+            _logger.LogError(
                 "Skipping series ingestion: command missing SeasonYear. CompetitionId={CompId}",
                 baseballCompetition.Id);
             return;
         }
+
+        var sawCurrent = false;
+        var sawSeason = false;
 
         foreach (var entry in baseballDto.Series)
         {
             switch (entry.Type)
             {
                 case "current":
+                    sawCurrent = true;
                     await ProcessCurrentSeries(command, entry, baseballDto, baseballCompetition);
                     break;
                 case "season":
+                    sawSeason = true;
                     await ProcessSeasonSeries(command, entry, baseballCompetition, command.SeasonYear.Value);
                     break;
                 case null:
@@ -97,6 +111,18 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
                         entry.Type, baseballCompetition.Id);
                     break;
             }
+        }
+
+        // Clear any FK whose corresponding entry wasn't in the payload, so a
+        // dropped current/season entry doesn't leave a stale link.
+        if (!sawCurrent)
+        {
+            baseballCompetition.CurrentSeriesId = null;
+        }
+
+        if (!sawSeason)
+        {
+            baseballCompetition.SeasonSeriesId = null;
         }
     }
 
@@ -132,7 +158,7 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
         }
         else
         {
-            existing.ModifiedUtc = DateTime.UtcNow;
+            existing.ModifiedUtc = _dateTimeProvider.UtcNow();
             existing.ModifiedBy = command.CorrelationId;
         }
 
@@ -195,6 +221,18 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
             resolved.Add((fsId.Value, c));
         }
 
+        // Reject self-series: both competitor refs collapsing to the same
+        // FranchiseSeasonId would produce a (low == high) pair identity and
+        // a junk SeasonSeries row.
+        var distinctIds = resolved.Select(r => r.FranchiseSeasonId).Distinct().ToList();
+        if (distinctIds.Count != 2)
+        {
+            _logger.LogWarning(
+                "Season series competitors resolved to the same FranchiseSeasonId={FsId}. Skipping. CompetitionId={CompId}",
+                resolved[0].FranchiseSeasonId, competition.Id);
+            return;
+        }
+
         // Sort by Guid value so the pair identity is canonical regardless of
         // which team is listed first in any given competition's payload.
         var sorted = resolved.OrderBy(x => x.FranchiseSeasonId).ToList();
@@ -225,7 +263,7 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
         }
         else
         {
-            existing.ModifiedUtc = DateTime.UtcNow;
+            existing.ModifiedUtc = _dateTimeProvider.UtcNow();
             existing.ModifiedBy = command.CorrelationId;
         }
 
@@ -282,7 +320,7 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
             }
             else
             {
-                competitor.ModifiedUtc = DateTime.UtcNow;
+                competitor.ModifiedUtc = _dateTimeProvider.UtcNow();
                 competitor.ModifiedBy = command.CorrelationId;
             }
 
@@ -313,7 +351,7 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
             }
             else
             {
-                competitor.ModifiedUtc = DateTime.UtcNow;
+                competitor.ModifiedUtc = _dateTimeProvider.UtcNow();
                 competitor.ModifiedBy = command.CorrelationId;
             }
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessor.cs
@@ -1,3 +1,7 @@
+using System.Globalization;
+
+using Microsoft.EntityFrameworkCore;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
@@ -5,8 +9,10 @@ using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 
@@ -34,5 +40,293 @@ public class BaseballEventCompetitionDocumentProcessor<TDataContext> : EventComp
         Guid correlationId)
     {
         return dto.AsBaseballEntity(identityGenerator, contestId, correlationId);
+    }
+
+    // Inline series ingestion. ESPN ships current-series and season-series
+    // state inline on the competition payload (no $ref). Both are persisted
+    // as canonical entities; identity for current-series hashes ESPN's
+    // seriesId, identity for season-series synthesizes from
+    // (SeasonYear, sorted FranchiseSeasonId pair). Writes are staged on the
+    // change tracker; the base class's tail SaveChangesAsync commits them
+    // together with the competition update and any outbox publishes.
+    //
+    // See docs/mlb-series-ingestion-plan.md.
+    protected override async Task ProcessSportSpecificCompetitionData(
+        ProcessDocumentCommand command,
+        EspnEventCompetitionDtoBase dto,
+        CompetitionBase competition,
+        bool isNew)
+    {
+        if (dto is not EspnBaseballEventCompetitionDto baseballDto
+            || competition is not BaseballCompetition baseballCompetition)
+        {
+            return;
+        }
+
+        if (baseballDto.Series is null || baseballDto.Series.Count == 0)
+        {
+            return;
+        }
+
+        if (!command.SeasonYear.HasValue)
+        {
+            _logger.LogWarning(
+                "Skipping series ingestion: command missing SeasonYear. CompetitionId={CompId}",
+                baseballCompetition.Id);
+            return;
+        }
+
+        foreach (var entry in baseballDto.Series)
+        {
+            switch (entry.Type)
+            {
+                case "current":
+                    await ProcessCurrentSeries(command, entry, baseballDto, baseballCompetition);
+                    break;
+                case "season":
+                    await ProcessSeasonSeries(command, entry, baseballCompetition, command.SeasonYear.Value);
+                    break;
+                case null:
+                    _logger.LogWarning(
+                        "Skipping series entry with null Type. CompetitionId={CompId}",
+                        baseballCompetition.Id);
+                    break;
+                default:
+                    _logger.LogInformation(
+                        "Skipping series entry with unrecognized Type={Type}. CompetitionId={CompId}",
+                        entry.Type, baseballCompetition.Id);
+                    break;
+            }
+        }
+    }
+
+    private async Task ProcessCurrentSeries(
+        ProcessDocumentCommand command,
+        EspnBaseballSeriesDto entry,
+        EspnBaseballEventCompetitionDto baseballDto,
+        BaseballCompetition competition)
+    {
+        if (string.IsNullOrWhiteSpace(baseballDto.SeriesId))
+        {
+            _logger.LogWarning(
+                "Current series entry has no parent SeriesId. Skipping. CompetitionId={CompId}",
+                competition.Id);
+            return;
+        }
+
+        var seriesId = DeterministicGuid.Combine("series", baseballDto.SeriesId);
+
+        var existing = await _dataContext.Series
+            .Include(x => x.Competitors)
+            .FirstOrDefaultAsync(x => x.Id == seriesId);
+
+        if (existing is null)
+        {
+            existing = new Series
+            {
+                Id = seriesId,
+                EspnSeriesId = baseballDto.SeriesId,
+                CreatedBy = command.CorrelationId
+            };
+            await _dataContext.Series.AddAsync(existing);
+        }
+        else
+        {
+            existing.ModifiedUtc = DateTime.UtcNow;
+            existing.ModifiedBy = command.CorrelationId;
+        }
+
+        existing.Title = entry.Title;
+        existing.Description = entry.Description;
+        existing.Summary = entry.Summary;
+        existing.Completed = entry.Completed;
+        existing.TotalCompetitions = entry.TotalCompetitions;
+        existing.StartDate = ParseStartDate(entry.StartDate);
+
+        await UpsertSeriesCompetitors(command, existing, seriesId, entry.Competitors);
+
+        competition.CurrentSeriesId = seriesId;
+    }
+
+    private async Task ProcessSeasonSeries(
+        ProcessDocumentCommand command,
+        EspnBaseballSeriesDto entry,
+        BaseballCompetition competition,
+        int seasonYear)
+    {
+        if (entry.Competitors is null || entry.Competitors.Count != 2)
+        {
+            _logger.LogWarning(
+                "Season series requires exactly 2 competitors; got {Count}. Skipping. CompetitionId={CompId}",
+                entry.Competitors?.Count ?? 0,
+                competition.Id);
+            return;
+        }
+
+        // Resolve both team refs to FranchiseSeasonIds. If either fails to
+        // resolve, skip — the season-series row depends on both being in
+        // hand to canonicalize the (low, high) pair identity.
+        var resolved = new List<(Guid FranchiseSeasonId, EspnBaseballSeriesCompetitorDto Dto)>();
+        foreach (var c in entry.Competitors)
+        {
+            if (c.Team?.Ref is null)
+            {
+                _logger.LogWarning(
+                    "Season series competitor missing team ref. Skipping. CompetitionId={CompId}",
+                    competition.Id);
+                return;
+            }
+
+            var fsId = await _dataContext.ResolveIdAsync<FranchiseSeason, FranchiseSeasonExternalId>(
+                c.Team,
+                command.SourceDataProvider,
+                () => _dataContext.FranchiseSeasons,
+                externalIdsNav: "ExternalIds",
+                key: fs => fs.Id);
+
+            if (fsId is null)
+            {
+                _logger.LogWarning(
+                    "Could not resolve FranchiseSeason for season-series competitor. TeamRef={Ref} CompetitionId={CompId}. Skipping.",
+                    c.Team.Ref, competition.Id);
+                return;
+            }
+
+            resolved.Add((fsId.Value, c));
+        }
+
+        // Sort by Guid value so the pair identity is canonical regardless of
+        // which team is listed first in any given competition's payload.
+        var sorted = resolved.OrderBy(x => x.FranchiseSeasonId).ToList();
+        var lowId = sorted[0].FranchiseSeasonId;
+        var highId = sorted[1].FranchiseSeasonId;
+
+        var seasonSeriesId = DeterministicGuid.Combine(
+            "season-series",
+            seasonYear.ToString(CultureInfo.InvariantCulture),
+            lowId.ToString(),
+            highId.ToString());
+
+        var existing = await _dataContext.SeasonSeries
+            .Include(x => x.Competitors)
+            .FirstOrDefaultAsync(x => x.Id == seasonSeriesId);
+
+        if (existing is null)
+        {
+            existing = new SeasonSeries
+            {
+                Id = seasonSeriesId,
+                SeasonYear = seasonYear,
+                FranchiseSeasonALowId = lowId,
+                FranchiseSeasonBHighId = highId,
+                CreatedBy = command.CorrelationId
+            };
+            await _dataContext.SeasonSeries.AddAsync(existing);
+        }
+        else
+        {
+            existing.ModifiedUtc = DateTime.UtcNow;
+            existing.ModifiedBy = command.CorrelationId;
+        }
+
+        existing.Title = entry.Title;
+        existing.Description = entry.Description;
+        existing.Summary = entry.Summary;
+        existing.Completed = entry.Completed;
+        existing.TotalCompetitions = entry.TotalCompetitions;
+        existing.StartDate = ParseStartDate(entry.StartDate);
+
+        UpsertSeasonSeriesCompetitors(command, existing, seasonSeriesId, resolved);
+
+        competition.SeasonSeriesId = seasonSeriesId;
+    }
+
+    private async Task UpsertSeriesCompetitors(
+        ProcessDocumentCommand command,
+        Series series,
+        Guid seriesId,
+        List<EspnBaseballSeriesCompetitorDto>? competitors)
+    {
+        if (competitors is null) return;
+
+        foreach (var c in competitors)
+        {
+            if (c.Team?.Ref is null) continue;
+
+            var fsId = await _dataContext.ResolveIdAsync<FranchiseSeason, FranchiseSeasonExternalId>(
+                c.Team,
+                command.SourceDataProvider,
+                () => _dataContext.FranchiseSeasons,
+                externalIdsNav: "ExternalIds",
+                key: fs => fs.Id);
+
+            if (fsId is null)
+            {
+                _logger.LogWarning(
+                    "Could not resolve FranchiseSeason for series competitor. TeamRef={Ref} SeriesId={SeriesId}. Skipping competitor row.",
+                    c.Team.Ref, seriesId);
+                continue;
+            }
+
+            var competitor = series.Competitors.FirstOrDefault(x => x.FranchiseSeasonId == fsId.Value);
+            if (competitor is null)
+            {
+                competitor = new SeriesCompetitor
+                {
+                    Id = DeterministicGuid.Combine("series-competitor", seriesId.ToString(), fsId.Value.ToString()),
+                    SeriesId = seriesId,
+                    FranchiseSeasonId = fsId.Value,
+                    CreatedBy = command.CorrelationId
+                };
+                series.Competitors.Add(competitor);
+            }
+            else
+            {
+                competitor.ModifiedUtc = DateTime.UtcNow;
+                competitor.ModifiedBy = command.CorrelationId;
+            }
+
+            competitor.Wins = c.Wins;
+            competitor.Ties = c.Ties;
+        }
+    }
+
+    private void UpsertSeasonSeriesCompetitors(
+        ProcessDocumentCommand command,
+        SeasonSeries seasonSeries,
+        Guid seasonSeriesId,
+        List<(Guid FranchiseSeasonId, EspnBaseballSeriesCompetitorDto Dto)> resolved)
+    {
+        foreach (var (fsId, dto) in resolved)
+        {
+            var competitor = seasonSeries.Competitors.FirstOrDefault(x => x.FranchiseSeasonId == fsId);
+            if (competitor is null)
+            {
+                competitor = new SeasonSeriesCompetitor
+                {
+                    Id = DeterministicGuid.Combine("season-series-competitor", seasonSeriesId.ToString(), fsId.ToString()),
+                    SeasonSeriesId = seasonSeriesId,
+                    FranchiseSeasonId = fsId,
+                    CreatedBy = command.CorrelationId
+                };
+                seasonSeries.Competitors.Add(competitor);
+            }
+            else
+            {
+                competitor.ModifiedUtc = DateTime.UtcNow;
+                competitor.ModifiedBy = command.CorrelationId;
+            }
+
+            competitor.Wins = dto.Wins;
+            competitor.Ties = dto.Ties;
+        }
+    }
+
+    private static DateTimeOffset? ParseStartDate(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        return DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed)
+            ? parsed
+            : null;
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
@@ -240,6 +240,13 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
     {
         _logger.LogInformation("Processing child documents for Competition. CompetitionId={CompId}, IsNew={IsNew}", competition.Id, isNew);
 
+        // Sport-specific inline-data extraction (e.g. MLB series state). Runs
+        // before child-doc spawning so series writes share the tail
+        // SaveChangesAsync transaction with the competition update and any
+        // outbox publishes. Concerns are kept separate from
+        // ProcessSportSpecificChildDocuments, which spawns child documents.
+        await ProcessSportSpecificCompetitionData(command, dto, competition, isNew);
+
         if (isNew || ShouldSpawn(DocumentType.EventCompetitionOdds, command))
             await PublishChildDocumentRequest(command, dto.Odds, competition.Id, DocumentType.EventCompetitionOdds);
 
@@ -278,6 +285,19 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
     }
 
     protected virtual Task ProcessSportSpecificChildDocuments(
+        ProcessDocumentCommand command,
+        EspnEventCompetitionDtoBase dto,
+        CompetitionBase competition,
+        bool isNew) => Task.CompletedTask;
+
+    /// <summary>
+    /// Sport-specific inline-data extraction hook. Override to read fields
+    /// that ESPN ships inline on the competition payload (no separate $ref)
+    /// and persist them as canonical state. Examples: MLB series, future
+    /// NBA/NHL series state. Called before child-document spawning so any
+    /// writes share the tail SaveChangesAsync transaction.
+    /// </summary>
+    protected virtual Task ProcessSportSpecificCompetitionData(
         ProcessDocumentCommand command,
         EspnEventCompetitionDtoBase dto,
         CompetitionBase competition,

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
@@ -32,6 +32,14 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
 
         public DbSet<AthleteSeasonHotZoneEntry> AthleteSeasonHotZoneEntries { get; set; }
 
+        public DbSet<Series> Series { get; set; }
+
+        public DbSet<SeriesCompetitor> SeriesCompetitors { get; set; }
+
+        public DbSet<SeasonSeries> SeasonSeries { get; set; }
+
+        public DbSet<SeasonSeriesCompetitor> SeasonSeriesCompetitors { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -45,6 +53,10 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatusFeaturedAthlete.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeasonHotZone.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeasonHotZoneEntry.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new Series.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new SeriesCompetitor.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new SeasonSeries.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new SeasonSeriesCompetitor.EntityConfiguration());
         }
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetition.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetition.cs
@@ -14,6 +14,17 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
         // without an OfType cast.
         public BaseballCompetitionStatus? Status { get; set; }
 
+        // Series links populated by BaseballEventCompetitionDocumentProcessor
+        // when ESPN's competition payload carries inline series data.
+        // Both nullable: historical games predate this work, and ESPN
+        // omits series for postponed/preseason competitions.
+        // See docs/mlb-series-ingestion-plan.md.
+        public Guid? CurrentSeriesId { get; set; }
+        public Series? CurrentSeries { get; set; }
+
+        public Guid? SeasonSeriesId { get; set; }
+        public SeasonSeries? SeasonSeries { get; set; }
+
         public new class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetition>
         {
             public void Configure(EntityTypeBuilder<BaseballCompetition> builder)
@@ -32,6 +43,16 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
                     .WithOne()
                     .HasForeignKey<BaseballCompetitionStatus>(x => x.CompetitionId)
                     .OnDelete(DeleteBehavior.Cascade);
+
+                builder.HasOne(x => x.CurrentSeries)
+                    .WithMany(x => x.Competitions)
+                    .HasForeignKey(x => x.CurrentSeriesId)
+                    .OnDelete(DeleteBehavior.SetNull);
+
+                builder.HasOne(x => x.SeasonSeries)
+                    .WithMany(x => x.Competitions)
+                    .HasForeignKey(x => x.SeasonSeriesId)
+                    .OnDelete(DeleteBehavior.SetNull);
             }
         }
     }

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/SeasonSeries.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/SeasonSeries.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+
+// MLB "season series" — the season-long head-to-head between two
+// teams. ESPN ships this inline alongside the current series but
+// gives it no $ref / id of its own. We synthesize a deterministic
+// identity from (SeasonYear, sorted FranchiseSeasonId pair) via
+// DeterministicGuid.Combine so concurrent processing of multiple
+// competitions between the same two teams converges on the same row.
+//
+// FranchiseSeasonALowId / BHighId are sorted by Guid value so the
+// pair is canonical regardless of which team is home/away on any
+// given competition.
+//
+// See docs/mlb-series-ingestion-plan.md.
+public class SeasonSeries : CanonicalEntityBase<Guid>
+{
+    public int SeasonYear { get; set; }
+
+    public Guid FranchiseSeasonALowId { get; set; }
+    public FranchiseSeason FranchiseSeasonALow { get; set; } = default!;
+
+    public Guid FranchiseSeasonBHighId { get; set; }
+    public FranchiseSeason FranchiseSeasonBHigh { get; set; } = default!;
+
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public string? Summary { get; set; }
+
+    public bool Completed { get; set; }
+    public int TotalCompetitions { get; set; }
+
+    public DateTimeOffset? StartDate { get; set; }
+
+    public ICollection<SeasonSeriesCompetitor> Competitors { get; set; } = [];
+    public ICollection<BaseballCompetition> Competitions { get; set; } = [];
+
+    public class EntityConfiguration : IEntityTypeConfiguration<SeasonSeries>
+    {
+        public void Configure(EntityTypeBuilder<SeasonSeries> builder)
+        {
+            builder.ToTable(nameof(SeasonSeries));
+            builder.HasKey(x => x.Id);
+
+            builder.HasIndex(x => new { x.SeasonYear, x.FranchiseSeasonALowId, x.FranchiseSeasonBHighId })
+                .IsUnique();
+
+            builder.Property(x => x.Title).HasMaxLength(100);
+            builder.Property(x => x.Description).HasMaxLength(250);
+            builder.Property(x => x.Summary).HasMaxLength(250);
+
+            builder.HasOne(x => x.FranchiseSeasonALow)
+                .WithMany()
+                .HasForeignKey(x => x.FranchiseSeasonALowId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(x => x.FranchiseSeasonBHigh)
+                .WithMany()
+                .HasForeignKey(x => x.FranchiseSeasonBHighId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasMany(x => x.Competitors)
+                .WithOne(x => x.SeasonSeries)
+                .HasForeignKey(x => x.SeasonSeriesId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/SeasonSeriesCompetitor.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/SeasonSeriesCompetitor.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+
+public class SeasonSeriesCompetitor : CanonicalEntityBase<Guid>
+{
+    public Guid SeasonSeriesId { get; set; }
+    public SeasonSeries SeasonSeries { get; set; } = default!;
+
+    public Guid FranchiseSeasonId { get; set; }
+    public FranchiseSeason FranchiseSeason { get; set; } = default!;
+
+    public int Wins { get; set; }
+    public int Ties { get; set; }
+
+    public class EntityConfiguration : IEntityTypeConfiguration<SeasonSeriesCompetitor>
+    {
+        public void Configure(EntityTypeBuilder<SeasonSeriesCompetitor> builder)
+        {
+            builder.ToTable(nameof(SeasonSeriesCompetitor));
+            builder.HasKey(x => x.Id);
+
+            builder.HasIndex(x => new { x.SeasonSeriesId, x.FranchiseSeasonId }).IsUnique();
+
+            builder.HasOne(x => x.FranchiseSeason)
+                .WithMany()
+                .HasForeignKey(x => x.FranchiseSeasonId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // SeasonSeries → Competitors relationship configured on SeasonSeries side.
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/Series.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/Series.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+
+// MLB "current series" — the active multi-game set between two teams.
+// Identity is a deterministic Guid derived from the ESPN seriesId so
+// concurrent processing of multiple competitions in the same series
+// converges on the same row. EspnSeriesId is preserved as a column
+// for traceability; no separate *ExternalId table because there's
+// only ever one provider for this data today.
+//
+// See docs/mlb-series-ingestion-plan.md.
+public class Series : CanonicalEntityBase<Guid>
+{
+    public string EspnSeriesId { get; set; } = default!;
+
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public string? Summary { get; set; }
+
+    public bool Completed { get; set; }
+    public int TotalCompetitions { get; set; }
+
+    public DateTimeOffset? StartDate { get; set; }
+
+    public ICollection<SeriesCompetitor> Competitors { get; set; } = [];
+    public ICollection<BaseballCompetition> Competitions { get; set; } = [];
+
+    public class EntityConfiguration : IEntityTypeConfiguration<Series>
+    {
+        public void Configure(EntityTypeBuilder<Series> builder)
+        {
+            builder.ToTable(nameof(Series));
+            builder.HasKey(x => x.Id);
+
+            builder.Property(x => x.EspnSeriesId).HasMaxLength(50).IsRequired();
+            builder.HasIndex(x => x.EspnSeriesId).IsUnique();
+
+            builder.Property(x => x.Title).HasMaxLength(100);
+            builder.Property(x => x.Description).HasMaxLength(250);
+            builder.Property(x => x.Summary).HasMaxLength(250);
+
+            builder.HasMany(x => x.Competitors)
+                .WithOne(x => x.Series)
+                .HasForeignKey(x => x.SeriesId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // BaseballCompetition.CurrentSeriesId nullable FK is configured
+            // on the BaseballCompetition side.
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/SeriesCompetitor.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/SeriesCompetitor.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+
+// Per-team participation in a Series. Wins/Ties carry the running
+// counters from ESPN's series.competitors[] array.
+public class SeriesCompetitor : CanonicalEntityBase<Guid>
+{
+    public Guid SeriesId { get; set; }
+    public Series Series { get; set; } = default!;
+
+    public Guid FranchiseSeasonId { get; set; }
+    public FranchiseSeason FranchiseSeason { get; set; } = default!;
+
+    public int Wins { get; set; }
+    public int Ties { get; set; }
+
+    public class EntityConfiguration : IEntityTypeConfiguration<SeriesCompetitor>
+    {
+        public void Configure(EntityTypeBuilder<SeriesCompetitor> builder)
+        {
+            builder.ToTable(nameof(SeriesCompetitor));
+            builder.HasKey(x => x.Id);
+
+            builder.HasIndex(x => new { x.SeriesId, x.FranchiseSeasonId }).IsUnique();
+
+            builder.HasOne(x => x.FranchiseSeason)
+                .WithMany()
+                .HasForeignKey(x => x.FranchiseSeasonId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // Series → Competitors relationship configured on Series side.
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/20260507145154_AddSeriesAndSeasonSeries.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260507145154_AddSeriesAndSeasonSeries.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260507145154_AddSeriesAndSeasonSeries")]
+    partial class AddSeriesAndSeasonSeries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260507145154_AddSeriesAndSeasonSeries.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260507145154_AddSeriesAndSeasonSeries.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class AddSeriesAndSeasonSeries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CurrentSeriesId",
+                table: "Competition",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "SeasonSeriesId",
+                table: "Competition",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "SeasonSeries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SeasonYear = table.Column<int>(type: "integer", nullable: false),
+                    FranchiseSeasonALowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FranchiseSeasonBHighId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Description = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: true),
+                    Summary = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: true),
+                    Completed = table.Column<bool>(type: "boolean", nullable: false),
+                    TotalCompetitions = table.Column<int>(type: "integer", nullable: false),
+                    StartDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeasonSeries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeasonSeries_FranchiseSeason_FranchiseSeasonALowId",
+                        column: x => x.FranchiseSeasonALowId,
+                        principalTable: "FranchiseSeason",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_SeasonSeries_FranchiseSeason_FranchiseSeasonBHighId",
+                        column: x => x.FranchiseSeasonBHighId,
+                        principalTable: "FranchiseSeason",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Series",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    EspnSeriesId = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Title = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Description = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: true),
+                    Summary = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: true),
+                    Completed = table.Column<bool>(type: "boolean", nullable: false),
+                    TotalCompetitions = table.Column<int>(type: "integer", nullable: false),
+                    StartDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Series", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SeasonSeriesCompetitor",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SeasonSeriesId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FranchiseSeasonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Wins = table.Column<int>(type: "integer", nullable: false),
+                    Ties = table.Column<int>(type: "integer", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeasonSeriesCompetitor", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeasonSeriesCompetitor_FranchiseSeason_FranchiseSeasonId",
+                        column: x => x.FranchiseSeasonId,
+                        principalTable: "FranchiseSeason",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_SeasonSeriesCompetitor_SeasonSeries_SeasonSeriesId",
+                        column: x => x.SeasonSeriesId,
+                        principalTable: "SeasonSeries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SeriesCompetitor",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SeriesId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FranchiseSeasonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Wins = table.Column<int>(type: "integer", nullable: false),
+                    Ties = table.Column<int>(type: "integer", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeriesCompetitor", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeriesCompetitor_FranchiseSeason_FranchiseSeasonId",
+                        column: x => x.FranchiseSeasonId,
+                        principalTable: "FranchiseSeason",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_SeriesCompetitor_Series_SeriesId",
+                        column: x => x.SeriesId,
+                        principalTable: "Series",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Competition_CurrentSeriesId",
+                table: "Competition",
+                column: "CurrentSeriesId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Competition_SeasonSeriesId",
+                table: "Competition",
+                column: "SeasonSeriesId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonSeries_FranchiseSeasonALowId",
+                table: "SeasonSeries",
+                column: "FranchiseSeasonALowId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonSeries_FranchiseSeasonBHighId",
+                table: "SeasonSeries",
+                column: "FranchiseSeasonBHighId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonSeries_SeasonYear_FranchiseSeasonALowId_FranchiseSeas~",
+                table: "SeasonSeries",
+                columns: new[] { "SeasonYear", "FranchiseSeasonALowId", "FranchiseSeasonBHighId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonSeriesCompetitor_FranchiseSeasonId",
+                table: "SeasonSeriesCompetitor",
+                column: "FranchiseSeasonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonSeriesCompetitor_SeasonSeriesId_FranchiseSeasonId",
+                table: "SeasonSeriesCompetitor",
+                columns: new[] { "SeasonSeriesId", "FranchiseSeasonId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Series_EspnSeriesId",
+                table: "Series",
+                column: "EspnSeriesId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeriesCompetitor_FranchiseSeasonId",
+                table: "SeriesCompetitor",
+                column: "FranchiseSeasonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeriesCompetitor_SeriesId_FranchiseSeasonId",
+                table: "SeriesCompetitor",
+                columns: new[] { "SeriesId", "FranchiseSeasonId" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Competition_SeasonSeries_SeasonSeriesId",
+                table: "Competition",
+                column: "SeasonSeriesId",
+                principalTable: "SeasonSeries",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Competition_Series_CurrentSeriesId",
+                table: "Competition",
+                column: "CurrentSeriesId",
+                principalTable: "Series",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Competition_SeasonSeries_SeasonSeriesId",
+                table: "Competition");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Competition_Series_CurrentSeriesId",
+                table: "Competition");
+
+            migrationBuilder.DropTable(
+                name: "SeasonSeriesCompetitor");
+
+            migrationBuilder.DropTable(
+                name: "SeriesCompetitor");
+
+            migrationBuilder.DropTable(
+                name: "SeasonSeries");
+
+            migrationBuilder.DropTable(
+                name: "Series");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Competition_CurrentSeriesId",
+                table: "Competition");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Competition_SeasonSeriesId",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "CurrentSeriesId",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "SeasonSeriesId",
+                table: "Competition");
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorSeriesTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorSeriesTests.cs
@@ -6,6 +6,8 @@ using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
@@ -45,6 +47,7 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
         "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/5?lang=en&region=us");
     private static readonly Uri Team7Ref = new(
         "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/7?lang=en&region=us");
+    private static readonly DateTime FixedNow = new(2026, 5, 4, 12, 0, 0, DateTimeKind.Utc);
 
     public BaseballEventCompetitionDocumentProcessorSeriesTests()
     {
@@ -53,6 +56,10 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
                 .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
                 .Options);
         Mocker.Use(_baseballDataContext);
+
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use(dateTimeProvider.Object);
     }
 
     [Fact]
@@ -104,7 +111,7 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
             Value = "401814844",
             SourceUrl = competitionRef.AbsoluteUri,
             SourceUrlHash = competitionUrlHash,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         });
         await _baseballDataContext.SaveChangesAsync();
@@ -188,7 +195,7 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
             Value = "401814844",
             SourceUrl = competitionRef.AbsoluteUri,
             SourceUrlHash = competitionUrlHash,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         });
         await _baseballDataContext.SaveChangesAsync();
@@ -218,6 +225,77 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
         (await _baseballDataContext.SeasonSeriesCompetitors.CountAsync()).Should().Be(2);
     }
 
+    [Fact]
+    public async Task WhenSeriesArrayMissing_ClearsStaleSeriesFKs()
+    {
+        // arrange — seed a competition that already has both FKs populated,
+        // then re-process with a payload whose Series array is empty.
+        var idGen = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(idGen);
+
+        var competitionRef = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844?lang=en&region=us");
+        var competitionUrlHash = HashProvider.GenerateHashFromUri(competitionRef);
+        var competitionId = idGen.Generate(competitionRef).CanonicalId;
+
+        var contestId = await SeedContestAndCompetition(competitionId);
+        await SeedFranchiseSeasons();
+
+        // Seed pre-existing FK state on the competition.
+        var staleSeriesId = Guid.NewGuid();
+        var staleSeasonSeriesId = Guid.NewGuid();
+        var seeded = await _baseballDataContext.Competitions
+            .OfType<BaseballCompetition>()
+            .FirstAsync(x => x.Id == competitionId);
+        seeded.CurrentSeriesId = staleSeriesId;
+        seeded.SeasonSeriesId = staleSeasonSeriesId;
+        await _baseballDataContext.SaveChangesAsync();
+
+        _baseballDataContext.Set<CompetitionExternalId>().Add(new CompetitionExternalId
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            Provider = SourceDataProvider.Espn,
+            Value = "401814844",
+            SourceUrl = competitionRef.AbsoluteUri,
+            SourceUrlHash = competitionUrlHash,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await _baseballDataContext.SaveChangesAsync();
+
+        // Load the real fixture and rewrite "series" to an empty array.
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
+        var dto = json.FromJson<EspnBaseballEventCompetitionDto>()!;
+        dto.Series = new List<EspnBaseballSeriesDto>();
+        dto.SeriesId = null;
+        var emptySeriesJson = dto.ToJson();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>();
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, contestId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetition)
+            .With(x => x.Document, emptySeriesJson)
+            .With(x => x.UrlHash, competitionUrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>?)null)
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — both FKs cleared
+        var refreshed = await _baseballDataContext.Competitions
+            .OfType<BaseballCompetition>()
+            .FirstAsync(x => x.Id == competitionId);
+        refreshed.CurrentSeriesId.Should().BeNull();
+        refreshed.SeasonSeriesId.Should().BeNull();
+    }
+
     private async Task<Guid> SeedContestAndCompetition(Guid competitionId)
     {
         var contestId = Guid.NewGuid();
@@ -229,10 +307,10 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
             ShortName = "Test",
             SeasonYear = 2026,
             Sport = Sport.BaseballMlb,
-            StartDateUtc = DateTime.UtcNow,
+            StartDateUtc = FixedNow,
             HomeTeamFranchiseSeasonId = Guid.NewGuid(),
             AwayTeamFranchiseSeasonId = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         };
 
@@ -240,8 +318,8 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
         {
             Id = competitionId,
             ContestId = contestId,
-            Date = DateTime.UtcNow,
-            CreatedUtc = DateTime.UtcNow,
+            Date = FixedNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         };
 
@@ -269,7 +347,7 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
             Location = "Test City",
             Abbreviation = "T5",
             ColorCodeHex = "#000000",
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid(),
             ExternalIds =
             [
@@ -281,7 +359,7 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
                     Value = "5",
                     SourceUrl = Team5Ref.AbsoluteUri,
                     SourceUrlHash = HashProvider.GenerateHashFromUri(Team5Ref),
-                    CreatedUtc = DateTime.UtcNow,
+                    CreatedUtc = FixedNow,
                     CreatedBy = Guid.NewGuid()
                 }
             ]
@@ -299,7 +377,7 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
             Location = "Test City",
             Abbreviation = "T7",
             ColorCodeHex = "#000000",
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid(),
             ExternalIds =
             [
@@ -311,7 +389,7 @@ public class BaseballEventCompetitionDocumentProcessorSeriesTests
                     Value = "7",
                     SourceUrl = Team7Ref.AbsoluteUri,
                     SourceUrlHash = HashProvider.GenerateHashFromUri(Team7Ref),
-                    CreatedUtc = DateTime.UtcNow,
+                    CreatedUtc = FixedNow,
                     CreatedBy = Guid.NewGuid()
                 }
             ]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorSeriesTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorSeriesTests.cs
@@ -1,0 +1,325 @@
+#nullable enable
+
+using AutoFixture;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
+
+/// <summary>
+/// Tests for the inline series ingestion in
+/// <see cref="BaseballEventCompetitionDocumentProcessor{TDataContext}.ProcessSportSpecificCompetitionData"/>.
+///
+/// ESPN's MLB EventCompetition payload carries series state inline (no
+/// separate $ref). The processor extracts it and persists Series +
+/// SeasonSeries (with their respective Competitor join rows), and links
+/// the competition via CurrentSeriesId / SeasonSeriesId. Unknown series
+/// types (e.g. "preseason" in the EventCompetition.json fixture) are
+/// logged and skipped.
+///
+/// See docs/mlb-series-ingestion-plan.md.
+/// </summary>
+[Collection("Sequential")]
+public class BaseballEventCompetitionDocumentProcessorSeriesTests
+    : ProducerTestBase<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>
+{
+    private readonly BaseballDataContext _baseballDataContext;
+
+    private static readonly Uri Team5Ref = new(
+        "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/5?lang=en&region=us");
+    private static readonly Uri Team7Ref = new(
+        "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/7?lang=en&region=us");
+
+    public BaseballEventCompetitionDocumentProcessorSeriesTests()
+    {
+        _baseballDataContext = new BaseballDataContext(
+            new DbContextOptionsBuilder<BaseballDataContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+                .Options);
+        Mocker.Use(_baseballDataContext);
+    }
+
+    [Fact]
+    public async Task DTO_Deserializes_Series_Fields_From_Fixture()
+    {
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
+
+        var dto = json.FromJson<EspnBaseballEventCompetitionDto>();
+
+        dto.Should().NotBeNull();
+        dto!.SeriesId.Should().Be("600055560");
+        dto.Series.Should().HaveCount(3);
+        dto.Series![0].Type.Should().Be("current");
+        dto.Series[0].Summary.Should().Be("Series tied 1-1");
+        dto.Series[0].TotalCompetitions.Should().Be(3);
+        dto.Series[0].Competitors.Should().HaveCount(2);
+        dto.Series[1].Type.Should().Be("preseason");
+        dto.Series[2].Type.Should().Be("season");
+        dto.Series[2].TotalCompetitions.Should().Be(13);
+    }
+
+    [Fact]
+    public async Task WhenSeriesPayloadProcessed_PersistsCurrent_SeasonSeries_AndLinksCompetition()
+    {
+        // arrange
+        var idGen = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(idGen);
+
+        var competitionRef = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844?lang=en&region=us");
+        var competitionUrlHash = HashProvider.GenerateHashFromUri(competitionRef);
+        // Seed the competition with the canonical Id derived from the URL,
+        // matching what AsBaseballEntity produces during the update path.
+        var competitionId = idGen.Generate(competitionRef).CanonicalId;
+
+        var contestId = await SeedContestAndCompetition(competitionId);
+        var (fs5Id, fs7Id) = await SeedFranchiseSeasons();
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>();
+
+        // Seed the existing competition's external id so the processor takes the update path.
+        _baseballDataContext.Set<CompetitionExternalId>().Add(new CompetitionExternalId
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            Provider = SourceDataProvider.Espn,
+            Value = "401814844",
+            SourceUrl = competitionRef.AbsoluteUri,
+            SourceUrlHash = competitionUrlHash,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await _baseballDataContext.SaveChangesAsync();
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, contestId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetition)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, competitionUrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>?)null)
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — Series row created + linked
+        var seriesRows = await _baseballDataContext.Series
+            .Include(x => x.Competitors)
+            .ToListAsync();
+        seriesRows.Should().ContainSingle();
+        var series = seriesRows[0];
+        series.EspnSeriesId.Should().Be("600055560");
+        series.Summary.Should().Be("Series tied 1-1");
+        series.TotalCompetitions.Should().Be(3);
+        series.Competitors.Should().HaveCount(2);
+        series.Competitors.Should().Contain(c => c.FranchiseSeasonId == fs5Id && c.Wins == 1);
+        series.Competitors.Should().Contain(c => c.FranchiseSeasonId == fs7Id && c.Wins == 1);
+
+        // SeasonSeries row created with sorted-pair identity
+        var seasonRows = await _baseballDataContext.SeasonSeries
+            .Include(x => x.Competitors)
+            .ToListAsync();
+        seasonRows.Should().ContainSingle();
+        var seasonSeries = seasonRows[0];
+        seasonSeries.SeasonYear.Should().Be(2026);
+        seasonSeries.TotalCompetitions.Should().Be(13);
+        var sortedLow = fs5Id.CompareTo(fs7Id) < 0 ? fs5Id : fs7Id;
+        var sortedHigh = fs5Id.CompareTo(fs7Id) < 0 ? fs7Id : fs5Id;
+        seasonSeries.FranchiseSeasonALowId.Should().Be(sortedLow);
+        seasonSeries.FranchiseSeasonBHighId.Should().Be(sortedHigh);
+        seasonSeries.Competitors.Should().HaveCount(2);
+
+        // Competition FK columns set
+        var refreshed = await _baseballDataContext.Competitions
+            .OfType<BaseballCompetition>()
+            .FirstAsync(x => x.Id == competitionId);
+        refreshed.CurrentSeriesId.Should().Be(series.Id);
+        refreshed.SeasonSeriesId.Should().Be(seasonSeries.Id);
+
+        // "preseason" entry hits the unrecognized branch and is skipped — no third row.
+        seriesRows.Should().HaveCount(1);
+        seasonRows.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task WhenReprocessed_DoesNotDuplicateRows_AndUpdatesCounters()
+    {
+        // arrange — process once, then process again with the same payload.
+        var idGen = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(idGen);
+
+        var competitionRef = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844?lang=en&region=us");
+        var competitionUrlHash = HashProvider.GenerateHashFromUri(competitionRef);
+        var competitionId = idGen.Generate(competitionRef).CanonicalId;
+
+        var contestId = await SeedContestAndCompetition(competitionId);
+        await SeedFranchiseSeasons();
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
+
+        _baseballDataContext.Set<CompetitionExternalId>().Add(new CompetitionExternalId
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            Provider = SourceDataProvider.Espn,
+            Value = "401814844",
+            SourceUrl = competitionRef.AbsoluteUri,
+            SourceUrlHash = competitionUrlHash,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await _baseballDataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>();
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, contestId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetition)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, competitionUrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>?)null)
+            .OmitAutoProperties()
+            .Create();
+
+        // act — process twice
+        await sut.ProcessAsync(cmd);
+        await sut.ProcessAsync(cmd);
+
+        // assert — exactly one row of each, counters intact
+        (await _baseballDataContext.Series.CountAsync()).Should().Be(1);
+        (await _baseballDataContext.SeriesCompetitors.CountAsync()).Should().Be(2);
+        (await _baseballDataContext.SeasonSeries.CountAsync()).Should().Be(1);
+        (await _baseballDataContext.SeasonSeriesCompetitors.CountAsync()).Should().Be(2);
+    }
+
+    private async Task<Guid> SeedContestAndCompetition(Guid competitionId)
+    {
+        var contestId = Guid.NewGuid();
+
+        var contest = new BaseballContest
+        {
+            Id = contestId,
+            Name = "Test Contest",
+            ShortName = "Test",
+            SeasonYear = 2026,
+            Sport = Sport.BaseballMlb,
+            StartDateUtc = DateTime.UtcNow,
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        var competition = new BaseballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Date = DateTime.UtcNow,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        await _baseballDataContext.Contests.AddAsync(contest);
+        await _baseballDataContext.Competitions.AddAsync(competition);
+        await _baseballDataContext.SaveChangesAsync();
+
+        return contestId;
+    }
+
+    private async Task<(Guid fs5Id, Guid fs7Id)> SeedFranchiseSeasons()
+    {
+        var fs5Id = Guid.NewGuid();
+        var fs7Id = Guid.NewGuid();
+
+        var fs5 = new FranchiseSeason
+        {
+            Id = fs5Id,
+            FranchiseId = Guid.NewGuid(),
+            SeasonYear = 2026,
+            DisplayName = "Team 5",
+            DisplayNameShort = "T5",
+            Name = "Team 5",
+            Slug = "team-5",
+            Location = "Test City",
+            Abbreviation = "T5",
+            ColorCodeHex = "#000000",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds =
+            [
+                new FranchiseSeasonExternalId
+                {
+                    Id = Guid.NewGuid(),
+                    FranchiseSeasonId = fs5Id,
+                    Provider = SourceDataProvider.Espn,
+                    Value = "5",
+                    SourceUrl = Team5Ref.AbsoluteUri,
+                    SourceUrlHash = HashProvider.GenerateHashFromUri(Team5Ref),
+                    CreatedUtc = DateTime.UtcNow,
+                    CreatedBy = Guid.NewGuid()
+                }
+            ]
+        };
+
+        var fs7 = new FranchiseSeason
+        {
+            Id = fs7Id,
+            FranchiseId = Guid.NewGuid(),
+            SeasonYear = 2026,
+            DisplayName = "Team 7",
+            DisplayNameShort = "T7",
+            Name = "Team 7",
+            Slug = "team-7",
+            Location = "Test City",
+            Abbreviation = "T7",
+            ColorCodeHex = "#000000",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds =
+            [
+                new FranchiseSeasonExternalId
+                {
+                    Id = Guid.NewGuid(),
+                    FranchiseSeasonId = fs7Id,
+                    Provider = SourceDataProvider.Espn,
+                    Value = "7",
+                    SourceUrl = Team7Ref.AbsoluteUri,
+                    SourceUrlHash = HashProvider.GenerateHashFromUri(Team7Ref),
+                    CreatedUtc = DateTime.UtcNow,
+                    CreatedBy = Guid.NewGuid()
+                }
+            ]
+        };
+
+        await _baseballDataContext.FranchiseSeasons.AddRangeAsync(fs5, fs7);
+        await _baseballDataContext.SaveChangesAsync();
+
+        return (fs5Id, fs7Id);
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/Event.json
+++ b/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/Event.json
@@ -1,781 +1,455 @@
 {
-    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844?lang=en&region=us",
-    "id": "401814844",
-    "uid": "s:1~l:10~e:401814844",
-    "date": "2026-04-07T17:10Z",
-    "name": "Kansas City Royals at Cleveland Guardians",
-    "shortName": "KC @ CLE",
-    "season": {
-        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026?lang=en&region=us"
-    },
-    "seasonType": {
-        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2?lang=en&region=us"
-    },
-    "week": {
-        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/weeks/14?lang=en&region=us"
-    },
-    "timeValid": true,
-    "competitions": [
+  "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224?lang=en&region=us",
+  "id": "401815224",
+  "uid": "s:1~l:10~e:401815224",
+  "date": "2026-05-06T00:40Z",
+  "name": "New York Mets at Colorado Rockies",
+  "shortName": "NYM @ COL",
+  "season": {
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026?lang=en&region=us"
+  },
+  "seasonType": {
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2?lang=en&region=us"
+  },
+  "week": {
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/weeks/18?lang=en&region=us"
+  },
+  "timeValid": true,
+  "competitions": [
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224?lang=en&region=us",
+      "id": "401815224",
+      "guid": "141f54c1-696a-3bc6-8e90-72ae4dd2ef10",
+      "uid": "s:1~l:10~e:401815224~c:401815224",
+      "date": "2026-05-06T00:40Z",
+      "timeOfDay": "NIGHT",
+      "attendance": 0,
+      "type": {
+        "id": "1",
+        "text": "Standard",
+        "abbreviation": "STD",
+        "slug": "standard",
+        "type": "standard"
+      },
+      "necessary": true,
+      "timeValid": true,
+      "neutralSite": false,
+      "divisionCompetition": false,
+      "conferenceCompetition": false,
+      "previewAvailable": false,
+      "recapAvailable": false,
+      "boxscoreAvailable": false,
+      "lineupAvailable": false,
+      "gamecastAvailable": false,
+      "playByPlayAvailable": false,
+      "conversationAvailable": true,
+      "commentaryAvailable": false,
+      "pickcenterAvailable": true,
+      "summaryAvailable": true,
+      "liveAvailable": false,
+      "ticketsAvailable": false,
+      "shotChartAvailable": false,
+      "timeoutsAvailable": false,
+      "possessionArrowAvailable": false,
+      "onWatchESPN": false,
+      "recent": false,
+      "wasSuspended": false,
+      "bracketAvailable": false,
+      "wallclockAvailable": false,
+      "highlightsAvailable": true,
+      "gameSource": {
+        "id": "1",
+        "description": "basic/manual",
+        "state": "basic"
+      },
+      "boxscoreSource": {
+        "id": "0",
+        "description": "none",
+        "state": "none"
+      },
+      "playByPlaySource": {
+        "id": "0",
+        "description": "none",
+        "state": "none"
+      },
+      "linescoreSource": {
+        "id": "1",
+        "description": "basic/manual",
+        "state": "basic"
+      },
+      "statsSource": {
+        "id": "0",
+        "description": "none",
+        "state": "none"
+      },
+      "venue": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/venues/27?lang=en&region=us",
+        "id": "27",
+        "fullName": "Coors Field",
+        "shortName": "Coors Field",
+        "address": {
+          "city": "Denver",
+          "state": "Colorado",
+          "zipCode": "80205"
+        },
+        "grass": true,
+        "indoor": false,
+        "images": [
+          {
+            "href": "https://a.espncdn.com/i/venues/mlb/day/27.jpg",
+            "width": 2000,
+            "height": 1125,
+            "alt": "",
+            "rel": [
+              "full",
+              "day"
+            ]
+          }
+        ]
+      },
+      "competitors": [
         {
-            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844?lang=en&region=us",
-            "id": "401814844",
-            "guid": "d64f19ff-a625-366e-a683-cf5f30d3f686",
-            "uid": "s:1~l:10~e:401814844~c:401814844",
-            "date": "2026-04-07T17:10Z",
-            "timeOfDay": "DAY",
-            "attendance": 10328,
-            "type": {
-                "id": "1",
-                "text": "Standard",
-                "abbreviation": "STD",
-                "slug": "standard",
-                "type": "standard"
-            },
-            "duration": {
-                "displayValue": "2:42"
-            },
-            "necessary": true,
-            "timeValid": true,
-            "neutralSite": false,
-            "divisionCompetition": false,
-            "conferenceCompetition": false,
-            "previewAvailable": false,
-            "recapAvailable": true,
-            "boxscoreAvailable": true,
-            "lineupAvailable": false,
-            "gamecastAvailable": true,
-            "playByPlayAvailable": true,
-            "conversationAvailable": true,
-            "commentaryAvailable": false,
-            "pickcenterAvailable": true,
-            "summaryAvailable": true,
-            "liveAvailable": false,
-            "ticketsAvailable": false,
-            "shotChartAvailable": false,
-            "timeoutsAvailable": false,
-            "possessionArrowAvailable": false,
-            "onWatchESPN": false,
-            "recent": false,
-            "wasSuspended": false,
-            "bracketAvailable": false,
-            "wallclockAvailable": true,
-            "highlightsAvailable": true,
-            "gameSource": {
-                "id": "2",
-                "description": "feed",
-                "state": "full"
-            },
-            "boxscoreSource": {
-                "id": "2",
-                "description": "feed",
-                "state": "full"
-            },
-            "playByPlaySource": {
-                "id": "2",
-                "description": "feed",
-                "state": "full"
-            },
-            "linescoreSource": {
-                "id": "2",
-                "description": "feed",
-                "state": "full"
-            },
-            "statsSource": {
-                "id": "2",
-                "description": "feed",
-                "state": "full"
-            },
-            "venue": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/venues/5?lang=en&region=us",
-                "id": "5",
-                "fullName": "Progressive Field",
-                "shortName": "Progressive Field",
-                "address": {
-                    "city": "Cleveland",
-                    "state": "Ohio",
-                    "zipCode": "44115"
-                },
-                "grass": true,
-                "indoor": false,
-                "images": [
-                    {
-                        "href": "https://a.espncdn.com/i/venues/mlb/day/5.jpg",
-                        "width": 2000,
-                        "height": 1125,
-                        "alt": "",
-                        "rel": [
-                            "full",
-                            "day"
-                        ]
-                    }
-                ]
-            },
-            "competitors": [
-                {
-                    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5?lang=en&region=us",
-                    "id": "5",
-                    "uid": "s:1~l:10~t:5",
-                    "type": "team",
-                    "order": 0,
-                    "homeAway": "home",
-                    "winner": true,
-                    "team": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/5?lang=en&region=us"
-                    },
-                    "score": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/score?lang=en&region=us"
-                    },
-                    "linescores": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/linescores?lang=en&region=us"
-                    },
-                    "roster": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/roster?lang=en&region=us"
-                    },
-                    "statistics": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/statistics?lang=en&region=us"
-                    },
-                    "leaders": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/leaders?lang=en&region=us"
-                    },
-                    "record": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/5/records?lang=en&region=us"
-                    },
-                    "probables": [
-                        {
-                            "name": "probableStartingPitcher",
-                            "displayName": "Probable Starting Pitcher",
-                            "shortDisplayName": "Starter",
-                            "abbreviation": "SP",
-                            "playerId": 4345076,
-                            "athlete": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4345076?lang=en&region=us"
-                            },
-                            "statistics": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/athletes/4345076/statistics/0?lang=en&region=us"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7?lang=en&region=us",
-                    "id": "7",
-                    "uid": "s:1~l:10~t:7",
-                    "type": "team",
-                    "order": 1,
-                    "homeAway": "away",
-                    "winner": false,
-                    "team": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/7?lang=en&region=us"
-                    },
-                    "score": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7/score?lang=en&region=us"
-                    },
-                    "linescores": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7/linescores?lang=en&region=us"
-                    },
-                    "roster": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7/roster?lang=en&region=us"
-                    },
-                    "statistics": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7/statistics?lang=en&region=us"
-                    },
-                    "leaders": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7/leaders?lang=en&region=us"
-                    },
-                    "record": {
-                        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/competitors/7/records?lang=en&region=us"
-                    },
-                    "probables": [
-                        {
-                            "name": "probableStartingPitcher",
-                            "displayName": "Probable Starting Pitcher",
-                            "shortDisplayName": "Starter",
-                            "abbreviation": "SP",
-                            "playerId": 4417208,
-                            "athlete": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4417208?lang=en&region=us"
-                            },
-                            "statistics": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/athletes/4417208/statistics/0?lang=en&region=us"
-                            }
-                        }
-                    ]
-                }
-            ],
-            "notes": [],
-            "situation": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/situation?lang=en&region=us"
-            },
-            "status": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/status?lang=en&region=us"
-            },
-            "odds": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/odds?lang=en&region=us"
-            },
-            "broadcasts": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/broadcasts?lang=en&region=us"
-            },
-            "seriesId": "600055560",
-            "series": [
-                {
-                    "type": "current",
-                    "title": "Current Series",
-                    "description": "Current Series",
-                    "summary": "Series tied 1-1",
-                    "completed": false,
-                    "totalCompetitions": 3,
-                    "competitors": [
-                        {
-                            "id": "5",
-                            "uid": "s:1~l:10~t:5",
-                            "wins": 1,
-                            "ties": 0,
-                            "team": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/5?lang=en&region=us"
-                            }
-                        },
-                        {
-                            "id": "7",
-                            "uid": "s:1~l:10~t:7",
-                            "wins": 1,
-                            "ties": 0,
-                            "team": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/7?lang=en&region=us"
-                            }
-                        }
-                    ],
-                    "events": [
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814829?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814859?lang=en&region=us"
-                        }
-                    ],
-                    "startDate": "2026-04-06T04:00Z"
-                },
-                {
-                    "type": "preseason",
-                    "title": "Preseason Series",
-                    "description": "Preseason Series",
-                    "summary": "CLE wins series 2-0",
-                    "completed": true,
-                    "totalCompetitions": 2,
-                    "competitors": [
-                        {
-                            "id": "5",
-                            "uid": "s:1~l:10~t:5",
-                            "wins": 2,
-                            "ties": 0,
-                            "team": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/5?lang=en&region=us"
-                            }
-                        },
-                        {
-                            "id": "7",
-                            "uid": "s:1~l:10~t:7",
-                            "wins": 0,
-                            "ties": 0,
-                            "team": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/7?lang=en&region=us"
-                            }
-                        }
-                    ],
-                    "events": [
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401833126?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401833264?lang=en&region=us"
-                        }
-                    ],
-                    "startDate": "2026-03-09T20:05Z"
-                },
-                {
-                    "type": "season",
-                    "title": "Regular Season Series",
-                    "description": "Regular Season Series",
-                    "summary": "Series tied 1-1",
-                    "completed": false,
-                    "totalCompetitions": 13,
-                    "competitors": [
-                        {
-                            "id": "5",
-                            "uid": "s:1~l:10~t:5",
-                            "wins": 1,
-                            "ties": 0,
-                            "team": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/5?lang=en&region=us"
-                            }
-                        },
-                        {
-                            "id": "7",
-                            "uid": "s:1~l:10~t:7",
-                            "wins": 1,
-                            "ties": 0,
-                            "team": {
-                                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/7?lang=en&region=us"
-                            }
-                        }
-                    ],
-                    "events": [
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814829?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814859?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815207?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815221?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815236?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815250?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816705?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816720?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816735?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401817079?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401817094?lang=en&region=us"
-                        },
-                        {
-                            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401817109?lang=en&region=us"
-                        }
-                    ],
-                    "startDate": "2026-04-06T22:10Z"
-                }
-            ],
-            "officials": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/officials?lang=en&region=us"
-            },
-            "details": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/plays?lang=en&region=us"
-            },
-            "leaders": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/leaders?lang=en&region=us"
-            },
-            "links": [
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "summary",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/game/_/gameId/401814844/royals-guardians",
-                    "text": "Gamecast",
-                    "shortText": "Summary",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "summary",
-                        "sportscenter",
-                        "app",
-                        "event"
-                    ],
-                    "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401814844",
-                    "text": "Gamecast",
-                    "shortText": "Summary",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "now",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/game/_/gameId/401814844",
-                    "text": "Now",
-                    "shortText": "Now",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "teamstats",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/matchup?gameId=401814844",
-                    "text": "Team Stats",
-                    "shortText": "Team Stats",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "boxscore",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/boxscore/_/gameId/401814844",
-                    "text": "Box Score",
-                    "shortText": "Box Score",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "boxscore",
-                        "sportscenter",
-                        "app",
-                        "event"
-                    ],
-                    "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401814844",
-                    "text": "Box Score",
-                    "shortText": "Box Score",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "gamecast",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/game/_/gameId/401814844",
-                    "text": "Gamecast",
-                    "shortText": "Gamecast",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "gamecast",
-                        "mobile",
-                        "event"
-                    ],
-                    "href": "http://m.espn.com/mlb/gamecast?gameId=401814844&action=summary",
-                    "text": "Gamecast",
-                    "shortText": "Gamecast",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "gamecast",
-                        "sportscenter",
-                        "app",
-                        "event"
-                    ],
-                    "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401814844",
-                    "text": "Gamecast",
-                    "shortText": "Gamecast",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "recap",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/recap?gameId=401814844",
-                    "text": "Recap",
-                    "shortText": "Recap",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "pbp",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/playbyplay/_/gameId/401814844",
-                    "text": "Play-by-Play",
-                    "shortText": "Play-by-Play",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "videos",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/video?gameId=401814844",
-                    "text": "Videos",
-                    "shortText": "Videos",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "odds",
-                        "desktop",
-                        "event"
-                    ],
-                    "href": "https://www.espn.com/mlb/odds/_/gameId/401814844",
-                    "text": "Odds",
-                    "shortText": "Odds",
-                    "isExternal": false,
-                    "isPremium": false
-                },
-                {
-                    "language": "en-US",
-                    "rel": [
-                        "odds",
-                        "mobile",
-                        "event"
-                    ],
-                    "href": "https://m.espn.com/mlb/odds/_/gameId/401814844",
-                    "text": "Odds",
-                    "shortText": "Odds",
-                    "isExternal": false,
-                    "isPremium": false
-                }
-            ],
-            "predictor": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/predictor?lang=en&region=us"
-            },
-            "probabilities": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/probabilities?lang=en&region=us"
-            },
-            "dataFormat": "API",
-            "powerIndexes": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/powerindex?lang=en&region=us"
-            },
-            "format": {
-                "regulation": {
-                    "periods": 9,
-                    "displayName": "Inning",
-                    "slug": "inning"
-                }
-            },
-            "relevancy": {
-                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/relevancy?lang=en&region=us"
+          "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/competitors/27?lang=en&region=us",
+          "id": "27",
+          "uid": "s:1~l:10~t:27",
+          "type": "team",
+          "order": 0,
+          "homeAway": "home",
+          "team": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/27?lang=en&region=us"
+          },
+          "score": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/competitors/27/score?lang=en&region=us"
+          },
+          "record": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/teams/27/record?lang=en&region=us"
+          },
+          "probables": [
+            {
+              "name": "probableStartingPitcher",
+              "displayName": "Probable Starting Pitcher",
+              "shortDisplayName": "Starter",
+              "abbreviation": "SP",
+              "playerId": 33252,
+              "athlete": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/33252?lang=en&region=us"
+              },
+              "statistics": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/athletes/33252/statistics/0?lang=en&region=us"
+              }
             }
+          ]
+        },
+        {
+          "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/competitors/21?lang=en&region=us",
+          "id": "21",
+          "uid": "s:1~l:10~t:21",
+          "type": "team",
+          "order": 1,
+          "homeAway": "away",
+          "team": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/21?lang=en&region=us"
+          },
+          "score": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/competitors/21/score?lang=en&region=us"
+          },
+          "record": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/teams/21/record?lang=en&region=us"
+          },
+          "probables": [
+            {
+              "name": "probableStartingPitcher",
+              "displayName": "Probable Starting Pitcher",
+              "shortDisplayName": "Starter",
+              "abbreviation": "SP",
+              "playerId": 39825,
+              "athlete": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/39825?lang=en&region=us"
+              },
+              "statistics": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/athletes/39825/statistics/0?lang=en&region=us"
+              }
+            }
+          ]
         }
-    ],
-    "links": [
+      ],
+      "notes": [
         {
-            "language": "en-US",
-            "rel": [
-                "summary",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/game/_/gameId/401814844/royals-guardians",
-            "text": "Gamecast",
-            "shortText": "Summary",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "summary",
-                "sportscenter",
-                "app",
-                "event"
-            ],
-            "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401814844",
-            "text": "Gamecast",
-            "shortText": "Summary",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "now",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/game/_/gameId/401814844",
-            "text": "Now",
-            "shortText": "Now",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "teamstats",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/matchup?gameId=401814844",
-            "text": "Team Stats",
-            "shortText": "Team Stats",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "boxscore",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/boxscore/_/gameId/401814844",
-            "text": "Box Score",
-            "shortText": "Box Score",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "boxscore",
-                "sportscenter",
-                "app",
-                "event"
-            ],
-            "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401814844",
-            "text": "Box Score",
-            "shortText": "Box Score",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "gamecast",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/game/_/gameId/401814844",
-            "text": "Gamecast",
-            "shortText": "Gamecast",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "gamecast",
-                "mobile",
-                "event"
-            ],
-            "href": "http://m.espn.com/mlb/gamecast?gameId=401814844&action=summary",
-            "text": "Gamecast",
-            "shortText": "Gamecast",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "gamecast",
-                "sportscenter",
-                "app",
-                "event"
-            ],
-            "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401814844",
-            "text": "Gamecast",
-            "shortText": "Gamecast",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "recap",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/recap?gameId=401814844",
-            "text": "Recap",
-            "shortText": "Recap",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "pbp",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/playbyplay/_/gameId/401814844",
-            "text": "Play-by-Play",
-            "shortText": "Play-by-Play",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "videos",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/video?gameId=401814844",
-            "text": "Videos",
-            "shortText": "Videos",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "odds",
-                "desktop",
-                "event"
-            ],
-            "href": "https://www.espn.com/mlb/odds/_/gameId/401814844",
-            "text": "Odds",
-            "shortText": "Odds",
-            "isExternal": false,
-            "isPremium": false
-        },
-        {
-            "language": "en-US",
-            "rel": [
-                "odds",
-                "mobile",
-                "event"
-            ],
-            "href": "https://m.espn.com/mlb/odds/_/gameId/401814844",
-            "text": "Odds",
-            "shortText": "Odds",
-            "isExternal": false,
-            "isPremium": false
+          "type": "event",
+          "headline": "Inclement Weather - Makeup date May 7"
         }
-    ],
-    "venues": [
+      ],
+      "status": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/status?lang=en&region=us"
+      },
+      "odds": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/odds?lang=en&region=us"
+      },
+      "broadcasts": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/broadcasts?lang=en&region=us"
+      },
+      "seriesId": "600056136",
+      "series": [
         {
-            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/venues/5?lang=en&region=us"
+          "type": "current",
+          "title": "Current Series",
+          "description": "Current Series",
+          "summary": "NYM lead series 1-0",
+          "completed": false,
+          "totalCompetitions": 3,
+          "competitors": [
+            {
+              "id": "27",
+              "uid": "s:1~l:10~t:27",
+              "wins": 0,
+              "ties": 0,
+              "team": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/27?lang=en&region=us"
+              }
+            },
+            {
+              "id": "21",
+              "uid": "s:1~l:10~t:21",
+              "wins": 1,
+              "ties": 0,
+              "team": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/21?lang=en&region=us"
+              }
+            }
+          ],
+          "events": [
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815210?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815239?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401871498?lang=en&region=us"
+            }
+          ],
+          "startDate": "2026-05-04T04:00Z"
+        },
+        {
+          "type": "season",
+          "title": "Regular Season Series",
+          "description": "Regular Season Series",
+          "summary": "COL leads series 3-1",
+          "completed": false,
+          "totalCompetitions": 6,
+          "competitors": [
+            {
+              "id": "27",
+              "uid": "s:1~l:10~t:27",
+              "wins": 3,
+              "ties": 0,
+              "team": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/27?lang=en&region=us"
+              }
+            },
+            {
+              "id": "21",
+              "uid": "s:1~l:10~t:21",
+              "wins": 1,
+              "ties": 0,
+              "team": {
+                "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/21?lang=en&region=us"
+              }
+            }
+          ],
+          "events": [
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815067?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815082?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815097?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401870380?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815210?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815239?lang=en&region=us"
+            },
+            {
+              "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401871498?lang=en&region=us"
+            }
+          ],
+          "startDate": "2026-04-24T23:10Z"
         }
-    ],
-    "league": {
-        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb?lang=en&region=us"
+      ],
+      "links": [
+        {
+          "language": "en-US",
+          "rel": [
+            "summary",
+            "desktop",
+            "event"
+          ],
+          "href": "https://www.espn.com/mlb/game/_/gameId/401815224/mets-rockies",
+          "text": "Gamecast",
+          "shortText": "Summary",
+          "isExternal": false,
+          "isPremium": false
+        },
+        {
+          "language": "en-US",
+          "rel": [
+            "summary",
+            "sportscenter",
+            "app",
+            "event"
+          ],
+          "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401815224",
+          "text": "Gamecast",
+          "shortText": "Summary",
+          "isExternal": false,
+          "isPremium": false
+        },
+        {
+          "language": "en-US",
+          "rel": [
+            "now",
+            "desktop",
+            "event"
+          ],
+          "href": "https://www.espn.com/mlb/game/_/gameId/401815224",
+          "text": "Now",
+          "shortText": "Now",
+          "isExternal": false,
+          "isPremium": false
+        },
+        {
+          "language": "en-US",
+          "rel": [
+            "odds",
+            "desktop",
+            "event"
+          ],
+          "href": "https://www.espn.com/mlb/odds/_/gameId/401815224",
+          "text": "Odds",
+          "shortText": "Odds",
+          "isExternal": false,
+          "isPremium": false
+        },
+        {
+          "language": "en-US",
+          "rel": [
+            "odds",
+            "mobile",
+            "event"
+          ],
+          "href": "https://m.espn.com/mlb/odds/_/gameId/401815224",
+          "text": "Odds",
+          "shortText": "Odds",
+          "isExternal": false,
+          "isPremium": false
+        }
+      ],
+      "predictor": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/predictor?lang=en&region=us"
+      },
+      "dataFormat": "API",
+      "powerIndexes": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/powerindex?lang=en&region=us"
+      },
+      "format": {
+        "regulation": {
+          "periods": 9,
+          "displayName": "Inning",
+          "slug": "inning"
+        }
+      },
+      "relevancy": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815224/competitions/401815224/relevancy?lang=en&region=us"
+      }
     }
+  ],
+  "links": [
+    {
+      "language": "en-US",
+      "rel": [
+        "summary",
+        "desktop",
+        "event"
+      ],
+      "href": "https://www.espn.com/mlb/game/_/gameId/401815224/mets-rockies",
+      "text": "Gamecast",
+      "shortText": "Summary",
+      "isExternal": false,
+      "isPremium": false
+    },
+    {
+      "language": "en-US",
+      "rel": [
+        "summary",
+        "sportscenter",
+        "app",
+        "event"
+      ],
+      "href": "sportscenter://x-callback-url/showGame?sportName=baseball&leagueAbbrev=mlb&gameId=401815224",
+      "text": "Gamecast",
+      "shortText": "Summary",
+      "isExternal": false,
+      "isPremium": false
+    },
+    {
+      "language": "en-US",
+      "rel": [
+        "now",
+        "desktop",
+        "event"
+      ],
+      "href": "https://www.espn.com/mlb/game/_/gameId/401815224",
+      "text": "Now",
+      "shortText": "Now",
+      "isExternal": false,
+      "isPremium": false
+    },
+    {
+      "language": "en-US",
+      "rel": [
+        "odds",
+        "desktop",
+        "event"
+      ],
+      "href": "https://www.espn.com/mlb/odds/_/gameId/401815224",
+      "text": "Odds",
+      "shortText": "Odds",
+      "isExternal": false,
+      "isPremium": false
+    },
+    {
+      "language": "en-US",
+      "rel": [
+        "odds",
+        "mobile",
+        "event"
+      ],
+      "href": "https://m.espn.com/mlb/odds/_/gameId/401815224",
+      "text": "Odds",
+      "shortText": "Odds",
+      "isExternal": false,
+      "isPremium": false
+    }
+  ],
+  "venues": [
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/venues/27?lang=en&region=us"
+    }
+  ],
+  "league": {
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb?lang=en&region=us"
+  }
 }


### PR DESCRIPTION
## Summary

ESPN's MLB EventCompetition payload now ships current-series and season-series state inline (no `\$ref`). This PR captures both as canonical entities and links them on `BaseballCompetition`. Design lives at `docs/mlb-series-ingestion-plan.md` (committed in this PR).

**Decisions locked in the doc:**
- **Inline extraction**, no new `DocumentType`. Read site is `BaseballEventCompetitionDocumentProcessor` — the standalone EventCompetition payload also carries series, so a single read site covers both Event-cascade and direct-EventCompetition refresh paths.
- **Persist both flavors.** Current-series identity hashes ESPN's `seriesId` via `DeterministicGuid`. Season-series identity synthesizes from `(SeasonYear, sorted FranchiseSeasonId pair)` — no ESPN id but treated as canonical data.
- **MLB-only entities** in `Baseball/Entities/`. No interface, no `*Base` parent. Class names unprefixed since the namespace conveys scope; rename later if NBA/NHL forces a shared abstraction.

**Changes:**
- `Series` + `SeriesCompetitor` + `SeasonSeries` + `SeasonSeriesCompetitor` entities under `Infrastructure/Data/Baseball/Entities/`.
- `BaseballCompetition` gets nullable `CurrentSeriesId` / `SeasonSeriesId` FKs.
- New virtual `ProcessSportSpecificCompetitionData` hook on `EventCompetitionDocumentProcessorBase`, defaulted no-op. Called from `ProcessChildDocuments` before child-doc spawning so writes share the tail `SaveChangesAsync` transaction. Distinct from the existing `ProcessSportSpecificChildDocuments` hook (which handles spawning).
- `BaseballEventCompetitionDocumentProcessor` overrides the hook, iterating the inline series array. `type=current` and `type=season` handled; unknown types (e.g. `preseason` in the `EventCompetition.json` fixture) logged at Information and skipped.
- EF migration: 4 new tables + 2 nullable FK columns on `Competition`.
- Unit tests against existing `EventCompetition.json` fixture covering DTO deserialization, full upsert + FK linkage, and idempotency.

## Test plan

- [x] \`dotnet build\` SportsData.Producer — clean
- [x] \`dotnet test\` SportsData.Producer.Tests.Unit — 368 passed, 18 skipped, 0 failed
- [x] EF migration applied locally against \`sdProducer.BaseballMlb\`; E2E run confirmed series rows persisted and \`Competition\` FKs set correctly
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented ingestion and persistence of MLB series data from ESPN feeds, including current series and season series with competitor information, wins/ties statistics, and automatic linking to baseball competitions.

* **Documentation**
  * Added planning documentation outlining the MLB series data modeling approach and implementation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->