### PR TITLE
feat(ui): MLB live rows on MatchupCard; per-sport InProgress split

### DIFF
--- a/docs/matchup-card.md
+++ b/docs/matchup-card.md
@@ -1,161 +1,154 @@
-# Matchup Card — live-state enrichment plan
+# Matchup Card — live-state enrichment
 
-Working notes capturing the next round of changes to the picks-page
-matchup card. Use as context in follow-up sessions; update in place as
-decisions land.
+Working notes for the matchup card's live-state work. Updated in place
+as decisions land. Use as context in follow-up sessions.
 
-## Goal
+## Status
 
-Give a quick at-a-glance read of in-progress games on the picks page
-without forcing the user to click into the contest overview. Surface
-sport-shaped live state directly on the card.
+**MLB live rows landed** in `feat/matchup-card-mlb-enrichment` (PR
+forthcoming): score line picks up the live status, score, and a
+last-play description on every `BaseballPlayCompleted`. Inning/count/
+outs and runner rows render when populated; suppressed when the
+canonical play data emits defaults (which is most of the time today
+— see "Next blocker" below).
 
-## Current structure (as of 2026-05-10)
+**Football left untouched.** Existing FB block was lifted verbatim
+into `FootballGameStatusInProgress.jsx`; class names, behavior, and
+visual output are unchanged. The deferred decisions (last-play row on
+FB, status-neutral class renames on the FB markup) live in
+`Deferred / Open` below.
 
-- `src/UI/sd-ui/src/components/matchups/MatchupCard.jsx` — the card.
-  Renders teams, odds, status, AI predictions, pick buttons.
-- `src/UI/sd-ui/src/components/matchups/GameStatus.jsx` — extracted
-  child component invoked at `MatchupCard.jsx:218`. Owns the
-  Scheduled / InProgress / Final rendering and the classes named
-  below. **This is where the `game-result` / `final-score` JSX lives.**
-- `src/UI/sd-ui/src/components/matchups/MatchupCard.css` — selectors
-  for `.game-result`, `.final-score`, `.score-display`, etc.
-- Live state arrives via `ContestUpdatesContext` (populated by the
-  merged `FootballPlayCompleted` / `BaseballPlayCompleted` SignalR
-  events from PR Issue #9). `PicksPage.jsx` enriches each matchup with
-  `getContestUpdate(contestId)` before passing to `MatchupCard`.
+## Architecture as it landed
 
-### Class names that need replacing (status-misleading)
+```
+MatchupCard.jsx
+  └─ GameStatus.jsx                       ← thin dispatcher
+       ├─ Final / Scheduled branches      ← shared markup, unchanged
+       └─ InProgress branch:
+            ├─ BaseballGameStatusInProgress.jsx  ← NEW (status-neutral classes)
+            └─ FootballGameStatusInProgress.jsx  ← FB block, lifted verbatim
+```
 
-The current names imply "Final" but the same wrappers also render the
-InProgress and Scheduled branches:
+Routing key: `leagueSport` (backend Sport enum name, e.g.
+`"BaseballMlb"`). When `leagueSport` is missing or unrecognized, the
+dispatcher falls back to football rendering — preserves prior behavior
+on routes that haven't been re-plumbed.
 
-| Current | Issue | Proposed (status-neutral) |
+### File map
+
+| File | Role |
+|---|---|
+| `components/matchups/GameStatus.jsx` | Dispatcher. Owns Scheduled / Final markup. |
+| `components/matchups/FootballGameStatusInProgress.jsx` | FB live block (period, clock, score with 🏈, scoring flash). |
+| `components/matchups/BaseballGameStatusInProgress.jsx` | MLB live block (LIVE label, score with ⚾ on batting team, inning+count+outs row, runners row, last-play row — each suppressed at defaults). |
+| `components/matchups/MatchupCard.jsx` | Threads `leagueSport` + the union of FB/MLB live fields into `GameStatus`. |
+| `components/matchups/MatchupCard.css` | New status-neutral wrappers (`.game-status-block`, `.game-status-row`, `.game-status-link`, `.status-label`) + MLB row styles. Old FB classes (`.game-result`, `.final-score`, etc.) still in use; rename deferred. |
+
+### Class names (current state)
+
+| Sport | Wrapper / inner | Class |
 |---|---|---|
-| `.game-result` | reads as "Final" only | `.game-status-block` |
-| `.final-score` | inner row, used for live too | `.game-status-row` |
-| `.final-score-link` | the wrapping `<Link>` | `.game-status-link` |
-| `.result-label` | "FINAL" / "LIVE" / etc. | `.status-label` |
-| `.game-result.scoring-play` | flash modifier | `.game-status-block.is-scoring-play` |
-| `.game-result.game-result-stream` | upcoming-stream CTA modifier | `.game-status-block.is-stream` |
-| `.score-display` | already neutral — keep | (no change) |
+| Football InProgress / Final / Scheduled | outer / inner / link / label | `.game-result` / `.final-score` / `.final-score-link` / `.result-label` |
+| Baseball InProgress | outer / inner / link / label | `.game-status-block` / `.game-status-row` / `.game-status-link` / `.status-label` |
+| Both | score line | `.score-display` (already neutral) |
 
-### Picks-page enrichment gap
-
-`PicksPage.jsx` currently merges only football live fields onto the
-matchup before render:
-
-```js
-status, awayScore, homeScore, period, clock,
-possessionFranchiseSeasonId, isScoringPlay
-```
-
-Baseball-shaped fields from `BaseballPlayCompleted`
-(`halfInning`, `inning`, `balls`, `strikes`, `outs`,
-`runnerOnFirst/Second/Third`, `lastPlayDescription`) never reach the
-card. **Any baseball live UI needs this merge extended first.**
-
-## Decision: split per sport (probably)
-
-Working hypothesis is that football and baseball should diverge at the
-status component, mirroring the sport-specific-subtype pattern used
-elsewhere in the codebase (`feedback_sport_specific_subtype_split` in
-auto-memory).
-
-```
-GameStatus.jsx              ← thin dispatcher: routes by sport
-  ├─ FootballGameStatus.jsx ← period, clock, possession 🏈, scoring flash
-  └─ BaseballGameStatus.jsx ← inning + count + outs row, runners row,
-                               last-play row, batting-team ⚾ indicator
-```
-
-Rationale:
-- One component with `if (sport === ...)` branches piles up fast as
-  more sports come online (NBA, NHL, soccer all have different live
-  shapes).
-- The football and baseball "live" rows are visually different enough
-  that sharing markup is more painful than splitting.
-- Shared concerns (Scheduled time/venue, Final score) can stay on the
-  parent `GameStatus` dispatcher or be a small shared sub-component.
-
-Open: do we keep a single `GameStatus.jsx` as the entry point that
-dispatches, or replace it entirely with sport-keyed components rendered
-directly from `MatchupCard.jsx`?
-
-## Proposed in-progress layout (baseball)
-
-Stacked rows inside the same outer block. Rows render conditionally
-when their fields are populated.
-
-```
-┌─ .game-status-block ────────────────────────────┐
-│  LIVE                          ← .status-label   │
-│  ⚾ KC 3 — 2 SF                ← .score-display  │
-│  Top 5 · 2-1 · 1 out          ← .live-state-summary │
-│  Runners: 1B  2B               ← .live-state-runners │
-│  "Single — runner to first."   ← .live-state-lastplay │
-└──────────────────────────────────────────────────┘
-```
-
-- ⚾ icon position derived from `halfInning`: Top → away batting (icon
-  on away side), Bottom → home batting (icon on home side). Mirrors
-  football's 🏈-next-to-possessing-team pattern.
-- Suppress rows whose fields are absent rather than showing dashes.
-- `is-scoring-play` flash still fires when `isScoringPlay` lands true.
-- Last play text should be ellipsised for long descriptions.
-
-## Proposed in-progress layout (football)
-
-Working assumption: leave football's existing layout (LIVE label,
-period+clock, score with 🏈, scoring flash) but optionally append a
-last-play row using the new `lastPlayDescription` field that
-`FootballPlayCompleted` now carries. Decision pending.
-
-## Open scope questions
-
-1. **Football last-play row — yes / no?** `FootballPlayCompleted`
-   carries `playDescription`, but the existing football card has been
-   fine without it. Adding it is a one-line render but it does add
-   visual density.
-2. **Picks-page enrichment** — extend `PicksPage.jsx` merge to include
-   baseball fields. Required for any of this to render on the picks
-   page (admin debug page already merges them).
-3. **Dispatcher vs per-sport components** — keep `GameStatus.jsx` as
-   the entry point + add sport-specific children, OR delete
-   `GameStatus.jsx` and call the right component directly from
-   `MatchupCard`?
-4. **Class renames in one shot vs piecemeal** — rename now (one big
-   diff that touches CSS + JSX) or land the enrichment first and
-   rename in a follow-up?
+The neutral names cover only baseball today. Renaming the football
+markup is intentionally deferred — see `Deferred / Open` below.
 
 ## Reference: live-state field shapes
 
-From the current `ContestUpdatesContext.jsx` handlers:
+From `ContestUpdatesContext.jsx` handlers:
 
-**`handleFootballPlayCompleted`** writes:
-- `period`, `clock`, `awayScore`, `homeScore`,
-  `possessionFranchiseSeasonId`, `isScoringPlay`, `ballOnYardLine`,
-  `lastPlayId`, `lastPlayDescription`, `lastPlayAt`, `lastUpdated`
+**`handleFootballPlayCompleted`**: `period`, `clock`, `awayScore`,
+`homeScore`, `possessionFranchiseSeasonId`, `isScoringPlay`,
+`ballOnYardLine`, `lastPlayId`, `lastPlayDescription`, `lastPlayAt`,
+`lastUpdated`.
 
-**`handleBaseballPlayCompleted`** writes:
-- `inning`, `halfInning`, `awayScore`, `homeScore`,
-  `balls`, `strikes`, `outs`,
-  `runnerOnFirst`, `runnerOnSecond`, `runnerOnThird`,
-  `atBatAthleteId`, `pitchingAthleteId`,
-  `lastPlayId`, `lastPlayDescription`, `lastPlayAt`, `lastUpdated`
+**`handleBaseballPlayCompleted`**: `inning`, `halfInning`, `awayScore`,
+`homeScore`, `balls`, `strikes`, `outs`, `runnerOnFirst`,
+`runnerOnSecond`, `runnerOnThird`, `atBatAthleteId`, `pitchingAthleteId`,
+`lastPlayId`, `lastPlayDescription`, `lastPlayAt`, `lastUpdated`.
 
-**`handleStatusUpdate`** writes:
-- `status`, `lastUpdated`
+**`handleStatusUpdate`**: `status`, `lastUpdated`.
+
+## Parent-merge gotcha (important)
+
+`MatchupCard` is a "dumb" component — props in, render out. It does
+NOT call `useContestUpdates()` itself. Each *parent* that renders the
+card and wants live updates is responsible for:
+
+1. Calling `useContestUpdates()` and reading `getContestUpdate(contestId)`.
+2. Merging the returned `live` fields onto the matchup before passing
+   to `MatchupCard`.
+
+Two parents do this today, **and both must be kept in sync** when a
+new live field is introduced:
+
+- `components/picks/PicksPage.jsx` — `enrichedMatchups` useMemo.
+- `components/admin/AdminBaseballPage.jsx` — `enrichedMatchup` useMemo.
+
+If one is updated and the other isn't, `MatchupCard` silently gets
+undefined values for the new fields and the new rows will fail to
+render on whichever page was missed. (This bit me on the admin page
+when the picks-page enrichment was extended for MLB.)
+
+Future cleanup options (not for this PR):
+- Move the subscription into `MatchupCard` itself (one place to
+  update, but couples the card to the context — bad for snapshots /
+  tests / non-live views).
+- Extract a `useEnrichedMatchup(matchup)` hook so callers can't
+  forget to merge a new field.
+
+## Next blocker — canonical play data
+
+The MLB live emission (`BaseballEventCompetitionPlayDocumentProcessor`
+and `BaseballContestReplayService`) currently sends defaults for
+fields that aren't materialized on `BaseballCompetitionPlay`:
+
+| Wire field | Source today | What gets emitted |
+|---|---|---|
+| `HalfInning` | not on the play entity (lives on `BaseballCompetitionStatus`) | empty string |
+| `Outs` | not on the play entity | `0` |
+| `RunnerOnFirst` / `Second` / `Third` | not on the play entity | `false` |
+| `AtBatAthleteId` | not on the play entity | `null` |
+| `PitchingAthleteId` | not on the play entity | `null` |
+
+Visible consequence on `MatchupCard`:
+- ⚾ batting-team indicator never appears (derived from `halfInning`
+  — empty string fails the Top/Bottom check).
+- Inning row would render with bare `inning` value but is suppressed
+  whenever `halfInning` is also empty (current behavior — see
+  `hasInningRow` guard in `BaseballGameStatusInProgress.jsx`).
+- Runners row never appears (all three booleans false).
+
+The fix is sourcing-side: capture the missing fields onto
+`BaseballCompetitionPlay` (or read from `BaseballCompetitionStatus`
+during the play emission). That's the next PR per user's call.
+
+## Deferred / Open
+
+1. **FB last-play row** — `FootballPlayCompleted` carries
+   `playDescription`, but FB rendering wasn't touched in this pass.
+   Decision deferred until FB matchup card is revisited.
+2. **FB class renames** (`.game-result` → `.game-status-block` etc.)
+   — left for a follow-up; would touch CSS + JSX in
+   `FootballGameStatusInProgress`. Not blocking anything.
+3. **`BaseballLiveStatePanel`** in `AdminBaseballPage` — kept on
+   purpose because it renders defaulted fields with `?? '—'`
+   placeholders, useful while the canonical-data gap above persists.
+   Delete when sourcing fills the fields for real.
+4. **Subscription pattern** — see "Parent-merge gotcha" above. Both
+   parents must be updated when adding a new live field.
 
 ## Caveats
 
-- `BaseballCompetitionPlay` doesn't materialize half-inning, outs,
-  runner state, or athlete IDs at the play-entity level today — the
-  baseball play processor and replay service emit these fields with
-  defaults until the AtBat sourcing pipeline lands. UI should treat
-  the values as best-effort and degrade gracefully (suppress rows
-  rather than show "0-0 · 0 out" for a stale state).
-- `MatchupCard` is rendered both on `/picks` and on `/admin/baseball`.
-  Any change here lights up the debug page too — once baseball live
-  rows are visible on the card, the `BaseballLiveStatePanel` debug
-  readout on the admin page becomes redundant and can be deleted.
+- `BaseballDebugCard` (right column of `/admin/baseball`) subscribes
+  to `BASEBALL_DEBUG_CONTEST_ID` (sandbox), separate from the
+  contestId entered in the input form. So the diamond on the right
+  reacts to synthetic events; the matchup card on the left reacts to
+  real replay events. Same code path, different keys. Mixing the two
+  for end-to-end visual proof requires firing synthetic events at the
+  real contestId or extending `BaseballDebugCard` to accept the
+  page-level contestId — not done here.
+- `MatchupCard` is rendered on both `/picks` and `/admin/baseball`.
+  See "Parent-merge gotcha" above for the implication.

--- a/docs/matchup-card.md
+++ b/docs/matchup-card.md
@@ -5,8 +5,8 @@ as decisions land. Use as context in follow-up sessions.
 
 ## Status
 
-**MLB live rows landed** in `feat/matchup-card-mlb-enrichment` (PR
-forthcoming): score line picks up the live status, score, and a
+**MLB live rows landed** in PR #309 (`feat/matchup-card-mlb-enrichment`):
+score line picks up the live status, score, and a
 last-play description on every `BaseballPlayCompleted`. Inning/count/
 outs and runner rows render when populated; suppressed when the
 canonical play data emits defaults (which is most of the time today
@@ -20,7 +20,7 @@ FB, status-neutral class renames on the FB markup) live in
 
 ## Architecture as it landed
 
-```
+```text
 MatchupCard.jsx
   └─ GameStatus.jsx                       ← thin dispatcher
        ├─ Final / Scheduled branches      ← shared markup, unchanged
@@ -116,9 +116,12 @@ fields that aren't materialized on `BaseballCompetitionPlay`:
 Visible consequence on `MatchupCard`:
 - ⚾ batting-team indicator never appears (derived from `halfInning`
   — empty string fails the Top/Bottom check).
-- Inning row would render with bare `inning` value but is suppressed
-  whenever `halfInning` is also empty (current behavior — see
-  `hasInningRow` guard in `BaseballGameStatusInProgress.jsx`).
+- Inning row renders whenever `inning > 0` regardless of `halfInning`
+  — the `hasInningRow` guard in `BaseballGameStatusInProgress.jsx` is
+  `(inning > 0) || (halfInning non-empty)`, so a real-game replay with
+  `inning=5, halfInning=""` shows the row formatted as
+  `Inning 5 · 0-0 · 0 outs` (the count and outs placeholder values
+  also reflect the canonical-data gap above).
 - Runners row never appears (all three booleans false).
 
 The fix is sourcing-side: capture the missing fields onto

--- a/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
@@ -45,16 +45,18 @@ export default function AdminBaseballPage() {
       awayScore: live.awayScore ?? matchup.awayScore,
       homeScore: live.homeScore ?? matchup.homeScore,
       // Baseball-shaped live fields (handleBaseballPlayCompleted writes
-      // these onto the context record).
-      inning: live.inning,
-      halfInning: live.halfInning,
-      balls: live.balls,
-      strikes: live.strikes,
-      outs: live.outs,
-      runnerOnFirst: live.runnerOnFirst,
-      runnerOnSecond: live.runnerOnSecond,
-      runnerOnThird: live.runnerOnThird,
-      lastPlayDescription: live.lastPlayDescription,
+      // these onto the context record). Use nullish-fallback so a
+      // future partial-update handler that doesn't carry the full set
+      // can't silently undefine a previously-populated field.
+      inning: live.inning ?? matchup.inning,
+      halfInning: live.halfInning ?? matchup.halfInning,
+      balls: live.balls ?? matchup.balls,
+      strikes: live.strikes ?? matchup.strikes,
+      outs: live.outs ?? matchup.outs,
+      runnerOnFirst: live.runnerOnFirst ?? matchup.runnerOnFirst,
+      runnerOnSecond: live.runnerOnSecond ?? matchup.runnerOnSecond,
+      runnerOnThird: live.runnerOnThird ?? matchup.runnerOnThird,
+      lastPlayDescription: live.lastPlayDescription ?? matchup.lastPlayDescription,
     };
   }, [matchup, live]);
 

--- a/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
@@ -33,10 +33,9 @@ export default function AdminBaseballPage() {
   const live = contestId ? getContestUpdate(contestId) : null;
 
   // Mirror the picks-page enrichment pattern (PicksPage.jsx) so the
-  // canonical MatchupCard re-renders with live status/score deltas as
-  // SignalR events land. Baseball-specific fields (inning, count,
-  // runners, last play) aren't surfaced on MatchupCard yet — see the
-  // separate live-state panel below this card.
+  // canonical MatchupCard re-renders as SignalR events land — including
+  // baseball-specific fields (inning, count, runners, last play) that
+  // BaseballGameStatusInProgress now renders inside MatchupCard.
   const enrichedMatchup = useMemo(() => {
     if (!matchup) return null;
     if (!live) return matchup;
@@ -45,6 +44,17 @@ export default function AdminBaseballPage() {
       status: live.status ?? matchup.status,
       awayScore: live.awayScore ?? matchup.awayScore,
       homeScore: live.homeScore ?? matchup.homeScore,
+      // Baseball-shaped live fields (handleBaseballPlayCompleted writes
+      // these onto the context record).
+      inning: live.inning,
+      halfInning: live.halfInning,
+      balls: live.balls,
+      strikes: live.strikes,
+      outs: live.outs,
+      runnerOnFirst: live.runnerOnFirst,
+      runnerOnSecond: live.runnerOnSecond,
+      runnerOnThird: live.runnerOnThird,
+      lastPlayDescription: live.lastPlayDescription,
     };
   }, [matchup, live]);
 
@@ -169,11 +179,14 @@ export default function AdminBaseballPage() {
 
 /**
  * Debug-only readout of the per-contest live state arriving via SignalR.
- * MatchupCard doesn't render baseball scoreboard fields (inning, count,
- * runners, last play description) today — this panel exists so we can
- * confirm the merged BaseballPlayCompleted payload is landing in the
- * ContestUpdatesContext correctly. Once the picks-page MLB UI is built,
- * this panel can go away.
+ * MatchupCard now renders the same fields via BaseballGameStatusInProgress,
+ * but suppresses rows whose source values are at defaults — useful for the
+ * end-user, less so when debugging the pipeline. This panel renders every
+ * field with a `?? '—'` placeholder so you can distinguish "event arrived
+ * but field was default" from "no event at all," which matters while the
+ * canonical play data still emits empty HalfInning / 0 outs / all-false
+ * runners. Drop this panel once the AtBat sourcing pipeline populates
+ * those fields for real.
  */
 function BaseballLiveStatePanel({ live }) {
   const empty = !live;

--- a/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
@@ -1,0 +1,121 @@
+import { Link } from "react-router-dom";
+import { contestLink } from '../../utils/sportLinks';
+
+/**
+ * Baseball per-play live block. Renders LIVE label, score with ⚾ next
+ * to the batting team (derived from halfInning: Top → away batting,
+ * Bottom → home batting), then three optional rows:
+ *
+ *   1. Inning + count + outs    (.live-state-summary)
+ *   2. Runners on base          (.live-state-runners)
+ *   3. Last play description    (.live-state-lastplay)
+ *
+ * Each optional row is suppressed when its source fields are at
+ * defaults — half-inning, outs, runners, athlete IDs aren't yet
+ * materialized on BaseballCompetitionPlay (see PR #308 / Issue #9
+ * notes), so live MLB events arrive with mostly-default values until
+ * the AtBat sourcing pipeline lands. The card degrades gracefully
+ * rather than rendering "Top — · 0-0 · 0 outs" placeholders.
+ *
+ * Uses status-neutral class names (`.game-status-block`, `.score-display`,
+ * etc.) — the broader rename of football's `.game-result` / `.final-score`
+ * markup is deferred to a follow-up effort per docs/matchup-card.md.
+ */
+function BaseballGameStatusInProgress({
+  awayShort,
+  homeShort,
+  awayScore,
+  homeScore,
+  inning,
+  halfInning,
+  balls,
+  strikes,
+  outs,
+  runnerOnFirst,
+  runnerOnSecond,
+  runnerOnThird,
+  lastPlayDescription,
+  isScoringPlay,
+  contestId,
+  sport,
+  league,
+}) {
+  // Top of the inning → away team is batting; Bottom → home batting.
+  // Empty/unknown halfInning produces no indicator (graceful degrade).
+  const half = (halfInning ?? '').toLowerCase();
+  const awayIsBatting = half === 'top';
+  const homeIsBatting = half === 'bottom';
+
+  // Suppress rows whose source fields are absent. Inning is the only
+  // truthiness check that needs care because PeriodNumber=0 isn't a
+  // valid inning — we render the row when we have a positive inning OR
+  // a non-empty half-inning string.
+  const hasInningRow =
+    (typeof inning === 'number' && inning > 0) ||
+    (typeof halfInning === 'string' && halfInning.length > 0);
+  const hasRunnersRow = runnerOnFirst || runnerOnSecond || runnerOnThird;
+  const hasLastPlayRow =
+    typeof lastPlayDescription === 'string' && lastPlayDescription.length > 0;
+
+  const outsLabel = outs === 1 ? 'out' : 'outs';
+  const formattedHalfInning = halfInning && inning
+    ? `${halfInning} ${inning}`
+    : (halfInning || (inning ? `Inning ${inning}` : ''));
+
+  const liveContent = (
+    <>
+      <span className="status-label live-indicator">LIVE</span>
+      <span className={`score-display ${isScoringPlay ? 'score-flash' : ''}`}>
+        {awayIsBatting && <span className="possession-indicator" aria-label="batting">⚾</span>}
+        {awayShort} {awayScore} - {homeScore} {homeShort}
+        {homeIsBatting && <span className="possession-indicator" aria-label="batting">⚾</span>}
+      </span>
+
+      {hasInningRow && (
+        <span className="live-state-summary">
+          {formattedHalfInning}
+          {' · '}
+          {balls ?? 0}-{strikes ?? 0}
+          {' · '}
+          {outs ?? 0} {outsLabel}
+        </span>
+      )}
+
+      {hasRunnersRow && (
+        <span className="live-state-runners">
+          Runners:
+          {runnerOnFirst && <span className="live-state-runner-base"> 1B</span>}
+          {runnerOnSecond && <span className="live-state-runner-base"> 2B</span>}
+          {runnerOnThird && <span className="live-state-runner-base"> 3B</span>}
+        </span>
+      )}
+
+      {hasLastPlayRow && (
+        <span className="live-state-lastplay" title={lastPlayDescription}>
+          {lastPlayDescription}
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <div className={`game-status-block ${isScoringPlay ? 'is-scoring-play' : ''}`}>
+      <div className="game-status-row">
+        {contestId ? (
+          <Link
+            to={contestLink(contestId, sport, league)}
+            className="game-status-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {liveContent}
+          </Link>
+        ) : (
+          liveContent
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BaseballGameStatusInProgress;

--- a/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
@@ -28,8 +28,16 @@ function FootballGameStatusInProgress({
   sport,
   league,
 }) {
-  const awayHasPossession = possessionFranchiseSeasonId === awayFranchiseSeasonId;
-  const homeHasPossession = possessionFranchiseSeasonId === homeFranchiseSeasonId;
+  // Guard against null/undefined possession — without the != null check,
+  // a missing possessionFranchiseSeasonId could match a missing
+  // awayFranchiseSeasonId / homeFranchiseSeasonId via `===` and falsely
+  // mark a team as having possession.
+  const awayHasPossession =
+    possessionFranchiseSeasonId != null
+    && possessionFranchiseSeasonId === awayFranchiseSeasonId;
+  const homeHasPossession =
+    possessionFranchiseSeasonId != null
+    && possessionFranchiseSeasonId === homeFranchiseSeasonId;
 
   const liveContent = (
     <>

--- a/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
@@ -1,0 +1,72 @@
+import { Link } from "react-router-dom";
+import { contestLink } from '../../utils/sportLinks';
+
+/**
+ * Football per-play live block. Lifted verbatim from GameStatus.jsx so
+ * the per-sport split (FB vs MLB) can land without disturbing the
+ * existing football layout. Behavior is unchanged: LIVE label,
+ * period+clock, score with 🏈 next to the team in possession, scoring
+ * flash + 🎉 TOUCHDOWN! indicator.
+ *
+ * Class names are intentionally kept (`.game-result`, `.final-score`,
+ * `.score-display`, etc.) — the broader status-neutral rename is a
+ * separate effort tracked in docs/matchup-card.md and is out of scope
+ * for the MLB-first enrichment PR.
+ */
+function FootballGameStatusInProgress({
+  awayShort,
+  homeShort,
+  awayScore,
+  homeScore,
+  period,
+  clock,
+  awayFranchiseSeasonId,
+  homeFranchiseSeasonId,
+  possessionFranchiseSeasonId,
+  isScoringPlay,
+  contestId,
+  sport,
+  league,
+}) {
+  const awayHasPossession = possessionFranchiseSeasonId === awayFranchiseSeasonId;
+  const homeHasPossession = possessionFranchiseSeasonId === homeFranchiseSeasonId;
+
+  const liveContent = (
+    <>
+      <span className="result-label live-indicator">LIVE</span>
+      {period && clock && (
+        <span className="game-clock">{period} - {clock}</span>
+      )}
+      <span className={`score-display ${isScoringPlay ? 'score-flash' : ''}`}>
+        {awayHasPossession && <span className="possession-indicator">🏈</span>}
+        {awayShort} {awayScore} - {homeScore} {homeShort}
+        {homeHasPossession && <span className="possession-indicator">🏈</span>}
+      </span>
+      {isScoringPlay && (
+        // TODO: Determine score type (TD, FG, etc.) for better indicator
+        <span className="touchdown-indicator">🎉 TOUCHDOWN!</span>
+      )}
+    </>
+  );
+
+  return (
+    <div className={`game-result ${isScoringPlay ? 'scoring-play' : ''}`}>
+      <div className="final-score">
+        {contestId ? (
+          <Link
+            to={contestLink(contestId, sport, league)}
+            className="final-score-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {liveContent}
+          </Link>
+        ) : (
+          liveContent
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FootballGameStatusInProgress;

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -12,10 +12,11 @@ import BaseballGameStatusInProgress from './BaseballGameStatusInProgress';
  *   - 'InProgress' → dispatch to a per-sport child component
  *                    (FootballGameStatusInProgress / BaseballGameStatusInProgress).
  *                    The two sports diverge meaningfully here — football
- *                    has period+clock+possession+yard line, baseball has
- *                    inning+count+outs+runners+last-play — so they own
- *                    their own JSX rather than one component piling up
- *                    sport-conditional branches.
+ *                    renders period, clock, score, and possession (with
+ *                    a scoring-play flash); baseball renders score plus
+ *                    inning+count+outs, runners, and a last-play line —
+ *                    so they own their own JSX rather than one component
+ *                    piling up sport-conditional branches.
  *   - default      → Scheduled / unknown: shared time+venue markup.
  *
  * Sport routing is keyed off `leagueSport` (the backend Sport enum

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -1,33 +1,27 @@
 import { Link } from "react-router-dom";
 import { Webcam } from "lucide-react";
 import { contestLink } from '../../utils/sportLinks';
+import FootballGameStatusInProgress from './FootballGameStatusInProgress';
+import BaseballGameStatusInProgress from './BaseballGameStatusInProgress';
 
 /**
- * GameStatus component - displays game status (Final, Live, or Scheduled)
- * @param {object} props
- * @param {string} props.status - Game status ('Final', 'InProgress', 'Scheduled')
- * @param {string} props.awayShort - Away team short name
- * @param {string} props.homeShort - Home team short name
- * @param {number} props.awayScore - Away team score
- * @param {number} props.homeScore - Home team score
- * @param {string} props.gameTime - Formatted game time
- * @param {string} props.broadcasts - Broadcast information
- * @param {string} props.venue - Venue name
- * @param {string} props.location - Venue location
- * @param {string} props.period - Current period (Q1, Q2, Q3, Q4, OT, etc.)
- * @param {string} props.clock - Game clock time
- * @param {string} props.awayFranchiseSeasonId - Away team franchise season ID
- * @param {string} props.homeFranchiseSeasonId - Home team franchise season ID
- * @param {string} props.possessionFranchiseSeasonId - Team with possession ID
- * @param {boolean} props.isScoringPlay - Whether this update is for a scoring play
- * @param {string} props.contestId - Contest ID for linking to contest overview
- * @param {string} [props.sport] - URL sport segment (e.g. "baseball"); falls
- *   back to football/ncaa via contestLink defaults when omitted.
- * @param {string} [props.league] - URL league segment (e.g. "mlb").
- * @param {string} [props.streamScheduledTimeUtc] - ISO UTC timestamp; non-null
- *   when an actionable CompetitionStream row exists. Drives the "View" CTA
- *   for upcoming games so users can confirm the live-stream is scheduled and
- *   jump to the contest overview.
+ * GameStatus - top-level dispatcher for the status block on a matchup
+ * card. Branches on `status`:
+ *
+ *   - 'Final'      → shared score-line markup (sport-agnostic).
+ *   - 'InProgress' → dispatch to a per-sport child component
+ *                    (FootballGameStatusInProgress / BaseballGameStatusInProgress).
+ *                    The two sports diverge meaningfully here — football
+ *                    has period+clock+possession+yard line, baseball has
+ *                    inning+count+outs+runners+last-play — so they own
+ *                    their own JSX rather than one component piling up
+ *                    sport-conditional branches.
+ *   - default      → Scheduled / unknown: shared time+venue markup.
+ *
+ * Sport routing is keyed off `leagueSport` (the backend Sport enum
+ * name, e.g. "BaseballMlb"). When omitted or unrecognized, falls back
+ * to football rendering — preserves prior behavior on routes that
+ * don't yet plumb the prop through.
  */
 function GameStatus({
   status,
@@ -45,10 +39,22 @@ function GameStatus({
   homeFranchiseSeasonId,
   possessionFranchiseSeasonId,
   isScoringPlay,
+  // Baseball-specific live fields (populated by ContestUpdatesContext
+  // on BaseballPlayCompleted). Ignored on the football branch.
+  inning,
+  halfInning,
+  balls,
+  strikes,
+  outs,
+  runnerOnFirst,
+  runnerOnSecond,
+  runnerOnThird,
+  lastPlayDescription,
   contestId,
+  leagueSport,
   sport,
   league,
-  streamScheduledTimeUtc
+  streamScheduledTimeUtc,
 }) {
   if (status === 'Final') {
     const scoreContent = (
@@ -81,44 +87,49 @@ function GameStatus({
   }
 
   if (status === 'InProgress') {
-    const awayHasPossession = possessionFranchiseSeasonId === awayFranchiseSeasonId;
-    const homeHasPossession = possessionFranchiseSeasonId === homeFranchiseSeasonId;
+    if (leagueSport === 'BaseballMlb') {
+      return (
+        <BaseballGameStatusInProgress
+          awayShort={awayShort}
+          homeShort={homeShort}
+          awayScore={awayScore}
+          homeScore={homeScore}
+          inning={inning}
+          halfInning={halfInning}
+          balls={balls}
+          strikes={strikes}
+          outs={outs}
+          runnerOnFirst={runnerOnFirst}
+          runnerOnSecond={runnerOnSecond}
+          runnerOnThird={runnerOnThird}
+          lastPlayDescription={lastPlayDescription}
+          isScoringPlay={isScoringPlay}
+          contestId={contestId}
+          sport={sport}
+          league={league}
+        />
+      );
+    }
 
-    const liveContent = (
-      <>
-        <span className="result-label live-indicator">LIVE</span>
-        {period && clock && (
-          <span className="game-clock">{period} - {clock}</span>
-        )}
-        <span className={`score-display ${isScoringPlay ? 'score-flash' : ''}`}>
-          {awayHasPossession && <span className="possession-indicator">🏈</span>}
-          {awayShort} {awayScore} - {homeScore} {homeShort}
-          {homeHasPossession && <span className="possession-indicator">🏈</span>}
-        </span>
-        {isScoringPlay && (
-          // TODO: Determine score type (TD, FG, etc.) for better indicator
-          <span className="touchdown-indicator">🎉 TOUCHDOWN!</span>
-        )}
-      </>
-    );
-
+    // Default: football rendering. Covers FootballNcaa / FootballNfl
+    // explicitly and any unrecognized leagueSport (so callers that
+    // don't yet thread the prop through don't regress).
     return (
-      <div className={`game-result ${isScoringPlay ? 'scoring-play' : ''}`}>
-        <div className="final-score">
-          {contestId ? (
-            <Link
-              to={contestLink(contestId, sport, league)}
-              className="final-score-link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {liveContent}
-            </Link>
-          ) : (
-            liveContent
-          )}
-        </div>
-      </div>
+      <FootballGameStatusInProgress
+        awayShort={awayShort}
+        homeShort={homeShort}
+        awayScore={awayScore}
+        homeScore={homeScore}
+        period={period}
+        clock={clock}
+        awayFranchiseSeasonId={awayFranchiseSeasonId}
+        homeFranchiseSeasonId={homeFranchiseSeasonId}
+        possessionFranchiseSeasonId={possessionFranchiseSeasonId}
+        isScoringPlay={isScoringPlay}
+        contestId={contestId}
+        sport={sport}
+        league={league}
+      />
     );
   }
 

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -661,3 +661,101 @@
   margin-right: 6px;
   vertical-align: middle;
 }
+
+/* ==========================================================================
+   Baseball in-progress live rows (BaseballGameStatusInProgress.jsx)
+   --------------------------------------------------------------------------
+   New status-neutral wrappers; the broader rename of football's
+   .game-result/.final-score classes is deferred (see docs/matchup-card.md).
+   These rules style the MLB-specific rows that stack below the score line:
+   inning+count+outs, runners, and last play description.
+   ========================================================================== */
+
+.game-status-block {
+  text-align: center;
+  padding: 8px;
+  background: linear-gradient(135deg, var(--bg-elevated) 0%, var(--bg-primary) 100%);
+  border-radius: 6px;
+  margin: 8px 0;
+}
+
+.game-status-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.game-status-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  color: inherit;
+  transition: opacity 0.2s ease;
+}
+
+.game-status-link:hover {
+  opacity: 0.8;
+}
+
+.game-status-link:hover .status-label,
+.game-status-link:hover .score-display {
+  color: var(--accent);
+}
+
+.status-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* Reuse the existing .live-indicator pulse from the football block for
+   consistency; .status-label.live-indicator picks up the same animation. */
+
+.live-state-summary {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.live-state-runners {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.live-state-runner-base {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.live-state-lastplay {
+  font-size: 0.8rem;
+  font-style: italic;
+  color: var(--text-secondary);
+  max-width: 100%;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+/* Scoring-play flash on the new wrapper (mirrors .game-result.scoring-play). */
+.game-status-block.is-scoring-play {
+  animation: score-pulse 2s ease-in-out;
+  background: linear-gradient(135deg, var(--ranking-gold) 0%, #ff8c00 100%);
+  box-shadow: 0 0 20px rgba(255, 215, 0, 0.6);
+}

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -225,13 +225,28 @@ function MatchupCard({
           broadcasts={matchup.broadcasts}
           venue={venue}
           location={location}
+          // Football-shaped live fields
           period={matchup.period}
           clock={matchup.clock}
           awayFranchiseSeasonId={matchup.awayFranchiseSeasonId}
           homeFranchiseSeasonId={matchup.homeFranchiseSeasonId}
           possessionFranchiseSeasonId={matchup.possessionFranchiseSeasonId}
           isScoringPlay={matchup.isScoringPlay}
+          // Baseball-shaped live fields (populated by ContestUpdatesContext
+          // on BaseballPlayCompleted; ignored on the football branch)
+          inning={matchup.inning}
+          halfInning={matchup.halfInning}
+          balls={matchup.balls}
+          strikes={matchup.strikes}
+          outs={matchup.outs}
+          runnerOnFirst={matchup.runnerOnFirst}
+          runnerOnSecond={matchup.runnerOnSecond}
+          runnerOnThird={matchup.runnerOnThird}
+          lastPlayDescription={matchup.lastPlayDescription}
           contestId={matchup.contestId}
+          // leagueSport drives the in-progress sport dispatch inside
+          // GameStatus (e.g. "BaseballMlb" → BaseballGameStatusInProgress).
+          leagueSport={leagueSport}
           sport={sportLeague?.sport}
           league={sportLeague?.league}
           streamScheduledTimeUtc={matchup.streamScheduledTimeUtc}

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -60,21 +60,37 @@ function PicksPage() {
       .filter(p => p !== null && p !== undefined);
   }, [userPicks]);
 
-  // Merge live updates with matchups
+  // Merge live updates with matchups. Live state arrives via
+  // ContestUpdatesContext from the merged *PlayCompleted SignalR
+  // events (FootballPlayCompleted / BaseballPlayCompleted). Football
+  // and baseball write their own field sets onto the same context
+  // record; the union is included here so MatchupCard / GameStatus
+  // can pick out whichever fields its sport branch needs.
   const enrichedMatchups = useMemo(() => {
     return matchups.map(matchup => {
       const liveUpdate = getContestUpdate(matchup.contestId);
       if (liveUpdate) {
-        // Merge live data, overriding static matchup data
         return {
           ...matchup,
           status: liveUpdate.status,
           awayScore: liveUpdate.awayScore,
           homeScore: liveUpdate.homeScore,
+          // Football-shaped
           period: liveUpdate.period,
           clock: liveUpdate.clock,
           possessionFranchiseSeasonId: liveUpdate.possessionFranchiseSeasonId,
-          isScoringPlay: liveUpdate.isScoringPlay
+          isScoringPlay: liveUpdate.isScoringPlay,
+          // Baseball-shaped
+          inning: liveUpdate.inning,
+          halfInning: liveUpdate.halfInning,
+          balls: liveUpdate.balls,
+          strikes: liveUpdate.strikes,
+          outs: liveUpdate.outs,
+          runnerOnFirst: liveUpdate.runnerOnFirst,
+          runnerOnSecond: liveUpdate.runnerOnSecond,
+          runnerOnThird: liveUpdate.runnerOnThird,
+          // Sport-neutral last-play (written by both *PlayCompleted handlers)
+          lastPlayDescription: liveUpdate.lastPlayDescription
         };
       }
       return matchup;

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -72,25 +72,32 @@ function PicksPage() {
       if (liveUpdate) {
         return {
           ...matchup,
-          status: liveUpdate.status,
-          awayScore: liveUpdate.awayScore,
-          homeScore: liveUpdate.homeScore,
+          // Nullish-fallback so a partial context state (e.g. a
+          // ContestStatusChanged that landed before any *PlayCompleted —
+          // ContestUpdatesContext's status handler writes only `status` /
+          // `lastUpdated`) can't undefine real canonical fields like
+          // awayScore / homeScore.
+          status: liveUpdate.status ?? matchup.status,
+          awayScore: liveUpdate.awayScore ?? matchup.awayScore,
+          homeScore: liveUpdate.homeScore ?? matchup.homeScore,
           // Football-shaped
-          period: liveUpdate.period,
-          clock: liveUpdate.clock,
-          possessionFranchiseSeasonId: liveUpdate.possessionFranchiseSeasonId,
-          isScoringPlay: liveUpdate.isScoringPlay,
-          // Baseball-shaped
-          inning: liveUpdate.inning,
-          halfInning: liveUpdate.halfInning,
-          balls: liveUpdate.balls,
-          strikes: liveUpdate.strikes,
-          outs: liveUpdate.outs,
-          runnerOnFirst: liveUpdate.runnerOnFirst,
-          runnerOnSecond: liveUpdate.runnerOnSecond,
-          runnerOnThird: liveUpdate.runnerOnThird,
+          period: liveUpdate.period ?? matchup.period,
+          clock: liveUpdate.clock ?? matchup.clock,
+          possessionFranchiseSeasonId: liveUpdate.possessionFranchiseSeasonId ?? matchup.possessionFranchiseSeasonId,
+          isScoringPlay: liveUpdate.isScoringPlay ?? matchup.isScoringPlay,
+          // Baseball-shaped — nullish-fallback so a future partial-update
+          // handler that doesn't carry the full set can't silently undefine
+          // a previously-populated field (mirrors the score/status pattern).
+          inning: liveUpdate.inning ?? matchup.inning,
+          halfInning: liveUpdate.halfInning ?? matchup.halfInning,
+          balls: liveUpdate.balls ?? matchup.balls,
+          strikes: liveUpdate.strikes ?? matchup.strikes,
+          outs: liveUpdate.outs ?? matchup.outs,
+          runnerOnFirst: liveUpdate.runnerOnFirst ?? matchup.runnerOnFirst,
+          runnerOnSecond: liveUpdate.runnerOnSecond ?? matchup.runnerOnSecond,
+          runnerOnThird: liveUpdate.runnerOnThird ?? matchup.runnerOnThird,
           // Sport-neutral last-play (written by both *PlayCompleted handlers)
-          lastPlayDescription: liveUpdate.lastPlayDescription
+          lastPlayDescription: liveUpdate.lastPlayDescription ?? matchup.lastPlayDescription
         };
       }
       return matchup;


### PR DESCRIPTION
## Summary

Adds at-a-glance live state to in-progress games on the `MatchupCard` so users don't have to click into the contest overview just for the basics. MLB-first per the user's call; football was deliberately untouched (existing block lifted verbatim into its own file). Implements the plan captured in `docs/matchup-card.md`.

**Architecture:** `GameStatus.jsx` becomes a thin dispatcher. Final and Scheduled stay shared; InProgress picks a per-sport child by `leagueSport`. Football renders identically to before (classes intact, behavior unchanged). MLB gets a new `BaseballGameStatusInProgress` component using status-neutral classes (`.game-status-block`, `.game-status-row`, `.game-status-link`, `.status-label`) with three conditional rows below the score:

```
LIVE
⚾ KC 3 — 2 SF
Top 5 · 2-1 · 1 out          ← .live-state-summary
Runners: 1B 2B                ← .live-state-runners
\"Single — runner to first.\"   ← .live-state-lastplay
```

Each MLB row suppresses when its source fields are at defaults (no \"Top — · 0-0 · 0 outs\" placeholders).

**Plumbing:** `MatchupCard` threads `leagueSport` + the union of FB/MLB live fields into `GameStatus`. `PicksPage` and `AdminBaseballPage` enrichment merges both extended to include the MLB shape — both parents must stay in sync because the card reads from props, not context (gotcha documented in the design doc).

## Test plan

- [x] ESLint clean on every changed JSX file
- [x] **E2E verified locally on `/admin/baseball`**: paste a real MLB contest GUID → Load matchup → Start replay. `MatchupCard` flips to LIVE, score deltas land, last-play description rolls through per event at ~1s cadence.
- [x] Football matchup card on `/picks` renders identically to before (block was moved verbatim).

## Known gap (intentional, next PR)

The live MLB processor and replay service emit defaults for `HalfInning` (empty), `Outs` (0), runners (all false), `AtBatAthleteId` / `PitchingAthleteId` (null) — the canonical `BaseballCompetitionPlay` entity doesn't materialize those fields today. Visible consequence: ⚾ batting indicator and Runners row stay hidden on real-contest replays because their source values are at defaults; only the LIVE label, score, and last-play description light up. The synthetic `BaseballDebugCard` (right column of `/admin/baseball`) fires fully-populated payloads for the full visual treatment but keys off a separate sandbox contestId.

`AdminBaseballPage`'s `BaseballLiveStatePanel` debug readout is intentionally kept — it renders defaulted fields with `?? '—'` placeholders so you can distinguish \"event arrived but field was default\" from \"no event at all\" while the gap persists. Delete when sourcing fills the fields for real.

## Follow-ups (not in this PR)

1. **MLB canonical play data** — capture `HalfInning`, outs, runners, athlete IDs onto `BaseballCompetitionPlay` (or pull from `BaseballCompetitionStatus` at emission time). Unblocks the ⚾ indicator + runners row + at-bat / pitcher fields.
2. **Football status-neutral class renames** — `.game-result` → `.game-status-block` etc. on the FB markup. Deferred; not blocking anything.
3. **Football last-play row** — `FootballPlayCompleted` carries `playDescription`; rendering decision deferred.
4. **Subscription pattern cleanup** — currently both `PicksPage` and `AdminBaseballPage` merge live fields onto matchups before render, and adding a new field requires updating both. Consider extracting a `useEnrichedMatchup(matchup)` hook or moving the subscription into `MatchupCard` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced live baseball matchup displays with detailed in-game information including inning, count, and runners on base
  * Improved live game status rendering with sport-specific formatting for baseball and football
  * Expanded live game data enrichment across picks and admin pages for comprehensive game state updates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/309)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->