### PR TITLE
fix(mobile): revert MatchupCard 2-col Scheduled layout + readability bumps

### DIFF
--- a/docs/ui/matchup-card-blueprint.md
+++ b/docs/ui/matchup-card-blueprint.md
@@ -39,24 +39,20 @@ flowchart TB
     PB -.overlays.-> M
 ```
 
-Two ways the rendered structure can deviate from the default:
+Ways the rendered structure can deviate from the default:
 
 1. **Headline banner is always optional** — rendered only when
    `matchup.headLine` is present.
-2. **A platform may reorganize slots for a specific state** when it
-   suits the surface. Mobile's Scheduled state uses a 2-column compact
-   layout that fuses the OddsRow + the Scheduled-branch content of
-   GameStatus into a right-column `ScheduledMeta` block alongside the
-   team rows on the left (see the `isScheduled` branch in mobile's
-   `MatchupCard.tsx`). This is acceptable *platform expression* of the
-   same underlying contract: data and lifecycle are unchanged; only
-   the spatial arrangement adapts. When such a reorganization is
-   intentional, document it here; when it's drift between platforms,
-   file it in the "Known drift" section.
+2. **Sub-elements inside a slot may be conditional** — e.g. the rank
+   prefix on team rows only renders when `awayRank`/`homeRank` is
+   non-null; the probable-pitcher row renders only on MLB matchups.
 
-Sub-elements inside a slot may also be conditional — e.g. the rank
-prefix on team rows only renders when `awayRank`/`homeRank` is
-non-null.
+A platform *may* reorganize slots for a specific state when it suits
+the surface, but the default is uniform slot order. If a reorganization
+is intentional, document it here; if it's drift, file it under "Known
+drift" instead. See Round 3 for the mobile 2-column Scheduled
+experiment that was tried and reverted — the slot stack proved more
+durable across screen widths than a width-fragile compact layout.
 
 ---
 
@@ -222,17 +218,31 @@ become its own follow-up — don't bundle these into one mega-PR.
   tap-the-whole-status-block pattern with an explicit `OverviewLink`
   component (chevron + state-specific label in `theme.tint`):
   `Game Preview ›` (Scheduled), `Live Box Score ›` (InProgress),
-  `Box Score ›` (Final). Documented in `GameStatus.tsx` and used by
-  both `GameStatus` and mobile's `ScheduledMeta`.
-- **Compact 2-column Scheduled layout (mobile)** — new platform
-  expression, not a drift fix. Documented in the slot layout section
-  above.
+  `Box Score ›` (Final). Defined in `GameStatus.tsx` and rendered by
+  each of its state branches.
 
 ### Resolved in Round 2 (2026-05-19)
 
 - **`userDto.isReadOnly` in lock check** — mobile `MatchupCard` now
   calls `useCurrentUser` and ORs `me?.isReadOnly` into the lock
   computation. Read-only viewers can no longer tap pick buttons.
+
+### Resolved in Round 3 (2026-05-20)
+
+- **Compact 2-column Scheduled layout reverted** — the Round 1
+  platform-expression experiment didn't survive at 390pt screen
+  widths (iPhone 14 / 12 / 13 / SE Plus class). Right column was
+  ~105pt of usable space, which forced multi-line wrapping on the
+  date, broadcasts, and venue strings at the small font sizes that
+  fit. Bumping fonts made it worse (more wrapping). Mobile Scheduled
+  now matches web's vertical stack: time → broadcasts → venue →
+  city/state → `Game Preview ›` link. Documented here so we don't
+  re-litigate.
+- **Meta text readability bumps (mobile)** — `statusTime` 13→14,
+  `statusMeta` 11→13, `recordText` 12→13, `probablePitcherName` 11→12.
+  Pure font-size changes against `theme.textMuted`; palette
+  unchanged. Driven by the same iPhone-14 readability complaint that
+  motivated the 2-col revert.
 
 ### Mobile is missing
 

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -42,6 +42,7 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStat
 
   // ── Scheduled ──────────────────────────────────────────────────────────────
   if (status === 'scheduled') {
+    const cityState = [matchup.venueCity, matchup.venueState].filter(Boolean).join(', ');
     return (
       <View style={styles.statusSection}>
         <Text style={[styles.statusTime, { color: theme.text }]}>
@@ -54,9 +55,15 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStat
         ) : null}
         {matchup.venue ? (
           <Text style={[styles.statusMeta, { color: theme.textMuted }]} numberOfLines={1}>
-            {[matchup.venue, matchup.venueCity, matchup.venueState].filter(Boolean).join(', ')}
+            {matchup.venue}
           </Text>
         ) : null}
+        {cityState ? (
+          <Text style={[styles.statusMeta, { color: theme.textMuted }]} numberOfLines={1}>
+            {cityState}
+          </Text>
+        ) : null}
+        <OverviewLink label="Game Preview" onPress={onPressGameDetail} theme={theme} />
       </View>
     );
   }
@@ -112,7 +119,7 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStat
 // TouchableOpacity (which gave no visual hint that it was tappable).
 //
 // Per-state labels live at the call sites:
-//   Scheduled  → "Game Preview"   (rendered by MatchupCard's ScheduledMeta)
+//   Scheduled  → "Game Preview"
 //   InProgress → "Live Box Score"
 //   Final      → "Box Score"
 
@@ -365,11 +372,11 @@ const styles = StyleSheet.create({
     gap: 2,
   },
   statusTime: {
-    fontSize: 13,
+    fontSize: 14,
     fontWeight: '600',
   },
   statusMeta: {
-    fontSize: 11,
+    fontSize: 13,
   },
   statusLabel: {
     fontSize: 12,

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -7,11 +7,9 @@ import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
 import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
 import { useCurrentUser } from '@/src/hooks/useStandings';
-import { formatToUserTime } from '@/src/utils/timeUtils';
-import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 import { InsightModal } from './InsightModal';
 import { StatsComparisonModal } from './StatsComparisonModal';
-import { GameStatus, OverviewLink } from './GameStatus';
+import { GameStatus } from './GameStatus';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -244,96 +242,6 @@ function OddsRow({ matchup }: { matchup: Matchup }) {
 
 // StatusSection extracted → see GameStatus.tsx
 
-// ─── Scheduled meta (compact 2-column right side) ────────────────────────────
-//
-// Pre-game stack: spread (and O/U) above, then date/time, then broadcasts,
-// then venue. Mirrors what GameStatus renders for Scheduled but stacked
-// vertically in a narrow right column instead of centered full-width.
-
-function ScheduledMeta({
-  matchup,
-  onPressGameDetail,
-}: {
-  matchup: Matchup;
-  onPressGameDetail?: () => void;
-}) {
-  const scheme = useColorScheme();
-  const theme = getTheme(scheme);
-  const userTz = useUserTimeZone();
-
-  const spread = matchup.spreadCurrent;
-  const spreadOpen = matchup.spreadOpen ?? null;
-  const ou = matchup.overUnderCurrent;
-  const ouOpen = matchup.overUnderOpen ?? null;
-  const hasSpread = spread != null;
-  const hasOu = ou != null && ou !== 0;
-
-  const sArrow = spreadArrow(spread, spreadOpen);
-  const oArrow = ouArrow(ou, ouOpen);
-
-  const cityState = [matchup.venueCity, matchup.venueState]
-    .filter(Boolean)
-    .join(', ');
-
-  return (
-    <View style={styles.compactMeta}>
-      {(hasSpread || hasOu) && (
-        <View style={styles.compactOddsStack}>
-          {hasSpread && (
-            <View style={styles.compactOddsLine}>
-              <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>SPREAD </Text>
-              {sArrow && (
-                <Text style={[styles.oddsArrow, { color: sArrow.color }]}>{sArrow.symbol}</Text>
-              )}
-              <Text style={[styles.oddsValue, { color: theme.tint }]}>
-                {spreadLabel(spread)}
-              </Text>
-            </View>
-          )}
-          {hasOu && (
-            <View style={styles.compactOddsLine}>
-              <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>O/U </Text>
-              {oArrow && (
-                <Text style={[styles.oddsArrow, { color: oArrow.color }]}>{oArrow.symbol}</Text>
-              )}
-              <Text style={[styles.oddsValue, { color: theme.tint }]}>{ou}</Text>
-            </View>
-          )}
-        </View>
-      )}
-
-      <Text style={[styles.compactTime, { color: theme.text }]}>
-        {formatToUserTime(matchup.startDateUtc, userTz)}
-      </Text>
-
-      {matchup.broadcasts ? (
-        <Text style={[styles.compactMetaText, { color: theme.textMuted }]} numberOfLines={3}>
-          {matchup.broadcasts}
-        </Text>
-      ) : null}
-
-      {matchup.venue ? (
-        <Text style={[styles.compactMetaText, { color: theme.textMuted }]} numberOfLines={1}>
-          {matchup.venue}
-        </Text>
-      ) : null}
-
-      {cityState ? (
-        <Text style={[styles.compactMetaText, { color: theme.textMuted }]} numberOfLines={1}>
-          {cityState}
-        </Text>
-      ) : null}
-
-      <OverviewLink
-        label="Game Preview"
-        onPress={onPressGameDetail}
-        theme={theme}
-        align="flex-start"
-      />
-    </View>
-  );
-}
-
 // ─── PickButton (mirrors web PickButton component) ───────────────────────────
 //
 // States (parallel to web CSS classes):
@@ -551,9 +459,6 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
 
   const status = enrichedMatchup.status.toLowerCase();
   const isFinal = status === 'final' || status === 'completed';
-  // Compact 2-column layout only applies pre-game — once the game starts,
-  // the score column reactivates and the single-column flow makes more sense.
-  const isScheduled = status === 'scheduled';
 
   // Optimistic local pick — shows selection instantly before server confirms
   const [optimisticFranchiseId, setOptimisticFranchiseId] = useState<string | null>(null);
@@ -658,99 +563,56 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         </View>
       )}
 
-      {isScheduled ? (
-        // ── Compact 2-column layout: team rows on the left, meta on the
-        // right. Active only pre-game; once the game starts, the score
-        // column reactivates and the standard single-column flow returns.
-        <View style={styles.compactRow}>
-          <View style={styles.compactLeft}>
-            <TouchableOpacity
-              onPress={onPressTeam ? () => onPressTeam('away') : undefined}
-              activeOpacity={onPressTeam ? 0.6 : 1}
-              disabled={!onPressTeam}
-            >
-              <TeamRow
-                matchup={enrichedMatchup}
-                side="away"
-                isWinning={!homeIsWinning}
-                isPicked={pickedAway}
-                isPickCorrect={isPickCorrect}
-                isFinal={isFinal}
-              />
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={onPressTeam ? () => onPressTeam('home') : undefined}
-              activeOpacity={onPressTeam ? 0.6 : 1}
-              disabled={!onPressTeam}
-            >
-              <TeamRow
-                matchup={enrichedMatchup}
-                side="home"
-                isWinning={homeIsWinning}
-                isPicked={pickedHome}
-                isPickCorrect={isPickCorrect}
-                isFinal={isFinal}
-              />
-            </TouchableOpacity>
-          </View>
-          <View style={styles.compactRight}>
-            <ScheduledMeta matchup={enrichedMatchup} onPressGameDetail={onPress} />
-          </View>
-        </View>
-      ) : (
-        <>
-          {/* Away team — taps go to the team page, not the contest overview. */}
-          <TouchableOpacity
-            onPress={onPressTeam ? () => onPressTeam('away') : undefined}
-            activeOpacity={onPressTeam ? 0.6 : 1}
-            disabled={!onPressTeam}
-          >
-            <TeamRow
-              matchup={enrichedMatchup}
-              side="away"
-              isWinning={!homeIsWinning}
-              isPicked={pickedAway}
-              isPickCorrect={isPickCorrect}
-              isFinal={isFinal}
-            />
-          </TouchableOpacity>
+      {/* Away team — taps go to the team page, not the contest overview. */}
+      <TouchableOpacity
+        onPress={onPressTeam ? () => onPressTeam('away') : undefined}
+        activeOpacity={onPressTeam ? 0.6 : 1}
+        disabled={!onPressTeam}
+      >
+        <TeamRow
+          matchup={enrichedMatchup}
+          side="away"
+          isWinning={!homeIsWinning}
+          isPicked={pickedAway}
+          isPickCorrect={isPickCorrect}
+          isFinal={isFinal}
+        />
+      </TouchableOpacity>
 
-          {/* Home team */}
-          <TouchableOpacity
-            onPress={onPressTeam ? () => onPressTeam('home') : undefined}
-            activeOpacity={onPressTeam ? 0.6 : 1}
-            disabled={!onPressTeam}
-          >
-            <TeamRow
-              matchup={enrichedMatchup}
-              side="home"
-              isWinning={homeIsWinning}
-              isPicked={pickedHome}
-              isPickCorrect={isPickCorrect}
-              isFinal={isFinal}
-            />
-          </TouchableOpacity>
+      {/* Home team */}
+      <TouchableOpacity
+        onPress={onPressTeam ? () => onPressTeam('home') : undefined}
+        activeOpacity={onPressTeam ? 0.6 : 1}
+        disabled={!onPressTeam}
+      >
+        <TeamRow
+          matchup={enrichedMatchup}
+          side="home"
+          isWinning={homeIsWinning}
+          isPicked={pickedHome}
+          isPickCorrect={isPickCorrect}
+          isFinal={isFinal}
+        />
+      </TouchableOpacity>
 
-          {/* Spread & O/U — tap goes to the contest overview. */}
-          <TouchableOpacity
-            onPress={onPress}
-            activeOpacity={onPress ? 0.75 : 1}
-            disabled={!onPress}
-          >
-            <OddsRow matchup={enrichedMatchup} />
-          </TouchableOpacity>
+      {/* Spread & O/U — tap goes to the contest overview. */}
+      <TouchableOpacity
+        onPress={onPress}
+        activeOpacity={onPress ? 0.75 : 1}
+        disabled={!onPress}
+      >
+        <OddsRow matchup={enrichedMatchup} />
+      </TouchableOpacity>
 
-          {/* Game status — time/score/live; GameStatus owns its own touchable
-              and routes to the contest overview via onPressGameDetail.
-              enriched data drives all status branches; leagueSport dispatches
-              the InProgress UI between baseball and football. */}
-          <GameStatus
-            matchup={enrichedMatchup}
-            leagueSport={leagueSport}
-            onPressGameDetail={onPress}
-          />
-        </>
-      )}
+      {/* Game status — time/score/live; GameStatus owns its own touchable
+          and routes to the contest overview via onPressGameDetail.
+          enriched data drives all status branches; leagueSport dispatches
+          the InProgress UI between baseball and football. */}
+      <GameStatus
+        matchup={enrichedMatchup}
+        leagueSport={leagueSport}
+        onPressGameDetail={onPress}
+      />
 
       {/* Inline pick buttons */}
       {onPick && (
@@ -808,41 +670,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.2,
   },
 
-  // Compact 2-column scheduled layout
-  compactRow: {
-    flexDirection: 'row',
-    alignItems: 'stretch',
-  },
-  compactLeft: {
-    flex: 65,
-  },
-  compactRight: {
-    flex: 35,
-    paddingHorizontal: 10,
-    paddingVertical: 10,
-    justifyContent: 'flex-start',
-  },
-  compactMeta: {
-    gap: 4,
-  },
-  compactOddsStack: {
-    gap: 2,
-    marginBottom: 4,
-  },
-  compactOddsLine: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  compactTime: {
-    fontSize: 12,
-    fontWeight: '600',
-  },
-  compactMetaText: {
-    fontSize: 11,
-    textAlign: 'center',
-  },
-
   // Headline
   headline: {
     backgroundColor: Colors.brand.navy,
@@ -895,7 +722,7 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   recordText: {
-    fontSize: 12,
+    fontSize: 13,
   },
   probablePitcherRow: {
     flexDirection: 'row',
@@ -909,7 +736,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   probablePitcherName: {
-    fontSize: 11,
+    fontSize: 12,
     fontWeight: '500',
     flexShrink: 1,
   },


### PR DESCRIPTION
## Summary

The compact 2-column Scheduled layout shipped in Round 1 (PR #337) didn't survive at 390pt screen widths — iPhone 14 / 12 / 13 / SE-Plus class, which is the bulk of iPhones. The right column had ~105pt of usable space, which forced multi-line wrapping on the date, broadcasts, and venue strings at the small font sizes that fit. Bumping the fonts to fix readability made the wrapping worse. The 2-col only really worked on Pro Max-class phones (430pt+).

Reverts to web's vertical-stack pattern under the team rows: spread → time → broadcasts → venue → city/state → `Game Preview ›` link. Reads cleanly at any width.

Validated visually on iPhone 14 device.

## Changes

### `MatchupCard.tsx`
- Removed the `isScheduled` branch, the `ScheduledMeta` sub-component, and all `compact*` styles. Always renders the standard team-rows + OddsRow + GameStatus slot stack now.
- Dropped unused `OverviewLink` / `formatToUserTime` / `useUserTimeZone` imports.
- `recordText` 12 → 13, `probablePitcherName` 11 → 12.

### `GameStatus.tsx`
- `Game Preview ›` link now renders inside the Scheduled branch (was previously only on InProgress / Final).
- Venue split from city/state onto separate `Text` lines so neither truncates.
- `statusTime` 13 → 14, `statusMeta` 11 → 13.

### `docs/ui/matchup-card-blueprint.md`
- Removed the 2-col carve-out from the slot layout section.
- Added Round 3 entry to "Known drift → Resolved" so the reasoning is preserved and we don't re-litigate the experiment.

## Stats

Net -156 lines (94 insertions / 250 deletions) — bulk is `ScheduledMeta` going away.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Visual check on iPhone 14 (real device): Scheduled cards read at arm's length without leaning in; broadcasts / venue / city no longer wrap or truncate; `Game Preview ›` link appears below the venue line
- [ ] Reviewer spot-check: InProgress and Final states still render correctly (untouched by this PR, but verify no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)