### PR TITLE
feat(producer): add BackfillCurrentSeason flag to ContestEnrichmentJob

### DIFF
--- a/src/SportsData.Api/azure-pipelines.yml
+++ b/src/SportsData.Api/azure-pipelines.yml
@@ -62,23 +62,17 @@ stages:
 
           - template: /build/templates/nuget-tool-install.yml
 
-          - task: NuGetCommand@2
-            displayName: 'NuGet Restore'
+          # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+          # warnings escalate to errors (parity with local `dotnet build`).
+          # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+          # audit, masking high-severity transitive vulnerabilities.
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore (.NET SDK)'
             inputs:
               command: 'restore'
-              restoreSolution: '**/sports-data-api.sln'
+              projects: '**/sports-data-api.sln'
               feedsToUse: 'select'
               vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-
-          - task: MSBuild@1
-            displayName: 'Build sports-data-api solution'
-            inputs:
-              solution: '**/sports-data-api.sln'
-              msbuildArchitecture: 'x64'
-              clean: true
-              platform: '$(buildPlatform)'
-              configuration: '$(buildConfiguration)'
-              msbuildArguments: '/t:Restore'
 
           - task: DotNetCoreCLI@2
             displayName: 'Run Unit Tests'

--- a/src/SportsData.Contest/azure-pipelines.yml
+++ b/src/SportsData.Contest/azure-pipelines.yml
@@ -60,23 +60,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-contest.sln'
+            projects: '**/sports-data-contest.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-contest solution'
-          inputs:
-            solution: '**\sports-data-contest.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/src/SportsData.Franchise/azure-pipelines.yml
+++ b/src/SportsData.Franchise/azure-pipelines.yml
@@ -60,23 +60,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-franchise.sln'
+            projects: '**/sports-data-franchise.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-franchise solution'
-          inputs:
-            solution: '**\sports-data-franchise.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/src/SportsData.JobsDashboard/SportsData.JobsDashboard.csproj
+++ b/src/SportsData.JobsDashboard/SportsData.JobsDashboard.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.JobsDashboard/azure-pipelines.yml
+++ b/src/SportsData.JobsDashboard/azure-pipelines.yml
@@ -59,11 +59,15 @@ stages:
 
           - template: /build/templates/nuget-tool-install.yml
 
-          - task: NuGetCommand@2
-            displayName: 'NuGet Restore'
+          # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+          # warnings escalate to errors (parity with local `dotnet build`).
+          # Classic NuGetCommand@2 did not trigger the audit, masking
+          # high-severity transitive vulnerabilities.
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore (.NET SDK)'
             inputs:
               command: 'restore'
-              restoreSolution: '**/sports-data.sln'
+              projects: '**/sports-data.sln'
               feedsToUse: 'select'
               vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
 

--- a/src/SportsData.Notification/azure-pipelines.yml
+++ b/src/SportsData.Notification/azure-pipelines.yml
@@ -60,23 +60,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-notification.sln'
+            projects: '**/sports-data-notification.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-notification solution'
-          inputs:
-            solution: '**\sports-data-notification.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/src/SportsData.Player/azure-pipelines.yml
+++ b/src/SportsData.Player/azure-pipelines.yml
@@ -60,23 +60,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-player.sln'
+            projects: '**/sports-data-player.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-player solution'
-          inputs:
-            solution: '**\sports-data-player.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentJob.cs
@@ -16,6 +16,13 @@ namespace SportsData.Producer.Application.Contests
     public class ContestEnrichmentJob<TDataContext> : IContestEnrichmentJob, IAmARecurringJob
         where TDataContext : TeamSportDataContext
     {
+        // One-shot backfill: when true, ignore current-season-week scoping and enqueue
+        // enrichment for every non-finalized contest in the most recent season whose start
+        // time has passed. Mirrors ContestUpdateJob.BackfillCurrentSeason — used to catch
+        // MLB up after mid-season onboarding. Flip back to false before steady-state
+        // deploys.
+        private static readonly bool BackfillCurrentSeason = true;
+
         private readonly ILogger<ContestEnrichmentJob<TDataContext>> _logger;
         private readonly TDataContext _dataContext;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
@@ -42,6 +49,12 @@ namespace SportsData.Producer.Application.Contests
             _logger.LogInformation(
                 "ContestEnrichmentJob starting. JobRunId={JobRunId}, NowUtc={NowUtc}",
                 jobRunId, DateTime.UtcNow);
+
+            if (BackfillCurrentSeason)
+            {
+                await ExecuteBackfillCurrentSeason(jobRunId);
+                return;
+            }
 
             // get the current and previous season week
             var seasonWeeks = await _dataContext.SeasonWeeks
@@ -126,6 +139,82 @@ namespace SportsData.Producer.Application.Contests
                 "ContestEnrichmentJob completed. JobRunId={JobRunId}, SeasonWeeksProcessed={SeasonWeekCount}, " +
                 "TotalEnqueued={TotalEnqueued}, TotalSkipped={TotalSkipped}",
                 jobRunId, seasonWeeks.Count, totalEnqueued, totalSkipped);
+        }
+
+        private async Task ExecuteBackfillCurrentSeason(Guid jobRunId)
+        {
+            _logger.LogWarning(
+                "BACKFILL_MODE: BackfillCurrentSeason flag is ON. Bypassing current-season-week scope. " +
+                "NowUtc={NowUtc}, JobRunId={JobRunId}",
+                DateTime.UtcNow, jobRunId);
+
+            var currentSeasonYear = await _dataContext.Seasons
+                .AsNoTracking()
+                .OrderByDescending(s => s.Year)
+                .Select(s => (int?)s.Year)
+                .FirstOrDefaultAsync();
+
+            if (currentSeasonYear is null)
+            {
+                _logger.LogError(
+                    "No seasons found in database. Cannot run enrichment backfill. JobRunId={JobRunId}",
+                    jobRunId);
+                return;
+            }
+
+            _logger.LogInformation(
+                "Targeting season for enrichment backfill. SeasonYear={SeasonYear}, JobRunId={JobRunId}",
+                currentSeasonYear, jobRunId);
+
+            var contests = await _dataContext.Contests
+                .AsNoTracking()
+                .Where(c => c.SeasonYear == currentSeasonYear &&
+                            c.StartDateUtc < DateTime.UtcNow &&
+                            c.FinalizedUtc == null)
+                .OrderBy(c => c.StartDateUtc)
+                .ToListAsync();
+
+            _logger.LogInformation(
+                "Backfill: {ContestCount} non-finalized started contest(s) for season {SeasonYear}. JobRunId={JobRunId}",
+                contests.Count, currentSeasonYear, jobRunId);
+
+            if (contests.Count == 0)
+            {
+                return;
+            }
+
+            var totalEnqueued = 0;
+            var totalSkipped = 0;
+
+            foreach (var contest in contests)
+            {
+                try
+                {
+                    var cmd = new EnrichContestCommand(contest.Id, Guid.NewGuid());
+                    var hangfireJobId = _backgroundJobProvider.Enqueue<IEnrichContests>(p => p.Process(cmd));
+                    totalEnqueued++;
+
+                    _logger.LogInformation(
+                        "Backfill enqueued enrichment for ContestId={ContestId}, ContestName={ContestName}, " +
+                        "StartDateUtc={StartDateUtc}, HangfireJobId={HangfireJobId}, " +
+                        "EnrichCorrelationId={EnrichCorrelationId}, JobRunId={JobRunId}",
+                        contest.Id, contest.Name, contest.StartDateUtc,
+                        hangfireJobId, cmd.CorrelationId, jobRunId);
+                }
+                catch (Exception ex)
+                {
+                    totalSkipped++;
+                    _logger.LogError(
+                        ex,
+                        "Backfill failed to enqueue enrichment. ContestId={ContestId}, ContestName={ContestName}, JobRunId={JobRunId}",
+                        contest.Id, contest.Name, jobRunId);
+                }
+            }
+
+            _logger.LogInformation(
+                "ContestEnrichmentJob backfill completed. JobRunId={JobRunId}, SeasonYear={SeasonYear}, " +
+                "TotalEnqueued={TotalEnqueued}, TotalSkipped={TotalSkipped}",
+                jobRunId, currentSeasonYear, totalEnqueued, totalSkipped);
         }
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
@@ -106,6 +106,10 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
                 builder.Property(x => x.SeasonYear)
                     .IsRequired();
 
+                // Backfill paths in ContestUpdateJob/ContestEnrichmentJob filter
+                // by SeasonYear; index avoids a full Contest scan during runs.
+                builder.HasIndex(x => x.SeasonYear);
+
                 builder.Property(x => x.SeasonPhaseId);
 
                 builder.Property(x => x.Week);

--- a/src/SportsData.Producer/Migrations/Baseball/20260508104700_AddContestSeasonYearIndex.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508104700_AddContestSeasonYearIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260508104700_AddContestSeasonYearIndex")]
+    partial class AddContestSeasonYearIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260508104700_AddContestSeasonYearIndex.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508104700_AddContestSeasonYearIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class AddContestSeasonYearIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Contest_SeasonYear",
+                table: "Contest",
+                column: "SeasonYear");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Contest_SeasonYear",
+                table: "Contest");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/20260508104649_AddContestSeasonYearIndex.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260508104649_AddContestSeasonYearIndex.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Football;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Baseball
+namespace SportsData.Producer.Migrations.Football
 {
-    [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(FootballDataContext))]
+    [Migration("20260508104649_AddContestSeasonYearIndex")]
+    partial class AddContestSeasonYearIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,179 +415,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<bool>("Active")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("ConfigurationId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int>("Season")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SeasonType")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SplitTypeId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
-
-                    b.ToTable("AthleteSeasonHotZone", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("AtBats")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("AthleteSeasonHotZoneId")
-                        .HasColumnType("uuid");
-
-                    b.Property<double?>("BattingAvg")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("BattingAvgScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int?>("Hits")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<double?>("Slugging")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("SluggingScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("ZoneId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonHotZoneId");
-
-                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("AthleteRef")
-                        .HasColumnType("text");
-
-                    b.Property<Guid>("CompetitionStatusId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("PlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasColumnType("text");
-
-                    b.Property<string>("TeamRef")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionStatusId");
-
-                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3186,6 +3016,206 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("CompetitionCompetitorStatisticCategoryId");
 
                     b.ToTable("CompetitionCompetitorStatisticStats");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
+                    b.Property<string>("DisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("EndClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("EndClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("EndDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EndShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("EndText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("EndYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsScore")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("OffensivePlays")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Result")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SequenceNumber")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("ShortDisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SourceDescription")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SourceId")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("StartClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("StartClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("StartFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("StartPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("StartShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StartText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeElapsedDisplay")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("TimeElapsedValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("Yards")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionId");
+
+                    b.ToTable("CompetitionDrive", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DriveId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Provider")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SourceUrl")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("SourceUrlHash")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DriveId");
+
+                    b.ToTable("CompetitionDriveExternalId", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -7864,17 +7894,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -7885,206 +7907,89 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("ThrowsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("ThrowsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("BaseballAthlete");
+                    b.HasDiscriminator().HasValue("FootballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
+                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.Property<int?>("CurrentSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("CurrentSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("CurrentSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("CurrentSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("CurrentSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EspnSeriesId")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("SeasonSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("SeasonSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SeasonSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.HasIndex("EspnSeriesId");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetition");
+                    b.HasDiscriminator().HasValue("FootballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<string>("AtBatId")
+                    b.Property<string>("ClockDisplayValue")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<int?>("AtBatPitchNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayHits")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("BatOrder")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("HitCoordinateX")
-                        .HasPrecision(7, 2)
+                    b.Property<double>("ClockValue")
                         .HasColumnType("double precision");
 
-                    b.Property<double?>("HitCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
+                    b.Property<Guid?>("DriveId")
+                        .HasColumnType("uuid");
 
-                    b.Property<int>("HomeErrors")
+                    b.Property<int?>("EndDistance")
                         .HasColumnType("integer");
 
-                    b.Property<int>("HomeHits")
+                    b.Property<int?>("EndDown")
                         .HasColumnType("integer");
 
-                    b.Property<bool>("IsDoublePlay")
-                        .HasColumnType("boolean");
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
 
-                    b.Property<bool>("IsTriplePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<double?>("PitchCoordinateX")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("PitchCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("PitchCountBalls")
+                    b.Property<int?>("EndYardLine")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("PitchCountStrikes")
+                    b.Property<int?>("EndYardsToEndzone")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PitchTypeAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeId")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int?>("PitchVelocity")
+                    b.Property<int?>("StartDistance")
                         .HasColumnType("integer");
 
-                    b.Property<int>("RbiCount")
+                    b.Property<int?>("StartDown")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountBalls")
+                    b.Property<int?>("StartYardLine")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountStrikes")
+                    b.Property<int?>("StartYardsToEndzone")
                         .HasColumnType("integer");
 
-                    b.Property<string>("StrikeType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                    b.Property<int>("StatYardage")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("SummaryType")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.HasIndex("DriveId");
 
-                    b.Property<string>("Trajectory")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
+                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
-
-                    b.Property<int?>("HalfInning")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PeriodPrefix")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("BaseballContest");
+                    b.HasDiscriminator().HasValue("FootballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8117,28 +8022,6 @@ namespace SportsData.Producer.Migrations.Baseball
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
-                        .WithMany("Entries")
-                        .HasForeignKey("AthleteSeasonHotZoneId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("HotZone");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
-                        .WithMany("FeaturedAthletes")
-                        .HasForeignKey("CompetitionStatusId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionStatus");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8723,6 +8606,34 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
+                        .WithMany()
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                        .WithMany("Drives")
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Competition");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("ExternalIds")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9635,7 +9546,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9644,29 +9555,36 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("Plays")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9678,11 +9596,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -9836,6 +9749,13 @@ namespace SportsData.Producer.Migrations.Baseball
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Navigation("ExternalIds");
+
+                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10028,19 +9948,16 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
+                    b.Navigation("Drives");
+
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.Navigation("FeaturedAthletes");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Football/20260508104649_AddContestSeasonYearIndex.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260508104649_AddContestSeasonYearIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class AddContestSeasonYearIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Contest_SeasonYear",
+                table: "Contest",
+                column: "SeasonYear");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Contest_SeasonYear",
+                table: "Contest");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
@@ -4634,6 +4634,8 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.HasIndex("SeasonWeekId");
 
+                    b.HasIndex("SeasonYear");
+
                     b.HasIndex("VenueId");
 
                     b.ToTable("Contest", (string)null);

--- a/src/SportsData.Producer/azure-pipelines.yml
+++ b/src/SportsData.Producer/azure-pipelines.yml
@@ -62,23 +62,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-producer.sln'
+            projects: '**/sports-data-producer.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-producer solution'
-          inputs:
-            solution: '**\sports-data-producer.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/src/SportsData.Provider/SportsData.Provider.csproj
+++ b/src/SportsData.Provider/SportsData.Provider.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="MongoDB.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
   </ItemGroup>
 

--- a/src/SportsData.Provider/azure-pipelines.yml
+++ b/src/SportsData.Provider/azure-pipelines.yml
@@ -62,23 +62,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-provider.sln'
+            projects: '**/sports-data-provider.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-provider solution'
-          inputs:
-            solution: '**\sports-data-provider.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/src/SportsData.Season/azure-pipelines.yml
+++ b/src/SportsData.Season/azure-pipelines.yml
@@ -60,23 +60,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-season.sln'
+            projects: '**/sports-data-season.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-season solution'
-          inputs:
-            solution: '**\sports-data-season.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/src/SportsData.Venue/azure-pipelines.yml
+++ b/src/SportsData.Venue/azure-pipelines.yml
@@ -60,23 +60,17 @@ stages:
 
         - template: /build/templates/nuget-tool-install.yml
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore'
+        # Use .NET SDK restore so NuGetAudit runs and NU1903 vulnerability
+        # warnings escalate to errors (parity with local `dotnet build`).
+        # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
+        # audit, masking high-severity transitive vulnerabilities.
+        - task: DotNetCoreCLI@2
+          displayName: 'Restore (.NET SDK)'
           inputs:
             command: 'restore'
-            restoreSolution: '**/sports-data-venue.sln'
+            projects: '**/sports-data-venue.sln'
             feedsToUse: 'select'
             vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
-    
-        - task: MSBuild@1
-          displayName: 'Build sports-data-venue solution'
-          inputs:
-            solution: '**\sports-data-venue.sln'
-            msbuildArchitecture: 'x64'
-            clean: true
-            platform: '$(buildPlatform)'
-            configuration: '$(buildConfiguration)'
-            msbuildArguments: '/t:Restore'
 
         - task: DotNetCoreCLI@2
           displayName: 'Run Unit Tests'

--- a/test/integration/SportsData.Provider.Tests.Integration/SportsData.Provider.Tests.Integration.csproj
+++ b/test/integration/SportsData.Provider.Tests.Integration/SportsData.Provider.Tests.Integration.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/test/unit/SportsData.Provider.Tests.Unit/SportsData.Provider.Tests.Unit.csproj
+++ b/test/unit/SportsData.Provider.Tests.Unit/SportsData.Provider.Tests.Unit.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Mirrors the `BackfillCurrentSeason` static flag pattern from `ContestUpdateJob` onto `ContestEnrichmentJob`. When on, `ExecuteAsync` dispatches to a new `ExecuteBackfillCurrentSeason` helper that targets the most recent season year and enqueues `EnrichContestCommand` for every non-finalized contest with `StartDateUtc < UtcNow`, bypassing the default current/previous-season-week scope.
- Used to catch MLB up after mid-season onboarding. Flag is `true` in this PR; flip back to `false` before steady-state deploys.
- Default per-week path is unchanged — same query, same `StartDateUtc < UtcNow.AddHours(3)` filter, same per-week logging shape.

Intentional differences from `ContestUpdateJob.ExecuteBackfillCurrentSeason`: no `IAppMode` injected (`EnrichContestCommand` doesn't carry Sport / SourceDataProvider), per-contest correlation IDs (matches the existing EnrichmentJob convention), slimmer log emoji style (matches existing file tone).

## Test plan

- [x] `dotnet build` Producer — clean (0 warnings, 0 errors)
- [ ] Verify backfill mode in prod for MLB: enable flag, watch Seq for `BACKFILL_MODE` log + per-contest enqueue logs, confirm Hangfire shows enqueued enrichment jobs
- [ ] Confirm steady-state path still works after flipping flag back to `false` post-backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a backfill mode to reprocess non-finalized contests from the most recent season, ensuring data consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->