### PR TITLE
fix(mobile): left-align tab headers on iOS to match Android + web

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/_layout.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/_layout.tsx
@@ -32,6 +32,11 @@ export default function TabLayout() {
         headerShadowVisible: false,
         headerTintColor: theme.text,
         headerTitleStyle: { fontWeight: '700', fontSize: 18 },
+        // React Navigation defaults headerTitleAlign to 'center' on iOS
+        // (Apple HIG convention) and 'left' on Android. Force 'left' on
+        // both for parity with web — the Wordmark is the brand affordance
+        // and belongs in the top-left across all platforms.
+        headerTitleAlign: 'left',
       }}
     >
       <Tabs.Screen


### PR DESCRIPTION
## Summary

The Wordmark lockup is centered in the iOS production build but left-aligned in dev (Android emulator / Metro web). That's because React Navigation defaults \`headerTitleAlign\` per-platform: 'center' on iOS (Apple HIG convention), 'left' on Android. The Wordmark was designed to live in the top-left across all platforms (web parity) — the iOS centering is wrong for our intent.

## Fix

One line in \`app/(tabs)/_layout.tsx\` — \`headerTitleAlign: 'left'\` on the Tabs \`screenOptions\` block. Applies to all four tab headers (Home, Picks, Standings, Profile) on both platforms.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] iOS dev client / next EAS build: Wordmark renders in the top-left, not centered, on all four tab headers
- [ ] Android: no visual regression (was already left-aligned by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)