### PR TITLE
chore(csp,signalr): CSP Report-Only header + consumer diagnostic logging

### DIFF
--- a/docs/csp-hardening-plan.md
+++ b/docs/csp-hardening-plan.md
@@ -122,97 +122,94 @@ Replacing it with nonces or hashes restores the protection.
 
 ### Current state
 
-The SPA is built with Vite, served as static assets by nginx. After
-`vite build`, the output `index.html` contains:
+The SPA is built with **Create React App** (`react-scripts 5.0.1`),
+served as static assets by nginx. Build output lives under
+`src/UI/sd-ui/build/`.
 
-- A `<script type="module" crossorigin src="/assets/index-XXXX.js">`
-  tag — external, doesn't need nonce/hash.
-- Vite-injected inline module preload + runtime bootstrap blocks —
-  these are the actual reason `'unsafe-inline'` is currently in
-  place.
+Audit of the current production build (`build/index.html`) — **zero
+inline `<script>` tags**. Just two externals:
 
-Plus runtime concerns:
+```html
+<script defer src="https://analytics.sportdeets.com/script.js" ...></script>
+<script defer src="/static/js/main.5b1f5d35.js"></script>
+```
 
-- **Google Maps** (`https://maps.googleapis.com`) injects inline
-  scripts when loaded via the JS API. Already allowed via origin,
-  but worth verifying the injected scripts don't trip CSP.
-- **Firebase auth** opens its iframe with its own script tags
-  (frame-src handles those; not in scope here).
-- **Analytics** loads as an external script tag; no inline.
+The source template (`public/index.html`) also has no inline
+scripts. CRA 5 bundles the webpack runtime into `main.*.js` rather
+than emitting a separate inline runtime chunk, so the standard
+`INLINE_RUNTIME_CHUNK=false` escape hatch isn't even needed here.
 
-### Two approaches
+So **`'unsafe-inline'` is dead permission at the static-asset
+layer**. The remaining question is runtime — whether third-party
+scripts inject inline `<script>` children:
 
-**Approach A: externalize all inline scripts.** Configure Vite to
-emit zero inline scripts (`build.modulePreload.polyfill: false`,
-review the output for any remaining inline blocks). Drop
-`'unsafe-inline'`, add no replacement — `'self'` covers the
-externalized bundle.
+- **Google Maps** loads via `@react-google-maps/api`'s
+  `useLoadScript` hook, which appends a `<script src=…>` tag with
+  origin `https://maps.googleapis.com` (already allowlisted). Once
+  loaded, the Maps JS API *may* inject inline scripts internally.
+  Verify empirically.
+- **Firebase auth** uses an iframe (covered by `frame-src`). The
+  `firebase/*` SDK is bundled into `main.js`, no external load.
+- **Analytics** is the external `script.js` referenced above.
 
-- Pros: simple CSP, no runtime templating, nginx stays a pure
-  static-file server.
-- Cons: needs a build audit; some Vite features (HMR runtime,
-  module preload polyfill) emit inline by default. Some may
-  require switching to hash-based SRI instead of nonces.
+### Approach
 
-**Approach B: per-response nonce.** nginx generates a random nonce
-per request, substitutes it into both the CSP header and every
-inline `<script>` tag in the served `index.html` via
-`ngx_http_sub_module`.
+Because the build emits no inline scripts, no externalization work
+is needed. The plan is a **staged drop** of `'unsafe-inline'`:
 
-- Pros: handles arbitrary inline scripts without rebuilding.
-- Cons: nginx becomes a templating layer for HTML. `index.html`
-  must serve with `Cache-Control: no-store` (a cached nonce is
-  worthless and breaks subsequent loads). Adds attack surface
-  (sub-module misconfig). CDN behavior needs reckoning.
+1. Ship CSP Report-Only alongside the enforcing header — when both
+   are present, browsers enforce the existing header AND report
+   violations against the stricter one. Lets us see what (if
+   anything) trips without breaking prod.
+2. Watch for violations across one or two releases — exercise
+   login, map view, live game updates, every page that touches
+   third-party JS.
+3. If no violations, flip: drop `'unsafe-inline'` from the
+   enforcing header and remove the Report-Only header.
+4. If violations surface, decide per-case: add SHA-256 hash for a
+   known-safe inline, or document the third-party as requiring a
+   targeted exemption.
 
-**Recommendation: Approach A.** Cleaner long-term, fits the static-
-serving model, no per-response state. The audit is the real cost
-and pays back in simpler ops.
+### Plan
 
-### Plan (Approach A)
-
-1. **Audit**. Run `vite build` locally, grep
-   `dist/index.html` for `<script>` tags without `src`. Capture
-   each inline block — count, size, what it does.
-2. **Externalize**. For each inline block, decide:
-   - Module preload polyfill → disable via Vite config; modern
-     browsers handle native module preload.
-   - Vite legacy runtime (if present) → likely not needed for our
-     browser support matrix.
-   - Anything else → move to a separate file under `public/` or
-     `src/` and reference via `<script src="...">`.
-3. **Add SRI hashes** (`integrity` attribute) on the externalized
-   scripts so we can drop `'unsafe-inline'` and add
-   `'sha256-...'` hashes if any inline survives.
-4. **Drop `'unsafe-inline'`** from `script-src` in
-   `security-headers.conf`.
-5. **Test in Firefox + Chromium** — they enforce slightly
-   differently. Verify in CSP report-only mode first
-   (`Content-Security-Policy-Report-Only` for a release or two,
-   then flip to enforcing).
-6. **Verify third parties** still work: Google Maps script
-   injection, Firebase popup, analytics.
+1. **Add Report-Only header** to `security-headers.conf` mirroring
+   the enforcing CSP minus `'unsafe-inline'` from `script-src`. The
+   enforcing header stays unchanged in this step.
+2. **Deploy and watch** — exercise the app in Chromium + Firefox
+   (they enforce slightly differently). Check browser console for
+   `Content-Security-Policy-Report-Only` violations. No `report-uri`
+   endpoint exists today; console inspection is sufficient for a
+   solo-dev product. (Adding a reporting endpoint is a separate
+   follow-up if violations are too noisy to track manually.)
+3. **Verify third-party flows**: Google Maps render, Firebase login
+   popup, analytics script execution. Each should produce zero
+   Report-Only violations.
+4. **Cutover** — once the report-only header has been clean for a
+   release, drop `'unsafe-inline'` from the enforcing `script-src`
+   and remove the Report-Only header.
 
 ### Risks
 
-- **Vite emits more inline than we think.** The audit might find
-  something hard to externalize (HMR runtime in some dev configs,
-  but that's dev-only). Production builds should be cleaner.
-- **A stale CSP without `'unsafe-inline'` while production still
-  serves inline scripts** bricks the app. Use `Content-Security-
-  Policy-Report-Only` for at least one release to surface
-  violations before enforcing.
-- **Third-party scripts injecting inline children**. Google Maps
-  is the prime suspect — when the JS API loads, it can inject
-  `<script>` tags. The origin-allowlist (`https://maps.googleapis.com`)
-  should cover the src=… variant; inline children would need
-  `'unsafe-inline'` or a separate exemption. Verify empirically.
+- **Third-party scripts injecting inline children**. Google Maps is
+  the prime suspect — once loaded, internal modules can inject
+  inline `<script>` blocks. The origin allowlist covers external
+  `src=…` loads but not inline children. The Report-Only watch
+  period catches this before enforcing.
+- **Cached `index.html` after cutover**. Not a real risk here —
+  nginx serves the SPA shell and `index.html` isn't aggressively
+  cached. CSP headers come from the response itself, no
+  build-coupling.
+- **Future inline introductions**. Once enforcing, any future code
+  that does `dangerouslySetInnerHTML` with a `<script>`, or adds
+  inline analytics snippets, will break silently. Document the
+  enforcement in the file header so future contributors know to
+  externalize.
 
 ### Estimate
 
-~1-2 days, mostly audit + verification. Build/config change is
-small. The "release once with report-only, watch for violations,
-then enforce" cadence stretches calendar time across two deploys.
+Half a day for the report-only header + verification, then a
+calendar gap (a release or two) before the cutover. The cutover
+itself is a one-line edit.
 
 ### CodeRabbit reference
 

--- a/docs/csp-hardening-plan.md
+++ b/docs/csp-hardening-plan.md
@@ -8,8 +8,9 @@ is its own coordinated work. This doc captures the plans so future
 sessions don't have to rediscover the context.
 
 CSP source: `src/UI/sd-ui/security-headers.conf`. Served by nginx
-in front of the Vite-built React SPA. Same headers apply in every
-environment because nginx is the only HTTP-layer config we own.
+in front of the CRA-built React SPA (`react-scripts 5.0.1`). Same
+headers apply in every environment because nginx is the only
+HTTP-layer config we own.
 
 ---
 
@@ -67,10 +68,12 @@ complete (other auth-flow consumers may exist).
    nothing to point at and we'd just be shuffling the same literal.
 2. **Define a single env var name** — `FIREBASE_AUTH_DOMAIN` is the
    obvious one. Used everywhere downstream.
-3. **JS client**: Vite's build pipeline already supports
-   `VITE_FIREBASE_AUTH_DOMAIN`. Read it in `firebase.js` instead of
-   the hardcoded string. Set per-environment in the EAS build
-   config and the local `.env.local`.
+3. **JS client**: CRA's build pipeline picks up any `REACT_APP_*`
+   env var at `react-scripts build` time. Read
+   `REACT_APP_FIREBASE_AUTH_DOMAIN` in `firebase.js` instead of the
+   hardcoded string. Set per-environment in `.env.prod` / `.env.dev`
+   (already loaded via the `env-cmd` build scripts in `package.json`)
+   and the local `.env.local`.
 4. **Nginx CSP**: switch to `envsubst` at container entrypoint.
    Rename `security-headers.conf` → `security-headers.conf.template`,
    substitute `${FIREBASE_AUTH_DOMAIN}` at startup, write to the
@@ -89,8 +92,8 @@ complete (other auth-flow consumers may exist).
   suspenders: keep a default value in the template that falls back
   to the dev domain so a missing env var doesn't take down login
   in lower environments.
-- **Caching**: nginx CSP is per-response; no cache issue. Vite
-  bundles the auth domain into JS at build time, so build-time
+- **Caching**: nginx CSP is per-response; no cache issue. CRA
+  bundles `REACT_APP_*` env vars into JS at build time, so build-time
   injection is correct (no runtime fetch).
 
 ### Estimate

--- a/docs/csp-hardening-plan.md
+++ b/docs/csp-hardening-plan.md
@@ -1,0 +1,243 @@
+# CSP hardening plan
+
+Follow-up tracking for two Content-Security-Policy weaknesses
+surfaced by CodeRabbit on PR #311. Both were skipped at the time as
+out-of-scope ("heavy lift") because PR #311 was an at-bat header
+feature with a single-line CSP `wss://` hotfix; full CSP hardening
+is its own coordinated work. This doc captures the plans so future
+sessions don't have to rediscover the context.
+
+CSP source: `src/UI/sd-ui/security-headers.conf`. Served by nginx
+in front of the Vite-built React SPA. Same headers apply in every
+environment because nginx is the only HTTP-layer config we own.
+
+---
+
+## Finding 1 — Parameterize the Firebase auth domain
+
+### Problem
+
+The CSP `frame-src` directive hardcodes the dev Firebase auth
+domain:
+
+```text
+frame-src 'self' https://www.youtube.com https://accounts.google.com
+          https://sportdeets-dev.firebaseapp.com;
+```
+
+Production currently trusts the **dev** Firebase tenant for iframe
+embedding. Firebase auth uses an iframe-based redirect popup, so
+this is load-bearing — without `sportdeets-dev.firebaseapp.com` in
+`frame-src`, login breaks. But it also means a prod page can embed
+a dev tenant frame, which is a (mild) trust boundary leak.
+
+### Existing state
+
+The file's header comment already documents this — has since the
+config landed:
+
+```nginx
+# TODO: When migrating to a production Firebase project, parameterize the Firebase
+# auth domain (sportdeets-dev.firebaseapp.com) across firebase.js, this CSP config,
+# and Program.cs CORS origins. Use envsubst or nginx variable substitution at
+# container startup so all layers share a single FIREBASE_AUTH_DOMAIN env var.
+```
+
+So the team has known about this for a while. The blocker is that
+prod still uses the dev Firebase tenant — the parameterization only
+becomes meaningful once a dedicated prod Firebase project exists.
+
+### Touch points
+
+Three files hardcode `sportdeets-dev.firebaseapp.com` (or related
+literals):
+
+1. `src/UI/sd-ui/security-headers.conf` — CSP `frame-src`.
+2. `src/UI/sd-ui/src/firebase.js` — Firebase client config
+   (`authDomain` field). This is build-time injected today.
+3. `src/SportsData.Api/Program.cs` — CORS allowed origins.
+
+A grep pass at implementation time should verify the list is
+complete (other auth-flow consumers may exist).
+
+### Plan
+
+1. **Provision a prod Firebase project** (or confirm one exists).
+   This is the actual prerequisite — without it the env var has
+   nothing to point at and we'd just be shuffling the same literal.
+2. **Define a single env var name** — `FIREBASE_AUTH_DOMAIN` is the
+   obvious one. Used everywhere downstream.
+3. **JS client**: Vite's build pipeline already supports
+   `VITE_FIREBASE_AUTH_DOMAIN`. Read it in `firebase.js` instead of
+   the hardcoded string. Set per-environment in the EAS build
+   config and the local `.env.local`.
+4. **Nginx CSP**: switch to `envsubst` at container entrypoint.
+   Rename `security-headers.conf` → `security-headers.conf.template`,
+   substitute `${FIREBASE_AUTH_DOMAIN}` at startup, write to the
+   real conf path before nginx boots. Add the env var to the k8s
+   deployment manifest in `sports-data-config`.
+5. **API CORS**: `Program.cs` reads the same env var (via
+   `IConfiguration`). Add to the Azure App Config layer for each
+   environment.
+6. **Verify both flows**: login redirect works in dev and prod, no
+   CSP violation in the browser console after switching domains.
+
+### Risks
+
+- **Hard cutover**: if the env var is unset in any environment,
+  Firebase login redirect frame breaks (CSP blocks). Belt and
+  suspenders: keep a default value in the template that falls back
+  to the dev domain so a missing env var doesn't take down login
+  in lower environments.
+- **Caching**: nginx CSP is per-response; no cache issue. Vite
+  bundles the auth domain into JS at build time, so build-time
+  injection is correct (no runtime fetch).
+
+### Estimate
+
+~half-day of focused work once a prod Firebase project exists. The
+infra-config side (k8s deployment manifest, Azure App Config) is
+the deploy-time risk; the code change is mechanical.
+
+### CodeRabbit reference
+
+PR #311 review thread on `src/UI/sd-ui/security-headers.conf` line 8.
+
+---
+
+## Finding 2 — Remove `'unsafe-inline'` from `script-src`
+
+### Problem
+
+Current `script-src` directive:
+
+```text
+script-src 'self' 'unsafe-inline' https://maps.googleapis.com
+           https://apis.google.com https://analytics.sportdeets.com;
+```
+
+`'unsafe-inline'` defeats most of the CSP XSS protection for
+scripts — any successful HTML injection can execute arbitrary JS.
+Replacing it with nonces or hashes restores the protection.
+
+### Current state
+
+The SPA is built with Vite, served as static assets by nginx. After
+`vite build`, the output `index.html` contains:
+
+- A `<script type="module" crossorigin src="/assets/index-XXXX.js">`
+  tag — external, doesn't need nonce/hash.
+- Vite-injected inline module preload + runtime bootstrap blocks —
+  these are the actual reason `'unsafe-inline'` is currently in
+  place.
+
+Plus runtime concerns:
+
+- **Google Maps** (`https://maps.googleapis.com`) injects inline
+  scripts when loaded via the JS API. Already allowed via origin,
+  but worth verifying the injected scripts don't trip CSP.
+- **Firebase auth** opens its iframe with its own script tags
+  (frame-src handles those; not in scope here).
+- **Analytics** loads as an external script tag; no inline.
+
+### Two approaches
+
+**Approach A: externalize all inline scripts.** Configure Vite to
+emit zero inline scripts (`build.modulePreload.polyfill: false`,
+review the output for any remaining inline blocks). Drop
+`'unsafe-inline'`, add no replacement — `'self'` covers the
+externalized bundle.
+
+- Pros: simple CSP, no runtime templating, nginx stays a pure
+  static-file server.
+- Cons: needs a build audit; some Vite features (HMR runtime,
+  module preload polyfill) emit inline by default. Some may
+  require switching to hash-based SRI instead of nonces.
+
+**Approach B: per-response nonce.** nginx generates a random nonce
+per request, substitutes it into both the CSP header and every
+inline `<script>` tag in the served `index.html` via
+`ngx_http_sub_module`.
+
+- Pros: handles arbitrary inline scripts without rebuilding.
+- Cons: nginx becomes a templating layer for HTML. `index.html`
+  must serve with `Cache-Control: no-store` (a cached nonce is
+  worthless and breaks subsequent loads). Adds attack surface
+  (sub-module misconfig). CDN behavior needs reckoning.
+
+**Recommendation: Approach A.** Cleaner long-term, fits the static-
+serving model, no per-response state. The audit is the real cost
+and pays back in simpler ops.
+
+### Plan (Approach A)
+
+1. **Audit**. Run `vite build` locally, grep
+   `dist/index.html` for `<script>` tags without `src`. Capture
+   each inline block — count, size, what it does.
+2. **Externalize**. For each inline block, decide:
+   - Module preload polyfill → disable via Vite config; modern
+     browsers handle native module preload.
+   - Vite legacy runtime (if present) → likely not needed for our
+     browser support matrix.
+   - Anything else → move to a separate file under `public/` or
+     `src/` and reference via `<script src="...">`.
+3. **Add SRI hashes** (`integrity` attribute) on the externalized
+   scripts so we can drop `'unsafe-inline'` and add
+   `'sha256-...'` hashes if any inline survives.
+4. **Drop `'unsafe-inline'`** from `script-src` in
+   `security-headers.conf`.
+5. **Test in Firefox + Chromium** — they enforce slightly
+   differently. Verify in CSP report-only mode first
+   (`Content-Security-Policy-Report-Only` for a release or two,
+   then flip to enforcing).
+6. **Verify third parties** still work: Google Maps script
+   injection, Firebase popup, analytics.
+
+### Risks
+
+- **Vite emits more inline than we think.** The audit might find
+  something hard to externalize (HMR runtime in some dev configs,
+  but that's dev-only). Production builds should be cleaner.
+- **A stale CSP without `'unsafe-inline'` while production still
+  serves inline scripts** bricks the app. Use `Content-Security-
+  Policy-Report-Only` for at least one release to surface
+  violations before enforcing.
+- **Third-party scripts injecting inline children**. Google Maps
+  is the prime suspect — when the JS API loads, it can inject
+  `<script>` tags. The origin-allowlist (`https://maps.googleapis.com`)
+  should cover the src=… variant; inline children would need
+  `'unsafe-inline'` or a separate exemption. Verify empirically.
+
+### Estimate
+
+~1-2 days, mostly audit + verification. Build/config change is
+small. The "release once with report-only, watch for violations,
+then enforce" cadence stretches calendar time across two deploys.
+
+### CodeRabbit reference
+
+PR #311 review thread on `src/UI/sd-ui/security-headers.conf` line 8.
+
+---
+
+## Sequencing
+
+Finding 1 and Finding 2 are independent. Suggested order:
+
+1. **Finding 1 first** — small, isolated, low rollback risk. Lands
+   alongside the prod Firebase project switch when that happens.
+2. **Finding 2 second** — requires its own report-only watch
+   period before enforcing. Larger calendar footprint but doesn't
+   block #1.
+
+Both should ship as their own PRs labeled `infra` / `security` so
+the rationale is preserved in commit history.
+
+## Reference
+
+- `src/UI/sd-ui/security-headers.conf` — the CSP source.
+- `src/UI/sd-ui/src/firebase.js` — Firebase client config.
+- `src/SportsData.Api/Program.cs` — API CORS origins.
+- PR #311 — landed the `wss://*.service.signalr.net` hotfix; CR
+  comments on `security-headers.conf` line 8 surfaced these two
+  findings.

--- a/src/SportsData.Api/Application/Events/BaseballPlayCompletedHandler.cs
+++ b/src/SportsData.Api/Application/Events/BaseballPlayCompletedHandler.cs
@@ -17,19 +17,31 @@ namespace SportsData.Api.Application.Events
     public class BaseballPlayCompletedHandler : IConsumer<BaseballPlayCompleted>
     {
         private readonly IHubContext<NotificationHub> _hubContext;
+        private readonly ILogger<BaseballPlayCompletedHandler> _logger;
 
-        public BaseballPlayCompletedHandler(IHubContext<NotificationHub> hubContext)
+        public BaseballPlayCompletedHandler(
+            IHubContext<NotificationHub> hubContext,
+            ILogger<BaseballPlayCompletedHandler> logger)
         {
             _hubContext = hubContext;
+            _logger = logger;
         }
 
         public async Task Consume(ConsumeContext<BaseballPlayCompleted> context)
         {
             var msg = context.Message;
 
+            _logger.LogInformation(
+                "BaseballPlayCompleted consume: received. ContestId={ContestId}, PlayId={PlayId}, Inning={Inning} {HalfInning}, CausationId={CausationId}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.PlayId, msg.Inning, msg.HalfInning, msg.CausationId, msg.CorrelationId, context.MessageId);
+
             await _hubContext.Clients
                 .All
                 .SendAsync("BaseballPlayCompleted", msg, context.CancellationToken);
+
+            _logger.LogInformation(
+                "BaseballPlayCompleted consume: SignalR Clients.All.SendAsync completed. ContestId={ContestId}, PlayId={PlayId}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.PlayId, msg.CorrelationId, context.MessageId);
         }
     }
 }

--- a/src/SportsData.Api/Application/Events/ContestStatusChangedHandler.cs
+++ b/src/SportsData.Api/Application/Events/ContestStatusChangedHandler.cs
@@ -18,19 +18,31 @@ namespace SportsData.Api.Application.Events
     public class ContestStatusChangedHandler : IConsumer<ContestStatusChanged>
     {
         private readonly IHubContext<NotificationHub> _hubContext;
+        private readonly ILogger<ContestStatusChangedHandler> _logger;
 
-        public ContestStatusChangedHandler(IHubContext<NotificationHub> hubContext)
+        public ContestStatusChangedHandler(
+            IHubContext<NotificationHub> hubContext,
+            ILogger<ContestStatusChangedHandler> logger)
         {
             _hubContext = hubContext;
+            _logger = logger;
         }
 
         public async Task Consume(ConsumeContext<ContestStatusChanged> context)
         {
             var msg = context.Message;
 
+            _logger.LogInformation(
+                "ContestStatusChanged consume: received. ContestId={ContestId}, Status={Status}, Sport={Sport}, CausationId={CausationId}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.Status, msg.Sport, msg.CausationId, msg.CorrelationId, context.MessageId);
+
             await _hubContext.Clients
                 .All // ← simple, global broadcast for now
                 .SendAsync("ContestStatusChanged", msg, context.CancellationToken);
+
+            _logger.LogInformation(
+                "ContestStatusChanged consume: SignalR Clients.All.SendAsync completed. ContestId={ContestId}, Status={Status}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.Status, msg.CorrelationId, context.MessageId);
         }
     }
 }

--- a/src/SportsData.Api/Application/Events/FootballPlayCompletedHandler.cs
+++ b/src/SportsData.Api/Application/Events/FootballPlayCompletedHandler.cs
@@ -17,19 +17,31 @@ namespace SportsData.Api.Application.Events
     public class FootballPlayCompletedHandler : IConsumer<FootballPlayCompleted>
     {
         private readonly IHubContext<NotificationHub> _hubContext;
+        private readonly ILogger<FootballPlayCompletedHandler> _logger;
 
-        public FootballPlayCompletedHandler(IHubContext<NotificationHub> hubContext)
+        public FootballPlayCompletedHandler(
+            IHubContext<NotificationHub> hubContext,
+            ILogger<FootballPlayCompletedHandler> logger)
         {
             _hubContext = hubContext;
+            _logger = logger;
         }
 
         public async Task Consume(ConsumeContext<FootballPlayCompleted> context)
         {
             var msg = context.Message;
 
+            _logger.LogInformation(
+                "FootballPlayCompleted consume: received. ContestId={ContestId}, PlayId={PlayId}, Period={Period}, Clock={Clock}, CausationId={CausationId}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.PlayId, msg.Period, msg.Clock, msg.CausationId, msg.CorrelationId, context.MessageId);
+
             await _hubContext.Clients
                 .All
                 .SendAsync("FootballPlayCompleted", msg, context.CancellationToken);
+
+            _logger.LogInformation(
+                "FootballPlayCompleted consume: SignalR Clients.All.SendAsync completed. ContestId={ContestId}, PlayId={PlayId}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.PlayId, msg.CorrelationId, context.MessageId);
         }
     }
 }

--- a/src/UI/sd-ui/security-headers.conf
+++ b/src/UI/sd-ui/security-headers.conf
@@ -3,9 +3,17 @@
 # auth domain (sportdeets-dev.firebaseapp.com) across firebase.js, this CSP config,
 # and Program.cs CORS origins. Use envsubst or nginx variable substitution at
 # container startup so all layers share a single FIREBASE_AUTH_DOMAIN env var.
+#
+# CSP hardening: the enforcing header still allows 'unsafe-inline' in script-src
+# for safety. The Report-Only header below mirrors the enforcing policy but
+# drops 'unsafe-inline' — browsers will log violations to the console without
+# blocking. After a release or two with zero violations across login, map view,
+# and live game flows, drop 'unsafe-inline' from the enforcing header and
+# remove the Report-Only header. See docs/csp-hardening-plan.md.
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets-dev.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
+add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets-dev.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;


### PR DESCRIPTION
## Summary

Two threads bundled together on this branch:

### CSP hardening (Finding 2 from `docs/csp-hardening-plan.md`)
- Audited CRA production build (`src/UI/sd-ui/build/`): zero inline `<script>` tags; webpack runtime is bundled into `main.*.js` rather than emitted as a separate inline chunk. `'unsafe-inline'` in `script-src` is dead permission at the static-asset layer.
- Added a `Content-Security-Policy-Report-Only` header mirroring the enforcing CSP minus `'unsafe-inline'` from `script-src`. Enforcing header stays unchanged, so prod is safe — browsers will console-log any violations from third-party JS (Google Maps, Firebase, analytics) before we flip the enforcing header.
- Updated the plan doc: corrected the initial Vite assumption (project is Create React App `react-scripts 5.0.1`), rewrote Finding 2 as a staged drop instead of an externalize-then-drop given the build is already inline-free.

### SignalR diagnostic logging (live replay events not reaching prod browser)
- `BaseballPlayCompletedHandler`, `FootballPlayCompletedHandler`, and `ContestStatusChangedHandler` each now log on consume entry and again after `Clients.All.SendAsync` returns. Captures ContestId, PlayId/Status, CorrelationId, MessageId, CausationId.
- Working theory: prod Producer Worker writes replay events to its EF outbox (Seq shows the `"BaseballReplay: published ..."` entries) but they may not be reaching the prod API consumer. The new consumer-side logs split the question:
  - **Consume logs present in Seq for the replay's `CorrelationId`** → broker leg works, broadcast is happening but the prod browser still isn't seeing it (look at hub-side: auth/JWT, group membership, serializer).
  - **No consume logs** → broker leg is broken. Most likely candidate is a `CommonConfig:AzureServiceBusConnectionString` mismatch between the `Prod.BaseballMlb.Producer` and `Prod.All.Api` App Config labels.
- WebSocket URL spot-check ruled out the SignalR backplane theory: prod browser is on `sportdeets-prod.service.signalr.net`, local browser on `sportdeets-dev.service.signalr.net`. Debug-card path works in prod, so the prod API pod is already broadcasting to the right backplane.

## Test plan

- [x] `dotnet build src/SportsData.Api` — zero errors
- [x] `dotnet test test/unit/SportsData.Api.Tests.Unit` — only the pre-existing `DisplayNameGenerator` failure unrelated to this branch
- [ ] Deploy to prod, run `POST /admin/baseball/contests/{id}/replay` against a known-good MLB contest, check Seq for `BaseballPlayCompleted consume: received` entries matching the replay's `CorrelationId`
- [ ] Confirm the Report-Only header lands in prod browser response headers (DevTools → Network → any response from `sportdeets.com`)
- [ ] Watch the browser console across login, map view, and any live-game flow for `Content-Security-Policy-Report-Only` violations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CSP hardening plan documenting staged security improvements, including parameterizing Firebase auth domain and removing unsafe-inline from script-src directives.

* **New Features**
  * Introduced Content-Security-Policy-Report-Only header to enable validation of security policy changes before full enforcement.

* **Chores**
  * Enhanced event handler observability with structured logging for improved debugging and monitoring capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/312)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->