### PR TITLE
chore(ui): instrument ContestUpdatesContext for cross-instance diagnosis

### DIFF
--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -52,7 +52,7 @@ function PicksPage() {
   const leagues = Object.values(userDto?.leagues || {});
 
   // Get contest updates for live game data
-  const { getContestUpdate } = useContestUpdates();
+  const { getContestUpdate, _instanceId: contestCtxInstanceId } = useContestUpdates();
 
   const usedConfidencePoints = useMemo(() => {
     return Object.values(userPicks)
@@ -67,6 +67,12 @@ function PicksPage() {
   // record; the union is included here so MatchupCard / GameStatus
   // can pick out whichever fields its sport branch needs.
   const enrichedMatchups = useMemo(() => {
+    // DIAG (refresh-loses-updates investigation): how many matchups
+    // have a live update merged in, AND which ContestCtx instance
+    // we're reading from. If setContests fires on #1 but PicksPage
+    // reads from #2, withLive stays 0 — the cross-instance bug.
+    const withLive = matchups.filter(m => getContestUpdate(m.contestId)).length;
+    console.log(`[PicksPage] enrichedMatchups recompute (reading ContestCtx#${contestCtxInstanceId})`, { total: matchups.length, withLive });
     return matchups.map(matchup => {
       const liveUpdate = getContestUpdate(matchup.contestId);
       if (liveUpdate) {
@@ -109,6 +115,10 @@ function PicksPage() {
       }
       return matchup;
     });
+    // contestCtxInstanceId is intentionally NOT in deps — it's stable
+    // per Provider mount, and re-running the memo just to update the
+    // log tag is pointless. Tracked in console output.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [matchups, getContestUpdate]);
 
   // Select default league on load or when leagues change

--- a/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
+++ b/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
@@ -1,5 +1,12 @@
 import { createContext, useContext, useState, useCallback } from 'react';
 
+// DIAG (refresh-loses-updates investigation): module-level counter so
+// each ContestUpdatesProvider mount gets a unique instance ID. If the
+// console shows logs tagged with different IDs (e.g. "#1" and "#2"),
+// the React tree has two Provider instances and SignalR callbacks may
+// be writing to one while consumers read from the other.
+let _ctxInstanceCounter = 0;
+
 /**
  * Context for managing real-time contest updates from SignalR.
  * Stores live game data including lifecycle status, play description,
@@ -8,8 +15,12 @@ import { createContext, useContext, useState, useCallback } from 'react';
 const ContestUpdatesContext = createContext(null);
 
 export const ContestUpdatesProvider = ({ children }) => {
+  // DIAG: stable instance ID for this Provider's lifetime (lazy init via useState).
+  const [instanceId] = useState(() => ++_ctxInstanceCounter);
   // Map of contestId -> live update data
   const [contests, setContests] = useState({});
+
+  console.log(`[ContestCtx#${instanceId}] render, contests size:`, Object.keys(contests).length, 'keys:', Object.keys(contests));
 
   /**
    * Handle ContestStatusChanged (lifecycle) event from SignalR.
@@ -24,6 +35,7 @@ export const ContestUpdatesProvider = ({ children }) => {
       return;
     }
 
+    console.log(`[ContestCtx#${instanceId}] setContests (status)`, { contestId: data.contestId, status: data.status });
     setContests(prev => ({
       ...prev,
       [data.contestId]: {
@@ -33,7 +45,7 @@ export const ContestUpdatesProvider = ({ children }) => {
         lastUpdated: Date.now()
       }
     }));
-  }, []);
+  }, [instanceId]);
 
   /**
    * Handle FootballPlayCompleted — merged per-play event carrying both
@@ -48,6 +60,7 @@ export const ContestUpdatesProvider = ({ children }) => {
       return;
     }
 
+    console.log(`[ContestCtx#${instanceId}] setContests (football play)`, { contestId: data.contestId, period: data.period, clock: data.clock });
     setContests(prev => ({
       ...prev,
       [data.contestId]: {
@@ -79,7 +92,7 @@ export const ContestUpdatesProvider = ({ children }) => {
         }));
       }, 2000);
     }
-  }, []);
+  }, [instanceId]);
 
   /**
    * Handle BaseballPlayCompleted — merged per-play event carrying both
@@ -94,6 +107,7 @@ export const ContestUpdatesProvider = ({ children }) => {
       return;
     }
 
+    console.log(`[ContestCtx#${instanceId}] setContests (baseball play)`, { contestId: data.contestId, inning: data.inning, half: data.halfInning });
     setContests(prev => ({
       ...prev,
       [data.contestId]: {
@@ -123,7 +137,7 @@ export const ContestUpdatesProvider = ({ children }) => {
         lastUpdated: Date.now()
       }
     }));
-  }, []);
+  }, [instanceId]);
 
   /**
    * Get live update data for a specific contest
@@ -162,6 +176,7 @@ export const ContestUpdatesProvider = ({ children }) => {
   }, []);
 
   const value = {
+    _instanceId: instanceId, // DIAG: lets consumers log which Provider they're reading from
     contests,
     handleStatusUpdate,
     handleFootballPlayCompleted,


### PR DESCRIPTION
## Context
After a hard refresh on the picks page (and admin replay pages), SignalR events still arrive — `MainApp`'s console logs prove the callbacks fire — but `MatchupCard`s stop updating. The smoking gun in our diagnostic ladder was the `[PicksPage] enrichedMatchups recompute` log showing `withLive=0` even though the context handlers were being called: a strong signal that the SignalR callback's `setContests` writes to **one** `ContestUpdatesProvider` instance while `PicksPage` reads from a **different** one (cross-instance state desync).

Pre-rolled in dev, but the free-tier Azure SignalR quota burned out during repeated refreshes. Production has a different SignalR instance with capacity, so we ship the diagnostic there to catch a real occurrence.

## What this adds
Pure logging — no behavior changes.

- `ContestUpdatesContext.jsx`: a module-level counter (`_ctxInstanceCounter`) assigns each `ContestUpdatesProvider` mount a unique `instanceId`. Every Provider render and every handler's `setContests` now logs with `[ContestCtx#N]`. The `instanceId` is also exposed via the context value as `_instanceId` so consumers can identify which Provider they're reading.
- `PicksPage.jsx`: reads `_instanceId` and includes it in its existing recompute log: `[PicksPage] enrichedMatchups recompute (reading ContestCtx#N) ...`.

## How to use in prod
1. Open the picks page, then DevTools console.
2. Filter the console by `ContestCtx` (or regex `ContestCtx|PicksPage`).
3. At startup, note how many distinct `#N` IDs appear in `[ContestCtx#N] render` logs.
   - **One** ID → healthy single Provider.
   - **Two or more** IDs → cross-instance bug confirmed.
4. After triggering a replay, compare the `#N` in `[ContestCtx#N] setContests (...)` vs the `#N` PicksPage reports it's reading from. Mismatch = the bug.

## Cleanup plan
Once an occurrence is captured and the root cause is identified, follow-up PR removes these logs and lands the structural fix.

## Test plan
- [x] `npm run lint` clean
- [x] Local build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal debugging and logging capabilities for contest updates tracking and monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/321)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->