### PR TITLE
feat(admin): per-sport SignalR debug routes + MLB matchup harness

### DIFF
--- a/docs/LIVE_UPDATES_REFACTORING.md
+++ b/docs/LIVE_UPDATES_REFACTORING.md
@@ -572,17 +572,17 @@ The contest pipeline emits four events where three will do. The boundary between
 | Event | Carries | Used? |
 |---|---|---|
 | `ContestStatusChanged` | sport-neutral lifecycle (Scheduled → InProgress → Final) | ✅ keep |
-| `ContestPlayCompleted` | `PlayId`, `PlayDescription` — sport-neutral, no state | 📤 emit-only, no consumer |
-| `FootballContestStateChanged` | `Period`, `Clock`, scores, possession, `IsScoringPlay` — no description | ✅ wired (SignalR) |
-| `BaseballContestStateChanged` | inning/half, scores, count, runners, atBat/pitcher — no description | 🟡 consumer wired, no producer emitter yet |
+| `ContestPlayCompleted` | `PlayId`, `PlayDescription` — sport-neutral, no state | ✅ wired: `ContestPlayCompletedHandler` (API) → SignalR `"ContestPlayCompleted"` → UI `ContestUpdatesContext.handlePlayCompleted` |
+| `FootballContestStateChanged` | `Period`, `Clock`, scores, possession, `IsScoringPlay` — no description | ✅ wired (SignalR) → UI `handleFootballStateUpdate` |
+| `BaseballContestStateChanged` | inning/half, scores, count, runners, atBat/pitcher — no description | 🟡 API handler + UI `handleBaseballStateUpdate` wired; no Producer emitter yet (`BaseballEventCompetitionPlayDocumentProcessor` inherits the base class's `ContestPlayCompleted` emission instead) |
 
-A play and the resulting state are emitted from the same processor, in the same DB-write turn, with the same `CausationId`. Splitting them buys nothing: the UI needs both halves to render a play card, the backend never publishes one without the other, and the sport-neutral `ContestPlayCompleted` payload has no consumer because every consumer also wants the sport-specific state.
+For each live football play, Producer emits two events — `ContestPlayCompleted` (description) and `FootballContestStateChanged` (state) — from the same `EventCompetitionPlayDocumentProcessor` in the same DB-write turn, against the same canonical play. API hands them off to two parallel SignalR messages, which `ContestUpdatesContext` merges into the same per-contest record via two independent handlers (`handlePlayCompleted` writes `lastPlayId` + `lastPlayDescription`; `handleFootballStateUpdate` writes `period`/`clock`/scores/etc.). They're one logical update split across the wire and across the consumer surface for no architectural reason.
 
 **Impact:**
 
-- UI consumers reassemble the pair from two separate SignalR messages keyed by `CausationId`. The `ContestUpdatesContext` has more wiring than it needs.
+- 2× the bus traffic, 2× the SignalR fan-out, 2× the UI handler surface for what is conceptually a single per-play update. Each play creates two RabbitMQ messages, two `Clients.All.SendAsync` calls, and two context-state slices that any reader has to reassemble at render time.
 - The `*ContestStateChanged` name reads like a generic state delta when each instance is in fact a per-play tick. Future readers (and a future me adding `Soccer*StateChanged`) will guess wrong.
-- `BaseballEventCompetitionPlayDocumentProcessor` doesn't emit a sport-specific event today — it inherits the base class which fires `ContestPlayCompleted` (no state), so MLB live updates currently can't render scoreboard ticks. The taxonomy gap is blocking the MLB live-UI work.
+- `BaseballEventCompetitionPlayDocumentProcessor` doesn't emit a sport-specific event today — it inherits `EventCompetitionPlayDocumentProcessorBase` which fires `ContestPlayCompleted` (description only, no state), so MLB live updates currently can't render scoreboard ticks. The taxonomy gap is blocking the MLB live-UI work.
 
 **Solution:**
 
@@ -622,7 +622,7 @@ public record BaseballPlayCompleted(
 3. `BaseballEventCompetitionPlayDocumentProcessor` (MLB): override the base method, publish `BaseballPlayCompleted` directly. This is the new emitter that closes the wiring gap noted above.
 4. Remove `ContestPlayCompleted` emission from `EventCompetitionPlayDocumentProcessorBase` once both sport processors override.
 5. API: rename `FootballContestStateChangedHandler` → `FootballPlayCompletedHandler`; rename `BaseballContestStateChangedHandler` → `BaseballPlayCompletedHandler`. SignalR method names follow.
-6. UI: update `ContestUpdatesContext` to subscribe to `FootballPlayCompleted` / `BaseballPlayCompleted` and merge play description + state in one handler. Remove the `CausationId`-keyed reassembly.
+6. UI `ContestUpdatesContext`: collapse the parallel `handlePlayCompleted` + `handleFootballStateUpdate` (and `+ handleBaseballStateUpdate`) into one merged handler per sport that writes `lastPlayId` / `lastPlayDescription` and the scoreboard fields in a single `setContests` call. Drop the `"ContestPlayCompleted"` SignalR subscription once `*PlayCompleted` is live.
 7. Delete `ContestPlayCompleted`, `FootballContestStateChanged`, `BaseballContestStateChanged` event records.
 8. Update `docs/event-surface-overview.md` matrix to reflect the new shape.
 
@@ -636,7 +636,7 @@ public record BaseballPlayCompleted(
 
 **Open questions:**
 
-- `ContestPlayCompleted` is currently emit-only with no consumer. Confirm nothing outside this repo subscribes before deleting; if yes, this is a coordinated breaking change.
+- `ContestPlayCompleted` has an in-repo consumer (`ContestPlayCompletedHandler` → SignalR → UI `handlePlayCompleted`); deletion is a coordinated rename inside this repo, sequenced via steps 5–7 above. Confirm nothing outside this repo subscribes before merging — none known today.
 - Should `PlayDescription` always ride the message, or should the UI fetch on demand? Today it fits inline; rich-text/structured plays would force a revisit.
 - `BaseballPlayCompleted` carries 5 athlete IDs (runners + atBat + pitcher). At-bat changes inside an inning don't change runners — leave finer-grained `BaseballAtBatChanged` until a UI use case demands it.
 

--- a/docs/LIVE_UPDATES_REFACTORING.md
+++ b/docs/LIVE_UPDATES_REFACTORING.md
@@ -561,6 +561,87 @@ The headline ratio is `changed / total` — if it's <10% we're over-polling and 
 
 ---
 
+### Issue #9: Collapse 4 contest events into 3 (Planned)
+
+**Severity:** **MEDIUM** (architectural cleanup, not a bug)
+
+**Problem:**
+
+The contest pipeline emits four events where three will do. The boundary between "what changed" (state) and "why it changed" (play description) was drawn one event too early — the result is two scoreboard-tick events with no description, and one play event with no scoreboard.
+
+| Event | Carries | Used? |
+|---|---|---|
+| `ContestStatusChanged` | sport-neutral lifecycle (Scheduled → InProgress → Final) | ✅ keep |
+| `ContestPlayCompleted` | `PlayId`, `PlayDescription` — sport-neutral, no state | 📤 emit-only, no consumer |
+| `FootballContestStateChanged` | `Period`, `Clock`, scores, possession, `IsScoringPlay` — no description | ✅ wired (SignalR) |
+| `BaseballContestStateChanged` | inning/half, scores, count, runners, atBat/pitcher — no description | 🟡 consumer wired, no producer emitter yet |
+
+A play and the resulting state are emitted from the same processor, in the same DB-write turn, with the same `CausationId`. Splitting them buys nothing: the UI needs both halves to render a play card, the backend never publishes one without the other, and the sport-neutral `ContestPlayCompleted` payload has no consumer because every consumer also wants the sport-specific state.
+
+**Impact:**
+
+- UI consumers reassemble the pair from two separate SignalR messages keyed by `CausationId`. The `ContestUpdatesContext` has more wiring than it needs.
+- The `*ContestStateChanged` name reads like a generic state delta when each instance is in fact a per-play tick. Future readers (and a future me adding `Soccer*StateChanged`) will guess wrong.
+- `BaseballEventCompetitionPlayDocumentProcessor` doesn't emit a sport-specific event today — it inherits the base class which fires `ContestPlayCompleted` (no state), so MLB live updates currently can't render scoreboard ticks. The taxonomy gap is blocking the MLB live-UI work.
+
+**Solution:**
+
+Three events. One per concern. Each sport-specific play processor emits its own merged event:
+
+```csharp
+// Sport-neutral lifecycle — unchanged.
+public record ContestStatusChanged(
+    Guid ContestId, string Status, Uri? Ref, Sport Sport,
+    int? SeasonYear, Guid CorrelationId, Guid CausationId);
+
+// Football per-play tick + description.
+public record FootballPlayCompleted(
+    Guid ContestId, Guid CompetitionId, Guid PlayId, string PlayDescription,
+    string Period, string Clock,
+    int AwayScore, int HomeScore,
+    Guid? PossessionFranchiseSeasonId, bool IsScoringPlay, string? BallOnYardLine,
+    Uri? Ref, Sport Sport, int? SeasonYear,
+    Guid CorrelationId, Guid CausationId);
+
+// Baseball per-play tick + description.
+public record BaseballPlayCompleted(
+    Guid ContestId, Guid CompetitionId, Guid PlayId, string PlayDescription,
+    int Inning, string HalfInning,
+    int AwayScore, int HomeScore,
+    int Balls, int Strikes, int Outs,
+    Guid? RunnerOnFirstAthleteId, Guid? RunnerOnSecondAthleteId, Guid? RunnerOnThirdAthleteId,
+    Guid? AtBatAthleteId, Guid? PitchingAthleteId,
+    Uri? Ref, Sport Sport, int? SeasonYear,
+    Guid CorrelationId, Guid CausationId);
+```
+
+**Migration order:**
+
+1. Add `FootballPlayCompleted` and `BaseballPlayCompleted` records (parallel to existing `*ContestStateChanged` — don't delete yet).
+2. `EventCompetitionPlayDocumentProcessor` (FB): switch its existing `FootballContestStateChanged` publish to `FootballPlayCompleted`, populating `PlayId` + `PlayDescription` from the play it just processed. Stop emitting `ContestPlayCompleted` from the base class for the FB sub-tree.
+3. `BaseballEventCompetitionPlayDocumentProcessor` (MLB): override the base method, publish `BaseballPlayCompleted` directly. This is the new emitter that closes the wiring gap noted above.
+4. Remove `ContestPlayCompleted` emission from `EventCompetitionPlayDocumentProcessorBase` once both sport processors override.
+5. API: rename `FootballContestStateChangedHandler` → `FootballPlayCompletedHandler`; rename `BaseballContestStateChangedHandler` → `BaseballPlayCompletedHandler`. SignalR method names follow.
+6. UI: update `ContestUpdatesContext` to subscribe to `FootballPlayCompleted` / `BaseballPlayCompleted` and merge play description + state in one handler. Remove the `CausationId`-keyed reassembly.
+7. Delete `ContestPlayCompleted`, `FootballContestStateChanged`, `BaseballContestStateChanged` event records.
+8. Update `docs/event-surface-overview.md` matrix to reflect the new shape.
+
+**Replay service rename + split:**
+
+`ContestReplayService` (Producer) is football-only despite the sport-neutral name — it emits `ContestStatusChanged` once and `FootballContestStateChanged` per play. As part of this work:
+
+- Rename `ContestReplayService` → `FootballContestReplayService`.
+- Create `BaseballContestReplayService` with the same shape, emitting `BaseballPlayCompleted` per play. The MLB admin debug page (`/admin/baseball`) calls into this for synthetic event playback against the matchup card.
+- Don't extract a shared `IContestReplayService` interface unless a real second caller appears — admin endpoints can resolve concrete services by sport.
+
+**Open questions:**
+
+- `ContestPlayCompleted` is currently emit-only with no consumer. Confirm nothing outside this repo subscribes before deleting; if yes, this is a coordinated breaking change.
+- Should `PlayDescription` always ride the message, or should the UI fetch on demand? Today it fits inline; rich-text/structured plays would force a revisit.
+- `BaseballPlayCompleted` carries 5 athlete IDs (runners + atBat + pitcher). At-bat changes inside an inning don't change runners — leave finer-grained `BaseballAtBatChanged` until a UI use case demands it.
+
+---
+
 ## Visualizations
 
 ### 1. Streaming Lifecycle Sequence

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -11,12 +11,14 @@ using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutCompetitors
 using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutDrives;
 using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutMetrics;
 using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutPlays;
+using SportsData.Api.Application.Admin.Queries.GetMatchupForContest;
 using SportsData.Api.Application.Admin.Queries.GetMatchupPreview;
 using SportsData.Api.Application.Admin.SignalRDebug;
 using SportsData.Api.Application.Previews;
 using SportsData.Api.Application.Scoring;
 using SportsData.Api.Application.UI.Contest.Commands.SubmitContestPredictions;
 using SportsData.Api.Application.UI.Contest.Dtos;
+using SportsData.Api.Application.UI.Leagues.Dtos;
 using SportsData.Api.Infrastructure.Data.Canonical.Models;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Common;
@@ -198,6 +200,25 @@ namespace SportsData.Api.Application.Admin
             CancellationToken cancellationToken)
         {
             var query = new GetCompetitionsWithoutMetricsQuery();
+            var result = await handler.ExecuteAsync(query, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Returns one canonical MLB matchup in the same shape as the picks page
+        /// (<see cref="LeagueWeekMatchupsDto.MatchupForPickDto"/>), without league
+        /// context. Backs the SignalR debug page so a real MatchupCard can be
+        /// rendered against a chosen contest. League-context fields (Predictions,
+        /// AiWinner, IsPreview*, HeadLine) are intentionally null/empty.
+        /// </summary>
+        [HttpGet]
+        [Route("baseball/contests/{contestId:guid}/matchup")]
+        public async Task<ActionResult<LeagueWeekMatchupsDto.MatchupForPickDto>> GetBaseballMatchupForContest(
+            [FromRoute] Guid contestId,
+            [FromServices] IGetMatchupForContestQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var query = new GetMatchupForContestQuery(contestId, Sport.BaseballMlb);
             var result = await handler.ExecuteAsync(query, cancellationToken);
             return result.ToActionResult();
         }

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQuery.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQuery.cs
@@ -1,0 +1,11 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Queries.GetMatchupForContest;
+
+/// <summary>
+/// Returns one canonical matchup in the same shape the picks page consumes
+/// (<see cref="UI.Leagues.Dtos.LeagueWeekMatchupsDto.MatchupForPickDto"/>),
+/// without any league-context fields. Used by the SignalR debug pages so a
+/// real MatchupCard can be rendered for a chosen contest.
+/// </summary>
+public sealed record GetMatchupForContestQuery(Guid ContestId, Sport Sport);

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQueryHandler.cs
@@ -1,0 +1,61 @@
+using FluentValidation.Results;
+
+using SportsData.Api.Application.UI.Leagues.Dtos;
+using SportsData.Api.Application.UI.Leagues.Mapping;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.Admin.Queries.GetMatchupForContest;
+
+public interface IGetMatchupForContestQueryHandler
+{
+    Task<Result<LeagueWeekMatchupsDto.MatchupForPickDto>> ExecuteAsync(
+        GetMatchupForContestQuery query,
+        CancellationToken cancellationToken);
+}
+
+public class GetMatchupForContestQueryHandler : IGetMatchupForContestQueryHandler
+{
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly ILogger<GetMatchupForContestQueryHandler> _logger;
+
+    public GetMatchupForContestQueryHandler(
+        IContestClientFactory contestClientFactory,
+        ILogger<GetMatchupForContestQueryHandler> logger)
+    {
+        _contestClientFactory = contestClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<Result<LeagueWeekMatchupsDto.MatchupForPickDto>> ExecuteAsync(
+        GetMatchupForContestQuery query,
+        CancellationToken cancellationToken)
+    {
+        var matchupsResult = await _contestClientFactory
+            .Resolve(query.Sport)
+            .GetMatchupsByContestIds(new List<Guid> { query.ContestId });
+
+        if (!matchupsResult.IsSuccess)
+        {
+            _logger.LogError(
+                "Producer GetMatchupsByContestIds failed for ContestId={ContestId}, Sport={Sport}",
+                query.ContestId, query.Sport);
+            return new Failure<LeagueWeekMatchupsDto.MatchupForPickDto>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure("matchup", "Failed to retrieve matchup data from Producer")]);
+        }
+
+        var canonical = matchupsResult.Value?.FirstOrDefault();
+        if (canonical is null)
+        {
+            return new Failure<LeagueWeekMatchupsDto.MatchupForPickDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure("contestId", $"No matchup found for ContestId {query.ContestId}")]);
+        }
+
+        return new Success<LeagueWeekMatchupsDto.MatchupForPickDto>(
+            MatchupForPickDtoMapper.FromCanonical(canonical));
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQueryHandler.cs
@@ -33,7 +33,7 @@ public class GetMatchupForContestQueryHandler : IGetMatchupForContestQueryHandle
     {
         var matchupsResult = await _contestClientFactory
             .Resolve(query.Sport)
-            .GetMatchupsByContestIds(new List<Guid> { query.ContestId });
+            .GetMatchupsByContestIds(new List<Guid> { query.ContestId }, cancellationToken);
 
         if (!matchupsResult.IsSuccess)
         {

--- a/src/SportsData.Api/Application/UI/Leagues/Mapping/MatchupForPickDtoMapper.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Mapping/MatchupForPickDtoMapper.cs
@@ -1,0 +1,116 @@
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Leagues.Dtos;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+
+namespace SportsData.Api.Application.UI.Leagues.Mapping;
+
+/// <summary>
+/// Maps the canonical Producer-side <see cref="LeagueMatchupDto"/> into
+/// the API-side <see cref="LeagueWeekMatchupsDto.MatchupForPickDto"/>
+/// shape consumed by UI matchup cards. Pure: only canonical fields.
+///
+/// League-context fields — Predictions, AiWinnerFranchiseSeasonId,
+/// IsPreviewAvailable, IsPreviewReviewed, HeadLine — are NOT set here;
+/// callers layer those on top from their own data sources.
+/// </summary>
+public static class MatchupForPickDtoMapper
+{
+    /// <summary>
+    /// Mutates an existing matchup in-place with all canonical-derived
+    /// fields. Used by the league/week query handler which already has
+    /// a partially-populated DTO from the league's PickemGroupMatchup row.
+    /// </summary>
+    public static void ApplyCanonical(
+        LeagueWeekMatchupsDto.MatchupForPickDto matchup,
+        LeagueMatchupDto canonical)
+    {
+        matchup.Status = Enum.TryParse<ContestStatus>(canonical.Status, true, out var status)
+            ? status
+            : ContestStatus.Undefined;
+        matchup.Broadcasts = canonical.Broadcasts;
+
+        // Away team
+        matchup.Away = canonical.Away ?? matchup.Away;
+        matchup.AwayShort = canonical.AwayShort ?? matchup.AwayShort;
+        matchup.AwayFranchiseSeasonId = canonical.AwayFranchiseSeasonId;
+        matchup.AwayLogoUri = canonical.AwayLogoUri ?? matchup.AwayLogoUri;
+        matchup.AwayLogoUriDark = canonical.AwayLogoUriDark;
+        matchup.AwaySlug = canonical.AwaySlug ?? matchup.AwaySlug;
+        matchup.AwayColor = canonical.AwayColor ?? matchup.AwayColor;
+        matchup.AwayWins = canonical.AwayWins;
+        matchup.AwayLosses = canonical.AwayLosses;
+        matchup.AwayConferenceWins = canonical.AwayConferenceWins;
+        matchup.AwayConferenceLosses = canonical.AwayConferenceLosses;
+        matchup.AwayRank = canonical.AwayRank;
+
+        // Home team
+        matchup.Home = canonical.Home ?? matchup.Home;
+        matchup.HomeShort = canonical.HomeShort ?? matchup.HomeShort;
+        matchup.HomeFranchiseSeasonId = canonical.HomeFranchiseSeasonId;
+        matchup.HomeLogoUri = canonical.HomeLogoUri ?? matchup.HomeLogoUri;
+        matchup.HomeLogoUriDark = canonical.HomeLogoUriDark;
+        matchup.HomeSlug = canonical.HomeSlug ?? matchup.HomeSlug;
+        matchup.HomeColor = canonical.HomeColor ?? matchup.HomeColor;
+        matchup.HomeWins = canonical.HomeWins;
+        matchup.HomeLosses = canonical.HomeLosses;
+        matchup.HomeConferenceWins = canonical.HomeConferenceWins;
+        matchup.HomeConferenceLosses = canonical.HomeConferenceLosses;
+        matchup.HomeRank = canonical.HomeRank;
+
+        // Odds — round to one decimal for display.
+        matchup.SpreadCurrent = canonical.SpreadCurrent.HasValue
+            ? (decimal)Math.Round(canonical.SpreadCurrent.Value, 1, MidpointRounding.AwayFromZero)
+            : null;
+
+        matchup.SpreadOpen = canonical.SpreadOpen.HasValue
+            ? (decimal)Math.Round(canonical.SpreadOpen.Value, 1, MidpointRounding.AwayFromZero)
+            : null;
+
+        matchup.OverUnderCurrent = canonical.OverUnderCurrent.HasValue
+            ? (decimal)Math.Round(canonical.OverUnderCurrent.Value, 1, MidpointRounding.AwayFromZero)
+            : null;
+
+        matchup.OverUnderOpen = canonical.OverUnderOpen.HasValue
+            ? (decimal)Math.Round(canonical.OverUnderOpen.Value, 1, MidpointRounding.AwayFromZero)
+            : null;
+
+        // Venue
+        matchup.Venue = canonical.Venue ?? matchup.Venue;
+        matchup.VenueCity = canonical.VenueCity ?? matchup.VenueCity;
+        matchup.VenueState = canonical.VenueState ?? matchup.VenueState;
+
+        // Result
+        matchup.IsComplete = canonical.CompletedUtc.HasValue;
+        matchup.AwayScore = canonical.AwayScore;
+        matchup.HomeScore = canonical.HomeScore;
+        matchup.WinnerFranchiseSeasonId = canonical.WinnerFranchiseSeasonId;
+        matchup.SpreadWinnerFranchiseSeasonId = canonical.SpreadWinnerFranchiseSeasonId;
+        matchup.OverUnderResult = canonical.OverUnderResult.HasValue
+            ? (OverUnderPick)canonical.OverUnderResult.Value
+            : null;
+        matchup.CompletedUtc = canonical.CompletedUtc;
+
+        matchup.StreamScheduledTimeUtc = canonical.StreamScheduledTimeUtc;
+
+        // MLB only — null for non-MLB leagues; UI conditionally renders.
+        matchup.HomeProbablePitcher = canonical.HomeProbablePitcher;
+        matchup.AwayProbablePitcher = canonical.AwayProbablePitcher;
+    }
+
+    /// <summary>
+    /// Builds a fresh <see cref="LeagueWeekMatchupsDto.MatchupForPickDto"/>
+    /// populated from canonical fields only. Used by the admin debug
+    /// endpoint where there's no league context to merge with.
+    /// </summary>
+    public static LeagueWeekMatchupsDto.MatchupForPickDto FromCanonical(LeagueMatchupDto canonical)
+    {
+        var matchup = new LeagueWeekMatchupsDto.MatchupForPickDto
+        {
+            ContestId = canonical.ContestId,
+            StartDateUtc = canonical.StartDateUtc,
+        };
+        ApplyCanonical(matchup, canonical);
+        return matchup;
+    }
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.UI.Contest.Dtos;
 using SportsData.Api.Application.UI.Leagues.Dtos;
+using SportsData.Api.Application.UI.Leagues.Mapping;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common;
@@ -202,73 +203,12 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
             {
                 if (canonicalMap.TryGetValue(matchup.ContestId, out var canonical))
                 {
-                    matchup.Status = Enum.TryParse<ContestStatus>(canonical.Status, true, out var status) ? status : ContestStatus.Undefined;
-                    matchup.Broadcasts = canonical.Broadcasts;
-
-                    // Away team
-                    matchup.Away = canonical.Away ?? matchup.Away;
-                    matchup.AwayShort = canonical.AwayShort ?? matchup.AwayShort;
-                    matchup.AwayFranchiseSeasonId = canonical.AwayFranchiseSeasonId;
-                    matchup.AwayLogoUri = canonical.AwayLogoUri ?? matchup.AwayLogoUri;
-                    matchup.AwayLogoUriDark = canonical.AwayLogoUriDark;
-                    matchup.AwaySlug = canonical.AwaySlug ?? matchup.AwaySlug;
-                    matchup.AwayColor = canonical.AwayColor ?? matchup.AwayColor;
-                    matchup.AwayWins = canonical.AwayWins;
-                    matchup.AwayLosses = canonical.AwayLosses;
-                    matchup.AwayConferenceWins = canonical.AwayConferenceWins;
-                    matchup.AwayConferenceLosses = canonical.AwayConferenceLosses;
-                    matchup.AwayRank = canonical.AwayRank;
-
-                    // Home team
-                    matchup.Home = canonical.Home ?? matchup.Home;
-                    matchup.HomeShort = canonical.HomeShort ?? matchup.HomeShort;
-                    matchup.HomeFranchiseSeasonId = canonical.HomeFranchiseSeasonId;
-                    matchup.HomeLogoUri = canonical.HomeLogoUri ?? matchup.HomeLogoUri;
-                    matchup.HomeLogoUriDark = canonical.HomeLogoUriDark;
-                    matchup.HomeSlug = canonical.HomeSlug ?? matchup.HomeSlug;
-                    matchup.HomeColor = canonical.HomeColor ?? matchup.HomeColor;
-                    matchup.HomeWins = canonical.HomeWins;
-                    matchup.HomeLosses = canonical.HomeLosses;
-                    matchup.HomeConferenceWins = canonical.HomeConferenceWins;
-                    matchup.HomeConferenceLosses = canonical.HomeConferenceLosses;
-                    matchup.HomeRank = canonical.HomeRank;
-
-                    // Odds
-                    matchup.SpreadCurrent = canonical.SpreadCurrent.HasValue
-                        ? (decimal)Math.Round(canonical.SpreadCurrent.Value, 1, MidpointRounding.AwayFromZero)
-                        : null;
-
-                    matchup.SpreadOpen = canonical.SpreadOpen.HasValue
-                        ? (decimal)Math.Round(canonical.SpreadOpen.Value, 1, MidpointRounding.AwayFromZero)
-                        : null;
-
-                    matchup.OverUnderCurrent = canonical.OverUnderCurrent.HasValue
-                        ? (decimal)Math.Round(canonical.OverUnderCurrent.Value, 1, MidpointRounding.AwayFromZero)
-                        : null;
-
-                    matchup.OverUnderOpen = canonical.OverUnderOpen.HasValue
-                        ? (decimal)Math.Round(canonical.OverUnderOpen.Value, 1, MidpointRounding.AwayFromZero)
-                        : null;
-
-                    // Venue
-                    matchup.Venue = canonical.Venue ?? matchup.Venue;
-                    matchup.VenueCity = canonical.VenueCity ?? matchup.VenueCity;
-                    matchup.VenueState = canonical.VenueState ?? matchup.VenueState;
-
-                    // Result
-                    matchup.IsComplete = canonical.CompletedUtc.HasValue;
-                    matchup.AwayScore = canonical.AwayScore;
-                    matchup.HomeScore = canonical.HomeScore;
-                    matchup.WinnerFranchiseSeasonId = canonical.WinnerFranchiseSeasonId;
-                    matchup.SpreadWinnerFranchiseSeasonId = canonical.SpreadWinnerFranchiseSeasonId;
-                    matchup.OverUnderResult = canonical.OverUnderResult.HasValue ? (OverUnderPick)canonical.OverUnderResult.Value : null;
-                    matchup.CompletedUtc = canonical.CompletedUtc;
-
-                    matchup.StreamScheduledTimeUtc = canonical.StreamScheduledTimeUtc;
-
-                    // MLB only — null for non-MLB leagues; UI conditionally renders.
-                    matchup.HomeProbablePitcher = canonical.HomeProbablePitcher;
-                    matchup.AwayProbablePitcher = canonical.AwayProbablePitcher;
+                    // Canonical fields (teams, odds, scores, status, probables,
+                    // streaming, etc.) — extracted to MatchupForPickDtoMapper so
+                    // the admin debug endpoint can reuse the same shape without
+                    // a league context. League-context fields (HeadLine,
+                    // Predictions, AiWinner, IsPreview*) stay below.
+                    MatchupForPickDtoMapper.ApplyCanonical(matchup, canonical);
 
                     var preview = previews
                         .Where(x => x.ContestId == matchup.ContestId &&

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -132,6 +132,8 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetCompetitionsWithoutMetricsQueryHandler, GetCompetitionsWithoutMetricsQueryHandler>();
             services.AddScoped<SportsData.Api.Application.Admin.Queries.GetMatchupPreview.IGetMatchupPreviewQueryHandler,
                 SportsData.Api.Application.Admin.Queries.GetMatchupPreview.GetMatchupPreviewQueryHandler>();
+            services.AddScoped<SportsData.Api.Application.Admin.Queries.GetMatchupForContest.IGetMatchupForContestQueryHandler,
+                SportsData.Api.Application.Admin.Queries.GetMatchupForContest.GetMatchupForContestQueryHandler>();
 
             // Analytics Queries
             services.AddScoped<IGetFranchiseSeasonMetricsQueryHandler, GetFranchiseSeasonMetricsQueryHandler>();

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -31,6 +31,8 @@ import AutoJoinRedirect from "./components/signup/AutoJoinRedirect";
 import LeagueDiscoverPage from "components/leagues/LeagueDiscoverPage";
 import ContestOverview from "./components/contests/ContestOverview";
 import AdminPage from "./components/admin/AdminPage";
+import AdminFootballPage from "./components/admin/AdminFootballPage";
+import AdminBaseballPage from "./components/admin/AdminBaseballPage";
 import AdminRoute from "./routes/AdminRoute";
 import SeasonOverview from "./components/season/SeasonOverview";
 
@@ -194,6 +196,22 @@ function MainApp() {
               element={
                 <AdminRoute>
                   <AdminPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/football"
+              element={
+                <AdminRoute>
+                  <AdminFootballPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/baseball"
+              element={
+                <AdminRoute>
+                  <AdminBaseballPage />
                 </AdminRoute>
               }
             />

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -13,6 +13,13 @@ const AdminApi = {
   resetPreview: (contestId) =>
     apiClient.post(`/admin/matchup/preview/${contestId}/reset`),
 
+  // Returns one MLB matchup in the same shape as the picks page so the
+  // baseball SignalR debug page can render a real <MatchupCard /> for a
+  // chosen contest. League-context fields (Predictions, AiWinner,
+  // IsPreview*, HeadLine) come back null/empty per the endpoint contract.
+  getBaseballMatchupForContest: (contestId) =>
+    apiClient.get(`/admin/baseball/contests/${contestId}/matchup`),
+
   // SignalR debug harness — see docs/signalr-debug-harness-plan.md.
   // Each call publishes a synthetic integration event through API's
   // MassTransit + own consumer + SignalR fan-out, exercising the same

--- a/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import './AdminPage.css';
+import AdminHeader from './AdminHeader';
+import BaseballDebugCard from './signalr-debug/BaseballDebugCard';
+import MatchupCard from '../matchups/MatchupCard';
+import apiWrapper from '../../api/apiWrapper';
+
+const CONTEST_ID_STORAGE_KEY = 'admin.baseball.debugContestId';
+
+/**
+ * Baseball SignalR debug harness page. Hosts the baseball-specific debug
+ * card on its own route (`/admin/baseball`) so the parent /admin page
+ * stays focused on system-health/data-quality widgets.
+ *
+ * Also renders a real <MatchupCard /> for a chosen contest (entered in
+ * the input below) so we can visually verify how SignalR-driven updates
+ * will land on the same component the picks page uses. The contestId
+ * persists to localStorage so reloads keep the last value.
+ */
+export default function AdminBaseballPage() {
+  const [contestId, setContestId] = useState(
+    () => localStorage.getItem(CONTEST_ID_STORAGE_KEY) ?? ''
+  );
+  const [pendingId, setPendingId] = useState(contestId);
+  const [matchup, setMatchup] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!contestId) {
+      setMatchup(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiWrapper.Admin.getBaseballMatchupForContest(contestId);
+        if (!cancelled) setMatchup(res.data ?? null);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.response?.data?.errors?.[0]?.errorMessage ?? err.message ?? 'Failed to load matchup');
+          setMatchup(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [contestId]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const trimmed = pendingId.trim();
+    setContestId(trimmed);
+    if (trimmed) {
+      localStorage.setItem(CONTEST_ID_STORAGE_KEY, trimmed);
+    } else {
+      localStorage.removeItem(CONTEST_ID_STORAGE_KEY);
+    }
+  };
+
+  const seasonYear = matchup?.startDateUtc
+    ? new Date(matchup.startDateUtc).getUTCFullYear()
+    : undefined;
+
+  return (
+    <div className="admin-page">
+      <AdminHeader />
+
+      <div className="admin-baseball-debug-grid">
+        {/* Left column — the observer: pick a contest, render its MatchupCard */}
+        <section className="admin-baseball-matchup-debug">
+          <form onSubmit={handleSubmit} style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>
+            <label htmlFor="admin-baseball-contest-id" style={{ fontWeight: 600 }}>
+              Contest ID:
+            </label>
+            <input
+              id="admin-baseball-contest-id"
+              type="text"
+              value={pendingId}
+              onChange={(e) => setPendingId(e.target.value)}
+              placeholder="paste an MLB contest GUID"
+              style={{ flex: 1, padding: '6px 8px', minWidth: 0 }}
+            />
+            <button type="submit">Load matchup</button>
+          </form>
+
+          {loading && <div>Loading matchup…</div>}
+          {error && <div style={{ color: 'red' }}>{error}</div>}
+          {matchup && !loading && !error && (
+            <MatchupCard
+              matchup={matchup}
+              leagueSport="BaseballMlb"
+              leagueSeasonYear={seasonYear}
+            />
+          )}
+        </section>
+
+        {/* Right column — the controls: synthetic SignalR events */}
+        <section className="admin-signalr-debug">
+          <BaseballDebugCard />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './AdminPage.css';
+import AdminHeader from './AdminHeader';
+import FootballDebugCard from './signalr-debug/FootballDebugCard';
+
+/**
+ * Football SignalR debug harness page. Hosts the football-specific debug
+ * card on its own route (`/admin/football`) so the parent /admin page
+ * stays focused on system-health/data-quality widgets.
+ */
+export default function AdminFootballPage() {
+  return (
+    <div className="admin-page">
+      <AdminHeader />
+      <section className="admin-signalr-debug">
+        <FootballDebugCard />
+      </section>
+    </div>
+  );
+}

--- a/src/UI/sd-ui/src/components/admin/AdminPage.css
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.css
@@ -95,3 +95,20 @@
   gap: 1rem;
   margin: 1rem 0 1.5rem;
 }
+
+/* /admin/baseball — left column hosts the matchup-card observer (driven by
+   the contest-id input), right column hosts the BaseballDebugCard control
+   panel that fires synthetic SignalR events. */
+.admin-baseball-debug-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 12px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .admin-baseball-debug-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/UI/sd-ui/src/components/admin/AdminPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.jsx
@@ -7,9 +7,6 @@ import CompetitionsWithoutPlays from './CompetitionsWithoutPlays';
 import CompetitionsWithoutDrives from './CompetitionsWithoutDrives';
 import SystemHealth from './SystemHealth';
 import RecentErrors from './RecentErrors';
-import FootballDebugCard from './signalr-debug/FootballDebugCard';
-import BaseballDebugCard from './signalr-debug/BaseballDebugCard';
-
 export default function AdminPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -133,14 +130,7 @@ export default function AdminPage() {
     <div className="admin-page">
       <AdminHeader />
 
-      {/* SignalR debug harness — fires synthetic integration events
-          through API → MassTransit → SignalR → UI. Lets us verify the
-          live-game pipeline without needing a real game in progress.
-          See docs/signalr-debug-harness-plan.md. */}
-      <section className="admin-signalr-debug">
-        <FootballDebugCard />
-        <BaseballDebugCard />
-      </section>
+      {/* SignalR debug cards moved to /admin/football and /admin/baseball. */}
 
       <div className="admin-grid">
         <div className="admin-main">


### PR DESCRIPTION
## Summary
- Splits `/admin` SignalR debug into `/admin/football` and `/admin/baseball` so each sport gets a focused harness.
- `/admin/baseball` renders a real `<MatchupCard />` for a chosen contest GUID alongside the existing `BaseballDebugCard`, so synthetic SignalR events can be visually verified end-to-end against the same component the picks page uses.
- Adds `GET /admin/baseball/contests/{id}/matchup` returning the same `MatchupForPickDto` the picks page receives. League-context fields (`HeadLine`, `Predictions`, `AiWinner`, `IsPreview*`) come back null/empty per the canonical contract.
- Extracts `MatchupForPickDtoMapper` from `GetLeagueWeekMatchupsQueryHandler`. `ApplyCanonical()` preserves the existing handler path, `FromCanonical()` serves the new admin handler.
- Adds Issue #9 to `docs/LIVE_UPDATES_REFACTORING.md` proposing the 4-event → 3-event collapse (drop `ContestPlayCompleted`, rename `*ContestStateChanged` → `*PlayCompleted` carrying play description, rename `ContestReplayService` → `FootballContestReplayService` and add `BaseballContestReplayService`). The design lands alongside its trigger (the debug page); implementation is a follow-up PR.

## Test plan
- [ ] `dotnet build src/SportsData.Api/SportsData.Api.csproj` — clean
- [ ] `dotnet test test/unit/SportsData.Api.Tests.Unit` — 329 passing
- [ ] Manual: navigate to `/app/admin/football`, confirm `FootballDebugCard` renders
- [ ] Manual: navigate to `/app/admin/baseball`, paste an MLB contest GUID, confirm `MatchupCard` loads and `BaseballDebugCard` is side-by-side
- [ ] Manual: reload `/app/admin/baseball`, confirm contestId persists from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated admin debug pages for football (`/admin/football`) and baseball (`/admin/baseball`) with contest data exploration and SignalR testing capabilities.
  * Added admin endpoint for retrieving baseball matchup information by contest ID.

* **Documentation**
  * Added planned refactoring issue documenting the consolidation of contest event emissions from four to three events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->