### PR TITLE
feat(producer): MLB Probables ingestion on CompetitionCompetitor

### DIFF
--- a/docs/competition-competitor-probables.md
+++ b/docs/competition-competitor-probables.md
@@ -1,0 +1,108 @@
+# MLB CompetitionCompetitor — Probables ingestion
+
+Captured 2026-05-08. Phase 2 of the
+[CompetitionCompetitor sport-specific split](competition-competitor-split.md).
+Phase 1 created `BaseballCompetitionCompetitor` as a TPH subtype of the
+shared `CompetitionCompetitorBase`. This phase hangs MLB's `probables[]`
+collection off that subtype and wires inline ingestion into the
+EventCompetitionCompetitor processor.
+
+## What ESPN ships
+
+The MLB EventCompetitionCompetitor payload carries an inline `probables`
+array. Today it contains a single entry — the probable starting pitcher
+— but the array shape leaves room for future roles (closer, etc.).
+
+```json
+"probables": [
+  {
+    "name": "probableStartingPitcher",
+    "displayName": "Probable Starting Pitcher",
+    "shortDisplayName": "Starter",
+    "abbreviation": "SP",
+    "playerId": 4311625,
+    "athlete": { "$ref": ".../seasons/2026/athletes/4311625?lang=en&region=us" },
+    "statistics": { "$ref": ".../seasons/2026/types/2/athletes/4311625/statistics/0?..." }
+  }
+]
+```
+
+Football has no analogue, so this lives entirely on the baseball side
+of the split.
+
+## Schema
+
+New canonical entity: `CompetitionCompetitorProbable` — a 1:N child of
+`BaseballCompetitionCompetitor`.
+
+| Column | Notes |
+|---|---|
+| `Id` (PK) | Deterministic Guid: `Combine("competitor-probable", competitorId, name)` |
+| `CompetitionCompetitorId` (FK, cascade) | Parent competitor row |
+| `AthleteSeasonId` (FK, restrict) | Resolved from `athlete.$ref` |
+| `EspnPlayerId` | Convenience copy of ESPN's int playerId |
+| `Name` | Role key (`probableStartingPitcher`) |
+| `DisplayName` / `ShortDisplayName` / `Abbreviation` | UI copy |
+
+Unique index on `(CompetitionCompetitorId, Name)` so the role-name is
+the natural key — reprocessing the same competitor with the same role
+upserts the same row.
+
+Cascade vs restrict choice:
+- **Cascade from competitor** — a probable row is meaningless without
+  its parent competitor; deleting the competitor takes its probables
+  with it.
+- **Restrict from athlete** — deleting an `AthleteSeason` should NOT
+  cascade-cull historical probable rows. The probable is a record of
+  what was advertised at game time; we want it to outlive the athlete's
+  season row if that ever gets pruned.
+
+## Ingestion path
+
+`BaseballEventCompetitionCompetitorDocumentProcessor` overrides two
+virtual hooks added to the base in this PR:
+
+1. **`DeserializeDto`** — returns the sport-specific
+   `EspnBaseballEventCompetitionCompetitorDto` so the base pipeline can
+   pass the full payload (including `Probables`) through to the
+   sport-specific hook.
+2. **`ProcessSportSpecificCompetitorData`** — runs after the competitor
+   entity is staged on the change tracker but before
+   `SaveChangesAsync`, so probable rows commit in the same transaction
+   as the competitor.
+
+Per probable:
+- Skip with a warning if `Name` or `Athlete.Ref` is missing.
+- Resolve `AthleteSeasonId` via `IGenerateExternalRefIdentities`.
+- If the AthleteSeason isn't in the DB yet:
+  - `PublishDependencyRequest(... DocumentType.AthleteSeason)`
+  - throw `ExternalDocumentNotSourcedException` so Hangfire retries
+    the competitor document. This is the established not-sourced
+    pattern; persisting a probable without a resolved athlete is
+    worthless on the matchup card, so we fail loud and retry.
+- Upsert by deterministic Id; the `(competitorId, role-name)` key
+  collapses repeat runs onto the same row and updates the audit fields.
+
+## Why not...
+
+- **...persist the probable with a null `AthleteSeasonId`?** An empty
+  probable is worthless on the matchup card. The not-sourced retry
+  pattern is the established convention here.
+- **...denormalize the pitcher's statistics onto the competitor?** ESPN
+  ships a `statistics.$ref` per probable but those numbers drift through
+  the season. Phase 3 will snapshot a small set of stats on the
+  probable row at game-start time (ERA, W-L, K, etc.) so the matchup
+  card renders the at-game-start view rather than today's rolled-up
+  numbers — same time-travel problem we already solved for series
+  state in PR #299. Out of scope here.
+- **...add a `Role` enum?** Today only `probableStartingPitcher`
+  exists. A string column with a unique-index discriminator keeps the
+  schema flexible if ESPN starts shipping additional roles. We can
+  promote to an enum once a second role appears and the closed set
+  stops being speculative.
+
+## Out of scope (later phases)
+
+- Phase 3: pitcher stat snapshot (the time-travel concern above).
+- Phase 4: UI surface — matchup card / Command Center tile rendering
+  the probable starter pair.

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
@@ -21,13 +21,19 @@ namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Ba
 public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> : EventCompetitionCompetitorDocumentProcessorBase<TDataContext>
     where TDataContext : BaseballDataContext
 {
+    private readonly IDateTimeProvider _dateTimeProvider;
+
     public BaseballEventCompetitionCompetitorDocumentProcessor(
         ILogger<BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,
-        IGenerateResourceRefs refs)
-        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
+        IGenerateResourceRefs refs,
+        IDateTimeProvider dateTimeProvider)
+        : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs)
+    {
+        _dateTimeProvider = dateTimeProvider;
+    }
 
     protected override EspnEventCompetitionCompetitorDto? DeserializeDto(string document)
         => document.FromJson<EspnBaseballEventCompetitionCompetitorDto>();
@@ -131,20 +137,22 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
                 CompetitionCompetitorId = competitorId,
                 AthleteSeasonId = athleteSeasonIdentity.CanonicalId,
                 EspnPlayerId = probableDto.PlayerId,
-                CreatedUtc = DateTime.UtcNow,
+                Name = probableDto.Name,
+                CreatedUtc = _dateTimeProvider.UtcNow(),
                 CreatedBy = command.CorrelationId
             };
             await _dataContext.CompetitionCompetitorProbables.AddAsync(existing);
         }
         else
         {
-            existing.ModifiedUtc = DateTime.UtcNow;
+            existing.ModifiedUtc = _dateTimeProvider.UtcNow();
             existing.ModifiedBy = command.CorrelationId;
         }
 
+        // Name is the natural-key component of the deterministic Id, so
+        // it never changes for a given row — no reassignment needed.
         existing.AthleteSeasonId = athleteSeasonIdentity.CanonicalId;
         existing.EspnPlayerId = probableDto.PlayerId;
-        existing.Name = probableDto.Name;
         existing.DisplayName = probableDto.DisplayName;
         existing.ShortDisplayName = probableDto.ShortDisplayName;
         existing.Abbreviation = probableDto.Abbreviation;

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
@@ -1,9 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+using SportsData.Producer.Exceptions;
 using SportsData.Producer.Infrastructure.Data.Baseball;
 using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -23,6 +29,9 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
         IGenerateResourceRefs refs)
         : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs) { }
 
+    protected override EspnEventCompetitionCompetitorDto? DeserializeDto(string document)
+        => document.FromJson<EspnBaseballEventCompetitionCompetitorDto>();
+
     protected override CompetitionCompetitorBase CreateEntity(
         EspnEventCompetitionCompetitorDto dto,
         Guid competitionId,
@@ -34,5 +43,110 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
             franchiseSeasonId,
             _externalRefIdentityGenerator,
             correlationId);
+    }
+
+    // MLB Probables ingestion. Each Probable has a hard FK to AthleteSeason
+    // — if the athlete isn't sourced yet we request it and throw
+    // ExternalDocumentNotSourcedException so Hangfire retries the document.
+    // No partial Probable rows; an empty Probable is worthless on the
+    // matchup card.
+    //
+    // See docs/competition-competitor-probables.md.
+    protected override async Task ProcessSportSpecificCompetitorData(
+        ProcessDocumentCommand command,
+        EspnEventCompetitionCompetitorDto dto,
+        CompetitionCompetitorBase entity)
+    {
+        if (dto is not EspnBaseballEventCompetitionCompetitorDto baseballDto
+            || entity is not BaseballCompetitionCompetitor baseballCompetitor)
+        {
+            return;
+        }
+
+        if (baseballDto.Probables is null || baseballDto.Probables.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var probableDto in baseballDto.Probables)
+        {
+            await UpsertProbable(command, baseballCompetitor.Id, probableDto);
+        }
+    }
+
+    private async Task UpsertProbable(
+        ProcessDocumentCommand command,
+        Guid competitorId,
+        EspnBaseballProbableDto probableDto)
+    {
+        if (string.IsNullOrWhiteSpace(probableDto.Name))
+        {
+            _logger.LogWarning(
+                "Probable entry has no Name. Skipping. CompetitorId={CompetitorId}",
+                competitorId);
+            return;
+        }
+
+        if (probableDto.Athlete?.Ref is null)
+        {
+            _logger.LogWarning(
+                "Probable entry has no athlete ref. Skipping. CompetitorId={CompetitorId}, Name={Name}",
+                competitorId, probableDto.Name);
+            return;
+        }
+
+        // Resolve AthleteSeason or fail-loud per the not-sourced pattern.
+        var athleteSeasonIdentity = _externalRefIdentityGenerator.Generate(probableDto.Athlete.Ref);
+        var athleteSeasonExists = await _dataContext.AthleteSeasons
+            .AsNoTracking()
+            .AnyAsync(x => x.Id == athleteSeasonIdentity.CanonicalId);
+
+        if (!athleteSeasonExists)
+        {
+            await PublishDependencyRequest<string?>(
+                command,
+                new EspnLinkDto { Ref = probableDto.Athlete.Ref },
+                parentId: null,
+                DocumentType.AthleteSeason);
+
+            throw new ExternalDocumentNotSourcedException(
+                $"Probable AthleteSeason {athleteSeasonIdentity.CleanUrl} not sourced. Requested. Will retry. CompetitorId={competitorId}");
+        }
+
+        // Deterministic Id from (competitorId, role-name) so reprocessing
+        // updates the same row instead of inserting duplicates.
+        var probableId = DeterministicGuid.Combine(
+            "competitor-probable",
+            competitorId.ToString(),
+            probableDto.Name);
+
+        var existing = await _dataContext.CompetitionCompetitorProbables
+            .FirstOrDefaultAsync(x => x.Id == probableId);
+
+        if (existing is null)
+        {
+            existing = new CompetitionCompetitorProbable
+            {
+                Id = probableId,
+                CompetitionCompetitorId = competitorId,
+                AthleteSeasonId = athleteSeasonIdentity.CanonicalId,
+                EspnPlayerId = probableDto.PlayerId,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = command.CorrelationId
+            };
+            await _dataContext.CompetitionCompetitorProbables.AddAsync(existing);
+        }
+        else
+        {
+            existing.ModifiedUtc = DateTime.UtcNow;
+            existing.ModifiedBy = command.CorrelationId;
+        }
+
+        existing.AthleteSeasonId = athleteSeasonIdentity.CanonicalId;
+        existing.EspnPlayerId = probableDto.PlayerId;
+        existing.Name = probableDto.Name;
+        existing.DisplayName = probableDto.DisplayName;
+        existing.ShortDisplayName = probableDto.ShortDisplayName;
+        existing.Abbreviation = probableDto.Abbreviation;
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
@@ -44,9 +44,33 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
         Guid franchiseSeasonId,
         Guid correlationId);
 
+    /// <summary>
+    /// DTO deserializer hook. Override in sports that ship inline
+    /// extras on the competitor payload (e.g. MLB Probables) so the
+    /// override returns the sport-specific subclass DTO. The base
+    /// pipeline then passes that instance through to ProcessSportSpecific*
+    /// hooks where the override can downcast and act on the extras.
+    /// </summary>
+    protected virtual EspnEventCompetitionCompetitorDto? DeserializeDto(string document)
+        => document.FromJson<EspnEventCompetitionCompetitorDto>();
+
+    /// <summary>
+    /// Sport-specific hook for inline-data ingestion that hangs off the
+    /// competitor entity (e.g. MLB Probables). Runs after the competitor
+    /// row is staged on the change tracker but before SaveChangesAsync,
+    /// so any rows added by the override commit in the same transaction.
+    /// Throwing ExternalDocumentNotSourcedException here is supported and
+    /// expected when a referenced dependency (e.g. AthleteSeason) isn't
+    /// in the DB yet — Hangfire will retry the document.
+    /// </summary>
+    protected virtual Task ProcessSportSpecificCompetitorData(
+        ProcessDocumentCommand command,
+        EspnEventCompetitionCompetitorDto dto,
+        CompetitionCompetitorBase entity) => Task.CompletedTask;
+
     protected override async Task ProcessInternal(ProcessDocumentCommand command)
     {
-        var dto = command.Document.FromJson<EspnEventCompetitionCompetitorDto>();
+        var dto = DeserializeDto(command.Document);
 
         if (dto is null)
         {
@@ -167,6 +191,13 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
             canonicalEntity.Id,
             competitionId);
 
+        // Sport-specific inline-data ingestion (e.g. MLB Probables). Runs
+        // before child-doc spawning so any rows added share the tail
+        // SaveChangesAsync transaction. May throw
+        // ExternalDocumentNotSourcedException when a referenced
+        // dependency isn't in the DB yet — Hangfire retries the document.
+        await ProcessSportSpecificCompetitorData(command, dto, canonicalEntity);
+
         await ProcessChildDocuments(command, dto, canonicalEntity.Id, isNew: true);
     }
 
@@ -180,6 +211,11 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
             "CompetitorId={CompetitorId}, HomeAway={HomeAway}",
             entity.Id,
             dto.HomeAway);
+
+        // Sport-specific inline-data ingestion runs on update too — the
+        // payload's mutable extras (e.g. Probables) may have changed
+        // since the last fetch.
+        await ProcessSportSpecificCompetitorData(command, dto, entity);
 
         await ProcessChildDocuments(command, dto, entity.Id, isNew: false);
     }

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
@@ -32,6 +32,8 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
 
         public DbSet<AthleteSeasonHotZoneEntry> AthleteSeasonHotZoneEntries { get; set; }
 
+        public DbSet<CompetitionCompetitorProbable> CompetitionCompetitorProbables { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -41,6 +43,7 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
             modelBuilder.ApplyConfiguration(new AthleteSeason.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetition.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionCompetitor.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new CompetitionCompetitorProbable.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionPlay.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatus.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatusFeaturedAthlete.EntityConfiguration());

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionCompetitor.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionCompetitor.cs
@@ -5,20 +5,22 @@ using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
 {
-    // MLB-specific competitor row. Carries no extra columns yet; Probables
-    // (probable starting pitcher and similar) land here in Phase 2 of the
-    // competition-competitor split.
+    // MLB-specific competitor row. Owns the Probables collection (probable
+    // starting pitcher today; ESPN's array shape allows future roles).
     //
-    // See docs/competition-competitor-split.md.
+    // See docs/competition-competitor-split.md and
+    // docs/competition-competitor-probables.md.
     public class BaseballCompetitionCompetitor : CompetitionCompetitorBase
     {
+        public ICollection<CompetitionCompetitorProbable> Probables { get; set; } = [];
+
         public new class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetitionCompetitor>
         {
             public void Configure(EntityTypeBuilder<BaseballCompetitionCompetitor> builder)
             {
-                // No sport-specific columns yet; the base config (mapped under
-                // CompetitionCompetitorBase.EntityConfiguration) handles the
-                // shared columns and TPH discriminator.
+                // Probables relationship is owned by
+                // CompetitionCompetitorProbable.EntityConfiguration; this
+                // hook stays for future baseball-only schema.
             }
         }
     }

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/CompetitionCompetitorProbable.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/CompetitionCompetitorProbable.cs
@@ -1,0 +1,82 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
+{
+    // Per-competitor probable role for an MLB game. Today only the
+    // probable starting pitcher (Name = "probableStartingPitcher") shows
+    // up in ESPN's payload, but the array shape leaves room for future
+    // roles (closer, etc.). Modeled as a 1:N collection on
+    // BaseballCompetitionCompetitor.
+    //
+    // AthleteSeasonId is required: per the established not-sourced
+    // pattern, the processor throws ExternalDocumentNotSourcedException
+    // when the athlete ref can't be resolved, so this row is never
+    // persisted with a missing FK. An empty Probable is worthless on
+    // the matchup card.
+    //
+    // See docs/competition-competitor-split.md (Phase 2 outline) and
+    // docs/competition-competitor-probables.md.
+    public class CompetitionCompetitorProbable : CanonicalEntityBase<Guid>
+    {
+        public required Guid CompetitionCompetitorId { get; set; }
+
+        public BaseballCompetitionCompetitor CompetitionCompetitor { get; set; } = null!;
+
+        public required Guid AthleteSeasonId { get; set; }
+
+        public AthleteSeason AthleteSeason { get; set; } = null!;
+
+        public required int EspnPlayerId { get; set; }
+
+        public string? Name { get; set; }
+
+        public string? DisplayName { get; set; }
+
+        public string? ShortDisplayName { get; set; }
+
+        public string? Abbreviation { get; set; }
+
+        public class EntityConfiguration : IEntityTypeConfiguration<CompetitionCompetitorProbable>
+        {
+            public void Configure(EntityTypeBuilder<CompetitionCompetitorProbable> builder)
+            {
+                builder.ToTable(nameof(CompetitionCompetitorProbable));
+                builder.HasKey(x => x.Id);
+
+                builder.Property(x => x.CompetitionCompetitorId).IsRequired();
+                builder.Property(x => x.AthleteSeasonId).IsRequired();
+                builder.Property(x => x.EspnPlayerId).IsRequired();
+
+                builder.Property(x => x.Name).HasMaxLength(50);
+                builder.Property(x => x.DisplayName).HasMaxLength(100);
+                builder.Property(x => x.ShortDisplayName).HasMaxLength(50);
+                builder.Property(x => x.Abbreviation).HasMaxLength(10);
+
+                // FK: BaseballCompetitionCompetitor (parent) -> Probables
+                builder.HasOne(p => p.CompetitionCompetitor)
+                    .WithMany(cc => cc.Probables)
+                    .HasForeignKey(p => p.CompetitionCompetitorId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                // FK: AthleteSeason (reference). Restrict so deleting an
+                // AthleteSeason doesn't cascade-cull historical probables.
+                builder.HasOne(p => p.AthleteSeason)
+                    .WithMany()
+                    .HasForeignKey(p => p.AthleteSeasonId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                // Uniqueness: one probable role per competitor at a time.
+                // Today only "probableStartingPitcher" exists, but the
+                // (CompetitorId, Name) pair is the natural key if more
+                // roles arrive.
+                builder.HasIndex(x => new { x.CompetitionCompetitorId, x.Name })
+                    .IsUnique();
+            }
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/CompetitionCompetitorProbable.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/CompetitionCompetitorProbable.cs
@@ -33,7 +33,10 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
 
         public required int EspnPlayerId { get; set; }
 
-        public string? Name { get; set; }
+        // Required: the (CompetitionCompetitorId, Name) unique index is
+        // the natural key, and the processor skips persistence when Name
+        // is null/whitespace — so Name is never null at the DB.
+        public required string Name { get; set; }
 
         public string? DisplayName { get; set; }
 
@@ -52,7 +55,7 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
                 builder.Property(x => x.AthleteSeasonId).IsRequired();
                 builder.Property(x => x.EspnPlayerId).IsRequired();
 
-                builder.Property(x => x.Name).HasMaxLength(50);
+                builder.Property(x => x.Name).IsRequired().HasMaxLength(50);
                 builder.Property(x => x.DisplayName).HasMaxLength(100);
                 builder.Property(x => x.ShortDisplayName).HasMaxLength(50);
                 builder.Property(x => x.Abbreviation).HasMaxLength(10);

--- a/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260508154951_AddCompetitionCompetitorProbable")]
+    partial class AddCompetitionCompetitorProbable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.Designer.cs
@@ -626,6 +626,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 

--- a/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.cs
@@ -19,7 +19,7 @@ namespace SportsData.Producer.Migrations.Baseball
                     CompetitionCompetitorId = table.Column<Guid>(type: "uuid", nullable: false),
                     AthleteSeasonId = table.Column<Guid>(type: "uuid", nullable: false),
                     EspnPlayerId = table.Column<int>(type: "integer", nullable: false),
-                    Name = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    Name = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     DisplayName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
                     ShortDisplayName = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
                     Abbreviation = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: true),

--- a/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260508154951_AddCompetitionCompetitorProbable.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionCompetitorProbable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CompetitionCompetitorProbable",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CompetitionCompetitorId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AthleteSeasonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EspnPlayerId = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    DisplayName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ShortDisplayName = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    Abbreviation = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionCompetitorProbable", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CompetitionCompetitorProbable_AthleteSeason_AthleteSeasonId",
+                        column: x => x.AthleteSeasonId,
+                        principalTable: "AthleteSeason",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_CompetitionCompetitorProbable_CompetitionCompetitor_Competi~",
+                        column: x => x.CompetitionCompetitorId,
+                        principalTable: "CompetitionCompetitor",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionCompetitorProbable_AthleteSeasonId",
+                table: "CompetitionCompetitorProbable",
+                column: "AthleteSeasonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionCompetitorProbable_CompetitionCompetitorId_Name",
+                table: "CompetitionCompetitorProbable",
+                columns: new[] { "CompetitionCompetitorId", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CompetitionCompetitorProbable");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
@@ -623,6 +623,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorProbablesTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorProbablesTests.cs
@@ -1,0 +1,327 @@
+#nullable enable
+
+using AutoFixture;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Core.Infrastructure.Refs;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+using SportsData.Producer.Exceptions;
+using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
+
+/// <summary>
+/// Tests for inline MLB Probables ingestion driven by
+/// <see cref="BaseballEventCompetitionCompetitorDocumentProcessor{TDataContext}.ProcessSportSpecificCompetitorData"/>.
+///
+/// ESPN ships probable starting pitchers inline on the
+/// EventCompetitionCompetitor payload. Each Probable carries a hard FK to
+/// AthleteSeason — when the athlete isn't in the DB yet, the processor
+/// publishes a dependency request and throws
+/// ExternalDocumentNotSourcedException so Hangfire retries. No partial
+/// rows; an empty Probable is worthless on the matchup card.
+///
+/// See docs/competition-competitor-probables.md.
+/// </summary>
+[Collection("Sequential")]
+public class BaseballEventCompetitionCompetitorProbablesTests
+    : ProducerTestBase<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>
+{
+    private readonly BaseballDataContext _baseballDataContext;
+    private static readonly DateTime FixedNow = new(2026, 5, 4, 12, 0, 0, DateTimeKind.Utc);
+
+    // Refs that match the Data/EspnBaseballMlb/EventCompetitionCompetitor.json fixture.
+    private static readonly Uri CompetitorRef = new(
+        "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815254/competitions/401815254/competitors/1?lang=en&region=us");
+    private static readonly Uri TeamRef = new(
+        "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/1?lang=en&region=us");
+    private static readonly Uri AthleteSeasonRef = new(
+        "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4311625?lang=en&region=us");
+
+    public BaseballEventCompetitionCompetitorProbablesTests()
+    {
+        _baseballDataContext = new BaseballDataContext(
+            new DbContextOptionsBuilder<BaseballDataContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+                .Options);
+        Mocker.Use(_baseballDataContext);
+
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use(dateTimeProvider.Object);
+    }
+
+    [Fact]
+    public async Task DTO_Deserializes_Probables_From_Fixture()
+    {
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionCompetitor.json");
+
+        var dto = json.FromJson<EspnBaseballEventCompetitionCompetitorDto>();
+
+        dto.Should().NotBeNull();
+        dto!.Probables.Should().NotBeNull().And.HaveCount(1);
+        var probable = dto.Probables![0];
+        probable.Name.Should().Be("probableStartingPitcher");
+        probable.DisplayName.Should().Be("Probable Starting Pitcher");
+        probable.ShortDisplayName.Should().Be("Starter");
+        probable.Abbreviation.Should().Be("SP");
+        probable.PlayerId.Should().Be(4311625);
+        probable.Athlete.Should().NotBeNull();
+        probable.Athlete!.Ref.Should().Be(AthleteSeasonRef);
+    }
+
+    [Fact]
+    public async Task WhenAthleteSeasonExists_ProbableIsPersisted()
+    {
+        var (cmd, athleteSeasonId) = await SetupHappyPath();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        var probables = await _baseballDataContext.CompetitionCompetitorProbables
+            .AsNoTracking()
+            .ToListAsync();
+
+        probables.Should().HaveCount(1);
+        var probable = probables.Single();
+        probable.AthleteSeasonId.Should().Be(athleteSeasonId);
+        probable.EspnPlayerId.Should().Be(4311625);
+        probable.Name.Should().Be("probableStartingPitcher");
+        probable.DisplayName.Should().Be("Probable Starting Pitcher");
+        probable.ShortDisplayName.Should().Be("Starter");
+        probable.Abbreviation.Should().Be("SP");
+        probable.CompetitionCompetitorId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenAthleteSeasonMissing_PublishesDependencyAndRequestsRetry()
+    {
+        // arrange — competition + franchise season seeded, but NOT AthleteSeason.
+        var (cmd, _) = await SetupHappyPath(seedAthleteSeason: false);
+        var bus = Mocker.GetMock<IEventBus>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
+
+        // The processor throws ExternalDocumentNotSourcedException, which
+        // DocumentProcessorBase.ProcessAsync catches and converts into a
+        // DocumentCreated republish for Hangfire retry — see the base
+        // catch block. So we observe the contract via published events,
+        // not a bubbled exception.
+        await sut.ProcessAsync(cmd);
+
+        // Dependency request for the missing AthleteSeason was published.
+        bus.Verify(x => x.Publish(
+                It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeason),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Retry-republish: a DocumentCreated was emitted with the retry
+        // headers (the base catch path).
+        bus.Verify(x => x.Publish(
+                It.IsAny<DocumentCreated>(),
+                It.IsAny<IDictionary<string, object>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // No probable row should have been persisted (the throw happened
+        // before any AddAsync on the probables DbSet).
+        var probables = await _baseballDataContext.CompetitionCompetitorProbables
+            .AsNoTracking()
+            .ToListAsync();
+        probables.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenReprocessed_RowIsIdempotent_AndAuditUpdates()
+    {
+        // arrange — first pass creates the probable row.
+        var (cmd, athleteSeasonId) = await SetupHappyPath();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        var first = await _baseballDataContext.CompetitionCompetitorProbables
+            .AsNoTracking()
+            .SingleAsync();
+
+        // act — reprocess the same document. The deterministic Id from
+        // (competitorId, role-name) means the upsert hits the same row.
+        await sut.ProcessAsync(cmd);
+
+        // assert — still one row, same Id; audit fields reflect the update path.
+        var probables = await _baseballDataContext.CompetitionCompetitorProbables
+            .AsNoTracking()
+            .ToListAsync();
+        probables.Should().HaveCount(1);
+
+        var second = probables.Single();
+        second.Id.Should().Be(first.Id);
+        second.AthleteSeasonId.Should().Be(athleteSeasonId);
+        second.EspnPlayerId.Should().Be(first.EspnPlayerId);
+        second.ModifiedUtc.Should().NotBeNull();
+        second.ModifiedBy.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task WhenProbableHasMissingName_IsSkippedWithoutThrowing()
+    {
+        // arrange — happy-path setup, then mutate the fixture to drop Name.
+        var (cmd, _) = await SetupHappyPath();
+        var dto = cmd.Document.FromJson<EspnBaseballEventCompetitionCompetitorDto>()!;
+        dto.Probables![0].Name = null;
+        var mutatedJson = dto.ToJson();
+        var mutatedCmd = RebuildCommand(cmd, mutatedJson);
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
+
+        // act — must NOT throw; missing-Name is a soft skip.
+        await sut.ProcessAsync(mutatedCmd);
+
+        // assert — competitor saved, but no probable row.
+        var probables = await _baseballDataContext.CompetitionCompetitorProbables
+            .AsNoTracking()
+            .ToListAsync();
+        probables.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenProbableHasNoAthleteRef_IsSkippedWithoutThrowing()
+    {
+        // arrange — happy-path setup, then mutate the fixture to drop the athlete ref.
+        var (cmd, _) = await SetupHappyPath();
+        var dto = cmd.Document.FromJson<EspnBaseballEventCompetitionCompetitorDto>()!;
+        dto.Probables![0].Athlete = null;
+        var mutatedJson = dto.ToJson();
+        var mutatedCmd = RebuildCommand(cmd, mutatedJson);
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
+
+        // act — must NOT throw; no athlete to resolve means a soft skip.
+        await sut.ProcessAsync(mutatedCmd);
+
+        // assert — no probable row, and no AthleteSeason dependency request fired.
+        var probables = await _baseballDataContext.CompetitionCompetitorProbables
+            .AsNoTracking()
+            .ToListAsync();
+        probables.Should().BeEmpty();
+
+        var bus = Mocker.GetMock<IEventBus>();
+        bus.Verify(x => x.Publish(
+                It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeason),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private async Task<(ProcessDocumentCommand Cmd, Guid AthleteSeasonId)> SetupHappyPath(
+        bool seedAthleteSeason = true)
+    {
+        var idGen = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(idGen);
+
+        var competitorIdentity = idGen.Generate(CompetitorRef);
+        var teamIdentity = idGen.Generate(TeamRef);
+        var athleteSeasonIdentity = idGen.Generate(AthleteSeasonRef);
+
+        // Parent competition (FK from CompetitionCompetitor).
+        var competitionId = Guid.NewGuid();
+        await _baseballDataContext.Competitions.AddAsync(new BaseballCompetition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        // FranchiseSeason resolved by team URL hash.
+        await _baseballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+        {
+            Id = Guid.NewGuid(),
+            Abbreviation = "TST",
+            DisplayName = "Test FS",
+            DisplayNameShort = "TFS",
+            Slug = teamIdentity.CanonicalId.ToString(),
+            Location = "Test Location",
+            Name = "Test Franchise Season",
+            ColorCodeHex = "#FFFFFF",
+            ColorCodeAltHex = "#000000",
+            IsActive = true,
+            SeasonYear = 2026,
+            FranchiseId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds =
+            [
+                new FranchiseSeasonExternalId
+                {
+                    Id = Guid.NewGuid(),
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = teamIdentity.CleanUrl,
+                    SourceUrlHash = teamIdentity.UrlHash,
+                    Value = teamIdentity.UrlHash
+                }
+            ]
+        });
+
+        if (seedAthleteSeason)
+        {
+            await _baseballDataContext.AthleteSeasons.AddAsync(new BaseballAthleteSeason
+            {
+                Id = athleteSeasonIdentity.CanonicalId,
+                AthleteId = Guid.NewGuid(),
+                FranchiseSeasonId = null,
+                PositionId = Guid.NewGuid(),
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+
+        await _baseballDataContext.SaveChangesAsync();
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionCompetitor.json");
+
+        var cmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, competitionId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitor)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, competitorIdentity.UrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>?)null)
+            .OmitAutoProperties()
+            .Create();
+
+        return (cmd, athleteSeasonIdentity.CanonicalId);
+    }
+
+    private ProcessDocumentCommand RebuildCommand(ProcessDocumentCommand source, string newDocument)
+    {
+        return Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, source.ParentId)
+            .With(x => x.SeasonYear, source.SeasonYear)
+            .With(x => x.SourceDataProvider, source.SourceDataProvider)
+            .With(x => x.Sport, source.Sport)
+            .With(x => x.DocumentType, source.DocumentType)
+            .With(x => x.Document, newDocument)
+            .With(x => x.UrlHash, source.UrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, source.IncludeLinkedDocumentTypes)
+            .OmitAutoProperties()
+            .Create();
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorProbablesTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorProbablesTests.cs
@@ -107,6 +107,11 @@ public class BaseballEventCompetitionCompetitorProbablesTests
         probable.ShortDisplayName.Should().Be("Starter");
         probable.Abbreviation.Should().Be("SP");
         probable.CompetitionCompetitorId.Should().NotBeEmpty();
+        // Pin audit fields to the test harness's known values — these
+        // assertions fail loudly if someone reverts to DateTime.UtcNow
+        // or breaks correlation-id propagation.
+        probable.CreatedUtc.Should().Be(FixedNow);
+        probable.CreatedBy.Should().Be(cmd.CorrelationId);
     }
 
     [Fact]
@@ -173,8 +178,10 @@ public class BaseballEventCompetitionCompetitorProbablesTests
         second.Id.Should().Be(first.Id);
         second.AthleteSeasonId.Should().Be(athleteSeasonId);
         second.EspnPlayerId.Should().Be(first.EspnPlayerId);
-        second.ModifiedUtc.Should().NotBeNull();
-        second.ModifiedBy.Should().NotBeNull();
+        // Tighter than NotBeNull — pinned to harness values so the test
+        // fails if DateTime.UtcNow or a stray CreatedBy slips back in.
+        second.ModifiedUtc.Should().Be(FixedNow);
+        second.ModifiedBy.Should().Be(cmd.CorrelationId);
     }
 
     [Fact]
@@ -184,8 +191,7 @@ public class BaseballEventCompetitionCompetitorProbablesTests
         var (cmd, _) = await SetupHappyPath();
         var dto = cmd.Document.FromJson<EspnBaseballEventCompetitionCompetitorDto>()!;
         dto.Probables![0].Name = null;
-        var mutatedJson = dto.ToJson();
-        var mutatedCmd = RebuildCommand(cmd, mutatedJson);
+        var mutatedCmd = BuildCommand(dto.ToJson(), cmd.ParentId!, cmd.UrlHash);
 
         var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
 
@@ -206,8 +212,7 @@ public class BaseballEventCompetitionCompetitorProbablesTests
         var (cmd, _) = await SetupHappyPath();
         var dto = cmd.Document.FromJson<EspnBaseballEventCompetitionCompetitorDto>()!;
         dto.Probables![0].Athlete = null;
-        var mutatedJson = dto.ToJson();
-        var mutatedCmd = RebuildCommand(cmd, mutatedJson);
+        var mutatedCmd = BuildCommand(dto.ToJson(), cmd.ParentId!, cmd.UrlHash);
 
         var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
 
@@ -295,32 +300,25 @@ public class BaseballEventCompetitionCompetitorProbablesTests
 
         var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionCompetitor.json");
 
-        var cmd = Fixture.Build<ProcessDocumentCommand>()
-            .With(x => x.ParentId, competitionId.ToString())
-            .With(x => x.SeasonYear, 2026)
-            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
-            .With(x => x.Sport, Sport.BaseballMlb)
-            .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitor)
-            .With(x => x.Document, json)
-            .With(x => x.UrlHash, competitorIdentity.UrlHash)
-            .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>?)null)
-            .OmitAutoProperties()
-            .Create();
+        var cmd = BuildCommand(json, competitionId.ToString(), competitorIdentity.UrlHash);
 
         return (cmd, athleteSeasonIdentity.CanonicalId);
     }
 
-    private ProcessDocumentCommand RebuildCommand(ProcessDocumentCommand source, string newDocument)
+    // Single source of truth for ProcessDocumentCommand construction in
+    // this test class. Sport/year/document-type are baked since this
+    // suite only exercises the MLB EventCompetitionCompetitor pipeline.
+    private ProcessDocumentCommand BuildCommand(string document, string parentId, string urlHash)
     {
         return Fixture.Build<ProcessDocumentCommand>()
-            .With(x => x.ParentId, source.ParentId)
-            .With(x => x.SeasonYear, source.SeasonYear)
-            .With(x => x.SourceDataProvider, source.SourceDataProvider)
-            .With(x => x.Sport, source.Sport)
-            .With(x => x.DocumentType, source.DocumentType)
-            .With(x => x.Document, newDocument)
-            .With(x => x.UrlHash, source.UrlHash)
-            .With(x => x.IncludeLinkedDocumentTypes, source.IncludeLinkedDocumentTypes)
+            .With(x => x.ParentId, parentId)
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitor)
+            .With(x => x.Document, document)
+            .With(x => x.UrlHash, urlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>?)null)
             .OmitAutoProperties()
             .Create();
     }


### PR DESCRIPTION
## Summary

Phase 2 of the CompetitionCompetitor sport-specific split (Phase 1 = #301). ESPN ships probable starting pitchers inline on the MLB EventCompetitionCompetitor payload; this hangs them off `BaseballCompetitionCompetitor` as a 1:N collection and wires inline ingestion into the processor pipeline.

- New `CompetitionCompetitorProbable` entity — cascade FK from competitor, restrict FK from athlete, unique index on `(CompetitionCompetitorId, Name)` so the role-name is the natural key.
- Two virtual hooks on `EventCompetitionCompetitorDocumentProcessorBase`:
  - `DeserializeDto` — lets baseball return the sport-specific subclass DTO so `Probables` reaches the pipeline.
  - `ProcessSportSpecificCompetitorData` — runs after the competitor entity is staged but before `SaveChangesAsync`, so probable rows commit in the same transaction. Called from both new-entity and update paths.
- Baseball override resolves `athlete.$ref` to `AthleteSeason`. On miss it publishes a `DocumentRequested` for the AthleteSeason and throws `ExternalDocumentNotSourcedException` — the established not-sourced retry pattern. No partial probable rows; an empty Probable is worthless on the matchup card.
- Deterministic upsert keyed by `(competitorId, role-name)` so reprocessing collapses onto the same row and only updates audit fields.
- See `docs/competition-competitor-probables.md` for the full design rationale (FK direction, why-not denormalize stats, why string Name vs enum, what's deferred to Phase 3/4).

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] 6 new unit tests in `BaseballEventCompetitionCompetitorProbablesTests` — DTO deserialize, happy-path persist, missing-AthleteSeason → dependency-request + retry-republish, idempotent reprocess, missing-Name skip, missing-athlete-ref skip
- [x] Full Producer unit suite green (375 passed, 18 pre-existing skips, 0 failures)
- [x] EF migration applied locally
- [ ] Verify in-flight MLB ingestion picks up Probables on the next live game payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ingesting and storing MLB competition competitor probables (e.g., probable pitchers) with automatic athlete season resolution and idempotent processing.

* **Documentation**
  * Added comprehensive documentation for the probables ingestion pipeline, including schema design, processing logic, and out-of-scope future work.

* **Tests**
  * Added unit test coverage for probable ingestion, including scenarios for missing athlete data, idempotent reprocessing, and missing required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->