### PR TITLE
feat(admin): replay all Final contests on a league's week (multi-card SignalR test)

### DIFF
--- a/bruno/api/league-week-replay.yml
+++ b/bruno/api/league-week-replay.yml
@@ -1,0 +1,21 @@
+info:
+  name: league-week-replay
+  type: http
+  seq: 18
+
+http:
+  method: POST
+  url: "{{baseUrlApi}}/admin/leagues/8a209215-2f8e-42d0-93e3-f9e519543216/weeks/5/replay"
+  headers:
+    - name: X-Admin-Token
+      value: "{{X-Admin-Token}}"
+  body:
+    type: json
+    data: ""
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -11,6 +11,7 @@ using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutCompetitors
 using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutDrives;
 using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutMetrics;
 using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutPlays;
+using SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests;
 using SportsData.Api.Application.Admin.Queries.GetMatchupForContest;
 using SportsData.Api.Application.Admin.Queries.GetMatchupPreview;
 using SportsData.Api.Application.Admin.SignalRDebug;
@@ -291,6 +292,109 @@ namespace SportsData.Api.Application.Admin
                 .ReplayContest(contestId, cancellationToken);
 
             return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Replays every Final contest on a pickem league's matchup page
+        /// for a given week, exercising the Producer → broker → API →
+        /// SignalR fan-out path against every MatchupCard the user sees
+        /// at GET /ui/leagues/{leagueId}/matchups/{week}. Used to verify
+        /// that each card updates independently when its contest's plays
+        /// arrive over SignalR — the multi-card analogue of the per-sport
+        /// admin debug pages.
+        ///
+        /// Filtered to Status=="Final" because the per-contest replay
+        /// service emits ContestStatusChanged=InProgress as its first
+        /// step (no "revert to Scheduled" counterpart). Replaying a
+        /// scheduled game would briefly flash it to In Progress in the
+        /// UI with no recovery — undesired noise during testing.
+        /// </summary>
+        [HttpPost]
+        [Route("leagues/{leagueId:guid}/weeks/{week:int}/replay")]
+        public async Task<IActionResult> ReplayLeagueWeekContests(
+            [FromRoute] Guid leagueId,
+            [FromRoute] int week,
+            [FromServices] IGetLeagueWeekContestsQueryHandler queryHandler,
+            [FromServices] IContestClientFactory contestClientFactory,
+            CancellationToken cancellationToken)
+        {
+            var queryResult = await queryHandler.ExecuteAsync(
+                new GetLeagueWeekContestsQuery(leagueId, week),
+                cancellationToken);
+
+            if (!queryResult.IsSuccess)
+                return queryResult.ToActionResult().Result!;
+
+            var (sport, contestIds) = queryResult.Value;
+            if (contestIds.Count == 0)
+            {
+                return Accepted(new
+                {
+                    leagueId,
+                    week,
+                    sport = sport.ToString(),
+                    totalMatchups = 0,
+                    finalContests = 0,
+                    replaysQueued = 0,
+                });
+            }
+
+            var client = contestClientFactory.Resolve(sport);
+
+            // Canonical statuses come from Producer in one round-trip;
+            // .ToList() is for the cast — GetMatchupsByContestIds takes
+            // a List<Guid>, contestIds is IReadOnlyList<Guid>.
+            var matchupsResult = await client.GetMatchupsByContestIds(
+                contestIds.ToList(),
+                cancellationToken);
+
+            if (!matchupsResult.IsSuccess)
+                return matchupsResult.ToActionResult().Result!;
+
+            var finalContestIds = (matchupsResult.Value ?? new List<LeagueMatchupDto>())
+                .Where(m => string.Equals(m.Status, "Final", StringComparison.OrdinalIgnoreCase))
+                .Select(m => m.ContestId)
+                .ToList();
+
+            if (finalContestIds.Count == 0)
+            {
+                _logger.LogInformation(
+                    "ReplayLeagueWeek: no Final contests to replay. LeagueId={LeagueId}, Week={Week}, Sport={Sport}, TotalMatchups={TotalMatchups}",
+                    leagueId, week, sport, contestIds.Count);
+                return Accepted(new
+                {
+                    leagueId,
+                    week,
+                    sport = sport.ToString(),
+                    totalMatchups = contestIds.Count,
+                    finalContests = 0,
+                    replaysQueued = 0,
+                });
+            }
+
+            // Fan out per-contest replays in parallel. Producer enqueues
+            // a Hangfire job per call and returns immediately, so this is
+            // a quick burst of HTTP calls — not waiting on play emission.
+            var replayResults = await Task.WhenAll(
+                finalContestIds.Select(id => client.ReplayContest(id, cancellationToken)));
+
+            var succeeded = replayResults.Count(r => r.IsSuccess);
+            var failed = replayResults.Length - succeeded;
+
+            _logger.LogInformation(
+                "ReplayLeagueWeek: queued. LeagueId={LeagueId}, Week={Week}, Sport={Sport}, TotalMatchups={TotalMatchups}, FinalContests={FinalContests}, Succeeded={Succeeded}, Failed={Failed}",
+                leagueId, week, sport, contestIds.Count, finalContestIds.Count, succeeded, failed);
+
+            return Accepted(new
+            {
+                leagueId,
+                week,
+                sport = sport.ToString(),
+                totalMatchups = contestIds.Count,
+                finalContests = finalContestIds.Count,
+                replaysQueued = succeeded,
+                replaysFailed = failed,
+            });
         }
 
         [HttpPost]

--- a/src/SportsData.Api/Application/Admin/Queries/GetLeagueWeekContests/GetLeagueWeekContestsQuery.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetLeagueWeekContests/GetLeagueWeekContestsQuery.cs
@@ -1,0 +1,14 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests;
+
+/// <summary>
+/// Returns the sport and contest IDs for a given pickem league's week.
+/// Used by the admin league-week replay endpoint to drive a SignalR
+/// fan-out test across every MatchupCard on the picks page for a
+/// chosen (league, week) — same identifiers the picks page itself
+/// consumes via GET /ui/leagues/{leagueId}/matchups/{week}.
+/// </summary>
+public sealed record GetLeagueWeekContestsQuery(Guid LeagueId, int Week);
+
+public sealed record GetLeagueWeekContestsResult(Sport Sport, IReadOnlyList<Guid> ContestIds);

--- a/src/SportsData.Api/Application/Admin/Queries/GetLeagueWeekContests/GetLeagueWeekContestsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetLeagueWeekContests/GetLeagueWeekContestsQueryHandler.cs
@@ -1,0 +1,64 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests;
+
+public interface IGetLeagueWeekContestsQueryHandler
+{
+    Task<Result<GetLeagueWeekContestsResult>> ExecuteAsync(
+        GetLeagueWeekContestsQuery query,
+        CancellationToken cancellationToken);
+}
+
+public class GetLeagueWeekContestsQueryHandler : IGetLeagueWeekContestsQueryHandler
+{
+    private readonly AppDataContext _dbContext;
+    private readonly ILogger<GetLeagueWeekContestsQueryHandler> _logger;
+
+    public GetLeagueWeekContestsQueryHandler(
+        AppDataContext dbContext,
+        ILogger<GetLeagueWeekContestsQueryHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result<GetLeagueWeekContestsResult>> ExecuteAsync(
+        GetLeagueWeekContestsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var sport = await _dbContext.PickemGroups
+            .AsNoTracking()
+            .Where(x => x.Id == query.LeagueId)
+            .Select(x => (Sport?)x.Sport)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (sport is null)
+        {
+            _logger.LogWarning(
+                "GetLeagueWeekContests: league not found. LeagueId={LeagueId}, Week={Week}",
+                query.LeagueId, query.Week);
+            return new Failure<GetLeagueWeekContestsResult>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(query.LeagueId), "League not found")]);
+        }
+
+        var contestIds = await _dbContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(x => x.GroupId == query.LeagueId && x.SeasonWeek == query.Week)
+            .Select(x => x.ContestId)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "GetLeagueWeekContests: resolved {Count} contest IDs. LeagueId={LeagueId}, Week={Week}, Sport={Sport}",
+            contestIds.Count, query.LeagueId, query.Week, sport);
+
+        return new Success<GetLeagueWeekContestsResult>(
+            new GetLeagueWeekContestsResult(sport.Value, contestIds));
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -134,6 +134,8 @@ namespace SportsData.Api.DependencyInjection
                 SportsData.Api.Application.Admin.Queries.GetMatchupPreview.GetMatchupPreviewQueryHandler>();
             services.AddScoped<SportsData.Api.Application.Admin.Queries.GetMatchupForContest.IGetMatchupForContestQueryHandler,
                 SportsData.Api.Application.Admin.Queries.GetMatchupForContest.GetMatchupForContestQueryHandler>();
+            services.AddScoped<SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests.IGetLeagueWeekContestsQueryHandler,
+                SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests.GetLeagueWeekContestsQueryHandler>();
 
             // Analytics Queries
             services.AddScoped<IGetFranchiseSeasonMetricsQueryHandler, GetFranchiseSeasonMetricsQueryHandler>();


### PR DESCRIPTION
## Summary
Adds `POST /admin/leagues/{leagueId:guid}/weeks/{week:int}/replay` so a single curl exercises the Producer → broker → API → SignalR fan-out path against **every Final MatchupCard** the picks page renders for a chosen `(league, week)`. The multi-card analogue of the per-sport debug pages — verifies that each card on the picks page updates independently when its contest's plays arrive over SignalR.

This is what made the screenshot of eight live MLB games updating in parallel possible.

## Flow
1. New `IGetLeagueWeekContestsQueryHandler` reads `PickemGroup.Sport` and `PickemGroupMatchups` for `(GroupId, SeasonWeek)` → `(Sport, ContestIds[])`.
2. Controller resolves the `IContestClient` by sport, calls `GetMatchupsByContestIds` for canonical statuses, **filters to `Status=="Final"`**.
3. Fans out `ReplayContest` per filtered ID in parallel.
4. Returns `Accepted` with `{ leagueId, week, sport, totalMatchups, finalContests, replaysQueued, replaysFailed }`.

## Why strict "Final" filter
The per-contest replay service emits `ContestStatusChanged=InProgress` as its first step with no `revert to Scheduled` counterpart. Replaying a scheduled game would briefly flash it to In Progress in the UI with no recovery — undesired noise during testing.

## Scope
- API only. No Producer changes — reuses the existing per-contest replay endpoint (`IContestClient.ReplayContest`).
- For a typical NCAA week (~12 picks) that's 12 parallel HTTP calls to Producer — fine for an admin path.
- No UI in this PR (no hidden button on the picks page). Curl/Bruno-driven for now.

## Files
- New: `Application/Admin/Queries/GetLeagueWeekContests/` (Query, Result, Handler interface, Handler)
- Modified: `AdminController.cs` (new action), `ServiceRegistration.cs` (DI registration)
- New: `bruno/api/league-week-replay.yml` for hitting the endpoint locally/prod

## Test plan
- [x] `dotnet build SportsData.Api` clean, 0 warnings
- [x] Local end-to-end: curl the endpoint against an MLB pickem league → all eight Final games' MatchupCards updated in parallel on the picks page via SignalR (screenshot captured)
- [ ] Production verification after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin API endpoint to replay all Final contests for a specific pick'em league week
  * Endpoint provides counts of successfully queued replays and any failures for monitoring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/319)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->