### PR TITLE
feat(admin,football): NCAAFB/NFL matchup harness + replay parity with baseball

### DIFF
--- a/docker-compose.local.ncaa.yml
+++ b/docker-compose.local.ncaa.yml
@@ -1,0 +1,194 @@
+# Local dev compose tailored for NCAAFB in-season testing.
+#
+# Difference from docker-compose.local.mlb.yml:
+#   - NCAA:        ONE Producer container, -mode FootballNcaa, no -role flag
+#                  ONE Provider container, -mode FootballNcaa, no -role flag
+#   - NFL / MLB:   API-only Producer containers (sport-scoped, no Ingest/Worker)
+#
+# Why -mode is required even though the flag defaults to Sport.All: the runtime
+# sport switches in Producer/Provider Program.cs throw ArgumentOutOfRangeException
+# when mode is Sport.All. The unhandled managed exception terminates the process
+# with exit code 1 at startup if you omit the flag.
+# Role *can* be omitted — it defaults to All and activates every role branch
+# via HasFlag checks, giving us api+ingest+worker in a single container.
+# Single-process All is required for admin/contest replay: ContestController
+# (Api role) enqueues a Hangfire job that only the Worker role executes, so
+# api-only Producers will accept the request and silently park the job.
+#
+# Usage:
+#   docker compose -f docker-compose.local.ncaa.yml up --build
+#
+# Prerequisites: same as docker-compose.local.yml (host PostgreSQL, RabbitMQ,
+# Seq, plus the .env file with APPCONFIG_CONNSTR / PG_CONNSTR / AZURE_*).
+#
+# Ports:
+#   API                http://localhost:5262
+#   Producer NFL API   http://localhost:7040
+#   Producer MLB API   http://localhost:7041
+#   Producer NCAA      http://localhost:7042 (api + ingest + worker, football schema)
+#   Provider NCAA      http://localhost:7050 (all roles)
+
+x-common-env: &common-env
+  APPCONFIG_CONNSTR: ${APPCONFIG_CONNSTR}
+  APPCONFIG_LABEL: Local
+  ASPNETCORE_ENVIRONMENT: Development
+  ASPNETCORE_HTTP_PORTS: "8080"
+  AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+  AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+  AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+  CommonConfig__SqlBaseConnectionString: ${PG_CONNSTR}
+  CommonConfig__SeqUri: http://host.docker.internal:5341/
+  CommonConfig__Messaging__RabbitMq__Host: host.docker.internal
+  CommonConfig__Messaging__RabbitMq__ManagementApiBaseUrl: http://host.docker.internal:15672
+  # MongoDB runs on the host (Bender, not in Docker). The Provider's
+  # ProviderDocDatabaseConfig.ConnectionString is read from Azure App Config's
+  # Local label and is bound as the *host only* — the value in KV is just
+  # `localhost` for native VS debug. Inside a container that resolves to the
+  # container itself, so we override via the bridge alias. Bare hostname,
+  # NO port: MongoDocumentService passes this to `new MongoServerAddress(host)`
+  # which treats the entire string as the host and defaults port to 27017
+  # internally; appending `:27017` produces the invalid endpoint
+  # `host.docker.internal:27017:27017`.
+  # User/Password come from App Config separately and don't need overriding.
+  SportsData.Provider__ProviderDocDatabaseConfig__ConnectionString: host.docker.internal
+
+# Reused by every Producer + Provider service.
+#
+# IMPORTANT: This probe relies on bash's `/dev/tcp` pseudo-device — bash MUST
+# be present in the base image. Today every service builds on
+# `mcr.microsoft.com/dotnet/aspnet:10.0-noble`, which ships bash; the probe
+# was chosen specifically because that image ships *neither* curl *nor*
+# wget. If the base image is ever swapped to a chiseled / alpine / distroless
+# variant (none of which ship bash), this probe must be replaced — options:
+#   - install curl in the Dockerfile and use `curl -fsS http://127.0.0.1:8080/api/health/live`
+#   - use the dotnet runtime's `/api/health/live` endpoint via a dedicated
+#     healthcheck binary copied into the image
+#   - revert to a longer `start_period` and let dependent services tolerate
+#     missing healthchecks
+x-service-healthcheck: &service-healthcheck
+  test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/127.0.0.1/8080"]
+  interval: 5s
+  timeout: 3s
+  retries: 12
+  start_period: 20s
+
+services:
+  # ─── NFL Producer API (sport-scoped, single role) ───────────────────────────
+  producer-nfl-api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-nfl-api
+    ports:
+      - "7040:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "FootballNfl", "-role", "Api"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── MLB Producer API (sport-scoped, single role) ───────────────────────────
+  producer-mlb-api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-mlb-api
+    ports:
+      - "7041:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "BaseballMlb", "-role", "Api"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── NCAA Producer (-mode FootballNcaa, role defaults to All) ───────────────
+  # Single container handles API + Ingest + Worker for NCAA. -role omitted →
+  # ProducerRole.All → every HasFlag branch (Api, Ingest, Worker) activates.
+  # Required for admin contest-replay — the Hangfire job lives in the Worker
+  # role.
+  producer-ncaa:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-ncaa
+    ports:
+      - "7042:8080"
+    environment:
+      <<: *common-env
+      # Provider's local-dev URL in App Config is http://localhost:5205/api/.
+      # Inside this container localhost is the container itself, so calls to
+      # Provider (e.g. ProviderClient.GetExternalImage during image processing)
+      # would refuse-connect. Route to the Provider container via Docker DNS.
+      CommonConfig__ProviderClientConfig__ApiUrl: http://provider-ncaa:8080/api/
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "FootballNcaa"]
+    healthcheck: *service-healthcheck
+    # Producer's image-fetch path (ProviderClient.GetExternalImage) hits
+    # provider-ncaa during startup-warmed Hangfire jobs. Wait for the Provider
+    # to pass its healthcheck before starting Producer so we don't pile up
+    # retries against a not-yet-ready Provider on cold compose-up.
+    depends_on:
+      provider-ncaa:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── NCAA Provider (-mode FootballNcaa, role defaults to All) ───────────────
+  # One container handles ESPN sourcing + DocumentRequested fan-out for NCAA.
+  provider-ncaa:
+    build:
+      context: .
+      dockerfile: src/SportsData.Provider/Dockerfile
+    container_name: provider-ncaa
+    ports:
+      - "7050:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Provider.dll", "-mode", "FootballNcaa"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── API (sport-keyed client URLs route per-sport requests) ─────────────────
+  api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Api/Dockerfile
+    container_name: api-all
+    ports:
+      - "5262:8080"
+    environment:
+      <<: *common-env
+      CommonConfig__ContestClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa:8080/api/
+      CommonConfig__ContestClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__ContestClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__FranchiseClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa:8080/api/
+      CommonConfig__FranchiseClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__FranchiseClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__ProducerClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa:8080/api/
+      CommonConfig__ProducerClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__ProducerClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__SeasonClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa:8080/api/
+      CommonConfig__SeasonClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__SeasonClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__VenueClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa:8080/api/
+      CommonConfig__VenueClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__VenueClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__PlayerClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa:8080/api/
+      CommonConfig__PlayerClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__PlayerClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__NotificationClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa:8080/api/
+      CommonConfig__NotificationClientConfig__FootballNfl__ApiUrl: http://producer-nfl-api:8080/api/
+      CommonConfig__NotificationClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+    depends_on:
+      producer-nfl-api:
+        condition: service_healthy
+      producer-mlb-api:
+        condition: service_healthy
+      producer-ncaa:
+        condition: service_healthy
+      provider-ncaa:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker-compose.local.nfl.yml
+++ b/docker-compose.local.nfl.yml
@@ -1,0 +1,194 @@
+# Local dev compose tailored for NFL in-season testing.
+#
+# Difference from docker-compose.local.mlb.yml:
+#   - NFL:         ONE Producer container, -mode FootballNfl, no -role flag
+#                  ONE Provider container, -mode FootballNfl, no -role flag
+#   - NCAA / MLB:  API-only Producer containers (sport-scoped, no Ingest/Worker)
+#
+# Why -mode is required even though the flag defaults to Sport.All: the runtime
+# sport switches in Producer/Provider Program.cs throw ArgumentOutOfRangeException
+# when mode is Sport.All. The unhandled managed exception terminates the process
+# with exit code 1 at startup if you omit the flag.
+# Role *can* be omitted — it defaults to All and activates every role branch
+# via HasFlag checks, giving us api+ingest+worker in a single container.
+# Single-process All is required for admin/contest replay: ContestController
+# (Api role) enqueues a Hangfire job that only the Worker role executes, so
+# api-only Producers will accept the request and silently park the job.
+#
+# Usage:
+#   docker compose -f docker-compose.local.nfl.yml up --build
+#
+# Prerequisites: same as docker-compose.local.yml (host PostgreSQL, RabbitMQ,
+# Seq, plus the .env file with APPCONFIG_CONNSTR / PG_CONNSTR / AZURE_*).
+#
+# Ports:
+#   API                http://localhost:5262
+#   Producer NCAA API  http://localhost:7040
+#   Producer MLB API   http://localhost:7041
+#   Producer NFL       http://localhost:7042 (api + ingest + worker, football schema)
+#   Provider NFL       http://localhost:7050 (all roles)
+
+x-common-env: &common-env
+  APPCONFIG_CONNSTR: ${APPCONFIG_CONNSTR}
+  APPCONFIG_LABEL: Local
+  ASPNETCORE_ENVIRONMENT: Development
+  ASPNETCORE_HTTP_PORTS: "8080"
+  AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+  AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+  AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+  CommonConfig__SqlBaseConnectionString: ${PG_CONNSTR}
+  CommonConfig__SeqUri: http://host.docker.internal:5341/
+  CommonConfig__Messaging__RabbitMq__Host: host.docker.internal
+  CommonConfig__Messaging__RabbitMq__ManagementApiBaseUrl: http://host.docker.internal:15672
+  # MongoDB runs on the host (Bender, not in Docker). The Provider's
+  # ProviderDocDatabaseConfig.ConnectionString is read from Azure App Config's
+  # Local label and is bound as the *host only* — the value in KV is just
+  # `localhost` for native VS debug. Inside a container that resolves to the
+  # container itself, so we override via the bridge alias. Bare hostname,
+  # NO port: MongoDocumentService passes this to `new MongoServerAddress(host)`
+  # which treats the entire string as the host and defaults port to 27017
+  # internally; appending `:27017` produces the invalid endpoint
+  # `host.docker.internal:27017:27017`.
+  # User/Password come from App Config separately and don't need overriding.
+  SportsData.Provider__ProviderDocDatabaseConfig__ConnectionString: host.docker.internal
+
+# Reused by every Producer + Provider service.
+#
+# IMPORTANT: This probe relies on bash's `/dev/tcp` pseudo-device — bash MUST
+# be present in the base image. Today every service builds on
+# `mcr.microsoft.com/dotnet/aspnet:10.0-noble`, which ships bash; the probe
+# was chosen specifically because that image ships *neither* curl *nor*
+# wget. If the base image is ever swapped to a chiseled / alpine / distroless
+# variant (none of which ship bash), this probe must be replaced — options:
+#   - install curl in the Dockerfile and use `curl -fsS http://127.0.0.1:8080/api/health/live`
+#   - use the dotnet runtime's `/api/health/live` endpoint via a dedicated
+#     healthcheck binary copied into the image
+#   - revert to a longer `start_period` and let dependent services tolerate
+#     missing healthchecks
+x-service-healthcheck: &service-healthcheck
+  test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/127.0.0.1/8080"]
+  interval: 5s
+  timeout: 3s
+  retries: 12
+  start_period: 20s
+
+services:
+  # ─── NCAA Producer API (sport-scoped, single role) ──────────────────────────
+  producer-ncaa-api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-ncaa-api
+    ports:
+      - "7040:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "FootballNcaa", "-role", "Api"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── MLB Producer API (sport-scoped, single role) ───────────────────────────
+  producer-mlb-api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-mlb-api
+    ports:
+      - "7041:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "BaseballMlb", "-role", "Api"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── NFL Producer (-mode FootballNfl, role defaults to All) ─────────────────
+  # Single container handles API + Ingest + Worker for NFL. -role omitted →
+  # ProducerRole.All → every HasFlag branch (Api, Ingest, Worker) activates.
+  # Required for admin contest-replay — the Hangfire job lives in the Worker
+  # role.
+  producer-nfl:
+    build:
+      context: .
+      dockerfile: src/SportsData.Producer/Dockerfile
+    container_name: producer-nfl
+    ports:
+      - "7042:8080"
+    environment:
+      <<: *common-env
+      # Provider's local-dev URL in App Config is http://localhost:5205/api/.
+      # Inside this container localhost is the container itself, so calls to
+      # Provider (e.g. ProviderClient.GetExternalImage during image processing)
+      # would refuse-connect. Route to the Provider container via Docker DNS.
+      CommonConfig__ProviderClientConfig__ApiUrl: http://provider-nfl:8080/api/
+    command: ["dotnet", "SportsData.Producer.dll", "-mode", "FootballNfl"]
+    healthcheck: *service-healthcheck
+    # Producer's image-fetch path (ProviderClient.GetExternalImage) hits
+    # provider-nfl during startup-warmed Hangfire jobs. Wait for the Provider
+    # to pass its healthcheck before starting Producer so we don't pile up
+    # retries against a not-yet-ready Provider on cold compose-up.
+    depends_on:
+      provider-nfl:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── NFL Provider (-mode FootballNfl, role defaults to All) ─────────────────
+  # One container handles ESPN sourcing + DocumentRequested fan-out for NFL.
+  provider-nfl:
+    build:
+      context: .
+      dockerfile: src/SportsData.Provider/Dockerfile
+    container_name: provider-nfl
+    ports:
+      - "7050:8080"
+    environment:
+      <<: *common-env
+    command: ["dotnet", "SportsData.Provider.dll", "-mode", "FootballNfl"]
+    healthcheck: *service-healthcheck
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ─── API (sport-keyed client URLs route per-sport requests) ─────────────────
+  api:
+    build:
+      context: .
+      dockerfile: src/SportsData.Api/Dockerfile
+    container_name: api-all
+    ports:
+      - "5262:8080"
+    environment:
+      <<: *common-env
+      CommonConfig__ContestClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__ContestClientConfig__FootballNfl__ApiUrl: http://producer-nfl:8080/api/
+      CommonConfig__ContestClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__FranchiseClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__FranchiseClientConfig__FootballNfl__ApiUrl: http://producer-nfl:8080/api/
+      CommonConfig__FranchiseClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__ProducerClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__ProducerClientConfig__FootballNfl__ApiUrl: http://producer-nfl:8080/api/
+      CommonConfig__ProducerClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__SeasonClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__SeasonClientConfig__FootballNfl__ApiUrl: http://producer-nfl:8080/api/
+      CommonConfig__SeasonClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__VenueClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__VenueClientConfig__FootballNfl__ApiUrl: http://producer-nfl:8080/api/
+      CommonConfig__VenueClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__PlayerClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__PlayerClientConfig__FootballNfl__ApiUrl: http://producer-nfl:8080/api/
+      CommonConfig__PlayerClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+      CommonConfig__NotificationClientConfig__FootballNcaa__ApiUrl: http://producer-ncaa-api:8080/api/
+      CommonConfig__NotificationClientConfig__FootballNfl__ApiUrl: http://producer-nfl:8080/api/
+      CommonConfig__NotificationClientConfig__BaseballMlb__ApiUrl: http://producer-mlb-api:8080/api/
+    depends_on:
+      producer-ncaa-api:
+        condition: service_healthy
+      producer-mlb-api:
+        condition: service_healthy
+      producer-nfl:
+        condition: service_healthy
+      provider-nfl:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -245,6 +245,31 @@ namespace SportsData.Api.Application.Admin
             return result.ToActionResult();
         }
 
+        /// <summary>
+        /// Football twin of <see cref="GetBaseballMatchupForContest"/>. Returns one
+        /// canonical NCAA/NFL matchup in the same shape as the picks page so the
+        /// football SignalR debug page can render a real MatchupCard for a chosen
+        /// contest. League-context fields (Predictions, AiWinner, IsPreview*,
+        /// HeadLine) are intentionally null/empty.
+        /// </summary>
+        [HttpGet]
+        [Route("football/contests/{contestId:guid}/matchup")]
+        public async Task<ActionResult<LeagueWeekMatchupsDto.MatchupForPickDto>> GetFootballMatchupForContest(
+            [FromRoute] Guid contestId,
+            [FromQuery] string? league,
+            [FromServices] IGetMatchupForContestQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            // Mirrors ReplayFootballContest's routing: NCAA default, NFL when league=nfl.
+            var sport = string.Equals(league, "nfl", StringComparison.OrdinalIgnoreCase)
+                ? Sport.FootballNfl
+                : Sport.FootballNcaa;
+
+            var query = new GetMatchupForContestQuery(contestId, sport);
+            var result = await handler.ExecuteAsync(query, cancellationToken);
+            return result.ToActionResult();
+        }
+
         [HttpPost]
         [Route("football/contests/{contestId:guid}/replay")]
         public async Task<ActionResult<bool>> ReplayFootballContest(

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -23,6 +23,7 @@ using SportsData.Api.Infrastructure.Data.Canonical.Models;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Common.Mapping;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Eventing.Events.Contests.Baseball;
@@ -256,14 +257,14 @@ namespace SportsData.Api.Application.Admin
         [Route("football/contests/{contestId:guid}/matchup")]
         public async Task<ActionResult<LeagueWeekMatchupsDto.MatchupForPickDto>> GetFootballMatchupForContest(
             [FromRoute] Guid contestId,
-            [FromQuery] string? league,
-            [FromServices] IGetMatchupForContestQueryHandler handler,
-            CancellationToken cancellationToken)
+            [FromQuery] string league = "ncaa",
+            [FromServices] IGetMatchupForContestQueryHandler handler = default!,
+            CancellationToken cancellationToken = default)
         {
-            // Mirrors ReplayFootballContest's routing: NCAA default, NFL when league=nfl.
-            var sport = string.Equals(league, "nfl", StringComparison.OrdinalIgnoreCase)
-                ? Sport.FootballNfl
-                : Sport.FootballNcaa;
+            // API runs in Sport.All; route encodes the sport (football), the
+            // league query param distinguishes NCAA vs NFL. ModeMapper is the
+            // canonical place for sport+league → Sport resolution.
+            var sport = ModeMapper.ResolveMode("football", league);
 
             var query = new GetMatchupForContestQuery(contestId, sport);
             var result = await handler.ExecuteAsync(query, cancellationToken);
@@ -274,16 +275,16 @@ namespace SportsData.Api.Application.Admin
         [Route("football/contests/{contestId:guid}/replay")]
         public async Task<ActionResult<bool>> ReplayFootballContest(
             [FromRoute] Guid contestId,
-            [FromQuery] string? league,
-            [FromServices] IContestClientFactory contestClientFactory,
-            CancellationToken cancellationToken)
+            [FromQuery] string league = "ncaa",
+            [FromServices] IContestClientFactory contestClientFactory = default!,
+            CancellationToken cancellationToken = default)
         {
-            // Football has two leagues sharing the FootballDataContext (NCAA + NFL).
-            // The replay client routing is per-sport, so either NCAA or NFL resolves
-            // the same Producer pod; default to NCAA when caller doesn't specify.
-            var sport = string.Equals(league, "nfl", StringComparison.OrdinalIgnoreCase)
-                ? Sport.FootballNfl
-                : Sport.FootballNcaa;
+            // API runs in Sport.All; route encodes the sport (football), the
+            // league query param distinguishes NCAA vs NFL. Football's two
+            // leagues share the FootballDataContext so either resolves the
+            // same Producer pod, but we still need a concrete Sport enum to
+            // route the client factory.
+            var sport = ModeMapper.ResolveMode("football", league);
 
             var result = await contestClientFactory
                 .Resolve(sport)

--- a/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
@@ -29,15 +29,18 @@ namespace SportsData.Producer.Application.Contests
         private readonly ILogger<FootballContestReplayService> _logger;
         private readonly FootballDataContext _dataContext;
         private readonly IEventBus _eventBus;
+        private readonly IMessageDeliveryScope _deliveryScope;
 
         public FootballContestReplayService(
             ILogger<FootballContestReplayService> logger,
             FootballDataContext dataContext,
-            IEventBus eventBus)
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope)
         {
             _logger = logger;
             _dataContext = dataContext;
             _eventBus = eventBus;
+            _deliveryScope = deliveryScope;
         }
 
         public async Task ReplayContest(
@@ -88,6 +91,16 @@ namespace SportsData.Producer.Application.Contests
 
                 await _dataContext.SaveChangesAsync(ct);
 
+                // Replay re-emits stored data through the same SignalR
+                // fan-out path as a live game. It is an admin tool, not a
+                // real-time ingestion pipeline, and does not need the EF
+                // outbox's at-least-once safety. Use DeliveryMode.Direct
+                // so messages go straight to the broker — bypassing a
+                // role-split outbox-dispatch issue in prod where Worker
+                // pod outbox rows were not being delivered to the API
+                // consumer (mirror of the baseball fix in PR #313).
+                using var _directDelivery = _deliveryScope.Use(DeliveryMode.Direct);
+
                 // Lifecycle bookend — Scheduled→InProgress. Sport-neutral.
                 await _eventBus.Publish(new ContestStatusChanged(
                     contestId,
@@ -98,8 +111,6 @@ namespace SportsData.Producer.Application.Contests
                     correlationId,
                     CausationId.Producer.EventCompetitionStatusDocumentProcessor
                 ), ct);
-
-                await _dataContext.SaveChangesAsync(ct);
 
                 _logger.LogInformation(
                     "FootballReplay: published ContestStatusChanged=InProgress. ContestId={ContestId}, CorrelationId={CorrelationId}",
@@ -161,8 +172,6 @@ namespace SportsData.Producer.Application.Contests
                         CorrelationId: correlationId,
                         CausationId: CausationId.Producer.EventCompetitionStatusDocumentProcessor
                     ), ct);
-
-                    await _dataContext.SaveChangesAsync(ct);
 
                     emittedCount++;
                     _logger.LogInformation(

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -19,6 +19,10 @@ const AdminApi = {
   // IsPreview*, HeadLine) come back null/empty per the endpoint contract.
   getBaseballMatchupForContest: (contestId) =>
     apiClient.get(`/admin/baseball/contests/${contestId}/matchup`),
+  getFootballMatchupForContest: (contestId, league) =>
+    apiClient.get(`/admin/football/contests/${contestId}/matchup`, {
+      params: league ? { league } : undefined,
+    }),
 
   // Triggers a contest replay through the matching sport's Producer.
   // Producer enqueues the work and the bus emits ContestStatusChanged

--- a/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx
@@ -136,7 +136,7 @@ export default function AdminBaseballPage() {
     <div className="admin-page">
       <AdminHeader />
 
-      <div className="admin-baseball-debug-grid">
+      <div className="admin-sport-debug-grid">
         {/* Left column — the observer: pick a contest, render its MatchupCard */}
         <section className="admin-baseball-matchup-debug">
           <form onSubmit={handleSubmit} style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>

--- a/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
@@ -145,9 +145,9 @@ export default function AdminFootballPage() {
   return (
     <div className="admin-page">
       <AdminHeader />
-      <a href="https://messaging-footballncaa.sportdeets.com/#/" target="_blank">Rabbit - NCAAFB</a>
+      <a href="https://messaging-footballncaa.sportdeets.com/#/" target="_blank" rel="noreferrer">Rabbit - NCAAFB</a>
       <br/>
-      <a href="https://messaging-footballnfl.sportdeets.com/#/" target="_blank">Rabbit - NFL</a>
+      <a href="https://messaging-footballnfl.sportdeets.com/#/" target="_blank" rel="noreferrer">Rabbit - NFL</a>
       <div className="admin-sport-debug-grid">
         {/* Left column — the observer: pick a contest, render its MatchupCard */}
         <section className="admin-football-matchup-debug">

--- a/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
@@ -27,9 +27,13 @@ const LEAGUE_OPTIONS = [
  * to localStorage so reloads keep the last values.
  */
 export default function AdminFootballPage() {
-  const [league, setLeague] = useState(
-    () => localStorage.getItem(LEAGUE_STORAGE_KEY) ?? 'ncaa'
-  );
+  const [league, setLeague] = useState(() => {
+    // Validate against LEAGUE_OPTIONS so a stale/unsupported value in
+    // localStorage (older app version, manual edit) can't reach the
+    // backend — ModeMapper.ResolveMode throws on unknown leagues.
+    const stored = localStorage.getItem(LEAGUE_STORAGE_KEY);
+    return LEAGUE_OPTIONS.some(o => o.value === stored) ? stored : 'ncaa';
+  });
   const [contestId, setContestId] = useState(
     () => localStorage.getItem(CONTEST_ID_STORAGE_KEY) ?? ''
   );
@@ -65,6 +69,7 @@ export default function AdminFootballPage() {
       possessionFranchiseSeasonId:
         live.possessionFranchiseSeasonId ?? matchup.possessionFranchiseSeasonId,
       isScoringPlay: live.isScoringPlay ?? matchup.isScoringPlay,
+      ballOnYardLine: live.ballOnYardLine ?? matchup.ballOnYardLine,
       lastPlayDescription: live.lastPlayDescription ?? matchup.lastPlayDescription,
     };
   }, [matchup, live]);

--- a/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminFootballPage.jsx
@@ -1,20 +1,262 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
 import './AdminPage.css';
 import AdminHeader from './AdminHeader';
 import FootballDebugCard from './signalr-debug/FootballDebugCard';
+import MatchupCard from '../matchups/MatchupCard';
+import apiWrapper from '../../api/apiWrapper';
+import { useContestUpdates } from '../../contexts/ContestUpdatesContext';
+
+const CONTEST_ID_STORAGE_KEY = 'admin.football.debugContestId';
+const LEAGUE_STORAGE_KEY = 'admin.football.debugLeague';
+
+const LEAGUE_OPTIONS = [
+  { value: 'ncaa', label: 'NCAAFB', sport: 'FootballNcaa' },
+  { value: 'nfl', label: 'NFL', sport: 'FootballNfl' },
+];
 
 /**
- * Football SignalR debug harness page. Hosts the football-specific debug
- * card on its own route (`/admin/football`) so the parent /admin page
- * stays focused on system-health/data-quality widgets.
+ * Football SignalR debug harness page. Mirrors AdminBaseballPage — left
+ * column renders a real <MatchupCard /> for a chosen contest so SignalR-
+ * driven updates can be observed on the same component the picks page
+ * uses; right column hosts the FootballDebugCard control panel that
+ * fires synthetic events.
+ *
+ * Replay supports both NCAA and NFL — the league selector drives both
+ * the matchup fetch and the replay endpoint. Contest ID + league persist
+ * to localStorage so reloads keep the last values.
  */
 export default function AdminFootballPage() {
+  const [league, setLeague] = useState(
+    () => localStorage.getItem(LEAGUE_STORAGE_KEY) ?? 'ncaa'
+  );
+  const [contestId, setContestId] = useState(
+    () => localStorage.getItem(CONTEST_ID_STORAGE_KEY) ?? ''
+  );
+  const [pendingId, setPendingId] = useState(contestId);
+  const [matchup, setMatchup] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [replaying, setReplaying] = useState(false);
+
+  const { getContestUpdate } = useContestUpdates();
+  const live = contestId ? getContestUpdate(contestId) : null;
+
+  const leagueSport = useMemo(
+    () => LEAGUE_OPTIONS.find(o => o.value === league)?.sport ?? 'FootballNcaa',
+    [league]
+  );
+
+  // Mirror the picks-page enrichment pattern (PicksPage.jsx) so the
+  // canonical MatchupCard re-renders as SignalR events land — football
+  // live fields (period, clock, scores, possession, ballOnYardLine,
+  // isScoringPlay, last play) are written onto the context record by
+  // handleFootballPlayCompleted.
+  const enrichedMatchup = useMemo(() => {
+    if (!matchup) return null;
+    if (!live) return matchup;
+    return {
+      ...matchup,
+      status: live.status ?? matchup.status,
+      awayScore: live.awayScore ?? matchup.awayScore,
+      homeScore: live.homeScore ?? matchup.homeScore,
+      period: live.period ?? matchup.period,
+      clock: live.clock ?? matchup.clock,
+      possessionFranchiseSeasonId:
+        live.possessionFranchiseSeasonId ?? matchup.possessionFranchiseSeasonId,
+      isScoringPlay: live.isScoringPlay ?? matchup.isScoringPlay,
+      lastPlayDescription: live.lastPlayDescription ?? matchup.lastPlayDescription,
+    };
+  }, [matchup, live]);
+
+  useEffect(() => {
+    if (!contestId) {
+      setMatchup(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiWrapper.Admin.getFootballMatchupForContest(contestId, league);
+        if (!cancelled) setMatchup(res.data ?? null);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.response?.data?.errors?.[0]?.errorMessage ?? err.message ?? 'Failed to load matchup');
+          setMatchup(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [contestId, league]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const trimmed = pendingId.trim();
+    setContestId(trimmed);
+    if (trimmed) {
+      localStorage.setItem(CONTEST_ID_STORAGE_KEY, trimmed);
+    } else {
+      localStorage.removeItem(CONTEST_ID_STORAGE_KEY);
+    }
+  };
+
+  const handleLeagueChange = (e) => {
+    const next = e.target.value;
+    setLeague(next);
+    localStorage.setItem(LEAGUE_STORAGE_KEY, next);
+  };
+
+  // Producer fires ContestStatusChanged once and a FootballPlayCompleted
+  // per stored play. The matchup card on the left reacts to the resulting
+  // SignalR fan-out; the field on the right (FootballDebugCard) is for
+  // synthetic-event testing and uses its own hardcoded sandbox contestId.
+  const handleStartReplay = async () => {
+    if (!contestId) {
+      toast.error('Load a matchup first.');
+      return;
+    }
+    setReplaying(true);
+    try {
+      await apiWrapper.Admin.replayFootballContest(contestId, league);
+      toast.success('Replay queued — events will start flowing.');
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.errors?.[0]?.errorMessage
+          ?? err.message
+          ?? 'Replay failed'
+      );
+    } finally {
+      setReplaying(false);
+    }
+  };
+
+  const seasonYear = matchup?.startDateUtc
+    ? new Date(matchup.startDateUtc).getUTCFullYear()
+    : undefined;
+
   return (
     <div className="admin-page">
       <AdminHeader />
-      <section className="admin-signalr-debug">
-        <FootballDebugCard />
-      </section>
+      <a href="https://messaging-footballncaa.sportdeets.com/#/" target="_blank">Rabbit - NCAAFB</a>
+      <br/>
+      <a href="https://messaging-footballnfl.sportdeets.com/#/" target="_blank">Rabbit - NFL</a>
+      <div className="admin-sport-debug-grid">
+        {/* Left column — the observer: pick a contest, render its MatchupCard */}
+        <section className="admin-football-matchup-debug">
+          <form onSubmit={handleSubmit} style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12, flexWrap: 'wrap' }}>
+            <label htmlFor="admin-football-league" style={{ fontWeight: 600 }}>
+              League:
+            </label>
+            <select
+              id="admin-football-league"
+              value={league}
+              onChange={handleLeagueChange}
+              style={{ padding: '6px 8px' }}
+            >
+              {LEAGUE_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+            <label htmlFor="admin-football-contest-id" style={{ fontWeight: 600 }}>
+              Contest ID:
+            </label>
+            <input
+              id="admin-football-contest-id"
+              type="text"
+              value={pendingId}
+              onChange={(e) => setPendingId(e.target.value)}
+              placeholder="paste a football contest GUID"
+              style={{ flex: 1, padding: '6px 8px', minWidth: 0 }}
+            />
+            <button type="submit">Load matchup</button>
+            <button
+              type="button"
+              onClick={handleStartReplay}
+              disabled={replaying || !contestId}
+              title={contestId ? 'Replay this contest through the bus → SignalR pipeline' : 'Load a matchup first'}
+            >
+              {replaying ? 'Queuing…' : 'Start replay'}
+            </button>
+          </form>
+
+          {loading && <div>Loading matchup…</div>}
+          {error && <div style={{ color: 'red' }}>{error}</div>}
+          {enrichedMatchup && !loading && !error && (
+            <>
+              <MatchupCard
+                matchup={enrichedMatchup}
+                leagueSport={leagueSport}
+                leagueSeasonYear={seasonYear}
+              />
+              <FootballLiveStatePanel live={live} />
+            </>
+          )}
+        </section>
+
+        {/* Right column — the controls: synthetic SignalR events */}
+        <section className="admin-signalr-debug">
+          <FootballDebugCard />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Debug-only readout of the per-contest live state arriving via SignalR.
+ * MatchupCard renders the same fields through GameStatus, but suppresses
+ * rows whose source values are at defaults — useful for the end-user,
+ * less so when debugging the pipeline. This panel renders every field
+ * with a `?? '—'` placeholder so you can distinguish "event arrived but
+ * field was default" from "no event at all".
+ */
+function FootballLiveStatePanel({ live }) {
+  const empty = !live;
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        padding: 12,
+        border: '1px dashed var(--border-primary)',
+        borderRadius: 6,
+        background: 'var(--table-stripe)',
+        fontSize: '0.9rem',
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 6 }}>
+        Live state (debug readout)
+      </div>
+      {empty && (
+        <div style={{ color: 'var(--text-secondary)' }}>
+          Waiting for the first SignalR event for this contest…
+        </div>
+      )}
+      {!empty && (
+        <ul style={{ margin: 0, paddingLeft: 18, lineHeight: 1.5 }}>
+          <li>Status: <strong>{live.status ?? '—'}</strong></li>
+          <li>Score: away <strong>{live.awayScore ?? 0}</strong> · home <strong>{live.homeScore ?? 0}</strong></li>
+          <li>
+            Period: <strong>{live.period ?? '—'}</strong>
+            {' · '}Clock: <strong>{live.clock ?? '—'}</strong>
+          </li>
+          <li>
+            Possession: <strong>{live.possessionFranchiseSeasonId ?? '—'}</strong>
+            {' · '}Ball on yard: <strong>{typeof live.ballOnYardLine === 'number' ? live.ballOnYardLine : '—'}</strong>
+            {' · '}Scoring: <strong>{live.isScoringPlay ? '✓' : '·'}</strong>
+          </li>
+          {live.lastPlayDescription && (
+            <li>Last play: <em>{live.lastPlayDescription}</em></li>
+          )}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/UI/sd-ui/src/components/admin/AdminPage.css
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.css
@@ -96,10 +96,11 @@
   margin: 1rem 0 1.5rem;
 }
 
-/* /admin/baseball — left column hosts the matchup-card observer (driven by
-   the contest-id input), right column hosts the BaseballDebugCard control
-   panel that fires synthetic SignalR events. */
-.admin-baseball-debug-grid {
+/* /admin/{sport} — left column hosts the matchup-card observer (driven by
+   the contest-id input), right column hosts the per-sport DebugCard control
+   panel that fires synthetic SignalR events. Shared between baseball and
+   football debug pages. */
+.admin-sport-debug-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
@@ -108,7 +109,7 @@
 }
 
 @media (max-width: 900px) {
-  .admin-baseball-debug-grid {
+  .admin-sport-debug-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
@@ -2,16 +2,13 @@ import { Link } from "react-router-dom";
 import { contestLink } from '../../utils/sportLinks';
 
 /**
- * Football per-play live block. Lifted verbatim from GameStatus.jsx so
- * the per-sport split (FB vs MLB) can land without disturbing the
- * existing football layout. Behavior is unchanged: LIVE label,
- * period+clock, score with 🏈 next to the team in possession, scoring
- * flash + 🎉 TOUCHDOWN! indicator.
+ * Football per-play live block. Renders LIVE label, period+clock, score
+ * with 🏈 next to the team in possession, scoring flash + 🎉 TOUCHDOWN!
+ * indicator, and a last-play description row (mirrors baseball).
  *
  * Class names are intentionally kept (`.game-result`, `.final-score`,
  * `.score-display`, etc.) — the broader status-neutral rename is a
- * separate effort tracked in docs/matchup-card.md and is out of scope
- * for the MLB-first enrichment PR.
+ * separate effort tracked in docs/matchup-card.md.
  */
 function FootballGameStatusInProgress({
   awayShort,
@@ -24,6 +21,7 @@ function FootballGameStatusInProgress({
   homeFranchiseSeasonId,
   possessionFranchiseSeasonId,
   isScoringPlay,
+  lastPlayDescription,
   contestId,
   sport,
   league,
@@ -39,6 +37,9 @@ function FootballGameStatusInProgress({
     possessionFranchiseSeasonId != null
     && possessionFranchiseSeasonId === homeFranchiseSeasonId;
 
+  const hasLastPlayRow =
+    typeof lastPlayDescription === 'string' && lastPlayDescription.length > 0;
+
   const liveContent = (
     <>
       <span className="result-label live-indicator">LIVE</span>
@@ -53,6 +54,11 @@ function FootballGameStatusInProgress({
       {isScoringPlay && (
         // TODO: Determine score type (TD, FG, etc.) for better indicator
         <span className="touchdown-indicator">🎉 TOUCHDOWN!</span>
+      )}
+      {hasLastPlayRow && (
+        <span className="live-state-lastplay" title={lastPlayDescription}>
+          {lastPlayDescription}
+        </span>
       )}
     </>
   );

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -143,6 +143,7 @@ function GameStatus({
         homeFranchiseSeasonId={homeFranchiseSeasonId}
         possessionFranchiseSeasonId={possessionFranchiseSeasonId}
         isScoringPlay={isScoringPlay}
+        lastPlayDescription={lastPlayDescription}
         contestId={contestId}
         sport={sport}
         league={league}


### PR DESCRIPTION
## Summary
- Add `/admin/football` matchup harness (mirror of `/admin/baseball`) — league selector (NCAA/NFL), contest-id input, MatchupCard observer enriched from `ContestUpdatesContext`, and a live-state debug panel
- New `GET /admin/football/contests/{id}/matchup?league=ncaa|nfl` endpoint reusing the existing `IGetMatchupForContestQueryHandler`
- Apply `DeliveryMode.Direct` to `FootballContestReplayService` (mirror of #313's baseball fix) so replays bypass the EF outbox — same role-split dispatch issue would otherwise swallow events in prod
- Render `lastPlayDescription` in `FootballGameStatusInProgress` for parity with the baseball MatchupCard
- Add `docker-compose.local.{ncaa,nfl}.yml` so the football Producer/Provider run in single-process All-roles mode for local replay testing (mirrors `docker-compose.local.mlb.yml`)
- Rename `.admin-baseball-debug-grid` → `.admin-sport-debug-grid` (shared between baseball and football admin pages)

## Test plan
- [x] `dotnet build src/SportsData.Api` + `src/SportsData.Producer` → 0 errors
- [x] `npm run build` (sd-ui) → compiled successfully
- [x] `docker compose -f docker-compose.local.ncaa.yml up --build`
- [x] /app/admin/football: paste NCAAFB contest GUID, Load matchup, Start replay → play events flow to the MatchupCard via SignalR, last play description renders
- [ ] Repeat against `docker-compose.local.nfl.yml` with an NFL contest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Football games now show the last-play description during live play.
  * Admin API + UI method to fetch canonical football matchups.
  * Admin football page: matchup loading, persisted league/contest selection, live-state overlay, and replay controls.

* **Chores**
  * Added local Docker Compose configs for NFL and NCAA in-season local testing.
  * Admin debug UI CSS made sport-generic.

* **Bug Fixes / Reliability**
  * Replay publishing now uses a direct delivery scope for more reliable message dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/316)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->