### PR TITLE
fix: pin SharpCompress 0.48.0 to override vulnerable transitive

### DIFF
--- a/src/SportsData.JobsDashboard/SportsData.JobsDashboard.csproj
+++ b/src/SportsData.JobsDashboard/SportsData.JobsDashboard.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 

--- a/src/SportsData.Provider/SportsData.Provider.csproj
+++ b/src/SportsData.Provider/SportsData.Provider.csproj
@@ -32,6 +32,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      GHSA-6c8g-7p36-r338 — moderate severity (CVSS 5.9) path-traversal in
+      SharpCompress.WriteToDirectory(). Pulled in transitively via
+      MongoDB.Driver 3.5.0 → MongoDB.EntityFrameworkCore. As of 2026-05-09
+      no patched SharpCompress release exists (all versions through 0.47.4
+      are affected per the advisory), so an upgrade override isn't an
+      option. Neither our code nor MongoDB.Driver's wire-protocol use of
+      SharpCompress goes through WriteToDirectory — we don't extract
+      untrusted archives. Suppression is therefore safe; revisit and
+      remove this entry when SharpCompress ships a fixed release.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-6c8g-7p36-r338" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Infrastructure\Providers\CBS\" />
     <Folder Include="Infrastructure\Providers\Yahoo\" />
     <Folder Include="Infrastructure\Providers\SportsDataIO\" />

--- a/src/SportsData.Provider/SportsData.Provider.csproj
+++ b/src/SportsData.Provider/SportsData.Provider.csproj
@@ -27,23 +27,17 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="MongoDB.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <!--
+      Direct reference solely to override the transitive SharpCompress 0.30.1
+      pulled in via MongoDB.Driver 3.5.0 → MongoDB.EntityFrameworkCore, which
+      was flagged by GHSA-6c8g-7p36-r338 (path traversal in WriteToDirectory,
+      affects all versions through 0.47.4). 0.48.0 is the first patched
+      release. Once MongoDB.Driver bumps its minimum SharpCompress past 0.47.4,
+      drop this line.
+    -->
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!--
-      GHSA-6c8g-7p36-r338 — moderate severity (CVSS 5.9) path-traversal in
-      SharpCompress.WriteToDirectory(). Pulled in transitively via
-      MongoDB.Driver 3.5.0 → MongoDB.EntityFrameworkCore. As of 2026-05-09
-      no patched SharpCompress release exists (all versions through 0.47.4
-      are affected per the advisory), so an upgrade override isn't an
-      option. Neither our code nor MongoDB.Driver's wire-protocol use of
-      SharpCompress goes through WriteToDirectory — we don't extract
-      untrusted archives. Suppression is therefore safe; revisit and
-      remove this entry when SharpCompress ships a fixed release.
-    -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-6c8g-7p36-r338" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/integration/SportsData.Provider.Tests.Integration/SportsData.Provider.Tests.Integration.csproj
+++ b/test/integration/SportsData.Provider.Tests.Integration/SportsData.Provider.Tests.Integration.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>

--- a/test/unit/SportsData.Provider.Tests.Unit/SportsData.Provider.Tests.Unit.csproj
+++ b/test/unit/SportsData.Provider.Tests.Unit/SportsData.Provider.Tests.Unit.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary

Unblocks the post-merge pipeline on `main`, which started failing on 2026-05-09 with `NU1902 Warning As Error: Package 'SharpCompress' 0.30.1 has a known moderate severity vulnerability (GHSA-6c8g-7p36-r338)`. Path-traversal in `SharpCompress.WriteToDirectory()`; we pull `0.30.1` transitively via `MongoDB.Driver 3.5.0 → MongoDB.EntityFrameworkCore`.

**Why the local builds were silent.** NuGet's vulnerability index is HTTP-cached locally with a multi-hour TTL — the pipeline always fetches fresh, local restore reuses the stale cache. After `dotnet nuget locals http-cache --clear`, local CLI restore reproduces the failure exactly. Not pipeline drift.

**Fix.** Direct `PackageReference` to `SharpCompress 0.48.0` to override the transitive `0.30.1`. `0.48.0` is the first release past the advisory's affected range (`through 0.47.4`), so the advisory simply no longer matches — no `NuGetAuditSuppress` needed and no risk-acceptance escape hatch in tree. Drop these lines when `MongoDB.Driver` bumps its minimum SharpCompress past `0.47.4`.

**Scope.** Pinned in every project that resolves SharpCompress under the VS restore graph (CLI restore was satisfied with the Provider pin alone, but VS evaluates more aggressively):

- `SportsData.Provider` (the original CI failure site)
- `SportsData.JobsDashboard`
- `SportsData.Provider.Tests.Integration`
- `SportsData.Provider.Tests.Unit`

The branch was originally named `fix/sharpcompress-audit-suppress` — initial pass used `<NuGetAuditSuppress>` because no patched release existed when I fetched the advisory; the pin approach replaced it once 0.48.0 was confirmed available. Squash-merge will collapse the two commits into one clean entry.

## Test plan

- [x] Reproduced the failure locally after `dotnet nuget locals http-cache --clear` + `dotnet restore` on Provider
- [x] `dotnet build src/sports-data-provider.sln` — 0 warnings, 0 errors after the pin (warning previously appeared on the integration test project too; that's gone now)
- [x] Confirmed only `SportsData.Provider` directly references `MongoDB.*` packages — no other service is at risk
- [ ] Watch the pipeline on this PR — expect green restore + build
- [ ] After merge, rebase any in-flight feature branches (PR #305 etc.) so their pipelines also pick up the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)