### PR TITLE
feat(mobile): Phase 2 — MatchupCard consumes live SignalR updates

### DIFF
--- a/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// MatchupCard's transitive import chain pulls in firebase/auth (via the
+// axios api client). The Firebase v12 ESM shim trips Jest's transformer
+// on `@firebase/util/dist/postinstall.mjs`, so stub the auth module —
+// the card we render never calls a Firebase method anyway.
+jest.mock('firebase/auth', () => ({
+  getAuth: () => ({ currentUser: null }),
+}));
+
+import { MatchupCard } from '@/src/components/features/games/MatchupCard';
+import { useContestUpdatesStore } from '@/src/stores/contestUpdatesStore';
+import type { Matchup } from '@/src/types/models';
+
+// GameStatus → useUserTimeZone → useCurrentUser uses TanStack Query.
+// Wrap renders in a fresh QueryClient (retry off so failed queries don't
+// schedule timers that leak between tests).
+function renderWithProviders(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+const CID = '00000000-0000-0000-0000-000000000001';
+
+const buildBaseballMatchup = (overrides?: Partial<Matchup>): Matchup => ({
+  contestId: CID,
+  startDateUtc: '2026-05-15T18:00:00Z',
+
+  away: 'Yankees',
+  awayShort: 'NYY',
+  awaySlug: 'yankees',
+  awayFranchiseSeasonId: '00000000-0000-0000-0000-0000000000a1',
+  awayLogoUri: null,
+
+  home: 'Red Sox',
+  homeShort: 'BOS',
+  homeSlug: 'red-sox',
+  homeFranchiseSeasonId: '00000000-0000-0000-0000-0000000000a2',
+  homeLogoUri: null,
+
+  status: 'Scheduled',
+  ...overrides,
+});
+
+const buildFootballMatchup = (overrides?: Partial<Matchup>): Matchup => ({
+  contestId: CID,
+  startDateUtc: '2026-05-15T18:00:00Z',
+
+  away: 'Chiefs',
+  awayShort: 'KC',
+  awaySlug: 'chiefs',
+  awayFranchiseSeasonId: '00000000-0000-0000-0000-0000000000b1',
+  awayLogoUri: null,
+
+  home: 'Bills',
+  homeShort: 'BUF',
+  homeSlug: 'bills',
+  homeFranchiseSeasonId: '00000000-0000-0000-0000-0000000000b2',
+  homeLogoUri: null,
+
+  status: 'Scheduled',
+  ...overrides,
+});
+
+describe('MatchupCard — live updates', () => {
+  beforeEach(() => {
+    useContestUpdatesStore.setState(useContestUpdatesStore.getInitialState(), true);
+  });
+
+  it('renders baseball InProgress UI after a BaseballPlayCompleted event arrives', () => {
+    const matchup = buildBaseballMatchup();
+    renderWithProviders(<MatchupCard matchup={matchup} leagueSport="BaseballMlb" />);
+
+    // Before any event: card shows Scheduled-state copy (no LIVE label).
+    expect(screen.queryByText('LIVE')).toBeNull();
+
+    // Push a baseball play event for this contest into the store.
+    act(() => {
+      useContestUpdatesStore.getState().handleBaseballPlayCompleted({
+        contestId: CID,
+        competitionId: '00000000-0000-0000-0000-0000000000cc',
+        playId: '00000000-0000-0000-0000-0000000000dd',
+        playDescription: 'A. Judge homers to deep center.',
+        inning: 3,
+        halfInning: 'Top',
+        awayScore: 4,
+        homeScore: 2,
+        balls: 1,
+        strikes: 2,
+        outs: 1,
+        runnerOnFirst: true,
+        runnerOnSecond: false,
+        runnerOnThird: true,
+        atBatAthleteSeasonId: null,
+        atBatShortName: 'A. Judge',
+        atBatPositionAbbreviation: 'RF',
+        atBatHeadshotUrl: null,
+        pitchingAthleteSeasonId: null,
+        pitchingShortName: 'C. Sale',
+        pitchingPositionAbbreviation: 'P',
+        pitchingHeadshotUrl: null,
+      });
+    });
+
+    // LIVE label appears (status was self-healed to InProgress by the store).
+    expect(screen.getByText('LIVE')).toBeTruthy();
+
+    // Baseball summary row: "Top 3 · 1-2 · 1 out".
+    expect(screen.getByText(/Top 3/)).toBeTruthy();
+    expect(screen.getByText(/1-2/)).toBeTruthy();
+    expect(screen.getByText(/1 out\b/)).toBeTruthy();
+
+    // At-bat header.
+    expect(screen.getByText(/AB:\s*A\. Judge/)).toBeTruthy();
+    expect(screen.getByText(/P:\s*C\. Sale/)).toBeTruthy();
+
+    // Last-play description.
+    expect(screen.getByText(/homers to deep center/)).toBeTruthy();
+
+    // Score line includes both teams' new scores.
+    expect(screen.getByText(/NYY 4 – 2 BOS/)).toBeTruthy();
+  });
+
+  it('renders football InProgress UI after a FootballPlayCompleted event arrives', () => {
+    const matchup = buildFootballMatchup();
+    renderWithProviders(<MatchupCard matchup={matchup} leagueSport="FootballNfl" />);
+
+    expect(screen.queryByText('LIVE')).toBeNull();
+
+    act(() => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted({
+        contestId: CID,
+        competitionId: '00000000-0000-0000-0000-0000000000ee',
+        playId: '00000000-0000-0000-0000-0000000000ff',
+        playDescription: 'P. Mahomes 18-yard pass.',
+        period: 'Q3',
+        clock: '4:21',
+        awayScore: 14,
+        homeScore: 17,
+        possessionFranchiseSeasonId: '00000000-0000-0000-0000-0000000000b1', // away
+        isScoringPlay: false,
+        ballOnYardLine: 22,
+      });
+    });
+
+    // LIVE + period/clock + new score.
+    expect(screen.getByText('LIVE')).toBeTruthy();
+    expect(screen.getByText(/Q3\s*–\s*4:21/)).toBeTruthy();
+    expect(screen.getByText(/KC 14 – 17 BUF/)).toBeTruthy();
+  });
+
+  it('does not subscribe to events for a different contestId', () => {
+    const matchup = buildBaseballMatchup();
+    renderWithProviders(<MatchupCard matchup={matchup} leagueSport="BaseballMlb" />);
+
+    // Event for a DIFFERENT contest — must not flip this card.
+    act(() => {
+      useContestUpdatesStore.getState().handleBaseballPlayCompleted({
+        contestId: 'some-other-contest',
+        competitionId: '00000000-0000-0000-0000-0000000000cc',
+        playId: '00000000-0000-0000-0000-0000000000dd',
+        playDescription: '',
+        inning: 9,
+        halfInning: 'Bottom',
+        awayScore: 99,
+        homeScore: 99,
+        balls: 0,
+        strikes: 0,
+        outs: 0,
+        runnerOnFirst: false,
+        runnerOnSecond: false,
+        runnerOnThird: false,
+        atBatAthleteSeasonId: null,
+        atBatShortName: null,
+        atBatPositionAbbreviation: null,
+        atBatHeadshotUrl: null,
+        pitchingAthleteSeasonId: null,
+        pitchingShortName: null,
+        pitchingPositionAbbreviation: null,
+        pitchingHeadshotUrl: null,
+      });
+    });
+
+    expect(screen.queryByText('LIVE')).toBeNull();
+  });
+});

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -172,6 +172,7 @@ export default function PicksScreen() {
             <MatchupCard
               matchup={item.matchup}
               pick={item.pick}
+              leagueSport={matchupsResponse?.sport ?? null}
               onPress={() => {
                 if (!sportLeague) {
                   // Sport hasn't resolved yet (matchups response still in flight)

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -10,6 +10,14 @@ import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 
 interface GameStatusProps {
   matchup: Matchup;
+  /**
+   * Backend Sport enum name ("FootballNcaa" | "FootballNfl" | "BaseballMlb").
+   * Used to dispatch the InProgress UI; baseball renders inning + count +
+   * runners + at-bat / pitcher, football renders period + clock +
+   * possession. Defaults to football for unknown / missing values so
+   * callers that don't yet thread it through don't regress.
+   */
+  leagueSport?: string | null;
   /** If provided, called when the user taps on a FINAL/completed game row (preserves full nav context from caller). */
   onPressGameDetail?: () => void;
 }
@@ -19,11 +27,13 @@ interface GameStatusProps {
  *
  * States:
  *   Scheduled   – game time, broadcasts, venue
- *   InProgress  – pulsing LIVE dot + period/clock + possession 🏈 + score + 🎉 TOUCHDOWN!
+ *   InProgress  – dispatched by leagueSport:
+ *                   BaseballMlb → inning + count + outs + runners + at-bat
+ *                   default     → LIVE dot + period/clock + possession 🏈
  *   Final       – FINAL label + score (tappable → game detail)
  *   Other       – raw status string (postponed, cancelled, etc.)
  */
-export function GameStatus({ matchup, onPressGameDetail }: GameStatusProps) {
+export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStatusProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
   const userTz = useUserTimeZone();
@@ -53,43 +63,10 @@ export function GameStatus({ matchup, onPressGameDetail }: GameStatusProps) {
 
   // ── In Progress ────────────────────────────────────────────────────────────
   if (status === 'inprogress' || status === 'ongoing' || status === 'halftime') {
-    const awayScore = matchup.awayScore ?? 0;
-    const homeScore = matchup.homeScore ?? 0;
-    const awayHasPossession =
-      !!matchup.possessionFranchiseSeasonId &&
-      matchup.possessionFranchiseSeasonId === matchup.awayFranchiseSeasonId;
-    const homeHasPossession =
-      !!matchup.possessionFranchiseSeasonId &&
-      matchup.possessionFranchiseSeasonId === matchup.homeFranchiseSeasonId;
-
-    return (
-      <View style={styles.statusSection}>
-        {/* LIVE indicator + period/clock */}
-        <View style={styles.liveRow}>
-          <View style={styles.liveDot} />
-          <Text style={styles.liveText}>LIVE</Text>
-          {matchup.period && matchup.clock ? (
-            <Text style={[styles.clockText, { color: theme.textMuted }]}>
-              {matchup.period} – {matchup.clock}
-            </Text>
-          ) : null}
-        </View>
-
-        {/* Score with possession indicators */}
-        <View style={styles.scoreRow}>
-          {awayHasPossession ? <Text style={styles.possessionIcon}>🏈</Text> : null}
-          <Text style={[styles.scoreText, { color: theme.text }]}>
-            {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
-          </Text>
-          {homeHasPossession ? <Text style={styles.possessionIcon}>🏈</Text> : null}
-        </View>
-
-        {/* Scoring play flash */}
-        {matchup.isScoringPlay ? (
-          <Text style={styles.scoringPlayText}>🎉 TOUCHDOWN!</Text>
-        ) : null}
-      </View>
-    );
+    if (leagueSport === 'BaseballMlb') {
+      return <BaseballInProgress matchup={matchup} theme={theme} />;
+    }
+    return <FootballInProgress matchup={matchup} theme={theme} />;
   }
 
   // ── Final ──────────────────────────────────────────────────────────────────
@@ -116,6 +93,139 @@ export function GameStatus({ matchup, onPressGameDetail }: GameStatusProps) {
   return (
     <View style={styles.statusSection}>
       <Text style={[styles.statusLabel, { color: theme.error }]}>{matchup.status}</Text>
+    </View>
+  );
+}
+
+// ─── InProgress sub-components ───────────────────────────────────────────────
+
+type Theme = ReturnType<typeof getTheme>;
+
+function FootballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme }) {
+  const awayScore = matchup.awayScore ?? 0;
+  const homeScore = matchup.homeScore ?? 0;
+  const awayHasPossession =
+    !!matchup.possessionFranchiseSeasonId &&
+    matchup.possessionFranchiseSeasonId === matchup.awayFranchiseSeasonId;
+  const homeHasPossession =
+    !!matchup.possessionFranchiseSeasonId &&
+    matchup.possessionFranchiseSeasonId === matchup.homeFranchiseSeasonId;
+
+  return (
+    <View style={styles.statusSection}>
+      <View style={styles.liveRow}>
+        <View style={styles.liveDot} />
+        <Text style={styles.liveText}>LIVE</Text>
+        {matchup.period && matchup.clock ? (
+          <Text style={[styles.clockText, { color: theme.textMuted }]}>
+            {matchup.period} – {matchup.clock}
+          </Text>
+        ) : null}
+      </View>
+
+      <View style={styles.scoreRow}>
+        {awayHasPossession ? <Text style={styles.possessionIcon}>🏈</Text> : null}
+        <Text style={[styles.scoreText, { color: theme.text }]}>
+          {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
+        </Text>
+        {homeHasPossession ? <Text style={styles.possessionIcon}>🏈</Text> : null}
+      </View>
+
+      {matchup.isScoringPlay ? (
+        <Text style={styles.scoringPlayText}>🎉 TOUCHDOWN!</Text>
+      ) : null}
+    </View>
+  );
+}
+
+function BaseballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme }) {
+  const awayScore = matchup.awayScore ?? 0;
+  const homeScore = matchup.homeScore ?? 0;
+  // halfInning "Top" → away batting (gets the ⚾); "Bottom" → home batting.
+  const half = (matchup.halfInning ?? '').toLowerCase();
+  const awayIsBatting = half === 'top';
+  const homeIsBatting = half === 'bottom';
+
+  const hasInningRow =
+    (typeof matchup.inning === 'number' && matchup.inning > 0) ||
+    (typeof matchup.halfInning === 'string' && matchup.halfInning.length > 0);
+  const hasRunnersRow = !!(
+    matchup.runnerOnFirst || matchup.runnerOnSecond || matchup.runnerOnThird
+  );
+  const hasAtBatRow = !!(matchup.atBatShortName || matchup.pitchingShortName);
+  const hasLastPlay =
+    typeof matchup.lastPlayDescription === 'string' &&
+    matchup.lastPlayDescription.length > 0;
+
+  const outsLabel = matchup.outs === 1 ? 'out' : 'outs';
+  const formattedHalfInning =
+    matchup.halfInning && matchup.inning
+      ? `${matchup.halfInning} ${matchup.inning}`
+      : matchup.halfInning || (matchup.inning ? `Inning ${matchup.inning}` : '');
+
+  return (
+    <View style={styles.statusSection}>
+      <View style={styles.liveRow}>
+        <View style={styles.liveDot} />
+        <Text style={styles.liveText}>LIVE</Text>
+      </View>
+
+      <View style={styles.scoreRow}>
+        {awayIsBatting ? <Text style={styles.possessionIcon}>⚾</Text> : null}
+        <Text style={[styles.scoreText, { color: theme.text }]}>
+          {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
+        </Text>
+        {homeIsBatting ? <Text style={styles.possessionIcon}>⚾</Text> : null}
+      </View>
+
+      {hasAtBatRow ? (
+        <View style={styles.baseballAtBatRow}>
+          {matchup.atBatShortName ? (
+            <Text style={[styles.baseballAtBatText, { color: theme.text }]}>
+              AB: {matchup.atBatShortName}
+              {matchup.atBatPositionAbbreviation
+                ? ` (${matchup.atBatPositionAbbreviation})`
+                : ''}
+            </Text>
+          ) : null}
+          {matchup.pitchingShortName ? (
+            <Text style={[styles.baseballAtBatText, { color: theme.textMuted }]}>
+              P: {matchup.pitchingShortName}
+              {matchup.pitchingPositionAbbreviation
+                ? ` (${matchup.pitchingPositionAbbreviation})`
+                : ''}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
+
+      {hasInningRow ? (
+        <Text style={[styles.baseballSummary, { color: theme.textMuted }]}>
+          {formattedHalfInning}
+          {' · '}
+          {matchup.balls ?? 0}-{matchup.strikes ?? 0}
+          {' · '}
+          {matchup.outs ?? 0} {outsLabel}
+        </Text>
+      ) : null}
+
+      {hasRunnersRow ? (
+        <Text style={[styles.baseballRunners, { color: theme.textMuted }]}>
+          Runners:
+          {matchup.runnerOnFirst ? ' 1B' : ''}
+          {matchup.runnerOnSecond ? ' 2B' : ''}
+          {matchup.runnerOnThird ? ' 3B' : ''}
+        </Text>
+      ) : null}
+
+      {hasLastPlay ? (
+        <Text
+          style={[styles.baseballLastPlay, { color: theme.textMuted }]}
+          numberOfLines={2}
+        >
+          {matchup.lastPlayDescription}
+        </Text>
+      ) : null}
     </View>
   );
 }
@@ -182,6 +292,33 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '700',
     color: '#FACC15',
+    marginTop: 2,
+  },
+  // Baseball-specific InProgress rows
+  baseballAtBatRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    columnGap: 12,
+    marginTop: 2,
+  },
+  baseballAtBatText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  baseballSummary: {
+    fontSize: 12,
+    fontWeight: '500',
+    marginTop: 2,
+  },
+  baseballRunners: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  baseballLastPlay: {
+    fontSize: 11,
+    fontStyle: 'italic',
+    textAlign: 'center',
     marginTop: 2,
   },
 });

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, UserPick, PickChoice, PreviewResponse, TeamComparisonData } from '@/src/types/models';
 import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
+import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
 import { InsightModal } from './InsightModal';
 import { StatsComparisonModal } from './StatsComparisonModal';
 import { GameStatus } from './GameStatus';
@@ -367,12 +368,66 @@ export interface MatchupCardProps {
   onPick?: (matchup: Matchup, choice: PickChoice, franchiseSeasonId: string) => void;
   /** Season year used for team stats API calls. Defaults to the game start year. */
   seasonYear?: number;
+  /**
+   * Backend Sport enum name ("FootballNcaa" | "FootballNfl" | "BaseballMlb").
+   * Threaded through to GameStatus for sport-aware InProgress rendering.
+   * Resolved from LeagueMatchupsResponse.sport at the screen level.
+   */
+  leagueSport?: string | null;
 }
 
-export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear }: MatchupCardProps) {
+export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear, leagueSport }: MatchupCardProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
-  const status = matchup.status.toLowerCase();
+
+  // Live-update subscription. Only re-renders this card when its own
+  // contestId's record changes — see contestUpdatesStore selector design.
+  const live = useContestUpdate(matchup.contestId);
+
+  // Merge live data over the static REST payload via nullish fallback so
+  // a partial future-update handler can't silently undefine a previously
+  // populated field. Mirrors the web pattern in AdminBaseballPage.jsx
+  // and AdminFootballPage.jsx.
+  const enrichedMatchup = useMemo<Matchup>(() => {
+    if (!live) return matchup;
+    return {
+      ...matchup,
+      status: live.status ?? matchup.status,
+      awayScore: live.awayScore ?? matchup.awayScore,
+      homeScore: live.homeScore ?? matchup.homeScore,
+      // Football live fields
+      period: live.period ?? matchup.period,
+      clock: live.clock ?? matchup.clock,
+      possessionFranchiseSeasonId:
+        live.possessionFranchiseSeasonId ?? matchup.possessionFranchiseSeasonId,
+      isScoringPlay: live.isScoringPlay ?? matchup.isScoringPlay,
+      ballOnYardLine: live.ballOnYardLine ?? matchup.ballOnYardLine,
+      // Baseball live fields
+      inning: live.inning ?? matchup.inning,
+      halfInning: live.halfInning ?? matchup.halfInning,
+      balls: live.balls ?? matchup.balls,
+      strikes: live.strikes ?? matchup.strikes,
+      outs: live.outs ?? matchup.outs,
+      runnerOnFirst: live.runnerOnFirst ?? matchup.runnerOnFirst,
+      runnerOnSecond: live.runnerOnSecond ?? matchup.runnerOnSecond,
+      runnerOnThird: live.runnerOnThird ?? matchup.runnerOnThird,
+      atBatAthleteSeasonId: live.atBatAthleteSeasonId ?? matchup.atBatAthleteSeasonId,
+      atBatShortName: live.atBatShortName ?? matchup.atBatShortName,
+      atBatPositionAbbreviation:
+        live.atBatPositionAbbreviation ?? matchup.atBatPositionAbbreviation,
+      atBatHeadshotUrl: live.atBatHeadshotUrl ?? matchup.atBatHeadshotUrl,
+      pitchingAthleteSeasonId:
+        live.pitchingAthleteSeasonId ?? matchup.pitchingAthleteSeasonId,
+      pitchingShortName: live.pitchingShortName ?? matchup.pitchingShortName,
+      pitchingPositionAbbreviation:
+        live.pitchingPositionAbbreviation ?? matchup.pitchingPositionAbbreviation,
+      pitchingHeadshotUrl: live.pitchingHeadshotUrl ?? matchup.pitchingHeadshotUrl,
+      lastPlayId: live.lastPlayId ?? matchup.lastPlayId,
+      lastPlayDescription: live.lastPlayDescription ?? matchup.lastPlayDescription,
+    };
+  }, [matchup, live]);
+
+  const status = enrichedMatchup.status.toLowerCase();
   const isFinal = status === 'final' || status === 'completed';
 
   // Optimistic local pick — shows selection instantly before server confirms
@@ -427,9 +482,9 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   };
 
   const homeIsWinning =
-    matchup.homeScore != null &&
-    matchup.awayScore != null &&
-    matchup.homeScore >= matchup.awayScore;
+    enrichedMatchup.homeScore != null &&
+    enrichedMatchup.awayScore != null &&
+    enrichedMatchup.homeScore >= enrichedMatchup.awayScore;
 
   // Use server pick if available, otherwise optimistic
   const effectiveFranchiseId = pick?.franchiseId ?? optimisticFranchiseId;
@@ -441,7 +496,8 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   // Pick result
   const isPickCorrect = isFinal && hasPick ? (pick?.isCorrect ?? null) : null;
 
-  const locked = isPickLocked(matchup);
+  // Use enriched status — a live transition to InProgress must lock picks.
+  const locked = isPickLocked(enrichedMatchup);
 
   // Card border color based on pick result (matches web)
   let cardBorderColor = theme.border;
@@ -481,7 +537,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         disabled={!onPressTeam}
       >
         <TeamRow
-          matchup={matchup}
+          matchup={enrichedMatchup}
           side="away"
           isWinning={!homeIsWinning}
           isPicked={pickedAway}
@@ -497,7 +553,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         disabled={!onPressTeam}
       >
         <TeamRow
-          matchup={matchup}
+          matchup={enrichedMatchup}
           side="home"
           isWinning={homeIsWinning}
           isPicked={pickedHome}
@@ -512,12 +568,18 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         activeOpacity={onPress ? 0.75 : 1}
         disabled={!onPress}
       >
-        <OddsRow matchup={matchup} />
+        <OddsRow matchup={enrichedMatchup} />
       </TouchableOpacity>
 
       {/* Game status — time/score/live; GameStatus owns its own touchable
-          and routes to the contest overview via onPressGameDetail. */}
-      <GameStatus matchup={matchup} onPressGameDetail={onPress} />
+          and routes to the contest overview via onPressGameDetail.
+          enriched data drives all status branches; leagueSport dispatches
+          the InProgress UI between baseball and football. */}
+      <GameStatus
+        matchup={enrichedMatchup}
+        leagueSport={leagueSport}
+        onPressGameDetail={onPress}
+      />
 
       {/* Inline pick buttons */}
       {onPick && (

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -57,11 +57,37 @@ export interface Matchup {
   status: string;               // "Scheduled" | "InProgress" | "Halftime" | "Final" | etc.
   isComplete?: boolean;
 
-  // Live game state (populated when status = InProgress / Halftime)
+  // Live game state — football (populated when status = InProgress / Halftime)
   period?: string | null;
   clock?: string | null;
   possessionFranchiseSeasonId?: string | null;
   isScoringPlay?: boolean | null;
+  /** 0–100 yards from the away (visitor) goal line. Null pre-snap / halftime / post-game. */
+  ballOnYardLine?: number | null;
+
+  // Live game state — baseball (populated by BaseballPlayCompleted via contestUpdatesStore)
+  inning?: number | null;
+  /** "Top" or "Bottom" (case-insensitive consumers welcome). */
+  halfInning?: string | null;
+  balls?: number | null;
+  strikes?: number | null;
+  outs?: number | null;
+  runnerOnFirst?: boolean | null;
+  runnerOnSecond?: boolean | null;
+  runnerOnThird?: boolean | null;
+  /** Season-scoped — resolves to AthleteSeason.Id, not AthleteBase.Id. */
+  atBatAthleteSeasonId?: string | null;
+  atBatShortName?: string | null;
+  atBatPositionAbbreviation?: string | null;
+  atBatHeadshotUrl?: string | null;
+  pitchingAthleteSeasonId?: string | null;
+  pitchingShortName?: string | null;
+  pitchingPositionAbbreviation?: string | null;
+  pitchingHeadshotUrl?: string | null;
+
+  // Sport-neutral last-play info (written by either *PlayCompleted handler)
+  lastPlayId?: string | null;
+  lastPlayDescription?: string | null;
 
   // Scores
   awayScore?: number | null;


### PR DESCRIPTION
## Summary

Phase 2 of the mobile SignalR rollout planned in [`docs/mobile/mobile-signalr-admin-plan.md`](docs/mobile/mobile-signalr-admin-plan.md). Phase 1 ([#325](https://github.com/jrandallsexton/sports-data-core/pull/325)) landed the SignalR plumbing and a Zustand store that nothing read. This PR is what makes the picks screen actually light up.

- `Matchup` type gains baseball live fields (`inning`, `halfInning`, `balls/strikes/outs`, `runner*`, at-bat / pitcher names + positions + headshots, `lastPlayDescription`) and `ballOnYardLine` for football
- `MatchupCard` subscribes via `useContestUpdate(matchup.contestId)` and computes `enrichedMatchup` with `useMemo` — nullish-fallback merge of live over static, mirroring the web's `AdminBaseballPage.jsx` / `AdminFootballPage.jsx` shape. The enriched object drives `status`, `isPickLocked`, scores, odds, and `GameStatus`; raw `matchup` is retained for modal data and `onPick` callbacks for stable identity.
- `GameStatus` takes a new `leagueSport` prop. The InProgress branch dispatches `BaseballInProgress` for `BaseballMlb`; the existing football UI is extracted into `FootballInProgress`. New baseball UI: LIVE label, score with ⚾ marker on the batting team, at-bat / pitcher row, `{halfInning} {inning} · B-S · N outs` summary, runners row, last-play line.
- `app/(tabs)/picks.tsx` threads `leagueSport={matchupsResponse?.sport ?? null}` into `MatchupCard`.

## Why per-contest selector hooks matter here

`useContestUpdate(contestId)` returns `state.contests[contestId]`. Only the MatchupCard for the specific contestId whose record changed re-renders — not every card on the picks screen. During a busy Sunday slate (16 in-progress NFL games) this keeps re-renders scoped to the card whose play just landed.

## Tests

- `__tests__/components/features/games/MatchupCard.live.test.tsx` — 3 facts:
  - Baseball event arrives → baseball InProgress UI renders with correct inning/count/runners/at-bat/score
  - Football event arrives → football InProgress UI renders with correct period/clock/score
  - Event for a *different* contestId leaves this card untouched
- Test render wraps in `QueryClientProvider` because `GameStatus → useUserTimeZone → useCurrentUser` consumes TanStack Query. Firebase auth is stubbed since the card transitively imports the auth-aware api client.

## Test plan
- [x] `npm test` → **36/36** passing across 7 suites (3 new in this PR)
- [x] `npx tsc --noEmit` → clean except pre-existing `submitPending` error in `game/[id].tsx`
- [ ] Dev-client smoke test on a real MLB game (or admin-replay) — picks screen card should show LIVE + inning + count as `BaseballPlayCompleted` events arrive
- [ ] CodeRabbit review

## Known unrelated
- Pre-existing TS2304 in `app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx:328` (`submitPending` undefined). Blocks adding `tsc --noEmit` to the ADO pipeline. Separate fix.

## Out of scope (Phase 3)
- Sport-agnostic admin replay page at `app/admin/index.tsx` — that's what triggers the events this PR consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live game updates now display real-time scores and game status with sport-specific formatting.
  * Baseball games show inning, ball/strike/out counts, and pitcher/batter information.
  * Football games display period, game clock, and team scores.

* **Tests**
  * Added comprehensive test coverage for live game update behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->