### PR TITLE
fix(mobile): guard initializeAuth behind Platform.OS for web bundle

### DIFF
--- a/src/UI/sd-mobile/src/lib/firebase.ts
+++ b/src/UI/sd-mobile/src/lib/firebase.ts
@@ -10,6 +10,7 @@ import {
   type Auth,
 } from 'firebase/auth';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
 
 /**
  * Firebase config is loaded from EXPO_PUBLIC_ environment variables.
@@ -29,24 +30,38 @@ const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0
 
 // initializeAuth wires AsyncStorage so the user's session survives cold
 // launch (iOS kills backgrounded apps under memory pressure — without
-// persistence the user re-signs-in every cold open). Must be called exactly
-// once per app instance; on Fast Refresh the app instance is reused, so
-// subsequent calls throw 'auth/already-initialized' — fall back to getAuth
-// for that case only. Any other error means our config is broken (e.g.
-// missing keys, AsyncStorage unavailable); rethrow so we don't silently
-// degrade back to in-memory persistence, which is the bug this file fixes.
+// persistence the user re-signs-in every cold open).
+//
+// Platform split:
+//   - iOS / Android: initializeAuth with getReactNativePersistence(AsyncStorage)
+//   - Web: getAuth() — Firebase defaults to browserLocalPersistence on web,
+//     which gives the same "session survives reload" via localStorage.
+//     getReactNativePersistence is undefined on the browser build of
+//     firebase/auth, so calling it on web throws TypeError (and breaks
+//     `eas update`'s --platform=all bundle step during static rendering).
+//
+// On native: must be called exactly once per app instance. Fast Refresh
+// reuses the app instance, so subsequent calls throw
+// 'auth/already-initialized' — fall back to getAuth for that case only.
+// Any other error means our config is broken (missing keys, AsyncStorage
+// unavailable); rethrow so we don't silently degrade back to in-memory
+// persistence, which is the bug this file fixes.
 let authInstance: Auth;
-try {
-  authInstance = initializeAuth(app, {
-    persistence: getReactNativePersistence(AsyncStorage),
-  });
-} catch (err) {
-  const code = (err as { code?: string })?.code;
-  if (code === 'auth/already-initialized') {
-    authInstance = getAuth(app);
-  } else {
-    console.error('[firebase] initializeAuth failed unexpectedly', err);
-    throw err;
+if (Platform.OS === 'web') {
+  authInstance = getAuth(app);
+} else {
+  try {
+    authInstance = initializeAuth(app, {
+      persistence: getReactNativePersistence(AsyncStorage),
+    });
+  } catch (err) {
+    const code = (err as { code?: string })?.code;
+    if (code === 'auth/already-initialized') {
+      authInstance = getAuth(app);
+    } else {
+      console.error('[firebase] initializeAuth failed unexpectedly', err);
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

First attempt at the EAS Update smoke test failed: \`eas update --branch production\` couldn't complete its \`--platform=all\` bundle step because the **web** static-render pass crashed with:

\`\`\`
TypeError: (0 , n.getReactNativePersistence) is not a function
    at factory (src/lib/firebase.ts:41:43)
\`\`\`

The browser build of \`firebase/auth\` doesn't export \`getReactNativePersistence\` — it's only in the React Native runtime build (resolved by Metro via the \`react-native\` condition). Our \`initializeAuth(...)\` call at module top-level was unconditional, so the web bundle crashed during load.

The TestFlight iOS bundle was unaffected — \`Platform.OS\` is \`ios\` there and the existing code path works. But \`eas update\` won't ship anything until **all** configured platforms (iOS + Android + Web per \`app.json\`) bundle successfully. This blocks every OTA.

## Fix

Branch on \`Platform.OS\` inside \`firebase.ts\`:

- **Web**: \`getAuth(app)\`. Firebase defaults to \`browserLocalPersistence\` on web — equivalent "session survives reload" via localStorage, no \`getReactNativePersistence\` needed.
- **iOS / Android**: unchanged. \`initializeAuth(app, { persistence: getReactNativePersistence(AsyncStorage) })\` with the same Fast-Refresh \`auth/already-initialized\` fallback we added in #342.

The \`@ts-expect-error\` on the import stays — the symbol is still RN-only from TypeScript's perspective.

## Why no new native build needed

This is a JS-only change. The native binary in TestFlight just runs whatever JS bundle is delivered. Once this PR merges, the next \`eas update\` will publish the platform-aware bundle, devices pick it up on cold launch, and we're unblocked.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] After merge: \`eas update --branch production --message "test: ota verification"\` from \`src/UI/sd-mobile/\`
- [ ] All three platforms (iOS, Android, Web) should bundle successfully this time
- [ ] After two cold launches on iPhone, verify the trivial visible change shipped in the same OTA actually lands
- [ ] Sign-in screen still works (no regression on the auth persistence behavior #342 fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Firebase authentication initialization with better platform-specific handling for enhanced reliability and stability.
* Strengthened authentication persistence across different runtime environments.
* Enhanced error recovery during authentication setup to prevent initialization failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->