### PR TITLE
chore(ci): add ADO pipeline for sd-mobile

### DIFF
--- a/src/UI/sd-mobile/azure-pipelines.yml
+++ b/src/UI/sd-mobile/azure-pipelines.yml
@@ -1,0 +1,58 @@
+# Mobile (Expo / React Native) pre-merge CI for ADO visibility, mirroring
+# the .NET services' and web app's pipeline pattern. Runs alongside the
+# existing GitHub Action at .github/workflows/ci-mobile.yml — both gate
+# the same checks. The GH Action provides a fallback if the self-hosted
+# Bender agent is offline; the ADO pipeline provides visibility in the
+# same dashboard as every other service.
+#
+# Mobile-specific scope: Jest only. No lint script exists in mobile
+# package.json today. No Dockerfile — production mobile builds happen via
+# EAS post-merge, not from this pipeline.
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - 'src/UI/sd-mobile/**'
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - 'src/UI/sd-mobile/**'
+
+pool:
+  name: Default
+  demands:
+    - Agent.Name -equals Bender
+
+resources:
+  repositories:
+    - repository: self
+      type: git
+
+stages:
+  - stage: Test
+    displayName: 'Test: sd-mobile'
+    jobs:
+      - job: JestTest
+        displayName: 'Jest test'
+        steps:
+          - task: NodeTool@0
+            displayName: 'Use Node.js 20'
+            inputs:
+              versionSpec: '20.x'
+
+          - script: |
+              cd $(Build.SourcesDirectory)/src/UI/sd-mobile
+              npm ci --legacy-peer-deps
+            displayName: 'Install dependencies'
+
+          - script: |
+              cd $(Build.SourcesDirectory)/src/UI/sd-mobile
+              npx jest --ci --coverage --forceExit
+            displayName: 'Run Jest'


### PR DESCRIPTION
## Summary

Adds an Azure DevOps pipeline for the mobile app at `src/UI/sd-mobile/azure-pipelines.yml`, mirroring the pattern used by the web app (`src/UI/sd-ui/azure-pipelines.yml`) and the .NET services. Pre-merge CI for mobile becomes visible in the same ADO dashboard as everything else.

The existing GitHub Action at `.github/workflows/ci-mobile.yml` stays in place — **belt-and-suspenders**: the GH Action keeps gating PRs if the self-hosted `Bender` agent is offline, and ADO gives dashboard parity with the rest of the stack.

## What this pipeline runs

- Node 20 (NodeTool@0)
- `npm ci --legacy-peer-deps`
- `npx jest --ci --coverage --forceExit`

That's it. No image build (mobile uses EAS post-merge, no Dockerfile), no lint (mobile `package.json` has no `lint` script today).

## What's intentionally *not* in scope

- **`tsc --noEmit` gating** — deferred. There's a pre-existing TS2304 in `app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx:328` (`submitPending` undefined). Once that's fixed in a separate small PR, we can add `npx tsc --noEmit` to this pipeline.
- **Removing the GitHub Action** — kept deliberately for Bender outage fallback.

## Post-merge: you have to do this in ADO

The YAML file is half the work. You'll need to do the rest in the ADO UI (I can't reach it):

1. Create a new pipeline definition pointing at `src/UI/sd-mobile/azure-pipelines.yml`
2. Authorize it on first run
3. (Optional) Add it to the branch protection rules on `main` if you want it gating merges

## Test plan
- [x] YAML lints clean (manual inspection vs the web's `azure-pipelines.yml`)
- [ ] First run after pipeline definition is created in ADO — expect Jest to pass (matches what the GH Action already does on every PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)