### PR TITLE
fix(mobile): include Firebase env vars in EAS preview+production builds

### DIFF
--- a/docs/mobile/expo-deployment-model.md
+++ b/docs/mobile/expo-deployment-model.md
@@ -132,3 +132,152 @@ The build profiles live in `eas.json` at the project root. A typical setup:
 - **development** — builds the dev client (supports hot reload + custom native modules)
 - **preview** — internal TestFlight distribution for QA/stakeholder testing
 - **production** — App Store submission build
+
+---
+
+## One-Shot Preview Build for iPhone (Ad-Hoc Install)
+
+Use this when you want to sideload a preview build onto your own iPhone without TestFlight review — useful for validating the app against prod APIs while off your dev network.
+
+The `preview` profile in `eas.json` is set up for this: `distribution: internal` produces an ad-hoc-signed IPA that installs from an EAS-hosted URL. SignalR falls back to `EXPO_PUBLIC_API_BASE_URL` (`useSignalRClient.ts`), so the same env var that points the REST client at prod also routes the hub.
+
+### Prerequisites (one-time)
+
+- Active Apple Developer membership ($99/yr) on the Apple ID you'll use
+- `eas-cli` installed (`npm i -g eas-cli`)
+- Your iPhone's UDID — or skip and let `eas device:create` walk you through registering it
+
+### Steps
+
+Run from `src/UI/sd-mobile/`:
+
+1. **Log in to EAS** (one-time):
+   ```bash
+   eas login
+   ```
+   Use the Expo account that owns the project (`app.json` `owner: "sportdeets"`).
+
+2. **Register your iPhone for ad-hoc distribution** (one-time per device):
+   ```bash
+   eas device:create
+   ```
+   EAS prints a URL/QR. Open it on the iPhone, install the config profile from Settings → General → VPN & Device Management. EAS now knows the device and can include it in the ad-hoc provisioning profile.
+
+3. **Build the preview IPA**:
+   ```bash
+   eas build --platform ios --profile preview
+   ```
+   First-run prompts:
+   - "Generate a new Apple Distribution Certificate?" → **Yes** (let EAS manage credentials)
+   - "Generate a new Ad Hoc Provisioning Profile?" → **Yes**
+   - Apple ID login → the one tied to your Developer membership
+
+   Build runs in EAS cloud (~10–20 min on `m-medium`).
+
+4. **Install on iPhone**: When the build finishes EAS prints a URL of the form `https://expo.dev/accounts/sportdeets/projects/sportdeets/builds/<id>`. Open it in Safari on the iPhone → tap **Install**. The IPA installs directly via the ad-hoc profile — no TestFlight, no App Store review.
+
+### Gotchas
+
+- **Prod hub auth**: this is the first time the mobile client negotiates SignalR against `https://api.sportdeets.com/hubs/notifications`. Confirm in Seq that the hub returns 200 for the new connection after you log in on the device.
+- **Device cap**: Apple's ad-hoc program allows 100 registered iPhones per year per account. Fine for personal testing; if you grow QA testers past that, move to TestFlight via `eas submit`.
+- **Profile expiry**: ad-hoc provisioning profiles expire after 12 months. A rebuild after expiry just regenerates the profile.
+
+---
+
+## TestFlight Distribution to External Testers
+
+This is the model for shipping builds to **people who aren't on your network and whose devices you don't want to register individually** — friends helping with beta testing, stakeholders, etc. They install Apple's TestFlight app from the App Store, tap your invite link, and the build appears on their phone. No UDIDs, no config profiles.
+
+TestFlight has two tiers:
+
+| | Internal | External |
+|---|---|---|
+| Tester cap | 100 | 10,000 |
+| How they're added | By Apple ID in App Store Connect | By email **or** public invite link |
+| Apple review required | No | **Yes, first time per group** (~24h, lighter than App Store review) |
+| Subsequent builds in same group | Instant | Instant (no re-review) |
+| Build lifetime | 90 days | 90 days |
+
+For friends-testing the right answer is usually **External + public link** — you paste a URL in iMessage and they're in.
+
+### Prerequisites (one-time)
+
+- Apple Developer membership ($99/yr)
+- App Store Connect record for the app — `Bundle ID` must match `app.json` (`com.sportdeets.mobile`)
+- App Store Connect API key for non-interactive `eas submit` (optional but strongly recommended; otherwise every submit prompts for Apple ID + 2FA)
+
+### One-Time Setup
+
+1. **Create the app in App Store Connect** (https://appstoreconnect.apple.com → My Apps → `+`):
+   - Bundle ID: `com.sportdeets.mobile` (must be registered in the Developer portal first; EAS does this on the first production build)
+   - SKU: any unique string, e.g. `sportdeets-mobile`
+   - Primary language: English
+
+2. **Generate an ASC API key** (Users and Access → Keys → App Store Connect API → `+`):
+   - Role: **App Manager** (or Admin)
+   - Download the `.p8` file — Apple shows it once, never again
+   - Record the **Key ID** and **Issuer ID** shown on that page
+
+3. **Add a `submit` block to `eas.json`**:
+   ```json
+   "submit": {
+     "production": {
+       "ios": {
+         "ascApiKeyPath": "./secrets/AuthKey_<KEY_ID>.p8",
+         "ascApiKeyId": "<KEY_ID>",
+         "ascApiIssuerId": "<ISSUER_ID>",
+         "appleId": "you@example.com",
+         "ascAppId": "<APP_ID_FROM_APP_STORE_CONNECT>"
+       }
+     }
+   }
+   ```
+   Add `secrets/` to `.gitignore` — the `.p8` is a credential. Alternative: upload the key to EAS once with `eas credentials` and skip the local file.
+
+4. **Create an external TestFlight group** in App Store Connect → TestFlight → External Testing → `+`:
+   - Name it (e.g., `Friends`)
+   - Toggle "Enable Public Link" → copy the URL — this is what you share
+
+### Per-Build Workflow
+
+From `src/UI/sd-mobile/`:
+
+1. **Build the production IPA**:
+   ```bash
+   eas build --platform ios --profile production
+   ```
+   The `production` profile in `eas.json` already has `autoIncrement: true`, so the build number bumps automatically — Apple requires every TestFlight upload to have a unique, monotonically increasing build number.
+
+2. **Submit to TestFlight**:
+   ```bash
+   eas submit --platform ios --latest
+   ```
+   `--latest` grabs the most recent successful build. Apple processes the upload (~5–15 min); it appears in App Store Connect → TestFlight under "iOS Builds."
+
+3. **Attach the build to the external group**:
+   - First time: select the build, add it to the `Friends` group, fill in "What to Test" notes → **Submit for Beta App Review**. Wait ~24h.
+   - Subsequent builds: just attach to the group — no review needed because the group is already approved.
+
+4. **Share the public link**. Friends:
+   - Install TestFlight from the App Store
+   - Open the link → tap "Accept" → tap "Install"
+   - Build is on their phone, no network sharing, no UDID
+
+### Hotfixes Between Builds
+
+For JS/asset-only changes (most UI tweaks, copy fixes, bug fixes that don't touch native modules), skip the rebuild:
+
+```bash
+eas update --branch production --message "Fix pick button overflow"
+```
+
+Existing TestFlight installs pick up the update on next app launch. Native code or SDK changes still require a fresh `eas build` + `eas submit`.
+
+### Gotchas
+
+- **First external review delay**: budget 24h before the first invite. Once the group is approved, every subsequent build skips review. Plan the first submission ahead of the day you want friends testing.
+- **90-day build expiry**: TestFlight builds stop launching after 90 days. If a build sits unused that long, ship a new one before re-engaging testers.
+- **Export compliance**: `ITSAppUsesNonExemptEncryption: false` is already in `app.json` — keeps Apple from prompting on every upload. If the app ever adds custom crypto (beyond HTTPS), this has to change.
+- **Privacy nutrition labels**: TestFlight upload will warn if these are missing but won't block. The actual App Store submission will block — easier to fill them in once when creating the app record.
+- **Build numbers can't go backward**: if `autoIncrement` ever desynchronizes (e.g., you build outside EAS), App Store Connect rejects the upload. Fix is `eas build:version:set` to a number above the highest one already uploaded.
+- **Tester invite emails go to spam**: if a friend says they didn't get the email, point them at the public link instead — it always works.

--- a/docs/mobile/firebase-config-in-eas-builds.md
+++ b/docs/mobile/firebase-config-in-eas-builds.md
@@ -1,0 +1,68 @@
+# Firebase Config in EAS Builds
+
+**Status (2026-05-16)**: Fix applied. EAS `preview` and `production` profiles now embed the dev Firebase project's config so TestFlight builds boot past `initializeApp()`. Migration to a real prod Firebase project (`sportdeets`, separate from `sportdeets-dev`) is deferred until pre-season — see [Deferred Work](#deferred-work).
+
+---
+
+## The Problem
+
+The first TestFlight build (build 2) crashed on launch with `EXC_BAD_ACCESS` in the Hermes JS engine, triggered by a TurboModule converting an NSException. Root cause: Firebase initialized with `apiKey: undefined` because the production build had no Firebase env vars baked in.
+
+## Why Dev Works but Prod Doesn't
+
+| | Dev (Metro on PC) | Prod (EAS Build in cloud) |
+|---|---|---|
+| How the JS bundle is built | `npx expo start` runs Metro, reads `.env.local` on disk, injects values into `process.env.EXPO_PUBLIC_*` at bundle time | EAS runs in a Mac VM in Expo's cloud, pulls a tarball of the repo. `.env.local` is **gitignored** → EAS never sees it |
+| Where env vars come from | `.env.local` | The `env` block of the active profile in `eas.json`, plus EAS dashboard secrets |
+| Before the fix | All six `EXPO_PUBLIC_FIREBASE_*` keys set | Only `EXPO_PUBLIC_API_BASE_URL` set; all `EXPO_PUBLIC_FIREBASE_*` → `undefined` |
+
+Same Firebase project, two different config-delivery paths. Production path wasn't configured.
+
+## What We Did
+
+Pasted the existing `.env.local` Firebase values into the `env` block of both `preview` and `production` profiles in `eas.json`:
+
+```json
+"env": {
+  "EXPO_PUBLIC_API_BASE_URL": "https://api.sportdeets.com",
+  "EXPO_PUBLIC_FIREBASE_API_KEY": "AIzaSyBRkQwtEl3jeqoYKBN-hPv8VxTjUycNJgM",
+  "EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN": "sportdeets-dev.firebaseapp.com",
+  "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "sportdeets-dev",
+  "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "sportdeets-dev.appspot.com",
+  "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "your-sender-id",
+  "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id"
+}
+```
+
+For Firebase Web SDK Auth, only `apiKey` and `authDomain` are actually consulted at runtime. The other four (`projectId`, `storageBucket`, `messagingSenderId`, `appId`) sit unused for the current feature set, so the literal placeholder strings (`your-sender-id`, `your-app-id`) are fine — they'll get replaced when the prod Firebase project comes online.
+
+**On committing keys to `eas.json`**: Firebase Web config values are designed to be public. They identify the project, not authorize anything — auth is gated by Firestore rules + Firebase Auth allow-list. Google explicitly documents pasting these into client code. Committing them is the standard pattern.
+
+## Rebuild + Reinstall
+
+From `src/UI/sd-mobile/`:
+
+```bash
+eas build --platform ios --profile production
+eas submit --platform ios --latest
+```
+
+After Apple finishes processing the upload (~5–10 min), reinstall via TestFlight on the iPhone — TestFlight will offer the new build automatically. Open the app; it should reach the login screen instead of crashing.
+
+If it crashes again, grab the new `.ips` from **Settings → Privacy & Security → Analytics & Improvements → Analytics Data**. The signature should look different from the original Hermes/TurboModule crash, which would confirm Firebase init is no longer the failure point — and that's when Sentry earns its keep.
+
+## Deferred Work
+
+Two related items planned for pre-season:
+
+1. **Register a Web app in the prod Firebase project** (`sportdeets`, distinct from `sportdeets-dev`). This generates real values for the `messagingSenderId` and `appId` placeholders, and gives prod its own analytics/messaging scoping.
+2. **Migrate the existing user(s)** from `sportdeets-dev` to the prod project.
+
+When both land:
+- New Firebase config values get pasted into `eas.json` `preview` + `production` profiles (replacing the dev values + placeholders)
+- `.env.local` keeps the dev values for local development
+- The web app (`sd-ui`) needs the same prod-config update
+
+## The General Rule
+
+Every new `EXPO_PUBLIC_*` env var added during dev needs a matching entry in `eas.json` (or an EAS dashboard secret) or it'll silently become `undefined` in production builds. Metro reads `.env*`; EAS doesn't.

--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -17,7 +17,8 @@
       "bundleIdentifier": "com.sportdeets.mobile",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
-      }
+      },
+      "buildNumber": "2"
     },
     "android": {
       "package": "com.sportdeets.mobile",

--- a/src/UI/sd-mobile/eas.json
+++ b/src/UI/sd-mobile/eas.json
@@ -14,7 +14,13 @@
     "preview": {
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://api.sportdeets.com"
+        "EXPO_PUBLIC_API_BASE_URL": "https://api.sportdeets.com",
+        "EXPO_PUBLIC_FIREBASE_API_KEY": "AIzaSyBRkQwtEl3jeqoYKBN-hPv8VxTjUycNJgM",
+        "EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN": "sportdeets-dev.firebaseapp.com",
+        "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "sportdeets-dev",
+        "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "sportdeets-dev.appspot.com",
+        "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "your-sender-id",
+        "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id"
       },
       "ios": {
         "resourceClass": "m-medium"
@@ -23,7 +29,13 @@
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://api.sportdeets.com"
+        "EXPO_PUBLIC_API_BASE_URL": "https://api.sportdeets.com",
+        "EXPO_PUBLIC_FIREBASE_API_KEY": "AIzaSyBRkQwtEl3jeqoYKBN-hPv8VxTjUycNJgM",
+        "EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN": "sportdeets-dev.firebaseapp.com",
+        "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "sportdeets-dev",
+        "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "sportdeets-dev.appspot.com",
+        "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "your-sender-id",
+        "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id"
       },
       "ios": {
         "resourceClass": "m-medium"


### PR DESCRIPTION
## Summary

- TestFlight production build (build 2) crashed on launch with `EXC_BAD_ACCESS` in Hermes — root cause: `EXPO_PUBLIC_FIREBASE_*` env vars resolved to `undefined` in the EAS build because Metro reads `.env.local` on disk but EAS in the cloud does not. `initializeApp({apiKey: undefined, ...})` threw at startup and the error-propagation path (TurboModule `convertNSExceptionToJSError` → Hermes `addOwnPropertyImpl`) took the runtime down.
- Pasted the existing dev-project Firebase values from `.env.local` into the `env` block of both `preview` and `production` profiles in `eas.json`. Firebase Web config values are designed to be public (they identify the project; auth is gated by Firestore rules + Firebase Auth allow-list).
- `app.json` buildNumber bumped 1 → 2 as an artifact of the first production `eas build` (autoIncrement is on). Committed so future EAS builds keep monotonically increasing it.

## Deferred work (pre-season)

- Register a Web app in the **prod** Firebase project (`sportdeets`, distinct from `sportdeets-dev`) to replace the `your-sender-id` / `your-app-id` placeholders with real values.
- Migrate the existing user(s) from `sportdeets-dev` to the prod project.
- At that point, swap the dev-project values out of `eas.json` for the prod ones; `.env.local` keeps the dev values for local dev.

## Docs

- `docs/mobile/firebase-config-in-eas-builds.md` — new — captures the diagnosis, what we did, why dev works but prod doesn't, the deferred-work plan, and the general rule that every `EXPO_PUBLIC_*` var added during dev needs a matching `eas.json` entry.
- `docs/mobile/expo-deployment-model.md` — extended with two operational sections written during this session:
  - One-shot preview build for iPhone via ad-hoc install (own device only)
  - TestFlight distribution to external testers (friends, no UDID registration)

## Test plan

- [ ] `eas build --platform ios --profile production` succeeds (build number auto-bumps to 3)
- [ ] `eas submit --platform ios --latest` uploads cleanly
- [ ] After Apple processing, reinstall via TestFlight on iPhone — app reaches the login screen instead of crashing
- [ ] If it still crashes, the new `.ips` should show a different signature than the original Hermes/TurboModule one — that would confirm Firebase init is past the failure point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added iOS deployment guides with step-by-step instructions for preview builds and TestFlight distribution to external testers
  * Added Firebase configuration documentation for cloud-based iOS builds with troubleshooting guidance

* **Chores**
  * Updated build configuration settings
  * Incremented iOS build number

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->