### PR TITLE
feat(mobile): integrate Sentry crash + error reporting

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -18,7 +18,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "2"
+      "buildNumber": "4"
     },
     "android": {
       "package": "com.sportdeets.mobile",
@@ -36,7 +36,14 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      [
+        "@sentry/react-native",
+        {
+          "organization": "randall-sexton",
+          "project": "sportdeets-mobile"
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -1,9 +1,15 @@
+// Sentry MUST initialize before any other module that could throw at
+// import time (Firebase, React Query, navigation). Side-effect import
+// kept on its own line, above all other imports, for that reason.
+import '@/src/lib/sentry';
+
 import { DarkTheme, DefaultTheme, ThemeProvider as NavThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
+import * as Sentry from '@sentry/react-native';
 import 'react-native-reanimated';
 
 import { queryClient } from '@/src/lib/queryClient';
@@ -45,13 +51,25 @@ function AuthGuard() {
   return null;
 }
 
-export default function RootLayout() {
+function RootLayout() {
   const [loaded, error] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
 
   // Kick off Firebase auth listener immediately.
   useAuthInit();
+
+  // Tag every Sentry event with the signed-in user (or clear on sign-out).
+  // The store is the source of truth — useAuthInit already syncs Firebase
+  // auth state into it, so this just mirrors that state into Sentry.
+  const { user } = useAuth();
+  useEffect(() => {
+    if (user) {
+      Sentry.setUser({ id: user.uid, email: user.email ?? undefined });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [user]);
 
   useEffect(() => {
     if (error) throw error;
@@ -70,6 +88,10 @@ export default function RootLayout() {
     </QueryClientProvider>
   );
 }
+
+// Wrap with Sentry so navigation transitions become breadcrumbs and the
+// root error boundary forwards into the SDK.
+export default Sentry.wrap(RootLayout);
 
 function RootLayoutNav() {
   // Feed the user-resolved scheme into React Navigation so native header

--- a/src/UI/sd-mobile/eas.json
+++ b/src/UI/sd-mobile/eas.json
@@ -21,7 +21,8 @@
         "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "sportdeets-dev.appspot.com",
         "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "your-sender-id",
         "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id",
-        "EXPO_PUBLIC_SENTRY_DSN": "https://3ff92120e166bebbe395faa904795362@o4511399352729600.ingest.us.sentry.io/4511405062225920"
+        "EXPO_PUBLIC_SENTRY_DSN": "https://3ff92120e166bebbe395faa904795362@o4511399352729600.ingest.us.sentry.io/4511405062225920",
+        "EXPO_PUBLIC_SENTRY_ENV": "preview"
       },
       "ios": {
         "resourceClass": "m-medium"
@@ -37,7 +38,8 @@
         "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "sportdeets-dev.appspot.com",
         "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "your-sender-id",
         "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id",
-        "EXPO_PUBLIC_SENTRY_DSN": "https://3ff92120e166bebbe395faa904795362@o4511399352729600.ingest.us.sentry.io/4511405062225920"
+        "EXPO_PUBLIC_SENTRY_DSN": "https://3ff92120e166bebbe395faa904795362@o4511399352729600.ingest.us.sentry.io/4511405062225920",
+        "EXPO_PUBLIC_SENTRY_ENV": "production"
       },
       "ios": {
         "resourceClass": "m-medium"

--- a/src/UI/sd-mobile/eas.json
+++ b/src/UI/sd-mobile/eas.json
@@ -20,7 +20,8 @@
         "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "sportdeets-dev",
         "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "sportdeets-dev.appspot.com",
         "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "your-sender-id",
-        "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id"
+        "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://3ff92120e166bebbe395faa904795362@o4511399352729600.ingest.us.sentry.io/4511405062225920"
       },
       "ios": {
         "resourceClass": "m-medium"
@@ -35,7 +36,8 @@
         "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "sportdeets-dev",
         "EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET": "sportdeets-dev.appspot.com",
         "EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "your-sender-id",
-        "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id"
+        "EXPO_PUBLIC_FIREBASE_APP_ID": "your-app-id",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://3ff92120e166bebbe395faa904795362@o4511399352729600.ingest.us.sentry.io/4511405062225920"
       },
       "ios": {
         "resourceClass": "m-medium"

--- a/src/UI/sd-mobile/jest.setup.js
+++ b/src/UI/sd-mobile/jest.setup.js
@@ -11,3 +11,18 @@
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );
+
+/**
+ * Mock Sentry — the real SDK pulls in native modules and would warn about
+ * an undefined DSN under Jest. Tests don't need real telemetry; they need
+ * the call surface available as no-ops so production code paths that
+ * `Sentry.setUser(...)` / `Sentry.captureException(...)` don't blow up.
+ */
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  wrap: (component) => component,
+  setUser: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));

--- a/src/UI/sd-mobile/package-lock.json
+++ b/src/UI/sd-mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@microsoft/signalr": "^9.0.6",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.1.28",
+        "@sentry/react-native": "~7.11.0",
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.6",
         "expo": "~55.0.4",
@@ -4224,6 +4225,314 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.37.0.tgz",
+      "integrity": "sha512-rqdESYaVio9Ktz55lhUhtBsBUCF3wvvJuWia5YqoHDd+egyIfwWxITTAa0TSEyZl7283A4WNHNl0hyeEMblmfA==",
+      "dependencies": {
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.37.0.tgz",
+      "integrity": "sha512-P0PVlfrDvfvCYg2KPIS7YUG/4i6ZPf8z1MicXx09C9Cz9W9UhSBh/nii13eBdDtLav2BFMKhvaFMcghXHX03Hw==",
+      "dependencies": {
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.37.0.tgz",
+      "integrity": "sha512-snuk12ZaDerxesSnetNIwKoth/51R0y/h3eXD/bGtXp+hnSkeXN5HanI/RJl297llRjn4zJYRShW9Nx86Ay0Dw==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.37.0",
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.37.0.tgz",
+      "integrity": "sha512-PyIYSbjLs+L5essYV0MyIsh4n5xfv2eV7l0nhUoPJv9Bak3kattQY3tholOj0EP3SgKgb+8HSZnmazgF++Hbog==",
+      "dependencies": {
+        "@sentry-internal/replay": "10.37.0",
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.8.0.tgz",
+      "integrity": "sha512-cy/9Eipkv23MsEJ4IuB4dNlVwS9UqOzI3Eu+QPake5BVFgPYCX0uP0Tr3Z43Ime6Rb+BiDnWC51AJK9i9afHYw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.37.0.tgz",
+      "integrity": "sha512-kheqJNqGZP5TSBCPv4Vienv1sfZwXKHQDYR+xrdHHYdZqwWuZMJJW/cLO9XjYAe+B9NnJ4UwJOoY4fPvU+HQ1Q==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.37.0",
+        "@sentry-internal/feedback": "10.37.0",
+        "@sentry-internal/replay": "10.37.0",
+        "@sentry-internal/replay-canvas": "10.37.0",
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.4.tgz",
+      "integrity": "sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.4",
+        "@sentry/cli-linux-arm": "2.58.4",
+        "@sentry/cli-linux-arm64": "2.58.4",
+        "@sentry/cli-linux-i686": "2.58.4",
+        "@sentry/cli-linux-x64": "2.58.4",
+        "@sentry/cli-win32-arm64": "2.58.4",
+        "@sentry/cli-win32-i686": "2.58.4",
+        "@sentry/cli-win32-x64": "2.58.4"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.4.tgz",
+      "integrity": "sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.4.tgz",
+      "integrity": "sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.4.tgz",
+      "integrity": "sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.4.tgz",
+      "integrity": "sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.4.tgz",
+      "integrity": "sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.4.tgz",
+      "integrity": "sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.4.tgz",
+      "integrity": "sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.4.tgz",
+      "integrity": "sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.37.0.tgz",
+      "integrity": "sha512-hkRz7S4gkKLgPf+p3XgVjVm7tAfvcEPZxeACCC6jmoeKhGkzN44nXwLiqqshJ25RMcSrhfFvJa/FlBg6zupz7g==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.37.0.tgz",
+      "integrity": "sha512-XLnXJOHgsCeVAVBbO+9AuGlZWnCxLQHLOmKxpIr8wjE3g7dHibtug6cv8JLx78O4dd7aoCqv2TTyyKY9FLJ2EQ==",
+      "dependencies": {
+        "@sentry/browser": "10.37.0",
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.11.0.tgz",
+      "integrity": "sha512-OiDaLCAGpRN18YG/o7IIwLhU0Xpb0tYKQ5QxkGHiwb+L3VHn+MqGCGfITYNdhqr06HHMvu9Lysm+UJxaNmGaJg==",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "4.8.0",
+        "@sentry/browser": "10.37.0",
+        "@sentry/cli": "2.58.4",
+        "@sentry/core": "10.37.0",
+        "@sentry/react": "10.37.0",
+        "@sentry/types": "10.37.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.37.0.tgz",
+      "integrity": "sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw==",
+      "dependencies": {
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/src/UI/sd-mobile/package.json
+++ b/src/UI/sd-mobile/package.json
@@ -42,6 +42,7 @@
     "@microsoft/signalr": "^9.0.6",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^7.1.28",
+    "@sentry/react-native": "~7.11.0",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",
     "expo": "~55.0.4",

--- a/src/UI/sd-mobile/src/lib/sentry.ts
+++ b/src/UI/sd-mobile/src/lib/sentry.ts
@@ -1,0 +1,42 @@
+/**
+ * Sentry initialization — runs once at app boot.
+ *
+ * This module is imported for its side effects from `app/_layout.tsx` as
+ * the very first import line so Sentry is wired before any other module
+ * (Firebase, React Query, navigation) executes. Earlier this week the
+ * production app crashed on launch because Firebase init threw against
+ * undefined config — that exact class of early-boot failure is what
+ * Sentry's native crash reporting catches when it loads first.
+ *
+ * The DSN comes from `EXPO_PUBLIC_SENTRY_DSN`:
+ *   - Dev:   `.env.local`
+ *   - Prod:  `eas.json` `preview` / `production` `env` blocks
+ *
+ * If the DSN is unset (e.g. local-only branch, contributor without
+ * Sentry access), the SDK no-ops gracefully and errors still bubble to
+ * `ErrorBoundary` — they just don't get reported. A warning fires in
+ * production builds so a missing DSN is loud.
+ */
+import * as Sentry from '@sentry/react-native';
+
+const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    // Tag every event with the runtime so dev noise can be filtered out
+    // in the Sentry UI without setting up separate projects (free-tier
+    // friendly).
+    environment: __DEV__ ? 'development' : 'production',
+    // Perf tracing off for now — flip to a small sample (e.g. 0.1) when
+    // we want span data on slow screen transitions. Keeps event volume
+    // proportional to actual errors during early use.
+    tracesSampleRate: 0,
+  });
+} else if (!__DEV__) {
+  // Prod build without a DSN is a misconfiguration. Don't throw — errors
+  // still bubble to ErrorBoundary, just nothing gets reported.
+  console.warn(
+    '[Sentry] EXPO_PUBLIC_SENTRY_DSN is unset in a production build; crash reporting is disabled.'
+  );
+}

--- a/src/UI/sd-mobile/src/lib/sentry.ts
+++ b/src/UI/sd-mobile/src/lib/sentry.ts
@@ -21,13 +21,22 @@ import * as Sentry from '@sentry/react-native';
 
 const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
 
+// Environment tag — drives filtering / alerting / release tracking in the
+// Sentry UI. Three distinct buckets so TestFlight (preview) crashes from
+// internal testers don't blend with real App Store (production) users:
+//   - dev:        Metro running locally
+//   - preview:    EAS preview profile (internal TestFlight builds)
+//   - production: EAS production profile (App Store releases)
+// EXPO_PUBLIC_SENTRY_ENV is set per profile in eas.json; the fallback
+// to 'production' is defensive in case a new profile forgets to set it.
+const environment = __DEV__
+  ? 'development'
+  : process.env.EXPO_PUBLIC_SENTRY_ENV || 'production';
+
 if (dsn) {
   Sentry.init({
     dsn,
-    // Tag every event with the runtime so dev noise can be filtered out
-    // in the Sentry UI without setting up separate projects (free-tier
-    // friendly).
-    environment: __DEV__ ? 'development' : 'production',
+    environment,
     // Perf tracing off for now — flip to a small sample (e.g. 0.1) when
     // we want span data on slow screen transitions. Keeps event volume
     // proportional to actual errors during early use.


### PR DESCRIPTION
## Summary

Wires \`@sentry/react-native\` into the Expo app so unhandled JS exceptions, native crashes, and explicit \`captureException\` calls are reported to the \`sportdeets-mobile\` Sentry project. Symbolicated stack traces, breadcrumbs, and per-user attribution are all in scope.

## Wiring choices

- \`src/lib/sentry.ts\` initializes the SDK from \`EXPO_PUBLIC_SENTRY_DSN\`. The module is imported for its side effects as the **very first import line** in \`app/_layout.tsx\` so Sentry is wired before Firebase, React Query, or navigation — exactly the class of early-boot failure that took down the first TestFlight build (PR #329).
- \`RootLayout\` is wrapped via \`Sentry.wrap\` so navigation events become breadcrumbs and the root error boundary forwards into the SDK.
- An effect on the authStore user tags every Sentry event with the Firebase UID + email, then clears on sign-out.
- \`jest.setup.js\` mocks \`@sentry/react-native\` as a no-op surface so unit tests neither hit the network nor warn about a missing DSN.
- DSN goes in \`.env.local\` for dev (gitignored) and \`eas.json\` env blocks for preview + production. Firebase Web keys are public-by-design, and so is the Sentry DSN — committing to \`eas.json\` is the standard pattern.
- \`app.json\` plugin entry carries the org + project slugs (\`randall-sexton\` / \`sportdeets-mobile\`) so the EAS build's sourcemap upload step knows where to push.
- \`SENTRY_AUTH_TOKEN\` is set as an EAS environment variable with \`visibility=secret\` in both preview and production environments. It never lands in the bundle; only the builder sees it.

## Validation

End-to-end smoke-tested locally via a temporary \`Sentry.captureMessage('Sentry init smoke-test')\` on boot (removed before commit). The event surfaced in the Sentry UI with \`environment: development\` and user attribution as expected.

## Test plan

- [x] \`npm test\` — 39 passed, 0 regressions
- [x] Dev smoke-test event appears in Sentry UI
- [ ] After merge: \`eas build --profile production\` + \`eas submit\` — confirm sourcemap upload step succeeds in EAS build logs
- [ ] On the new TestFlight install: trigger a deliberate error from within the app; confirm it appears in Sentry with **symbolicated** stack (real source lines, not minified bundle offsets) and \`environment: production\`

## Out of scope

- Custom tags/context beyond user ID (could add active league, sport, week later if useful)
- Performance tracing (currently \`tracesSampleRate: 0\` — flip to a small sample once we want span data on slow transitions)
- Web side CSP \`report-uri\` integration (the third value from your Sentry config; slots into \`security-headers.conf\` when task #45 lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated comprehensive error and crash monitoring to track app stability, identify issues faster, and improve overall reliability.

* **Chores**
  * Updated build configuration, environment variables, and deployment setup to support monitoring infrastructure; build number increased to version 4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->