### PR TITLE
feat(mobile): matchup card round 1 — compact Scheduled layout + drift fixes

### DIFF
--- a/docs/ui/matchup-card-blueprint.md
+++ b/docs/ui/matchup-card-blueprint.md
@@ -1,0 +1,256 @@
+# MatchupCard blueprint
+
+The canonical structure for the `MatchupCard` component across web (sd-ui)
+and mobile (sd-mobile). Both platforms should render the same slot
+stack, the same state-driven presentation, and the same GameStatus
+dispatch. Drift between platforms is corrected against this document.
+
+This is the **card itself + GameStatus dispatch**. Modals (Stats
+comparison, Insight preview, Confidence picker) are treated as black
+boxes — they have their own contracts and surfaces that this doc
+references but does not specify.
+
+---
+
+## Slot layout (structurally invariant)
+
+Every MatchupCard renders the same vertical stack in the same order,
+regardless of state. State changes the *content and presentation* of
+individual slots, never the order or presence of slots themselves
+(headline is the only optional slot).
+
+```mermaid
+flowchart TB
+    H["Headline banner<br/>(optional — matchup.headLine)"]
+    AT["Away team row<br/>logo · rank · name · record · score · pick indicator"]
+    HT["Home team row<br/>logo · rank · name · record · score · pick indicator"]
+    O["Odds row<br/>spread (with movement arrow) · O/U (with movement arrow)"]
+    GS["GameStatus block<br/>(see lifecycle below)"]
+    DM["DeetsMeter<br/>AI prediction bars"]
+    PB["Pick buttons row<br/>Away pick · Stats button · Insight button · Home pick"]
+    M["Modals<br/>(Stats · Insight · ConfidencePicker)"]
+
+    H --> AT
+    AT --> HT
+    HT --> O
+    O --> GS
+    GS --> DM
+    DM --> PB
+    PB -.overlays.-> M
+```
+
+The headline banner is omitted when `matchup.headLine` is null/empty.
+Every other slot is always rendered (though individual sub-elements
+inside a slot may be conditional — e.g. the rank prefix on team rows
+only renders when `awayRank`/`homeRank` is non-null).
+
+---
+
+## GameStatus lifecycle
+
+The GameStatus block is the only slot whose entire content is driven
+by `matchup.status`. Three primary states, plus a fallthrough for
+postponed/cancelled/etc. InProgress dispatches further by `leagueSport`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Scheduled
+
+    Scheduled --> InProgress: kickoff / first pitch
+    InProgress --> Final: game ends
+
+    state InProgress {
+        [*] --> SportDispatch
+        SportDispatch --> Football: leagueSport ∈ {FootballNcaa, FootballNfl} or unknown
+        SportDispatch --> Baseball: leagueSport = BaseballMlb
+    }
+
+    Scheduled: kickoff time<br/>broadcasts<br/>venue + city<br/>(web: stream link if streamScheduledTimeUtc)
+    Football: 🔴 LIVE · period · clock<br/>score line<br/>🏈 possession indicator<br/>scoring-play flash<br/>last play description
+    Baseball: 🔴 LIVE<br/>score line · ⚾ batting team<br/>at-bat batter (headshot · logo · name · pos)<br/>at-bat pitcher (headshot · logo · name · pos)<br/>inning summary · count · outs<br/>runners on base<br/>last play description
+    Final: FINAL label<br/>final score (tappable → contest overview)
+
+    Final --> [*]
+
+    note right of Scheduled
+        Fallthrough: postponed/cancelled/other
+        renders raw status string in error color (mobile)
+        or falls through to scheduled markup (web).
+        Treat as a known drift point.
+    end note
+```
+
+**Sport dispatch is by `leagueSport` (backend Sport enum name)**, not by
+inspecting the matchup payload. Today: `FootballNcaa` / `FootballNfl`
+both render the football block; `BaseballMlb` renders the baseball
+block; any unknown/missing value falls back to football. This default
+exists for backwards compatibility with callers that haven't threaded
+the prop through yet — new sports should be added as explicit branches.
+
+---
+
+## State-driven presentation matrix
+
+The invariant slots above change their *presentation* (border colors,
+glyphs, dim states, lock indicators) based on a small set of derived
+flags. The flags are derived from `matchup.status` + the user's pick
+record; the table below is the source of truth for which slot reacts
+to which flag.
+
+| Derived state                         | Card border       | Team rows                                | Pick buttons             |
+| ------------------------------------- | ----------------- | ---------------------------------------- | ------------------------ |
+| Scheduled · unlocked                  | neutral           | both active                              | tappable                 |
+| Scheduled · locked (≤5 min pre-game)  | neutral           | both active                              | 🔒 lock icon, unpickable |
+| InProgress                            | neutral           | live scores; loser dims as gap grows     | 🔒 lock icon, unpickable |
+| Final · pick correct                  | **green**         | losing team dimmed                       | ✓ on picked team         |
+| Final · pick incorrect                | **red**           | losing team dimmed                       | ✗ on picked team         |
+| Final · no pick made (missed)         | **red**           | losing team dimmed                       | 🔒 on both (missed)      |
+| Read-only user (any state)            | per above         | per above                                | 🔒 lock icon, unpickable |
+
+**Derivation rules** (single source for both platforms):
+
+- `isFinal` = `status ∈ {Final, Completed}` (case-insensitive)
+- `isLocked` = `isFinal` OR `status ∈ {InProgress, Ongoing, Halftime}` OR `(kickoff - now) ≤ 5min` OR `user.isReadOnly`
+- `hasPick` = a pick row exists for this contest + user
+- `isPickCorrect` = on Final only; from the server-calculated `userPickResult.isCorrect`. **Never client-computed.**
+
+The read-only check is currently a web-only path (`usePickLocking`
+checks `userDto.isReadOnly`); mobile's lock function does not consult
+the user. **Drift.**
+
+---
+
+## Modals (referenced, not specified here)
+
+Three modals are owned by MatchupCard. They have their own contracts;
+this doc only specifies *when* they open from the card.
+
+| Modal              | Trigger                                      | Notes                                                  |
+| ------------------ | -------------------------------------------- | ------------------------------------------------------ |
+| Stats comparison   | `📋` button in pick row                      | Lazy-loads team stats + metrics on first open          |
+| Insight preview    | `📈` button (or 🔒 when locked) in pick row  | Disabled when `!matchup.isPreviewAvailable`            |
+| Confidence picker  | Tap a team's pick button in a CP league      | **Web only today.** Mobile has no confidence path yet. |
+
+---
+
+## Data contract (input)
+
+Every MatchupCard consumes one `Matchup` (or `LeagueWeekMatchup`) shape
+plus an optional `UserPick`. The fields the card needs are below; the
+canonical wire types live in `LeagueWeekMatchupsDto` (server) and are
+mirrored in `src/types/models` (mobile) and the props of `MatchupCard.jsx`
+(web).
+
+Required for all states:
+
+```
+contestId, status, startDateUtc,
+home, homeShort, homeSlug, homeLogoUri, homeFranchiseSeasonId,
+away, awayShort, awaySlug, awayLogoUri, awayFranchiseSeasonId
+```
+
+Required when present (state-conditional):
+
+```
+headLine                                            // headline banner
+homeRank, awayRank                                  // rank prefixes
+homeWins, homeLosses, awayWins, awayLosses          // records
+homeConferenceWins, homeConferenceLosses, ...       // conference records
+homeScore, awayScore                                // InProgress + Final
+spreadCurrent, spreadOpen, overUnderCurrent, overUnderOpen  // odds row
+broadcasts, venue, venueCity, venueState            // Scheduled
+streamScheduledTimeUtc                              // Scheduled stream link (web)
+isPreviewAvailable, isPreviewReviewed               // insight button state
+aiWinnerFranchiseSeasonId                           // AI pick indicator
+homeLogoUriDark, awayLogoUriDark                    // dark-theme logo variants (web)
+```
+
+InProgress football fields:
+
+```
+period, clock,
+possessionFranchiseSeasonId, isScoringPlay, ballOnYardLine,
+lastPlayDescription
+```
+
+InProgress baseball fields:
+
+```
+inning, halfInning,
+balls, strikes, outs,
+runnerOnFirst, runnerOnSecond, runnerOnThird,
+atBatShortName, atBatPositionAbbreviation, atBatHeadshotUrl,
+pitchingShortName, pitchingPositionAbbreviation, pitchingHeadshotUrl,
+lastPlayDescription
+```
+
+Live updates flow in over SignalR via `ContestUpdatesContext` (web) /
+`contestUpdatesStore` (mobile). Both platforms merge live fields over
+the REST payload with nullish fallback — a partial update never
+undefines a previously-populated field.
+
+---
+
+## Known drift (audit findings, 2026-05-18)
+
+Drift that this blueprint flags for correction. Each item should
+become its own follow-up — don't bundle these into one mega-PR.
+
+### Mobile is missing
+
+1. **DeetsMeter / AI prediction bars** — web renders the meters inside
+   the card; mobile omits the slot entirely.
+2. **ConfidencePicker integration** — confidence-points leagues work
+   on web; mobile has no path to set a confidence score.
+3. **TeamRow expandable schedule** — web's TeamRow opens a per-team
+   schedule on tap via `useTeamSchedule`; mobile's TeamRow has no
+   equivalent.
+4. **Probable pitcher row** — web's baseball TeamRow surfaces
+   `probablePitcher`; mobile doesn't.
+5. **`userDto.isReadOnly` in lock check** — web's `usePickLocking`
+   consults the user record; mobile's `isPickLocked` does not. A
+   read-only viewer on mobile can theoretically still tap pick
+   buttons.
+6. **Stream-scheduled "View" link in Scheduled state** — web shows a
+   Webcam icon link when `streamScheduledTimeUtc` is set; mobile has
+   no equivalent treatment.
+7. **Postponed/cancelled handling** — mobile shows the raw status
+   string in error color; web falls through to Scheduled markup.
+   Either is defensible — pick one and apply on both.
+
+### Cross-cutting
+
+8. **Icon library divergence** — web uses `react-icons` (FaChartLine,
+   FaLock, FaClipboardList); mobile uses emoji (📈, 🔒, 📋). Acceptable
+   as long as we acknowledge it — the alternative (RN vector icons)
+   is a bigger lift. Document the decision; don't churn it.
+9. **Dark-mode logo variants** — both platforms have access to
+   `homeLogoUriDark`/`awayLogoUriDark`; web swaps via `useTheme()`;
+   mobile uses the default URI in both schemes. Mobile gap.
+
+### Server-side
+
+10. **Headline banner population** — `matchup.headLine` is the
+    blueprint slot; we should confirm the server populates this
+    consistently across all sports + states. (Today it appears only
+    for some marquee games.)
+
+---
+
+## How to use this document
+
+- **Before changing MatchupCard on either platform**: read the slot
+  layout + state matrix sections to confirm the change preserves the
+  contract.
+- **When adding a new state or sport-specific InProgress UI**: extend
+  the lifecycle diagram first, then implement.
+- **When you spot drift between platforms**: add it to the "Known
+  drift" section before fixing — that converts a one-off into a
+  trackable line item.
+- **Don't add per-platform-only features without flagging them here**.
+  If web grows a new card slot, this document and mobile both need
+  follow-up. Same for mobile.
+
+The blueprint outlives any individual implementation. If we ever spin
+up a third client (e.g. a TV/wallboard renderer for the Command Center
+vision), it consumes this document — not the existing implementations.

--- a/docs/ui/matchup-card-blueprint.md
+++ b/docs/ui/matchup-card-blueprint.md
@@ -12,12 +12,12 @@ references but does not specify.
 
 ---
 
-## Slot layout (structurally invariant)
+## Slot layout (default structure)
 
-Every MatchupCard renders the same vertical stack in the same order,
-regardless of state. State changes the *content and presentation* of
-individual slots, never the order or presence of slots themselves
-(headline is the only optional slot).
+The slot model below is the **default** — what every MatchupCard
+renders at minimum, in the order shown. Most state transitions affect
+the *content and presentation* of individual slots rather than the
+structure.
 
 ```mermaid
 flowchart TB
@@ -39,10 +39,24 @@ flowchart TB
     PB -.overlays.-> M
 ```
 
-The headline banner is omitted when `matchup.headLine` is null/empty.
-Every other slot is always rendered (though individual sub-elements
-inside a slot may be conditional — e.g. the rank prefix on team rows
-only renders when `awayRank`/`homeRank` is non-null).
+Two ways the rendered structure can deviate from the default:
+
+1. **Headline banner is always optional** — rendered only when
+   `matchup.headLine` is present.
+2. **A platform may reorganize slots for a specific state** when it
+   suits the surface. Mobile's Scheduled state uses a 2-column compact
+   layout that fuses the OddsRow + the Scheduled-branch content of
+   GameStatus into a right-column `ScheduledMeta` block alongside the
+   team rows on the left (see the `isScheduled` branch in mobile's
+   `MatchupCard.tsx`). This is acceptable *platform expression* of the
+   same underlying contract: data and lifecycle are unchanged; only
+   the spatial arrangement adapts. When such a reorganization is
+   intentional, document it here; when it's drift between platforms,
+   file it in the "Known drift" section.
+
+Sub-elements inside a slot may also be conditional — e.g. the rank
+prefix on team rows only renders when `awayRank`/`homeRank` is
+non-null.
 
 ---
 
@@ -143,7 +157,7 @@ mirrored in `src/types/models` (mobile) and the props of `MatchupCard.jsx`
 
 Required for all states:
 
-```
+```text
 contestId, status, startDateUtc,
 home, homeShort, homeSlug, homeLogoUri, homeFranchiseSeasonId,
 away, awayShort, awaySlug, awayLogoUri, awayFranchiseSeasonId
@@ -151,7 +165,7 @@ away, awayShort, awaySlug, awayLogoUri, awayFranchiseSeasonId
 
 Required when present (state-conditional):
 
-```
+```text
 headLine                                            // headline banner
 homeRank, awayRank                                  // rank prefixes
 homeWins, homeLosses, awayWins, awayLosses          // records
@@ -167,7 +181,7 @@ homeLogoUriDark, awayLogoUriDark                    // dark-theme logo variants 
 
 InProgress football fields:
 
-```
+```text
 period, clock,
 possessionFranchiseSeasonId, isScoringPlay, ballOnYardLine,
 lastPlayDescription
@@ -175,7 +189,7 @@ lastPlayDescription
 
 InProgress baseball fields:
 
-```
+```text
 inning, halfInning,
 balls, strikes, outs,
 runnerOnFirst, runnerOnSecond, runnerOnThird,
@@ -205,35 +219,33 @@ become its own follow-up — don't bundle these into one mega-PR.
 3. **TeamRow expandable schedule** — web's TeamRow opens a per-team
    schedule on tap via `useTeamSchedule`; mobile's TeamRow has no
    equivalent.
-4. **Probable pitcher row** — web's baseball TeamRow surfaces
-   `probablePitcher`; mobile doesn't.
-5. **`userDto.isReadOnly` in lock check** — web's `usePickLocking`
+4. **`userDto.isReadOnly` in lock check** — web's `usePickLocking`
    consults the user record; mobile's `isPickLocked` does not. A
    read-only viewer on mobile can theoretically still tap pick
    buttons.
-6. **Stream-scheduled "View" link in Scheduled state** — web shows a
+5. **Stream-scheduled "View" link in Scheduled state** — web shows a
    Webcam icon link when `streamScheduledTimeUtc` is set; mobile has
    no equivalent treatment.
-7. **Postponed/cancelled handling** — mobile shows the raw status
+6. **Postponed/cancelled handling** — mobile shows the raw status
    string in error color; web falls through to Scheduled markup.
    Either is defensible — pick one and apply on both.
 
 ### Cross-cutting
 
-8. **Icon library divergence** — web uses `react-icons` (FaChartLine,
+7. **Icon library divergence** — web uses `react-icons` (FaChartLine,
    FaLock, FaClipboardList); mobile uses emoji (📈, 🔒, 📋). Acceptable
    as long as we acknowledge it — the alternative (RN vector icons)
    is a bigger lift. Document the decision; don't churn it.
-9. **Dark-mode logo variants** — both platforms have access to
+8. **Dark-mode logo variants** — both platforms have access to
    `homeLogoUriDark`/`awayLogoUriDark`; web swaps via `useTheme()`;
    mobile uses the default URI in both schemes. Mobile gap.
 
 ### Server-side
 
-10. **Headline banner population** — `matchup.headLine` is the
-    blueprint slot; we should confirm the server populates this
-    consistently across all sports + states. (Today it appears only
-    for some marquee games.)
+9. **Headline banner population** — `matchup.headLine` is the
+   blueprint slot; we should confirm the server populates this
+   consistently across all sports + states. (Today it appears only
+   for some marquee games.)
 
 ---
 

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -308,6 +308,7 @@ function PickSelector({
   awayFranchiseSeasonId,
   existingPickFranchiseId,
   isLocked,
+  submitPending,
   onPick,
 }: {
   homeTeamName: string;

--- a/src/UI/sd-mobile/package-lock.json
+++ b/src/UI/sd-mobile/package-lock.json
@@ -49,7 +49,7 @@
         "typescript": "~5.9.2"
       },
       "optionalDependencies": {
-        "lightningcss-win32-x64-msvc": "^1.31.1"
+        "lightningcss-win32-x64-msvc": "^1.32.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/UI/sd-mobile/package.json
+++ b/src/UI/sd-mobile/package.json
@@ -82,7 +82,7 @@
     "@tootallnate/once": "~3.0.1"
   },
   "optionalDependencies": {
-    "lightningcss-win32-x64-msvc": "^1.31.1"
+    "lightningcss-win32-x64-msvc": "^1.32.0"
   },
   "private": true
 }

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -64,9 +64,21 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStat
   // ── In Progress ────────────────────────────────────────────────────────────
   if (status === 'inprogress' || status === 'ongoing' || status === 'halftime') {
     if (leagueSport === 'BaseballMlb') {
-      return <BaseballInProgress matchup={matchup} theme={theme} />;
+      return (
+        <BaseballInProgress
+          matchup={matchup}
+          theme={theme}
+          onPressGameDetail={onPressGameDetail}
+        />
+      );
     }
-    return <FootballInProgress matchup={matchup} theme={theme} />;
+    return (
+      <FootballInProgress
+        matchup={matchup}
+        theme={theme}
+        onPressGameDetail={onPressGameDetail}
+      />
+    );
   }
 
   // ── Final ──────────────────────────────────────────────────────────────────
@@ -75,17 +87,13 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStat
     const homeScore = matchup.homeScore ?? 0;
 
     return (
-      <TouchableOpacity
-        style={styles.statusSection}
-        onPress={onPressGameDetail}
-        activeOpacity={onPressGameDetail ? 0.7 : 1}
-        disabled={!onPressGameDetail}
-      >
+      <View style={styles.statusSection}>
         <Text style={[styles.statusLabel, { color: theme.textMuted }]}>FINAL</Text>
         <Text style={[styles.scoreText, { color: theme.text }]}>
           {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
         </Text>
-      </TouchableOpacity>
+        <OverviewLink label="Box Score" onPress={onPressGameDetail} theme={theme} />
+      </View>
     );
   }
 
@@ -97,11 +105,56 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStat
   );
 }
 
+// ─── Overview link ───────────────────────────────────────────────────────────
+//
+// Bottom-of-status-block affordance for "tap to open the Contest Overview".
+// Replaces the older pattern of wrapping the whole status block in a
+// TouchableOpacity (which gave no visual hint that it was tappable).
+//
+// Per-state labels live at the call sites:
+//   Scheduled  → "Game Preview"   (rendered by MatchupCard's ScheduledMeta)
+//   InProgress → "Live Box Score"
+//   Final      → "Box Score"
+
+export function OverviewLink({
+  label,
+  onPress,
+  theme,
+  align = 'center',
+}: {
+  label: string;
+  onPress?: () => void;
+  theme: Theme;
+  align?: 'center' | 'flex-start';
+}) {
+  if (!onPress) return null;
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.7}
+      style={[styles.overviewLink, { alignSelf: align }]}
+      hitSlop={8}
+    >
+      <Text style={[styles.overviewLinkText, { color: theme.tint }]}>
+        {label} ›
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
 // ─── InProgress sub-components ───────────────────────────────────────────────
 
 type Theme = ReturnType<typeof getTheme>;
 
-function FootballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme }) {
+function FootballInProgress({
+  matchup,
+  theme,
+  onPressGameDetail,
+}: {
+  matchup: Matchup;
+  theme: Theme;
+  onPressGameDetail?: () => void;
+}) {
   const awayScore = matchup.awayScore ?? 0;
   const homeScore = matchup.homeScore ?? 0;
   const awayHasPossession =
@@ -146,11 +199,21 @@ function FootballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
           {matchup.lastPlayDescription}
         </Text>
       ) : null}
+
+      <OverviewLink label="Live Box Score" onPress={onPressGameDetail} theme={theme} />
     </View>
   );
 }
 
-function BaseballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme }) {
+function BaseballInProgress({
+  matchup,
+  theme,
+  onPressGameDetail,
+}: {
+  matchup: Matchup;
+  theme: Theme;
+  onPressGameDetail?: () => void;
+}) {
   const awayScore = matchup.awayScore ?? 0;
   const homeScore = matchup.homeScore ?? 0;
   // halfInning "Top" → away batting (gets the ⚾); "Bottom" → home batting.
@@ -286,6 +349,8 @@ function BaseballInProgress({ matchup, theme }: { matchup: Matchup; theme: Theme
           {matchup.lastPlayDescription}
         </Text>
       ) : null}
+
+      <OverviewLink label="Live Box Score" onPress={onPressGameDetail} theme={theme} />
     </View>
   );
 }
@@ -311,6 +376,16 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
+  },
+  // Overview link — shared affordance for "tap to open the Contest Overview",
+  // sized to be obviously a link without competing visually with the status
+  // info above it. Color comes from theme.tint at the call site.
+  overviewLink: {
+    marginTop: 4,
+  },
+  overviewLinkText: {
+    fontSize: 12,
+    fontWeight: '600',
   },
   // Live
   liveRow: {

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -683,14 +683,9 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
               />
             </TouchableOpacity>
           </View>
-          <TouchableOpacity
-            style={styles.compactRight}
-            onPress={onPress}
-            activeOpacity={onPress ? 0.75 : 1}
-            disabled={!onPress}
-          >
+          <View style={styles.compactRight}>
             <ScheduledMeta matchup={enrichedMatchup} onPressGameDetail={onPress} />
-          </TouchableOpacity>
+          </View>
         </View>
       ) : (
         <>

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -6,9 +6,11 @@ import type { Matchup, UserPick, PickChoice, PreviewResponse, TeamComparisonData
 import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
 import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
+import { formatToUserTime } from '@/src/utils/timeUtils';
+import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 import { InsightModal } from './InsightModal';
 import { StatsComparisonModal } from './StatsComparisonModal';
-import { GameStatus } from './GameStatus';
+import { GameStatus, OverviewLink } from './GameStatus';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -87,6 +89,7 @@ function TeamRow({
   const losses = isHome ? matchup.homeLosses : matchup.awayLosses;
   const confWins = isHome ? matchup.homeConferenceWins : matchup.awayConferenceWins;
   const confLosses = isHome ? matchup.homeConferenceLosses : matchup.awayConferenceLosses;
+  const probablePitcher = isHome ? matchup.homeProbablePitcher : matchup.awayProbablePitcher;
 
   const isActive = !isFinal || isWinning;
   const record = formatRecord(wins, losses, confWins, confLosses);
@@ -126,27 +129,49 @@ function TeamRow({
         {record !== '' && (
           <Text style={[styles.recordText, { color: theme.textMuted }]}>{record}</Text>
         )}
+        {probablePitcher?.displayName ? (
+          <View style={styles.probablePitcherRow}>
+            {probablePitcher.headshotUrl ? (
+              <Image
+                source={{ uri: probablePitcher.headshotUrl }}
+                style={styles.probablePitcherHeadshot}
+                accessibilityIgnoresInvertColors
+              />
+            ) : null}
+            <Text
+              style={[styles.probablePitcherName, { color: theme.textMuted }]}
+              numberOfLines={1}
+            >
+              {probablePitcher.displayName}
+            </Text>
+          </View>
+        ) : null}
       </View>
 
-      {/* Score + pick indicator */}
-      <View style={styles.scoreBox}>
-        {pickIndicatorColor && (
-          <Text style={[styles.pickIndicator, { color: pickIndicatorColor }]}>
-            {isPicked && isFinal ? (isPickCorrect ? '✓' : '✗') : '▶'}
-          </Text>
-        )}
-        {score != null && (
-          <Text
-            style={[
-              styles.score,
-              { color: isWinning && isFinal ? theme.tint : theme.text },
-              isWinning && isFinal && styles.scoreWinner,
-            ]}
-          >
-            {score}
-          </Text>
-        )}
-      </View>
+      {/* Score + pick indicator — only render when there's content to show.
+          Pre-game with no pick, the empty box was reserving minWidth + the
+          parent row's gap, which squeezed the team name in the compact
+          layout and forced truncation ("Cleveland Guar..."). */}
+      {(pickIndicatorColor || score != null) && (
+        <View style={styles.scoreBox}>
+          {pickIndicatorColor && (
+            <Text style={[styles.pickIndicator, { color: pickIndicatorColor }]}>
+              {isPicked && isFinal ? (isPickCorrect ? '✓' : '✗') : '▶'}
+            </Text>
+          )}
+          {score != null && (
+            <Text
+              style={[
+                styles.score,
+                { color: isWinning && isFinal ? theme.tint : theme.text },
+                isWinning && isFinal && styles.scoreWinner,
+              ]}
+            >
+              {score}
+            </Text>
+          )}
+        </View>
+      )}
     </View>
   );
 }
@@ -217,6 +242,96 @@ function OddsRow({ matchup }: { matchup: Matchup }) {
 }
 
 // StatusSection extracted → see GameStatus.tsx
+
+// ─── Scheduled meta (compact 2-column right side) ────────────────────────────
+//
+// Pre-game stack: spread (and O/U) above, then date/time, then broadcasts,
+// then venue. Mirrors what GameStatus renders for Scheduled but stacked
+// vertically in a narrow right column instead of centered full-width.
+
+function ScheduledMeta({
+  matchup,
+  onPressGameDetail,
+}: {
+  matchup: Matchup;
+  onPressGameDetail?: () => void;
+}) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const userTz = useUserTimeZone();
+
+  const spread = matchup.spreadCurrent;
+  const spreadOpen = matchup.spreadOpen ?? null;
+  const ou = matchup.overUnderCurrent;
+  const ouOpen = matchup.overUnderOpen ?? null;
+  const hasSpread = spread != null;
+  const hasOu = ou != null && ou !== 0;
+
+  const sArrow = spreadArrow(spread, spreadOpen);
+  const oArrow = ouArrow(ou, ouOpen);
+
+  const cityState = [matchup.venueCity, matchup.venueState]
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <View style={styles.compactMeta}>
+      {(hasSpread || hasOu) && (
+        <View style={styles.compactOddsStack}>
+          {hasSpread && (
+            <View style={styles.compactOddsLine}>
+              <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>SPREAD </Text>
+              {sArrow && (
+                <Text style={[styles.oddsArrow, { color: sArrow.color }]}>{sArrow.symbol}</Text>
+              )}
+              <Text style={[styles.oddsValue, { color: theme.tint }]}>
+                {spreadLabel(spread)}
+              </Text>
+            </View>
+          )}
+          {hasOu && (
+            <View style={styles.compactOddsLine}>
+              <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>O/U </Text>
+              {oArrow && (
+                <Text style={[styles.oddsArrow, { color: oArrow.color }]}>{oArrow.symbol}</Text>
+              )}
+              <Text style={[styles.oddsValue, { color: theme.tint }]}>{ou}</Text>
+            </View>
+          )}
+        </View>
+      )}
+
+      <Text style={[styles.compactTime, { color: theme.text }]}>
+        {formatToUserTime(matchup.startDateUtc, userTz)}
+      </Text>
+
+      {matchup.broadcasts ? (
+        <Text style={[styles.compactMetaText, { color: theme.textMuted }]} numberOfLines={3}>
+          {matchup.broadcasts}
+        </Text>
+      ) : null}
+
+      {matchup.venue ? (
+        <Text style={[styles.compactMetaText, { color: theme.textMuted }]} numberOfLines={1}>
+          {matchup.venue}
+        </Text>
+      ) : null}
+
+      {cityState ? (
+        <Text style={[styles.compactMetaText, { color: theme.textMuted }]} numberOfLines={1}>
+          {cityState}
+        </Text>
+      ) : null}
+
+      <OverviewLink
+        label="Game Preview"
+        onPress={onPressGameDetail}
+        theme={theme}
+        align="flex-start"
+      />
+    </View>
+  );
+}
 
 // ─── PickButton (mirrors web PickButton component) ───────────────────────────
 //
@@ -342,7 +457,7 @@ function PickButtons({
         hitSlop={6}
       >
         <Text style={[styles.actionBtnIcon, !matchup.isPreviewAvailable && { opacity: 0.4 }]}>
-          {matchup.isPreviewAvailable ? '📈' : '🔒'}
+          📈
         </Text>
       </TouchableOpacity>
       <PickButton
@@ -429,6 +544,9 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
 
   const status = enrichedMatchup.status.toLowerCase();
   const isFinal = status === 'final' || status === 'completed';
+  // Compact 2-column layout only applies pre-game — once the game starts,
+  // the score column reactivates and the single-column flow makes more sense.
+  const isScheduled = status === 'scheduled';
 
   // Optimistic local pick — shows selection instantly before server confirms
   const [optimisticFranchiseId, setOptimisticFranchiseId] = useState<string | null>(null);
@@ -530,56 +648,104 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         </View>
       )}
 
-      {/* Away team — taps go to the team page, not the contest overview. */}
-      <TouchableOpacity
-        onPress={onPressTeam ? () => onPressTeam('away') : undefined}
-        activeOpacity={onPressTeam ? 0.6 : 1}
-        disabled={!onPressTeam}
-      >
-        <TeamRow
-          matchup={enrichedMatchup}
-          side="away"
-          isWinning={!homeIsWinning}
-          isPicked={pickedAway}
-          isPickCorrect={isPickCorrect}
-          isFinal={isFinal}
-        />
-      </TouchableOpacity>
+      {isScheduled ? (
+        // ── Compact 2-column layout: team rows on the left, meta on the
+        // right. Active only pre-game; once the game starts, the score
+        // column reactivates and the standard single-column flow returns.
+        <View style={styles.compactRow}>
+          <View style={styles.compactLeft}>
+            <TouchableOpacity
+              onPress={onPressTeam ? () => onPressTeam('away') : undefined}
+              activeOpacity={onPressTeam ? 0.6 : 1}
+              disabled={!onPressTeam}
+            >
+              <TeamRow
+                matchup={enrichedMatchup}
+                side="away"
+                isWinning={!homeIsWinning}
+                isPicked={pickedAway}
+                isPickCorrect={isPickCorrect}
+                isFinal={isFinal}
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={onPressTeam ? () => onPressTeam('home') : undefined}
+              activeOpacity={onPressTeam ? 0.6 : 1}
+              disabled={!onPressTeam}
+            >
+              <TeamRow
+                matchup={enrichedMatchup}
+                side="home"
+                isWinning={homeIsWinning}
+                isPicked={pickedHome}
+                isPickCorrect={isPickCorrect}
+                isFinal={isFinal}
+              />
+            </TouchableOpacity>
+          </View>
+          <TouchableOpacity
+            style={styles.compactRight}
+            onPress={onPress}
+            activeOpacity={onPress ? 0.75 : 1}
+            disabled={!onPress}
+          >
+            <ScheduledMeta matchup={enrichedMatchup} onPressGameDetail={onPress} />
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <>
+          {/* Away team — taps go to the team page, not the contest overview. */}
+          <TouchableOpacity
+            onPress={onPressTeam ? () => onPressTeam('away') : undefined}
+            activeOpacity={onPressTeam ? 0.6 : 1}
+            disabled={!onPressTeam}
+          >
+            <TeamRow
+              matchup={enrichedMatchup}
+              side="away"
+              isWinning={!homeIsWinning}
+              isPicked={pickedAway}
+              isPickCorrect={isPickCorrect}
+              isFinal={isFinal}
+            />
+          </TouchableOpacity>
 
-      {/* Home team */}
-      <TouchableOpacity
-        onPress={onPressTeam ? () => onPressTeam('home') : undefined}
-        activeOpacity={onPressTeam ? 0.6 : 1}
-        disabled={!onPressTeam}
-      >
-        <TeamRow
-          matchup={enrichedMatchup}
-          side="home"
-          isWinning={homeIsWinning}
-          isPicked={pickedHome}
-          isPickCorrect={isPickCorrect}
-          isFinal={isFinal}
-        />
-      </TouchableOpacity>
+          {/* Home team */}
+          <TouchableOpacity
+            onPress={onPressTeam ? () => onPressTeam('home') : undefined}
+            activeOpacity={onPressTeam ? 0.6 : 1}
+            disabled={!onPressTeam}
+          >
+            <TeamRow
+              matchup={enrichedMatchup}
+              side="home"
+              isWinning={homeIsWinning}
+              isPicked={pickedHome}
+              isPickCorrect={isPickCorrect}
+              isFinal={isFinal}
+            />
+          </TouchableOpacity>
 
-      {/* Spread & O/U — tap goes to the contest overview. */}
-      <TouchableOpacity
-        onPress={onPress}
-        activeOpacity={onPress ? 0.75 : 1}
-        disabled={!onPress}
-      >
-        <OddsRow matchup={enrichedMatchup} />
-      </TouchableOpacity>
+          {/* Spread & O/U — tap goes to the contest overview. */}
+          <TouchableOpacity
+            onPress={onPress}
+            activeOpacity={onPress ? 0.75 : 1}
+            disabled={!onPress}
+          >
+            <OddsRow matchup={enrichedMatchup} />
+          </TouchableOpacity>
 
-      {/* Game status — time/score/live; GameStatus owns its own touchable
-          and routes to the contest overview via onPressGameDetail.
-          enriched data drives all status branches; leagueSport dispatches
-          the InProgress UI between baseball and football. */}
-      <GameStatus
-        matchup={enrichedMatchup}
-        leagueSport={leagueSport}
-        onPressGameDetail={onPress}
-      />
+          {/* Game status — time/score/live; GameStatus owns its own touchable
+              and routes to the contest overview via onPressGameDetail.
+              enriched data drives all status branches; leagueSport dispatches
+              the InProgress UI between baseball and football. */}
+          <GameStatus
+            matchup={enrichedMatchup}
+            leagueSport={leagueSport}
+            onPressGameDetail={onPress}
+          />
+        </>
+      )}
 
       {/* Inline pick buttons */}
       {onPick && (
@@ -637,6 +803,41 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.2,
   },
 
+  // Compact 2-column scheduled layout
+  compactRow: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+  },
+  compactLeft: {
+    flex: 65,
+  },
+  compactRight: {
+    flex: 35,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    justifyContent: 'flex-start',
+  },
+  compactMeta: {
+    gap: 4,
+  },
+  compactOddsStack: {
+    gap: 2,
+    marginBottom: 4,
+  },
+  compactOddsLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  compactTime: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  compactMetaText: {
+    fontSize: 11,
+    textAlign: 'center',
+  },
+
   // Headline
   headline: {
     backgroundColor: Colors.brand.navy,
@@ -690,6 +891,22 @@ const styles = StyleSheet.create({
   },
   recordText: {
     fontSize: 12,
+  },
+  probablePitcherRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 2,
+  },
+  probablePitcherHeadshot: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+  },
+  probablePitcherName: {
+    fontSize: 11,
+    fontWeight: '500',
+    flexShrink: 1,
   },
   scoreBox: {
     flexDirection: 'row',

--- a/src/UI/sd-mobile/src/components/features/selectors/LeagueWeekSelector.tsx
+++ b/src/UI/sd-mobile/src/components/features/selectors/LeagueWeekSelector.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   View,
   Text,
-  ScrollView,
   TouchableOpacity,
   StyleSheet,
   LayoutAnimation,
@@ -98,11 +97,7 @@ export function LeagueWeekSelector({
         <View>
           {/* League selector — only shown when user belongs to 2+ leagues */}
           {leagues.length > 1 && (
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.row}
-            >
+            <View style={styles.chipRow}>
               {leagues.map((league) => {
                 const active = league.id === selectedLeagueId;
                 return (
@@ -127,11 +122,11 @@ export function LeagueWeekSelector({
                   </TouchableOpacity>
                 );
               })}
-            </ScrollView>
+            </View>
           )}
 
           {/* Week selector */}
-          <View style={styles.weekRow}>
+          <View style={styles.chipRow}>
             {weeks.map((w) => {
               const active = w === selectedWeek;
               return (
@@ -182,12 +177,7 @@ const styles = StyleSheet.create({
   chevron: {
     fontSize: 14,
   },
-  row: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    gap: 8,
-  },
-  weekRow: {
+  chipRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     paddingHorizontal: 14,

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -19,6 +19,14 @@ export interface League {
   seasonWeeks?: number[];
 }
 
+// ─── Probable Pitcher (MLB only) ─────────────────────────────────────────────
+
+/** Matches ProbablePitcherDto from the canonical layer. */
+export interface ProbablePitcher {
+  displayName: string;
+  headshotUrl?: string | null;
+}
+
 // ─── Matchup ─────────────────────────────────────────────────────────────────
 
 /** Matches MatchupForPickDto from GET /ui/leagues/{id}/matchups/{week} */
@@ -88,6 +96,10 @@ export interface Matchup {
   // Sport-neutral last-play info (written by either *PlayCompleted handler)
   lastPlayId?: string | null;
   lastPlayDescription?: string | null;
+
+  // MLB only — null on non-MLB matchups.
+  homeProbablePitcher?: ProbablePitcher | null;
+  awayProbablePitcher?: ProbablePitcher | null;
 
   // Scores
   awayScore?: number | null;


### PR DESCRIPTION
## Summary

Round 1 of working through the drift list captured in the new MatchupCard blueprint (`docs/ui/matchup-card-blueprint.md`).

**New behavior**
- Compact 2-column layout for Scheduled MLB matchups: team rows on the left, meta (spread/O/U, date, broadcasts, venue, `Game Preview ›` link) on the right. Reverts to single-column once the game flips to InProgress/Final.
- State-specific Contest Overview affordance — `Game Preview ›` / `Live Box Score ›` / `Box Score ›` — replaces the prior hidden tap-the-whole-status-block pattern.
- Probable pitcher row inside TeamRow (MLB only).

**Web parity / drift fixes**
- Insight icon: always 📈, dim+disabled when no preview available (matches web's behavior in practice; subscription paywall path is dead code).
- Conditionally render TeamRow's score column so empty pre-game boxes don't reserve width (was truncating team names like "Cleveland Guar…" in compact layout).
- LeagueWeekSelector league chips now wrap into rows like the week chips do, instead of scrolling horizontally.

**Quality**
- Fix pre-existing TS error in `game/[id].tsx` — `PickSelector` was missing `submitPending` in its destructure. The lock-during-pending-submit behavior was silently broken too.
- New `docs/ui/matchup-card-blueprint.md` — canonical structure for the MatchupCard component across both platforms.
- Minor `lightningcss-win32-x64-msvc` optionalDependency bump (`^1.31.1` → `^1.32.0`).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 39/39 passing
- [x] Manually verified each state in browser dev build for an MLB matchup:
  - Scheduled: compact 2-col layout, centered SPREAD/O/U/broadcasts/venue, `Game Preview ›` link at bottom of right column
  - InProgress: standard single-column layout, `Live Box Score ›` link at bottom of live block
  - Final: standard single-column layout, FINAL+score lines static, `Box Score ›` link below
- [x] Probable pitcher row appears on MLB games, not on NFL
- [x] Team name no longer truncates pre-game in compact layout

## Out of scope (deferred)

- `app.json` `buildNumber` bump (sitting in working tree from an earlier session — will ride with the next EAS build PR)
- Remaining drift items in the blueprint (DeetsMeter, ConfidencePicker, etc.) — future rounds
- Component-file extraction in `MatchupCard.tsx` / `game/[id].tsx` — its own housekeeping PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added probable pitcher display for MLB games on matchup cards
  * Introduced "Box Score" and "Live Box Score" links for quick access to game details
  * Implemented compact layout for scheduled games with improved information organization

* **Bug Fixes**
  * Fixed submit buttons remaining enabled during pending submissions

* **Chores**
  * Updated dependency version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->