### PR TITLE
feat(producer): source AthleteSeasonStatistics for MLB Probables

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
@@ -119,6 +119,17 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
                 $"Probable AthleteSeason {athleteSeasonIdentity.CleanUrl} not sourced. Requested. Will retry. CompetitorId={competitorId}");
         }
 
+        // Spawn the season-stats fetch for the probable's athlete so the
+        // matchup card has ERA / W-L / K available downstream. Idempotent
+        // by design — the AthleteSeasonStatistics processor upserts.
+        // Parent is the AthleteSeason, not the competitor, since that's
+        // the canonical owner of season-stat rows.
+        await PublishChildDocumentRequest(
+            command,
+            probableDto.Statistics,
+            athleteSeasonIdentity.CanonicalId,
+            DocumentType.AthleteSeasonStatistics);
+
         // Deterministic Id from (competitorId, role-name) so reprocessing
         // updates the same row instead of inserting duplicates.
         var probableId = DeterministicGuid.Combine(

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessor.cs
@@ -119,17 +119,6 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
                 $"Probable AthleteSeason {athleteSeasonIdentity.CleanUrl} not sourced. Requested. Will retry. CompetitorId={competitorId}");
         }
 
-        // Spawn the season-stats fetch for the probable's athlete so the
-        // matchup card has ERA / W-L / K available downstream. Idempotent
-        // by design — the AthleteSeasonStatistics processor upserts.
-        // Parent is the AthleteSeason, not the competitor, since that's
-        // the canonical owner of season-stat rows.
-        await PublishChildDocumentRequest(
-            command,
-            probableDto.Statistics,
-            athleteSeasonIdentity.CanonicalId,
-            DocumentType.AthleteSeasonStatistics);
-
         // Deterministic Id from (competitorId, role-name) so reprocessing
         // updates the same row instead of inserting duplicates.
         var probableId = DeterministicGuid.Combine(
@@ -140,7 +129,9 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
         var existing = await _dataContext.CompetitionCompetitorProbables
             .FirstOrDefaultAsync(x => x.Id == probableId);
 
-        if (existing is null)
+        var isNew = existing is null;
+
+        if (isNew)
         {
             existing = new CompetitionCompetitorProbable
             {
@@ -156,7 +147,7 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
         }
         else
         {
-            existing.ModifiedUtc = _dateTimeProvider.UtcNow();
+            existing!.ModifiedUtc = _dateTimeProvider.UtcNow();
             existing.ModifiedBy = command.CorrelationId;
         }
 
@@ -167,5 +158,22 @@ public class BaseballEventCompetitionCompetitorDocumentProcessor<TDataContext> :
         existing.DisplayName = probableDto.DisplayName;
         existing.ShortDisplayName = probableDto.ShortDisplayName;
         existing.Abbreviation = probableDto.Abbreviation;
+
+        // Spawn the season-stats fetch for the probable's athlete so the
+        // matchup card has ERA / W-L / K available downstream. Mirrors
+        // the isNew-or-ShouldSpawn pattern in
+        // EventCompetitionCompetitorDocumentProcessorBase.ProcessChildDocuments
+        // so a Refresh Contest with a narrow IncludeLinkedDocumentTypes
+        // can suppress the fan-out on update without dropping it for
+        // first-time inserts. Parent is the AthleteSeason (canonical
+        // owner of season-stat rows), not the competitor.
+        if (isNew || ShouldSpawn(DocumentType.AthleteSeasonStatistics, command))
+        {
+            await PublishChildDocumentRequest(
+                command,
+                probableDto.Statistics,
+                athleteSeasonIdentity.CanonicalId,
+                DocumentType.AthleteSeasonStatistics);
+        }
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessorTests.cs
@@ -115,6 +115,36 @@ public class BaseballEventCompetitionCompetitorDocumentProcessorTests
     }
 
     [Fact]
+    public async Task WhenExistingProbable_AndCascadeFilterExcludesStats_DoesNotRequestStatistics()
+    {
+        // arrange — first pass creates the row (new path always fans out).
+        var (cmd, _) = await SetupHappyPath();
+        var bus = Mocker.GetMock<IEventBus>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+        bus.Invocations.Clear();
+
+        // Second pass with a narrow IncludeLinkedDocumentTypes that does
+        // NOT include AthleteSeasonStatistics — mirrors a Refresh Contest
+        // narrowing the cascade. Existing-row path must respect the filter.
+        var narrowedCmd = BuildCommand(
+            cmd.Document,
+            cmd.ParentId!,
+            cmd.UrlHash,
+            includeLinkedDocumentTypes: new[] { DocumentType.EventCompetitionCompetitorScore });
+
+        // act
+        await sut.ProcessAsync(narrowedCmd);
+
+        // assert — the stats fan-out is suppressed on the update path.
+        bus.Verify(x => x.Publish(
+                It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeasonStatistics),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task WhenProbableIsPersisted_RequestsAthleteSeasonStatistics()
     {
         // arrange — happy-path setup wires AthleteSeason; the probable's
@@ -337,7 +367,13 @@ public class BaseballEventCompetitionCompetitorDocumentProcessorTests
     // Single source of truth for ProcessDocumentCommand construction in
     // this test class. Sport/year/document-type are baked since this
     // suite only exercises the MLB EventCompetitionCompetitor pipeline.
-    private ProcessDocumentCommand BuildCommand(string document, string parentId, string urlHash)
+    // includeLinkedDocumentTypes lets a test pin the cascade-filter
+    // behavior (Refresh Contest narrowing).
+    private ProcessDocumentCommand BuildCommand(
+        string document,
+        string parentId,
+        string urlHash,
+        IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null)
     {
         return Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.ParentId, parentId)
@@ -347,7 +383,7 @@ public class BaseballEventCompetitionCompetitorDocumentProcessorTests
             .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitor)
             .With(x => x.Document, document)
             .With(x => x.UrlHash, urlHash)
-            .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>?)null)
+            .With(x => x.IncludeLinkedDocumentTypes, includeLinkedDocumentTypes)
             .OmitAutoProperties()
             .Create();
     }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessorTests.cs
@@ -27,20 +27,20 @@ using Xunit;
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
 
 /// <summary>
-/// Tests for inline MLB Probables ingestion driven by
-/// <see cref="BaseballEventCompetitionCompetitorDocumentProcessor{TDataContext}.ProcessSportSpecificCompetitorData"/>.
+/// Tests for <see cref="BaseballEventCompetitionCompetitorDocumentProcessor{TDataContext}"/>.
 ///
-/// ESPN ships probable starting pitchers inline on the
-/// EventCompetitionCompetitor payload. Each Probable carries a hard FK to
-/// AthleteSeason — when the athlete isn't in the DB yet, the processor
-/// publishes a dependency request and throws
-/// ExternalDocumentNotSourcedException so Hangfire retries. No partial
-/// rows; an empty Probable is worthless on the matchup card.
+/// Today the only sport-specific behavior on this processor is the MLB
+/// Probables ingestion path, so the suite is currently dominated by
+/// Probables scenarios. Each Probable carries a hard FK to AthleteSeason —
+/// when the athlete isn't in the DB yet, the processor publishes a
+/// dependency request and throws ExternalDocumentNotSourcedException so
+/// Hangfire retries. No partial rows; an empty Probable is worthless on
+/// the matchup card.
 ///
 /// See docs/competition-competitor-probables.md.
 /// </summary>
 [Collection("Sequential")]
-public class BaseballEventCompetitionCompetitorProbablesTests
+public class BaseballEventCompetitionCompetitorDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>
 {
     private readonly BaseballDataContext _baseballDataContext;
@@ -54,7 +54,7 @@ public class BaseballEventCompetitionCompetitorProbablesTests
     private static readonly Uri AthleteSeasonRef = new(
         "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4311625?lang=en&region=us");
 
-    public BaseballEventCompetitionCompetitorProbablesTests()
+    public BaseballEventCompetitionCompetitorDocumentProcessorTests()
     {
         _baseballDataContext = new BaseballDataContext(
             new DbContextOptionsBuilder<BaseballDataContext>()
@@ -115,6 +115,28 @@ public class BaseballEventCompetitionCompetitorProbablesTests
     }
 
     [Fact]
+    public async Task WhenProbableIsPersisted_RequestsAthleteSeasonStatistics()
+    {
+        // arrange — happy-path setup wires AthleteSeason; the probable's
+        // statistics.$ref should fan out as a child doc request so the
+        // matchup card has season stats downstream.
+        var (cmd, athleteSeasonId) = await SetupHappyPath();
+        var bus = Mocker.GetMock<IEventBus>();
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — child request fired with parent = AthleteSeasonId.
+        bus.Verify(x => x.Publish(
+                It.Is<DocumentRequested>(d =>
+                    d.DocumentType == DocumentType.AthleteSeasonStatistics &&
+                    d.ParentId == athleteSeasonId.ToString()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task WhenAthleteSeasonMissing_PublishesDependencyAndRequestsRetry()
     {
         // arrange — competition + franchise season seeded, but NOT AthleteSeason.
@@ -142,6 +164,13 @@ public class BaseballEventCompetitionCompetitorProbablesTests
                 It.IsAny<IDictionary<string, object>>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // The stats child fan-out is gated on AthleteSeason existing —
+        // the throw happens before the publish, so nothing fires.
+        bus.Verify(x => x.Publish(
+                It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeasonStatistics),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
 
         // No probable row should have been persisted (the throw happened
         // before any AddAsync on the probables DbSet).

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
@@ -25,26 +25,27 @@ using Xunit;
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
 
 /// <summary>
-/// Tests for the inline series snapshot in
-/// <see cref="BaseballEventCompetitionDocumentProcessor{TDataContext}.ProcessSportSpecificCompetitionData"/>.
+/// Tests for <see cref="BaseballEventCompetitionDocumentProcessor{TDataContext}"/>.
 ///
-/// ESPN ships current-series and season-series state inline on the
-/// EventCompetition payload. We snapshot it onto BaseballCompetition
-/// columns and lock on first non-null write. Subsequent reprocessing
-/// does not overwrite, so historical matchup pages render at-game-start
-/// state instead of current rolled-up state. EspnSeriesId is the
-/// grouping key (not historical state) and refreshes every pass.
+/// Today the only sport-specific behavior on this processor is the
+/// inline series snapshot (current-series and season-series state ships
+/// on the EventCompetition payload), so the suite is currently
+/// dominated by series scenarios. Snapshot columns lock on first
+/// non-null write — subsequent reprocessing does not overwrite, so
+/// historical matchup pages render at-game-start state instead of
+/// current rolled-up state. EspnSeriesId is the grouping key (not
+/// historical state) and refreshes every pass.
 ///
 /// See docs/series-snapshot-redesign.md.
 /// </summary>
 [Collection("Sequential")]
-public class BaseballEventCompetitionDocumentProcessorSeriesTests
+public class BaseballEventCompetitionDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>
 {
     private readonly BaseballDataContext _baseballDataContext;
     private static readonly DateTime FixedNow = new(2026, 5, 4, 12, 0, 0, DateTimeKind.Utc);
 
-    public BaseballEventCompetitionDocumentProcessorSeriesTests()
+    public BaseballEventCompetitionDocumentProcessorTests()
     {
         _baseballDataContext = new BaseballDataContext(
             new DbContextOptionsBuilder<BaseballDataContext>()


### PR DESCRIPTION
## Summary

Sets up downstream sourcing for MLB probable-pitcher season stats — the data the matchup card / Command Center tile needs (ERA, W-L, K, …). Narrow slice: just the fan-out, no new entity / processor / migration.

- `BaseballEventCompetitionCompetitorDocumentProcessor.UpsertProbable` now calls `PublishChildDocumentRequest(... DocumentType.AthleteSeasonStatistics)` after the AthleteSeason existence check passes. Parent is the AthleteSeason (canonical owner of season-stat rows), not the competitor. The shared `AthleteSeasonStatisticsDocumentProcessor` (already registered for `Sport.BaseballMlb`) handles the rest.
- Gated correctly: nothing fans out when the AthleteSeason isn't sourced yet — the existing fail-loud throw runs first, Hangfire retries the document, and the stats request only fires once the dependency lands.
- Snapshotting specific stat fields onto `CompetitionCompetitorProbable` at game-start time (the true Phase 3 from `docs/competition-competitor-probables.md`) is deferred. It only matters for historical-game replay and doesn't block the upcoming-game UI.

Also folds in two SUT-naming corrections (CR-style cleanup) since the test classes were named after features instead of the class under test:
- `BaseballEventCompetitionCompetitorProbablesTests` → `BaseballEventCompetitionCompetitorDocumentProcessorTests`
- `BaseballEventCompetitionDocumentProcessorSeriesTests` → `BaseballEventCompetitionDocumentProcessorTests`

## Test plan

- [x] New test `WhenProbableIsPersisted_RequestsAthleteSeasonStatistics` — verifies the child request fires with `DocumentType.AthleteSeasonStatistics` and `ParentId = athleteSeasonId`
- [x] Tightened `WhenAthleteSeasonMissing_PublishesDependencyAndRequestsRetry` — asserts the stats fan-out is `Times.Never` so a regression that fires it before the dependency lands fails the suite
- [x] Full Producer unit suite green (376 passed, 18 pre-existing skips, 0 failures)
- [ ] Verify in-flight MLB ingestion: a fresh probable triggers the AthleteSeasonStatistics fetch and the row lands in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured pitcher statistics (ERA, W-L, K) are now fetched and available for matchup card display when processing probable players.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/303)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->