### PR TITLE
feat(picks): show MLB probable starting pitchers on matchups

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekMatchupsDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekMatchupsDto.cs
@@ -1,5 +1,6 @@
 using SportsData.Api.Application.UI.Contest.Dtos;
 using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
 
 using SportsData.Api.Application.Common.Enums;
 
@@ -91,6 +92,10 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
             // exists in an actionable state (Scheduled / AwaitingStart / Active).
             // Drives the "View" call-to-action on matchup cards.
             public DateTime? StreamScheduledTimeUtc { get; set; }
+
+            // MLB only — null on non-MLB matchups.
+            public ProbablePitcherDto? HomeProbablePitcher { get; set; }
+            public ProbablePitcherDto? AwayProbablePitcher { get; set; }
         }
     }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -266,6 +266,10 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
 
                     matchup.StreamScheduledTimeUtc = canonical.StreamScheduledTimeUtc;
 
+                    // MLB only — null for non-MLB leagues; UI conditionally renders.
+                    matchup.HomeProbablePitcher = canonical.HomeProbablePitcher;
+                    matchup.AwayProbablePitcher = canonical.AwayProbablePitcher;
+
                     var preview = previews
                         .Where(x => x.ContestId == matchup.ContestId &&
                                     x.RejectedUtc == null)

--- a/src/SportsData.Core/Dtos/Canonical/LeagueMatchupDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/LeagueMatchupDto.cs
@@ -68,4 +68,10 @@ public class LeagueMatchupDto
     /// the UI; future enhancements can render a countdown.
     /// </summary>
     public DateTime? StreamScheduledTimeUtc { get; set; }
+
+    // MLB only — null on non-MLB matchups. Stitched onto the SQL result
+    // by GetMatchupsByContestIdsQueryHandler from the Probables ingestion
+    // landed in PR #302.
+    public ProbablePitcherDto? HomeProbablePitcher { get; set; }
+    public ProbablePitcherDto? AwayProbablePitcher { get; set; }
 }

--- a/src/SportsData.Core/Dtos/Canonical/ProbablePitcherDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ProbablePitcherDto.cs
@@ -1,0 +1,12 @@
+namespace SportsData.Core.Dtos.Canonical;
+
+/// <summary>
+/// Probable starting pitcher for an MLB matchup. Optional — non-MLB
+/// matchups serialize this as null. UI conditionally renders.
+/// </summary>
+public sealed class ProbablePitcherDto
+{
+    public string DisplayName { get; set; } = default!;
+
+    public string? HeadshotUrl { get; set; }
+}

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Producer.Enums;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Sql;
 
@@ -56,12 +57,82 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
             .ToList();
 
         var streamTimes = await GetActiveStreamTimesAsync(query.ContestIds, cancellationToken);
+        var probables = await GetProbablePitchersAsync(query.ContestIds, cancellationToken);
         foreach (var matchup in matchups)
         {
             matchup.StreamScheduledTimeUtc = streamTimes.GetValueOrDefault(matchup.ContestId);
+
+            if (probables.TryGetValue(matchup.ContestId, out var pair))
+            {
+                matchup.HomeProbablePitcher = pair.Home;
+                matchup.AwayProbablePitcher = pair.Away;
+            }
         }
 
         return new Success<List<LeagueMatchupDto>>(matchups);
+    }
+
+    /// <summary>
+    /// Stitches MLB probable starting pitchers onto the matchup result.
+    /// Sport-gated: only runs when the underlying context is the Baseball
+    /// one. NFL/NCAAFB Producer instances no-op without a round-trip,
+    /// keeping the canonical matchups SQL sport-agnostic. Mirrors the
+    /// 2-phase pattern in GetContestOverviewQueryHandler for headshots.
+    /// </summary>
+    internal async Task<Dictionary<Guid, (ProbablePitcherDto? Home, ProbablePitcherDto? Away)>> GetProbablePitchersAsync(
+        Guid[] contestIds,
+        CancellationToken cancellationToken)
+    {
+        var empty = new Dictionary<Guid, (ProbablePitcherDto?, ProbablePitcherDto?)>();
+
+        if (_dbContext is not BaseballDataContext baseballCtx)
+        {
+            return empty;
+        }
+
+        const string ProbableStartingPitcherRole = "probableStartingPitcher";
+
+        var rows = await baseballCtx.CompetitionCompetitorProbables
+            .AsNoTracking()
+            .Where(p => p.Name == ProbableStartingPitcherRole)
+            .Where(p => contestIds.Contains(p.CompetitionCompetitor.Competition.ContestId))
+            .Select(p => new
+            {
+                ContestId = p.CompetitionCompetitor.Competition.ContestId,
+                p.CompetitionCompetitor.HomeAway,
+                p.AthleteSeason.DisplayName,
+                HeadshotUrl = p.AthleteSeason.Athlete != null && p.AthleteSeason.Athlete.Images.Any()
+                    ? p.AthleteSeason.Athlete.Images.OrderBy(i => i.CreatedUtc).First().Uri.ToString()
+                    : null
+            })
+            .ToListAsync(cancellationToken);
+
+        var dict = new Dictionary<Guid, (ProbablePitcherDto? Home, ProbablePitcherDto? Away)>();
+        foreach (var r in rows)
+        {
+            if (string.IsNullOrWhiteSpace(r.DisplayName))
+            {
+                continue;
+            }
+
+            var pitcher = new ProbablePitcherDto
+            {
+                DisplayName = r.DisplayName!,
+                HeadshotUrl = r.HeadshotUrl
+            };
+
+            dict.TryGetValue(r.ContestId, out var entry);
+            if (string.Equals(r.HomeAway, "home", StringComparison.OrdinalIgnoreCase))
+            {
+                entry = (pitcher, entry.Away);
+            }
+            else if (string.Equals(r.HomeAway, "away", StringComparison.OrdinalIgnoreCase))
+            {
+                entry = (entry.Home, pitcher);
+            }
+            dict[r.ContestId] = entry;
+        }
+        return dict;
     }
 
     /// <summary>

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
@@ -92,10 +92,18 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
 
         const string ProbableStartingPitcherRole = "probableStartingPitcher";
 
+        // Order by CompetitionCompetitorId for deterministic picking.
+        // The unique index (CompetitionCompetitorId, Name) guarantees one
+        // SP probable per CompetitionCompetitor — but a single Contest can
+        // host multiple Competitions (1:N), so a Contest could in theory
+        // surface multiple home/away SP rows. With this ordering combined
+        // with the "first wins" stitch below, the chosen row is stable
+        // across calls regardless of physical row order from Postgres.
         var rows = await baseballCtx.CompetitionCompetitorProbables
             .AsNoTracking()
             .Where(p => p.Name == ProbableStartingPitcherRole)
             .Where(p => contestIds.Contains(p.CompetitionCompetitor.Competition.ContestId))
+            .OrderBy(p => p.CompetitionCompetitorId)
             .Select(p => new
             {
                 ContestId = p.CompetitionCompetitor.Competition.ContestId,
@@ -115,18 +123,21 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
                 continue;
             }
 
+            dict.TryGetValue(r.ContestId, out var entry);
             var pitcher = new ProbablePitcherDto
             {
                 DisplayName = r.DisplayName!,
                 HeadshotUrl = r.HeadshotUrl
             };
 
-            dict.TryGetValue(r.ContestId, out var entry);
-            if (string.Equals(r.HomeAway, "home", StringComparison.OrdinalIgnoreCase))
+            // First match wins per side. Combined with the OrderBy above,
+            // this means the lowest CompetitionCompetitorId is the chosen
+            // pitcher when multiple Competitions share a Contest.
+            if (string.Equals(r.HomeAway, "home", StringComparison.OrdinalIgnoreCase) && entry.Home is null)
             {
                 entry = (pitcher, entry.Away);
             }
-            else if (string.Equals(r.HomeAway, "away", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(r.HomeAway, "away", StringComparison.OrdinalIgnoreCase) && entry.Away is null)
             {
                 entry = (entry.Home, pitcher);
             }

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -191,6 +191,30 @@
   color: var(--text-muted);
 }
 
+/* MLB probable starting pitcher row, rendered just below the team-record-row */
+.team-probable-pitcher {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.probable-pitcher-headshot {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.probable-pitcher-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
 .team-spread {
   font-weight: bold;
   font-size: 1.2rem;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -183,6 +183,7 @@ function MatchupCard({
           schedule={awaySchedule}
           loading={awayLoading}
           error={awayError}
+          probablePitcher={matchup.awayProbablePitcher}
         />
 
         {/* Home Team Row */}
@@ -202,6 +203,7 @@ function MatchupCard({
           schedule={homeSchedule}
           loading={homeLoading}
           error={homeError}
+          probablePitcher={matchup.homeProbablePitcher}
         />
 
         {/* Spread and Over/Under */}

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -20,6 +20,7 @@ import MiniSchedule from "./MiniSchedule";
  * @param {array} props.schedule - Schedule data array
  * @param {boolean} props.loading - Schedule loading state
  * @param {string} props.error - Schedule error message
+ * @param {object} [props.probablePitcher] - MLB only; { displayName, headshotUrl }
  */
 function TeamRow({
   teamName,
@@ -36,7 +37,8 @@ function TeamRow({
   onToggleSchedule,
   schedule,
   loading,
-  error
+  error,
+  probablePitcher
 }) {
   // resolveSportLeague returns null for unknown/missing enums so unsupported
   // sports don't silently render as an NCAA football route. Fall back to a
@@ -88,6 +90,18 @@ function TeamRow({
                 </button>
               </div>
             </div>
+            {probablePitcher?.displayName && (
+              <div className="team-probable-pitcher">
+                {probablePitcher.headshotUrl && (
+                  <img
+                    src={probablePitcher.headshotUrl}
+                    alt={probablePitcher.displayName}
+                    className="probable-pitcher-headshot"
+                  />
+                )}
+                <span className="probable-pitcher-name">{probablePitcher.displayName}</span>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -95,7 +95,8 @@ function TeamRow({
                 {probablePitcher.headshotUrl && (
                   <img
                     src={probablePitcher.headshotUrl}
-                    alt={probablePitcher.displayName}
+                    alt=""
+                    aria-hidden="true"
                     className="probable-pitcher-headshot"
                   />
                 )}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandlerTests.cs
@@ -110,6 +110,72 @@ public class GetMatchupsByContestIdsQueryHandlerTests
     }
 
     [Fact]
+    public async Task GetProbablePitchers_MultipleCompetitionsPerContest_PicksDeterministicallyByCompetitorId()
+    {
+        // arrange — single Contest with TWO Competitions (e.g. a stale
+        // reschedule artifact), each with its own home CompetitionCompetitor
+        // and SP probable. The unique index allows this — it's per
+        // CompetitionCompetitor, not per Contest. Without a stable OrderBy,
+        // the dict-stitch was overwriting on the last row Postgres
+        // happened to return.
+        var ctx = NewBaseballContext();
+        var contestId = Guid.NewGuid();
+        var competitionA = Guid.NewGuid();
+        var competitionB = Guid.NewGuid();
+
+        // Two Competitions hanging off the same Contest.
+        ctx.Contests.Add(new BaseballContest
+        {
+            Id = contestId,
+            Name = "Test",
+            ShortName = "TST",
+            SeasonYear = 2026,
+            Sport = SportsData.Core.Common.Sport.BaseballMlb,
+            StartDateUtc = FixedNow,
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.Competitions.Add(new BaseballCompetition
+        {
+            Id = competitionA,
+            ContestId = contestId,
+            Date = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.Competitions.Add(new BaseballCompetition
+        {
+            Id = competitionB,
+            ContestId = contestId,
+            Date = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        // Pin CompetitorIds so we can predict the deterministic winner
+        // (lowest CompetitorId by GUID compare).
+        var lowerCompetitorId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var higherCompetitorId = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+        SeedHomeCompetitorWithProbable(ctx, competitionA, lowerCompetitorId, "Lower Wins");
+        SeedHomeCompetitorWithProbable(ctx, competitionB, higherCompetitorId, "Higher Loses");
+
+        await ctx.SaveChangesAsync();
+
+        var sut = NewSut(ctx);
+
+        // act — call twice, assert same answer both times.
+        var first = await sut.GetProbablePitchersAsync(new[] { contestId }, CancellationToken.None);
+        var second = await sut.GetProbablePitchersAsync(new[] { contestId }, CancellationToken.None);
+
+        // assert
+        first[contestId].Home!.DisplayName.Should().Be("Lower Wins");
+        second[contestId].Home!.DisplayName.Should().Be(first[contestId].Home!.DisplayName);
+    }
+
+    [Fact]
     public async Task GetProbablePitchers_PicksEarliestHeadshotByCreatedUtc()
     {
         // arrange — seed an athlete with two images; expect the earliest one.
@@ -222,6 +288,58 @@ public class GetMatchupsByContestIdsQueryHandlerTests
             Id = competitionId,
             ContestId = contestId,
             Date = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+    }
+
+    // Variant that lets the test pin CompetitorId so the OrderBy in the
+    // production code is exercised against a known relative order.
+    private static void SeedHomeCompetitorWithProbable(
+        BaseballDataContext ctx,
+        Guid competitionId,
+        Guid competitorId,
+        string athleteName)
+    {
+        ctx.CompetitionCompetitors.Add(new BaseballCompetitionCompetitor
+        {
+            Id = competitorId,
+            CompetitionId = competitionId,
+            HomeAway = "home",
+            FranchiseSeasonId = Guid.NewGuid(),
+            Order = 0,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        var athleteId = Guid.NewGuid();
+        var athleteSeasonId = Guid.NewGuid();
+        ctx.Set<BaseballAthlete>().Add(new BaseballAthlete
+        {
+            Id = athleteId,
+            FirstName = athleteName,
+            LastName = "Doe",
+            DisplayName = athleteName,
+            ShortName = athleteName,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.AthleteSeasons.Add(new BaseballAthleteSeason
+        {
+            Id = athleteSeasonId,
+            AthleteId = athleteId,
+            DisplayName = athleteName,
+            PositionId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.CompetitionCompetitorProbables.Add(new CompetitionCompetitorProbable
+        {
+            Id = Guid.NewGuid(),
+            CompetitionCompetitorId = competitorId,
+            AthleteSeasonId = athleteSeasonId,
+            EspnPlayerId = athleteName.GetHashCode(),
+            Name = "probableStartingPitcher",
             CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         });

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandlerTests.cs
@@ -1,0 +1,296 @@
+#nullable enable
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsByContestIds;
+using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+using SportsData.Producer.Infrastructure.Sql;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests.Queries.GetMatchupsByContestIds;
+
+/// <summary>
+/// Tests for the probables-stitch helper on GetMatchupsByContestIdsQueryHandler.
+/// The main ExecuteAsync runs raw SQL via Dapper and isn't testable through the
+/// EF InMemory provider — these tests target only the EF-side companion fetch
+/// that augments the SQL result with MLB probable starting pitcher info.
+/// </summary>
+public class GetMatchupsByContestIdsQueryHandlerTests
+{
+    private static readonly DateTime FixedNow = new(2026, 5, 9, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task GetProbablePitchers_HappyPath_ReturnsHomeAndAwayPitchers()
+    {
+        // arrange — one MLB matchup with both home and away probable SPs.
+        var ctx = NewBaseballContext();
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+        SeedContestWithCompetition(ctx, contestId, competitionId);
+
+        var (homeCompetitorId, _) = SeedCompetitorWithProbable(ctx, competitionId,
+            homeAway: "home", athleteName: "Home Ace", headshot: "https://cdn/home.png");
+        var (awayCompetitorId, _) = SeedCompetitorWithProbable(ctx, competitionId,
+            homeAway: "away", athleteName: "Away Ace", headshot: "https://cdn/away.png");
+
+        await ctx.SaveChangesAsync();
+
+        var sut = NewSut(ctx);
+
+        // act
+        var result = await sut.GetProbablePitchersAsync(new[] { contestId }, CancellationToken.None);
+
+        // assert
+        result.Should().ContainKey(contestId);
+        var pair = result[contestId];
+        pair.Home.Should().NotBeNull();
+        pair.Home!.DisplayName.Should().Be("Home Ace");
+        pair.Home.HeadshotUrl.Should().Be("https://cdn/home.png");
+        pair.Away.Should().NotBeNull();
+        pair.Away!.DisplayName.Should().Be("Away Ace");
+        pair.Away.HeadshotUrl.Should().Be("https://cdn/away.png");
+
+        // unused locals quieted
+        _ = homeCompetitorId;
+        _ = awayCompetitorId;
+    }
+
+    [Fact]
+    public async Task GetProbablePitchers_FiltersOutNonStartingPitcherRoles()
+    {
+        // arrange — seed a probable with a non-SP role; should be ignored.
+        var ctx = NewBaseballContext();
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+        SeedContestWithCompetition(ctx, contestId, competitionId);
+
+        SeedCompetitorWithProbable(ctx, competitionId,
+            homeAway: "home", athleteName: "Closer Carl", headshot: null,
+            probableName: "probableCloser");
+
+        await ctx.SaveChangesAsync();
+
+        var sut = NewSut(ctx);
+
+        // act
+        var result = await sut.GetProbablePitchersAsync(new[] { contestId }, CancellationToken.None);
+
+        // assert — no entry for this contest because no SP probable exists.
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetProbablePitchers_NonBaseballContext_ReturnsEmpty()
+    {
+        // arrange — use a Football context. The helper should sport-gate
+        // and short-circuit without a query.
+        var footballCtx = new FootballDataContext(
+            new DbContextOptionsBuilder<FootballDataContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+                .Options);
+
+        var handler = new GetMatchupsByContestIdsQueryHandler(
+            NullLogger<GetMatchupsByContestIdsQueryHandler>.Instance,
+            footballCtx,
+            new ProducerSqlQueryProvider());
+
+        // act
+        var result = await handler.GetProbablePitchersAsync(new[] { Guid.NewGuid() }, CancellationToken.None);
+
+        // assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetProbablePitchers_PicksEarliestHeadshotByCreatedUtc()
+    {
+        // arrange — seed an athlete with two images; expect the earliest one.
+        var ctx = NewBaseballContext();
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+        SeedContestWithCompetition(ctx, contestId, competitionId);
+
+        var competitorId = Guid.NewGuid();
+        ctx.CompetitionCompetitors.Add(new BaseballCompetitionCompetitor
+        {
+            Id = competitorId,
+            CompetitionId = competitionId,
+            HomeAway = "home",
+            FranchiseSeasonId = Guid.NewGuid(),
+            Order = 1,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        var athleteId = Guid.NewGuid();
+        var athleteSeasonId = Guid.NewGuid();
+        ctx.Set<BaseballAthlete>().Add(new BaseballAthlete
+        {
+            Id = athleteId,
+            FirstName = "Ace",
+            LastName = "Pitcher",
+            DisplayName = "Ace Pitcher",
+            ShortName = "A. Pitcher",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.AthleteSeasons.Add(new BaseballAthleteSeason
+        {
+            Id = athleteSeasonId,
+            AthleteId = athleteId,
+            DisplayName = "Ace Pitcher",
+            PositionId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.Set<AthleteImage>().Add(new AthleteImage
+        {
+            Id = Guid.NewGuid(),
+            AthleteId = athleteId,
+            OriginalUrlHash = "hashLater",
+            Uri = new Uri("https://cdn/later.png"),
+            CreatedUtc = FixedNow.AddDays(2),
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.Set<AthleteImage>().Add(new AthleteImage
+        {
+            Id = Guid.NewGuid(),
+            AthleteId = athleteId,
+            OriginalUrlHash = "hashEarlier",
+            Uri = new Uri("https://cdn/earlier.png"),
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.CompetitionCompetitorProbables.Add(new CompetitionCompetitorProbable
+        {
+            Id = Guid.NewGuid(),
+            CompetitionCompetitorId = competitorId,
+            AthleteSeasonId = athleteSeasonId,
+            EspnPlayerId = 1,
+            Name = "probableStartingPitcher",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await ctx.SaveChangesAsync();
+
+        var sut = NewSut(ctx);
+
+        // act
+        var result = await sut.GetProbablePitchersAsync(new[] { contestId }, CancellationToken.None);
+
+        // assert — earliest CreatedUtc image wins.
+        result.Should().ContainKey(contestId);
+        result[contestId].Home!.HeadshotUrl.Should().Be("https://cdn/earlier.png");
+    }
+
+    private static BaseballDataContext NewBaseballContext() =>
+        new(new DbContextOptionsBuilder<BaseballDataContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+            .Options);
+
+    private static GetMatchupsByContestIdsQueryHandler NewSut(BaseballDataContext ctx) =>
+        new(NullLogger<GetMatchupsByContestIdsQueryHandler>.Instance,
+            ctx,
+            new ProducerSqlQueryProvider());
+
+    private static void SeedContestWithCompetition(BaseballDataContext ctx, Guid contestId, Guid competitionId)
+    {
+        ctx.Contests.Add(new BaseballContest
+        {
+            Id = contestId,
+            Name = "Test",
+            ShortName = "TST",
+            SeasonYear = 2026,
+            Sport = SportsData.Core.Common.Sport.BaseballMlb,
+            StartDateUtc = FixedNow,
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        ctx.Competitions.Add(new BaseballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Date = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+    }
+
+    private static (Guid CompetitorId, Guid AthleteSeasonId) SeedCompetitorWithProbable(
+        BaseballDataContext ctx,
+        Guid competitionId,
+        string homeAway,
+        string athleteName,
+        string? headshot,
+        string probableName = "probableStartingPitcher")
+    {
+        var competitorId = Guid.NewGuid();
+        ctx.CompetitionCompetitors.Add(new BaseballCompetitionCompetitor
+        {
+            Id = competitorId,
+            CompetitionId = competitionId,
+            HomeAway = homeAway,
+            FranchiseSeasonId = Guid.NewGuid(),
+            Order = string.Equals(homeAway, "home", StringComparison.OrdinalIgnoreCase) ? 0 : 1,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        var athleteId = Guid.NewGuid();
+        var athleteSeasonId = Guid.NewGuid();
+        ctx.Set<BaseballAthlete>().Add(new BaseballAthlete
+        {
+            Id = athleteId,
+            FirstName = athleteName.Split(' ')[0],
+            LastName = athleteName.Split(' ').Length > 1 ? athleteName.Split(' ')[1] : "Doe",
+            DisplayName = athleteName,
+            ShortName = athleteName,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        ctx.AthleteSeasons.Add(new BaseballAthleteSeason
+        {
+            Id = athleteSeasonId,
+            AthleteId = athleteId,
+            DisplayName = athleteName,
+            PositionId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        if (headshot is not null)
+        {
+            ctx.Set<AthleteImage>().Add(new AthleteImage
+            {
+                Id = Guid.NewGuid(),
+                AthleteId = athleteId,
+                OriginalUrlHash = Guid.NewGuid().ToString("N").Substring(0, 16),
+                Uri = new Uri(headshot),
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+        ctx.CompetitionCompetitorProbables.Add(new CompetitionCompetitorProbable
+        {
+            Id = Guid.NewGuid(),
+            CompetitionCompetitorId = competitorId,
+            AthleteSeasonId = athleteSeasonId,
+            EspnPlayerId = athleteName.GetHashCode(),
+            Name = probableName,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        return (competitorId, athleteSeasonId);
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces MLB probable starting pitcher (headshot + name) inside each team's `.team-details` block on the picks-page matchup card, just below the record row. Foundational for the live-game updates that follow.

- **Core DTO**: new `ProbablePitcherDto { DisplayName, HeadshotUrl? }`. `LeagueMatchupDto` and the API's `MatchupForPickDto` each gain nullable `HomeProbablePitcher` / `AwayProbablePitcher`. Non-MLB matchups serialize them as null and the UI no-ops — auth-UI stays sport-neutral.
- **Producer**: keeps `GetMatchupsByContestIds.sql` untouched. `GetMatchupsByContestIdsQueryHandler` adds a 2-phase EF stitch (`GetProbablePitchersAsync`) modeled on the existing `GetActiveStreamTimesAsync` helper. Sport-gated on `_dbContext is BaseballDataContext` — non-MLB Producer pods short-circuit without a round-trip.
- **Headshot resolution**: `AthleteSeason.Athlete.Images.OrderBy(CreatedUtc).First().Uri` — same precedent as the contest-overview leaders panel, so we have one consistent rule for picking an athlete image.
- **API**: `GetLeagueWeekMatchupsQueryHandler` carries the new fields through the canonical → matchup mapping (one new line block).
- **UI**: `TeamRow.jsx` accepts an optional `probablePitcher` prop and renders `<img>` + name conditionally inside `.team-details`. `MatchupCard.jsx` passes `matchup.{home,away}ProbablePitcher`. `MatchupCard.css` adds a small flex row with a 28px circular headshot — sized smaller than the leaders panel since it lives inside an already-dense row.

We discussed splitting into `BaseballMatchupCard` / `FootballMatchupCard` and decided **not yet** — today's divergence is one conditional row in `TeamRow`. The next sport-specific block (live inning state via the `BoxScoreTable` extraction) is the natural trigger to revisit. Ticketed as the follow-on PR.

## Test plan

- [x] 4 new unit tests on `GetMatchupsByContestIdsQueryHandler.GetProbablePitchersAsync`:
  - Happy path — both home and away probable SPs stitched onto the result with correct DisplayName + HeadshotUrl
  - Role filter — only `probableStartingPitcher` is picked (a `probableCloser` row is ignored)
  - Sport gate — a `FootballDataContext` instance returns an empty dictionary without querying
  - Headshot ordering — when the athlete has multiple images, earliest `CreatedUtc` wins
- [x] Producer suite: 381 passed, 18 skipped, 0 failed
- [x] API suite: 329 passed, 0 failed
- [x] Manual visual check on `localhost:3000/app/picks/{contestId}` — every MLB matchup renders both starters; non-MLB matchups unchanged
- [ ] Spot-check in prod after merge: a fresh probable cycle attaches both pitchers to the upcoming MLB picks page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MLB matchups now display probable starting pitcher information, including the pitcher's name and headshot image on the matchup card.

* **Tests**
  * Added comprehensive unit tests to validate probable pitcher data retrieval and display logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/304)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->