### PR TITLE
feat(mobile): matchup card round 2 — isReadOnly lock check + blueprint sync

### DIFF
--- a/docs/ui/matchup-card-blueprint.md
+++ b/docs/ui/matchup-card-blueprint.md
@@ -205,10 +205,34 @@ undefines a previously-populated field.
 
 ---
 
-## Known drift (audit findings, 2026-05-18)
+## Known drift
 
 Drift that this blueprint flags for correction. Each item should
 become its own follow-up — don't bundle these into one mega-PR.
+
+### Resolved in Round 1 (PR #337, 2026-05-19)
+
+- **Probable pitcher row** — mobile TeamRow now renders the row from
+  `matchup.{home,away}ProbablePitcher` on MLB matchups, matching web.
+- **Insight icon parity** — mobile now always shows 📈, dimmed +
+  disabled when no preview is available, matching web's effective
+  behavior (the `isInsightUnlocked` subscription path is dead code
+  hardcoded `true`).
+- **Contest Overview affordance** — replaces the prior hidden
+  tap-the-whole-status-block pattern with an explicit `OverviewLink`
+  component (chevron + state-specific label in `theme.tint`):
+  `Game Preview ›` (Scheduled), `Live Box Score ›` (InProgress),
+  `Box Score ›` (Final). Documented in `GameStatus.tsx` and used by
+  both `GameStatus` and mobile's `ScheduledMeta`.
+- **Compact 2-column Scheduled layout (mobile)** — new platform
+  expression, not a drift fix. Documented in the slot layout section
+  above.
+
+### Resolved in Round 2 (2026-05-19)
+
+- **`userDto.isReadOnly` in lock check** — mobile `MatchupCard` now
+  calls `useCurrentUser` and ORs `me?.isReadOnly` into the lock
+  computation. Read-only viewers can no longer tap pick buttons.
 
 ### Mobile is missing
 
@@ -219,33 +243,38 @@ become its own follow-up — don't bundle these into one mega-PR.
 3. **TeamRow expandable schedule** — web's TeamRow opens a per-team
    schedule on tap via `useTeamSchedule`; mobile's TeamRow has no
    equivalent.
-4. **`userDto.isReadOnly` in lock check** — web's `usePickLocking`
-   consults the user record; mobile's `isPickLocked` does not. A
-   read-only viewer on mobile can theoretically still tap pick
-   buttons.
-5. **Stream-scheduled "View" link in Scheduled state** — web shows a
-   Webcam icon link when `streamScheduledTimeUtc` is set; mobile has
-   no equivalent treatment.
-6. **Postponed/cancelled handling** — mobile shows the raw status
+4. **Postponed/cancelled handling** — mobile shows the raw status
    string in error color; web falls through to Scheduled markup.
    Either is defensible — pick one and apply on both.
 
 ### Cross-cutting
 
-7. **Icon library divergence** — web uses `react-icons` (FaChartLine,
+5. **Icon library divergence** — web uses `react-icons` (FaChartLine,
    FaLock, FaClipboardList); mobile uses emoji (📈, 🔒, 📋). Acceptable
    as long as we acknowledge it — the alternative (RN vector icons)
    is a bigger lift. Document the decision; don't churn it.
-8. **Dark-mode logo variants** — both platforms have access to
+6. **Dark-mode logo variants** — both platforms have access to
    `homeLogoUriDark`/`awayLogoUriDark`; web swaps via `useTheme()`;
    mobile uses the default URI in both schemes. Mobile gap.
 
 ### Server-side
 
-9. **Headline banner population** — `matchup.headLine` is the
+7. **Headline banner population** — `matchup.headLine` is the
    blueprint slot; we should confirm the server populates this
    consistently across all sports + states. (Today it appears only
    for some marquee games.)
+
+### Out of scope (won't fix)
+
+- **Stream-scheduled "View" link** — web's webcam icon link tied to
+  `streamScheduledTimeUtc` was originally a developer affordance for
+  verifying the competition broadcasting scheduler picked up a game.
+  Not a real end-user feature. The mobile-side equivalent (general
+  navigation to Contest Overview from Scheduled state) is now covered
+  by the new `Game Preview ›` link via `OverviewLink`. Web may
+  eventually consolidate by replacing the webcam-icon-only link with
+  the same `OverviewLink`-style affordance, but that's a web cleanup,
+  not blueprint drift.
 
 ---
 

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -6,6 +6,7 @@ import type { Matchup, UserPick, PickChoice, PreviewResponse, TeamComparisonData
 import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
 import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
+import { useCurrentUser } from '@/src/hooks/useStandings';
 import { formatToUserTime } from '@/src/utils/timeUtils';
 import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 import { InsightModal } from './InsightModal';
@@ -499,6 +500,12 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   // contestId's record changes — see contestUpdatesStore selector design.
   const live = useContestUpdate(matchup.contestId);
 
+  // Current user — only the isReadOnly flag is consumed here, to lock
+  // picks for read-only viewers regardless of matchup status. Shares a
+  // TanStack Query cache with the screen-level useCurrentUser call, so
+  // this doesn't trigger an extra network request per card.
+  const { data: me } = useCurrentUser();
+
   // Merge live data over the static REST payload via nullish fallback so
   // a partial future-update handler can't silently undefine a previously
   // populated field. Mirrors the web pattern in AdminBaseballPage.jsx
@@ -615,7 +622,10 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   const isPickCorrect = isFinal && hasPick ? (pick?.isCorrect ?? null) : null;
 
   // Use enriched status — a live transition to InProgress must lock picks.
-  const locked = isPickLocked(enrichedMatchup);
+  // Also lock for read-only viewers (e.g. shared link accounts) so they
+  // can't tap pick buttons regardless of game state. Mirrors the web
+  // `usePickLocking` hook's `userDto.isReadOnly` consultation.
+  const locked = isPickLocked(enrichedMatchup) || !!me?.isReadOnly;
 
   // Card border color based on pick result (matches web)
   let cardBorderColor = theme.border;


### PR DESCRIPTION
## Summary

Round 2 of the MatchupCard drift cleanup tracked by `docs/ui/matchup-card-blueprint.md`. Scope kept small — single drift item + doc sync — per the blueprint's "don't bundle into one mega-PR" guidance.

**Drift item #4 resolved: `isReadOnly` lock check on mobile.**

- `MatchupCard` now calls `useCurrentUser` and ORs `me?.isReadOnly` into the lock computation.
- Read-only viewers (e.g. shared-link / demo accounts) can no longer tap pick buttons regardless of game state.
- Mirrors web's `usePickLocking` hook which already consults `userDto.isReadOnly`.
- TanStack Query dedupes `/user/me` with the screen-level call, so no extra network request per card.

**Blueprint sync.**

- Adds a `Resolved in Round 1` section retroactively listing what shipped in PR #337 (probable pitcher, insight icon parity, `OverviewLink` affordance, compact 2-col Scheduled layout).
- Adds a `Resolved in Round 2` entry for this PR's fix.
- Renumbers remaining drift items as a continuous sequence.
- Moves the stream-scheduled "View" link item to a new `Out of scope (won't fix)` section — was a dev affordance for the broadcasting scheduler, not an end-user feature; the new `OverviewLink` covers the actual nav need.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 39/39 passing
- [x] Manual: log in as a read-only account → pick buttons stay locked across Scheduled / InProgress / Final
- [x] Manual: log in as a regular account → existing pick behavior unchanged

## Out of scope (deferred for future rounds)

Remaining drift items in priority order:

1. **Postponed/cancelled handling** (drift #4) — pick mobile's approach (raw status in error color) and apply on both sides, OR pick web's (Scheduled fallthrough). Small change once a direction is decided.
2. **Dark-mode logo variants** (drift #6) — wire field already on `LeagueWeekMatchupsDto`; just need mobile to consume it. Touches Matchup type, MatchupCard, and GameStatus baseball at-bat slots.
3. **TeamRow expandable schedule** (drift #3) — needs port of web's `useTeamSchedule` hook and a per-row schedule view.
4. **DeetsMeter / AI prediction bars** (drift #1) — full slot implementation; needs design discussion.
5. **ConfidencePicker integration** (drift #2) — modal port; needs design discussion.
6. **Headline banner population** (drift #7) — server-side; observational only until we audit.

Also outside drift, the file-extraction housekeeping PR (split `MatchupCard.tsx` / `game/[id].tsx` into per-component files) is queued and will be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)