### PR TITLE
fix(producer): emit ContestStatusChanged=Final at end of replay

### DIFF
--- a/src/SportsData.Producer/Application/Contests/BaseballContestReplayService.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestReplayService.cs
@@ -209,6 +209,26 @@ namespace SportsData.Producer.Application.Contests
                     await Task.Delay(1000, ct);
                 }
 
+                // Lifecycle bookend — InProgress→Final. Published after
+                // the last play so the UI transitions out of the live
+                // layout once the replay ends. The 1-sec inter-play pace
+                // above means there's already a beat between the final
+                // play and this transition. Mirrors the symmetric
+                // InProgress publish at the top of the try block.
+                await _eventBus.Publish(new ContestStatusChanged(
+                    contestId,
+                    nameof(ContestStatus.Final),
+                    null,
+                    contest.Sport,
+                    contest.SeasonYear,
+                    correlationId,
+                    CausationId.Producer.EventCompetitionStatusDocumentProcessor
+                ), ct);
+
+                _logger.LogInformation(
+                    "BaseballReplay: published ContestStatusChanged=Final. ContestId={ContestId}, CorrelationId={CorrelationId}",
+                    contestId, correlationId);
+
                 _logger.LogInformation(
                     "BaseballReplay: completed. ContestId={ContestId}, EmittedPlays={EmittedPlays}, CorrelationId={CorrelationId}",
                     contestId, emittedCount, correlationId);

--- a/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
@@ -181,6 +181,26 @@ namespace SportsData.Producer.Application.Contests
                     await Task.Delay(1000, ct);
                 }
 
+                // Lifecycle bookend — InProgress→Final. Published after
+                // the last play so the UI transitions out of the live
+                // layout once the replay ends. The 1-sec inter-play pace
+                // above means there's already a beat between the final
+                // play and this transition. Mirrors the symmetric
+                // InProgress publish at the top of the try block.
+                await _eventBus.Publish(new ContestStatusChanged(
+                    contestId,
+                    nameof(ContestStatus.Final),
+                    null,
+                    contest.Sport,
+                    contest.SeasonYear,
+                    correlationId,
+                    CausationId.Producer.EventCompetitionStatusDocumentProcessor
+                ), ct);
+
+                _logger.LogInformation(
+                    "FootballReplay: published ContestStatusChanged=Final. ContestId={ContestId}, CorrelationId={CorrelationId}",
+                    contestId, correlationId);
+
                 _logger.LogInformation(
                     "FootballReplay: completed. ContestId={ContestId}, EmittedPlays={EmittedPlays}, CorrelationId={CorrelationId}",
                     contestId, emittedCount, correlationId);


### PR DESCRIPTION
## Summary

- Both \`BaseballContestReplayService\` and \`FootballContestReplayService\` publish \`ContestStatusChanged=InProgress\` at the start of a replay but never the closing \`Final\`, so \`MatchupCard\` stays in the LIVE layout indefinitely after the last play. The mobile + web SignalR stores already handle \`status='Final'\` — only the producer-side bookend was missing.
- Added a mirror-symmetric \`Final\` publish after the play loop in both services, inside the same \`using var _directDelivery = _deliveryScope.Use(DeliveryMode.Direct)\` scope as the opening publish, with the same \`correlationId\` and \`CausationId\`.
- The existing 1-sec inter-play pacing in the foreach loop already gives the UI a beat between the last play emit and the \`Final\` transition — no extra delay needed.

## Sequence on a successful replay

1. Publish \`ContestStatusChanged → InProgress\`
2. For each play: emit \`*PlayCompleted\` (which self-heals status back to InProgress in the store per PR #322) + 1-sec pace
3. Publish \`ContestStatusChanged → Final\` ← **new**
4. \`finally\` restores \`FinalizedUtc\`

## Test plan

- [x] Validated locally against a baseball replay; \`MatchupCard\` transitions out of the live layout after the last play
- [ ] Football replay validated end-to-end after merge

## Tests

No existing unit tests on either replay service. Scaffolding meaningful coverage means standing up mock \`DbContext\` + \`IEventBus\` + \`IMessageDeliveryScope\` from scratch — a bigger lift than the fix itself. Deferred to a follow-up if/when we want to add broader coverage on the replay services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved replay experience for baseball and football contests. The UI now correctly transitions out of live replay mode once the replay concludes, providing a smoother viewing experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->