### PR TITLE
fix(producer): direct-publish from BaseballContestReplayService

### DIFF
--- a/src/SportsData.Producer/Application/Contests/BaseballContestReplayService.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestReplayService.cs
@@ -35,15 +35,18 @@ namespace SportsData.Producer.Application.Contests
         private readonly ILogger<BaseballContestReplayService> _logger;
         private readonly BaseballDataContext _dataContext;
         private readonly IEventBus _eventBus;
+        private readonly IMessageDeliveryScope _deliveryScope;
 
         public BaseballContestReplayService(
             ILogger<BaseballContestReplayService> logger,
             BaseballDataContext dataContext,
-            IEventBus eventBus)
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope)
         {
             _logger = logger;
             _dataContext = dataContext;
             _eventBus = eventBus;
+            _deliveryScope = deliveryScope;
         }
 
         public async Task ReplayContest(
@@ -93,6 +96,16 @@ namespace SportsData.Producer.Application.Contests
 
                 await _dataContext.SaveChangesAsync(ct);
 
+                // Replay re-emits stored data through the same SignalR
+                // fan-out path as a live game. It is an admin tool, not a
+                // real-time ingestion pipeline, and does not need the EF
+                // outbox's at-least-once safety. Use DeliveryMode.Direct
+                // so messages go straight to the broker — bypassing a
+                // role-split outbox-dispatch issue in prod where Worker
+                // pod outbox rows were not being delivered to the API
+                // consumer (see PR #312 diagnostic logs).
+                using var _directDelivery = _deliveryScope.Use(DeliveryMode.Direct);
+
                 // Lifecycle bookend — Scheduled→InProgress. Sport-neutral.
                 await _eventBus.Publish(new ContestStatusChanged(
                     contestId,
@@ -103,8 +116,6 @@ namespace SportsData.Producer.Application.Contests
                     correlationId,
                     CausationId.Producer.EventCompetitionStatusDocumentProcessor
                 ), ct);
-
-                await _dataContext.SaveChangesAsync(ct);
 
                 _logger.LogInformation(
                     "BaseballReplay: published ContestStatusChanged=InProgress. ContestId={ContestId}, CorrelationId={CorrelationId}",
@@ -189,8 +200,6 @@ namespace SportsData.Producer.Application.Contests
                         CorrelationId: correlationId,
                         CausationId: CausationId.Producer.EventCompetitionStatusDocumentProcessor
                     ), ct);
-
-                    await _dataContext.SaveChangesAsync(ct);
 
                     emittedCount++;
                     _logger.LogInformation(


### PR DESCRIPTION
## Summary

Post-deploy of PR #312 in prod: Producer-side `"BaseballReplay: published BaseballPlayCompleted"` entries land in Seq, but **none** of the corresponding `"BaseballPlayCompleted consume: received"` entries on the API side ever appear. The outbox-published replay messages from the prod Worker pod aren't reaching the API consumer. Locally everything works because the dev Producer runs all three roles (Api+Ingest+Worker) in one pod.

Replay is an admin tool that re-emits already-stored data through the SignalR fan-out path. It does not need the EF outbox's at-least-once safety. Wrapping the publish loop in `IMessageDeliveryScope.Use(DeliveryMode.Direct)` makes it go straight to the broker — the same pattern the Admin SignalR-debug endpoints already use, which do work in prod.

## Changes

- Inject `IMessageDeliveryScope` into `BaseballContestReplayService`.
- `using var _directDelivery = _deliveryScope.Use(DeliveryMode.Direct);` at the top of the try block, after the `FinalizedUtc = null` save. Scope lives for the rest of the try.
- Drop the two outbox-flush `SaveChangesAsync` calls (after `ContestStatusChanged` publish, and per-play in the loop). Both existed only to commit outbox rows; direct publish has nothing to commit. Legitimate state-change saves (`FinalizedUtc = null` and the `finally`-block restore) are unchanged.
- `FootballContestReplayService` intentionally left alone until the baseball fix is verified in prod.

## Test plan

- [x] `dotnet build src/SportsData.Producer` — zero errors
- [ ] Local replay against a known-good MLB contest — confirm browser still receives plays (regression check on the local-works path)
- [ ] After deploy: prod replay — confirm `BaseballPlayCompleted consume: received` entries now land in Seq with matching `CorrelationId`, and MatchupCard updates in the prod browser

## Notes

- The replay now paces at ~2 sec/play (`EventBusAdapter.Publish` has a hardcoded 1s pre-publish delay in Direct mode + the loop's existing 1s `Task.Delay`). A ~639-play game will run ~21 min instead of ~11. Acceptable for an admin tool; left alone per directive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event routing during contest replay operations for more reliable event delivery.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/313)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->