### PR TITLE
fix(mobile): persist auth across cold launches via AsyncStorage

### DIFF
--- a/src/UI/sd-mobile/src/lib/firebase.ts
+++ b/src/UI/sd-mobile/src/lib/firebase.ts
@@ -31,15 +31,23 @@ const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0
 // launch (iOS kills backgrounded apps under memory pressure — without
 // persistence the user re-signs-in every cold open). Must be called exactly
 // once per app instance; on Fast Refresh the app instance is reused, so
-// subsequent calls throw — fall back to getAuth, which returns the
-// already-initialized instance.
+// subsequent calls throw 'auth/already-initialized' — fall back to getAuth
+// for that case only. Any other error means our config is broken (e.g.
+// missing keys, AsyncStorage unavailable); rethrow so we don't silently
+// degrade back to in-memory persistence, which is the bug this file fixes.
 let authInstance: Auth;
 try {
   authInstance = initializeAuth(app, {
     persistence: getReactNativePersistence(AsyncStorage),
   });
-} catch {
-  authInstance = getAuth(app);
+} catch (err) {
+  const code = (err as { code?: string })?.code;
+  if (code === 'auth/already-initialized') {
+    authInstance = getAuth(app);
+  } else {
+    console.error('[firebase] initializeAuth failed unexpectedly', err);
+    throw err;
+  }
 }
 
 export const auth = authInstance;

--- a/src/UI/sd-mobile/src/lib/firebase.ts
+++ b/src/UI/sd-mobile/src/lib/firebase.ts
@@ -1,5 +1,15 @@
 import { initializeApp, getApps } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
+import {
+  getAuth,
+  initializeAuth,
+  // @ts-expect-error — getReactNativePersistence is in firebase/auth's RN
+  // runtime build (resolved by Metro via the "react-native" condition) but
+  // the umbrella package's TypeScript exports map only exposes the browser
+  // surface, so TS can't see it. Known Firebase issue; safe at runtime.
+  getReactNativePersistence,
+  type Auth,
+} from 'firebase/auth';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 /**
  * Firebase config is loaded from EXPO_PUBLIC_ environment variables.
@@ -17,8 +27,20 @@ const firebaseConfig = {
 // Guard against double-initialization in Expo's Fast Refresh.
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
 
-// TODO: wire up AsyncStorage persistence once Firebase's React Native build is
-// correctly resolved by Metro. Currently uses in-memory persistence (auth state
-// lost on full app restart — acceptable for development).
-export const auth = getAuth(app);
+// initializeAuth wires AsyncStorage so the user's session survives cold
+// launch (iOS kills backgrounded apps under memory pressure — without
+// persistence the user re-signs-in every cold open). Must be called exactly
+// once per app instance; on Fast Refresh the app instance is reused, so
+// subsequent calls throw — fall back to getAuth, which returns the
+// already-initialized instance.
+let authInstance: Auth;
+try {
+  authInstance = initializeAuth(app, {
+    persistence: getReactNativePersistence(AsyncStorage),
+  });
+} catch {
+  authInstance = getAuth(app);
+}
+
+export const auth = authInstance;
 export { app };


### PR DESCRIPTION
## Summary

Every cold launch of the iOS app dumps the user back to the sign-in screen, even though their Firebase session is still valid. Real friction — exactly the kind of thing that makes users abandon.

iOS aggressively kills backgrounded apps under memory pressure. The Firebase JS SDK on React Native does *not* persist auth state by default (native Firebase SDKs do; the JS SDK does not). Without persistence wired, every cold launch starts with an empty in-memory auth state.

## Fix

Use `initializeAuth(app, { persistence: getReactNativePersistence(AsyncStorage) })` instead of `getAuth(app)`. AsyncStorage is already a dependency. Function is in `firebase/auth`'s React Native runtime build (resolved by Metro via the `react-native` condition), but the umbrella package's TypeScript exports map only exposes the browser surface — annotated with a `@ts-expect-error` block explaining the gap.

Also handles Fast Refresh: `initializeAuth` can only be called once per app instance, so subsequent calls fall back to `getAuth` (which returns the already-initialized instance).

Resolves the standing TODO in `src/lib/firebase.ts` (the prior comment claimed Metro couldn't resolve the RN build — stale, modern Expo SDK 55 + Firebase 12 resolves cleanly).

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Sign in on iOS dev client
- [ ] Force-quit the app (swipe up from app switcher)
- [ ] Reopen — should land directly in the authenticated app shell, not sign-in
- [ ] Verify the same works after iOS kills the app for memory (harder to test deliberately, but the AsyncStorage-backed persistence is the same mechanism)
- [ ] Sanity: sign out still works (`signOut(auth)` should clear the AsyncStorage entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication persistence to maintain user sessions across app restarts and development refresh cycles in the mobile app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->