### PR TITLE
refactor(producer): move ParentId requirement onto polling-target tuple

### DIFF
--- a/docs/competition-streamer-sport-neutralization.md
+++ b/docs/competition-streamer-sport-neutralization.md
@@ -1,6 +1,6 @@
 # CompetitionStreamerBase — sport-neutralization plan
 
-**Status:** Part 1 implemented in PR [#323](https://github.com/jrandallsexton/sports-data-core/pull/323) on 2026-05-15; Part 2 pending
+**Status:** Part 1 implemented in PR [#323](https://github.com/jrandallsexton/sports-data-core/pull/323) on 2026-05-15. Part 2 implementation underway on branch `refactor/streamer-base-polling-target-flag` (audit revealed 2 latent flag bugs — see Verification section).
 **Scope:** `src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs`
 **Why:** This class is the sport-neutral live-streaming base (typed on `TCompetitionDto`,
 subclassed by `FootballCompetitionStreamer` and `BaseballCompetitionStreamer`), but its
@@ -100,21 +100,37 @@ Then `PublishDocumentRequestAsync` takes the bool through the call chain (or a s
 record per target) and drops the `type is …` ladder entirely. The base no longer
 references any sport-specific DocumentType.
 
-### Verification before merge
+### Verification done (2026-05-15 audit)
 
-- Audit each existing polling target's `RequiresParentId` value against the consumer side
-  (the relevant `DocumentProcessor` for each `DocumentType`). If a processor today reads
-  `ParentId` from `DocumentRequested`, the flag must be `true`. If not, `false` is fine
-  but worth a code comment.
-- Add a unit test per streamer that materializes `GetPollingTargets(dto)` and asserts the
-  shape (count, doc types, intervals, flags). This is the first test in the
-  `CompetitionStreamer*` family — they currently have zero coverage (see
-  `live-event-scheduling-testing.md` if it exists, or the parent investigation).
+Audited each polling target against its downstream processor (via `TryGetOrDeriveParentId`
+in `DocumentProcessorBase`). Result:
 
-### Risk
+| DocumentType | Previous ladder | Audited truth | Flag set to |
+|---|---|---|---|
+| `EventCompetitionProbability` | `true` | **false** — processor resolves parent via DTO's `Competition` ref; never reads `ParentId` | `false` |
+| `EventCompetitionDrive` | `true` | `true` — `EventCompetitionDriveDocumentProcessor.cs:105` | `true` |
+| `EventCompetitionPlay` | `true` | `true` — `EventCompetitionPlayDocumentProcessorBase.cs:61` | `true` |
+| `EventCompetitionSituation` | `true` | `true` — football and baseball both call `TryGetOrDeriveParentId` | `true` |
+| `EventCompetitionLeaders` | (not in ladder = `false`) | **true** — `EventCompetitionLeadersDocumentProcessor.cs:46` | `true` |
 
-Behavior-equivalent if the flag mapping is correct on day one. The risk is mis-mapping a
-flag during the migration — hence the unit test.
+**Two latent bugs surfaced.** Probability shipped `ParentId` that nothing read (harmless waste).
+Leaders shipped without `ParentId` and downstream code relied on URI-based fallback in
+`TryGetOrDeriveParentId` — works today but is fragile against ESPN URL-shape changes. Both
+are corrected by Part 2; the PR is therefore **not a pure behavior-preserving refactor** and
+the commit message + PR description should call that out for reviewers.
+
+### Tests added
+
+Tests live in `test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/`:
+
+- `FootballCompetitionStreamerTests.cs` — `#region Polling Targets`: 5 facts asserting
+  count, `RequiresParentId` per type, intervals, ref-URI passthrough, and null-ref behavior.
+- `BaseballCompetitionStreamerTests.cs` (new file) — same 5 facts plus an explicit
+  `DoesNotIncludeDrive` test (Drive is football-only).
+
+Test pattern: nested `Testable*Streamer` subclass exposes the `protected GetPollingTargets`
+method; AutoMocker constructs it with `ProducerTestBase` deps. No mocking of the method
+itself — it's pure logic over a DTO.
 
 ## Recommended PR sequence
 

--- a/docs/competition-streamer-sport-neutralization.md
+++ b/docs/competition-streamer-sport-neutralization.md
@@ -1,6 +1,6 @@
 # CompetitionStreamerBase — sport-neutralization plan
 
-**Status:** Part 1 implemented in PR [#323](https://github.com/jrandallsexton/sports-data-core/pull/323) on 2026-05-15. Part 2 implementation underway on branch `refactor/streamer-base-polling-target-flag` (audit revealed 2 latent flag bugs — see Verification section).
+**Status:** Part 1 implemented in PR [#323](https://github.com/jrandallsexton/sports-data-core/pull/323) on 2026-05-15. Part 2 implemented in PR [#324](https://github.com/jrandallsexton/sports-data-core/pull/324) on 2026-05-15.
 **Scope:** `src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs`
 **Why:** This class is the sport-neutral live-streaming base (typed on `TCompetitionDto`,
 subclassed by `FootballCompetitionStreamer` and `BaseballCompetitionStreamer`), but its
@@ -86,11 +86,15 @@ protected abstract IEnumerable<(Uri? RefUri, DocumentType DocumentType, int Inte
 `FootballCompetitionStreamer.GetPollingTargets`:
 
 ```csharp
-yield return (competitionDto.Probabilities?.Ref, DocumentType.EventCompetitionProbability, 15, RequiresParentId: true);
+// Flag values shown here reflect the audited mapping (see Verification section
+// below) — NOT the pre-Part-2 hardcoded ladder. Probability is false because
+// its processor resolves the parent via the DTO's own Competition ref; the
+// other four call TryGetOrDeriveParentId downstream.
+yield return (competitionDto.Probabilities?.Ref, DocumentType.EventCompetitionProbability, 15, RequiresParentId: false);
 yield return (competitionDto.Drives?.Ref,        DocumentType.EventCompetitionDrive,       15, RequiresParentId: true);
 yield return (competitionDto.Details?.Ref,       DocumentType.EventCompetitionPlay,        10, RequiresParentId: true);
 yield return (competitionDto.Situation?.Ref,     DocumentType.EventCompetitionSituation,    5, RequiresParentId: true);
-yield return (competitionDto.Leaders?.Ref,       DocumentType.EventCompetitionLeaders,     60, RequiresParentId: false);
+yield return (competitionDto.Leaders?.Ref,       DocumentType.EventCompetitionLeaders,     60, RequiresParentId: true);
 ```
 
 `BaseballCompetitionStreamer.GetPollingTargets`: same shape, no Drives target, identical

--- a/src/SportsData.Producer/Application/Competitions/BaseballCompetitionStreamer.cs
+++ b/src/SportsData.Producer/Application/Competitions/BaseballCompetitionStreamer.cs
@@ -25,12 +25,15 @@ public class BaseballCompetitionStreamer : CompetitionStreamerBase<EspnBaseballE
     {
     }
 
-    protected override IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds)>
+    protected override IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds, bool RequiresParentId)>
         GetPollingTargets(EspnBaseballEventCompetitionDto competitionDto)
     {
-        yield return (competitionDto.Probabilities?.Ref, DocumentType.EventCompetitionProbability, 60);
-        yield return (competitionDto.Details?.Ref, DocumentType.EventCompetitionPlay, 30);
-        yield return (competitionDto.Situation?.Ref, DocumentType.EventCompetitionSituation, 30);
-        yield return (competitionDto.Leaders?.Ref, DocumentType.EventCompetitionLeaders, 60);
+        // RequiresParentId mirrors what the downstream processor actually reads
+        // (audited 2026-05-15). Probability resolves its parent via the DTO's
+        // Competition ref; the other three call TryGetOrDeriveParentId.
+        yield return (competitionDto.Probabilities?.Ref, DocumentType.EventCompetitionProbability, 60, RequiresParentId: false);
+        yield return (competitionDto.Details?.Ref,       DocumentType.EventCompetitionPlay,        30, RequiresParentId: true);
+        yield return (competitionDto.Situation?.Ref,     DocumentType.EventCompetitionSituation,   30, RequiresParentId: true);
+        yield return (competitionDto.Leaders?.Ref,       DocumentType.EventCompetitionLeaders,     60, RequiresParentId: true);
     }
 }

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -74,11 +74,20 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     }
 
     /// <summary>
-    /// Sport-specific polling targets. Each entry is (child-doc URI, doc type, polling interval seconds).
-    /// Returning a null URI signals that the parent doc lacks that child link for this competition; the worker
-    /// is silently skipped. Subclasses should keep the list short — every entry adds load to ESPN.
+    /// Sport-specific polling targets. Each entry is (child-doc URI, doc type, polling interval
+    /// seconds, requires-parent-id flag). Returning a null URI signals that the parent doc lacks
+    /// that child link for this competition; the worker is silently skipped. Subclasses should
+    /// keep the list short — every entry adds load to ESPN.
+    ///
+    /// <para>
+    /// <c>RequiresParentId</c> controls whether the published <c>DocumentRequested</c> message
+    /// carries <c>ParentId = CompetitionId</c>. Set <c>true</c> when the eventual document
+    /// processor calls <c>TryGetOrDeriveParentId</c> (Drive, Play, Situation, Leaders); set
+    /// <c>false</c> when the processor resolves its parent through its own DTO link (Probability).
+    /// Declaring this per-target keeps sport-specific DocumentType knowledge out of the base.
+    /// </para>
     /// </summary>
-    protected abstract IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds)>
+    protected abstract IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds, bool RequiresParentId)>
         GetPollingTargets(TCompetitionDto competitionDto);
 
     public async Task ExecuteAsync(StreamCompetitionCommand command, CancellationToken cancellationToken)
@@ -373,7 +382,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
         _logger.LogInformation("Spawning {Count} polling workers", refs.Count);
 
-        foreach (var (refUri, docType, intervalSeconds) in refs)
+        foreach (var (refUri, docType, intervalSeconds, requiresParentId) in refs)
         {
             if (refUri == null)
             {
@@ -382,7 +391,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             }
 
             SpawnPollingWorker(
-                () => PublishDocumentRequestAsync(refUri, docType, command, cancellationToken),
+                () => PublishDocumentRequestAsync(refUri, docType, requiresParentId, command, cancellationToken),
                 intervalSeconds,
                 docType,
                 cancellationToken);
@@ -531,16 +540,11 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     private async Task PublishDocumentRequestAsync(
         Uri refUri,
         DocumentType type,
+        bool requiresParentId,
         StreamCompetitionCommand command,
         CancellationToken cancellationToken)
     {
-        var parentId = type is
-            DocumentType.EventCompetitionProbability or
-            DocumentType.EventCompetitionDrive or
-            DocumentType.EventCompetitionSituation or
-            DocumentType.EventCompetitionPlay
-            ? command.CompetitionId.ToString()
-            : null;
+        var parentId = requiresParentId ? command.CompetitionId.ToString() : null;
 
         _logger.LogDebug("Publishing {Type} document request for {Uri}", type, refUri);
 

--- a/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamer.cs
+++ b/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamer.cs
@@ -24,13 +24,16 @@ public class FootballCompetitionStreamer : CompetitionStreamerBase<EspnFootballE
     {
     }
 
-    protected override IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds)>
+    protected override IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds, bool RequiresParentId)>
         GetPollingTargets(EspnFootballEventCompetitionDto competitionDto)
     {
-        yield return (competitionDto.Probabilities?.Ref, DocumentType.EventCompetitionProbability, 15);
-        yield return (competitionDto.Drives?.Ref, DocumentType.EventCompetitionDrive, 15);
-        yield return (competitionDto.Details?.Ref, DocumentType.EventCompetitionPlay, 10);
-        yield return (competitionDto.Situation?.Ref, DocumentType.EventCompetitionSituation, 5);
-        yield return (competitionDto.Leaders?.Ref, DocumentType.EventCompetitionLeaders, 60);
+        // RequiresParentId mirrors what the downstream processor actually reads
+        // (audited 2026-05-15). Probability resolves its parent via the DTO's
+        // Competition ref; the other four call TryGetOrDeriveParentId.
+        yield return (competitionDto.Probabilities?.Ref, DocumentType.EventCompetitionProbability, 15, RequiresParentId: false);
+        yield return (competitionDto.Drives?.Ref,        DocumentType.EventCompetitionDrive,       15, RequiresParentId: true);
+        yield return (competitionDto.Details?.Ref,       DocumentType.EventCompetitionPlay,        10, RequiresParentId: true);
+        yield return (competitionDto.Situation?.Ref,     DocumentType.EventCompetitionSituation,    5, RequiresParentId: true);
+        yield return (competitionDto.Leaders?.Ref,       DocumentType.EventCompetitionLeaders,     60, RequiresParentId: true);
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/BaseballCompetitionStreamerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/BaseballCompetitionStreamerTests.cs
@@ -1,0 +1,151 @@
+#nullable enable
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Producer.Application.Competitions;
+using SportsData.Producer.Enums;
+using SportsData.Producer.Infrastructure.Data.Baseball;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Competitions;
+
+/// <summary>
+/// Tests for BaseballCompetitionStreamer's polling-target declarations.
+/// Mirrors the FootballCompetitionStreamerTests "Polling Targets" region;
+/// kept in a sibling file because the SUT requires BaseballDataContext rather
+/// than the football one wired by ProducerTestBase.
+/// </summary>
+public class BaseballCompetitionStreamerTests
+    : ProducerTestBase<BaseballCompetitionStreamer>
+{
+    private readonly BaseballDataContext _baseballDataContext;
+
+    public BaseballCompetitionStreamerTests()
+    {
+        _baseballDataContext = new BaseballDataContext(
+            new DbContextOptionsBuilder<BaseballDataContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()[..8])
+                .Options);
+        Mocker.Use(_baseballDataContext);
+    }
+
+    // Test-only subclass exposing the protected GetPollingTargets method.
+    private sealed class TestableBaseballCompetitionStreamer : BaseballCompetitionStreamer
+    {
+        public TestableBaseballCompetitionStreamer(
+            ILogger<BaseballCompetitionStreamer> logger,
+            BaseballDataContext dataContext,
+            IHttpClientFactory httpClientFactory,
+            IServiceScopeFactory scopeFactory,
+            IDateTimeProvider dateTimeProvider)
+            : base(logger, dataContext, httpClientFactory, scopeFactory, dateTimeProvider)
+        {
+        }
+
+        public IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds, bool RequiresParentId)>
+            InvokeGetPollingTargets(EspnBaseballEventCompetitionDto dto)
+            => GetPollingTargets(dto);
+    }
+
+    private static EspnBaseballEventCompetitionDto BuildFullyLinkedDto() => new()
+    {
+        Probabilities = new EspnLinkDto { Ref = new Uri("http://test/probabilities") },
+        Details       = new EspnLinkDto { Ref = new Uri("http://test/plays") },
+        Situation     = new EspnLinkDto { Ref = new Uri("http://test/situation") },
+        Leaders       = new EspnLinkDto { Ref = new Uri("http://test/leaders") },
+    };
+
+    [Fact]
+    public void GetPollingTargets_ReturnsFourTargets_ForBaseball()
+    {
+        var sut = Mocker.CreateInstance<TestableBaseballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var targets = sut.InvokeGetPollingTargets(dto).ToList();
+
+        targets.Should().HaveCount(4);
+        targets.Select(t => t.DocumentType).Should().BeEquivalentTo(new[]
+        {
+            DocumentType.EventCompetitionProbability,
+            DocumentType.EventCompetitionPlay,
+            DocumentType.EventCompetitionSituation,
+            DocumentType.EventCompetitionLeaders,
+        });
+    }
+
+    [Fact]
+    public void GetPollingTargets_DoesNotIncludeDrive()
+    {
+        // Drives are a football-only concept; baseball must not poll them.
+        var sut = Mocker.CreateInstance<TestableBaseballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var targets = sut.InvokeGetPollingTargets(dto).ToList();
+
+        targets.Should().NotContain(t => t.DocumentType == DocumentType.EventCompetitionDrive);
+    }
+
+    [Fact]
+    public void GetPollingTargets_FlagsParentIdPerProcessorAudit()
+    {
+        // Same audit (2026-05-15) as the football counterpart: only Probability
+        // is `false`. The other three call TryGetOrDeriveParentId downstream.
+        var sut = Mocker.CreateInstance<TestableBaseballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var byType = sut.InvokeGetPollingTargets(dto).ToDictionary(t => t.DocumentType);
+
+        byType[DocumentType.EventCompetitionProbability].RequiresParentId.Should().BeFalse();
+        byType[DocumentType.EventCompetitionPlay].RequiresParentId.Should().BeTrue();
+        byType[DocumentType.EventCompetitionSituation].RequiresParentId.Should().BeTrue();
+        byType[DocumentType.EventCompetitionLeaders].RequiresParentId.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetPollingTargets_ReturnsExpectedIntervalsForBaseball()
+    {
+        var sut = Mocker.CreateInstance<TestableBaseballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var byType = sut.InvokeGetPollingTargets(dto).ToDictionary(t => t.DocumentType);
+
+        byType[DocumentType.EventCompetitionProbability].IntervalSeconds.Should().Be(60);
+        byType[DocumentType.EventCompetitionPlay].IntervalSeconds.Should().Be(30);
+        byType[DocumentType.EventCompetitionSituation].IntervalSeconds.Should().Be(30);
+        byType[DocumentType.EventCompetitionLeaders].IntervalSeconds.Should().Be(60);
+    }
+
+    [Fact]
+    public void GetPollingTargets_PassesThroughLinkRefUris()
+    {
+        var sut = Mocker.CreateInstance<TestableBaseballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var byType = sut.InvokeGetPollingTargets(dto).ToDictionary(t => t.DocumentType);
+
+        byType[DocumentType.EventCompetitionProbability].RefUri.Should().Be(new Uri("http://test/probabilities"));
+        byType[DocumentType.EventCompetitionPlay].RefUri.Should().Be(new Uri("http://test/plays"));
+        byType[DocumentType.EventCompetitionSituation].RefUri.Should().Be(new Uri("http://test/situation"));
+        byType[DocumentType.EventCompetitionLeaders].RefUri.Should().Be(new Uri("http://test/leaders"));
+    }
+
+    [Fact]
+    public void GetPollingTargets_ReturnsNullRefUri_WhenLinkAbsent()
+    {
+        var sut = Mocker.CreateInstance<TestableBaseballCompetitionStreamer>();
+        var dto = new EspnBaseballEventCompetitionDto(); // all links null
+
+        var targets = sut.InvokeGetPollingTargets(dto).ToList();
+
+        targets.Should().HaveCount(4, "shape is fixed; null links surface as null RefUri");
+        targets.Should().AllSatisfy(t => t.RefUri.Should().BeNull());
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamerTests.cs
@@ -3,11 +3,15 @@
 using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 using Moq.Protected;
 
 using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Application.Competitions;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Infrastructure.Data;
@@ -468,6 +472,122 @@ public class FootballCompetitionStreamerTests : ProducerTestBase<FootballCompeti
         // Act & Assert - should not throw
         var act = async () => await sut.ExecuteAsync(command, cts.Token);
         await act.Should().NotThrowAsync();
+    }
+
+    #endregion
+
+    #region Polling Targets
+
+    // Test-only subclass exposing the protected GetPollingTargets method.
+    // The base ctor requires non-null dependencies (httpClientFactory.CreateClient
+    // is invoked), so we route construction through AutoMocker which already wires
+    // those for ProducerTestBase.
+    private sealed class TestableFootballCompetitionStreamer : FootballCompetitionStreamer
+    {
+        public TestableFootballCompetitionStreamer(
+            ILogger<FootballCompetitionStreamer> logger,
+            FootballDataContext dataContext,
+            IHttpClientFactory httpClientFactory,
+            IServiceScopeFactory scopeFactory,
+            IDateTimeProvider dateTimeProvider)
+            : base(logger, dataContext, httpClientFactory, scopeFactory, dateTimeProvider)
+        {
+        }
+
+        public IEnumerable<(Uri? RefUri, DocumentType DocumentType, int IntervalSeconds, bool RequiresParentId)>
+            InvokeGetPollingTargets(EspnFootballEventCompetitionDto dto)
+            => GetPollingTargets(dto);
+    }
+
+    private static EspnFootballEventCompetitionDto BuildFullyLinkedDto() => new()
+    {
+        Probabilities = new EspnLinkDto { Ref = new Uri("http://test/probabilities") },
+        Drives        = new EspnLinkDto { Ref = new Uri("http://test/drives") },
+        Details       = new EspnLinkDto { Ref = new Uri("http://test/plays") },
+        Situation     = new EspnLinkDto { Ref = new Uri("http://test/situation") },
+        Leaders       = new EspnLinkDto { Ref = new Uri("http://test/leaders") },
+    };
+
+    [Fact]
+    public void GetPollingTargets_ReturnsFiveTargets_ForFootball()
+    {
+        var sut = Mocker.CreateInstance<TestableFootballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var targets = sut.InvokeGetPollingTargets(dto).ToList();
+
+        targets.Should().HaveCount(5);
+        targets.Select(t => t.DocumentType).Should().BeEquivalentTo(new[]
+        {
+            DocumentType.EventCompetitionProbability,
+            DocumentType.EventCompetitionDrive,
+            DocumentType.EventCompetitionPlay,
+            DocumentType.EventCompetitionSituation,
+            DocumentType.EventCompetitionLeaders,
+        });
+    }
+
+    [Fact]
+    public void GetPollingTargets_FlagsParentIdPerProcessorAudit()
+    {
+        // Audit (2026-05-15): Probability resolves its parent via the DTO's
+        // Competition ref and does not call TryGetOrDeriveParentId. The other
+        // four processors do. The flag values below mirror that audit.
+        var sut = Mocker.CreateInstance<TestableFootballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var byType = sut.InvokeGetPollingTargets(dto).ToDictionary(t => t.DocumentType);
+
+        byType[DocumentType.EventCompetitionProbability].RequiresParentId.Should().BeFalse();
+        byType[DocumentType.EventCompetitionDrive].RequiresParentId.Should().BeTrue();
+        byType[DocumentType.EventCompetitionPlay].RequiresParentId.Should().BeTrue();
+        byType[DocumentType.EventCompetitionSituation].RequiresParentId.Should().BeTrue();
+        byType[DocumentType.EventCompetitionLeaders].RequiresParentId.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetPollingTargets_ReturnsExpectedIntervalsForFootball()
+    {
+        var sut = Mocker.CreateInstance<TestableFootballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var byType = sut.InvokeGetPollingTargets(dto).ToDictionary(t => t.DocumentType);
+
+        byType[DocumentType.EventCompetitionProbability].IntervalSeconds.Should().Be(15);
+        byType[DocumentType.EventCompetitionDrive].IntervalSeconds.Should().Be(15);
+        byType[DocumentType.EventCompetitionPlay].IntervalSeconds.Should().Be(10);
+        byType[DocumentType.EventCompetitionSituation].IntervalSeconds.Should().Be(5);
+        byType[DocumentType.EventCompetitionLeaders].IntervalSeconds.Should().Be(60);
+    }
+
+    [Fact]
+    public void GetPollingTargets_PassesThroughLinkRefUris()
+    {
+        var sut = Mocker.CreateInstance<TestableFootballCompetitionStreamer>();
+        var dto = BuildFullyLinkedDto();
+
+        var byType = sut.InvokeGetPollingTargets(dto).ToDictionary(t => t.DocumentType);
+
+        byType[DocumentType.EventCompetitionProbability].RefUri.Should().Be(new Uri("http://test/probabilities"));
+        byType[DocumentType.EventCompetitionDrive].RefUri.Should().Be(new Uri("http://test/drives"));
+        byType[DocumentType.EventCompetitionPlay].RefUri.Should().Be(new Uri("http://test/plays"));
+        byType[DocumentType.EventCompetitionSituation].RefUri.Should().Be(new Uri("http://test/situation"));
+        byType[DocumentType.EventCompetitionLeaders].RefUri.Should().Be(new Uri("http://test/leaders"));
+    }
+
+    [Fact]
+    public void GetPollingTargets_ReturnsNullRefUri_WhenLinkAbsent()
+    {
+        // Mirrors live behavior: ESPN sometimes omits the child link before a
+        // competition reaches certain states. The base's StartPollingWorkers
+        // silently skips workers with null RefUri.
+        var sut = Mocker.CreateInstance<TestableFootballCompetitionStreamer>();
+        var dto = new EspnFootballEventCompetitionDto(); // all links null
+
+        var targets = sut.InvokeGetPollingTargets(dto).ToList();
+
+        targets.Should().HaveCount(5, "shape is fixed; null links surface as null RefUri");
+        targets.Should().AllSatisfy(t => t.RefUri.Should().BeNull());
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Part 2 of the sport-neutralization plan in `docs/competition-streamer-sport-neutralization.md`. Removes the football-flavored `DocumentType` ladder from `CompetitionStreamerBase.PublishDocumentRequestAsync` and replaces it with a per-target `RequiresParentId` flag declared on the polling tuple. The base no longer references any sport-specific `DocumentType` value.

- `GetPollingTargets` tuple gains `bool RequiresParentId`
- `FootballCompetitionStreamer` and `BaseballCompetitionStreamer` declare the flag per target
- `PublishDocumentRequestAsync` reads the flag and attaches `ParentId` accordingly
- Adds 11 unit tests across two files asserting the tuple shape per sport

## ⚠️ Not behavior-equivalent — audit fixed 2 latent flag bugs

| DocumentType | Prior ladder | Audited truth | New flag |
|---|---|---|---|
| Probability | `true` | **false** — processor never reads `ParentId`; resolves parent via DTO's `Competition` ref | `false` |
| Drive | `true` | `true` (`EventCompetitionDriveDocumentProcessor.cs:105`) | `true` |
| Play | `true` | `true` (`EventCompetitionPlayDocumentProcessorBase.cs:61`) | `true` |
| Situation | `true` | `true` (football + baseball variants) | `true` |
| Leaders | not in ladder = `false` | **true** — `EventCompetitionLeadersDocumentProcessor.cs:46` calls `TryGetOrDeriveParentId` | `true` |

**Probability fix:** drops an unused field on the wire. Harmless waste before.
**Leaders fix:** removes reliance on `TryGetOrDeriveParentId`'s URI-shape fallback. Worked today, would silently break if ESPN ever changed that URL.

## Test plan
- [x] `dotnet build` Producer + test project — 0 warnings, 0 errors
- [x] 11 new polling-target tests pass
- [x] Full Producer test suite: 402 passing, 0 failing, 15 pre-existing skips
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ParentId handling in document requests during ESPN live competition streaming.

* **Tests**
  * Added unit tests for football and baseball competition polling logic, validating document types and ParentId requirements per target.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/324)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->