### PR TITLE
refactor(ui): extract BoxScoreTable from ContestOverviewHeader

### DIFF
--- a/src/UI/sd-ui/src/components/contests/ContestOverview.css
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.css
@@ -113,64 +113,9 @@
   color: var(--text-muted);
 }
 
-.contest-boxscore-table-wrapper {
-  text-align: center;
-}
-
-.contest-boxscore-table-wrapper.compact {
-  min-width: 220px;
-  max-width: 320px;
-  margin: 0 12px;
-  padding: 0;
-}
-
-/* Sports with more than 4 periods (e.g. MLB 9 innings) need to grow past the
-   football-tuned default so the Total column doesn't collide with the home
-   team's score on the right. */
-.contest-boxscore-table-wrapper.compact.wide {
-  min-width: 0;
-  max-width: none;
-  width: auto;
-}
-
-.contest-boxscore-table {
-  border-collapse: collapse;
-  background: none;
-  color: var(--text-primary);
-  font-size: 1rem;
-  margin: 0 auto;
-}
-
-.contest-boxscore-table.compact {
-  font-size: 0.98rem;
-}
-
-.contest-boxscore-table th,
-.contest-boxscore-table td {
-  padding: 0 0.5rem;
-  text-align: center;
-}
-
-.contest-boxscore-table.compact.wide {
-  font-size: 0.85rem;
-}
-
-.contest-boxscore-table.compact.wide th,
-.contest-boxscore-table.compact.wide td {
-  padding: 0 0.3rem;
-}
-
-.contest-boxscore-table.compact.wide .contest-boxscore-total {
-  padding-left: 0.55rem;
-}
-
-.contest-boxscore-team-short {
-  font-weight: 600;
-}
-
-.contest-boxscore-total {
-  font-weight: 700;
-}
+/* Box-score-table styles (.boxscore-*) moved to
+   ../shared/BoxScoreTable.css when the table was lifted out of
+   ContestOverviewHeader. */
 
 .contest-meta {
   margin-bottom: 1rem;
@@ -556,20 +501,8 @@
 .contest-boxscore-section tr:last-child td {
   border-bottom: none;
 }
-.contest-boxscore-team-short,
-.contest-boxscore-total {
-  color: var(--accent) !important;
-  font-weight: 700;
-  background: var(--bg-input) !important;
-}
-.contest-boxscore-final {
-  color: var(--warning);
-  font-weight: 700;
-  background: var(--badge-bg);
-  border-radius: 6px;
-  padding: 4px 10px;
-  margin-bottom: 6px;
-}
+/* .contest-boxscore-team-short / .contest-boxscore-total / .contest-boxscore-final
+   moved to ../shared/BoxScoreTable.css and renamed without the contest- prefix. */
 .contest-winprob-section,
 .contest-winprob-item,
 .contest-winprob-final {
@@ -591,11 +524,6 @@
     flex-direction: column;
     gap: 18px;
     padding: 8px 0;
-  }
-  .contest-boxscore-table-wrapper.compact {
-    min-width: 0;
-    max-width: 100%;
-    margin: 0;
   }
 }
 
@@ -649,31 +577,10 @@
   padding: 4px;
   border: 1px solid var(--border-strong);
 }
-.contest-boxscore-table-wrapper.compact {
-  min-width: 180px;
-  max-width: 260px;
-  margin: 0 10px;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.contest-boxscore-table-wrapper.compact.wide {
-  min-width: 0;
-  max-width: none;
-  width: auto;
-}
-
 @media (max-width: 900px) {
   .contest-header-flex {
     flex-direction: column;
     gap: 12px;
     padding: 8px 0;
-  }
-  .contest-boxscore-table-wrapper.compact {
-    min-width: 0;
-    max-width: 100%;
-    margin: 0;
   }
 }

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { teamLink } from '../../utils/sportLinks';
+import BoxScoreTable from "../shared/BoxScoreTable";
 import "./ContestOverview.css";
 
 export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScores, homeTeamColor, awayTeamColor, seasonYear, sport, league }) {
@@ -28,10 +29,6 @@ export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScore
   const normAwayBg = getMutedColor(awayTeamColor);
   const awayTotal = quarterScores.reduce((sum, q) => sum + q.awayScore, 0);
   const homeTotal = quarterScores.reduce((sum, q) => sum + q.homeScore, 0);
-  // Football has 4 quarters (or 5+ with OT); baseball has 9 innings. Anything
-  // past the football default needs a wider wrapper and tighter cell padding
-  // so the Total ("T") column doesn't collide with the home-team score.
-  const wideClass = quarterScores.length > 4 ? " wide" : "";
 
   return (
     <div className="contest-section">
@@ -40,44 +37,19 @@ export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScore
         <div className="contest-team-logo-wrap" style={awayTeamColor ? { background: normAwayBg, borderColor: 'rgba(255,255,255,0.06)' } : {}}>
           <img src={awayTeam.logoUrl} alt={awayTeam.displayName} className="contest-team-logo" />
         </div>
-        <Link 
+        <Link
           to={teamLink(awayTeam.slug, seasonYear, sport, league)}
           className="contest-team-name contest-header-team-name contest-team-link"
         >
           {awayTeam.displayName}
         </Link>
         <div className="contest-team-score contest-header-team-score-away">{awayTotal}</div>
-        {/* Box Score Table */}
-        <div className={`contest-boxscore-table-wrapper compact${wideClass}`}>
-          <div className="contest-boxscore-final">Final</div>
-          <table className={`contest-boxscore-table compact${wideClass}`}>
-            <thead>
-              <tr>
-                <th></th>
-                {quarterScores.map(q => (
-                  <th key={q.quarter}>{q.quarter}</th>
-                ))}
-                <th>T</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="contest-boxscore-team-short">{awayTeam.displayName.split(' ')[0].toUpperCase()}</td>
-                {quarterScores.map(q => (
-                  <td key={q.quarter}>{q.awayScore}</td>
-                ))}
-                <td className="contest-boxscore-total">{awayTotal}</td>
-              </tr>
-              <tr>
-                <td className="contest-boxscore-team-short">{homeTeam.displayName.split(' ')[0].toUpperCase()}</td>
-                {quarterScores.map(q => (
-                  <td key={q.quarter}>{q.homeScore}</td>
-                ))}
-                <td className="contest-boxscore-total">{homeTotal}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <BoxScoreTable
+          periodScores={quarterScores}
+          awayLabel={awayTeam.displayName.split(' ')[0].toUpperCase()}
+          homeLabel={homeTeam.displayName.split(' ')[0].toUpperCase()}
+          statusLabel="Final"
+        />
         {/* Home Side */}
         <div className="contest-team-score contest-header-team-score-home">{homeTotal}</div>
         <Link 

--- a/src/UI/sd-ui/src/components/shared/BoxScoreTable.css
+++ b/src/UI/sd-ui/src/components/shared/BoxScoreTable.css
@@ -1,0 +1,100 @@
+/* Period-by-period scoreboard widget styles. Extracted from
+   ContestOverview.css when BoxScoreTable was lifted out of
+   ContestOverviewHeader so MatchupCard / Command Center can reuse
+   the same widget. The historical contest- prefix was dropped since
+   the styles no longer belong to the contest overview page. */
+
+.boxscore-table-wrapper {
+  text-align: center;
+}
+
+/* The original CSS defined .compact twice (later wins by cascade);
+   these are the merged effective values that were rendering before
+   the move. Keep both blocks aware: the contest-overview-page-tuned
+   widths + flex layout are required to keep the wrapper centered
+   between the two team scores in that page's header. */
+.boxscore-table-wrapper.compact {
+  min-width: 180px;
+  max-width: 260px;
+  margin: 0 10px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Sports with more than 4 periods (e.g. MLB 9 innings) need to grow past
+   the football-tuned default so the Total column doesn't collide with
+   the home team's score on the right. */
+.boxscore-table-wrapper.compact.wide {
+  min-width: 0;
+  max-width: none;
+  width: auto;
+}
+
+.boxscore-table {
+  border-collapse: collapse;
+  background: none;
+  color: var(--text-primary);
+  font-size: 1rem;
+  margin: 0 auto;
+}
+
+.boxscore-table.compact {
+  font-size: 0.98rem;
+}
+
+.boxscore-table th,
+.boxscore-table td {
+  padding: 0 0.5rem;
+  text-align: center;
+}
+
+.boxscore-table.compact.wide {
+  font-size: 0.85rem;
+}
+
+.boxscore-table.compact.wide th,
+.boxscore-table.compact.wide td {
+  padding: 0 0.3rem;
+}
+
+.boxscore-table.compact.wide .boxscore-total {
+  padding-left: 0.55rem;
+}
+
+.boxscore-team-short {
+  font-weight: 600;
+}
+
+.boxscore-total {
+  font-weight: 700;
+}
+
+/* Themed overrides — the original ContestOverview.css defined these
+   with !important to override default cell colors when the table is
+   embedded in a themed contest section. Preserving the same shape
+   here so any themed wrapper still wins. */
+.boxscore-team-short,
+.boxscore-total {
+  color: var(--accent) !important;
+  font-weight: 700;
+  background: var(--bg-input) !important;
+}
+
+.boxscore-status {
+  color: var(--warning);
+  font-weight: 700;
+  background: var(--badge-bg);
+  border-radius: 6px;
+  padding: 4px 10px;
+  margin-bottom: 6px;
+}
+
+@media (max-width: 900px) {
+  .boxscore-table-wrapper.compact {
+    min-width: 0;
+    max-width: 100%;
+    margin: 0;
+  }
+}

--- a/src/UI/sd-ui/src/components/shared/BoxScoreTable.jsx
+++ b/src/UI/sd-ui/src/components/shared/BoxScoreTable.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "./BoxScoreTable.css";
+
+/**
+ * Compact period-by-period scoreboard. Sport-agnostic: works for football
+ * quarters (4, +OT) and baseball innings (9+) — anything past 4 periods
+ * triggers a tighter "wide" cell padding so the Total ("T") column doesn't
+ * collide with adjacent header content.
+ *
+ * Originally inline JSX inside ContestOverviewHeader. Lifted so live-state
+ * matchup cards (Command Center / picks page when game is in progress) can
+ * reuse the same widget without forking it.
+ *
+ * @param {object} props
+ * @param {Array<{ quarter: string|number, awayScore: number, homeScore: number }>} props.periodScores
+ *   One entry per period, in order. The shape's `quarter` field name is
+ *   historical — semantically it's the period label (Q1 / I3 / etc.) and
+ *   is rendered verbatim as the column header.
+ * @param {string} props.awayLabel - Short label for away row (e.g., "TEX", "ANGELS")
+ * @param {string} props.homeLabel - Short label for home row
+ * @param {string} [props.statusLabel="Final"] - Label rendered above the table
+ *   (e.g., "Final", "Live · B5", "Top 3rd"). Caller computes from game state.
+ */
+export default function BoxScoreTable({
+  periodScores,
+  awayLabel,
+  homeLabel,
+  statusLabel = "Final",
+}) {
+  const awayTotal = periodScores.reduce((sum, p) => sum + p.awayScore, 0);
+  const homeTotal = periodScores.reduce((sum, p) => sum + p.homeScore, 0);
+  const wideClass = periodScores.length > 4 ? " wide" : "";
+
+  return (
+    <div className={`boxscore-table-wrapper compact${wideClass}`}>
+      <div className="boxscore-status">{statusLabel}</div>
+      <table className={`boxscore-table compact${wideClass}`}>
+        <thead>
+          <tr>
+            <th></th>
+            {periodScores.map((p) => (
+              <th key={p.quarter}>{p.quarter}</th>
+            ))}
+            <th>T</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="boxscore-team-short">{awayLabel}</td>
+            {periodScores.map((p) => (
+              <td key={p.quarter}>{p.awayScore}</td>
+            ))}
+            <td className="boxscore-total">{awayTotal}</td>
+          </tr>
+          <tr>
+            <td className="boxscore-team-short">{homeLabel}</td>
+            {periodScores.map((p) => (
+              <td key={p.quarter}>{p.homeScore}</td>
+            ))}
+            <td className="boxscore-total">{homeTotal}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change. Lifts the inline period-by-period scoreboard out of `ContestOverviewHeader` into a standalone shared component so live-game matchup cards (Command Center / picks page when a game is in progress) can reuse the same widget without forking it. Sets up the next slice cleanly.

- **New `components/shared/BoxScoreTable.jsx`** — parameterized props: `periodScores`, `awayLabel`, `homeLabel`, `statusLabel="Final"`. Component handles its own wide-mode threshold (`> 4` periods) internally so callers don't need to know the football-vs-baseball detail.
- **CSS extracted to `BoxScoreTable.css`** — class names drop the historical `contest-` prefix that became misleading once the widget moved out of the contest page (`contest-boxscore-*` → `boxscore-*`). The "Final" label class is renamed `boxscore-status` to reflect that callers will pass live-game labels too. The duplicate `.compact` rule that the cascade was effectively resolving has been collapsed into a single merged definition.
- **`ContestOverviewHeader.jsx`** — replaces the 30-line inline JSX with a single `<BoxScoreTable />` call. Same DOM, same styles, same labels.
- **`ContestOverview.css`** — boxscore-table rules removed (now in `BoxScoreTable.css`). Two unrelated orphan rules (`.contest-boxscore-row`, `.contest-boxscore-section`) stay — they're not the table widget. `ContestOverviewThemed.css` is dead code (unimported); left alone.

This is groundwork. The follow-up wires the component into `MatchupCard` once the wire DTO carries `PeriodScores` for in-progress games — that's where the meaningful behavior change lands.

## Test plan

- [x] Visual parity check on the contest overview page (final-state matchup) — confirmed identical rendering before/after the JSX extraction
- [x] Visual parity check after the CSS class rename + extraction — confirmed identical rendering
- [x] No JSX outside `BoxScoreTable.jsx` references the renamed classes (verified via grep — only `.contest-boxscore-row` and `.contest-boxscore-section` rules remain in `ContestOverview.css`, both orphan, neither is the table)
- [ ] Worth a glance after merge: confirm the contest overview at the 900px breakpoint still collapses correctly (the responsive `@media` rule for the table wrapper moved to `BoxScoreTable.css`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized scoring display components for improved maintainability and consistency across contest views.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/305)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->