### PR TITLE
fix(ui): self-heal contest status on play receipt to survive missed lifecycle event

### DIFF
--- a/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
+++ b/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
@@ -66,6 +66,15 @@ export const ContestUpdatesProvider = ({ children }) => {
       [data.contestId]: {
         ...prev[data.contestId],
         contestId: data.contestId,
+        // Receiving a play is itself proof the contest is live, so
+        // promote status to InProgress here even if the prior
+        // ContestStatusChanged lifecycle event was missed (e.g. a
+        // refresh happened after the replay's one-shot lifecycle
+        // fan-out — SignalR has no buffer, so post-connect clients
+        // miss any event published before their handshake completed).
+        // Without this, GameStatus stays on the Final/Scheduled
+        // branch and never renders the merged live data.
+        status: 'InProgress',
         period: data.period,
         clock: data.clock,
         awayScore: data.awayScore,
@@ -113,6 +122,11 @@ export const ContestUpdatesProvider = ({ children }) => {
       [data.contestId]: {
         ...prev[data.contestId],
         contestId: data.contestId,
+        // Receiving a play is itself proof the contest is live — see
+        // matching comment in handleFootballPlayCompleted. Without
+        // this, refresh-after-replay-start leaves the card stuck on
+        // the Final layout despite plays flowing into context.
+        status: 'InProgress',
         inning: data.inning,
         halfInning: data.halfInning,
         awayScore: data.awayScore,


### PR DESCRIPTION
## Symptom
After refreshing the picks page mid-replay, MatchupCards stay on the Final/Scheduled layout even though hundreds of `BaseballPlayCompleted` events arrive in the console. The diagnostic instrumentation from #321 proved the data pipeline is healthy end-to-end — single `ContestUpdatesProvider` instance, `setContests` fires, `[PicksPage] enrichedMatchups recompute` shows `withLive` growing as plays arrive.

## Root cause
SignalR has no event buffer. The replay service in Producer publishes **one** `ContestStatusChanged(InProgress)` event at the very start of each contest's replay, then ~200 `BaseballPlayCompleted` events ~1s apart for several minutes. If the user refreshes after the lifecycle event fanned out, the new SignalR connection misses it entirely (only events fired *during* a connection reach that client). The play stream keeps flowing and gets merged into context state, but `enrichedMatchup.status` falls back to `matchup.status` (`"Final"` for replay targets), so `GameStatus` routes to the Final branch and ignores all live data.

Console-log evidence: zero `Contest lifecycle update received` lines despite hundreds of play-completed lines.

## Fix
Write `status: 'InProgress'` inside both `handleFootballPlayCompleted` and `handleBaseballPlayCompleted` `setContests` payloads. Receiving a play is itself proof the contest is live. The merge in `PicksPage`'s `enrichedMatchups` already does `liveUpdate.status ?? matchup.status`, so the new value flows through and flips the card from Final → InProgress on the first play.

This also matches existing behavior: the replay service doesn't emit a "back to Final" lifecycle event, so all replays already leave the UI in InProgress until the next page load. The fix doesn't introduce a new lifecycle anomaly — it just makes the start-of-live transition robust to missed lifecycle events.

## Follow-up (separate ticket)
The proper long-term fix is to refetch `/ui/leagues/{id}/matchups/{week}` on every SignalR `start()` (initial connect AND `withAutomaticReconnect` reconnects) so the frontend has consistent canonical state rather than relying solely on events it managed to catch. Standard SignalR + REST hybrid pattern.

## Test plan
- [x] `npm run lint` clean
- [ ] Production: load picks page → trigger league-week replay → refresh mid-replay → cards continue updating (no Final-layout freeze)
- [ ] Production: load picks page → trigger league-week replay → cards update normally (no regression on the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where contest status could remain stuck on Final or Scheduled layouts when plays were received, ensuring the status properly updates to InProgress when football or baseball plays are completed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/322)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->