### PR TITLE
refactor(producer): split CompetitionCompetitor into base + sport subtypes

### DIFF
--- a/docs/competition-competitor-split.md
+++ b/docs/competition-competitor-split.md
@@ -1,0 +1,194 @@
+# CompetitionCompetitor — sport-specific subtype split
+
+Captured 2026-05-08. Plan to split the shared `CompetitionCompetitor`
+canonical entity into a base + per-sport subclasses, mirroring the
+pattern already used for `CompetitionBase` →
+`BaseballCompetition` / `FootballCompetition`. Scoped to Phase 1 of a
+multi-PR effort; downstream phases noted at the end.
+
+## Why
+
+Two pressure points have arrived at the same time:
+
+1. **`CuratedRankCurrent` is on the shared base** — that column is
+   NCAAFB-specific (poll ranks). It violates the
+   [sport-specific subtype split feedback memory](../memory/feedback_sport_specific_subtype_split.md):
+   "when a sport adds fields to a `*Base`-hanging entity, model a
+   sport-specific subclass; do NOT pile nullable columns on the
+   shared parent."
+2. **MLB's `probables[]`** — ESPN's MLB EventCompetitionCompetitor
+   payload carries a `probables[]` array (probable starting pitcher
+   today; possibly more roles in the future). Football has no
+   equivalent. Adding it to the shared base would compound the smell;
+   adding it to a sport-specific subclass needs that subclass to
+   exist first.
+
+ESPN payload shape comparison (live fixtures in the test data):
+
+| Field | NCAAFB | MLB | Where it should live |
+|---|---|---|---|
+| `id`, `uid`, `type`, `order`, `homeAway` | ✓ | ✓ | base |
+| `team.$ref` (FranchiseSeasonId) | ✓ | ✓ | base |
+| `score.$ref` | ✓ | ✓ | base |
+| `record.$ref` | ✓ | ✓ | base |
+| `winner` | ✓ | (implicit) | base |
+| `statistics.$ref` | ✓ | ✓ | base |
+| `linescores.$ref` | ✓ (quarters) | ✓ (innings) | base |
+| `leaders.$ref` | ✓ | ✓ | not yet ingested either way |
+| `roster.$ref` | ✓ | – | football subtype (not yet ingested) |
+| `ranks.$ref` | ✓ | – | football subtype (not yet ingested) |
+| `curatedRank.current` | ✓ | – | **moves: base → football subtype** |
+| `probables[]` | – | ✓ | **adds: baseball subtype** (Phase 2) |
+
+## What changes (Phase 1 scope)
+
+### Entity model
+
+Rename the existing `CompetitionCompetitor` to `CompetitionCompetitorBase`
+and make it abstract. The DB table name (`CompetitionCompetitor`)
+stays. The renamed type lives in the same path:
+`src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorBase.cs`.
+
+Add two sport-specific subclasses:
+
+- `src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionCompetitor.cs`
+- `src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionCompetitor.cs`
+
+Move `CuratedRankCurrent` off the base, onto
+`FootballCompetitionCompetitor`.
+
+`BaseballCompetitionCompetitor` carries no new columns in Phase 1
+(probables come in Phase 2).
+
+### Context registrations
+
+Each sport context exposes a typed `DbSet` on the concrete subclass:
+
+- `BaseballDataContext.CompetitionCompetitors`: `DbSet<BaseballCompetitionCompetitor>`
+- `FootballDataContext.CompetitionCompetitors`: `DbSet<FootballCompetitionCompetitor>`
+
+The base type is abstract, so EF will use TPH with a `Discriminator`
+column. Each DB is single-sport, so the discriminator is cosmetic —
+every row in Baseball DB has `Discriminator = "BaseballCompetitionCompetitor"`,
+every row in Football DB has `Discriminator = "FootballCompetitionCompetitor"`.
+This matches how `CompetitionBase` was split previously.
+
+### Processor wiring
+
+`EventCompetitionCompetitorDocumentProcessor` currently constructs
+`CompetitionCompetitor` directly. After the split it can't — it would
+have to construct an abstract base. Two options:
+
+1. **Mirror the `EventCompetitionDocumentProcessorBase` pattern**:
+   abstract `CreateEntity(...)` on the base processor, sport-specific
+   subclasses (`BaseballEventCompetitionCompetitorDocumentProcessor`,
+   `FootballEventCompetitionCompetitorDocumentProcessor`) override it.
+2. Keep one processor, dispatch on `Sport` from the command.
+
+Option 1 matches the existing pattern in this codebase and keeps each
+sport's logic isolated. Going with (1).
+
+### Extensions
+
+`CompetitionCompetitorExtensions.cs` has projection helpers that
+reference the canonical type. The shared projections (e.g. mapping
+DTO → canonical entity for the fields on the base) stay; sport-specific
+projections move into per-sport extension classes living in the
+sport entity folders.
+
+### CompetitionBase navigation
+
+`CompetitionBase.Competitors` is currently
+`ICollection<CompetitionCompetitor>`. After the rename it becomes
+`ICollection<CompetitionCompetitorBase>`. Sport-specific code that
+needs to read sport-specific fields (e.g. `CuratedRankCurrent` for
+NCAAFB) does so via `OfType<FootballCompetitionCompetitor>()` or by
+reading from `FootballDataContext.CompetitionCompetitors` directly.
+
+### Children entities
+
+`CompetitionCompetitorStatistic`, `CompetitionCompetitorLineScore`,
+`CompetitionCompetitorScore`, `CompetitionCompetitorRecord`, and
+`CompetitionCompetitorExternalId` all FK to
+`CompetitionCompetitor.Id`. After rename, the FK target is
+`CompetitionCompetitorBase.Id`. EF's TPH stores all subclasses in the
+same table, so the FK relationship doesn't change at the DB level —
+no schema change for the child tables. Child C# code references the
+base type, which is fine since the children don't care about
+sport-specific fields.
+
+## Migration plan
+
+Two migrations, one per sport context.
+
+**Baseball migration:**
+- Add `Discriminator` column (string) to `CompetitionCompetitor`,
+  default value `"BaseballCompetitionCompetitor"`, backfill all
+  existing rows.
+- Drop `CuratedRankCurrent` column (it's NCAAFB-only; Baseball never
+  had meaningful values).
+
+**Football migration:**
+- Add `Discriminator` column (string) to `CompetitionCompetitor`,
+  default value `"FootballCompetitionCompetitor"`, backfill all
+  existing rows.
+- `CuratedRankCurrent` stays — but its conceptual home is now the
+  football subtype. No DDL change for that column.
+
+Per the [test-migrations-locally feedback](../memory/feedback_test_migrations_locally.md),
+both migrations validated against a local prod copy before push.
+
+## Tests
+
+`CompetitionCompetitor` is referenced in:
+- DTO projection / extension tests
+- `EventCompetitionCompetitorDocumentProcessor` unit tests (if any)
+- Any query handler tests in API that read competitors
+
+Mechanical update: change references from `CompetitionCompetitor` to
+`CompetitionCompetitorBase` (or to the concrete sport subclass where
+construction is involved). No new test scenarios in Phase 1 — the
+split is a refactor, not a behavior change.
+
+## Out of scope (deferred phases)
+
+**Phase 2 — MLB Probables ingestion (separate PR):**
+- New entity `CompetitionCompetitorProbable` (Baseball-only):
+  `Name`, `DisplayName`, `ShortDisplayName`, `Abbreviation`,
+  `EspnPlayerId`, `BaseballAthleteId` (FK to BaseballAthlete), audit.
+- 1:N collection on `BaseballCompetitionCompetitor` (today only the SP,
+  but ESPN's array shape suggests room for more roles).
+- Processor extends to read `probables[]`, resolves
+  `athlete.$ref` to `BaseballAthlete.Id`. **Per the established
+  not-sourced pattern, if the athlete cannot be resolved, request
+  athlete sourcing and throw `NotSourcedException` so Hangfire
+  retries — do not persist Probable rows with null athlete FKs.
+  An empty Probable is worthless on the matchup card.**
+
+**Phase 3 — Probable pitcher stats snapshot (separate PR, separate doc):**
+- Pitcher season stats (ERA, WHIP, K/9, etc.) are mutable and drift
+  all season — same time-travel hazard as the
+  [series snapshot redesign](series-snapshot-redesign.md).
+  Matchup cards from May should display May-era ERA, not September-era.
+- Likely shape: snapshot stat columns directly on
+  `CompetitionCompetitorProbable`, locked on first non-null write.
+  Same pattern as series snapshots, just at a different parent.
+- Wider column set than series state (~10+ stat columns) — warrants
+  its own design doc when we get there.
+
+**Phase 4 — UI:**
+- API exposes `Probables` on the matchup payload.
+- MatchupCard component renders the SP per side, with athlete
+  name/photo and stat snapshot teaser.
+
+## Related
+
+- [`docs/series-snapshot-redesign.md`](series-snapshot-redesign.md) —
+  same general shape (sport-specific data on a sport-specific entity,
+  snapshot for time-travel correctness) we'll mirror in Phase 3.
+- [`memory/feedback_sport_specific_subtype_split.md`](../memory/feedback_sport_specific_subtype_split.md) —
+  the guardrail this PR honors.
+- [`memory/feedback_test_migrations_locally.md`](../memory/feedback_test_migrations_locally.md) —
+  applies to both migrations.
+- [`memory/feedback_design_doc_first.md`](../memory/feedback_design_doc_first.md) —
+  why this doc exists.

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
@@ -1,0 +1,38 @@
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
+
+namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+
+[DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionCompetitor)]
+public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> : EventCompetitionCompetitorDocumentProcessorBase<TDataContext>
+    where TDataContext : BaseballDataContext
+{
+    public BaseballEventCompetitionCompetitorDocumentProcessor(
+        ILogger<BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext>> logger,
+        TDataContext dataContext,
+        IEventBus publishEndpoint,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        IGenerateResourceRefs refs)
+        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
+
+    protected override CompetitionCompetitorBase CreateEntity(
+        EspnEventCompetitionCompetitorDto dto,
+        Guid competitionId,
+        Guid franchiseSeasonId,
+        Guid correlationId)
+    {
+        return dto.AsBaseballEntity(
+            competitionId,
+            franchiseSeasonId,
+            _externalRefIdentityGenerator,
+            correlationId);
+    }
+}

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
@@ -11,23 +11,38 @@ using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Exceptions;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
-using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 
-[DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.EventCompetitionCompetitor)]
-[DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNfl, DocumentType.EventCompetitionCompetitor)]
-[DocumentProcessor(SourceDataProvider.Espn, Sport.BaseballMlb, DocumentType.EventCompetitionCompetitor)]
-public class EventCompetitionCompetitorDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
+// Abstract base for the per-sport EventCompetitionCompetitor processors.
+// Shared work — competition existence guard, FranchiseSeason resolve,
+// existing-entity lookup, child-doc spawning, save — lives here. The
+// concrete-entity construction (CompetitionCompetitorBase subclass) is
+// deferred to CreateEntity, overridden by each sport-specific subclass.
+//
+// See docs/competition-competitor-split.md.
+public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {
-    public EventCompetitionCompetitorDocumentProcessor(
-        ILogger<EventCompetitionCompetitorDocumentProcessor<TDataContext>> logger,
+    protected EventCompetitionCompetitorDocumentProcessorBase(
+        ILogger logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,
         IGenerateResourceRefs refs)
         : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
+
+    /// <summary>
+    /// Construct the sport-specific concrete CompetitionCompetitorBase
+    /// subclass from the DTO. Subclasses set their sport-only fields here
+    /// (e.g. FootballCompetitionCompetitor.CuratedRankCurrent) in addition
+    /// to the shared columns.
+    /// </summary>
+    protected abstract CompetitionCompetitorBase CreateEntity(
+        EspnEventCompetitionCompetitorDto dto,
+        Guid competitionId,
+        Guid franchiseSeasonId,
+        Guid correlationId);
 
     protected override async Task ProcessInternal(ProcessDocumentCommand command)
     {
@@ -142,11 +157,7 @@ public class EventCompetitionCompetitorDocumentProcessor<TDataContext> : Documen
             franchiseSeasonId,
             dto.HomeAway);
 
-        var canonicalEntity = dto.AsEntity(
-            competitionId,
-            franchiseSeasonId,
-            _externalRefIdentityGenerator,
-            command.CorrelationId);
+        var canonicalEntity = CreateEntity(dto, competitionId, franchiseSeasonId, command.CorrelationId);
 
         await _dataContext.CompetitionCompetitors.AddAsync(canonicalEntity);
 
@@ -162,7 +173,7 @@ public class EventCompetitionCompetitorDocumentProcessor<TDataContext> : Documen
     private async Task ProcessUpdate(
         ProcessDocumentCommand command,
         EspnEventCompetitionCompetitorDto dto,
-        CompetitionCompetitor entity)
+        CompetitionCompetitorBase entity)
     {
         _logger.LogInformation(
             "🔄 UPDATE_COMPETITOR: Updating existing CompetitionCompetitor. " +

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionCompetitorDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionCompetitorDocumentProcessor.cs
@@ -1,0 +1,39 @@
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
+using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
+
+[DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.EventCompetitionCompetitor)]
+[DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNfl, DocumentType.EventCompetitionCompetitor)]
+public class FootballEventCompetitionCompetitorDocumentProcessor<TDataContext> : EventCompetitionCompetitorDocumentProcessorBase<TDataContext>
+    where TDataContext : FootballDataContext
+{
+    public FootballEventCompetitionCompetitorDocumentProcessor(
+        ILogger<FootballEventCompetitionCompetitorDocumentProcessor<TDataContext>> logger,
+        TDataContext dataContext,
+        IEventBus publishEndpoint,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        IGenerateResourceRefs refs)
+        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
+
+    protected override CompetitionCompetitorBase CreateEntity(
+        EspnEventCompetitionCompetitorDto dto,
+        Guid competitionId,
+        Guid franchiseSeasonId,
+        Guid correlationId)
+    {
+        return dto.AsFootballEntity(
+            competitionId,
+            franchiseSeasonId,
+            _externalRefIdentityGenerator,
+            correlationId);
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
@@ -40,6 +40,7 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
             modelBuilder.ApplyConfiguration(new BaseballAthlete.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeason.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetition.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new BaseballCompetitionCompetitor.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionPlay.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatus.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatusFeaturedAthlete.EntityConfiguration());

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionCompetitor.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionCompetitor.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
+{
+    // MLB-specific competitor row. Carries no extra columns yet; Probables
+    // (probable starting pitcher and similar) land here in Phase 2 of the
+    // competition-competitor split.
+    //
+    // See docs/competition-competitor-split.md.
+    public class BaseballCompetitionCompetitor : CompetitionCompetitorBase
+    {
+        public new class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetitionCompetitor>
+        {
+            public void Configure(EntityTypeBuilder<BaseballCompetitionCompetitor> builder)
+            {
+                // No sport-specific columns yet; the base config (mapped under
+                // CompetitionCompetitorBase.EntityConfiguration) handles the
+                // shared columns and TPH discriminator.
+            }
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Common/TeamSportDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Common/TeamSportDataContext.cs
@@ -54,7 +54,7 @@ namespace SportsData.Producer.Infrastructure.Data.Common
 
         public DbSet<CompetitionBase> Competitions { get; set; }
 
-        public DbSet<CompetitionCompetitor> CompetitionCompetitors { get; set; }
+        public DbSet<CompetitionCompetitorBase> CompetitionCompetitors { get; set; }
 
         public DbSet<CompetitionCompetitorLineScore> CompetitionCompetitorLineScores { get; set; }
 
@@ -187,7 +187,7 @@ namespace SportsData.Producer.Infrastructure.Data.Common
             modelBuilder.ApplyConfiguration(new CompetitionBase.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionExternalId.EntityConfiguration());
 
-            modelBuilder.ApplyConfiguration(new CompetitionCompetitor.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new CompetitionCompetitorBase.EntityConfiguration());
 
             modelBuilder.ApplyConfiguration(new CompetitionCompetitorLineScore.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionCompetitorLineScoreExternalId.EntityConfiguration());

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/AthleteCompetition.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/AthleteCompetition.cs
@@ -17,7 +17,7 @@ public class AthleteCompetition : CanonicalEntityBase<Guid>
 
     public Guid CompetitionCompetitorId { get; set; }
 
-    public CompetitionCompetitor CompetitionCompetitor { get; set; } = null!;
+    public CompetitionCompetitorBase CompetitionCompetitor { get; set; } = null!;
 
     public Guid AthleteSeasonId { get; set; }
 

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionBase.cs
@@ -99,7 +99,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
         public Guid? VenueId { get; set; } // FK to Venue
 
-        public ICollection<CompetitionCompetitor> Competitors { get; set; } = [];
+        public ICollection<CompetitionCompetitorBase> Competitors { get; set; } = [];
 
         public ICollection<CompetitionNote> Notes { get; set; } = [];
 

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorBase.cs
@@ -8,7 +8,15 @@ using SportsData.Producer.Infrastructure.Data.Entities.Contracts;
 
 namespace SportsData.Producer.Infrastructure.Data.Entities;
 
-public class CompetitionCompetitor : CanonicalEntityBase<Guid>, IHasExternalIds
+// Abstract base for the per-team competitor row attached to a Competition.
+// Sport-specific subclasses (BaseballCompetitionCompetitor,
+// FootballCompetitionCompetitor) carry sport-only fields and child collections.
+// Stored under TPH in the existing "CompetitionCompetitor" table; each sport
+// DB only ever stores one concrete type, so the Discriminator column is
+// cosmetic but required by EF.
+//
+// See docs/competition-competitor-split.md.
+public abstract class CompetitionCompetitorBase : CanonicalEntityBase<Guid>, IHasExternalIds
 {
     public required Guid CompetitionId { get; set; }
 
@@ -29,8 +37,6 @@ public class CompetitionCompetitor : CanonicalEntityBase<Guid>, IHasExternalIds
 
     public bool Winner { get; set; }
 
-    public int? CuratedRankCurrent { get; set; }
-
     public ICollection<CompetitionCompetitorStatistic> Statistics { get; set; } = [];
 
     public ICollection<CompetitionCompetitorLineScore> LineScores { get; set; } = [];
@@ -43,11 +49,11 @@ public class CompetitionCompetitor : CanonicalEntityBase<Guid>, IHasExternalIds
 
     public IEnumerable<ExternalId> GetExternalIds() => ExternalIds;
 
-    public class EntityConfiguration : IEntityTypeConfiguration<CompetitionCompetitor>
+    public class EntityConfiguration : IEntityTypeConfiguration<CompetitionCompetitorBase>
     {
-        public void Configure(EntityTypeBuilder<CompetitionCompetitor> builder)
+        public void Configure(EntityTypeBuilder<CompetitionCompetitorBase> builder)
         {
-            builder.ToTable(nameof(CompetitionCompetitor));
+            builder.ToTable("CompetitionCompetitor");
             builder.HasKey(x => x.Id);
 
             builder.Property(x => x.Type)
@@ -57,7 +63,6 @@ public class CompetitionCompetitor : CanonicalEntityBase<Guid>, IHasExternalIds
                 .IsRequired()
                 .HasMaxLength(10);
 
-            builder.Property(x => x.CuratedRankCurrent);
             builder.Property(x => x.Order).IsRequired();
             builder.Property(x => x.Winner).IsRequired();
             builder.Property(x => x.Points);
@@ -89,7 +94,7 @@ public class CompetitionCompetitor : CanonicalEntityBase<Guid>, IHasExternalIds
                 .HasForeignKey(x => x.CompetitionCompetitorId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            // NEW: Children: Statistics
+            // Children: Statistics
             builder.HasMany(x => x.Statistics)
                 .WithOne(x => x.CompetitionCompetitor)
                 .HasForeignKey(x => x.CompetitionCompetitorId)
@@ -121,5 +126,4 @@ public class CompetitionCompetitor : CanonicalEntityBase<Guid>, IHasExternalIds
                    .IsUnique();
         }
     }
-
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorExternalId.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorExternalId.cs
@@ -10,7 +10,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
     {
         public Guid CompetitionCompetitorId { get; set; }
 
-        public CompetitionCompetitor CompetitionCompetitor { get; set; } = null!;
+        public CompetitionCompetitorBase CompetitionCompetitor { get; set; } = null!;
 
         public class EntityConfiguration : IEntityTypeConfiguration<CompetitionCompetitorExternalId>
         {

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorLineScore.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorLineScore.cs
@@ -24,7 +24,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
         public string? SourceState { get; set; }
 
-        public CompetitionCompetitor CompetitionCompetitor { get; set; } = null!;
+        public CompetitionCompetitorBase CompetitionCompetitor { get; set; } = null!;
 
         public ICollection<CompetitionCompetitorLineScoreExternalId> ExternalIds { get; set; } = [];
 

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorRecord.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorRecord.cs
@@ -11,7 +11,7 @@ public class CompetitionCompetitorRecord : CanonicalEntityBase<Guid>
 {
     public required Guid CompetitionCompetitorId { get; set; }
 
-    public CompetitionCompetitor CompetitionCompetitor { get; set; } = null!;
+    public CompetitionCompetitorBase CompetitionCompetitor { get; set; } = null!;
 
     public required string Type { get; set; }
 

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorScore.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorScore.cs
@@ -12,7 +12,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
     {
         public Guid CompetitionCompetitorId { get; set; }
 
-        public CompetitionCompetitor CompetitionCompetitor { get; set; } = null!;
+        public CompetitionCompetitorBase CompetitionCompetitor { get; set; } = null!;
 
         public double Value { get; set; }
 
@@ -56,7 +56,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
                 builder.Property(x => x.CompetitionCompetitorId)
                     .IsRequired();
 
-                builder.HasOne<CompetitionCompetitor>()
+                builder.HasOne<CompetitionCompetitorBase>()
                     .WithMany(x => x.Scores)
                     .HasForeignKey(x => x.CompetitionCompetitorId)
                     .OnDelete(DeleteBehavior.Cascade);

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorStatistic.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorStatistic.cs
@@ -8,7 +8,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
     public class CompetitionCompetitorStatistic : CanonicalEntityBase<Guid>
     {
         public Guid? CompetitionCompetitorId { get; set; }
-        public CompetitionCompetitor? CompetitionCompetitor { get; set; }
+        public CompetitionCompetitorBase? CompetitionCompetitor { get; set; }
 
         public Guid FranchiseSeasonId { get; set; }
         public FranchiseSeason FranchiseSeason { get; set; } = null!;

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionCompetitorExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionCompetitorExtensions.cs
@@ -1,13 +1,18 @@
-﻿using SportsData.Core.Common;
+using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 
+// Sport-specific projections from EspnEventCompetitionCompetitorDto.
+// CuratedRankCurrent is football-only (NCAA poll snapshot); MLB has no
+// analogue. See docs/competition-competitor-split.md.
 public static class CompetitionCompetitorExtensions
 {
-    public static CompetitionCompetitor AsEntity(
+    public static BaseballCompetitionCompetitor AsBaseballEntity(
         this EspnEventCompetitionCompetitorDto dto,
         Guid competitionId,
         Guid franchiseSeasonId,
@@ -16,7 +21,36 @@ public static class CompetitionCompetitorExtensions
     {
         var identity = externalRefIdentityGenerator.Generate(dto.Ref);
 
-        return new CompetitionCompetitor
+        var entity = new BaseballCompetitionCompetitor
+        {
+            Id = identity.CanonicalId,
+            CompetitionId = competitionId,
+            FranchiseSeasonId = franchiseSeasonId,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = correlationId,
+            Type = dto.Type,
+            Order = dto.Order,
+            HomeAway = dto.HomeAway,
+            Winner = dto.Winner,
+            ExternalIds =
+            [
+                BuildExternalId(identity, dto)
+            ]
+        };
+
+        return entity;
+    }
+
+    public static FootballCompetitionCompetitor AsFootballEntity(
+        this EspnEventCompetitionCompetitorDto dto,
+        Guid competitionId,
+        Guid franchiseSeasonId,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        Guid correlationId)
+    {
+        var identity = externalRefIdentityGenerator.Generate(dto.Ref);
+
+        var entity = new FootballCompetitionCompetitor
         {
             Id = identity.CanonicalId,
             CompetitionId = competitionId,
@@ -30,15 +64,24 @@ public static class CompetitionCompetitorExtensions
             CuratedRankCurrent = dto.EspnCuratedRank?.Current,
             ExternalIds =
             [
-                new CompetitionCompetitorExternalId
-                {
-                    Id = Guid.NewGuid(),
-                    Provider = SourceDataProvider.Espn,
-                    Value = identity.UrlHash,
-                    SourceUrl = dto.Ref.ToCleanUrl(),
-                    SourceUrlHash = identity.UrlHash
-                }
+                BuildExternalId(identity, dto)
             ]
+        };
+
+        return entity;
+    }
+
+    private static CompetitionCompetitorExternalId BuildExternalId(
+        ExternalRefIdentity identity,
+        EspnEventCompetitionCompetitorDto dto)
+    {
+        return new CompetitionCompetitorExternalId
+        {
+            Id = Guid.NewGuid(),
+            Provider = SourceDataProvider.Espn,
+            Value = identity.UrlHash,
+            SourceUrl = dto.Ref.ToCleanUrl(),
+            SourceUrlHash = identity.UrlHash
         };
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionCompetitor.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionCompetitor.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Football.Entities
+{
+    // Football (NCAA + NFL) competitor row. Carries CuratedRankCurrent
+    // (NCAA AP/Coaches/CFP rank snapshot at fetch time) — moved off the
+    // shared base because MLB has no analogue.
+    //
+    // See docs/competition-competitor-split.md.
+    public class FootballCompetitionCompetitor : CompetitionCompetitorBase
+    {
+        public int? CuratedRankCurrent { get; set; }
+
+        public new class EntityConfiguration : IEntityTypeConfiguration<FootballCompetitionCompetitor>
+        {
+            public void Configure(EntityTypeBuilder<FootballCompetitionCompetitor> builder)
+            {
+                builder.Property(x => x.CuratedRankCurrent);
+            }
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionCompetitor.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionCompetitor.cs
@@ -18,7 +18,9 @@ namespace SportsData.Producer.Infrastructure.Data.Football.Entities
         {
             public void Configure(EntityTypeBuilder<FootballCompetitionCompetitor> builder)
             {
-                builder.Property(x => x.CuratedRankCurrent);
+                // CuratedRankCurrent (int?) is mapped by convention. No
+                // explicit overrides needed; this method exists as a hook
+                // for future football-only schema constraints.
             }
         }
     }

--- a/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
@@ -40,6 +40,7 @@ namespace SportsData.Producer.Infrastructure.Data.Football
             modelBuilder.ApplyConfiguration(new AthleteBase.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeason.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetition.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new FootballCompetitionCompetitor.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionPlay.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionStatus.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionDrive.EntityConfiguration());

--- a/src/SportsData.Producer/Migrations/Baseball/20260508134122_SplitCompetitionCompetitorBySport.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508134122_SplitCompetitionCompetitorBySport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260508134122_SplitCompetitionCompetitorBySport")]
+    partial class SplitCompetitionCompetitorBySport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260508134122_SplitCompetitionCompetitorBySport.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508134122_SplitCompetitionCompetitorBySport.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class SplitCompetitionCompetitorBySport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CuratedRankCurrent",
+                table: "CompetitionCompetitor");
+
+            // Each DB is single-sport, so existing rows in the baseball
+            // CompetitionCompetitor table all belong to the baseball subtype.
+            // Hardcoded default backfills existing rows; EF supplies the value
+            // for inserts going forward.
+            migrationBuilder.AddColumn<string>(
+                name: "Discriminator",
+                table: "CompetitionCompetitor",
+                type: "character varying(34)",
+                maxLength: 34,
+                nullable: false,
+                defaultValue: "BaseballCompetitionCompetitor");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Discriminator",
+                table: "CompetitionCompetitor");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CuratedRankCurrent",
+                table: "CompetitionCompetitor",
+                type: "integer",
+                nullable: true);
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/20260508134055_SplitCompetitionCompetitorBySport.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260508134055_SplitCompetitionCompetitorBySport.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Football;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Baseball
+namespace SportsData.Producer.Migrations.Football
 {
-    [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(FootballDataContext))]
+    [Migration("20260508134055_SplitCompetitionCompetitorBySport")]
+    partial class SplitCompetitionCompetitorBySport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,179 +415,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<bool>("Active")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("ConfigurationId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int>("Season")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SeasonType")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SplitTypeId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
-
-                    b.ToTable("AthleteSeasonHotZone", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("AtBats")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("AthleteSeasonHotZoneId")
-                        .HasColumnType("uuid");
-
-                    b.Property<double?>("BattingAvg")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("BattingAvgScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int?>("Hits")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<double?>("Slugging")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("SluggingScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("ZoneId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonHotZoneId");
-
-                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("AthleteRef")
-                        .HasColumnType("text");
-
-                    b.Property<Guid>("CompetitionStatusId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("PlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasColumnType("text");
-
-                    b.Property<string>("TeamRef")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionStatusId");
-
-                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3192,6 +3022,206 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("CompetitionCompetitorStatisticCategoryId");
 
                     b.ToTable("CompetitionCompetitorStatisticStats");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
+                    b.Property<string>("DisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("EndClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("EndClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("EndDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EndShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("EndText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("EndYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsScore")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("OffensivePlays")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Result")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SequenceNumber")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("ShortDisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SourceDescription")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SourceId")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("StartClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("StartClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("StartFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("StartPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("StartShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StartText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeElapsedDisplay")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("TimeElapsedValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("Yards")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionId");
+
+                    b.ToTable("CompetitionDrive", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DriveId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Provider")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SourceUrl")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("SourceUrlHash")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DriveId");
+
+                    b.ToTable("CompetitionDriveExternalId", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -7870,17 +7900,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -7891,213 +7913,99 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("ThrowsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("ThrowsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("BaseballAthlete");
+                    b.HasDiscriminator().HasValue("FootballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
+                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.Property<int?>("CurrentSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("CurrentSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("CurrentSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("CurrentSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("CurrentSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EspnSeriesId")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("SeasonSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("SeasonSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SeasonSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.HasIndex("EspnSeriesId");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetition");
+                    b.HasDiscriminator().HasValue("FootballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
+                    b.Property<int?>("CuratedRankCurrent")
+                        .HasColumnType("integer");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<string>("AtBatId")
+                    b.Property<string>("ClockDisplayValue")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<int?>("AtBatPitchNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayHits")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("BatOrder")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("HitCoordinateX")
-                        .HasPrecision(7, 2)
+                    b.Property<double>("ClockValue")
                         .HasColumnType("double precision");
 
-                    b.Property<double?>("HitCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
+                    b.Property<Guid?>("DriveId")
+                        .HasColumnType("uuid");
 
-                    b.Property<int>("HomeErrors")
+                    b.Property<int?>("EndDistance")
                         .HasColumnType("integer");
 
-                    b.Property<int>("HomeHits")
+                    b.Property<int?>("EndDown")
                         .HasColumnType("integer");
 
-                    b.Property<bool>("IsDoublePlay")
-                        .HasColumnType("boolean");
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
 
-                    b.Property<bool>("IsTriplePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<double?>("PitchCoordinateX")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("PitchCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("PitchCountBalls")
+                    b.Property<int?>("EndYardLine")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("PitchCountStrikes")
+                    b.Property<int?>("EndYardsToEndzone")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PitchTypeAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeId")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int?>("PitchVelocity")
+                    b.Property<int?>("StartDistance")
                         .HasColumnType("integer");
 
-                    b.Property<int>("RbiCount")
+                    b.Property<int?>("StartDown")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountBalls")
+                    b.Property<int?>("StartYardLine")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountStrikes")
+                    b.Property<int?>("StartYardsToEndzone")
                         .HasColumnType("integer");
 
-                    b.Property<string>("StrikeType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                    b.Property<int>("StatYardage")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("SummaryType")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.HasIndex("DriveId");
 
-                    b.Property<string>("Trajectory")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
+                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
-
-                    b.Property<int?>("HalfInning")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PeriodPrefix")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("BaseballContest");
+                    b.HasDiscriminator().HasValue("FootballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8130,28 +8038,6 @@ namespace SportsData.Producer.Migrations.Baseball
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
-                        .WithMany("Entries")
-                        .HasForeignKey("AthleteSeasonHotZoneId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("HotZone");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
-                        .WithMany("FeaturedAthletes")
-                        .HasForeignKey("CompetitionStatusId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionStatus");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8736,6 +8622,34 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
+                        .WithMany()
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                        .WithMany("Drives")
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Competition");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("ExternalIds")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9648,7 +9562,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9657,29 +9571,36 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("Plays")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9691,11 +9612,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -9849,6 +9765,13 @@ namespace SportsData.Producer.Migrations.Baseball
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Navigation("ExternalIds");
+
+                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10041,19 +9964,16 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
+                    b.Navigation("Drives");
+
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.Navigation("FeaturedAthletes");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Football/20260508134055_SplitCompetitionCompetitorBySport.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260508134055_SplitCompetitionCompetitorBySport.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class SplitCompetitionCompetitorBySport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Each DB is single-sport, so existing rows in the football
+            // CompetitionCompetitor table all belong to the football subtype.
+            // Hardcoded default backfills existing rows; EF supplies the value
+            // for inserts going forward.
+            migrationBuilder.AddColumn<string>(
+                name: "Discriminator",
+                table: "CompetitionCompetitor",
+                type: "character varying(34)",
+                maxLength: 34,
+                nullable: false,
+                defaultValue: "FootballCompetitionCompetitor");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Discriminator",
+                table: "CompetitionCompetitor");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
@@ -2460,7 +2460,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("CompetitionBroadcast", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -2475,8 +2475,10 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<DateTime>("CreatedUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int?>("CuratedRankCurrent")
-                        .HasColumnType("integer");
+                    b.Property<string>("Discriminator")
+                        .IsRequired()
+                        .HasMaxLength(34)
+                        .HasColumnType("character varying(34)");
 
                     b.Property<Guid>("FranchiseSeasonId")
                         .HasColumnType("uuid");
@@ -2518,6 +2520,10 @@ namespace SportsData.Producer.Migrations.Football
                         .IsUnique();
 
                     b.ToTable("CompetitionCompetitor", (string)null);
+
+                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionCompetitorBase");
+
+                    b.UseTphMappingStrategy();
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorExternalId", b =>
@@ -7923,6 +7929,16 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasDiscriminator().HasValue("FootballCompetition");
                 });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
+                {
+                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
+
+                    b.Property<int?>("CuratedRankCurrent")
+                        .HasColumnType("integer");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
+                });
+
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
@@ -8096,7 +8112,7 @@ namespace SportsData.Producer.Migrations.Football
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", "CompetitionCompetitor")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", "CompetitionCompetitor")
                         .WithMany()
                         .HasForeignKey("CompetitionCompetitorId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -8463,7 +8479,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Competition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
                         .WithMany("Competitors")
@@ -8482,7 +8498,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorExternalId", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", "CompetitionCompetitor")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", "CompetitionCompetitor")
                         .WithMany("ExternalIds")
                         .HasForeignKey("CompetitionCompetitorId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -8493,7 +8509,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorLineScore", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", "CompetitionCompetitor")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", "CompetitionCompetitor")
                         .WithMany("LineScores")
                         .HasForeignKey("CompetitionCompetitorId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -8515,7 +8531,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorRecord", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", "CompetitionCompetitor")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", "CompetitionCompetitor")
                         .WithMany("Records")
                         .HasForeignKey("CompetitionCompetitorId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -8537,7 +8553,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorScore", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", "CompetitionCompetitor")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", "CompetitionCompetitor")
                         .WithMany("Scores")
                         .HasForeignKey("CompetitionCompetitorId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -8559,7 +8575,7 @@ namespace SportsData.Producer.Migrations.Football
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatistic", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", "CompetitionCompetitor")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", "CompetitionCompetitor")
                         .WithMany("Statistics")
                         .HasForeignKey("CompetitionCompetitorId")
                         .OnDelete(DeleteBehavior.Cascade);
@@ -9710,7 +9726,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Situations");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase", b =>
                 {
                     b.Navigation("ExternalIds");
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -69,7 +69,7 @@ public class BaseballContestEnrichmentProcessorTests
             Id = Guid.NewGuid(),
             ContestId = contestId,
             Contest = contest,
-            Competitors = new List<CompetitionCompetitor>()
+            Competitors = new List<CompetitionCompetitorBase>()
         };
 
         _baseballDataContext.Contests.Add(contest);
@@ -109,7 +109,7 @@ public class BaseballContestEnrichmentProcessorTests
             ContestId = contestId,
             Contest = contest,
             Status = null,
-            Competitors = new List<CompetitionCompetitor>
+            Competitors = new List<CompetitionCompetitorBase>
             {
                 CreateCompetitor(competitionId, AwayFranchiseSeasonId, "away"),
                 CreateCompetitor(competitionId, HomeFranchiseSeasonId, "home")
@@ -412,7 +412,7 @@ public class BaseballContestEnrichmentProcessorTests
         SeasonYear = 2026
     };
 
-    private static CompetitionCompetitor CreateCompetitor(
+    private static BaseballCompetitionCompetitor CreateCompetitor(
         Guid competitionId, Guid franchiseSeasonId, string homeAway) => new()
     {
         Id = Guid.NewGuid(),
@@ -438,7 +438,7 @@ public class BaseballContestEnrichmentProcessorTests
                 CompetitionId = competitionId,
                 StatusTypeName = statusTypeName
             },
-            Competitors = new List<CompetitionCompetitor>
+            Competitors = new List<CompetitionCompetitorBase>
             {
                 CreateCompetitor(competitionId, AwayFranchiseSeasonId, "away"),
                 CreateCompetitor(competitionId, HomeFranchiseSeasonId, "home")

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
@@ -56,7 +56,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
             Id = Guid.NewGuid(),
             ContestId = contestId,
             Contest = contest,
-            Competitors = new List<CompetitionCompetitor>()
+            Competitors = new List<CompetitionCompetitorBase>()
         };
 
         FootballDataContext.Contests.Add(contest);
@@ -82,7 +82,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
             Id = competitionId,
             ContestId = contestId,
             Contest = contest,
-            Competitors = new List<CompetitionCompetitor>
+            Competitors = new List<CompetitionCompetitorBase>
             {
                 CreateCompetitor(competitionId, HomeFranchiseSeasonId, "home")
             }
@@ -111,7 +111,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
             Id = competitionId,
             ContestId = contestId,
             Contest = contest,
-            Competitors = new List<CompetitionCompetitor>
+            Competitors = new List<CompetitionCompetitorBase>
             {
                 CreateCompetitor(competitionId, AwayFranchiseSeasonId, "away")
             }
@@ -154,7 +154,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
             ContestId = contestId,
             Contest = contest,
             Status = null,
-            Competitors = new List<CompetitionCompetitor>
+            Competitors = new List<CompetitionCompetitorBase>
             {
                 CreateCompetitor(competitionId, AwayFranchiseSeasonId, "away"),
                 CreateCompetitor(competitionId, HomeFranchiseSeasonId, "home")
@@ -492,7 +492,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
         SeasonYear = 2024
     };
 
-    private static CompetitionCompetitor CreateCompetitor(
+    private static FootballCompetitionCompetitor CreateCompetitor(
         Guid competitionId, Guid franchiseSeasonId, string homeAway) => new()
     {
         Id = Guid.NewGuid(),
@@ -518,7 +518,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
                 CompetitionId = competitionId,
                 StatusTypeName = statusTypeName
             },
-            Competitors = new List<CompetitionCompetitor>
+            Competitors = new List<CompetitionCompetitorBase>
             {
                 CreateCompetitor(competitionId, AwayFranchiseSeasonId, "away"),
                 CreateCompetitor(competitionId, HomeFranchiseSeasonId, "home")

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
@@ -2,7 +2,7 @@
 
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
-using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 using SportsData.Producer.Infrastructure.Data.Football;
 
 using Xunit;
@@ -10,7 +10,7 @@ using Xunit;
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Common
 {
     public class EventCompetitionCompetitorDocumentProcessorTests
-        : ProducerTestBase<EventCompetitionCompetitorDocumentProcessor<FootballDataContext>>
+        : ProducerTestBase<FootballEventCompetitionCompetitorDocumentProcessor<FootballDataContext>>
     {
         [Fact]
         public async Task WhenJsonIsValid_DtoDeserializes()

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorLineScoreDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorLineScoreDocumentProcessorTests.cs
@@ -11,6 +11,7 @@ using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 using Xunit;
 
@@ -50,7 +51,7 @@ public class EventCompetitionCompetitorLineScoreDocumentProcessorTests : Produce
         var competitorId = Guid.NewGuid();
         
         // OPTIMIZATION: Create minimal competitor without AutoFixture overhead
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = Guid.NewGuid(),
@@ -128,7 +129,7 @@ public class EventCompetitionCompetitorLineScoreDocumentProcessorTests : Produce
         };
 
         // OPTIMIZATION: Create minimal competitor
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = Guid.NewGuid(),

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorRosterDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorRosterDocumentProcessorTests.cs
@@ -72,7 +72,7 @@ public class EventCompetitionCompetitorRosterDocumentProcessorTests
 
         // Create CompetitionCompetitor in database (required for FK)
         var competitorId = Guid.NewGuid();
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = competition.Id,
@@ -152,7 +152,7 @@ public class EventCompetitionCompetitorRosterDocumentProcessorTests
 
         // Create CompetitionCompetitor in database (required for FK)
         var competitorId = Guid.NewGuid();
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = competition.Id,
@@ -239,7 +239,7 @@ public class EventCompetitionCompetitorRosterDocumentProcessorTests
 
         // Create CompetitionCompetitor in database (required for FK)
         var competitorId = Guid.NewGuid();
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = competition.Id,
@@ -326,7 +326,7 @@ public class EventCompetitionCompetitorRosterDocumentProcessorTests
 
         // Create CompetitionCompetitor in database (required for FK)
         var competitorId = Guid.NewGuid();
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = competition.Id,
@@ -403,7 +403,7 @@ public class EventCompetitionCompetitorRosterDocumentProcessorTests
 
         // Create CompetitionCompetitor in database (required for FK)
         var competitorId = Guid.NewGuid();
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = competition.Id,

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
@@ -80,7 +80,7 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
         await FootballDataContext.Competitions.AddAsync(competition);
         
         // OPTIMIZATION: Direct instantiation instead of AutoFixture (was taking 29 seconds!)
-        var competitor = new CompetitionCompetitor
+        var competitor = new FootballCompetitionCompetitor
         {
             Id = competitorId,
             CompetitionId = competitionId,

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorStatisticsDocumentProcessorTests.cs
@@ -44,7 +44,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 CreatedBy = Guid.NewGuid()
             };
 
-            var competitionCompetitor = new CompetitionCompetitor
+            var competitionCompetitor = new FootballCompetitionCompetitor
             {
                 Id = Guid.NewGuid(),
                 CompetitionId = competition.Id,
@@ -126,7 +126,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 CreatedBy = Guid.NewGuid()
             };
 
-            var competitionCompetitor = new CompetitionCompetitor
+            var competitionCompetitor = new FootballCompetitionCompetitor
             {
                 Id = Guid.NewGuid(),
                 CompetitionId = competition.Id,
@@ -218,7 +218,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 CreatedBy = Guid.NewGuid()
             };
 
-            var competitionCompetitor = new CompetitionCompetitor
+            var competitionCompetitor = new FootballCompetitionCompetitor
             {
                 Id = Guid.NewGuid(),
                 CompetitionId = competition.Id,

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionDocumentProcessorTests.cs
@@ -402,7 +402,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                         Value = competitionIdentity.UrlHash
                     }
                 },
-                Competitors = new List<CompetitionCompetitor>()
+                Competitors = new List<CompetitionCompetitorBase>()
             };
 
             await base.FootballDataContext.Competitions.AddAsync(existingCompetition);
@@ -638,7 +638,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                         Value = competitionIdentity.UrlHash
                     }
                 },
-                Competitors = new List<CompetitionCompetitor>()
+                Competitors = new List<CompetitionCompetitorBase>()
             };
 
             await base.FootballDataContext.Competitions.AddAsync(existingCompetition);

--- a/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/EventCompetitionCompetitor.json
+++ b/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/EventCompetitionCompetitor.json
@@ -1,0 +1,32 @@
+{
+  "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815254/competitions/401815254/competitors/1?lang=en&region=us",
+  "id": "1",
+  "uid": "s:1~l:10~t:1",
+  "type": "team",
+  "order": 0,
+  "homeAway": "home",
+  "team": {
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/1?lang=en&region=us"
+  },
+  "score": {
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815254/competitions/401815254/competitors/1/score?lang=en&region=us"
+  },
+  "record": {
+    "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/teams/1/record?lang=en&region=us"
+  },
+  "probables": [
+    {
+      "name": "probableStartingPitcher",
+      "displayName": "Probable Starting Pitcher",
+      "shortDisplayName": "Starter",
+      "abbreviation": "SP",
+      "playerId": 4311625,
+      "athlete": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4311625?lang=en&region=us"
+      },
+      "statistics": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/types/2/athletes/4311625/statistics/0?lang=en&region=us"
+      }
+    }
+  ]
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
@@ -35,6 +35,7 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
         Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionBase), typeof(FootballCompetition)));
         Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionPlayBase), typeof(FootballCompetitionPlay)));
         Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionStatusBase), typeof(FootballCompetitionStatus)));
+        Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionCompetitorBase), typeof(FootballCompetitionCompetitor)));
 
         // Override mapper with Producer-specific mapping profile
         var mapperConfig = new MapperConfiguration(c =>

--- a/test/unit/SportsData.Producer.Tests.Unit/SportsData.Producer.Tests.Unit.csproj
+++ b/test/unit/SportsData.Producer.Tests.Unit/SportsData.Producer.Tests.Unit.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup>
     <Folder Include="Application\Handlers\" />
-    <Folder Include="Data\EspnBaseballMlb\" />
   </ItemGroup>
   <ItemGroup>
     <None Update="xunit.runner.json">


### PR DESCRIPTION
## Summary

- Phase 1 of a multi-PR effort to make room for sport-specific competitor state. Mirrors the existing `CompetitionBase` / `BaseballCompetition` / `FootballCompetition` split.
- `CompetitionCompetitor` (concrete, shared) becomes `CompetitionCompetitorBase` (abstract). New `BaseballCompetitionCompetitor` and `FootballCompetitionCompetitor` subtypes; `CuratedRankCurrent` (NCAA poll snapshot) moves off the shared base onto the football subtype where it belongs. Same DB table (`CompetitionCompetitor`), TPH discriminator added.
- Processor split mirrors the entity split: abstract `EventCompetitionCompetitorDocumentProcessorBase` with shared logic; sport-specific `BaseballEventCompetitionCompetitorDocumentProcessor` / `FootballEventCompetitionCompetitorDocumentProcessor` own the `[DocumentProcessor]` attributes and `CreateEntity` overrides.
- Out of scope (deferred to follow-on PRs, all called out in the design doc): MLB Probables ingestion (Phase 2), pitcher stat snapshot (Phase 3, parallels series-snapshot redesign), UI rendering (Phase 4).

See **`docs/competition-competitor-split.md`** for the full rationale, before/after entity shape, migration strategy, and out-of-scope phases.

## Test plan

- [x] `dotnet build` Producer + tests — clean (0 warnings, 0 errors)
- [x] Full Producer unit suite passes (369 / 18 unrelated skips / 0 failures)
- [x] Migrations validated locally against prod copy — both Football and Baseball DBs apply cleanly. Discriminator backfilled with the right per-DB default; `CuratedRankCurrent` cleanly dropped from the Baseball DB.
- [ ] Live in-flight EventCompetitionCompetitor doc reprocessing should still write rows correctly under the new TPH layout — verify in Seq after deploy that no `JSON deserialization` / `discriminator` errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured competition competitor data model to support sport-specific variants for Baseball and Football, enabling specialized handling of sport-related attributes and processing workflows.

* **Documentation**
  * Added design proposal outlining the entity hierarchy reorganization and implementation phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->