### PR TITLE
feat(api): auto-refresh contests when a pick'em group week generates matchups

### DIFF
--- a/src/SportsData.Api/Application/Events/ContestRefreshRequestedHandler.cs
+++ b/src/SportsData.Api/Application/Events/ContestRefreshRequestedHandler.cs
@@ -1,0 +1,67 @@
+using MassTransit;
+
+using SportsData.Api.Application.UI.Contest.Commands.RefreshContest;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Contests;
+
+namespace SportsData.Api.Application.Events
+{
+    public class ContestRefreshRequestedHandler : IConsumer<ContestRefreshRequested>
+    {
+        private readonly ILogger<ContestRefreshRequestedHandler> _logger;
+        private readonly IRefreshContestCommandHandler _refreshHandler;
+
+        public ContestRefreshRequestedHandler(
+            ILogger<ContestRefreshRequestedHandler> logger,
+            IRefreshContestCommandHandler refreshHandler)
+        {
+            _logger = logger;
+            _refreshHandler = refreshHandler;
+        }
+
+        public async Task Consume(ConsumeContext<ContestRefreshRequested> context)
+        {
+            var msg = context.Message;
+
+            using (_logger.BeginScope(new Dictionary<string, object>
+                   {
+                       ["CorrelationId"] = msg.CorrelationId,
+                       ["ContestId"] = msg.ContestId,
+                       ["Sport"] = msg.Sport
+                   }))
+            {
+                var command = new RefreshContestCommand
+                {
+                    ContestId = msg.ContestId,
+                    Sport = msg.Sport
+                };
+
+                var result = await _refreshHandler.ExecuteAsync(command, context.CancellationToken);
+
+                if (result.IsSuccess)
+                    return;
+
+                // Permanent failures (4xx-class): log and move on. Retrying won't help.
+                // Transient failures (Error, RateLimited): throw so MassTransit retries
+                // and eventually DLQs if persistent.
+                switch (result.Status)
+                {
+                    case ResultStatus.NotFound:
+                    case ResultStatus.BadRequest:
+                    case ResultStatus.Validation:
+                    case ResultStatus.Forbid:
+                    case ResultStatus.Unauthorized:
+                        _logger.LogWarning(
+                            "RefreshContest returned non-retryable status {Status} for ContestId={ContestId}; not retrying.",
+                            result.Status,
+                            msg.ContestId);
+                        return;
+
+                    default:
+                        throw new Exception(
+                            $"RefreshContest failed for ContestId={msg.ContestId} with status {result.Status}.");
+                }
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
@@ -61,7 +61,15 @@ namespace SportsData.Api.Application.PickemGroups
                 throw new Exception("No matchups found for group week");
             }
 
-            var groupWeekMatchupsContestIds = groupWeekMatchups.Select(x => x.ContestId).ToList();
+            // Distinct(): defensive against duplicates that could arise if ESPN
+            // ever returns a contest twice for a week or MatchupScheduleProcessor
+            // is re-run without a unique constraint catching the row. Without
+            // this, ContestRefreshRequested would fire 2+ times for the same
+            // contest, and the preview-enqueue loop would queue duplicate jobs.
+            var groupWeekMatchupsContestIds = groupWeekMatchups
+                .Select(x => x.ContestId)
+                .Distinct()
+                .ToList();
 
             // Request a refresh for every contest in the week. Contests may have
             // been added to the group before their ESPN metadata (probable

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Previews;
 using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Processing;
 
@@ -14,15 +16,21 @@ namespace SportsData.Api.Application.PickemGroups
         private readonly ILogger<PickemGroupWeekMatchupsGeneratedHandler> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IEventBus _eventBus;
+        private readonly IMessageDeliveryScope _deliveryScope;
 
         public PickemGroupWeekMatchupsGeneratedHandler(
             ILogger<PickemGroupWeekMatchupsGeneratedHandler> logger,
             AppDataContext dataContext,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope)
         {
             _logger = logger;
             _dataContext = dataContext;
             _backgroundJobProvider = backgroundJobProvider;
+            _eventBus = eventBus;
+            _deliveryScope = deliveryScope;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupWeekMatchupsGenerated> context)
@@ -36,16 +44,16 @@ namespace SportsData.Api.Application.PickemGroups
                    }))
             {
                 _logger.LogInformation("Processing AI Previews. {@Message}", context.Message);
-                await ConsumeInternal(context.Message);
+                await ConsumeInternal(context.Message, context.CancellationToken);
             }
         }
 
-        private async Task ConsumeInternal(PickemGroupWeekMatchupsGenerated @event)
+        private async Task ConsumeInternal(PickemGroupWeekMatchupsGenerated @event, CancellationToken ct)
         {
             // Implement logic to generate AI predictions for matchups in a pick'em group week (if not present)
             var groupWeekMatchups = await _dataContext.PickemGroupMatchups
                 .Where(x => x.GroupId == @event.GroupId && x.SeasonYear == @event.SeasonYear && x.SeasonWeek == @event.WeekNumber)
-                .ToListAsync();
+                .ToListAsync(ct);
 
             if (!groupWeekMatchups.Any())
             {
@@ -55,9 +63,30 @@ namespace SportsData.Api.Application.PickemGroups
 
             var groupWeekMatchupsContestIds = groupWeekMatchups.Select(x => x.ContestId).ToList();
 
+            // Request a refresh for every contest in the week. Contests may have
+            // been added to the group before their ESPN metadata (probable
+            // pitchers, opening spread, broadcasts) was fully populated; this
+            // fans out a per-contest refresh so the UI fills in quickly.
+            // Direct delivery — this consumer does no DbContext writes, so the
+            // outbox isn't involved.
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                foreach (var contestId in groupWeekMatchupsContestIds)
+                {
+                    await _eventBus.Publish(new ContestRefreshRequested(
+                        contestId,
+                        null,
+                        @event.Sport,
+                        @event.SeasonYear,
+                        @event.CorrelationId,
+                        Guid.NewGuid()),
+                        ct);
+                }
+            }
+
             var existingPreviews = await _dataContext.MatchupPreviews
                 .Where(p => groupWeekMatchupsContestIds.Contains(p.ContestId))
-                .ToListAsync();
+                .ToListAsync(ct);
 
             var existingPreviewsContestIds = existingPreviews.Select(x => x.ContestId).ToList();
 

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -229,6 +229,7 @@ namespace SportsData.Api
                     typeof(BaseballPlayCompletedHandler),
                     typeof(ContestOddsUpdatedHandler),
                     typeof(ContestRecapArticlePublishedHandler),
+                    typeof(ContestRefreshRequestedHandler),
                     typeof(ContestScoreChangedHandler),
                     typeof(ContestStartTimeUpdatedHandler),
                     typeof(ContestStatusChangedHandler),

--- a/src/SportsData.Core/Eventing/Events/Contests/ContestRefreshRequested.cs
+++ b/src/SportsData.Core/Eventing/Events/Contests/ContestRefreshRequested.cs
@@ -1,0 +1,14 @@
+using System;
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Contests
+{
+    public record ContestRefreshRequested(
+        Guid ContestId,
+        Uri? Ref,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+        ) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId);
+}


### PR DESCRIPTION
## Summary

- When a league is created and matchups are generated, ESPN metadata (probable pitchers, opening spreads, broadcasts) is often not yet populated. The UI then shows incomplete data until the next scheduled refresh cycle.
- Adds an event cascade: `PickemGroupWeekMatchupsGeneratedHandler` now fans out a per-contest `ContestRefreshRequested` event for every matchup in the week. A new `ContestRefreshRequestedHandler` consumes those events and dispatches the existing `RefreshContestCommand`.
- One event per contest (not one with an array) so each refresh retries / DLQs independently. Direct delivery from the parent handler since it does no DbContext writes — outbox isn't involved.
- Permanent failures (`NotFound`, `BadRequest`, `Validation`, `Forbid`, `Unauthorized`) are logged at warning and swallowed so one bad contest can't wedge the queue. Transient failures (`Error`, `RateLimited`) throw so MassTransit retries.

## Files
- `src/SportsData.Core/Eventing/Events/Contests/ContestRefreshRequested.cs` — new event record
- `src/SportsData.Api/Application/Events/ContestRefreshRequestedHandler.cs` — new consumer
- `src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs` — publishes the new event per matchup, threads `CancellationToken` through
- `src/SportsData.Api/Program.cs` — registers the new consumer in `AddMessaging`

## Test plan
- [ ] Local: create a new pick'em group league and trigger week-matchup generation
- [ ] Verify `ContestRefreshRequested` events appear in Seq, one per contest, with matching `CorrelationId`
- [ ] Verify `RefreshContest` HTTP calls land on Producer and contest metadata (probable pitcher, opening spread, broadcasts) appears in the API/UI within seconds — not after the next scheduled refresh
- [ ] Verify a contest that 404s on Producer logs a warning and does not retry / DLQ (queue keeps draining)
- [ ] Verify existing unit test passes: `PickemGroupWeekMatchupsGeneratedHandlerTests.Should_Enqueue_PreviewJobs_For_Contests_Without_Existing_Previews`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event-driven contest refresh mechanism that automatically triggers when pick'em group matchups are generated.
  * Implemented intelligent error handling with retry logic for failed refresh operations, distinguishing between recoverable and permanent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->