### PR TITLE
chore(web): drop 'unsafe-inline' from enforced script-src (task #45)

### DIFF
--- a/docs/csp-hardening-plan.md
+++ b/docs/csp-hardening-plan.md
@@ -110,16 +110,16 @@ PR #311 review thread on `src/UI/sd-ui/security-headers.conf` line 8.
 
 ## Finding 2 — Remove `'unsafe-inline'` from `script-src` ✅ **Resolved 2026-05-17**
 
-Shipped via PRs #333 (Report-Only + Sentry `report-uri` for telemetry) and
-the cutover PR that landed this update. The enforcing `script-src` now
-omits `'unsafe-inline'`; the Report-Only header has been removed; all
-remaining violations route to Sentry via `report-uri` for ongoing
-monitoring.
+Shipped via PR #333 (Report-Only + Sentry `report-uri` for telemetry) and
+PR #335 (cutover — dropped `'unsafe-inline'` from the enforcing header
+and removed Report-Only). The enforcing `script-src` now omits
+`'unsafe-inline'`; the Report-Only header has been removed; remaining
+violations route to Sentry via `report-uri` for ongoing monitoring.
 
-The watch period surfaced exactly zero violations from the app itself.
-The only reports that landed were Chrome extensions injecting content
-scripts onto dev machines — caught by Sentry's "Filter out errors known
-to be caused by browser extensions" inbound filter going forward.
+During the watch period Sentry recorded no app-origin CSP violations.
+The only Report-Only reports that landed came from Chrome extensions
+injecting content scripts on dev machines; those are now suppressed by
+the Sentry inbound filter for browser-extension errors.
 
 The original plan below is preserved as a historical record of the
 approach taken.

--- a/docs/csp-hardening-plan.md
+++ b/docs/csp-hardening-plan.md
@@ -108,7 +108,21 @@ PR #311 review thread on `src/UI/sd-ui/security-headers.conf` line 8.
 
 ---
 
-## Finding 2 — Remove `'unsafe-inline'` from `script-src`
+## Finding 2 — Remove `'unsafe-inline'` from `script-src` ✅ **Resolved 2026-05-17**
+
+Shipped via PRs #333 (Report-Only + Sentry `report-uri` for telemetry) and
+the cutover PR that landed this update. The enforcing `script-src` now
+omits `'unsafe-inline'`; the Report-Only header has been removed; all
+remaining violations route to Sentry via `report-uri` for ongoing
+monitoring.
+
+The watch period surfaced exactly zero violations from the app itself.
+The only reports that landed were Chrome extensions injecting content
+scripts onto dev machines — caught by Sentry's "Filter out errors known
+to be caused by browser extensions" inbound filter going forward.
+
+The original plan below is preserved as a historical record of the
+approach taken.
 
 ### Problem
 
@@ -222,16 +236,10 @@ PR #311 review thread on `src/UI/sd-ui/security-headers.conf` line 8.
 
 ## Sequencing
 
-Finding 1 and Finding 2 are independent. Suggested order:
-
-1. **Finding 1 first** — small, isolated, low rollback risk. Lands
-   alongside the prod Firebase project switch when that happens.
-2. **Finding 2 second** — requires its own report-only watch
-   period before enforcing. Larger calendar footprint but doesn't
-   block #1.
-
-Both should ship as their own PRs labeled `infra` / `security` so
-the rationale is preserved in commit history.
+Finding 2 shipped on 2026-05-17. Finding 1 remains open — it's
+gated on a dedicated prod Firebase project existing (today the
+mobile and web both authenticate against `sportdeets-dev`). The
+parameterization work lands alongside that migration.
 
 ## Reference
 

--- a/src/UI/sd-ui/security-headers.conf
+++ b/src/UI/sd-ui/security-headers.conf
@@ -5,11 +5,11 @@
 # container startup so all layers share a single FIREBASE_AUTH_DOMAIN env var.
 #
 # CSP: enforcing header only — 'unsafe-inline' was dropped from script-src after
-# a watch period under Content-Security-Policy-Report-Only confirmed the build
-# emits no inline scripts (CRA 5 bundles the webpack runtime into main.js) and
-# no third-party SDK injects inline children at runtime. The only Report-Only
-# violations observed during the watch were Chrome extensions on dev machines
-# injecting their own content scripts — not anything in the app itself.
+# a watch period under Content-Security-Policy-Report-Only. Observed during
+# that watch: the build emitted no inline scripts (CRA 5 bundles the webpack
+# runtime into main.js) and no third-party SDK injected inline children at
+# runtime. The only Report-Only violations recorded came from Chrome extensions
+# on dev machines injecting their own content scripts — not from the app.
 #
 # Violations from this enforcing policy POST to Sentry via `report-uri`. If
 # future code introduces an inline script (e.g. dangerouslySetInnerHTML with

--- a/src/UI/sd-ui/security-headers.conf
+++ b/src/UI/sd-ui/security-headers.conf
@@ -4,22 +4,22 @@
 # and Program.cs CORS origins. Use envsubst or nginx variable substitution at
 # container startup so all layers share a single FIREBASE_AUTH_DOMAIN env var.
 #
-# CSP hardening: the enforcing header still allows 'unsafe-inline' in script-src
-# for safety. The Report-Only header below mirrors the enforcing policy but
-# drops 'unsafe-inline' — browsers will log violations to the console without
-# blocking. After a release or two with zero violations across login, map view,
-# and live game flows, drop 'unsafe-inline' from the enforcing header and
-# remove the Report-Only header. See docs/csp-hardening-plan.md.
+# CSP: enforcing header only — 'unsafe-inline' was dropped from script-src after
+# a watch period under Content-Security-Policy-Report-Only confirmed the build
+# emits no inline scripts (CRA 5 bundles the webpack runtime into main.js) and
+# no third-party SDK injects inline children at runtime. The only Report-Only
+# violations observed during the watch were Chrome extensions on dev machines
+# injecting their own content scripts — not anything in the app itself.
 #
-# Both policies route violations to Sentry via `report-uri`. The endpoint is
-# the Sentry security report ingestion URL for the sportdeets-mobile project
-# (yes, mobile — we route web CSP into the same project for now; tagged
-# differently). report-uri POSTs are exempt from CSP itself, so no
-# connect-src entry is needed.
+# Violations from this enforcing policy POST to Sentry via `report-uri`. If
+# future code introduces an inline script (e.g. dangerouslySetInnerHTML with
+# <script>, a new analytics snippet), the page will silently break and the
+# violation will surface in Sentry — fix is to externalize the script or add
+# a SHA-256 hash to script-src. report-uri POSTs are exempt from CSP itself,
+# so no connect-src entry is needed for the Sentry host.
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://analytics.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets-dev.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri https://o4511399352729600.ingest.us.sentry.io/api/4511405062225920/security/?sentry_key=3ff92120e166bebbe395faa904795362;" always;
-add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://analytics.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets-dev.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri https://o4511399352729600.ingest.us.sentry.io/api/4511405062225920/security/?sentry_key=3ff92120e166bebbe395faa904795362;" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://analytics.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets-dev.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri https://o4511399352729600.ingest.us.sentry.io/api/4511405062225920/security/?sentry_key=3ff92120e166bebbe395faa904795362;" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;


### PR DESCRIPTION
## Summary

Completes the CSP hardening sequence started in PR #311 (initial Report-Only landed) and PR #333 (Sentry \`report-uri\` for telemetry).

- Drops \`'unsafe-inline'\` from the enforced \`script-src\` directive
- Removes the \`Content-Security-Policy-Report-Only\` header entirely (redundant once enforcing matches what it was reporting)
- Keeps the \`report-uri\` on the enforcing header so any future inline-script regression surfaces in Sentry instead of silently breaking the page
- Updates the file-header comment to reflect the new steady state (no more "hardening pending" narrative)
- \`docs/csp-hardening-plan.md\`: marks Finding 2 resolved with a brief "what actually shipped" note. Finding 1 (parameterize the Firebase auth domain) stays open — gated on a dedicated prod Firebase project existing.

## Why this is safe to ship now

The Report-Only header has been live in production since #333 merged. Browser-side CSP violations have been routing to Sentry. During the watch period, **zero app-generated violations** were observed. The only Report-Only reports that landed were Chrome extensions injecting content scripts onto dev machines — confirmed by reproducing in incognito mode (clean) vs regular Chrome (violation fires).

Sentry's "Filter out errors known to be caused by browser extensions" inbound filter is now enabled, so any future extension noise is dropped at ingestion.

The build itself ships clean HTML — view-source on any page shows zero inline \`<script>\` tags. CRA 5 bundles the webpack runtime into \`main.js\` and no third-party SDK we use injects inline children at runtime.

## Test plan

- [ ] Deploy (web image rebuild + pod roll)
- [ ] Open the site in regular Chrome + mobile Safari → no CSP violations in browser console
- [ ] Watch Sentry for 24h — any new violations under the enforcing policy are real regressions and need fixing immediately (the page would break)
- [ ] Sentry filter on extension noise stays effective

## What stays open

Finding 1 in \`docs/csp-hardening-plan.md\` — parameterize \`sportdeets-dev.firebaseapp.com\` out of the CSP \`frame-src\` (and \`firebase.js\`, and API CORS). Lands alongside the eventual prod Firebase project migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Strengthened Content Security Policy by removing unsafe inline script permissions, enhancing application security.

* **Documentation**
  * Updated security hardening documentation to reflect current implementation status and completed security improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->