### PR TITLE
feat(producer): capture canonical MLB play data + participants

### DIFF
--- a/docs/baseball-live-data-plan.md
+++ b/docs/baseball-live-data-plan.md
@@ -246,18 +246,23 @@ above are convenience copies. Schema:
   Position has no canonical entity yet; per-play statistics are a
   future processor target.
 - Indexes: `(CompetitionPlayId, Type)` for "pitcher for play X"
-  lookups, `(AthleteId)` for "all plays involving athlete Y".
+  lookups, `(AthleteSeasonId)` for "all plays involving
+  athlete-season Y", `(PositionId)` for position-based queries.
 
 **Extension + processor changes:**
-- `AsBaseballEntity` now takes `(atBatAthleteId, pitchingAthleteId)`
-  alongside `teamFranchiseSeasonId`, and populates every baseball
-  column from the DTO.
+- `AsBaseballEntity` now takes
+  `(atBatAthleteSeasonId, pitchingAthleteSeasonId)` alongside
+  `teamFranchiseSeasonId`, and populates every baseball column from
+  the DTO.
 - `BaseballEventCompetitionPlayDocumentProcessor` has two helpers:
   - `BuildParticipantsAsync` walks `participants[]` and emits a
     `List<BaseballCompetitionPlayParticipant>`, resolving each
-    `athlete.$ref` via `ResolveIdAsync<AthleteBase, AthleteExternalId>`
-    where possible. Unrecognized `Type` logs a Seq warning but
-    persists the row anyway — we don't drop data.
+    `athlete.$ref` via
+    `ResolveIdAsync<AthleteSeason, AthleteSeasonExternalId>` (the ref
+    is season-scoped, not global) and each `position.$ref` via
+    `ResolveIdAsync<AthletePosition, AthletePositionExternalId>` where
+    possible. Unrecognized `Type` logs a Seq warning but persists the
+    row anyway — we don't drop data.
   - `ExtractPrimaryAthletes` pulls the first pitcher/batter out of
     that list for the denormalized columns.
 - `BuildNewPlayAsync` builds the participants, attaches them to
@@ -267,10 +272,10 @@ above are convenience copies. Schema:
   ESPN can re-order or swap participants on a play between
   fetches (e.g., a substitution row appearing on a later refresh).
 - Empty/null participants (e.g. `start-inning`,
-  `end-batterpitcher`) yield empty lists. Unresolved athletes
-  (race during first ingest) yield null `AthleteId` — the update
-  path re-resolves on each re-ingest, so transient nulls heal
-  naturally without a throw-retry storm.
+  `end-batterpitcher`) yield empty lists. Unresolved athlete-seasons
+  (race during first ingest) yield null `AthleteSeasonId` — the
+  update path re-resolves on each re-ingest, so transient nulls
+  heal naturally without a throw-retry storm.
 
 **Migration:** `AddBaseballPlayCanonicalCaptureFields`. Eight
 nullable columns on `CompetitionPlay` + `IsValid` non-nullable with
@@ -302,9 +307,14 @@ the replay service so the matchup card stops showing placeholders.
 **Event population (`PublishSportPlayCompletedAsync`):**
 - `HalfInning: baseballPlay.HalfInning ?? string.Empty`
 - `Outs: baseballPlay.Outs ?? 0`
-- `AtBatAthleteId: baseballPlay.AtBatAthleteId`
-- `PitchingAthleteId: baseballPlay.PitchingAthleteId`
+- `AtBatAthleteSeasonId: baseballPlay.AtBatAthleteSeasonId`
+- `PitchingAthleteSeasonId: baseballPlay.PitchingAthleteSeasonId`
 - (Balls/Strikes already wired off `ResultCount*`.)
+
+The existing `BaseballPlayCompleted` event fields are named
+`AtBatAthleteId` / `PitchingAthleteId`; Phase 2 also renames them
+to `*AthleteSeasonId` so the wire shape matches the entity columns
+and the season-scoped resolution is explicit on the consumer side.
 
 **Replay service mirror.** `BaseballContestReplayService` reads
 from the entity, so once Phase 2 lands it picks up the new columns

--- a/docs/baseball-live-data-plan.md
+++ b/docs/baseball-live-data-plan.md
@@ -1,0 +1,414 @@
+# Baseball Live Data — capture & emission plan
+
+Working notes for capturing the rich per-play data ESPN gives us for
+MLB and surfacing it through the live event surface so the matchup
+card (and eventually the contest overview) can show real game state
+instead of placeholder defaults. Use as context in follow-up sessions;
+update in place as decisions land.
+
+> **Why this matters now.** Live MLB UI is currently rendering
+> defaults — empty `HalfInning`, `0` outs, all-false runners,
+> `null` athlete IDs — because the play-emission pipeline emits
+> placeholder values regardless of what ESPN sent us. Until that
+> pipeline carries real data, the rows added in PR #309
+> (`BaseballGameStatusInProgress`) stay mostly suppressed.
+> MLB launch target is **Spring 2027** with college baseball as
+> a likely follow-on; this is the foundation work that lights up
+> every downstream live experience.
+
+## Current state — what's actually wired
+
+### Entity (`BaseballCompetitionPlay`)
+
+The entity definition is generous and already has columns for most
+ESPN fields:
+
+```text
+✅ Existing columns:
+  AtBatId, AtBatPitchNumber, BatOrder, BatsType, BatsAbbreviation,
+  PitchCoordinateX/Y, HitCoordinateX/Y, PitchTypeId/Text/Abbreviation,
+  PitchVelocity, PitchCountBalls/Strikes, ResultCountBalls/Strikes,
+  Trajectory, StrikeType, SummaryType,
+  AwayHits, HomeHits, AwayErrors, HomeErrors, RbiCount,
+  IsDoublePlay, IsTriplePlay
+```
+
+The entity inherits from `CompetitionPlayBase`, which contributes the
+shared columns (`Id`, `EspnId`, `SequenceNumber`, `Type`, `TypeId`,
+`Text`, `AlternativeText`, `AwayScore`, `HomeScore`, `PeriodNumber`,
+`ScoringPlay`, `Priority`, `ScoreValue`, `Modified`, `StartFranchiseSeasonId`).
+
+### DTO (`EspnBaseballEventCompetitionPlayDto`)
+
+The DTO declares the baseball-specific shape that ESPN actually sends:
+
+```text
+✅ DTO fields today:
+  Valid, AtBatId, SummaryType,
+  PitchCount (Balls/Strikes), ResultCount (Balls/Strikes),
+  Outs, RbiCount,
+  AwayHits, HomeHits, AwayErrors, HomeErrors,
+  DoublePlay, TriplePlay
+```
+
+Plus the inherited shared fields from `EspnEventCompetitionPlayDtoBase`.
+
+### Extraction (`CompetitionPlayExtensions.AsBaseballEntity`)
+
+**This is the core gap.** The extension method maps almost nothing
+sport-specific:
+
+```csharp
+var entity = new BaseballCompetitionPlay
+{
+    Id = identity.CanonicalId,
+    EspnId = dto.Id,
+    SequenceNumber = dto.SequenceNumber,
+    Text = dto.Text ?? "UNK",
+    TypeId = dto.Type?.Id ?? "9999"
+};
+
+MapSharedProperties(...)   // shared fields only
+return entity;
+```
+
+**Every baseball-specific column on the entity stays null.** The DTO
+has the data, the entity has the columns, but the wiring between them
+doesn't exist for baseball. Football's `AsFootballEntity` does
+populate its sport-specific shape; baseball's was stubbed out and
+never filled in.
+
+### Event payload (`BaseballPlayCompleted`)
+
+`BaseballEventCompetitionPlayDocumentProcessor.PublishSportPlayCompletedAsync`
+emits hardcoded defaults for everything beyond what's on the
+entity-level base + ResultCount:
+
+```csharp
+HalfInning: string.Empty,        // not on entity, not on DTO
+Outs: 0,                          // not on entity (DTO has it)
+RunnerOnFirst/Second/Third: false,  // not anywhere
+AtBatAthleteId: null,             // not on entity, not on DTO (participants needed)
+PitchingAthleteId: null,          // same
+```
+
+## Field shape on the wire (sample analysis)
+
+The first 25 plays from `EventCompetitionPlays.json` (game
+401815268, page 1 of 26) show:
+
+| ESPN play field | Sample value | Captured today? |
+|---|---|---|
+| `id`, `sequenceNumber` | "4018152680000000059", "1" | ✅ on entity, mapped |
+| `type.{id,text,type}` | `{59, "Start Inning", "start-inning"}` | ✅ id mapped (TypeId), text not |
+| `text`, `shortText`, `alternativeText` | "Top of the 1st inning" | ✅ shared |
+| `period.number` | `1` | ✅ as PeriodNumber |
+| `period.type` | `"Top"` / `"Bottom"` | ❌ **DTO missing this field** |
+| `period.displayValue` | `"1st Inning"` | ❌ DTO missing |
+| `awayScore` / `homeScore` | `0` / `0` | ✅ shared |
+| `team.$ref` | `…/teams/3` | ✅ resolved → StartFranchiseSeasonId |
+| `wallclock` | "2026-05-09T19:08:04Z" | ❌ not captured (Modified is server-side) |
+| `atBatId` | `"4018152680001"` | ✅ DTO has it, ❌ extension doesn't map it |
+| `summaryType` | `"I"` / `"A"` / `"P"` | ✅ DTO has it, ❌ extension doesn't map |
+| `pitchCount.{balls,strikes}` | `{0,0}` | ✅ DTO has it, ❌ extension doesn't map |
+| `resultCount.{balls,strikes}` | `{0,1}` | ✅ DTO has it, ❌ extension doesn't map |
+| `outs` | `0` / `1` | ✅ DTO has it, ❌ no entity column, ❌ event hardcodes 0 |
+| `rbiCount`, `awayHits`, `homeHits`, `awayErrors`, `homeErrors` | various | ✅ DTO, ❌ extension |
+| `doublePlay`, `triplePlay` | `false` | ✅ DTO, ❌ extension |
+| `valid` | `true` | ✅ DTO has it, ❌ entity doesn't |
+| `participants[]` | `[{athlete, position, type:"pitcher"}, {…, type:"batter"}]` | ❌ **DTO missing entirely**; entity has no columns |
+| `batOrder` | `1` | ❌ DTO missing; entity has BatOrder column |
+| `bats.{type,abbreviation,displayValue}` | `{"RIGHT","R","Right"}` | ❌ DTO missing; entity has BatsType / BatsAbbreviation |
+| `pitches.{type,abbreviation,displayValue}` | `{"RIGHT","R","Right"}` | ❌ DTO missing entirely (pitcher handedness) |
+| `atBatPitchNumber` | `1`, `2`, `3` | ❌ DTO missing; entity has AtBatPitchNumber |
+| `pitchCoordinate.{x,y}` | `{118, 162}` (strike-zone ish) | ❌ DTO missing; entity has PitchCoordinateX/Y |
+| `pitchType.{id,text,abbreviation}` | `{17, "Four-seam FB", "FF"}` | ❌ DTO missing; entity has PitchTypeId/Text/Abbreviation |
+| `pitchVelocity` | `95` (mph) | ❌ DTO missing; entity has PitchVelocity |
+| `strikeType` | `"swinging"` / `"foul"` / `"looking"` | ❌ DTO missing; entity has StrikeType |
+| `previousPlayText` / `shortPreviousPlayText` | flavor text on `play-result` | ❌ DTO missing |
+| `alternativeType` / `alternativePlay` | available on `play-result` | ❌ DTO missing |
+| `probability` | `play-result` win-prob delta | ❌ DTO missing |
+
+### Notably absent from the play payload itself
+
+- **Runner state on bases.** No `runners[]`, `onFirst`, etc. anywhere
+  in any play (sampled across all 25 in the page). Comes from
+  `EventCompetitionSituation` (separate ESPN doc, processed in
+  football today via `EventCompetitionSituationDocumentProcessor`).
+- **Hit coordinates.** Only appear on `play-result` types when
+  there's contact; none in the sampled 25 plays.
+
+## Play-type taxonomy (from sample)
+
+Sampled types that appear on a single inning's worth of plays:
+
+```text
+start-inning              opens a half-inning ("Top of the 1st inning")
+start-batterpitcher       opens an at-bat ("X pitches to Y")
+ball                      ball
+strike-swinging           swinging strike
+strike-looking            called strike
+foul-ball                 foul ball
+play-result               at-bat outcome (hit, walk, strikeout, …)
+end-batterpitcher         closes an at-bat
+```
+
+Other types we'll see in the wild but not in the page-1 sample:
+`foul-tip`, `hit-by-pitch`, `pitcher-substitution`,
+`offensive-substitution`, `defensive-substitution`, `pickoff`,
+`stolen-base`, `caught-stealing`, `wild-pitch`, `passed-ball`, etc.
+The full taxonomy lives behind ESPN's play-type dictionary; we don't
+need to enumerate it for capture, just store `TypeId` and the text.
+
+## Phasing
+
+### Phase 1 — DTO + extraction symmetry **(this PR)**
+
+**Status:** in flight on `feat/mlb-canonical-play-data`.
+**Scope locked at:** full ingestion of the rich per-play data. No
+event payload changes, no UI changes, no replay changes — those are
+Phase 2. Capture-only means: every field ESPN gives us at the play
+level lands on the entity. Athlete resolution from `participants[]`
+*is* in scope here because it is part of capture (the play row is
+incomplete without it).
+
+**Scope:** make `EspnBaseballEventCompetitionPlayDto` carry every
+field the JSON sample shows, then make `AsBaseballEntity` populate
+every column the entity already has (plus the new ones), including
+resolved canonical Athlete IDs from `participants[]`.
+
+**DTO additions:**
+- `EspnEventCompetitionPlayPeriodDto.Type` (string) — adds Top/Bottom.
+- `EspnEventCompetitionPlayPeriodDto.DisplayValue` (string).
+- `EspnBaseballEventCompetitionPlayDto`:
+  - `BatOrder`, `Bats` (reuses existing `EspnAthleteHandDto`),
+    `Pitches` (same DTO type), `AtBatPitchNumber`, `PitchCoordinate`,
+    `PitchType`, `PitchVelocity`, `StrikeType`, `Participants[]`
+    (reuses existing `EspnEventCompetitionPlayParticipantDto`),
+    `PreviousPlayText`, `ShortPreviousPlayText`, `AlternativeType`,
+    `Probability`, `HitCoordinate`, `Trajectory`.
+- New small DTOs: `EspnBaseballCoordinateDto` (x/y),
+  `EspnBaseballPitchTypeDto` (id/text/abbreviation).
+
+**Entity additions on `BaseballCompetitionPlay`:**
+- `HalfInning` (string?, max 8) — captures `period.type`.
+- `Outs` (int?) — captures play-level outs.
+- `Wallclock` (DateTime?) — actual play time, distinct from
+  server-side `Modified`.
+- `IsValid` (bool, default true) — ESPN's `valid` flag.
+- `PitchesType` (string?, max 20) and `PitchesAbbreviation`
+  (string?, max 5) — pitcher handedness, mirrors existing
+  `BatsType` / `BatsAbbreviation`.
+- `AtBatAthleteSeasonId` (Guid?) and `PitchingAthleteSeasonId`
+  (Guid?) — denormalized convenience copy of the primary
+  pitcher/batter AthleteSeason IDs, sourced from the participants
+  table below. The athlete refs on play participants are
+  season-scoped (`/seasons/{year}/athletes/{id}`), so they resolve
+  to `AthleteSeason`, not the global `AthleteBase`. Cheap live-UI
+  lookup without an extra join. ID-only references (no FK
+  navigation), matching the `*FranchiseSeasonId` pattern on plays.
+
+**New entity hierarchy `CompetitionPlayParticipantBase` →
+`BaseballCompetitionPlayParticipant`:**
+Mirrors the existing `CompetitionPlayBase` /
+`BaseballCompetitionPlay` / `FootballCompetitionPlay` TPH split —
+one shared sport-agnostic table (`CompetitionPlayParticipant`)
+with EF auto-generating the `Discriminator` column. The abstract
+base lives in `Producer/Infrastructure/Data/Entities/`; the
+sport-specific subclass lives under `Baseball/Entities/` and owns
+the FK navigation back to `BaseballCompetitionPlay`. A future
+Football PR adds its own `FootballCompetitionPlayParticipant`
+into the same table.
+
+The abstract base is registered only in `BaseballDataContext`
+(not `TeamSportDataContext`) so a sport without a participant
+subclass doesn't drag the abstract base into its model — EF would
+fail validation otherwise (no concrete derived type).
+
+Source of truth for participant data; the denormalized columns
+above are convenience copies. Schema:
+
+- `Id` (Guid, PK), audit columns from `CanonicalEntityBase`.
+- `CompetitionPlayId` (Guid, FK → CompetitionPlay, cascade delete).
+- `Order` (int) — ESPN's order within the array.
+- `Type` (string, max 32) — "pitcher", "batter", and any future
+  taxonomy entries. Persisted verbatim; unknown types log a Seq
+  warning but are not dropped.
+- `AthleteSeasonId` (Guid?) — resolved canonical AthleteSeason
+  (the play's `participant.athlete.$ref` is season-scoped, so it
+  points at the season-bound athlete row, not the global
+  AthleteBase); null when not yet sourced. Update path
+  re-resolves on each re-ingest.
+- `PositionId` (Guid?) — resolved canonical AthletePosition;
+  same null-on-unsourced semantics.
+- `AthleteRef` / `PositionRef` / `StatisticsRef` (string?, max 512) —
+  ESPN refs preserved verbatim for audit + later re-resolution.
+  Position has no canonical entity yet; per-play statistics are a
+  future processor target.
+- Indexes: `(CompetitionPlayId, Type)` for "pitcher for play X"
+  lookups, `(AthleteId)` for "all plays involving athlete Y".
+
+**Extension + processor changes:**
+- `AsBaseballEntity` now takes `(atBatAthleteId, pitchingAthleteId)`
+  alongside `teamFranchiseSeasonId`, and populates every baseball
+  column from the DTO.
+- `BaseballEventCompetitionPlayDocumentProcessor` has two helpers:
+  - `BuildParticipantsAsync` walks `participants[]` and emits a
+    `List<BaseballCompetitionPlayParticipant>`, resolving each
+    `athlete.$ref` via `ResolveIdAsync<AthleteBase, AthleteExternalId>`
+    where possible. Unrecognized `Type` logs a Seq warning but
+    persists the row anyway — we don't drop data.
+  - `ExtractPrimaryAthletes` pulls the first pitcher/batter out of
+    that list for the denormalized columns.
+- `BuildNewPlayAsync` builds the participants, attaches them to
+  `play.Participants`, and EF cascades the insert.
+- `ApplyUpdateAsync` reloads the participants set, removes them,
+  and re-adds the new build — simpler than diffing per-row, and
+  ESPN can re-order or swap participants on a play between
+  fetches (e.g., a substitution row appearing on a later refresh).
+- Empty/null participants (e.g. `start-inning`,
+  `end-batterpitcher`) yield empty lists. Unresolved athletes
+  (race during first ingest) yield null `AthleteId` — the update
+  path re-resolves on each re-ingest, so transient nulls heal
+  naturally without a throw-retry storm.
+
+**Migration:** `AddBaseballPlayCanonicalCaptureFields`. Eight
+nullable columns on `CompetitionPlay` + `IsValid` non-nullable with
+`defaultValue: true` so existing rows on the shared TPH table
+don't break, plus the new `BaseballCompetitionPlayParticipant`
+table with FK + two indexes.
+
+**Risk:** medium. Migration on a hot table; new DTO fields are
+additive (deserializer ignores unknowns by default). Athlete
+resolution adds one DB round-trip per participant — acceptable at
+MLB cadence (one play every ~15s during action), and most plays
+have exactly two participants.
+
+**Football is intentionally out of scope.** Football's
+`EspnFootballEventCompetitionPlayDto` also carries `Participants`
+and `TeamParticipants` arrays that are not currently captured.
+That's its own PR — the shapes overlap on `Participants` but
+diverge on `TeamParticipants`, and Football has additional
+`teamParticipants[]` work that doesn't exist in baseball. Avoid
+folding it in here to keep the migration scope sport-bounded.
+
+### Phase 2 — Event population + replay drop the defaults
+
+**Scope:** wire the captured fields onto `BaseballPlayCompleted` and
+the replay service so the matchup card stops showing placeholders.
+
+**Entity additions:** none — Phase 1 captures everything.
+
+**Event population (`PublishSportPlayCompletedAsync`):**
+- `HalfInning: baseballPlay.HalfInning ?? string.Empty`
+- `Outs: baseballPlay.Outs ?? 0`
+- `AtBatAthleteId: baseballPlay.AtBatAthleteId`
+- `PitchingAthleteId: baseballPlay.PitchingAthleteId`
+- (Balls/Strikes already wired off `ResultCount*`.)
+
+**Replay service mirror.** `BaseballContestReplayService` reads
+from the entity, so once Phase 2 lands it picks up the new columns
+automatically — just remove the hardcoded defaults.
+
+**UI consequence (free):** `BaseballGameStatusInProgress` already
+renders these fields when present. The ⚾ batting indicator (driven
+by `halfInning === 'top'/'bottom'`) starts working. The
+inning+count+outs row stops showing `0-0 · 0 outs` placeholder
+values for real plays.
+
+**Risk:** low. Pure emission shift; rollback is a one-line revert
+of the publish payload.
+
+### Phase 3 — Runner state from situation document
+
+**Scope:** populate `runnerOnFirst/Second/Third` on `BaseballPlayCompleted`.
+
+**Why this is its own phase:** runner state isn't on the play
+payload. It comes from `EventCompetitionSituation` (which football
+already sources via `EventCompetitionSituationDocumentProcessor`).
+For MLB it carries the current base state plus current at-bat /
+pitcher athlete IDs.
+
+**Design choice (open):**
+
+- **Option A — emit a `BaseballSituationChanged` event.** Producer
+  has a separate processor for the situation doc that emits its own
+  event; UI merges into the same context record. Keeps responsibility
+  separated. Cost: one more event type; UI handler addition; possible
+  coordination problem (situation arrives before the play it
+  "belongs to").
+- **Option B — join situation onto play emission.** When the play
+  processor is about to publish, it queries the latest
+  `BaseballCompetitionSituation` row for that competition and folds
+  the runners + at-bat IDs into the `BaseballPlayCompleted` payload.
+  Cost: extra DB read on every play; coupling; risk of stale
+  situation if the situation doc lags the play doc.
+- **Option C — hold the play, wait for situation.** Buffer or
+  conditionally retry the play emission until the matching
+  situation row is present. Most accurate; most complex.
+
+Recommendation: **Option A** for symmetry with football's situation
+processor, deferred to its own PR after Phase 1+2 are in. It also
+gives the UI a useful event independently (situation changes that
+don't happen on a play boundary, e.g., a runner caught stealing
+between pitches, become first-class).
+
+### Phase 4 — UI enrichment (optional, deferrable)
+
+Once the plumbing is real, the matchup card can show more without
+shipping new wire fields:
+
+- Pitch ticker on the matchup card or contest overview:
+  `pitchType.text` + `pitchVelocity` per pitch, last N pitches.
+- At-bat header: `${pitcher} pitches to ${batter}` derived from
+  resolved athlete IDs (resolve names via existing athlete lookup).
+- Pitch handedness flavor: "RHP vs LHB" badge.
+
+These are low-risk UI additions that don't touch the wire shape.
+
+### Phase 5 — Hit coordinates / spray chart (later)
+
+`play-result` plays carry `hitCoordinate.{x,y}` plus `trajectory`.
+Useful for a spray chart on the contest overview, NOT on the
+matchup card. Defer until contest overview MLB work is on the
+roadmap.
+
+## Open questions
+
+1. ~~**Phase boundaries.**~~ **Resolved 2026-05-10:** Phase 1 covers
+   *all* play-level capture (including athlete resolution from
+   `participants[]`). Phase 2 is reduced to "drop the defaults on
+   the event payload + replay" — no entity work left to do there.
+
+2. ~~**Athlete unresolved race.**~~ **Resolved 2026-05-10:** persist
+   null when the athlete ref hasn't been sourced yet. The play
+   update path re-resolves on each re-ingest (which happens
+   regularly for in-progress games), so transient nulls heal
+   without a throw-retry storm on every play of a freshly-sourced
+   game. The capture-only philosophy: persist what we can, don't
+   fail the document.
+
+3. **`Valid` flag.** ESPN's `valid: true/false` on a play — is `false`
+   ever real? If so it's a hint to suppress. Punt to discovery
+   during local replay testing; not a blocker.
+
+4. **Wallclock vs Modified.** The DTO base captures `Modified`
+   (server-side). `wallclock` is the actual play time. We probably
+   want both eventually for play timelines; not blocking live UI.
+
+## Reference
+
+- ESPN play sample (page 1 of 26 = first 25 plays):
+  `test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/EventCompetitionPlays.json`
+- Existing entity:
+  `src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionPlay.cs`
+- Existing DTO:
+  `src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionPlayDto.cs`
+- Existing extraction:
+  `src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionPlayExtensions.cs`
+- Existing processor:
+  `src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs`
+- Existing event:
+  `src/SportsData.Core/Eventing/Events/Contests/Baseball/BaseballPlayCompleted.cs`
+- Existing replay:
+  `src/SportsData.Producer/Application/Contests/BaseballContestReplayService.cs`

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballCoordinateDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballCoordinateDto.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+
+public class EspnBaseballCoordinateDto
+{
+    [JsonPropertyName("x")]
+    public double? X { get; set; }
+
+    [JsonPropertyName("y")]
+    public double? Y { get; set; }
+}

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionPlayDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballEventCompetitionPlayDto.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS8618 // Non-nullable property is uninitialized
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 
@@ -13,6 +14,18 @@ public class EspnBaseballEventCompetitionPlayDto : EspnEventCompetitionPlayDtoBa
     [JsonPropertyName("atBatId")]
     public string? AtBatId { get; set; }
 
+    [JsonPropertyName("atBatPitchNumber")]
+    public int? AtBatPitchNumber { get; set; }
+
+    [JsonPropertyName("batOrder")]
+    public int? BatOrder { get; set; }
+
+    [JsonPropertyName("bats")]
+    public EspnAthleteHandDto? Bats { get; set; }
+
+    [JsonPropertyName("pitches")]
+    public EspnAthleteHandDto? Pitches { get; set; }
+
     [JsonPropertyName("summaryType")]
     public string? SummaryType { get; set; }
 
@@ -21,6 +34,24 @@ public class EspnBaseballEventCompetitionPlayDto : EspnEventCompetitionPlayDtoBa
 
     [JsonPropertyName("resultCount")]
     public EspnBaseballCountDto? ResultCount { get; set; }
+
+    [JsonPropertyName("pitchCoordinate")]
+    public EspnBaseballCoordinateDto? PitchCoordinate { get; set; }
+
+    [JsonPropertyName("pitchType")]
+    public EspnBaseballPitchTypeDto? PitchType { get; set; }
+
+    [JsonPropertyName("pitchVelocity")]
+    public int? PitchVelocity { get; set; }
+
+    [JsonPropertyName("strikeType")]
+    public string? StrikeType { get; set; }
+
+    [JsonPropertyName("hitCoordinate")]
+    public EspnBaseballCoordinateDto? HitCoordinate { get; set; }
+
+    [JsonPropertyName("trajectory")]
+    public string? Trajectory { get; set; }
 
     [JsonPropertyName("outs")]
     public int Outs { get; set; }
@@ -45,6 +76,26 @@ public class EspnBaseballEventCompetitionPlayDto : EspnEventCompetitionPlayDtoBa
 
     [JsonPropertyName("triplePlay")]
     public bool TriplePlay { get; set; }
+
+    // participants[].type is "pitcher" or "batter"; athlete refs need
+    // resolution to canonical Athlete IDs (Phase 2). Captured here so the
+    // wire shape is complete; not yet persisted to entity columns.
+    [JsonPropertyName("participants")]
+    public List<EspnEventCompetitionPlayParticipantDto>? Participants { get; set; }
+
+    // Flavor + analytics fields that ride on play-result rows. Kept
+    // optional; not persisted in this PR.
+    [JsonPropertyName("previousPlayText")]
+    public string? PreviousPlayText { get; set; }
+
+    [JsonPropertyName("shortPreviousPlayText")]
+    public string? ShortPreviousPlayText { get; set; }
+
+    [JsonPropertyName("alternativeType")]
+    public EspnEventCompetitionPlayTypeDto? AlternativeType { get; set; }
+
+    [JsonPropertyName("probability")]
+    public EspnLinkDto? Probability { get; set; }
 }
 
 public class EspnBaseballCountDto

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballPitchTypeDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Baseball/EspnBaseballPitchTypeDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+
+public class EspnBaseballPitchTypeDto
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+
+    [JsonPropertyName("abbreviation")]
+    public string? Abbreviation { get; set; }
+}

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionPlayPeriodDto.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/Dtos/Common/EspnEventCompetitionPlayPeriodDto.cs
@@ -7,4 +7,11 @@ public class EspnEventCompetitionPlayPeriodDto
 {
     [JsonPropertyName("number")]
     public int Number { get; set; }
+
+    // Baseball-only today: "Top" / "Bottom". Null on football payloads.
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("displayValue")]
+    public string? DisplayValue { get; set; }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
@@ -45,6 +45,102 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext>
         return status is null ? null : !status.IsCompleted;
     }
 
+    /// <summary>
+    /// Build the full participants list for a baseball play, resolving each
+    /// athlete ref to a canonical AthleteSeason ID where possible. The JSON
+    /// calls the field "athlete" but the URL is season-scoped
+    /// (`/seasons/{year}/athletes/{id}`), so it resolves against
+    /// AthleteSeason, not the global AthleteBase. Position resolves the same
+    /// way. Per-play statistics refs are captured verbatim — those
+    /// pipelines don't materialize canonical entities yet.
+    ///
+    /// Unrecognized participant types are still persisted (we don't drop
+    /// data) but log a warning so Seq surfaces forward-compat work. Null
+    /// AthleteSeasonId is acceptable — the play update path re-resolves on
+    /// each re-ingest, so transient nulls heal naturally without a
+    /// throw-retry loop on every play of a freshly-sourced game.
+    /// </summary>
+    private async Task<List<BaseballCompetitionPlayParticipant>> BuildParticipantsAsync(
+        EspnBaseballEventCompetitionPlayDto dto,
+        SourceDataProvider provider)
+    {
+        var result = new List<BaseballCompetitionPlayParticipant>();
+        if (dto.Participants is null || dto.Participants.Count == 0) return result;
+
+        foreach (var participant in dto.Participants)
+        {
+            Guid? athleteSeasonId = null;
+            if (participant.Athlete?.Ref is not null)
+            {
+                athleteSeasonId = await _dataContext.ResolveIdAsync<AthleteSeason, AthleteSeasonExternalId>(
+                    participant.Athlete,
+                    provider,
+                    () => _dataContext.AthleteSeasons,
+                    externalIdsNav: "ExternalIds",
+                    key: a => a.Id);
+            }
+
+            Guid? positionId = null;
+            if (participant.Position?.Ref is not null)
+            {
+                positionId = await _dataContext.ResolveIdAsync<AthletePosition, AthletePositionExternalId>(
+                    participant.Position,
+                    provider,
+                    () => _dataContext.AthletePositions,
+                    externalIdsNav: "ExternalIds",
+                    key: p => p.Id);
+            }
+
+            var type = participant.Type;
+            var isPitcher = string.Equals(type, "pitcher", StringComparison.OrdinalIgnoreCase);
+            var isBatter = string.Equals(type, "batter", StringComparison.OrdinalIgnoreCase);
+
+            if (!isPitcher && !isBatter)
+            {
+                // Forward-compat watch: ESPN's play taxonomy can grow (substitution
+                // rows, runner refs, fielders on a play-result, etc.). Surface in
+                // Seq so we notice and can decide whether to add denormalized
+                // columns. The row is still persisted — we don't drop data.
+                _logger.LogWarning(
+                    "Unrecognized baseball participant type '{ParticipantType}' on PlayId={PlayId}, PlayText={PlayText}",
+                    string.IsNullOrEmpty(type) ? "(null)" : type,
+                    dto.Id,
+                    dto.Type?.Text);
+            }
+
+            result.Add(new BaseballCompetitionPlayParticipant
+            {
+                Order = participant.Order,
+                Type = type ?? string.Empty,
+                AthleteSeasonId = athleteSeasonId,
+                PositionId = positionId,
+                StatisticsRef = participant.Statistics?.Ref?.ToString()
+            });
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Pull the primary pitcher/batter AthleteSeason IDs out of an
+    /// already-built participants list. Used to denormalize onto the play
+    /// row for cheap live-UI lookup without an extra join.
+    /// </summary>
+    private static (Guid? AtBatAthleteSeasonId, Guid? PitchingAthleteSeasonId) ExtractPrimaryAthletes(
+        List<BaseballCompetitionPlayParticipant> participants)
+    {
+        Guid? atBat = null;
+        Guid? pitching = null;
+        foreach (var p in participants)
+        {
+            if (atBat is null && string.Equals(p.Type, "batter", StringComparison.OrdinalIgnoreCase))
+                atBat = p.AthleteSeasonId;
+            else if (pitching is null && string.Equals(p.Type, "pitcher", StringComparison.OrdinalIgnoreCase))
+                pitching = p.AthleteSeasonId;
+        }
+        return (atBat, pitching);
+    }
+
     protected override async Task<CompetitionPlayBase> BuildNewPlayAsync(
         ProcessDocumentCommand command,
         EspnBaseballEventCompetitionPlayDto externalDto,
@@ -63,15 +159,27 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext>
                 key: fs => fs.Id);
         }
 
-        _logger.LogInformation(
-            "Creating baseball CompetitionPlay. CompetitionId={CompId}, PlayType={PlayType}",
-            competition.Id, externalDto.Type?.Text);
+        var participants = await BuildParticipantsAsync(externalDto, command.SourceDataProvider);
+        var (atBatAthleteSeasonId, pitchingAthleteSeasonId) = ExtractPrimaryAthletes(participants);
 
-        return externalDto.AsBaseballEntity(
+        _logger.LogInformation(
+            "Creating baseball CompetitionPlay. CompetitionId={CompId}, PlayType={PlayType}, ParticipantCount={Count}, AtBatAthleteSeasonId={AtBat}, PitchingAthleteSeasonId={Pitching}",
+            competition.Id, externalDto.Type?.Text, participants.Count, atBatAthleteSeasonId, pitchingAthleteSeasonId);
+
+        var play = externalDto.AsBaseballEntity(
             _externalRefIdentityGenerator,
             command.CorrelationId,
             competition.Id,
-            teamFranchiseSeasonId);
+            teamFranchiseSeasonId,
+            atBatAthleteSeasonId,
+            pitchingAthleteSeasonId);
+
+        foreach (var participant in participants)
+        {
+            play.Participants.Add(participant);
+        }
+
+        return play;
     }
 
     protected override Task PublishSportPlayCompletedAsync(
@@ -117,6 +225,12 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext>
         ProcessDocumentCommand command,
         EspnBaseballEventCompetitionPlayDto externalDto)
     {
+        if (entity is not BaseballCompetitionPlay baseballPlay)
+        {
+            throw new InvalidOperationException(
+                $"Expected BaseballCompetitionPlay but got {entity.GetType().Name}. PlayId={entity.Id}");
+        }
+
         Guid? teamFranchiseSeasonId = null;
         if (externalDto.Team?.Ref is not null)
         {
@@ -129,8 +243,66 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext>
                 key: fs => fs.Id);
         }
 
-        _logger.LogInformation("Updating baseball CompetitionPlay. PlayId={PlayId}", entity.Id);
+        var participants = await BuildParticipantsAsync(externalDto, command.SourceDataProvider);
+        var (atBatAthleteSeasonId, pitchingAthleteSeasonId) = ExtractPrimaryAthletes(participants);
 
-        entity.StartFranchiseSeasonId = teamFranchiseSeasonId;
+        // Replace the participants set wholesale: simpler than diffing per-row,
+        // and ESPN can re-order or swap participants on a play between fetches
+        // (e.g., a substitution row appearing on a later refresh).
+        var existingParticipants = await _dataContext.Set<BaseballCompetitionPlayParticipant>()
+            .Where(p => p.CompetitionPlayId == baseballPlay.Id)
+            .ToListAsync();
+
+        if (existingParticipants.Count > 0)
+        {
+            _dataContext.Set<BaseballCompetitionPlayParticipant>().RemoveRange(existingParticipants);
+        }
+
+        foreach (var participant in participants)
+        {
+            participant.CompetitionPlayId = baseballPlay.Id;
+            await _dataContext.Set<BaseballCompetitionPlayParticipant>().AddAsync(participant);
+        }
+
+        _logger.LogInformation(
+            "Updating baseball CompetitionPlay. PlayId={PlayId}, ParticipantCount={Count}, AtBatAthleteSeasonId={AtBat}, PitchingAthleteSeasonId={Pitching}",
+            entity.Id, participants.Count, atBatAthleteSeasonId, pitchingAthleteSeasonId);
+
+        baseballPlay.StartFranchiseSeasonId = teamFranchiseSeasonId;
+        baseballPlay.HalfInning = externalDto.Period?.Type;
+        baseballPlay.Outs = externalDto.Outs;
+        baseballPlay.Wallclock = externalDto.Wallclock == default ? null : externalDto.Wallclock;
+        baseballPlay.IsValid = externalDto.Valid;
+        baseballPlay.AtBatAthleteSeasonId = atBatAthleteSeasonId;
+        baseballPlay.PitchingAthleteSeasonId = pitchingAthleteSeasonId;
+        baseballPlay.AtBatId = externalDto.AtBatId;
+        baseballPlay.AtBatPitchNumber = externalDto.AtBatPitchNumber;
+        baseballPlay.BatOrder = externalDto.BatOrder;
+        baseballPlay.BatsType = externalDto.Bats?.Type;
+        baseballPlay.BatsAbbreviation = externalDto.Bats?.Abbreviation;
+        baseballPlay.PitchesType = externalDto.Pitches?.Type;
+        baseballPlay.PitchesAbbreviation = externalDto.Pitches?.Abbreviation;
+        baseballPlay.PitchCoordinateX = externalDto.PitchCoordinate?.X;
+        baseballPlay.PitchCoordinateY = externalDto.PitchCoordinate?.Y;
+        baseballPlay.HitCoordinateX = externalDto.HitCoordinate?.X;
+        baseballPlay.HitCoordinateY = externalDto.HitCoordinate?.Y;
+        baseballPlay.PitchTypeId = externalDto.PitchType?.Id;
+        baseballPlay.PitchTypeText = externalDto.PitchType?.Text;
+        baseballPlay.PitchTypeAbbreviation = externalDto.PitchType?.Abbreviation;
+        baseballPlay.PitchVelocity = externalDto.PitchVelocity;
+        baseballPlay.PitchCountBalls = externalDto.PitchCount?.Balls;
+        baseballPlay.PitchCountStrikes = externalDto.PitchCount?.Strikes;
+        baseballPlay.ResultCountBalls = externalDto.ResultCount?.Balls;
+        baseballPlay.ResultCountStrikes = externalDto.ResultCount?.Strikes;
+        baseballPlay.Trajectory = externalDto.Trajectory;
+        baseballPlay.StrikeType = externalDto.StrikeType;
+        baseballPlay.SummaryType = externalDto.SummaryType;
+        baseballPlay.AwayHits = externalDto.AwayHits;
+        baseballPlay.HomeHits = externalDto.HomeHits;
+        baseballPlay.AwayErrors = externalDto.AwayErrors;
+        baseballPlay.HomeErrors = externalDto.HomeErrors;
+        baseballPlay.RbiCount = externalDto.RbiCount;
+        baseballPlay.IsDoublePlay = externalDto.DoublePlay;
+        baseballPlay.IsTriplePlay = externalDto.TriplePlay;
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
@@ -20,6 +20,8 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
 
         public new DbSet<BaseballCompetitionPlay> CompetitionPlays { get; set; }
 
+        public DbSet<BaseballCompetitionPlayParticipant> CompetitionPlayParticipants { get; set; }
+
         // Sport-specific subclass set: the inherited DbSet<CompetitionStatus>
         // on TeamSportDataContext can still serve plain reads via the base
         // type, but eager-loading FeaturedAthletes / accessing HalfInning /
@@ -45,6 +47,8 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
             modelBuilder.ApplyConfiguration(new BaseballCompetitionCompetitor.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionCompetitorProbable.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionPlay.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new CompetitionPlayParticipantBase.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new BaseballCompetitionPlayParticipant.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatus.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatusFeaturedAthlete.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeasonHotZone.EntityConfiguration());

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionPlay.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionPlay.cs
@@ -7,15 +7,48 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
 
 public class BaseballCompetitionPlay : CompetitionPlayBase
 {
+    public string? HalfInning { get; set; }
+
+    public int? Outs { get; set; }
+
+    // ESPN's wallclock — actual play time. Distinct from CompetitionPlayBase.Modified
+    // (server-side last-update stamp). Useful for play timelines once we surface them.
+    public DateTime? Wallclock { get; set; }
+
+    // ESPN play "valid" flag. Default true; observed false plays are rare (overturned
+    // calls, void plays). Captured so future suppression logic can gate on it.
+    public bool IsValid { get; set; } = true;
+
     public string? AtBatId { get; set; }
 
     public int? AtBatPitchNumber { get; set; }
 
     public int? BatOrder { get; set; }
 
+    // Batter handedness for this at-bat (RIGHT/LEFT/SWITCH). Distinct from
+    // BaseballAthlete.BatsType (the athlete's general handedness): switch-hitters
+    // bat the opposite way against same-handed pitchers, so the per-at-bat copy
+    // captures what actually happened.
     public string? BatsType { get; set; }
 
     public string? BatsAbbreviation { get; set; }
+
+    // Pitcher handedness for this at-bat (RIGHT/LEFT). Mirror of Bats* but for the
+    // pitcher facing the batter. Same rationale: BaseballAthlete.ThrowsType is the
+    // athlete's general handedness; this is what threw this pitch.
+    public string? PitchesType { get; set; }
+
+    public string? PitchesAbbreviation { get; set; }
+
+    // Resolved canonical AthleteSeason IDs from participants[]. The athlete
+    // ref on a play participant is season-scoped (ESPN's URL path is
+    // `/seasons/{year}/athletes/{id}`), so this points at the AthleteSeason
+    // row, not the global AthleteBase. Null when the AthleteSeason hasn't
+    // been sourced yet (race during first ingest) — the play update path
+    // re-resolves on each re-ingest.
+    public Guid? AtBatAthleteSeasonId { get; set; }
+
+    public Guid? PitchingAthleteSeasonId { get; set; }
 
     public double? PitchCoordinateX { get; set; }
 
@@ -61,13 +94,23 @@ public class BaseballCompetitionPlay : CompetitionPlayBase
 
     public bool IsTriplePlay { get; set; }
 
+    // Full ESPN participants[] capture, one row per participant. Backed by
+    // the shared `CompetitionPlayParticipant` TPH table; the convenience
+    // AtBatAthleteId / PitchingAthleteId columns above are denormalizations
+    // of the primary pitcher/batter for cheap live-UI lookup.
+    public ICollection<BaseballCompetitionPlayParticipant> Participants { get; set; }
+        = new List<BaseballCompetitionPlayParticipant>();
+
     public new class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetitionPlay>
     {
         public void Configure(EntityTypeBuilder<BaseballCompetitionPlay> builder)
         {
+            builder.Property(x => x.HalfInning).HasMaxLength(8);
             builder.Property(x => x.AtBatId).HasMaxLength(32);
             builder.Property(x => x.BatsType).HasMaxLength(20);
             builder.Property(x => x.BatsAbbreviation).HasMaxLength(5);
+            builder.Property(x => x.PitchesType).HasMaxLength(20);
+            builder.Property(x => x.PitchesAbbreviation).HasMaxLength(5);
             builder.Property(x => x.PitchTypeId).HasMaxLength(10);
             builder.Property(x => x.PitchTypeText).HasMaxLength(50);
             builder.Property(x => x.PitchTypeAbbreviation).HasMaxLength(10);

--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionPlayParticipant.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetitionPlayParticipant.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities;
+
+/// <summary>
+/// Baseball participant row. Backed by the shared `CompetitionPlayParticipant`
+/// TPH table (configured on `CompetitionPlayParticipantBase`); the
+/// auto-generated discriminator distinguishes baseball rows from a future
+/// FootballCompetitionPlayParticipant. No baseball-specific fields today —
+/// the subclass exists so participant taxonomy can diverge cleanly per
+/// sport when needed (matches the BaseballCompetitionPlay pattern), and
+/// because the FK navigation back to the play is sport-specific (FK
+/// configured here, not on the abstract base, so a sport without
+/// participants doesn't drag the base into its model).
+/// </summary>
+public class BaseballCompetitionPlayParticipant : CompetitionPlayParticipantBase
+{
+    public BaseballCompetitionPlay CompetitionPlay { get; set; } = null!;
+
+    public new class EntityConfiguration : IEntityTypeConfiguration<BaseballCompetitionPlayParticipant>
+    {
+        public void Configure(EntityTypeBuilder<BaseballCompetitionPlayParticipant> builder)
+        {
+            builder.HasOne(t => t.CompetitionPlay)
+                .WithMany(p => p.Participants)
+                .HasForeignKey(t => t.CompetitionPlayId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionPlayParticipantBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionPlayParticipantBase.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Shared base for per-play participant rows. Mirrors the
+/// `CompetitionPlayBase` / `BaseballCompetitionPlay` / `FootballCompetitionPlay`
+/// TPH split: one sport-agnostic table (`CompetitionPlayParticipant`) backs
+/// all sport-specific subclasses, with EF auto-generating the discriminator.
+///
+/// The FK back to the play and the navigation collection live on the
+/// sport-specific subclass + sport-specific `CompetitionPlay` derived type
+/// — only sports that ship a participant subclass register the relationship,
+/// so a sport without participants doesn't drag the abstract base into its
+/// model.
+///
+/// Captures the full ESPN participants[] entry verbatim so we don't lose
+/// data when a referenced athlete or position hasn't been sourced yet —
+/// the play update path re-resolves AthleteId on each re-ingest, and the
+/// preserved refs stay available for future re-resolution / pipelines.
+/// </summary>
+public abstract class CompetitionPlayParticipantBase : CanonicalEntityBase<Guid>
+{
+    public Guid CompetitionPlayId { get; set; }
+
+    public int Order { get; set; }
+
+    // ESPN-supplied participant role. "pitcher" / "batter" for baseball today;
+    // future taxonomy entries land here verbatim. Processors log a warning
+    // on unrecognized types but still persist the row.
+    public string Type { get; set; } = string.Empty;
+
+    // Resolved canonical IDs. Null when the referenced doc hasn't been
+    // sourced yet — re-resolves on the next play update.
+    //
+    // The athlete ref on a play participant is a SEASON-scoped athlete
+    // URL (`/seasons/{year}/athletes/{id}`), so this resolves to an
+    // AthleteSeason row (not the global AthleteBase). ESPN names the
+    // JSON field "athlete" which is misleading; the path tells the truth.
+    public Guid? AthleteSeasonId { get; set; }
+
+    public Guid? PositionId { get; set; }
+
+    // Per-play participant statistics ref. Future processor target
+    // (batter-vs-pitcher splits, pitch-by-pitch outcomes); stays a string
+    // until those docs get their own canonical pipeline.
+    public string? StatisticsRef { get; set; }
+
+    public class EntityConfiguration : IEntityTypeConfiguration<CompetitionPlayParticipantBase>
+    {
+        public void Configure(EntityTypeBuilder<CompetitionPlayParticipantBase> builder)
+        {
+            builder.ToTable("CompetitionPlayParticipant");
+            builder.HasKey(t => t.Id);
+
+            builder.Property(t => t.Type).IsRequired().HasMaxLength(32);
+            builder.Property(t => t.StatisticsRef).HasMaxLength(512);
+
+            builder.HasIndex(t => new { t.CompetitionPlayId, t.Type });
+            builder.HasIndex(t => t.AthleteSeasonId);
+            builder.HasIndex(t => t.PositionId);
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionPlayExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionPlayExtensions.cs
@@ -52,7 +52,9 @@ public static class CompetitionPlayExtensions
         IGenerateExternalRefIdentities externalRefIdentityGenerator,
         Guid correlationId,
         Guid competitionId,
-        Guid? teamFranchiseSeasonId)
+        Guid? teamFranchiseSeasonId,
+        Guid? atBatAthleteSeasonId,
+        Guid? pitchingAthleteSeasonId)
     {
         var identity = externalRefIdentityGenerator.Generate(dto.Ref);
 
@@ -62,7 +64,42 @@ public static class CompetitionPlayExtensions
             EspnId = dto.Id,
             SequenceNumber = dto.SequenceNumber,
             Text = dto.Text ?? "UNK",
-            TypeId = dto.Type?.Id ?? "9999"
+            TypeId = dto.Type?.Id ?? "9999",
+            HalfInning = dto.Period?.Type,
+            Outs = dto.Outs,
+            Wallclock = dto.Wallclock == default ? null : dto.Wallclock,
+            IsValid = dto.Valid,
+            AtBatId = dto.AtBatId,
+            AtBatPitchNumber = dto.AtBatPitchNumber,
+            BatOrder = dto.BatOrder,
+            BatsType = dto.Bats?.Type,
+            BatsAbbreviation = dto.Bats?.Abbreviation,
+            PitchesType = dto.Pitches?.Type,
+            PitchesAbbreviation = dto.Pitches?.Abbreviation,
+            AtBatAthleteSeasonId = atBatAthleteSeasonId,
+            PitchingAthleteSeasonId = pitchingAthleteSeasonId,
+            PitchCoordinateX = dto.PitchCoordinate?.X,
+            PitchCoordinateY = dto.PitchCoordinate?.Y,
+            HitCoordinateX = dto.HitCoordinate?.X,
+            HitCoordinateY = dto.HitCoordinate?.Y,
+            PitchTypeId = dto.PitchType?.Id,
+            PitchTypeText = dto.PitchType?.Text,
+            PitchTypeAbbreviation = dto.PitchType?.Abbreviation,
+            PitchVelocity = dto.PitchVelocity,
+            PitchCountBalls = dto.PitchCount?.Balls,
+            PitchCountStrikes = dto.PitchCount?.Strikes,
+            ResultCountBalls = dto.ResultCount?.Balls,
+            ResultCountStrikes = dto.ResultCount?.Strikes,
+            Trajectory = dto.Trajectory,
+            StrikeType = dto.StrikeType,
+            SummaryType = dto.SummaryType,
+            AwayHits = dto.AwayHits,
+            HomeHits = dto.HomeHits,
+            AwayErrors = dto.AwayErrors,
+            HomeErrors = dto.HomeErrors,
+            RbiCount = dto.RbiCount,
+            IsDoublePlay = dto.DoublePlay,
+            IsTriplePlay = dto.TriplePlay
         };
 
         MapSharedProperties(dto, entity, identity, correlationId, competitionId, teamFranchiseSeasonId);

--- a/src/SportsData.Producer/Migrations/Baseball/20260511090203_AddBaseballPlayCanonicalCaptureFields.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260511090203_AddBaseballPlayCanonicalCaptureFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260511090203_AddBaseballPlayCanonicalCaptureFields")]
+    partial class AddBaseballPlayCanonicalCaptureFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260511090203_AddBaseballPlayCanonicalCaptureFields.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260511090203_AddBaseballPlayCanonicalCaptureFields.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class AddBaseballPlayCanonicalCaptureFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "AtBatAthleteSeasonId",
+                table: "CompetitionPlay",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HalfInning",
+                table: "CompetitionPlay",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            // Non-nullable on the entity (default true). Set defaultValue so
+            // existing rows (Football plays + previously-ingested Baseball plays)
+            // get a sensible value rather than NULL on TPH read.
+            migrationBuilder.AddColumn<bool>(
+                name: "IsValid",
+                table: "CompetitionPlay",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Outs",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PitchesAbbreviation",
+                table: "CompetitionPlay",
+                type: "character varying(5)",
+                maxLength: 5,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PitchesType",
+                table: "CompetitionPlay",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PitchingAthleteSeasonId",
+                table: "CompetitionPlay",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Wallclock",
+                table: "CompetitionPlay",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CompetitionPlayParticipant",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CompetitionPlayId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Order = table.Column<int>(type: "integer", nullable: false),
+                    Type = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    AthleteSeasonId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PositionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StatisticsRef = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Discriminator = table.Column<string>(type: "character varying(34)", maxLength: 34, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionPlayParticipant", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CompetitionPlayParticipant_CompetitionPlay_CompetitionPlayId",
+                        column: x => x.CompetitionPlayId,
+                        principalTable: "CompetitionPlay",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionPlayParticipant_AthleteSeasonId",
+                table: "CompetitionPlayParticipant",
+                column: "AthleteSeasonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionPlayParticipant_CompetitionPlayId_Type",
+                table: "CompetitionPlayParticipant",
+                columns: new[] { "CompetitionPlayId", "Type" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionPlayParticipant_PositionId",
+                table: "CompetitionPlayParticipant",
+                column: "PositionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CompetitionPlayParticipant");
+
+            migrationBuilder.DropColumn(
+                name: "AtBatAthleteSeasonId",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "HalfInning",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "IsValid",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "Outs",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "PitchesAbbreviation",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "PitchesType",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "PitchingAthleteSeasonId",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "Wallclock",
+                table: "CompetitionPlay");
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessorTests.cs
@@ -6,184 +6,390 @@ using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests.Baseball;
 using SportsData.Core.Extensions;
-using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Baseball;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities;
-using SportsData.Producer.Infrastructure.Data.Football;
-using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
 
+/// <summary>
+/// Tests for <see cref="BaseballEventCompetitionPlayDocumentProcessor{TDataContext}"/>.
+///
+/// Coverage focus is the capture-fidelity work and TPH wiring:
+///   • DTO deserialization of the rich per-play shape (pitches, bats,
+///     pitchCoordinate, hitCoordinate, participants, etc.).
+///   • Status-gated publish: missing status throws, completed games
+///     persist but don't publish, in-progress games persist + publish.
+///   • Participant capture into the shared CompetitionPlayParticipant
+///     TPH table, including AthleteSeasonId / PositionId resolution, race
+///     handling (null on unsourced refs), and forward-compat warning
+///     on unrecognized participant types.
+///   • ApplyUpdateAsync: re-resolves athletes, refreshes rich fields,
+///     and replaces the participants set wholesale.
+/// </summary>
 [Collection("Sequential")]
-public class BaseballEventCompetitionPlayDocumentProcessorTests : ProducerTestBase<FootballDataContext>
+public class BaseballEventCompetitionPlayDocumentProcessorTests
+    : ProducerTestBase<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>
 {
-    private async Task<(Guid competitionId, Guid teamFranchiseSeasonId)> SetupTestDataAsync(
-        ExternalRefIdentityGenerator generator,
-        string teamRef)
+    private readonly BaseballDataContext _baseballDataContext;
+    private static readonly DateTime FixedNow = new(2026, 5, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    public BaseballEventCompetitionPlayDocumentProcessorTests()
     {
-        var competitionId = Guid.NewGuid();
-        var competition = new FootballCompetition
-        {
-            Id = competitionId,
-            ContestId = Guid.NewGuid(),
-            Date = DateTime.UtcNow,
-            CreatedUtc = DateTime.UtcNow,
-            CreatedBy = Guid.NewGuid()
-        };
-        await FootballDataContext.Competitions.AddAsync(competition);
-
-        var teamIdentity = generator.Generate(teamRef);
-        var franchiseSeasonId = Guid.NewGuid();
-        var franchiseSeason = new FranchiseSeason
-        {
-            Id = franchiseSeasonId,
-            FranchiseId = Guid.NewGuid(),
-            SeasonYear = 2026,
-            Abbreviation = "KC",
-            DisplayName = "Kansas City Royals",
-            DisplayNameShort = "Royals",
-            Location = "Kansas City",
-            Name = "Royals",
-            Slug = "kansas-city-royals",
-            ColorCodeHex = "#004687",
-            CreatedUtc = DateTime.UtcNow,
-            CreatedBy = Guid.NewGuid(),
-            ExternalIds = new List<FranchiseSeasonExternalId>
-            {
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    FranchiseSeasonId = franchiseSeasonId,
-                    Provider = SourceDataProvider.Espn,
-                    SourceUrl = teamIdentity.CleanUrl,
-                    SourceUrlHash = teamIdentity.UrlHash,
-                    Value = teamIdentity.UrlHash
-                }
-            }
-        };
-        await FootballDataContext.FranchiseSeasons.AddAsync(franchiseSeason);
-        await FootballDataContext.SaveChangesAsync();
-
-        return (competitionId, franchiseSeasonId);
+        _baseballDataContext = new BaseballDataContext(
+            new DbContextOptionsBuilder<BaseballDataContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+                .Options);
+        Mocker.Use(_baseballDataContext);
     }
 
-    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
-    public async Task WhenNewBaseballPlay_ShouldCreateWithNullDriveAndStartEnd()
+    [Fact]
+    public async Task DTO_Deserializes_RichFields_From_ScoringFixture()
+    {
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionPlay_Scoring.json");
+
+        var dto = json.FromJson<EspnBaseballEventCompetitionPlayDto>();
+
+        dto.Should().NotBeNull();
+        dto!.Valid.Should().BeTrue();
+        dto.AtBatId.Should().Be("4018148440202");
+        dto.BatOrder.Should().Be(5);
+        dto.Bats!.Type.Should().Be("LEFT");
+        dto.Bats.Abbreviation.Should().Be("L");
+        dto.Pitches!.Type.Should().Be("RIGHT");
+        dto.Pitches.Abbreviation.Should().Be("R");
+        dto.AtBatPitchNumber.Should().Be(2);
+        dto.PitchCoordinate!.X.Should().Be(113);
+        dto.PitchCoordinate.Y.Should().Be(159);
+        dto.HitCoordinate!.X.Should().Be(205);
+        dto.HitCoordinate.Y.Should().Be(62);
+        dto.SummaryType.Should().Be("S");
+        dto.PitchCount!.Balls.Should().Be(1);
+        dto.ResultCount!.Strikes.Should().Be(0);
+        dto.Outs.Should().Be(1);
+        dto.Trajectory.Should().Be("F");
+        dto.RbiCount.Should().Be(1);
+        dto.Period!.Type.Should().Be("Top");
+        dto.Period.DisplayValue.Should().Be("2nd Inning");
+        dto.Participants.Should().HaveCount(2);
+        dto.Participants![0].Type.Should().Be("pitcher");
+        dto.Participants[1].Type.Should().Be("batter");
+    }
+
+    [Fact]
+    public async Task WhenStatusMissing_ThrowsForRetry()
+    {
+        // arrange — competition exists but no BaseballCompetitionStatus row.
+        // Tri-state IsCompetitionInProgressAsync returns null → base throws
+        // so MassTransit retries once status is sourced.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var (json, competitionId, _) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay.json",
+            seedStatus: null);
+
+        var cmd = BuildCommand(json, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
+
+        // act + assert
+        await FluentActions.Awaiting(() => sut.ProcessAsync(cmd))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*status not yet sourced*");
+
+        var plays = await _baseballDataContext.CompetitionPlays
+            .Where(p => p.CompetitionId == competitionId).ToListAsync();
+        plays.Should().BeEmpty("nothing should persist when the gating throw fires");
+    }
+
+    [Fact]
+    public async Task WhenInProgress_CreatesPlayAndPublishesPlayCompleted()
     {
         // arrange
         var generator = new ExternalRefIdentityGenerator();
         Mocker.Use<IGenerateExternalRefIdentities>(generator);
 
-        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionPlay.json");
-        var dto = json.FromJson<EspnBaseballEventCompetitionPlayDto>();
+        var (json, competitionId, contestId) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay.json",
+            seedStatus: BaseballStatus(isCompleted: false));
 
-        var teamRef = dto!.Team.Ref.ToString();
-        var (competitionId, teamFranchiseSeasonId) = await SetupTestDataAsync(generator, teamRef);
-
-        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
-
-        var command = Fixture.Build<ProcessDocumentCommand>()
-            .With(x => x.Document, json)
-            .With(x => x.DocumentType, DocumentType.EventCompetitionPlay)
-            .With(x => x.SeasonYear, 2026)
-            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
-            .With(x => x.Sport, Sport.BaseballMlb)
-            .With(x => x.ParentId, competitionId.ToString())
-            .OmitAutoProperties()
-            .Create();
+        var cmd = BuildCommand(json, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
 
         // act
-        await sut.ProcessAsync(command);
+        await sut.ProcessAsync(cmd);
 
-        // assert — query base CompetitionPlays since FootballDataContext.CompetitionPlays
-        // returns FootballCompetitionPlay, not BaseballCompetitionPlay
-        var play = await TeamSportDataContext.CompetitionPlays
-            // BaseballCompetitionPlay stored via base DbSet in test context
-            .Include(x => x.ExternalIds)
+        // assert — play persisted with the rich-capture columns populated
+        var play = await _baseballDataContext.CompetitionPlays
+            .OfType<BaseballCompetitionPlay>()
             .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
 
-        play.Should().NotBeNull("baseball preseason events should create plays");
-        play!.ExternalIds.Should().NotBeEmpty();
-        play.StartFranchiseSeasonId.Should().Be(teamFranchiseSeasonId);
-        play.Text.Should().Be("Top of the 1st inning");
-        play.PeriodNumber.Should().Be(1);
+        play.Should().NotBeNull();
+        play!.Text.Should().Be("Top of the 1st inning");
         play.TypeId.Should().Be("59");
+        play.PeriodNumber.Should().Be(1);
+        play.HalfInning.Should().Be("Top");
+        play.Outs.Should().Be(0);
+        play.IsValid.Should().BeTrue();
+        play.AtBatId.Should().Be("4018148440001");
+        play.SummaryType.Should().Be("I");
+
+        // start-inning has no participants in the JSON
+        play.Participants.Should().BeEmpty();
+        play.AtBatAthleteSeasonId.Should().BeNull();
+        play.PitchingAthleteSeasonId.Should().BeNull();
+
+        // BaseballPlayCompleted published once
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(
+                It.Is<BaseballPlayCompleted>(e =>
+                    e.CompetitionId == competitionId &&
+                    e.ContestId == contestId &&
+                    e.PlayId == play.Id),
+                It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
-    public async Task WhenScoringPlay_ShouldCreateWithScoreData()
+    [Fact]
+    public async Task WhenCompleted_CreatesPlayButDoesNotPublish()
     {
-        // arrange
+        // arrange — Final game: status exists with IsCompleted=true.
         var generator = new ExternalRefIdentityGenerator();
         Mocker.Use<IGenerateExternalRefIdentities>(generator);
 
-        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionPlay_Scoring.json");
-        var dto = json.FromJson<EspnBaseballEventCompetitionPlayDto>();
+        var (json, competitionId, _) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay.json",
+            seedStatus: BaseballStatus(isCompleted: true));
 
-        var teamRef = dto!.Team.Ref.ToString();
-        var (competitionId, _) = await SetupTestDataAsync(generator, teamRef);
-
-        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
-
-        var command = Fixture.Build<ProcessDocumentCommand>()
-            .With(x => x.Document, json)
-            .With(x => x.DocumentType, DocumentType.EventCompetitionPlay)
-            .With(x => x.SeasonYear, 2026)
-            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
-            .With(x => x.Sport, Sport.BaseballMlb)
-            .With(x => x.ParentId, competitionId.ToString())
-            .OmitAutoProperties()
-            .Create();
+        var cmd = BuildCommand(json, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
 
         // act
-        await sut.ProcessAsync(command);
+        await sut.ProcessAsync(cmd);
 
-        // assert
-        var play = await TeamSportDataContext.CompetitionPlays
+        // assert — play persisted, no PlayCompleted event published
+        var play = await _baseballDataContext.CompetitionPlays
+            .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
+
+        play.Should().NotBeNull();
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(
+                It.IsAny<BaseballPlayCompleted>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenScoringPlay_CapturesAllRichFields()
+    {
+        // arrange — scoring-play fixture has the wide field shape: bats,
+        // pitches, pitchCoordinate, hitCoordinate, trajectory, etc.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var (json, competitionId, _) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay_Scoring.json",
+            seedStatus: BaseballStatus(isCompleted: false));
+
+        var cmd = BuildCommand(json, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — the AsBaseballEntity extension populates every column
+        var play = await _baseballDataContext.CompetitionPlays
+            .OfType<BaseballCompetitionPlay>()
             .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
 
         play.Should().NotBeNull();
         play!.ScoringPlay.Should().BeTrue();
-        play.ScoreValue.Should().BeGreaterThan(0);
-        play.Text.Should().Contain("homered");
+        play.ScoreValue.Should().Be(1);
+        play.HalfInning.Should().Be("Top");
+        play.Outs.Should().Be(1);
+        play.AtBatId.Should().Be("4018148440202");
+        play.BatOrder.Should().Be(5);
+        play.BatsType.Should().Be("LEFT");
+        play.BatsAbbreviation.Should().Be("L");
+        play.PitchesType.Should().Be("RIGHT");
+        play.PitchesAbbreviation.Should().Be("R");
+        play.AtBatPitchNumber.Should().Be(2);
+        play.PitchCoordinateX.Should().Be(113);
+        play.PitchCoordinateY.Should().Be(159);
+        play.HitCoordinateX.Should().Be(205);
+        play.HitCoordinateY.Should().Be(62);
+        play.Trajectory.Should().Be("F");
+        play.SummaryType.Should().Be("S");
+        play.RbiCount.Should().Be(1);
+        play.AwayHits.Should().Be(1);
+        play.AwayErrors.Should().Be(1);
+        play.IsValid.Should().BeTrue();
+        play.Wallclock.Should().NotBeNull();
     }
 
-    [Fact(Skip = "Requires BaseballDataContext test infrastructure")]
-    public async Task WhenPlayAlreadyExists_ShouldUpdate()
+    [Fact]
+    public async Task WhenParticipantsResolve_PopulatesAthleteSeasonAndPositionIds()
     {
-        // arrange
+        // arrange — scoring fixture's participants[] has pitcher + batter
+        // with season-scoped athlete refs + position refs. Seed canonical
+        // AthleteSeason + AthletePosition rows so resolution succeeds.
         var generator = new ExternalRefIdentityGenerator();
         Mocker.Use<IGenerateExternalRefIdentities>(generator);
 
-        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionPlay.json");
-        var dto = json.FromJson<EspnBaseballEventCompetitionPlayDto>();
+        var (json, competitionId, _) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay_Scoring.json",
+            seedStatus: BaseballStatus(isCompleted: false));
 
-        var teamRef = dto!.Team.Ref.ToString();
-        var (competitionId, teamFranchiseSeasonId) = await SetupTestDataAsync(generator, teamRef);
+        var pitcherAthleteSeasonId = await SeedAthleteSeasonAsync(generator,
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4345076?lang=en&region=us");
+        var batterAthleteSeasonId = await SeedAthleteSeasonAsync(generator,
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4917812?lang=en&region=us");
+        var pitcherPositionId = await SeedPositionAsync(generator,
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/15?lang=en&region=us");
+        var batterPositionId = await SeedPositionAsync(generator,
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/2?lang=en&region=us");
 
+        var cmd = BuildCommand(json, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — denormalized columns on the play row carry the IDs and
+        // the participants table has both rows fully resolved.
+        var play = await _baseballDataContext.CompetitionPlays
+            .OfType<BaseballCompetitionPlay>()
+            .Include(p => p.Participants)
+            .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
+
+        play.Should().NotBeNull();
+        play!.AtBatAthleteSeasonId.Should().Be(batterAthleteSeasonId);
+        play.PitchingAthleteSeasonId.Should().Be(pitcherAthleteSeasonId);
+        play.Participants.Should().HaveCount(2);
+
+        var pitcherRow = play.Participants.Single(p => p.Type == "pitcher");
+        pitcherRow.AthleteSeasonId.Should().Be(pitcherAthleteSeasonId);
+        pitcherRow.PositionId.Should().Be(pitcherPositionId);
+        pitcherRow.Order.Should().Be(1);
+
+        var batterRow = play.Participants.Single(p => p.Type == "batter");
+        batterRow.AthleteSeasonId.Should().Be(batterAthleteSeasonId);
+        batterRow.PositionId.Should().Be(batterPositionId);
+        batterRow.Order.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task WhenAthleteSeasonsUnresolved_PersistsParticipantsWithNullIds()
+    {
+        // arrange — scoring fixture has participants but we deliberately do
+        // not seed any AthleteSeason / AthletePosition rows. ResolveIdAsync
+        // returns null; participant rows still persist for later re-resolve
+        // on the next play update.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var (json, competitionId, _) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay_Scoring.json",
+            seedStatus: BaseballStatus(isCompleted: false));
+
+        var cmd = BuildCommand(json, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert
+        var play = await _baseballDataContext.CompetitionPlays
+            .OfType<BaseballCompetitionPlay>()
+            .Include(p => p.Participants)
+            .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
+
+        play.Should().NotBeNull();
+        play!.AtBatAthleteSeasonId.Should().BeNull();
+        play.PitchingAthleteSeasonId.Should().BeNull();
+        play.Participants.Should().HaveCount(2, "rows persist even when refs aren't resolved yet");
+        play.Participants.Should().OnlyContain(p =>
+            p.AthleteSeasonId == null && p.PositionId == null);
+    }
+
+    [Fact]
+    public async Task WhenUnrecognizedParticipantType_StillPersistsRow()
+    {
+        // arrange — mutate the scoring fixture so one participant has an
+        // unknown Type. The unknown-type branch logs a warning but does
+        // not drop the row (forward-compat: ESPN can grow its taxonomy).
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var rawJson = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionPlay_Scoring.json");
+        var dto = rawJson.FromJson<EspnBaseballEventCompetitionPlayDto>()!;
+        dto.Participants![1].Type = "fielder";  // was "batter"
+        var mutatedJson = dto.ToJson();
+
+        var (_, competitionId, _) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay_Scoring.json",
+            seedStatus: BaseballStatus(isCompleted: false));
+
+        var cmd = BuildCommand(mutatedJson, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — both rows still landed; only pitcher counted as primary.
+        var play = await _baseballDataContext.CompetitionPlays
+            .OfType<BaseballCompetitionPlay>()
+            .Include(p => p.Participants)
+            .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
+
+        play.Should().NotBeNull();
+        play!.Participants.Should().HaveCount(2);
+        play.Participants.Should().Contain(p => p.Type == "fielder");
+        play.AtBatAthleteSeasonId.Should().BeNull("'fielder' isn't recognized as the batter slot");
+    }
+
+    [Fact]
+    public async Task WhenPlayAlreadyExists_UpdatesFieldsAndReplacesParticipants()
+    {
+        // arrange — seed an existing baseball play with stale data + one
+        // participant row, then re-process the scoring fixture.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionPlay_Scoring.json");
+        var dto = json.FromJson<EspnBaseballEventCompetitionPlayDto>()!;
         var playIdentity = generator.Generate(dto.Ref);
 
-        // Pre-create the play
-        var existingPlay = new FootballCompetitionPlay
+        var (_, competitionId, _) = await PrepareScenarioAsync(
+            "EspnBaseballMlb/EventCompetitionPlay_Scoring.json",
+            seedStatus: BaseballStatus(isCompleted: false));
+
+        var existing = new BaseballCompetitionPlay
         {
             Id = playIdentity.CanonicalId,
             CompetitionId = competitionId,
             EspnId = dto.Id,
             SequenceNumber = dto.SequenceNumber,
-            Text = "old text",
-            TypeId = "59",
+            Text = "stale",
+            TypeId = "0",
             Type = PlayType.Unknown,
-            Modified = DateTime.UtcNow,
-            CreatedUtc = DateTime.UtcNow,
+            Modified = FixedNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid(),
+            BatOrder = 99,
+            PitchVelocity = 999,
             ExternalIds = new List<CompetitionPlayExternalId>
             {
                 new()
@@ -197,29 +403,196 @@ public class BaseballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
                 }
             }
         };
-        await TeamSportDataContext.CompetitionPlays.AddAsync(existingPlay);
-        await FootballDataContext.SaveChangesAsync();
+        await _baseballDataContext.CompetitionPlays.AddAsync(existing);
 
-        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        // pre-existing stale participant row (different athlete) — should be wiped.
+        var staleAthleteSeasonId = Guid.NewGuid();
+        await _baseballDataContext.Set<BaseballCompetitionPlayParticipant>().AddAsync(
+            new BaseballCompetitionPlayParticipant
+            {
+                Id = Guid.NewGuid(),
+                CompetitionPlayId = playIdentity.CanonicalId,
+                Order = 9,
+                Type = "stale-type",
+                AthleteSeasonId = staleAthleteSeasonId,
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        await _baseballDataContext.SaveChangesAsync();
 
-        var command = Fixture.Build<ProcessDocumentCommand>()
-            .With(x => x.Document, json)
-            .With(x => x.DocumentType, DocumentType.EventCompetitionPlay)
+        var cmd = BuildCommand(json, competitionId);
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>();
+
+        // act
+        await sut.ProcessAsync(cmd);
+
+        // assert — fields refreshed from the new payload and the stale
+        // participant is gone, replaced by the JSON's two participants.
+        var play = await _baseballDataContext.CompetitionPlays
+            .OfType<BaseballCompetitionPlay>()
+            .Include(p => p.Participants)
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == playIdentity.CanonicalId);
+
+        play.BatOrder.Should().Be(5);
+        play.PitchesType.Should().Be("RIGHT");
+        play.HitCoordinateX.Should().Be(205);
+        play.Participants.Should().HaveCount(2);
+        play.Participants.Should().NotContain(p => p.AthleteSeasonId == staleAthleteSeasonId);
+        play.Participants.Should().OnlyContain(p =>
+            p.Type == "pitcher" || p.Type == "batter");
+    }
+
+    // ---- helpers ----
+
+    private async Task<(string json, Guid competitionId, Guid contestId)> PrepareScenarioAsync(
+        string fixturePath,
+        BaseballCompetitionStatus? seedStatus)
+    {
+        var json = await LoadJsonTestData(fixturePath);
+        var dto = json.FromJson<EspnBaseballEventCompetitionPlayDto>()!;
+
+        var competitionId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        await _baseballDataContext.Contests.AddAsync(new BaseballContest
+        {
+            Id = contestId,
+            Name = "Test Contest",
+            ShortName = "Test",
+            SeasonYear = 2026,
+            Sport = Sport.BaseballMlb,
+            StartDateUtc = FixedNow,
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        await _baseballDataContext.Competitions.AddAsync(new BaseballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Date = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        if (seedStatus is not null)
+        {
+            seedStatus.CompetitionId = competitionId;
+            await _baseballDataContext.Set<BaseballCompetitionStatus>().AddAsync(seedStatus);
+        }
+
+        await _baseballDataContext.SaveChangesAsync();
+
+        return (json, competitionId, contestId);
+    }
+
+    private static BaseballCompetitionStatus BaseballStatus(bool isCompleted) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            IsCompleted = isCompleted,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+    private async Task<Guid> SeedAthleteSeasonAsync(ExternalRefIdentityGenerator generator, string athleteSeasonRef)
+    {
+        // Seed a global AthleteBase + AthletePosition (required FKs) then
+        // the season-scoped AthleteSeason with its ExternalId. The play
+        // processor resolves against AthleteSeasonExternalId, so only the
+        // season-scoped URL hash needs to match.
+        var identity = generator.Generate(athleteSeasonRef);
+        var athleteSeasonId = identity.CanonicalId;
+
+        var parentAthleteId = Guid.NewGuid();
+        await _baseballDataContext.Athletes.AddAsync(new BaseballAthlete
+        {
+            Id = parentAthleteId,
+            FirstName = "Test",
+            LastName = "Athlete",
+            DisplayName = "Test Athlete",
+            ShortName = "T. Athlete",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        var parentPositionId = Guid.NewGuid();
+        await _baseballDataContext.AthletePositions.AddAsync(new AthletePosition
+        {
+            Id = parentPositionId,
+            Name = "Parent",
+            DisplayName = "Parent Position",
+            Abbreviation = "P",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        await _baseballDataContext.AthleteSeasons.AddAsync(new BaseballAthleteSeason
+        {
+            Id = athleteSeasonId,
+            AthleteId = parentAthleteId,
+            PositionId = parentPositionId,
+            DisplayName = "Test Athlete 2026",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds = new List<AthleteSeasonExternalId>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    AthleteSeasonId = athleteSeasonId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = identity.CleanUrl,
+                    SourceUrlHash = identity.UrlHash,
+                    Value = identity.UrlHash
+                }
+            }
+        });
+        await _baseballDataContext.SaveChangesAsync();
+        return athleteSeasonId;
+    }
+
+    private async Task<Guid> SeedPositionAsync(ExternalRefIdentityGenerator generator, string positionRef)
+    {
+        var identity = generator.Generate(positionRef);
+        var positionId = identity.CanonicalId;
+
+        await _baseballDataContext.AthletePositions.AddAsync(new AthletePosition
+        {
+            Id = positionId,
+            Name = "Test",
+            DisplayName = "Test Position",
+            Abbreviation = "T",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds = new List<AthletePositionExternalId>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    AthletePositionId = positionId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = identity.CleanUrl,
+                    SourceUrlHash = identity.UrlHash,
+                    Value = identity.UrlHash
+                }
+            }
+        });
+        await _baseballDataContext.SaveChangesAsync();
+        return positionId;
+    }
+
+    private ProcessDocumentCommand BuildCommand(string json, Guid competitionId) =>
+        Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, competitionId.ToString())
             .With(x => x.SeasonYear, 2026)
             .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
             .With(x => x.Sport, Sport.BaseballMlb)
-            .With(x => x.ParentId, competitionId.ToString())
+            .With(x => x.DocumentType, DocumentType.EventCompetitionPlay)
+            .With(x => x.Document, json)
             .OmitAutoProperties()
             .Create();
-
-        // act
-        await sut.ProcessAsync(command);
-
-        // assert
-        var play = await TeamSportDataContext.CompetitionPlays
-            .FirstOrDefaultAsync(x => x.Id == playIdentity.CanonicalId);
-
-        play.Should().NotBeNull();
-        play!.StartFranchiseSeasonId.Should().Be(teamFranchiseSeasonId);
-    }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/EventCompetitionPlays.json
+++ b/test/unit/SportsData.Producer.Tests.Unit/Data/EspnBaseballMlb/EventCompetitionPlays.json
@@ -1,0 +1,2290 @@
+{
+  "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays?lang=en&region=us",
+  "count": 639,
+  "pageIndex": 1,
+  "pageSize": 25,
+  "pageCount": 26,
+  "items": [
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680000000059?lang=en&region=us",
+      "id": "4018152680000000059",
+      "sequenceNumber": "1",
+      "type": {
+        "id": "59",
+        "text": "Start Inning",
+        "type": "start-inning"
+      },
+      "text": "Top of the 1st inning",
+      "shortText": "Top of the 1st inning",
+      "alternativeText": "Top of the 1st inning",
+      "shortAlternativeText": "Top of the 1st inning",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "wallclock": "2026-05-09T19:08:04Z",
+      "atBatId": "4018152680001",
+      "summaryType": "I",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 0,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001010001?lang=en&region=us",
+      "id": "4018152680001010001",
+      "sequenceNumber": "1",
+      "type": {
+        "id": "1",
+        "text": "Start Batter/Pitcher",
+        "alternativeText": "Now at bat",
+        "type": "start-batterpitcher"
+      },
+      "text": "Trey Yesavage pitches to Zach Neto",
+      "shortText": "Trey Yesavage pitches to Zach Neto",
+      "alternativeText": "Trey Yesavage pitches to Zach Neto",
+      "shortAlternativeText": "Trey Yesavage pitches to Zach Neto",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/competitors/14/roster/4949041/statistics/0?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/competitors/3/roster/4666100/statistics/0?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:08:04Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "summaryType": "A",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001020037?lang=en&region=us",
+      "id": "4018152680001020037",
+      "sequenceNumber": "2",
+      "type": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "text": "Pitch 1 : Strike 1 Swinging",
+      "shortText": "Pitch 1 : Strike 1 Swinging",
+      "alternativeText": "Pitch 1 : Strike 1 Swinging",
+      "shortAlternativeText": "Strike Swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:08:04Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 1,
+      "pitchCoordinate": {
+        "x": 118,
+        "y": 162
+      },
+      "pitchType": {
+        "id": "17",
+        "text": "Four-seam FB",
+        "abbreviation": "FF"
+      },
+      "pitchVelocity": 95,
+      "strikeType": "swinging",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 1
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001030021?lang=en&region=us",
+      "id": "4018152680001030021",
+      "sequenceNumber": "3",
+      "type": {
+        "id": "21",
+        "text": "Foul Ball",
+        "abbreviation": "F",
+        "type": "foul-ball"
+      },
+      "text": "Pitch 2 : Strike 2 Foul",
+      "shortText": "Pitch 2 : Strike 2 Foul",
+      "alternativeText": "Pitch 2 : Strike 2 Foul",
+      "shortAlternativeText": "Strike Foul",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:08:13Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 2,
+      "pitchCoordinate": {
+        "x": 113,
+        "y": 186
+      },
+      "pitchType": {
+        "id": "17",
+        "text": "Four-seam FB",
+        "abbreviation": "FF"
+      },
+      "pitchVelocity": 95,
+      "strikeType": "foul",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 1
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001040005?lang=en&region=us",
+      "id": "4018152680001040005",
+      "sequenceNumber": "4",
+      "type": {
+        "id": "5",
+        "text": "Ball",
+        "abbreviation": "B",
+        "alternativeText": "Walk",
+        "type": "ball"
+      },
+      "text": "Pitch 3 : Ball 1",
+      "shortText": "Pitch 3 : Ball 1",
+      "alternativeText": "Pitch 3 : Ball 1",
+      "shortAlternativeText": "Ball",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:08:46Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 3,
+      "pitchCoordinate": {
+        "x": 103,
+        "y": 228
+      },
+      "pitchType": {
+        "id": "5",
+        "text": "Slider",
+        "abbreviation": "SL"
+      },
+      "pitchVelocity": 87,
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 1,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001050005?lang=en&region=us",
+      "id": "4018152680001050005",
+      "sequenceNumber": "5",
+      "type": {
+        "id": "5",
+        "text": "Ball",
+        "abbreviation": "B",
+        "alternativeText": "Walk",
+        "type": "ball"
+      },
+      "text": "Pitch 4 : Ball 2",
+      "shortText": "Pitch 4 : Ball 2",
+      "alternativeText": "Pitch 4 : Ball 2",
+      "shortAlternativeText": "Ball",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:09:09Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 4,
+      "pitchCoordinate": {
+        "x": 124,
+        "y": 92
+      },
+      "pitchType": {
+        "id": "17",
+        "text": "Four-seam FB",
+        "abbreviation": "FF"
+      },
+      "pitchVelocity": 94,
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 1,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001060021?lang=en&region=us",
+      "id": "4018152680001060021",
+      "sequenceNumber": "6",
+      "type": {
+        "id": "21",
+        "text": "Foul Ball",
+        "abbreviation": "F",
+        "type": "foul-ball"
+      },
+      "text": "Pitch 5 : Strike 2 Foul",
+      "shortText": "Pitch 5 : Strike 2 Foul",
+      "alternativeText": "Pitch 5 : Strike 2 Foul",
+      "shortAlternativeText": "Strike Foul",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:09:27Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 5,
+      "pitchCoordinate": {
+        "x": 161,
+        "y": 149
+      },
+      "pitchType": {
+        "id": "8",
+        "text": "Splitter",
+        "abbreviation": "FS"
+      },
+      "pitchVelocity": 83,
+      "strikeType": "foul",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001070037?lang=en&region=us",
+      "id": "4018152680001070037",
+      "sequenceNumber": "7",
+      "type": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "text": "Pitch 6 : Strike 3 Swinging",
+      "shortText": "Pitch 6 : Strike 3 Swinging",
+      "alternativeText": "Pitch 6 : Strike 3 Swinging",
+      "shortAlternativeText": "Strike Swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:09:51Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 6,
+      "pitchCoordinate": {
+        "x": 136,
+        "y": 205
+      },
+      "pitchType": {
+        "id": "8",
+        "text": "Splitter",
+        "abbreviation": "FS"
+      },
+      "pitchVelocity": 83,
+      "strikeType": "swinging",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001990057?lang=en&region=us",
+      "id": "4018152680001990057",
+      "sequenceNumber": "8",
+      "type": {
+        "id": "57",
+        "text": "Play Result",
+        "type": "play-result"
+      },
+      "alternativeType": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "alternativePlay": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001070037?lang=en&region=us"
+      },
+      "text": "Neto struck out swinging.",
+      "shortText": "Neto struck out swinging.",
+      "alternativeText": "Neto struck out swinging.",
+      "shortAlternativeText": "Zach Neto strikes out swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "probability": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/probabilities/4018152680001990057?lang=en&region=us"
+      },
+      "wallclock": "2026-05-09T19:09:51Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 6,
+      "pitchCoordinate": {
+        "x": 136,
+        "y": 205
+      },
+      "summaryType": "N",
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680001990099?lang=en&region=us",
+      "id": "4018152680001990099",
+      "sequenceNumber": "9",
+      "type": {
+        "id": "99",
+        "text": "End Batter/Pitcher",
+        "type": "end-batterpitcher"
+      },
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:10Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4666100?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/6?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:09:51Z",
+      "atBatId": "4018152680001",
+      "batOrder": 1,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 6,
+      "pitchCoordinate": {
+        "x": 136,
+        "y": 205
+      },
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 1,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002010001?lang=en&region=us",
+      "id": "4018152680002010001",
+      "sequenceNumber": "1",
+      "type": {
+        "id": "1",
+        "text": "Start Batter/Pitcher",
+        "alternativeText": "Now at bat",
+        "type": "start-batterpitcher"
+      },
+      "text": "Trey Yesavage pitches to Mike Trout",
+      "shortText": "Trey Yesavage pitches to Mike Trout",
+      "alternativeText": "Trey Yesavage pitches to Mike Trout",
+      "shortAlternativeText": "Trey Yesavage pitches to Mike Trout",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/competitors/3/roster/30836/statistics/0?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:10:17Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "summaryType": "A",
+      "previousPlayText": "Zach Neto strikes out swinging.",
+      "shortPreviousPlayText": "Neto struck out swinging.",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002020036?lang=en&region=us",
+      "id": "4018152680002020036",
+      "sequenceNumber": "2",
+      "type": {
+        "id": "36",
+        "text": "Strike Looking",
+        "abbreviation": "SL",
+        "alternativeText": "Strikeout",
+        "type": "strike-looking"
+      },
+      "text": "Pitch 1 : Strike 1 Looking",
+      "shortText": "Pitch 1 : Strike 1 Looking",
+      "alternativeText": "Pitch 1 : Strike 1 Looking",
+      "shortAlternativeText": "Strike Looking",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:10:17Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 1,
+      "pitchCoordinate": {
+        "x": 96,
+        "y": 174
+      },
+      "pitchType": {
+        "id": "5",
+        "text": "Slider",
+        "abbreviation": "SL"
+      },
+      "pitchVelocity": 89,
+      "strikeType": "called",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 1
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002030037?lang=en&region=us",
+      "id": "4018152680002030037",
+      "sequenceNumber": "3",
+      "type": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "text": "Pitch 2 : Strike 2 Swinging",
+      "shortText": "Pitch 2 : Strike 2 Swinging",
+      "alternativeText": "Pitch 2 : Strike 2 Swinging",
+      "shortAlternativeText": "Strike Swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:10:33Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 2,
+      "pitchCoordinate": {
+        "x": 80,
+        "y": 204
+      },
+      "pitchType": {
+        "id": "5",
+        "text": "Slider",
+        "abbreviation": "SL"
+      },
+      "pitchVelocity": 88,
+      "strikeType": "swinging",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 1
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002040021?lang=en&region=us",
+      "id": "4018152680002040021",
+      "sequenceNumber": "4",
+      "type": {
+        "id": "21",
+        "text": "Foul Ball",
+        "abbreviation": "F",
+        "type": "foul-ball"
+      },
+      "text": "Pitch 3 : Strike 2 Foul",
+      "shortText": "Pitch 3 : Strike 2 Foul",
+      "alternativeText": "Pitch 3 : Strike 2 Foul",
+      "shortAlternativeText": "Strike Foul",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:10:54Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 3,
+      "pitchCoordinate": {
+        "x": 104,
+        "y": 182
+      },
+      "pitchType": {
+        "id": "17",
+        "text": "Four-seam FB",
+        "abbreviation": "FF"
+      },
+      "pitchVelocity": 94,
+      "strikeType": "foul",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002050005?lang=en&region=us",
+      "id": "4018152680002050005",
+      "sequenceNumber": "5",
+      "type": {
+        "id": "5",
+        "text": "Ball",
+        "abbreviation": "B",
+        "alternativeText": "Walk",
+        "type": "ball"
+      },
+      "text": "Pitch 4 : Ball 1",
+      "shortText": "Pitch 4 : Ball 1",
+      "alternativeText": "Pitch 4 : Ball 1",
+      "shortAlternativeText": "Ball",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:11:11Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 4,
+      "pitchCoordinate": {
+        "x": 112,
+        "y": 122
+      },
+      "pitchType": {
+        "id": "17",
+        "text": "Four-seam FB",
+        "abbreviation": "FF"
+      },
+      "pitchVelocity": 95,
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 1,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002060037?lang=en&region=us",
+      "id": "4018152680002060037",
+      "sequenceNumber": "6",
+      "type": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "text": "Pitch 5 : Strike 3 Swinging",
+      "shortText": "Pitch 5 : Strike 3 Swinging",
+      "alternativeText": "Pitch 5 : Strike 3 Swinging",
+      "shortAlternativeText": "Strike Swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:11:33Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 5,
+      "pitchCoordinate": {
+        "x": 164,
+        "y": 202
+      },
+      "pitchType": {
+        "id": "8",
+        "text": "Splitter",
+        "abbreviation": "FS"
+      },
+      "pitchVelocity": 83,
+      "strikeType": "swinging",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 1,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 1,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002990057?lang=en&region=us",
+      "id": "4018152680002990057",
+      "sequenceNumber": "7",
+      "type": {
+        "id": "57",
+        "text": "Play Result",
+        "type": "play-result"
+      },
+      "alternativeType": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "alternativePlay": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002060037?lang=en&region=us"
+      },
+      "text": "Trout struck out swinging.",
+      "shortText": "Trout struck out swinging.",
+      "alternativeText": "Trout struck out swinging.",
+      "shortAlternativeText": "Mike Trout strikes out swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "probability": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/probabilities/4018152680002990057?lang=en&region=us"
+      },
+      "wallclock": "2026-05-09T19:11:33Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 5,
+      "pitchCoordinate": {
+        "x": 164,
+        "y": 202
+      },
+      "summaryType": "N",
+      "pitchCount": {
+        "balls": 1,
+        "strikes": 3
+      },
+      "resultCount": {
+        "balls": 1,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680002990099?lang=en&region=us",
+      "id": "4018152680002990099",
+      "sequenceNumber": "8",
+      "type": {
+        "id": "99",
+        "text": "End Batter/Pitcher",
+        "type": "end-batterpitcher"
+      },
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:11Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/30836?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/8?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:11:33Z",
+      "atBatId": "4018152680002",
+      "batOrder": 2,
+      "bats": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 5,
+      "pitchCoordinate": {
+        "x": 164,
+        "y": 202
+      },
+      "pitchCount": {
+        "balls": 1,
+        "strikes": 3
+      },
+      "resultCount": {
+        "balls": 1,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 2,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003010001?lang=en&region=us",
+      "id": "4018152680003010001",
+      "sequenceNumber": "1",
+      "type": {
+        "id": "1",
+        "text": "Start Batter/Pitcher",
+        "alternativeText": "Now at bat",
+        "type": "start-batterpitcher"
+      },
+      "text": "Trey Yesavage pitches to Nolan Schanuel",
+      "shortText": "Trey Yesavage pitches to Nolan Schanuel",
+      "alternativeText": "Trey Yesavage pitches to Nolan Schanuel",
+      "shortAlternativeText": "Trey Yesavage pitches to Nolan Schanuel",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4739755?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/3?lang=en&region=us"
+          },
+          "statistics": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/competitors/3/roster/4739755/statistics/0?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:11:54Z",
+      "atBatId": "4018152680003",
+      "batOrder": 3,
+      "bats": {
+        "type": "LEFT",
+        "abbreviation": "L",
+        "displayValue": "Left"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "summaryType": "A",
+      "previousPlayText": "Mike Trout strikes out swinging.",
+      "shortPreviousPlayText": "Trout struck out swinging.",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 3,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003020005?lang=en&region=us",
+      "id": "4018152680003020005",
+      "sequenceNumber": "2",
+      "type": {
+        "id": "5",
+        "text": "Ball",
+        "abbreviation": "B",
+        "alternativeText": "Walk",
+        "type": "ball"
+      },
+      "text": "Pitch 1 : Ball 1",
+      "shortText": "Pitch 1 : Ball 1",
+      "alternativeText": "Pitch 1 : Ball 1",
+      "shortAlternativeText": "Ball",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4739755?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/3?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:11:54Z",
+      "atBatId": "4018152680003",
+      "batOrder": 3,
+      "bats": {
+        "type": "LEFT",
+        "abbreviation": "L",
+        "displayValue": "Left"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 1,
+      "pitchCoordinate": {
+        "x": 64,
+        "y": 169
+      },
+      "pitchType": {
+        "id": "17",
+        "text": "Four-seam FB",
+        "abbreviation": "FF"
+      },
+      "pitchVelocity": 94,
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 0,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 1,
+        "strikes": 0
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 3,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003030005?lang=en&region=us",
+      "id": "4018152680003030005",
+      "sequenceNumber": "3",
+      "type": {
+        "id": "5",
+        "text": "Ball",
+        "abbreviation": "B",
+        "alternativeText": "Walk",
+        "type": "ball"
+      },
+      "text": "Pitch 2 : Ball 2",
+      "shortText": "Pitch 2 : Ball 2",
+      "alternativeText": "Pitch 2 : Ball 2",
+      "shortAlternativeText": "Ball",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4739755?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/3?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:12:09Z",
+      "atBatId": "4018152680003",
+      "batOrder": 3,
+      "bats": {
+        "type": "LEFT",
+        "abbreviation": "L",
+        "displayValue": "Left"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 2,
+      "pitchCoordinate": {
+        "x": 90,
+        "y": 192
+      },
+      "pitchType": {
+        "id": "17",
+        "text": "Four-seam FB",
+        "abbreviation": "FF"
+      },
+      "pitchVelocity": 94,
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 1,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 0
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 3,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003040037?lang=en&region=us",
+      "id": "4018152680003040037",
+      "sequenceNumber": "4",
+      "type": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "text": "Pitch 3 : Strike 1 Swinging",
+      "shortText": "Pitch 3 : Strike 1 Swinging",
+      "alternativeText": "Pitch 3 : Strike 1 Swinging",
+      "shortAlternativeText": "Strike Swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4739755?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/3?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:12:28Z",
+      "atBatId": "4018152680003",
+      "batOrder": 3,
+      "bats": {
+        "type": "LEFT",
+        "abbreviation": "L",
+        "displayValue": "Left"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 3,
+      "pitchCoordinate": {
+        "x": 117,
+        "y": 183
+      },
+      "pitchType": {
+        "id": "5",
+        "text": "Slider",
+        "abbreviation": "SL"
+      },
+      "pitchVelocity": 89,
+      "strikeType": "swinging",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 0
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 1
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 3,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003050037?lang=en&region=us",
+      "id": "4018152680003050037",
+      "sequenceNumber": "5",
+      "type": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "text": "Pitch 4 : Strike 2 Swinging",
+      "shortText": "Pitch 4 : Strike 2 Swinging",
+      "alternativeText": "Pitch 4 : Strike 2 Swinging",
+      "shortAlternativeText": "Strike Swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4739755?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/3?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:12:45Z",
+      "atBatId": "4018152680003",
+      "batOrder": 3,
+      "bats": {
+        "type": "LEFT",
+        "abbreviation": "L",
+        "displayValue": "Left"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 4,
+      "pitchCoordinate": {
+        "x": 157,
+        "y": 195
+      },
+      "pitchType": {
+        "id": "8",
+        "text": "Splitter",
+        "abbreviation": "FS"
+      },
+      "pitchVelocity": 83,
+      "strikeType": "swinging",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 1
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 2
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 3,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003060037?lang=en&region=us",
+      "id": "4018152680003060037",
+      "sequenceNumber": "6",
+      "type": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "text": "Pitch 5 : Strike 3 Swinging",
+      "shortText": "Pitch 5 : Strike 3 Swinging",
+      "alternativeText": "Pitch 5 : Strike 3 Swinging",
+      "shortAlternativeText": "Strike Swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/14?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4739755?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/3?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "wallclock": "2026-05-09T19:13:09Z",
+      "atBatId": "4018152680003",
+      "batOrder": 3,
+      "bats": {
+        "type": "LEFT",
+        "abbreviation": "L",
+        "displayValue": "Left"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 5,
+      "pitchCoordinate": {
+        "x": 149,
+        "y": 187
+      },
+      "pitchType": {
+        "id": "8",
+        "text": "Splitter",
+        "abbreviation": "FS"
+      },
+      "pitchVelocity": 84,
+      "strikeType": "swinging",
+      "summaryType": "P",
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 2
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 3,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003990057?lang=en&region=us",
+      "id": "4018152680003990057",
+      "sequenceNumber": "7",
+      "type": {
+        "id": "57",
+        "text": "Play Result",
+        "type": "play-result"
+      },
+      "alternativeType": {
+        "id": "37",
+        "text": "Strike Swinging",
+        "abbreviation": "SS",
+        "alternativeText": "Strikeout",
+        "type": "strike-swinging"
+      },
+      "alternativePlay": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/plays/4018152680003060037?lang=en&region=us"
+      },
+      "text": "Schanuel struck out swinging.",
+      "shortText": "Schanuel struck out swinging.",
+      "alternativeText": "Schanuel struck out swinging.",
+      "shortAlternativeText": "Nolan Schanuel strikes out swinging",
+      "awayScore": 0,
+      "homeScore": 0,
+      "period": {
+        "type": "Top",
+        "number": 1,
+        "displayValue": "1st Inning"
+      },
+      "valid": true,
+      "scoringPlay": false,
+      "priority": false,
+      "scoreValue": 0,
+      "modified": "2026-05-09T19:13Z",
+      "team": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/teams/3?lang=en&region=us"
+      },
+      "participants": [
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4949041?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/1?lang=en&region=us"
+          },
+          "order": 1,
+          "type": "pitcher"
+        },
+        {
+          "athlete": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/2026/athletes/4739755?lang=en&region=us"
+          },
+          "position": {
+            "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/positions/3?lang=en&region=us"
+          },
+          "order": 2,
+          "type": "batter"
+        }
+      ],
+      "probability": {
+        "$ref": "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815268/competitions/401815268/probabilities/4018152680003990057?lang=en&region=us"
+      },
+      "wallclock": "2026-05-09T19:13:09Z",
+      "atBatId": "4018152680003",
+      "batOrder": 3,
+      "bats": {
+        "type": "LEFT",
+        "abbreviation": "L",
+        "displayValue": "Left"
+      },
+      "pitches": {
+        "type": "RIGHT",
+        "abbreviation": "R",
+        "displayValue": "Right"
+      },
+      "atBatPitchNumber": 5,
+      "pitchCoordinate": {
+        "x": 149,
+        "y": 187
+      },
+      "summaryType": "N",
+      "pitchCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "resultCount": {
+        "balls": 2,
+        "strikes": 3
+      },
+      "awayErrors": 0,
+      "awayHits": 0,
+      "homeErrors": 0,
+      "homeHits": 0,
+      "outs": 3,
+      "rbiCount": 0,
+      "doublePlay": false,
+      "triplePlay": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

ESPN's per-play MLB payload carries rich data we were dropping on the floor — pitch type/velocity/coords, hit coords, bats/pitches handedness, half-inning, outs, RBI, and the full `participants[]` array with athlete + position refs. `AsBaseballEntity` was a five-field stub; this PR makes it populate every column the entity already had plus a handful of new ones, and adds a sport-agnostic `CompetitionPlayParticipant` TPH table for full participants capture.

**Capture-only** — `BaseballPlayCompleted` event still emits hardcoded defaults. Phase 2 wires the captured data onto the event + replay.

## What landed

### Entity additions on `BaseballCompetitionPlay`
- `HalfInning`, `Outs`, `Wallclock`, `IsValid` (non-null, default true)
- `PitchesType` / `PitchesAbbreviation` — pitcher handedness mirror of existing `Bats*`
- `AtBatAthleteSeasonId` / `PitchingAthleteSeasonId` — denormalized primary pitcher/batter for cheap live-UI lookup

### New TPH hierarchy `CompetitionPlayParticipantBase` → `BaseballCompetitionPlayParticipant`
Mirrors the existing `CompetitionPlayBase` / `BaseballCompetitionPlay` pattern: one sport-agnostic table (`CompetitionPlayParticipant`) with EF auto-generating the `Discriminator`. Captures `Order`, `Type`, resolved `AthleteSeasonId` + `PositionId`, and `StatisticsRef` per participant. Registration is sport-scoped (`BaseballDataContext` only) so a sport without a participant subclass doesn't drag the abstract base into its model.

### Resolution semantics
- The play's `participant.athlete.$ref` is **season-scoped** (`/seasons/{year}/athletes/{id}`) — ESPN names the JSON field "athlete" but the URL path tells the truth, so we resolve to `AthleteSeason`, not the global `AthleteBase`. Position resolves to `AthletePosition` the same way.
- Unresolved refs (race during first ingest of a fresh game) persist as `null`. `ApplyUpdateAsync` re-resolves on every re-ingest, so transient nulls heal naturally without a throw-retry storm.
- Unrecognized participant `Type` logs a Seq warning but still persists the row (forward-compat for ESPN taxonomy growth — fielders, runners, substitutions).

### DTO + processor
- `EspnBaseballEventCompetitionPlayDto` grows by the full set of play-level fields ESPN sends: `BatOrder`, `Bats`, `Pitches`, `AtBatPitchNumber`, `PitchCoordinate`, `PitchType`, `PitchVelocity`, `StrikeType`, `HitCoordinate`, `Trajectory`, `Participants[]`, plus the play-result flavor fields.
- New small DTOs `EspnBaseballCoordinateDto`, `EspnBaseballPitchTypeDto`. Shared `EspnEventCompetitionPlayPeriodDto` gains `Type` (Top/Bottom).
- Processor refactor: `BuildParticipantsAsync` resolves the participants list, `ExtractPrimaryAthletes` denormalizes the convenience columns. `ApplyUpdateAsync` replaces the participants set wholesale on re-ingest.

### Migration
Single migration `AddBaseballPlayCanonicalCaptureFields`:
- Eight nullable columns on `CompetitionPlay`.
- `IsValid` non-nullable with `defaultValue: true` so existing rows on the shared TPH table don't break on read.
- New `CompetitionPlayParticipant` table with FK to `CompetitionPlay` + indexes on `(CompetitionPlayId, Type)`, `(AthleteSeasonId)`, and `(PositionId)`.

### Tests
Nine new running tests in `BaseballEventCompetitionPlayDocumentProcessorTests` (replaces three prior `[Skip]` placeholders), using `BaseballDataContext` directly per the established pattern. Covers DTO deserialization, the status-gated publish tri-state, full rich-field capture, athlete + position resolution, race handling, unrecognized-type warning, and the participant-replace update path.

**Suite: 391 passing, 0 failing, 15 skipped** (was 382/0/18).

### Out of scope
Football's `Participants` + `TeamParticipants` arrays remain uncaptured. The shape overlaps on `Participants` but diverges on `TeamParticipants` and is its own PR. Design captured in `docs/baseball-live-data-plan.md`.

## Test plan

- [ ] `dotnet ef database update --context BaseballDataContext` against local Producer DB
- [ ] Replay an in-progress baseball contest via the admin UI; verify SQL spot-check:
  ```sql
  SELECT "Type", "HalfInning", "Outs", "IsValid",
         "BatsAbbreviation", "PitchesAbbreviation",
         "PitchTypeText", "PitchVelocity", "StrikeType",
         "AtBatAthleteSeasonId", "PitchingAthleteSeasonId", "Wallclock"
  FROM "CompetitionPlay"
  WHERE "CompetitionId" = '<game-id>'
  ORDER BY "EspnId" LIMIT 25;
  ```
- [ ] Verify `CompetitionPlayParticipant` table populates:
  ```sql
  SELECT p."Type", p."Order", p."AthleteSeasonId", p."PositionId"
  FROM "CompetitionPlayParticipant" p
  JOIN "CompetitionPlay" cp ON cp."Id" = p."CompetitionPlayId"
  WHERE cp."CompetitionId" = '<game-id>'
  ORDER BY cp."EspnId", p."Order" LIMIT 50;
  ```
  - `start-inning` plays should have zero participants
  - Other plays should have 2 (pitcher + batter)
  - `AthleteSeasonId` populated when the season-scoped athlete has been sourced; null otherwise
- [ ] Confirm Seq shows the `BuildNewPlayAsync` / `ApplyUpdateAsync` log lines with non-null IDs once athletes resolve
- [ ] No regression on existing Football plays (TPH-shared table; verify a recent FB game still reads/writes cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning document for expanding MLB live data capture from ESPN sources.

* **New Features**
  * Enhanced baseball play data capture to include pitch coordinates, pitch types, and velocity information.
  * Expanded participant tracking to resolve and store batter, pitcher, and fielder information for each play.
  * Added support for additional inning-specific play metadata including half-inning tracking and play validity indicators.

* **Tests**
  * Expanded unit test coverage for baseball play processing, including participant resolution and rich scoring field persistence scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/310)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->