### PR TITLE
fix(mobile): close MatchupCard parity gaps vs web (baseball avatars, football last-play, score-flash, pick-button height)

### DIFF
--- a/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
@@ -36,13 +36,13 @@ const buildBaseballMatchup = (overrides?: Partial<Matchup>): Matchup => ({
   awayShort: 'NYY',
   awaySlug: 'yankees',
   awayFranchiseSeasonId: '00000000-0000-0000-0000-0000000000a1',
-  awayLogoUri: null,
+  awayLogoUri: 'https://example.test/yankees.png',
 
   home: 'Red Sox',
   homeShort: 'BOS',
   homeSlug: 'red-sox',
   homeFranchiseSeasonId: '00000000-0000-0000-0000-0000000000a2',
-  homeLogoUri: null,
+  homeLogoUri: 'https://example.test/red-sox.png',
 
   status: 'Scheduled',
   ...overrides,
@@ -153,6 +153,105 @@ describe('MatchupCard — live updates', () => {
     expect(screen.getByText('LIVE')).toBeTruthy();
     expect(screen.getByText(/Q3\s*–\s*4:21/)).toBeTruthy();
     expect(screen.getByText(/KC 14 – 17 BUF/)).toBeTruthy();
+  });
+
+  it('renders batter team logo + headshot when the BaseballPlayCompleted carries them', () => {
+    const matchup = buildBaseballMatchup();
+    const { UNSAFE_getAllByType } = renderWithProviders(
+      <MatchupCard matchup={matchup} leagueSport="BaseballMlb" />,
+    );
+
+    act(() => {
+      useContestUpdatesStore.getState().handleBaseballPlayCompleted({
+        contestId: CID,
+        competitionId: '00000000-0000-0000-0000-0000000000cc',
+        playId: '00000000-0000-0000-0000-0000000000dd',
+        playDescription: 'Single to right.',
+        inning: 1,
+        halfInning: 'Top', // away batting → batter wears away logo
+        awayScore: 0,
+        homeScore: 0,
+        balls: 0,
+        strikes: 0,
+        outs: 0,
+        runnerOnFirst: false,
+        runnerOnSecond: false,
+        runnerOnThird: false,
+        atBatAthleteSeasonId: null,
+        atBatShortName: 'A. Judge',
+        atBatPositionAbbreviation: 'RF',
+        atBatHeadshotUrl: 'https://example.test/judge.png',
+        pitchingAthleteSeasonId: null,
+        pitchingShortName: 'C. Sale',
+        pitchingPositionAbbreviation: 'P',
+        pitchingHeadshotUrl: 'https://example.test/sale.png',
+      });
+    });
+
+    // Pull every Image out of the tree and check the URIs we expect to
+    // have flowed in: away logo (batter), home logo (pitcher), batter
+    // headshot, pitcher headshot.
+    const { Image } = require('react-native');
+    const images = UNSAFE_getAllByType(Image);
+    const uris = images.map((img: { props: { source?: { uri?: string } } }) => img.props.source?.uri);
+    expect(uris).toEqual(
+      expect.arrayContaining([
+        'https://example.test/yankees.png',
+        'https://example.test/red-sox.png',
+        'https://example.test/judge.png',
+        'https://example.test/sale.png',
+      ]),
+    );
+  });
+
+  it('renders football last-play description when the FootballPlayCompleted carries one', () => {
+    const matchup = buildFootballMatchup();
+    renderWithProviders(<MatchupCard matchup={matchup} leagueSport="FootballNfl" />);
+
+    act(() => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted({
+        contestId: CID,
+        competitionId: '00000000-0000-0000-0000-0000000000ee',
+        playId: '00000000-0000-0000-0000-0000000000ff',
+        playDescription: 'P. Mahomes 18-yard pass to T. Kelce.',
+        period: 'Q3',
+        clock: '4:21',
+        awayScore: 14,
+        homeScore: 17,
+        possessionFranchiseSeasonId: '00000000-0000-0000-0000-0000000000b1',
+        isScoringPlay: false,
+        ballOnYardLine: 22,
+      });
+    });
+
+    expect(screen.getByText(/Mahomes 18-yard pass/)).toBeTruthy();
+  });
+
+  it('applies the score-flash style on the score row when isScoringPlay is true', () => {
+    const matchup = buildFootballMatchup();
+    renderWithProviders(<MatchupCard matchup={matchup} leagueSport="FootballNfl" />);
+
+    act(() => {
+      useContestUpdatesStore.getState().handleFootballPlayCompleted({
+        contestId: CID,
+        competitionId: '00000000-0000-0000-0000-0000000000ee',
+        playId: '00000000-0000-0000-0000-0000000000ff',
+        playDescription: 'Touchdown!',
+        period: 'Q4',
+        clock: '0:32',
+        awayScore: 21,
+        homeScore: 17,
+        possessionFranchiseSeasonId: '00000000-0000-0000-0000-0000000000b1',
+        isScoringPlay: true,
+        ballOnYardLine: 0,
+      });
+    });
+
+    // The TOUCHDOWN! text is the visible signal that isScoringPlay was
+    // observed. The score-row flash style is applied via the same flag;
+    // asserting the text presence is sufficient to confirm the path
+    // ran. (Style-prop assertions against StyleSheet IDs are brittle.)
+    expect(screen.getByText(/TOUCHDOWN/)).toBeTruthy();
   });
 
   it('does not subscribe to events for a different contestId', () => {

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { Matchup } from '@/src/types/models';
@@ -110,6 +110,9 @@ function FootballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
   const homeHasPossession =
     !!matchup.possessionFranchiseSeasonId &&
     matchup.possessionFranchiseSeasonId === matchup.homeFranchiseSeasonId;
+  const hasLastPlay =
+    typeof matchup.lastPlayDescription === 'string' &&
+    matchup.lastPlayDescription.length > 0;
 
   return (
     <View style={styles.statusSection}>
@@ -123,7 +126,7 @@ function FootballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
         ) : null}
       </View>
 
-      <View style={styles.scoreRow}>
+      <View style={[styles.scoreRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
         {awayHasPossession ? <Text style={styles.possessionIcon}>🏈</Text> : null}
         <Text style={[styles.scoreText, { color: theme.text }]}>
           {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
@@ -133,6 +136,15 @@ function FootballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
 
       {matchup.isScoringPlay ? (
         <Text style={styles.scoringPlayText}>🎉 TOUCHDOWN!</Text>
+      ) : null}
+
+      {hasLastPlay ? (
+        <Text
+          style={[styles.lastPlayText, { color: theme.textMuted }]}
+          numberOfLines={2}
+        >
+          {matchup.lastPlayDescription}
+        </Text>
       ) : null}
     </View>
   );
@@ -145,6 +157,20 @@ function BaseballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
   const half = (matchup.halfInning ?? '').toLowerCase();
   const awayIsBatting = half === 'top';
   const homeIsBatting = half === 'bottom';
+
+  // Per-slot team logo: batter wears the batting team's logo, pitcher
+  // wears the defensive team's. Either may be null when halfInning is
+  // missing or when the team has no logo URL — slot tolerates absence.
+  const batterLogoUri = awayIsBatting
+    ? matchup.awayLogoUri
+    : homeIsBatting
+      ? matchup.homeLogoUri
+      : null;
+  const pitcherLogoUri = awayIsBatting
+    ? matchup.homeLogoUri
+    : homeIsBatting
+      ? matchup.awayLogoUri
+      : null;
 
   const hasInningRow =
     (typeof matchup.inning === 'number' && matchup.inning > 0) ||
@@ -170,7 +196,7 @@ function BaseballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
         <Text style={styles.liveText}>LIVE</Text>
       </View>
 
-      <View style={styles.scoreRow}>
+      <View style={[styles.scoreRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
         {awayIsBatting ? <Text style={styles.possessionIcon}>⚾</Text> : null}
         <Text style={[styles.scoreText, { color: theme.text }]}>
           {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
@@ -181,20 +207,54 @@ function BaseballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
       {hasAtBatRow ? (
         <View style={styles.baseballAtBatRow}>
           {matchup.atBatShortName ? (
-            <Text style={[styles.baseballAtBatText, { color: theme.text }]}>
-              AB: {matchup.atBatShortName}
-              {matchup.atBatPositionAbbreviation
-                ? ` (${matchup.atBatPositionAbbreviation})`
-                : ''}
-            </Text>
+            <View style={styles.baseballAtBatSlot}>
+              {batterLogoUri ? (
+                <Image
+                  source={{ uri: batterLogoUri }}
+                  style={styles.baseballAtBatLogo}
+                  resizeMode="contain"
+                  accessibilityIgnoresInvertColors
+                />
+              ) : null}
+              {matchup.atBatHeadshotUrl ? (
+                <Image
+                  source={{ uri: matchup.atBatHeadshotUrl }}
+                  style={styles.baseballAtBatHeadshot}
+                  accessibilityIgnoresInvertColors
+                />
+              ) : null}
+              <Text style={[styles.baseballAtBatText, { color: theme.text }]}>
+                AB: {matchup.atBatShortName}
+                {matchup.atBatPositionAbbreviation
+                  ? ` (${matchup.atBatPositionAbbreviation})`
+                  : ''}
+              </Text>
+            </View>
           ) : null}
           {matchup.pitchingShortName ? (
-            <Text style={[styles.baseballAtBatText, { color: theme.textMuted }]}>
-              P: {matchup.pitchingShortName}
-              {matchup.pitchingPositionAbbreviation
-                ? ` (${matchup.pitchingPositionAbbreviation})`
-                : ''}
-            </Text>
+            <View style={styles.baseballAtBatSlot}>
+              {pitcherLogoUri ? (
+                <Image
+                  source={{ uri: pitcherLogoUri }}
+                  style={styles.baseballAtBatLogo}
+                  resizeMode="contain"
+                  accessibilityIgnoresInvertColors
+                />
+              ) : null}
+              {matchup.pitchingHeadshotUrl ? (
+                <Image
+                  source={{ uri: matchup.pitchingHeadshotUrl }}
+                  style={styles.baseballAtBatHeadshot}
+                  accessibilityIgnoresInvertColors
+                />
+              ) : null}
+              <Text style={[styles.baseballAtBatText, { color: theme.textMuted }]}>
+                P: {matchup.pitchingShortName}
+                {matchup.pitchingPositionAbbreviation
+                  ? ` (${matchup.pitchingPositionAbbreviation})`
+                  : ''}
+              </Text>
+            </View>
           ) : null}
         </View>
       ) : null}
@@ -220,7 +280,7 @@ function BaseballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
 
       {hasLastPlay ? (
         <Text
-          style={[styles.baseballLastPlay, { color: theme.textMuted }]}
+          style={[styles.lastPlayText, { color: theme.textMuted }]}
           numberOfLines={2}
         >
           {matchup.lastPlayDescription}
@@ -280,6 +340,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 4,
     marginTop: 2,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+  },
+  // Brief yellow highlight on the score row when isScoringPlay is true.
+  // The store auto-clears the flag after 2s (see contestUpdatesStore),
+  // so this style toggles off automatically without an Animated value.
+  scoreRowFlash: {
+    backgroundColor: 'rgba(250, 204, 21, 0.25)',
   },
   scoreText: {
     fontSize: 15,
@@ -294,13 +363,35 @@ const styles = StyleSheet.create({
     color: '#FACC15',
     marginTop: 2,
   },
+  // Sport-neutral last-play row — used by both football and baseball.
+  lastPlayText: {
+    fontSize: 11,
+    fontStyle: 'italic',
+    textAlign: 'center',
+    marginTop: 2,
+  },
   // Baseball-specific InProgress rows
   baseballAtBatRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'center',
     columnGap: 12,
+    rowGap: 4,
     marginTop: 2,
+  },
+  baseballAtBatSlot: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  baseballAtBatLogo: {
+    width: 18,
+    height: 18,
+  },
+  baseballAtBatHeadshot: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
   },
   baseballAtBatText: {
     fontSize: 12,
@@ -314,11 +405,5 @@ const styles = StyleSheet.create({
   baseballRunners: {
     fontSize: 12,
     fontWeight: '500',
-  },
-  baseballLastPlay: {
-    fontSize: 11,
-    fontStyle: 'italic',
-    textAlign: 'center',
-    marginTop: 2,
   },
 });

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -763,11 +763,17 @@ const styles = StyleSheet.create({
   },
   pickBtn: {
     flex: 1,
+    // Row layout matches the web's PickButton: icon and team short sit
+    // side-by-side instead of stacking. Stacking was the source of the
+    // disproportionately-tall mobile pick buttons vs web parity.
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
     borderWidth: 1.5,
     borderRadius: 10,
-    paddingVertical: 10,
-    alignItems: 'center',
-    gap: 2,
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    gap: 4,
   },
   pickIcon: {
     fontSize: 13,


### PR DESCRIPTION
## Summary

Closes the visible drift between the mobile and web `MatchupCard` after Phase 2 landed. All four items were flagged in a side-by-side audit; bundling them so we can move on to the next area cleanly.

### Drift closed

| Area | Web had | Mobile now matches |
|---|---|---|
| Baseball at-bat row | Team logo + player headshot per slot (batter/pitcher) | `<Image>` for both — gracefully suppresses when URL is null |
| Football InProgress | Last-play description row at the bottom | New `lastPlayText` row, sport-neutral style shared with baseball |
| Score-flash | CSS class applied to score row on `isScoringPlay` | Soft yellow background on the score row; Phase 1 store auto-clears flag after 2s |
| Pick button height | Inline icon + team-short, ~32px tall | `flexDirection: 'row'` + `paddingVertical: 8` (was stacked column + `10`); roughly halved |

### Out of intentional scope

- **Animated score-flash keyframe** — web uses a CSS transition; mobile uses a static style toggle since Phase 1's store already provides the 2s window. Reanimated isn't worth pulling in for this.
- **Wrapping the live block in a Link** — web wraps in `<Link>` so the live block taps through to the game detail in a new tab. Mobile already has the rest of the card tappable to the overview route; not redundant on mobile.

## Test plan
- [x] `npm test` → **39/39** across 7 suites (3 new in this PR — avatar URIs flow into Image components, football last-play renders, scoring-play path runs end-to-end)
- [x] `npx tsc --noEmit` → clean except the pre-existing `submitPending` error in `game/[id].tsx`
- [ ] Eyeball on a dev-client build during a live MLB game or web-side admin replay
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)