### PR TITLE
feat(mobile): Phase 1 — SignalR plumbing + contest updates store

### DIFF
--- a/docs/mobile/mobile-signalr-admin-plan.md
+++ b/docs/mobile/mobile-signalr-admin-plan.md
@@ -1,0 +1,312 @@
+# Mobile SignalR Live Updates + Sport-Agnostic Admin Page — Plan
+
+**Status:** Draft — not yet scheduled
+**Author:** planning pass, 2026-05-15
+**Target:** sd-mobile (Expo SDK 55, RN 0.83.2)
+**Related docs:** `docs/mobile/notifications-and-live-updates.md` (future SSE migration), `docs/web-signalr-surface-audit.md`
+
+---
+
+## 1. Goals
+
+1. Stand up a real-time live-updates pipeline in `src/UI/sd-mobile` that consumes the same SignalR hub (`/hubs/notifications`) the web app consumes today, with the same three event types: `ContestStatusChanged`, `FootballPlayCompleted`, `BaseballPlayCompleted`. (`PreviewGenerated` is intentionally out of scope for v1 — see §11.)
+2. Make `MatchupCard.tsx` re-render against live data the moment events arrive, using the same enrichment pattern the web's `PicksPage` and `AdminBaseballPage` use (live-record merged over the static REST payload via nullish fallback).
+3. Add a single sport-agnostic admin screen at `/admin` that consolidates what the web ships as two separate pages (`AdminFootballPage`, `AdminBaseballPage`). The screen offers a sport dropdown (FootballNfl / FootballNcaa / BaseballMlb), a contestId text input, a Load matchup button, a Trigger replay button, a rendered `MatchupCard`, and a scrolling debug-event log.
+4. Validate end-to-end on a dev-client build against the staging API while a real MLB game is in progress (or via the admin replay endpoint against a recently-completed game).
+
+## 2. Non-goals
+
+- SSE migration. `docs/mobile/notifications-and-live-updates.md` proposes replacing SignalR with SSE before the 2026 NCAAFB season. This plan ships against today's SignalR pipeline because: (a) the SSE work is unscheduled, (b) MLB is live now and the mobile gap exists now, (c) the web app would still be on SignalR concurrently. The mobile SignalR client lifetime in this plan is treated as 3–9 months — short enough that we should avoid premature abstraction.
+- Push notifications (FCM/APNS). That is its own scope.
+- Polling fallback. The 30s `staleTime` on `useMatchups` already gives us a soft fallback; the live channel is purely additive.
+- `PreviewGenerated` event. The mobile app has no `react-hot-toast` equivalent wired today and the existing in-flight preview UX is unfinished.
+- Pure SignalR debug card port (`FootballDebugCard` / `BaseballDebugCard` from web). The mobile admin page exposes only the more valuable real-replay flow; the synthetic-event sandbox stays a web tool.
+
+## 3. Current state (verified findings)
+
+### Mobile app
+- Expo SDK 55, React Native 0.83.2, React 19.2.0, `expo-router` (file-based routing, main = `expo-router/entry`). Confirmed in `src/UI/sd-mobile/package.json`.
+- State management is Zustand + TanStack Query. There is exactly one React Context in the app — `ThemeContext` (`src/lib/theme/`). Auth state, the most "global" mobile state, is a Zustand store (`src/stores/authStore.ts`).
+- Auth: Firebase 12.10.0. `onAuthStateChanged` is wired in `src/hooks/useAuth.ts` and pushed into the Zustand store. The axios client (`src/services/api/client.ts`) attaches `Bearer ${user.getIdToken()}` per request via an interceptor — the canonical pattern for "get a Firebase JWT now."
+- `me.isAdmin` already exists on the mobile side: `app/create-league.tsx` reads `me?.isAdmin === true` from the existing `useCurrentUser` hook (lines 144–239). The MLB-onboarding admin gate is already live.
+- `MatchupCard.tsx` at `src/components/features/games/MatchupCard.tsx` is static-only: it consumes `matchup.status`, `matchup.awayScore`, etc., but never subscribes to a live source. `GameStatus.tsx` already renders InProgress UI when `status === 'inprogress'` — once we feed it merged data, the InProgress branch will light up.
+- `useMatchups.ts` is REST-only, 30s staleTime, no SignalR awareness.
+- No SignalR library installed. `@microsoft/signalr` is absent from `package.json`.
+- No admin routes. `app/` contains `(auth)`, `(tabs)`, `create-league.tsx`, `+not-found.tsx`. There is no `admin/` route group.
+- Expo Router structure: `(tabs)` is the authenticated home. Auth gate lives in root `_layout.tsx`'s `AuthGuard` component, which redirects to `/(auth)/sign-in` when no user.
+
+### Web app reference (canonical, mirror these)
+- `src/UI/sd-ui/src/hooks/useSignalRClient.js` — builds a single `HubConnectionBuilder` against `${REACT_APP_SIGNALR_URL || REACT_APP_API_BASE_URL}/hubs/notifications`, attaches `accessTokenFactory` that calls `getAuth().currentUser.getIdToken()`, uses `withAutomaticReconnect()`, registers four `connection.on(...)` handlers, returns the connection ref.
+- `src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx` — single React Context holding `{ contests: { [contestId]: liveRecord } }`. Exposes `handleStatusUpdate`, `handleFootballPlayCompleted`, `handleBaseballPlayCompleted`, `getContestUpdate(contestId)`, `hasLiveUpdate(contestId)`, `clearContestUpdate(contestId)`, `clearAllUpdates()`. Critical detail — the PR #322 self-heal: receiving a `*PlayCompleted` event forces `status: 'InProgress'` because SignalR has no buffer and post-connect clients miss any earlier `ContestStatusChanged`. Mirror exactly.
+- `src/UI/sd-ui/src/MainApp.jsx` lines 88–127 — shows the wire-up: context handlers from `useContestUpdates()`, wrapped in `useCallback` so the SignalR effect doesn't tear down/reconnect on every render.
+- `src/UI/sd-ui/src/components/admin/AdminBaseballPage.jsx` and `AdminFootballPage.jsx` — pattern: contest-id-from-localStorage, league-from-localStorage (football only), Load matchup button (REST), Start replay button (POST), real `<MatchupCard>` rendered with `enrichedMatchup` merging static + live via nullish fallback, plus a `BaseballLiveStatePanel` / `FootballLiveStatePanel` debug readout.
+- `src/UI/sd-ui/src/api/adminApi.js` — endpoints: `GET /admin/baseball/contests/{id}/matchup`, `GET /admin/football/contests/{id}/matchup?league=ncaa|nfl`, `POST /admin/baseball/contests/{id}/replay`, `POST /admin/football/contests/{id}/replay?league=ncaa|nfl`.
+
+### Backend (verified)
+- Hub mapped at `/hubs/notifications` (`src/SportsData.Api/Program.cs:366`). Production URL is the API host.
+- Events emitted today by `IHubContext<NotificationHub>.Clients.All.SendAsync(...)`: `ContestStatusChanged`, `FootballPlayCompleted`, `BaseballPlayCompleted`, `ContestScoreChanged`, `ContestRecapArticlePublished`, `ContestOddsUpdated`, `PreviewGenerated`. The first three are what mobile needs for v1.
+- Firebase JWT auth on the hub — same scheme as REST.
+
+## 4. Library choice
+
+`@microsoft/signalr@^9` (latest 9.x). Decision is forced — it is the only first-party JS client for SignalR negotiation, and our backend uses `MapHub` (not raw WebSocket). Alternatives:
+
+- Rolling our own WebSocket client. Rejected: re-implements negotiate/protocol/reconnect for zero benefit and forks us from web.
+- Switching to SSE first. Rejected: see §2.
+
+Compatibility check items the implementation must verify on first install:
+- React Native 0.83.2 ships a working WebSocket polyfill; `@microsoft/signalr` defers to global `WebSocket` and `XMLHttpRequest`. No EventSource polyfill needed for the WebSocket transport.
+- Hermes engine (Expo 55 default). The `@microsoft/signalr` package has had Hermes issues historically with `MessagePack` protocol — stay on default JSON protocol. No `@microsoft/signalr-protocol-msgpack`.
+- Metro `transformIgnorePatterns` in `package.json` (the Jest config) — `@microsoft/signalr` ships ES modules; if Jest barfs, add `@microsoft/signalr` to the negative-lookahead group.
+- Expo Go vs dev-client: `@microsoft/signalr` is pure JS, no native code, so Expo Go is fine. No prebuild required.
+
+## 5. Architecture
+
+```
+                 (auth user signs in)
+                          │
+                          ▼
+            ┌──────────────────────────────┐
+            │ app/_layout.tsx              │
+            │  QueryClientProvider         │
+            │   ThemeProvider              │
+            │    AuthGuard                 │
+            │    ┌──────────────────────┐  │
+            │    │ <ContestUpdatesGate> │  │  ◄── only mounts when isAuthenticated
+            │    │   <SignalRGate>      │  │
+            │    │     <Stack/>         │  │
+            │    └──────────────────────┘  │
+            └──────────────────────────────┘
+                          │
+                          ▼
+            ┌──────────────────────────────────────────────┐
+            │ useSignalRClient (hook)                      │
+            │  builds HubConnection, accessTokenFactory =  │
+            │  () => getAuth().currentUser?.getIdToken()   │
+            │  registers .on('ContestStatusChanged', …)    │
+            │            .on('FootballPlayCompleted', …)   │
+            │            .on('BaseballPlayCompleted', …)   │
+            │  + AppState listener: background → stop,     │
+            │                       foreground → start     │
+            │  + NetInfo listener: connectivity loss → log │
+            └──────────────────────────────────────────────┘
+                          │
+                          ▼ (writes to Zustand store)
+            ┌──────────────────────────────────────────────┐
+            │ contestUpdatesStore (Zustand)                │
+            │   contests: { [contestId]: liveRecord }      │
+            │   actions: handleStatusUpdate,               │
+            │            handleFootballPlayCompleted,      │
+            │            handleBaseballPlayCompleted,      │
+            │            clearContestUpdate, clearAll      │
+            │   selectors: useContestUpdate(contestId)     │
+            └──────────────────────────────────────────────┘
+                          │
+                          ▼ (selector subscription)
+            ┌──────────────────────────────────────────────┐
+            │ MatchupCard (or any consumer)                │
+            │   const live = useContestUpdate(contestId);  │
+            │   const enriched = useMemo(() =>             │
+            │     merge(matchup, live), [matchup, live]);  │
+            └──────────────────────────────────────────────┘
+```
+
+### State management decision — Zustand, not React Context
+
+The web uses Context because `MainApp.jsx` was already context-shaped before live updates existed. The mobile codebase is uniformly Zustand for global state (auth) and TanStack Query for server state. Introducing a new React Context just for this would be inconsistent and adds re-render gotchas (every consumer re-renders on any contest update unless you split contexts).
+
+A Zustand store with **per-contest selector hooks** is strictly better here:
+
+```ts
+// pseudocode — not the final file
+const useContestUpdatesStore = create<State>(...)
+export const useContestUpdate = (contestId: string | undefined) =>
+  useContestUpdatesStore(s => contestId ? s.contests[contestId] : undefined);
+```
+
+Only cards whose `contestId` actually changed re-render. The web's Context broadcasts to every consumer on every event; on mobile with a FlatList of 16 picks during a Sunday slate, that's bad. **Recommendation: Zustand store.**
+
+Functional parity with the web is straightforward — same actions, same self-heal logic, same shape.
+
+### Connection lifecycle — mount in an auth-gated subtree
+
+The SignalR connection must not start before there is a Firebase user (otherwise `accessTokenFactory` returns `null` and the negotiate fails 401). Two options:
+
+1. Mount `useSignalRClient` in root `_layout.tsx` and guard inside the hook (`if (!user) return;`).
+2. Introduce a small `<SignalRGate>` component that mounts only the hook, rendered from inside `AuthGuard`'s success branch.
+
+Option 2 is cleaner and matches the way `ThemeProvider` is structured. The hook still needs an internal user check because Firebase token refresh can momentarily return null mid-session.
+
+### Mobile lifecycle differences from web — explicit handling
+
+Web's `useSignalRClient` relies on the browser's tab-visibility / WebSocket keepalive behavior; mobile cannot. Two mobile-only behaviors to add:
+
+- **AppState listener**: when the app moves to `background`, call `connection.stop()`. When it returns to `active`, call `connection.start()` again. Reason: iOS aggressively kills sockets that idle in the background and `withAutomaticReconnect` can spin pointless retries while the JS thread is paused. Use `AppState` from `react-native`.
+- **NetInfo listener** (optional v1.5): subscribe to `@react-native-community/netinfo` and force a reconnect on network type change. `@microsoft/signalr.withAutomaticReconnect()` covers the basic cases but is slow to detect Wi-Fi ↔ cellular handoffs; this is a nice-to-have.
+
+Reconnect strategy: `.withAutomaticReconnect([0, 2000, 10000, 30000, null])` so we don't hammer on prolonged outages.
+
+### Auth flow
+
+`accessTokenFactory` is async and called per-connection-attempt by `@microsoft/signalr`. Implementation:
+
+```ts
+accessTokenFactory: async () => {
+  const user = getAuth().currentUser;
+  if (!user) return null;
+  try {
+    return await user.getIdToken(); // Firebase auto-refreshes when within 5 min of expiry
+  } catch (err) {
+    console.warn('[useSignalRClient] token fetch failed', err);
+    return null;
+  }
+}
+```
+
+Identical to the web hook, with React Native–friendly error handling (no `console.error` which alarms Expo dev menu).
+
+Token refresh story: a Firebase ID token lives 1 hour. `@microsoft/signalr` calls `accessTokenFactory` on the initial negotiate and on each reconnect. While the WebSocket is alive across the hour boundary, the server keeps trusting the connection (the JWT was validated at handshake). If the server later disconnects (e.g., during reconnect), the factory is called again and a fresh token flows. **No explicit refresh timer needed.**
+
+### Admin route placement
+
+```
+app/
+  (auth)/
+  (tabs)/
+  admin/                ← new route group (no parentheses — visible in URL bar)
+    _layout.tsx         ← AdminGuard wraps Stack
+    index.tsx           ← the single sport-agnostic page
+  create-league.tsx
+```
+
+`admin/_layout.tsx` reads `useCurrentUser().data?.isAdmin` and `router.replace('/(tabs)')` if false. Same pattern as the existing `AuthGuard` in root `_layout.tsx`. Reached by a hidden "Admin" link in `profile.tsx` only visible when `me.isAdmin === true` (matches existing admin gate in `create-league.tsx`).
+
+### Sport dropdown UX
+
+`SegmentedControl` already exists at `src/components/ui/SegmentedControl.tsx` (used in profile.tsx). Three options fit cleanly: `NFL` / `NCAAF` / `MLB`. This is idiomatic for the rest of the app and avoids pulling in a new picker library. Internally the segment maps to the API's sport enum (`FootballNfl` / `FootballNcaa` / `BaseballMlb`) and the replay endpoint (football endpoint expects `league=ncaa|nfl` query param; baseball endpoint takes no league qualifier).
+
+### Debug panel design
+
+A `FlatList` (or simple `ScrollView` with `inverted`) showing the most recent 50 events:
+```
+12:04:31.847  FootballPlayCompleted  contest=abc…  per=Q3 clk=4:21  away=14 home=21
+12:04:30.214  FootballPlayCompleted  contest=abc…  per=Q3 clk=4:48  away=14 home=21
+12:04:21.012  ContestStatusChanged   contest=abc…  status=InProgress
+```
+
+Lives below the MatchupCard, dismissable via a header chevron (collapsed by default once a test is satisfying). Each event is appended via a separate small Zustand store (`adminDebugStore`) so the debug log doesn't slow down the main updates store.
+
+## 6. Phase-by-phase plan
+
+Each phase is its own PR.
+
+### Phase 1 — SignalR plumbing + contest updates store (no UI changes)
+
+Goal: stand up the live data pipeline behind the existing app surface. After this phase, `MatchupCard` is still static, but events flow into a store nothing yet reads. Easy to revert.
+
+Files created:
+- `src/UI/sd-mobile/src/services/signalR/connection.ts` — exports `createSignalRConnection({ url, accessTokenFactory, logger })`. Pure factory, no React.
+- `src/UI/sd-mobile/src/hooks/useSignalRClient.ts` — owns the connection lifecycle. Accepts handler callbacks as props (matches web shape). Adds AppState listener.
+- `src/UI/sd-mobile/src/stores/contestUpdatesStore.ts` — Zustand store, three action handlers + selector hooks (`useContestUpdate(contestId)`, `useHasLiveUpdate(contestId)`).
+- `src/UI/sd-mobile/src/types/signalR.ts` — TS types for `ContestStatusChangedPayload`, `FootballPlayCompletedPayload`, `BaseballPlayCompletedPayload` (mirror the web's untyped object shapes). Generated by reading the C# event classes (`SportsData.Core` IntegrationEvents) so we don't drift.
+- `src/UI/sd-mobile/__tests__/contestUpdatesStore.test.ts` — unit tests for the three handlers + self-heal behavior.
+- `src/UI/sd-mobile/__tests__/useSignalRClient.test.ts` — mocked-connection tests for handler dispatch.
+
+Files modified:
+- `src/UI/sd-mobile/package.json` — add `"@microsoft/signalr": "^9.0.0"`. Audit `transformIgnorePatterns` in the Jest config block — likely needs `@microsoft/signalr` added.
+- `src/UI/sd-mobile/app/_layout.tsx` — render a new `<SignalRGate>` inside the authenticated branch. Likely the simplest path: extract `<SignalRGate>` from `useAuth().isAuthenticated`.
+
+Env: introduce `EXPO_PUBLIC_SIGNALR_URL` (falls back to `EXPO_PUBLIC_API_BASE_URL`). Same precedence as the web's `REACT_APP_SIGNALR_URL` / `REACT_APP_API_BASE_URL`.
+
+CI: `npm install` in mobile CI will pull `@microsoft/signalr` — no native modules so EAS prebuild is untouched. Verify the GitHub Actions mobile workflow's `npm ci` step still passes; expected.
+
+PR criteria: app builds, jest tests pass (including new ones), running on dev-client shows `[SignalR] connected` in Metro logs once a user signs in.
+
+### Phase 2 — MatchupCard consumes live updates
+
+Goal: existing screens light up live. No admin yet.
+
+Files modified:
+- `src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx` — call `useContestUpdate(matchup.contestId)`, compute `enrichedMatchup` via `useMemo` with nullish fallbacks, pass enriched object down through `TeamRow`, `OddsRow`, `GameStatus`. Mirror exactly the web's `enrichedMatchup` shape from `AdminBaseballPage.jsx` lines 39–67 and `AdminFootballPage.jsx` lines 59–75 — both football and baseball fields, because the same MatchupCard renders all sports.
+- `src/UI/sd-mobile/src/types/models.ts` — extend `Matchup` with the baseball live fields (`inning`, `halfInning`, `balls`, `strikes`, `outs`, `runnerOnFirst/Second/Third`, `atBatShortName`, `atBatPositionAbbreviation`, `atBatHeadshotUrl`, `pitchingShortName`, `pitchingPositionAbbreviation`, `pitchingHeadshotUrl`, `lastPlayDescription`, `lastPlayId`, `ballOnYardLine`). Football live fields already exist (`period`, `clock`, `possessionFranchiseSeasonId`, `isScoringPlay`).
+- `src/UI/sd-mobile/src/components/features/games/GameStatus.tsx` — add a `BaseballGameStatusInProgress` branch (mirror web `BaseballGameStatusInProgress` already shipped on web). The football InProgress branch already exists per the file header read.
+- `src/UI/sd-mobile/__tests__/MatchupCard.live.test.tsx` — new test: render MatchupCard, push an event into the store, assert the rendered text updates.
+
+PR criteria: with the staging API and a running real MLB game (or admin replay from Phase 3 used out-of-order from the web's admin page), `picks.tsx` shows live scoreboard ticks on the in-progress card. No regression on Scheduled / Final cards.
+
+### Phase 3 — Sport-agnostic admin page + replay
+
+Goal: ship the dev tool.
+
+Files created:
+- `src/UI/sd-mobile/app/admin/_layout.tsx` — Stack + `AdminGuard` redirecting to `/(tabs)` when `!me.isAdmin`.
+- `src/UI/sd-mobile/app/admin/index.tsx` — the single sport-agnostic page. Sport segmented control, contestId TextInput, Load button, Trigger replay button, MatchupCard, collapsible debug log.
+- `src/UI/sd-mobile/src/services/api/adminApi.ts` — typed client for `/admin/{sport}/contests/{id}/matchup` (GET) and `/admin/{sport}/contests/{id}/replay` (POST). Endpoint shape:
+  ```
+  sport=baseball       → /admin/baseball/contests/{id}/{matchup|replay}
+  sport=football, league=ncaa|nfl → /admin/football/contests/{id}/{matchup|replay}?league={league}
+  ```
+- `src/UI/sd-mobile/src/stores/adminDebugStore.ts` — bounded ring buffer (50 events) Zustand store + `useAdminDebugLog()` selector. Separate from `contestUpdatesStore` so debug rendering doesn't trigger main UI re-renders.
+- `src/UI/sd-mobile/src/hooks/useAdminEventTap.ts` — small hook that subscribes to the live SignalR handlers and forwards every event into `adminDebugStore`. Mounted only by the admin screen.
+- `src/UI/sd-mobile/__tests__/admin/index.test.tsx` — basic render + interaction tests.
+
+Files modified:
+- `src/UI/sd-mobile/app/(tabs)/profile.tsx` — append an "Admin" link visible only when `me?.isAdmin === true`. `router.push('/admin')`.
+- `src/UI/sd-mobile/src/hooks/useSignalRClient.ts` — extend to optionally take a `onAny` callback so the admin screen can attach its event tap without re-registering the per-event handlers. Alternative: route every handler through the debug store always (cheap; 50-event ring buffer). Pick the always-on route — simpler, no extra subscription plumbing, and an Admin user is the only one whose screen reads the buffer.
+
+PR criteria: admin user signs in, taps Profile → Admin → MLB → pastes a recently-Final contest GUID → Load → MatchupCard renders → Trigger replay → debug log fills with `BaseballPlayCompleted` rows + the MatchupCard scoreboard ticks. Same flow works for NFL and NCAAF.
+
+## 7. Open questions and decisions to make at PR time
+
+1. **AsyncStorage persistence of `contestId` in admin page.** Web uses `localStorage`. Mobile equivalent is `@react-native-async-storage/async-storage` (already a dep). Worth doing for v1 ergonomics, but not load-bearing. Recommend yes.
+2. **Should `useSignalRClient` live in the root layout or inside `(tabs)`?** Argument for root: notifications and live updates apply across the whole authenticated app, including future admin screen. Argument for `(tabs)`: the admin screen is the only place outside tabs that needs it, and that's an unauthenticated edge case we don't have today. Recommend root + auth gate.
+3. **Crash on stale token.** `getIdToken()` can throw if Firebase decides the user is signed out. The web's hook returns null on error and lets SignalR fail. Mobile likely should do the same but emit a single toast (we have no toast lib installed — likely add one in a follow-up). Decision deferred.
+4. **Should the admin screen poll `useMatchups`-style or use `getMatchupForContest`?** The web admin pages use a one-shot `getBaseballMatchupForContest`/`getFootballMatchupForContest`. Mirror that — no React Query needed for a one-shot. Recommend `useState` + `useEffect`.
+5. **Phase 2.5 wedge — should `useContestOverview` (game detail screen) also consume live updates?** It currently polls every 30s. The merge logic would be identical to MatchupCard. Recommend ship in Phase 2 same PR if scope allows, otherwise defer to Phase 4 (not in this plan).
+6. **Self-heal write loop on `*PlayCompleted`.** The web sets `setTimeout(() => clearScoringFlag, 2000)` on football scoring plays. On mobile, replicate as a per-contest debounced cleaner inside the store. Verify no leak when the screen unmounts mid-timeout. Recommend a single shared `setTimeout` registry keyed by contestId.
+7. **What's the production SignalR URL?** Need to confirm — likely `https://api.sportdeets.com` (same host as REST). The web treats them as separable via `REACT_APP_SIGNALR_URL`. Mirror that with `EXPO_PUBLIC_SIGNALR_URL` even if it ends up unused.
+
+## 8. Test plan
+
+### Unit
+- `contestUpdatesStore`: each of three handlers writes the expected fields; status self-heal promotes `Scheduled` → `InProgress` on first play event; scoring flash auto-clears.
+- `useSignalRClient`: with a mocked `HubConnection` (DI'd via the factory), `.on(...)` handlers are registered for all three events; calling them dispatches to the store; AppState `background` triggers `stop`; `active` triggers `start`.
+
+### Integration (dev-client on Android emulator / iOS simulator)
+- Sign in as the dev test admin user.
+- Go to picks; pick a league/week containing an in-progress game (or use admin replay).
+- Verify in Metro logs: `[SignalR] connected`. Verify Seq shows the connection on the API side (filter by user).
+- From the admin screen, trigger a baseball replay; expect 1 `ContestStatusChanged` + N `BaseballPlayCompleted` over ~N seconds, MatchupCard scoreboard ticks per event, debug log shows the full event stream.
+- Background the app for >60 seconds; foreground; verify reconnect and a fresh `ContestStatusChanged` is requested (n/a — SignalR has no replay; this is just confirming the connection re-establishes).
+- Toggle airplane mode for 10s; verify the reconnect kicks in within the configured backoff (`[0, 2000, 10000, 30000]`).
+
+### Staging vs local
+- Local Producer + local API + local broker is overkill for the mobile-side validation; staging API against a real MLB game is more representative of production behavior (TLS, real auth, real rate limits). Use staging.
+
+### MLB-live caveat
+- Don't deploy to TestFlight / internal Play track during a live MLB game window without verifying staging first; this is real production traffic going through the same hub.
+
+## 9. Risks
+
+- **SignalR being deprecated mid-flight by the SSE migration.** Mitigation: the abstraction surface (`createSignalRConnection`, `useSignalRClient`, three handler callbacks, one Zustand store) is small. If SSE replaces the hub in 3–6 months, only `useSignalRClient.ts` and `services/signalR/connection.ts` need to change — the store, the selector hooks, and `MatchupCard` enrichment stay identical. Document this in the file headers.
+- **Hermes incompatibility with `@microsoft/signalr` internals.** Low probability — the library is widely used in RN — but worth a smoke test on day 1 of Phase 1.
+- **Re-render storm during a high-scoring NFL game** (think 30+ events in a 90s window). Mitigation: the per-contest selector hook means only the in-view cards re-render. `FlatList` virtualization further limits scope.
+- **Token refresh edge during a long-lived connection.** As noted in §5, the server doesn't re-validate the JWT mid-connection. If we deploy a backend change that adds per-message JWT validation, mobile clients will silently drop messages until reconnect. This is a backend-side concern, but worth flagging.
+- **Admin page on Android keyboard.** The TextInput for contestId is GUID-length; on a small Android device the keyboard occluding both buttons is likely. Use `KeyboardAvoidingView` like `create-league.tsx` does.
+- **Self-inflicted PicksScreen scope creep.** Phase 2 is "MatchupCard consumes live updates." The temptation will be to also fix the game-detail screen, the home screen, etc. Resist; ship them in follow-ups.
+- **Debug log perf.** Don't append to React state on every event — that's a render per event. Append to the Zustand store with a stable selector; the FlatList re-renders only when the slice changes.
+
+## 10. Out-of-scope follow-ups (forced surface area)
+
+- `PreviewGenerated` toast — needs a mobile toast library (likely `react-native-toast-message` or roll a minimal one).
+- Live updates on game-detail screen (`app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx`).
+- Push notifications (`docs/mobile/notifications-and-live-updates.md` Pillar C).
+- SSE migration alignment.
+
+## 11. Critical Files for Implementation
+
+- `src/UI/sd-mobile/package.json` — add `@microsoft/signalr`, update jest `transformIgnorePatterns`
+- `src/UI/sd-mobile/src/hooks/useSignalRClient.ts` — new — connection lifecycle hook
+- `src/UI/sd-mobile/src/stores/contestUpdatesStore.ts` — new — Zustand store w/ per-contest selector hooks + self-heal
+- `src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx` — modified — `enrichedMatchup` merge
+- `src/UI/sd-mobile/app/admin/index.tsx` — new — sport-agnostic admin page

--- a/docs/mobile/mobile-signalr-admin-plan.md
+++ b/docs/mobile/mobile-signalr-admin-plan.md
@@ -1,6 +1,6 @@
 # Mobile SignalR Live Updates + Sport-Agnostic Admin Page — Plan
 
-**Status:** Draft — not yet scheduled
+**Status:** In Progress — Phase 1 in PR [#325](https://github.com/jrandallsexton/sports-data-core/pull/325) on 2026-05-15; Phases 2–3 pending
 **Author:** planning pass, 2026-05-15
 **Target:** sd-mobile (Expo SDK 55, RN 0.83.2)
 **Related docs:** `docs/mobile/notifications-and-live-updates.md` (future SSE migration), `docs/web-signalr-surface-audit.md`
@@ -25,6 +25,7 @@
 ## 3. Current state (verified findings)
 
 ### Mobile app
+
 - Expo SDK 55, React Native 0.83.2, React 19.2.0, `expo-router` (file-based routing, main = `expo-router/entry`). Confirmed in `src/UI/sd-mobile/package.json`.
 - State management is Zustand + TanStack Query. There is exactly one React Context in the app — `ThemeContext` (`src/lib/theme/`). Auth state, the most "global" mobile state, is a Zustand store (`src/stores/authStore.ts`).
 - Auth: Firebase 12.10.0. `onAuthStateChanged` is wired in `src/hooks/useAuth.ts` and pushed into the Zustand store. The axios client (`src/services/api/client.ts`) attaches `Bearer ${user.getIdToken()}` per request via an interceptor — the canonical pattern for "get a Firebase JWT now."
@@ -36,6 +37,7 @@
 - Expo Router structure: `(tabs)` is the authenticated home. Auth gate lives in root `_layout.tsx`'s `AuthGuard` component, which redirects to `/(auth)/sign-in` when no user.
 
 ### Web app reference (canonical, mirror these)
+
 - `src/UI/sd-ui/src/hooks/useSignalRClient.js` — builds a single `HubConnectionBuilder` against `${REACT_APP_SIGNALR_URL || REACT_APP_API_BASE_URL}/hubs/notifications`, attaches `accessTokenFactory` that calls `getAuth().currentUser.getIdToken()`, uses `withAutomaticReconnect()`, registers four `connection.on(...)` handlers, returns the connection ref.
 - `src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx` — single React Context holding `{ contests: { [contestId]: liveRecord } }`. Exposes `handleStatusUpdate`, `handleFootballPlayCompleted`, `handleBaseballPlayCompleted`, `getContestUpdate(contestId)`, `hasLiveUpdate(contestId)`, `clearContestUpdate(contestId)`, `clearAllUpdates()`. Critical detail — the PR #322 self-heal: receiving a `*PlayCompleted` event forces `status: 'InProgress'` because SignalR has no buffer and post-connect clients miss any earlier `ContestStatusChanged`. Mirror exactly.
 - `src/UI/sd-ui/src/MainApp.jsx` lines 88–127 — shows the wire-up: context handlers from `useContestUpdates()`, wrapped in `useCallback` so the SignalR effect doesn't tear down/reconnect on every render.
@@ -43,13 +45,14 @@
 - `src/UI/sd-ui/src/api/adminApi.js` — endpoints: `GET /admin/baseball/contests/{id}/matchup`, `GET /admin/football/contests/{id}/matchup?league=ncaa|nfl`, `POST /admin/baseball/contests/{id}/replay`, `POST /admin/football/contests/{id}/replay?league=ncaa|nfl`.
 
 ### Backend (verified)
+
 - Hub mapped at `/hubs/notifications` (`src/SportsData.Api/Program.cs:366`). Production URL is the API host.
 - Events emitted today by `IHubContext<NotificationHub>.Clients.All.SendAsync(...)`: `ContestStatusChanged`, `FootballPlayCompleted`, `BaseballPlayCompleted`, `ContestScoreChanged`, `ContestRecapArticlePublished`, `ContestOddsUpdated`, `PreviewGenerated`. The first three are what mobile needs for v1.
 - Firebase JWT auth on the hub — same scheme as REST.
 
 ## 4. Library choice
 
-`@microsoft/signalr@^9` (latest 9.x). Decision is forced — it is the only first-party JS client for SignalR negotiation, and our backend uses `MapHub` (not raw WebSocket). Alternatives:
+`@microsoft/signalr@^9.0.6` (latest 9.x at install time). Decision is forced — it is the only first-party JS client for SignalR negotiation, and our backend uses `MapHub` (not raw WebSocket). Alternatives:
 
 - Rolling our own WebSocket client. Rejected: re-implements negotiate/protocol/reconnect for zero benefit and forks us from web.
 - Switching to SSE first. Rejected: see §2.
@@ -62,7 +65,7 @@ Compatibility check items the implementation must verify on first install:
 
 ## 5. Architecture
 
-```
+```text
                  (auth user signs in)
                           │
                           ▼
@@ -70,12 +73,9 @@ Compatibility check items the implementation must verify on first install:
             │ app/_layout.tsx              │
             │  QueryClientProvider         │
             │   ThemeProvider              │
-            │    AuthGuard                 │
-            │    ┌──────────────────────┐  │
-            │    │ <ContestUpdatesGate> │  │  ◄── only mounts when isAuthenticated
-            │    │   <SignalRGate>      │  │
-            │    │     <Stack/>         │  │
-            │    └──────────────────────┘  │
+            │    <Stack/>                  │
+            │    <AuthGuard/>              │
+            │    <SignalRGate/>  ◄── only mounts useSignalRClient when isAuthenticated
             └──────────────────────────────┘
                           │
                           ▼
@@ -169,7 +169,7 @@ Token refresh story: a Firebase ID token lives 1 hour. `@microsoft/signalr` call
 
 ### Admin route placement
 
-```
+```text
 app/
   (auth)/
   (tabs)/
@@ -188,7 +188,8 @@ app/
 ### Debug panel design
 
 A `FlatList` (or simple `ScrollView` with `inverted`) showing the most recent 50 events:
-```
+
+```text
 12:04:31.847  FootballPlayCompleted  contest=abc…  per=Q3 clk=4:21  away=14 home=21
 12:04:30.214  FootballPlayCompleted  contest=abc…  per=Q3 clk=4:48  away=14 home=21
 12:04:21.012  ContestStatusChanged   contest=abc…  status=InProgress
@@ -213,7 +214,7 @@ Files created:
 - `src/UI/sd-mobile/__tests__/useSignalRClient.test.ts` — mocked-connection tests for handler dispatch.
 
 Files modified:
-- `src/UI/sd-mobile/package.json` — add `"@microsoft/signalr": "^9.0.0"`. Audit `transformIgnorePatterns` in the Jest config block — likely needs `@microsoft/signalr` added.
+- `src/UI/sd-mobile/package.json` — add `"@microsoft/signalr": "^9.0.6"`. Audit `transformIgnorePatterns` in the Jest config block — likely needs `@microsoft/signalr` added.
 - `src/UI/sd-mobile/app/_layout.tsx` — render a new `<SignalRGate>` inside the authenticated branch. Likely the simplest path: extract `<SignalRGate>` from `useAuth().isAuthenticated`.
 
 Env: introduce `EXPO_PUBLIC_SIGNALR_URL` (falls back to `EXPO_PUBLIC_API_BASE_URL`). Same precedence as the web's `REACT_APP_SIGNALR_URL` / `REACT_APP_API_BASE_URL`.
@@ -242,7 +243,8 @@ Files created:
 - `src/UI/sd-mobile/app/admin/_layout.tsx` — Stack + `AdminGuard` redirecting to `/(tabs)` when `!me.isAdmin`.
 - `src/UI/sd-mobile/app/admin/index.tsx` — the single sport-agnostic page. Sport segmented control, contestId TextInput, Load button, Trigger replay button, MatchupCard, collapsible debug log.
 - `src/UI/sd-mobile/src/services/api/adminApi.ts` — typed client for `/admin/{sport}/contests/{id}/matchup` (GET) and `/admin/{sport}/contests/{id}/replay` (POST). Endpoint shape:
-  ```
+
+  ```text
   sport=baseball       → /admin/baseball/contests/{id}/{matchup|replay}
   sport=football, league=ncaa|nfl → /admin/football/contests/{id}/{matchup|replay}?league={league}
   ```

--- a/src/UI/sd-mobile/__tests__/hooks/useSignalRClient.test.tsx
+++ b/src/UI/sd-mobile/__tests__/hooks/useSignalRClient.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { AppState } from 'react-native';
+import { render, act } from '@testing-library/react-native';
+
+import { useSignalRClient } from '@/src/hooks/useSignalRClient';
+import { useContestUpdatesStore } from '@/src/stores/contestUpdatesStore';
+
+// --- Mock @microsoft/signalr -------------------------------------------------
+// The hook lives one level above the connection factory, but we mock the
+// underlying signalR package here so the factory's HubConnectionBuilder chain
+// returns a fake connection we can drive in tests.
+
+type Handler = (...args: unknown[]) => void;
+
+interface MockConnection {
+  state: number;
+  handlers: Map<string, Handler>;
+  on: jest.Mock;
+  start: jest.Mock;
+  stop: jest.Mock;
+  __invoke: (event: string, ...args: unknown[]) => void;
+}
+
+const HubConnectionState = {
+  Disconnected: 0,
+  Connecting: 1,
+  Connected: 2,
+  Disconnecting: 3,
+  Reconnecting: 4,
+};
+
+let mockConnection: MockConnection;
+
+const buildMockConnection = (): MockConnection => {
+  const handlers = new Map<string, Handler>();
+  const conn: Partial<MockConnection> = {
+    state: HubConnectionState.Disconnected,
+    handlers,
+    on: jest.fn((name: string, handler: Handler) => {
+      handlers.set(name, handler);
+    }),
+    start: jest.fn(function (this: MockConnection) {
+      this.state = HubConnectionState.Connected;
+      return Promise.resolve();
+    }),
+    stop: jest.fn(function (this: MockConnection) {
+      this.state = HubConnectionState.Disconnected;
+      return Promise.resolve();
+    }),
+    __invoke: (event: string, ...args: unknown[]) => {
+      const h = handlers.get(event);
+      if (h) h(...args);
+    },
+  };
+  // Bind `this` for start/stop so they mutate the same object.
+  conn.start = jest.fn(() => {
+    conn.state = HubConnectionState.Connected;
+    return Promise.resolve();
+  });
+  conn.stop = jest.fn(() => {
+    conn.state = HubConnectionState.Disconnected;
+    return Promise.resolve();
+  });
+  return conn as MockConnection;
+};
+
+jest.mock('@microsoft/signalr', () => {
+  return {
+    __esModule: true,
+    HubConnectionState,
+    LogLevel: { Information: 'Information' },
+    HubConnectionBuilder: jest.fn().mockImplementation(() => {
+      const builder: Record<string, unknown> = {};
+      builder.withUrl = jest.fn().mockReturnValue(builder);
+      builder.withAutomaticReconnect = jest.fn().mockReturnValue(builder);
+      builder.configureLogging = jest.fn().mockReturnValue(builder);
+      builder.build = jest.fn().mockImplementation(() => {
+        mockConnection = buildMockConnection();
+        return mockConnection;
+      });
+      return builder;
+    }),
+  };
+});
+
+// --- Mock firebase/auth ------------------------------------------------------
+jest.mock('firebase/auth', () => ({
+  getAuth: () => ({
+    currentUser: { getIdToken: async () => 'fake-token' },
+  }),
+}));
+
+// --- AppState — spy on addEventListener so we can drive change events --------
+let appStateListener: ((next: string) => void) | null = null;
+let appStateSubscriptionRemove: jest.Mock | null = null;
+
+// --- Test harness component --------------------------------------------------
+function HookHarness(): null {
+  useSignalRClient();
+  return null;
+}
+
+describe('useSignalRClient', () => {
+  beforeEach(() => {
+    useContestUpdatesStore.setState(useContestUpdatesStore.getInitialState(), true);
+    appStateListener = null;
+    appStateSubscriptionRemove = jest.fn(() => {
+      appStateListener = null;
+    });
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, listener) => {
+      appStateListener = listener as (next: string) => void;
+      return { remove: appStateSubscriptionRemove } as ReturnType<typeof AppState.addEventListener>;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('registers handlers for the three SignalR events', async () => {
+    render(<HookHarness />);
+    // Allow the start() promise to resolve.
+    await act(async () => { await Promise.resolve(); });
+
+    expect(mockConnection.on).toHaveBeenCalledWith('ContestStatusChanged', expect.any(Function));
+    expect(mockConnection.on).toHaveBeenCalledWith('FootballPlayCompleted', expect.any(Function));
+    expect(mockConnection.on).toHaveBeenCalledWith('BaseballPlayCompleted', expect.any(Function));
+    expect(mockConnection.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches incoming ContestStatusChanged into the store', async () => {
+    render(<HookHarness />);
+    await act(async () => { await Promise.resolve(); });
+
+    const cid = '00000000-0000-0000-0000-000000000abc';
+    act(() => {
+      mockConnection.__invoke('ContestStatusChanged', { contestId: cid, status: 'InProgress' });
+    });
+
+    expect(useContestUpdatesStore.getState().contests[cid]?.status).toBe('InProgress');
+  });
+
+  it('stops the connection when AppState transitions to background', async () => {
+    render(<HookHarness />);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(mockConnection.state).toBe(HubConnectionState.Connected);
+
+    act(() => {
+      appStateListener?.('background');
+    });
+    // The stop() call is async; flush.
+    await act(async () => { await Promise.resolve(); });
+
+    expect(mockConnection.stop).toHaveBeenCalled();
+    expect(mockConnection.state).toBe(HubConnectionState.Disconnected);
+  });
+
+  it('restarts the connection when AppState returns to active', async () => {
+    render(<HookHarness />);
+    await act(async () => { await Promise.resolve(); });
+
+    // Background, then foreground.
+    act(() => { appStateListener?.('background'); });
+    await act(async () => { await Promise.resolve(); });
+    act(() => { appStateListener?.('active'); });
+    await act(async () => { await Promise.resolve(); });
+
+    // start() was called once on initial mount, once on foreground.
+    expect(mockConnection.start).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops the connection and removes the AppState subscription on unmount', async () => {
+    const { unmount } = render(<HookHarness />);
+    await act(async () => { await Promise.resolve(); });
+
+    unmount();
+
+    expect(mockConnection.stop).toHaveBeenCalled();
+    expect(appStateSubscriptionRemove).toHaveBeenCalled();
+  });
+});

--- a/src/UI/sd-mobile/__tests__/hooks/useSignalRClient.test.tsx
+++ b/src/UI/sd-mobile/__tests__/hooks/useSignalRClient.test.tsx
@@ -39,20 +39,13 @@ const buildMockConnection = (): MockConnection => {
     on: jest.fn((name: string, handler: Handler) => {
       handlers.set(name, handler);
     }),
-    start: jest.fn(function (this: MockConnection) {
-      this.state = HubConnectionState.Connected;
-      return Promise.resolve();
-    }),
-    stop: jest.fn(function (this: MockConnection) {
-      this.state = HubConnectionState.Disconnected;
-      return Promise.resolve();
-    }),
     __invoke: (event: string, ...args: unknown[]) => {
       const h = handlers.get(event);
       if (h) h(...args);
     },
   };
-  // Bind `this` for start/stop so they mutate the same object.
+  // Arrow assignments (rather than `function(this: ...)`) so the closure
+  // mutates the same `conn` object that callers hold a reference to.
   conn.start = jest.fn(() => {
     conn.state = HubConnectionState.Connected;
     return Promise.resolve();

--- a/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
+++ b/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
@@ -1,0 +1,197 @@
+import { useContestUpdatesStore } from '@/src/stores/contestUpdatesStore';
+import type {
+  BaseballPlayCompletedPayload,
+  ContestStatusChangedPayload,
+  FootballPlayCompletedPayload,
+} from '@/src/types/signalR';
+
+const CID = '00000000-0000-0000-0000-000000000001';
+
+const statusPayload = (overrides?: Partial<ContestStatusChangedPayload>): ContestStatusChangedPayload => ({
+  contestId: CID,
+  status: 'Scheduled',
+  ...overrides,
+});
+
+const footballPayload = (overrides?: Partial<FootballPlayCompletedPayload>): FootballPlayCompletedPayload => ({
+  contestId: CID,
+  competitionId: '00000000-0000-0000-0000-0000000000aa',
+  playId: '00000000-0000-0000-0000-0000000000bb',
+  playDescription: '10-yard pass',
+  period: 'Q1',
+  clock: '14:53',
+  awayScore: 0,
+  homeScore: 0,
+  possessionFranchiseSeasonId: null,
+  isScoringPlay: false,
+  ballOnYardLine: 25,
+  ...overrides,
+});
+
+const baseballPayload = (overrides?: Partial<BaseballPlayCompletedPayload>): BaseballPlayCompletedPayload => ({
+  contestId: CID,
+  competitionId: '00000000-0000-0000-0000-0000000000aa',
+  playId: '00000000-0000-0000-0000-0000000000bb',
+  playDescription: 'Single to right',
+  inning: 1,
+  halfInning: 'Top',
+  awayScore: 0,
+  homeScore: 0,
+  balls: 0,
+  strikes: 0,
+  outs: 0,
+  runnerOnFirst: false,
+  runnerOnSecond: false,
+  runnerOnThird: false,
+  atBatAthleteSeasonId: null,
+  atBatShortName: null,
+  atBatPositionAbbreviation: null,
+  atBatHeadshotUrl: null,
+  pitchingAthleteSeasonId: null,
+  pitchingShortName: null,
+  pitchingPositionAbbreviation: null,
+  pitchingHeadshotUrl: null,
+  ...overrides,
+});
+
+describe('contestUpdatesStore', () => {
+  beforeEach(() => {
+    useContestUpdatesStore.setState(useContestUpdatesStore.getInitialState(), true);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('handleStatusUpdate', () => {
+    it('writes status and contestId for a fresh contest', () => {
+      useContestUpdatesStore.getState().handleStatusUpdate(statusPayload({ status: 'InProgress' }));
+
+      const record = useContestUpdatesStore.getState().contests[CID];
+      expect(record).toBeDefined();
+      expect(record.contestId).toBe(CID);
+      expect(record.status).toBe('InProgress');
+      expect(record.lastUpdated).toEqual(expect.any(Number));
+    });
+
+    it('ignores payloads missing contestId', () => {
+      useContestUpdatesStore.getState().handleStatusUpdate({ contestId: '', status: 'InProgress' });
+      expect(Object.keys(useContestUpdatesStore.getState().contests)).toHaveLength(0);
+    });
+
+    it('overwrites prior status without dropping other fields', () => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(footballPayload({ period: 'Q3' }));
+      useContestUpdatesStore.getState().handleStatusUpdate(statusPayload({ status: 'Final' }));
+
+      const record = useContestUpdatesStore.getState().contests[CID];
+      expect(record.status).toBe('Final');
+      expect(record.period).toBe('Q3');
+    });
+  });
+
+  describe('handleFootballPlayCompleted', () => {
+    it('promotes status to InProgress even if no prior status event arrived (self-heal)', () => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(footballPayload());
+
+      expect(useContestUpdatesStore.getState().contests[CID].status).toBe('InProgress');
+    });
+
+    it('writes football scoreboard fields', () => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(
+        footballPayload({
+          period: 'Q4',
+          clock: '0:32',
+          awayScore: 21,
+          homeScore: 24,
+          ballOnYardLine: 8,
+        }),
+      );
+
+      const record = useContestUpdatesStore.getState().contests[CID];
+      expect(record.period).toBe('Q4');
+      expect(record.clock).toBe('0:32');
+      expect(record.awayScore).toBe(21);
+      expect(record.homeScore).toBe(24);
+      expect(record.ballOnYardLine).toBe(8);
+    });
+
+    it('auto-clears isScoringPlay after 2 seconds', () => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(
+        footballPayload({ isScoringPlay: true }),
+      );
+
+      expect(useContestUpdatesStore.getState().contests[CID].isScoringPlay).toBe(true);
+
+      jest.advanceTimersByTime(1999);
+      expect(useContestUpdatesStore.getState().contests[CID].isScoringPlay).toBe(true);
+
+      jest.advanceTimersByTime(1);
+      expect(useContestUpdatesStore.getState().contests[CID].isScoringPlay).toBe(false);
+    });
+
+    it('does not schedule a clear-timer when isScoringPlay is false', () => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(
+        footballPayload({ isScoringPlay: false }),
+      );
+
+      // No timer should be pending — jest will fail if pending fake timers run.
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe('handleBaseballPlayCompleted', () => {
+    it('promotes status to InProgress (self-heal)', () => {
+      useContestUpdatesStore.getState().handleBaseballPlayCompleted(baseballPayload());
+
+      expect(useContestUpdatesStore.getState().contests[CID].status).toBe('InProgress');
+    });
+
+    it('writes baseball scoreboard fields including runners and at-bat header', () => {
+      useContestUpdatesStore.getState().handleBaseballPlayCompleted(
+        baseballPayload({
+          inning: 9,
+          halfInning: 'Bottom',
+          balls: 3,
+          strikes: 2,
+          outs: 2,
+          runnerOnFirst: true,
+          runnerOnSecond: false,
+          runnerOnThird: true,
+          atBatShortName: 'A. Judge',
+          pitchingShortName: 'C. Sale',
+        }),
+      );
+
+      const record = useContestUpdatesStore.getState().contests[CID];
+      expect(record.inning).toBe(9);
+      expect(record.halfInning).toBe('Bottom');
+      expect(record.balls).toBe(3);
+      expect(record.strikes).toBe(2);
+      expect(record.outs).toBe(2);
+      expect(record.runnerOnFirst).toBe(true);
+      expect(record.runnerOnSecond).toBe(false);
+      expect(record.runnerOnThird).toBe(true);
+      expect(record.atBatShortName).toBe('A. Judge');
+      expect(record.pitchingShortName).toBe('C. Sale');
+    });
+  });
+
+  describe('clearContestUpdate / clearAllUpdates', () => {
+    it('clearContestUpdate removes a single record', () => {
+      useContestUpdatesStore.getState().handleStatusUpdate(statusPayload());
+      useContestUpdatesStore.getState().clearContestUpdate(CID);
+
+      expect(useContestUpdatesStore.getState().contests[CID]).toBeUndefined();
+    });
+
+    it('clearAllUpdates removes every record', () => {
+      useContestUpdatesStore.getState().handleStatusUpdate(statusPayload());
+      useContestUpdatesStore.getState().handleStatusUpdate(statusPayload({ contestId: 'another' }));
+
+      useContestUpdatesStore.getState().clearAllUpdates();
+
+      expect(Object.keys(useContestUpdatesStore.getState().contests)).toHaveLength(0);
+    });
+  });
+});

--- a/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
+++ b/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
@@ -138,6 +138,30 @@ describe('contestUpdatesStore', () => {
       // No timer should be pending — jest will fail if pending fake timers run.
       expect(jest.getTimerCount()).toBe(0);
     });
+
+    it('debounces overlapping scoring plays — the flash window resets on the latest play', () => {
+      // Scoring play 1 at t=0
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(
+        footballPayload({ isScoringPlay: true }),
+      );
+      jest.advanceTimersByTime(1500);
+      expect(useContestUpdatesStore.getState().contests[CID].isScoringPlay).toBe(true);
+
+      // Scoring play 2 at t=1500ms — must reset the flash window. Without
+      // the debounce, the t=0 timer would still fire at t=2000ms and clear
+      // the flag prematurely.
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(
+        footballPayload({ isScoringPlay: true }),
+      );
+
+      // At t=2000ms (would-be-fire of play-1's timer if not cleared).
+      jest.advanceTimersByTime(500);
+      expect(useContestUpdatesStore.getState().contests[CID].isScoringPlay).toBe(true);
+
+      // At t=3500ms (2s after play 2). Flash clears.
+      jest.advanceTimersByTime(1500);
+      expect(useContestUpdatesStore.getState().contests[CID].isScoringPlay).toBe(false);
+    });
   });
 
   describe('handleBaseballPlayCompleted', () => {

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -9,6 +9,7 @@ import 'react-native-reanimated';
 import { queryClient } from '@/src/lib/queryClient';
 import { useAuthInit, useAuth } from '@/src/hooks/useAuth';
 import { ThemeProvider, useThemeMode } from '@/src/lib/theme/ThemeContext';
+import { SignalRGate } from '@/src/components/signalR/SignalRGate';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -91,6 +92,7 @@ function RootLayoutNav() {
         <Stack.Screen name="+not-found" />
       </Stack>
       <AuthGuard />
+      <SignalRGate />
     </NavThemeProvider>
   );
 }

--- a/src/UI/sd-mobile/package-lock.json
+++ b/src/UI/sd-mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@microsoft/signalr": "^9.0.6",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.1.28",
         "@tanstack/react-query": "^5.90.21",
@@ -3223,6 +3224,38 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@microsoft/signalr": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-9.0.6.tgz",
+      "integrity": "sha512-DrhgzFWI9JE4RPTsHYRxh4yr+OhnwKz8bnJe7eIi7mLLjqhJpEb62CiUy/YbFvLqLzcGzlzz1QWgVAW0zyipMQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
+      }
+    },
+    "node_modules/@microsoft/signalr/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -6050,6 +6083,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6607,6 +6648,15 @@
       "license": "MIT",
       "dependencies": {
         "asap": "~2.0.3"
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/fetch-nodeshim": {
@@ -10150,7 +10200,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -10162,7 +10211,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10204,8 +10252,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -10908,8 +10955,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -11217,6 +11263,11 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -11830,7 +11881,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -11961,7 +12011,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -12009,7 +12058,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/src/UI/sd-mobile/package.json
+++ b/src/UI/sd-mobile/package.json
@@ -12,7 +12,9 @@
   },
   "jest": {
     "preset": "jest-expo",
-    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"],
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|@tanstack/.*|zustand|firebase|@firebase/.*)"
     ],
@@ -21,12 +23,23 @@
     },
     "reporters": [
       "default",
-      ["jest-junit", { "outputDirectory": ".", "outputName": "junit.xml" }]
+      [
+        "jest-junit",
+        {
+          "outputDirectory": ".",
+          "outputName": "junit.xml"
+        }
+      ]
     ],
-    "coverageReporters": ["text", "cobertura", "lcov"]
+    "coverageReporters": [
+      "text",
+      "cobertura",
+      "lcov"
+    ]
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@microsoft/signalr": "^9.0.6",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^7.1.28",
     "@tanstack/react-query": "^5.90.21",

--- a/src/UI/sd-mobile/src/components/signalR/SignalRGate.tsx
+++ b/src/UI/sd-mobile/src/components/signalR/SignalRGate.tsx
@@ -16,7 +16,7 @@ function SignalRMount(): null {
   return null;
 }
 
-export function SignalRGate(): React.ReactElement | null {
+export function SignalRGate() {
   const { isAuthenticated, isInitialized } = useAuth();
   if (!isInitialized || !isAuthenticated) return null;
   return <SignalRMount />;

--- a/src/UI/sd-mobile/src/components/signalR/SignalRGate.tsx
+++ b/src/UI/sd-mobile/src/components/signalR/SignalRGate.tsx
@@ -1,0 +1,23 @@
+import { useAuth } from '@/src/hooks/useAuth';
+import { useSignalRClient } from '@/src/hooks/useSignalRClient';
+
+/**
+ * Auth-gated mount point for the SignalR connection. The inner component
+ * is only rendered once a Firebase user exists — that's the only way to
+ * keep `useSignalRClient` strictly mounted vs unmounted across sign-in /
+ * sign-out without making the hook itself auth-aware (hooks can't be
+ * conditional, but components can).
+ *
+ * Returns null — there is no visible UI. The hook does its work via
+ * side effects on `contestUpdatesStore`.
+ */
+function SignalRMount(): null {
+  useSignalRClient();
+  return null;
+}
+
+export function SignalRGate(): React.ReactElement | null {
+  const { isAuthenticated, isInitialized } = useAuth();
+  if (!isInitialized || !isAuthenticated) return null;
+  return <SignalRMount />;
+}

--- a/src/UI/sd-mobile/src/hooks/useSignalRClient.ts
+++ b/src/UI/sd-mobile/src/hooks/useSignalRClient.ts
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import * as signalR from '@microsoft/signalr';
+import { getAuth } from 'firebase/auth';
+
+import { createSignalRConnection } from '@/src/services/signalR/connection';
+import { useContestUpdatesStore } from '@/src/stores/contestUpdatesStore';
+
+const SIGNALR_URL =
+  process.env.EXPO_PUBLIC_SIGNALR_URL ??
+  process.env.EXPO_PUBLIC_API_BASE_URL ??
+  'https://api.sportdeets.com';
+
+/**
+ * Owns the SignalR connection lifecycle. Auth-gated by convention — the
+ * caller is responsible for only mounting this hook once a Firebase user
+ * exists (see `SignalRGate`). The hook still defends against a transient
+ * null token during Firebase refresh by failing the negotiate gracefully.
+ *
+ * Mobile lifecycle additions vs the web hook: iOS aggressively kills idle
+ * sockets when the app backgrounds, so an idle reconnect loop would burn
+ * battery. AppState listener stops the connection on background and
+ * starts it again on foreground.
+ *
+ * Event handlers dispatch directly into `contestUpdatesStore` rather than
+ * accepting callback props — keeps the wire-up simple and matches the way
+ * the mobile codebase already wires global state.
+ */
+export function useSignalRClient(): void {
+  const connectionRef = useRef<signalR.HubConnection | null>(null);
+
+  // Zustand returns stable function references for the lifetime of the
+  // store, so these selector subscriptions don't cause the effect below
+  // to tear down + reconnect on every render.
+  const handleStatusUpdate = useContestUpdatesStore((s) => s.handleStatusUpdate);
+  const handleFootballPlayCompleted = useContestUpdatesStore(
+    (s) => s.handleFootballPlayCompleted,
+  );
+  const handleBaseballPlayCompleted = useContestUpdatesStore(
+    (s) => s.handleBaseballPlayCompleted,
+  );
+
+  useEffect(() => {
+    const connection = createSignalRConnection({
+      url: SIGNALR_URL,
+      accessTokenFactory: async () => {
+        const user = getAuth().currentUser;
+        if (!user) return '';
+        try {
+          return await user.getIdToken();
+        } catch (err) {
+          // Don't console.error — Expo dev menu pops on error-level logs
+          // and a transient token-fetch miss is recoverable. Empty string
+          // signals "no token", server 401s, auto-reconnect retries.
+          console.warn('[useSignalRClient] token fetch failed', err);
+          return '';
+        }
+      },
+    });
+
+    connection.on('ContestStatusChanged', handleStatusUpdate);
+    connection.on('FootballPlayCompleted', handleFootballPlayCompleted);
+    connection.on('BaseballPlayCompleted', handleBaseballPlayCompleted);
+
+    connection
+      .start()
+      .then(() => console.log('[SignalR] connected'))
+      .catch((err) => console.warn('[SignalR] connection failed', err));
+
+    connectionRef.current = connection;
+
+    const appStateSub = AppState.addEventListener(
+      'change',
+      (next: AppStateStatus) => {
+        const conn = connectionRef.current;
+        if (!conn) return;
+
+        if (next === 'background' || next === 'inactive') {
+          if (conn.state === signalR.HubConnectionState.Connected) {
+            // Idempotent — swallow rejection in case stop() races with
+            // an in-flight reconnect attempt.
+            conn.stop().catch(() => undefined);
+          }
+        } else if (next === 'active') {
+          if (conn.state === signalR.HubConnectionState.Disconnected) {
+            conn
+              .start()
+              .then(() => console.log('[SignalR] reconnected on foreground'))
+              .catch((err) =>
+                console.warn('[SignalR] foreground reconnect failed', err),
+              );
+          }
+        }
+      },
+    );
+
+    return () => {
+      appStateSub.remove();
+      connection.stop().catch(() => undefined);
+      connectionRef.current = null;
+    };
+  }, [
+    handleStatusUpdate,
+    handleFootballPlayCompleted,
+    handleBaseballPlayCompleted,
+  ]);
+}

--- a/src/UI/sd-mobile/src/services/signalR/connection.ts
+++ b/src/UI/sd-mobile/src/services/signalR/connection.ts
@@ -1,0 +1,37 @@
+import * as signalR from '@microsoft/signalr';
+
+export interface CreateSignalRConnectionOptions {
+  /**
+   * Base API URL. The hub is mounted at `/hubs/notifications` and that
+   * suffix is appended internally so callers don't have to remember it.
+   */
+  url: string;
+  /**
+   * Returns a Firebase ID token. SignalR invokes this on the initial
+   * negotiate and on every reconnect. Returning an empty string signals
+   * "no token available" — the server will respond 401 and auto-reconnect
+   * will retry, which is the desired behavior during a transient
+   * sign-in / sign-out flip.
+   */
+  accessTokenFactory: () => Promise<string>;
+}
+
+/**
+ * Pure factory — no React, no globals beyond the @microsoft/signalr
+ * package. Kept separate from `useSignalRClient` so the hook can be tested
+ * by injecting a fake builder.
+ *
+ * Reconnect policy: defaults from withAutomaticReconnect() are [0, 2000,
+ * 10000, 30000] and then stop — matches the web hook's behavior.
+ */
+export function createSignalRConnection(
+  options: CreateSignalRConnectionOptions,
+): signalR.HubConnection {
+  return new signalR.HubConnectionBuilder()
+    .withUrl(`${options.url}/hubs/notifications`, {
+      accessTokenFactory: options.accessTokenFactory,
+    })
+    .withAutomaticReconnect()
+    .configureLogging(signalR.LogLevel.Information)
+    .build();
+}

--- a/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
+++ b/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
@@ -62,6 +62,15 @@ const initialState = {
   contests: {} as Record<string, ContestLiveRecord>,
 };
 
+/**
+ * Per-contest pending "clear isScoringPlay" timer. Kept outside Zustand
+ * because it's a side-effect bookkeeping concern, not state consumers
+ * should subscribe to. A second scoring play within the 2s flash window
+ * must clear the prior timer; otherwise the earlier timer fires first
+ * and ends the flash before the new window completes.
+ */
+const scoringFlashTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
 export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
   ...initialState,
 
@@ -110,9 +119,15 @@ export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
       },
     }));
 
-    // Auto-clear scoring flash after the UI's animation window.
+    // Auto-clear scoring flash after the UI's animation window. A
+    // second scoring play within 2s replaces the prior timer so the
+    // flash always runs the full window from the most recent play.
     if (data.isScoringPlay) {
-      setTimeout(() => {
+      const prior = scoringFlashTimers.get(data.contestId);
+      if (prior !== undefined) clearTimeout(prior);
+
+      const timer = setTimeout(() => {
+        scoringFlashTimers.delete(data.contestId);
         set((state) => {
           const existing = state.contests[data.contestId];
           if (!existing) return state;
@@ -124,6 +139,8 @@ export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
           };
         });
       }, 2000);
+
+      scoringFlashTimers.set(data.contestId, timer);
     }
   },
 
@@ -166,6 +183,11 @@ export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
   },
 
   clearContestUpdate: (contestId) => {
+    const pending = scoringFlashTimers.get(contestId);
+    if (pending !== undefined) {
+      clearTimeout(pending);
+      scoringFlashTimers.delete(contestId);
+    }
     set((state) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [contestId]: _removed, ...rest } = state.contests;
@@ -173,7 +195,11 @@ export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
     });
   },
 
-  clearAllUpdates: () => set({ contests: {} }),
+  clearAllUpdates: () => {
+    scoringFlashTimers.forEach((t) => clearTimeout(t));
+    scoringFlashTimers.clear();
+    set({ contests: {} });
+  },
 }));
 
 /**

--- a/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
+++ b/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
@@ -1,0 +1,194 @@
+import { create } from 'zustand';
+import type {
+  BaseballPlayCompletedPayload,
+  ContestStatusChangedPayload,
+  FootballPlayCompletedPayload,
+} from '@/src/types/signalR';
+
+/**
+ * Merged live snapshot for a single contest. Fields are accumulated from
+ * the three event types — readers should treat anything they don't expect
+ * for the current sport as undefined.
+ */
+export interface ContestLiveRecord {
+  contestId: string;
+  status?: string;
+
+  awayScore?: number;
+  homeScore?: number;
+
+  // Football fields
+  period?: string;
+  clock?: string;
+  possessionFranchiseSeasonId?: string | null;
+  isScoringPlay?: boolean;
+  ballOnYardLine?: number | null;
+
+  // Baseball fields
+  inning?: number;
+  halfInning?: string;
+  balls?: number;
+  strikes?: number;
+  outs?: number;
+  runnerOnFirst?: boolean;
+  runnerOnSecond?: boolean;
+  runnerOnThird?: boolean;
+  atBatAthleteSeasonId?: string | null;
+  atBatShortName?: string | null;
+  atBatPositionAbbreviation?: string | null;
+  atBatHeadshotUrl?: string | null;
+  pitchingAthleteSeasonId?: string | null;
+  pitchingShortName?: string | null;
+  pitchingPositionAbbreviation?: string | null;
+  pitchingHeadshotUrl?: string | null;
+
+  lastPlayId?: string;
+  lastPlayDescription?: string;
+  lastPlayAt?: number;
+  lastUpdated?: number;
+}
+
+interface ContestUpdatesState {
+  contests: Record<string, ContestLiveRecord>;
+
+  handleStatusUpdate: (data: ContestStatusChangedPayload) => void;
+  handleFootballPlayCompleted: (data: FootballPlayCompletedPayload) => void;
+  handleBaseballPlayCompleted: (data: BaseballPlayCompletedPayload) => void;
+  clearContestUpdate: (contestId: string) => void;
+  clearAllUpdates: () => void;
+}
+
+const initialState = {
+  contests: {} as Record<string, ContestLiveRecord>,
+};
+
+export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
+  ...initialState,
+
+  handleStatusUpdate: (data) => {
+    if (!data?.contestId) return;
+    const now = Date.now();
+    set((state) => ({
+      contests: {
+        ...state.contests,
+        [data.contestId]: {
+          ...state.contests[data.contestId],
+          contestId: data.contestId,
+          status: data.status,
+          lastUpdated: now,
+        },
+      },
+    }));
+  },
+
+  handleFootballPlayCompleted: (data) => {
+    if (!data?.contestId) return;
+    const now = Date.now();
+    set((state) => ({
+      contests: {
+        ...state.contests,
+        [data.contestId]: {
+          ...state.contests[data.contestId],
+          contestId: data.contestId,
+          // SignalR has no buffer; a client that connects after the
+          // ContestStatusChanged fan-out would otherwise stay stuck on
+          // the prior status. Receiving any play is itself proof the
+          // contest is live — promote here. (Web counterpart: PR #322.)
+          status: 'InProgress',
+          period: data.period,
+          clock: data.clock,
+          awayScore: data.awayScore,
+          homeScore: data.homeScore,
+          possessionFranchiseSeasonId: data.possessionFranchiseSeasonId,
+          isScoringPlay: data.isScoringPlay ?? false,
+          ballOnYardLine: data.ballOnYardLine,
+          lastPlayId: data.playId,
+          lastPlayDescription: data.playDescription,
+          lastPlayAt: now,
+          lastUpdated: now,
+        },
+      },
+    }));
+
+    // Auto-clear scoring flash after the UI's animation window.
+    if (data.isScoringPlay) {
+      setTimeout(() => {
+        set((state) => {
+          const existing = state.contests[data.contestId];
+          if (!existing) return state;
+          return {
+            contests: {
+              ...state.contests,
+              [data.contestId]: { ...existing, isScoringPlay: false },
+            },
+          };
+        });
+      }, 2000);
+    }
+  },
+
+  handleBaseballPlayCompleted: (data) => {
+    if (!data?.contestId) return;
+    const now = Date.now();
+    set((state) => ({
+      contests: {
+        ...state.contests,
+        [data.contestId]: {
+          ...state.contests[data.contestId],
+          contestId: data.contestId,
+          // Same self-heal rationale as handleFootballPlayCompleted.
+          status: 'InProgress',
+          inning: data.inning,
+          halfInning: data.halfInning,
+          awayScore: data.awayScore,
+          homeScore: data.homeScore,
+          balls: data.balls,
+          strikes: data.strikes,
+          outs: data.outs,
+          runnerOnFirst: data.runnerOnFirst,
+          runnerOnSecond: data.runnerOnSecond,
+          runnerOnThird: data.runnerOnThird,
+          atBatAthleteSeasonId: data.atBatAthleteSeasonId,
+          atBatShortName: data.atBatShortName,
+          atBatPositionAbbreviation: data.atBatPositionAbbreviation,
+          atBatHeadshotUrl: data.atBatHeadshotUrl,
+          pitchingAthleteSeasonId: data.pitchingAthleteSeasonId,
+          pitchingShortName: data.pitchingShortName,
+          pitchingPositionAbbreviation: data.pitchingPositionAbbreviation,
+          pitchingHeadshotUrl: data.pitchingHeadshotUrl,
+          lastPlayId: data.playId,
+          lastPlayDescription: data.playDescription,
+          lastPlayAt: now,
+          lastUpdated: now,
+        },
+      },
+    }));
+  },
+
+  clearContestUpdate: (contestId) => {
+    set((state) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [contestId]: _removed, ...rest } = state.contests;
+      return { contests: rest };
+    });
+  },
+
+  clearAllUpdates: () => set({ contests: {} }),
+}));
+
+/**
+ * Per-contest selector hook. Only consumers whose `contestId` actually
+ * changed re-render — avoids the broadcast re-render storm the equivalent
+ * React Context would produce during a busy slate.
+ */
+export const useContestUpdate = (
+  contestId: string | undefined,
+): ContestLiveRecord | undefined =>
+  useContestUpdatesStore((state) =>
+    contestId ? state.contests[contestId] : undefined,
+  );
+
+export const useHasLiveUpdate = (contestId: string | undefined): boolean =>
+  useContestUpdatesStore((state) =>
+    contestId ? !!state.contests[contestId] : false,
+  );

--- a/src/UI/sd-mobile/src/types/signalR.ts
+++ b/src/UI/sd-mobile/src/types/signalR.ts
@@ -1,0 +1,66 @@
+/**
+ * TypeScript shapes for SignalR event payloads received from
+ * `/hubs/notifications`. Each payload mirrors the corresponding C# event
+ * record under `SportsData.Core.Eventing.Events.Contests.*` — JSON
+ * serialization camel-cases the property names by default.
+ *
+ * Only fields the mobile app actually consumes are typed. The wire carries
+ * additional fields (Ref, Sport, SeasonYear, CorrelationId, CausationId)
+ * that mobile ignores today; if a future feature needs them, extend these
+ * interfaces rather than reaching at untyped properties.
+ */
+
+export interface ContestStatusChangedPayload {
+  contestId: string;
+  /** Sport-neutral lifecycle state, e.g. "Scheduled", "InProgress", "Final". */
+  status: string;
+}
+
+export interface FootballPlayCompletedPayload {
+  contestId: string;
+  competitionId: string;
+  playId: string;
+  playDescription: string;
+  period: string;
+  clock: string;
+  awayScore: number;
+  homeScore: number;
+  possessionFranchiseSeasonId: string | null;
+  isScoringPlay: boolean;
+  /**
+   * 0–100 yards from the away (visitor) goal line. Null at pre-snap,
+   * halftime, or post-game — match ESPN's YardLine convention.
+   */
+  ballOnYardLine: number | null;
+}
+
+export interface BaseballPlayCompletedPayload {
+  contestId: string;
+  competitionId: string;
+  playId: string;
+  playDescription: string;
+  inning: number;
+  /** "Top" or "Bottom". */
+  halfInning: string;
+  awayScore: number;
+  homeScore: number;
+  balls: number;
+  strikes: number;
+  outs: number;
+  runnerOnFirst: boolean;
+  runnerOnSecond: boolean;
+  runnerOnThird: boolean;
+  /**
+   * Athlete IDs are season-scoped — they resolve to AthleteSeason.Id, not
+   * AthleteBase.Id (ESPN's play `participant.athlete.$ref` points at
+   * AthleteSeason).
+   */
+  atBatAthleteSeasonId: string | null;
+  atBatShortName: string | null;
+  atBatPositionAbbreviation: string | null;
+  atBatHeadshotUrl: string | null;
+  pitchingAthleteSeasonId: string | null;
+  pitchingShortName: string | null;
+  pitchingPositionAbbreviation: string | null;
+  pitchingHeadshotUrl: string | null;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the three-phase mobile SignalR rollout planned in [`docs/mobile/mobile-signalr-admin-plan.md`](docs/mobile/mobile-signalr-admin-plan.md). Stands up the live-events pipeline behind the existing app surface — events flow into a Zustand store nothing currently reads. **No UI changes yet.** Easy to revert.

- Add `@microsoft/signalr@^9` to mobile `package.json`
- Payload types in `src/types/signalR.ts` mirror the C# event records (`ContestStatusChanged`, `FootballPlayCompleted`, `BaseballPlayCompleted`)
- Pure factory at `src/services/signalR/connection.ts` (no React, test-injectable)
- Zustand `contestUpdatesStore` with **per-contest selector hooks** (`useContestUpdate(contestId)`, `useHasLiveUpdate(contestId)`) — deliberate deviation from the web's React Context pattern so only in-view MatchupCards re-render
- Ports the PR #322 self-heal: receiving a `*PlayCompleted` event forces `status: 'InProgress'` to survive missed lifecycle events on post-fanout reconnect
- `useSignalRClient` hook owns connection lifecycle. Mobile-only addition vs web: AppState listener stops the connection on background (iOS aggressively kills idle sockets) and restarts on foreground
- Auth-gated mount via `<SignalRGate />` rendered next to `<AuthGuard />` in root `_layout.tsx`

## Why Zustand instead of React Context

Mobile is uniformly Zustand-shaped (`authStore`, etc.) — introducing a new React Context just for live updates would be inconsistent. More importantly, the web's Context broadcasts to every consumer on every event; a per-contest Zustand selector hook means only the MatchupCard whose `contestId` actually changed re-renders. That matters during a busy NFL slate. See plan doc §5.

## Test plan
- [x] `npm test` → 32/32 passing (16 new in this PR)
- [x] `npx tsc --noEmit` → clean except one pre-existing error in `app/(tabs)/(details)/.../game/[id].tsx` unrelated to this change
- [ ] Dev-client smoke test on Android/iOS: sign in, verify `[SignalR] connected` appears in Metro logs (Phase 2 will be where actual UI consumes events)
- [ ] CodeRabbit review

## Out of scope (later phases)
- Phase 2: MatchupCard reads `useContestUpdate` and renders enriched data
- Phase 3: sport-agnostic admin replay page at `app/admin/index.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented real-time live contest updates for mobile app
  * Added admin page for event replay and debug logging

* **Tests**
  * Added comprehensive test coverage for real-time update functionality and mobile lifecycle behavior

* **Chores**
  * Updated mobile app configuration to support new real-time features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/325)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->