### PR TITLE
refactor(producer): drop football-specific terms from CompetitionStreamerBase

### DIFF
--- a/docs/competition-streamer-sport-neutralization.md
+++ b/docs/competition-streamer-sport-neutralization.md
@@ -1,6 +1,6 @@
 # CompetitionStreamerBase — sport-neutralization plan
 
-**Status:** drafted 2026-05-14 — pending implementation
+**Status:** Part 1 implemented in PR [#323](https://github.com/jrandallsexton/sports-data-core/pull/323) on 2026-05-15; Part 2 pending
 **Scope:** `src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs`
 **Why:** This class is the sport-neutral live-streaming base (typed on `TCompetitionDto`,
 subclassed by `FootballCompetitionStreamer` and `BaseballCompetitionStreamer`), but its
@@ -17,12 +17,13 @@ We want the base to read cleanly for any sport we add next (MLB is already a sub
   TeamSchedule.css label, mobile timeUtils, EF migrations seeded data) are legitimate
   football domain usage and out of scope.
 
-## Part 1 — Terminology (mechanical, no behavior change)
+## Part 1 — Terminology (mechanical, no behavior change) — implemented
 
-Pure rename + log-string edits. Line numbers below are as of commit `66e096c4`; verify
-before editing.
+Implemented in PR #323. Line numbers below were as of pre-rename commit `66e096c4`.
+The renames and log-string edits below are now present in `CompetitionStreamerBase.cs`
+(verifiable by greping for `LiveStartOutcome` and `WaitForLiveStartAsync`).
 
-| What | Where | Suggested rename |
+| What | Where (pre-rename) | Renamed to |
 |---|---|---|
 | `KickoffOutcome` enum | `:43` | `LiveStartOutcome` |
 | `KickoffOutcome.KickoffDetected` | `:45` | `LiveStartOutcome.StartDetected` |
@@ -35,17 +36,17 @@ before editing.
 | Log: "Game went final while waiting for kickoff." | `:173` | "Competition went final while waiting for start." |
 | Log: "Kickoff was not detected within max stream duration. Aborting." | `:182` | "Live start was not detected within max stream duration. Aborting." |
 | Failure-reason string: "Kickoff not detected within max stream duration" | `:185` | "Live start not detected within max stream duration" |
-| XML doc comment on `KickoffOutcome` (lines 38–42, 43, 45) | `:38-48` | Replace "WaitForKickoffAsync" / "KickoffDetected" prose |
+| XML doc comment on `KickoffOutcome` (lines 38–42, 43, 45) | `:38-48` | "WaitForKickoffAsync" / "KickoffDetected" prose replaced |
 
-### Also: normalize "Game" → "Competition" in log strings
+### Also: normalized "Game" → "Competition" in log strings
 
-The base alternates between **Game** (`:165, :192, :196, :347, :353, :430, :434`) and
-**Competition** (`:92, :109, :141, :278, :287, :315`). The canonical domain term in this
-code is *Competition* (`CompetitionStreamerBase`, `StreamCompetitionCommand`,
-`CompetitionStream`, etc.). Replace "Game" with "Competition" in all log strings for
-consistency. No code identifiers change.
+The base previously alternated between **Game** (`:165, :192, :196, :347, :353, :430,
+:434`) and **Competition** (`:92, :109, :141, :278, :287, :315`). The canonical domain
+term in this code is *Competition* (`CompetitionStreamerBase`, `StreamCompetitionCommand`,
+`CompetitionStream`, etc.). "Game" was replaced with "Competition" in all log strings for
+consistency. No code identifiers changed.
 
-### Out of scope for this PR
+### Out of scope for Part 1
 
 Log fields, EF entity names, sport-specific PlayType values, mobile / web UI strings — all
 fine where they are.

--- a/docs/competition-streamer-sport-neutralization.md
+++ b/docs/competition-streamer-sport-neutralization.md
@@ -1,0 +1,132 @@
+# CompetitionStreamerBase — sport-neutralization plan
+
+**Status:** drafted 2026-05-14 — pending implementation
+**Scope:** `src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs`
+**Why:** This class is the sport-neutral live-streaming base (typed on `TCompetitionDto`,
+subclassed by `FootballCompetitionStreamer` and `BaseballCompetitionStreamer`), but its
+public surface and log prose still use football-specific terminology ("kickoff") and one
+section of its dispatch logic hardcodes a football-flavored set of `DocumentType` values.
+We want the base to read cleanly for any sport we add next (MLB is already a subclass; NBA
+/ NHL / PGA are on the roadmap).
+
+## Verification done before drafting
+
+- `KickoffOutcome` and `WaitForKickoffAsync` are referenced **only** inside
+  `CompetitionStreamerBase.cs`. No external callers, so renames are internal-only.
+- Other repo hits for "Kickoff" (PlayType enum, NFL season-start countdown UI,
+  TeamSchedule.css label, mobile timeUtils, EF migrations seeded data) are legitimate
+  football domain usage and out of scope.
+
+## Part 1 — Terminology (mechanical, no behavior change)
+
+Pure rename + log-string edits. Line numbers below are as of commit `66e096c4`; verify
+before editing.
+
+| What | Where | Suggested rename |
+|---|---|---|
+| `KickoffOutcome` enum | `:43` | `LiveStartOutcome` |
+| `KickoffOutcome.KickoffDetected` | `:45` | `LiveStartOutcome.StartDetected` |
+| `WaitForKickoffAsync` method | `:166`, `:313` | `WaitForLiveStartAsync` |
+| Local `kickoffOutcome` var | `:166` | `startOutcome` |
+| Log: "Waiting for kickoff..." | `:165` | "Waiting for competition to start..." |
+| Log: "Polling for kickoff every 20 seconds..." | `:315` | "Polling for live start every 20 seconds..." |
+| Log: "Waiting for kickoff exceeded max duration" | `:324` | "Waiting for live start exceeded max duration" |
+| Log: "Kickoff detected! Game is now in progress." | `:347` | "Live start detected. Competition is now in progress." |
+| Log: "Game went final while waiting for kickoff." | `:173` | "Competition went final while waiting for start." |
+| Log: "Kickoff was not detected within max stream duration. Aborting." | `:182` | "Live start was not detected within max stream duration. Aborting." |
+| Failure-reason string: "Kickoff not detected within max stream duration" | `:185` | "Live start not detected within max stream duration" |
+| XML doc comment on `KickoffOutcome` (lines 38–42, 43, 45) | `:38-48` | Replace "WaitForKickoffAsync" / "KickoffDetected" prose |
+
+### Also: normalize "Game" → "Competition" in log strings
+
+The base alternates between **Game** (`:165, :192, :196, :347, :353, :430, :434`) and
+**Competition** (`:92, :109, :141, :278, :287, :315`). The canonical domain term in this
+code is *Competition* (`CompetitionStreamerBase`, `StreamCompetitionCommand`,
+`CompetitionStream`, etc.). Replace "Game" with "Competition" in all log strings for
+consistency. No code identifiers change.
+
+### Out of scope for this PR
+
+Log fields, EF entity names, sport-specific PlayType values, mobile / web UI strings — all
+fine where they are.
+
+## Part 2 — Design smell (football leakage, separate PR)
+
+Lines `:537–543`:
+
+```csharp
+var parentId = type is
+    DocumentType.EventCompetitionProbability or
+    DocumentType.EventCompetitionDrive or          // football-only concept
+    DocumentType.EventCompetitionSituation or
+    DocumentType.EventCompetitionPlay
+    ? command.CompetitionId.ToString()
+    : null;
+```
+
+The sport-neutral base hardcodes a football-flavored set of doc types when deciding
+whether to attach `ParentId` to the outgoing `DocumentRequested` event. `Drive` does not
+exist in baseball. This means:
+
+1. The base **knows** about a football-only DocumentType, violating the abstraction.
+2. Adding any new child polling target in a future sport (e.g. an MLB-specific
+   `EventCompetitionPitching`) silently produces `parentId = null` until somebody
+   remembers to edit this list in the base.
+
+### Proposed shape
+
+Extend the polling-target tuple to carry the flag at declaration site:
+
+```csharp
+protected abstract IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds, bool RequiresParentId)>
+    GetPollingTargets(TCompetitionDto competitionDto);
+```
+
+`FootballCompetitionStreamer.GetPollingTargets`:
+
+```csharp
+yield return (competitionDto.Probabilities?.Ref, DocumentType.EventCompetitionProbability, 15, RequiresParentId: true);
+yield return (competitionDto.Drives?.Ref,        DocumentType.EventCompetitionDrive,       15, RequiresParentId: true);
+yield return (competitionDto.Details?.Ref,       DocumentType.EventCompetitionPlay,        10, RequiresParentId: true);
+yield return (competitionDto.Situation?.Ref,     DocumentType.EventCompetitionSituation,    5, RequiresParentId: true);
+yield return (competitionDto.Leaders?.Ref,       DocumentType.EventCompetitionLeaders,     60, RequiresParentId: false);
+```
+
+`BaseballCompetitionStreamer.GetPollingTargets`: same shape, no Drives target, identical
+flag values for the others.
+
+Then `PublishDocumentRequestAsync` takes the bool through the call chain (or a small
+record per target) and drops the `type is …` ladder entirely. The base no longer
+references any sport-specific DocumentType.
+
+### Verification before merge
+
+- Audit each existing polling target's `RequiresParentId` value against the consumer side
+  (the relevant `DocumentProcessor` for each `DocumentType`). If a processor today reads
+  `ParentId` from `DocumentRequested`, the flag must be `true`. If not, `false` is fine
+  but worth a code comment.
+- Add a unit test per streamer that materializes `GetPollingTargets(dto)` and asserts the
+  shape (count, doc types, intervals, flags). This is the first test in the
+  `CompetitionStreamer*` family — they currently have zero coverage (see
+  `live-event-scheduling-testing.md` if it exists, or the parent investigation).
+
+### Risk
+
+Behavior-equivalent if the flag mapping is correct on day one. The risk is mis-mapping a
+flag during the migration — hence the unit test.
+
+## Recommended PR sequence
+
+1. **Terminology PR** — Part 1 only. Mechanical, easy to review, no behavior change.
+   Title: `refactor(producer): drop football-specific terms from CompetitionStreamerBase`
+2. **Design PR** — Part 2 only. Behavior-equivalent (with the test in place).
+   Title: `refactor(producer): move parent-id requirement to polling-target declaration`
+
+Do **not** combine them. The design PR deserves dedicated review attention; bundling it
+with the rename will let it slip by.
+
+## Open question
+
+Naming: is `LiveStartOutcome` the right name, or do we prefer `InProgressOutcome` /
+`StartDetectedOutcome`? Decide at PR time. The enum value `StartDetected` is the
+load-bearing part — the enum type name is a bikeshed.

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
@@ -10,7 +9,6 @@ using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Infrastructure.Data;
 using SportsData.Producer.Infrastructure.Data.Common;
-using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Application.Competitions;
 
@@ -38,19 +36,19 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     private const int MaxConsecutiveFailures = 10;
 
     /// <summary>
-    /// Why WaitForKickoffAsync stopped. Drives whether ExecuteAsync proceeds
-    /// to spawn polling workers (KickoffDetected) or short-circuits to a
+    /// Why WaitForLiveStartAsync stopped. Drives whether ExecuteAsync proceeds
+    /// to spawn polling workers (StartDetected) or short-circuits to a
     /// terminal state (AlreadyFinal, Timeout).
     /// </summary>
-    protected enum KickoffOutcome
+    protected enum LiveStartOutcome
     {
-        KickoffDetected = 0,
+        StartDetected = 0,
         AlreadyFinal = 1,
         Timeout = 2,
     }
 
     /// <summary>
-    /// Why PollWhileInProgressAsync stopped. Final = normal game end (mark
+    /// Why PollWhileInProgressAsync stopped. Final = normal competition end (mark
     /// Completed); Timeout = stream exceeded MaxStreamDuration without seeing
     /// STATUS_FINAL (mark Failed with reason — likely indicates an abandoned
     /// stream or upstream data anomaly worth investigating).
@@ -77,7 +75,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
     /// <summary>
     /// Sport-specific polling targets. Each entry is (child-doc URI, doc type, polling interval seconds).
-    /// Returning a null URI signals that the parent doc lacks that child link for this game; the worker
+    /// Returning a null URI signals that the parent doc lacks that child link for this competition; the worker
     /// is silently skipped. Subclasses should keep the list short — every entry adds load to ESPN.
     /// </summary>
     protected abstract IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds)>
@@ -164,15 +162,15 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                 switch (status.Type.Name)
                 {
                     case "STATUS_SCHEDULED":
-                        _logger.LogInformation("Game is scheduled. Waiting for kickoff...");
-                        var kickoffOutcome = await WaitForKickoffAsync(statusUri, cancellationToken);
-                        switch (kickoffOutcome)
+                        _logger.LogInformation("Competition is scheduled. Waiting for competition to start...");
+                        var startOutcome = await WaitForLiveStartAsync(statusUri, cancellationToken);
+                        switch (startOutcome)
                         {
-                            case KickoffOutcome.KickoffDetected:
+                            case LiveStartOutcome.StartDetected:
                                 break;
 
-                            case KickoffOutcome.AlreadyFinal:
-                                _logger.LogInformation("Game went final while waiting for kickoff. Skipping live polling.");
+                            case LiveStartOutcome.AlreadyFinal:
+                                _logger.LogInformation("Competition went final while waiting for start. Skipping live polling.");
                                 if (stream != null)
                                 {
                                     stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
@@ -180,22 +178,22 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                                 }
                                 return;
 
-                            case KickoffOutcome.Timeout:
-                                _logger.LogWarning("Kickoff was not detected within max stream duration. Aborting.");
+                            case LiveStartOutcome.Timeout:
+                                _logger.LogWarning("Live start was not detected within max stream duration. Aborting.");
                                 if (stream != null)
                                 {
-                                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Kickoff not detected within max stream duration");
+                                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Live start not detected within max stream duration");
                                 }
                                 return;
                         }
                         break;
 
                     case "STATUS_IN_PROGRESS":
-                        _logger.LogInformation("Game already in progress. Starting workers immediately.");
+                        _logger.LogInformation("Competition already in progress. Starting workers immediately.");
                         break;
 
                     case "STATUS_FINAL":
-                        _logger.LogInformation("Game already final. Skipping streaming.");
+                        _logger.LogInformation("Competition already final. Skipping streaming.");
                         if (stream != null)
                         {
                             stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
@@ -205,7 +203,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
                     default:
                         // An unknown status string is anomalous data — bail rather than
-                        // optimistically spawning live workers against an unverified game state.
+                        // optimistically spawning live workers against an unverified competition state.
                         _logger.LogWarning("Unknown status type: {StatusType}. Aborting stream.", status.Type.Name);
                         if (stream != null)
                         {
@@ -214,7 +212,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                         return;
                 }
 
-                _logger.LogInformation("Starting polling workers for live game updates");
+                _logger.LogInformation("Starting polling workers for live competition updates");
 
                 if (stream != null)
                 {
@@ -312,9 +310,9 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
         }
     }
 
-    private async Task<KickoffOutcome> WaitForKickoffAsync(Uri statusUri, CancellationToken cancellationToken)
+    private async Task<LiveStartOutcome> WaitForLiveStartAsync(Uri statusUri, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Competition is scheduled. Polling for kickoff every 20 seconds...");
+        _logger.LogInformation("Competition is scheduled. Polling for live start every 20 seconds...");
 
         var startTime = _dateTimeProvider.UtcNow();
         var consecutiveFailures = 0;
@@ -323,8 +321,8 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
         {
             if (_dateTimeProvider.UtcNow() - startTime > MaxStreamDuration)
             {
-                _logger.LogWarning("Waiting for kickoff exceeded max duration ({Hours} hours). Stopping.", MaxStreamDuration.TotalHours);
-                return KickoffOutcome.Timeout;
+                _logger.LogWarning("Waiting for live start exceeded max duration ({Hours} hours). Stopping.", MaxStreamDuration.TotalHours);
+                return LiveStartOutcome.Timeout;
             }
 
             await Task.Delay(TimeSpan.FromSeconds(20), cancellationToken);
@@ -346,24 +344,24 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
             if (status.Type.Name == "STATUS_IN_PROGRESS")
             {
-                _logger.LogInformation("Kickoff detected! Game is now in progress.");
-                return KickoffOutcome.KickoffDetected;
+                _logger.LogInformation("Live start detected. Competition is now in progress.");
+                return LiveStartOutcome.StartDetected;
             }
 
             if (status.Type.Name == "STATUS_FINAL")
             {
-                _logger.LogWarning("Game marked final before starting. Exiting.");
-                return KickoffOutcome.AlreadyFinal;
+                _logger.LogWarning("Competition marked final before starting. Exiting.");
+                return LiveStartOutcome.AlreadyFinal;
             }
 
-            _logger.LogDebug("Game still scheduled. Status: {Status}", status.Type.Name);
+            _logger.LogDebug("Competition still scheduled. Status: {Status}", status.Type.Name);
         }
 
         // Cancellation observed by the while-condition (rather than via Task.Delay's
         // throwing overload). Treat as timeout-equivalent — caller's outer catch handles
         // the throwing case explicitly; reaching here means we exited cleanly without
-        // a kickoff signal, and we should not pretend kickoff happened.
-        return KickoffOutcome.Timeout;
+        // a live-start signal, and we should not pretend the competition started.
+        return LiveStartOutcome.Timeout;
     }
 
     private void StartPollingWorkers(
@@ -395,7 +393,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
     private async Task<PollOutcome> PollWhileInProgressAsync(Uri statusUri, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Monitoring game status every 30 seconds until completion...");
+        _logger.LogInformation("Monitoring competition status every 30 seconds until completion...");
 
         var startTime = _dateTimeProvider.UtcNow();
         var consecutiveFailures = 0;
@@ -429,11 +427,11 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
             if (status.Type.Name == "STATUS_FINAL")
             {
-                _logger.LogInformation("Game status is FINAL. Ending stream.");
+                _logger.LogInformation("Competition status is FINAL. Ending stream.");
                 return PollOutcome.Final;
             }
 
-            _logger.LogDebug("Game still in progress. Status: {Status}, Clock: {Clock}",
+            _logger.LogDebug("Competition still in progress. Status: {Status}, Clock: {Clock}",
                 status.Type.Name, status.DisplayClock);
         }
 


### PR DESCRIPTION
## Summary
- Rename `KickoffOutcome` → `LiveStartOutcome` (and `KickoffDetected` → `StartDetected`) and `WaitForKickoffAsync` → `WaitForLiveStartAsync` so the sport-neutral base stops using football vocabulary.
- Normalize log/XML-doc prose from "Game" to "Competition" — the canonical domain term in this code (`CompetitionStreamerBase`, `StreamCompetitionCommand`, `CompetitionStream`).
- Add `docs/competition-streamer-sport-neutralization.md` capturing this work (Part 1) and the follow-up design fix (Part 2 — moving the hardcoded football `DocumentType` ladder in `PublishDocumentRequestAsync` out of the base into the polling-target tuple).
- Drop two unused imports (`Microsoft.Extensions.DependencyInjection`, `SportsData.Producer.Infrastructure.Data.Entities`) that were already pending in the working tree.

No behavior change. All renamed identifiers are private/protected and used only inside `CompetitionStreamerBase.cs` (verified by grep).

## Test plan
- [x] `dotnet build src/SportsData.Producer/SportsData.Producer.csproj` — 0 warnings, 0 errors
- [x] `grep -rn 'KickoffOutcome\|WaitForKickoff' src/` — no remaining references
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal terminology, method names, and logging throughout competition workflows to use consistent, sport-neutral language.
  * Standardized status-handling logic to reduce sport-specific dependencies.

* **Documentation**
  * Added technical documentation outlining planned architecture improvements for enhanced multi-sport support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/323)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->