### PR TITLE
fix(auth): remove visibilitychange force-refresh causing spurious logouts

### DIFF
--- a/src/UI/sd-ui/src/contexts/AuthContext.jsx
+++ b/src/UI/sd-ui/src/contexts/AuthContext.jsx
@@ -37,12 +37,14 @@ export function AuthProvider({ children }) {
     };
   }, []);
 
-  // NOTE: Interval-based token refresh removed - it doesn't work when tab is suspended.
-  // Instead, we now:
-  // 1. Check token expiration on each API request (apiClient.js request interceptor)
-  // 2. Refresh proactively if token expires in <5 minutes
-  // 3. Verify auth state when tab resumes from suspension (firebase.js visibility listener)
-  // This is more reliable than a timer that doesn't run during tab suspension.
+  // Token refresh is owned by apiClient (request interceptor): expiration
+  // is checked per-request and the token force-refreshes if <5min to
+  // expiry, with a force-refresh + retry on 401. A previous experiment
+  // also force-refreshed on every visibilitychange in firebase.js — that
+  // raced when two tabs refocused at once and would auth.signOut() on a
+  // single transient failure, broadcasting sign-out to all tabs. The
+  // per-request path handles long suspensions correctly the moment the
+  // user interacts.
 
   return (
     <AuthContext.Provider value={{ user, loading, handleSignOut }}>

--- a/src/UI/sd-ui/src/contexts/AuthContext.jsx
+++ b/src/UI/sd-ui/src/contexts/AuthContext.jsx
@@ -42,9 +42,9 @@ export function AuthProvider({ children }) {
   // expiry, with a force-refresh + retry on 401. A previous experiment
   // also force-refreshed on every visibilitychange in firebase.js — that
   // raced when two tabs refocused at once and would auth.signOut() on a
-  // single transient failure, broadcasting sign-out to all tabs. The
-  // per-request path handles long suspensions correctly the moment the
-  // user interacts.
+  // single transient failure, which the localStorage storage event then
+  // broadcast to every tab. The per-request path handles long
+  // suspensions correctly the moment the user interacts.
 
   return (
     <AuthContext.Provider value={{ user, loading, handleSignOut }}>

--- a/src/UI/sd-ui/src/firebase.js
+++ b/src/UI/sd-ui/src/firebase.js
@@ -10,8 +10,8 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig);
 const auth = getAuth(firebaseApp);
 
-// ✅ CRITICAL: Explicitly set persistence to LOCAL
-// This ensures auth state survives browser refreshes and tab suspensions
+// Persistence in IndexedDB so auth state survives refreshes and tab
+// suspensions, and so all tabs of the same origin share one session.
 setPersistence(auth, browserLocalPersistence)
   .then(() => {
     console.log('✅ Firebase persistence set to LOCAL');
@@ -21,26 +21,12 @@ setPersistence(auth, browserLocalPersistence)
     console.error('Auth sessions may not survive tab suspensions!');
   });
 
-// ✅ Add session recovery on visibility change (tab resume from suspension)
-if (typeof document !== 'undefined') {
-  document.addEventListener('visibilitychange', async () => {
-    if (!document.hidden && auth.currentUser) {
-      console.log('📱 Tab became visible, verifying auth state...');
-      try {
-        // Verify token is still valid after tab was suspended/backgrounded
-        await auth.currentUser.getIdToken(true);
-        console.log('✅ Auth state verified after tab resume');
-      } catch (error) {
-        console.error('❌ Auth state invalid after tab resume:', error);
-        console.warn('Session was lost during tab suspension - redirecting to login');
-        // Session was lost during suspension - gracefully sign out and redirect
-        await auth.signOut();
-        if (window.location.pathname !== '/') {
-          window.location.href = '/';
-        }
-      }
-    }
-  });
-}
+// No visibilitychange handler: token validity is enforced per-request
+// by apiClient (proactive refresh if <5min to expiry, force-refresh +
+// retry on 401). A handler that force-refreshed on every tab refocus
+// caused spurious logouts — two tabs racing the same forced refresh
+// (e.g. when opening a contest overview in a new tab and switching
+// back) would occasionally fail one refresh, hit the catch path, and
+// auth.signOut() broadcast the sign-out to every tab via IndexedDB.
 
 export { auth };

--- a/src/UI/sd-ui/src/firebase.js
+++ b/src/UI/sd-ui/src/firebase.js
@@ -10,8 +10,10 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig);
 const auth = getAuth(firebaseApp);
 
-// Persistence in IndexedDB so auth state survives refreshes and tab
-// suspensions, and so all tabs of the same origin share one session.
+// browserLocalPersistence is backed by window.localStorage (per Firebase
+// Auth docs/source); the LOCAL label means auth state survives page
+// refreshes and tab suspensions, and the storage event broadcasts state
+// changes across tabs of the same origin so all tabs share one session.
 setPersistence(auth, browserLocalPersistence)
   .then(() => {
     console.log('✅ Firebase persistence set to LOCAL');
@@ -27,6 +29,7 @@ setPersistence(auth, browserLocalPersistence)
 // caused spurious logouts — two tabs racing the same forced refresh
 // (e.g. when opening a contest overview in a new tab and switching
 // back) would occasionally fail one refresh, hit the catch path, and
-// auth.signOut() broadcast the sign-out to every tab via IndexedDB.
+// auth.signOut() broadcast the sign-out to every tab via the
+// localStorage storage event.
 
 export { auth };


### PR DESCRIPTION
## Summary
Removes the `visibilitychange` handler in `firebase.js` that force-refreshed the Firebase token on every tab refocus and called `auth.signOut()` on any error. That path was the source of spurious logouts when opening a contest in a new tab via `target="_blank"`.

**Repro path that triggered it:**
1. User on `/picks`, clicks a `target="_blank"` link to a contest overview.
2. New tab opens, focuses → fires `visibilitychange(visible)` → force-refreshes token.
3. User switches back to picks tab → fires `visibilitychange(visible)` → force-refreshes token *again*, possibly concurrent with the new tab's refresh.
4. Either side hits a transient failure (rate limit on concurrent forced refresh, network blip, token rotation race) → catch path runs `auth.signOut()`.
5. Firebase broadcasts the sign-out to every tab via shared IndexedDB persistence → both tabs see `onAuthStateChanged` fire with `null` → user is logged out.

**Why removing it is safe:**
- `apiClient.js` already enforces token validity per request: checks expiration, proactively refreshes if <5min to expiry, and on 401 force-refreshes + retries.
- The "long tab suspension" scenario the handler was meant to cover is handled correctly the moment the user interacts (next API call triggers refresh).
- Brief tab switches no longer trigger Firebase auth traffic at all.

## Test plan
- [x] Local: open picks page, click contest link in new tab, switch back and forth → no logout, no "Auth state changed: No user" in console
- [x] `npm run lint` clean
- [ ] **Production verification still required** before this is called fully resolved — the symptom was intermittent and racey, so prod behavior over time is the real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cross-tab authentication stability by removing refocus-driven recovery and relying on per-request token handling to avoid sign-out race conditions.

* **Documentation**
  * Updated authentication docs to describe per-request token expiration checks, proactive refresh when tokens near expiry, and retry-on-401 behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/317)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->