### PR TITLE
feat(mobile): user-selectable text size (S | M | L) with AppText wrapper

### DIFF
--- a/docs/mobile/text-size-setting.md
+++ b/docs/mobile/text-size-setting.md
@@ -1,0 +1,333 @@
+# Text size user setting
+
+Companion to `expo-deployment-model.md`. This doc captures the plan
+for a user-facing text-size preference (S | M | L) layered on top of
+the existing theme setting, before any code lands.
+
+Status: **planning** as of 2026-05-21. Nothing wired up yet.
+
+---
+
+## Why now
+
+Two pressures pushed this up the queue:
+
+- iPhone 14 / iPhone 12 Pro readability work in mobile MatchupCard
+  Round 3 (PR #341) shipped font bumps in `MatchupCard` and
+  `GameStatus` to fix small-text complaints. That fix was global —
+  everyone gets the new larger sizes. Some users will want smaller
+  (more density), some will want larger (accessibility). One-size-fits-all
+  is the wrong default.
+- Theme already has a user preference (`light` / `dark` / `system`)
+  and a clean implementation pattern via `ThemeContext`. Text size is
+  the natural sibling — same persistence, same hydration gate, same
+  settings UI slot. Adding it doesn't introduce a new architectural
+  concept.
+
+---
+
+## Scope
+
+### In scope
+
+- Three options surfaced as a `SegmentedControl`: **S | M | L**.
+- Stored per-user in AsyncStorage. Mirrors the theme persistence
+  pattern; doesn't sync to the server (yet).
+- Applies to **all app text** rendered through the canonical Text
+  component. Modals, screens, headers, the works.
+
+### Out of scope (won't fix in this PR)
+
+- Per-surface granular control (one global setting, not "Picks: L,
+  Standings: M").
+- Line height, letter spacing, font weight — only `fontSize` scales.
+- Tab bar labels — they're laid out with fixed dimensions in the
+  Tabs navigator; scaling them risks overflow into the tab bar's
+  fixed 90/72pt height.
+- Wordmark text — the brand lockup uses its own size prop
+  (`<Wordmark size={20} />`). Scaling brand glyphs alongside body
+  text would shift visual hierarchy in ways the design doesn't want.
+- TextInput sizing — RN `TextInput` has its own font-size path.
+  Sign-in form fields will not scale in this PR.
+- Server-side sync (so the preference roams across devices). Worth
+  doing later but the API endpoint and `UserDto` field would need
+  matching changes; defer.
+
+---
+
+## Three concepts
+
+### 1. Scale values
+
+| Option | Multiplier | Effect |
+| ------ | ---------- | ------ |
+| `'small'` (S) | **1.00** | Current sizes (post-Round-3 readability bumps) — no change |
+| `'medium'` (M) | **1.125** | +12.5%. ~16pt body becomes ~18pt |
+| `'large'` (L) | **1.25** | +25%. ~16pt body becomes ~20pt |
+
+Defaults to **small** so existing users see no visual change after
+the feature ships. Larger sizes are opt-in.
+
+Rationale for `1.125` / `1.25`: matches web accessibility convention
+("100/112/125" steps). Tight enough that layouts don't break;
+visible enough that the user feels a real difference between steps.
+
+### 2. The `<AppText>` wrapper
+
+React Native renders text via the `<Text>` primitive. There's no
+parent-to-child font-size cascade — every Text component sets its
+own size. With **150 explicit `fontSize: <number>` declarations
+across 23 files** in the mobile app today, retroactively scaling
+them via a global mechanism requires either:
+
+- A wrapper component that multiplies `fontSize` at render time, OR
+- A migration to semantic tokens (`Typography.body`, etc.).
+
+This doc picks the wrapper. New file:
+
+```tsx
+// src/components/ui/AppText.tsx
+import { Text as RNText, StyleSheet, type TextProps } from 'react-native';
+import { useTextScale } from '@/src/lib/textSize/TextSizeContext';
+
+export function Text(props: TextProps) {
+  const scale = useTextScale();
+  const flat = StyleSheet.flatten(props.style);
+  const scaled =
+    flat && typeof flat.fontSize === 'number'
+      ? { ...flat, fontSize: flat.fontSize * scale }
+      : flat;
+  return (
+    <RNText
+      // Disable OS-level Dynamic Type scaling — our user setting is the
+      // single source of truth. Without this, large iOS Settings → Display
+      // text would compound with our multiplier and produce surprise jumps.
+      allowFontScaling={false}
+      {...props}
+      style={scaled}
+    />
+  );
+}
+```
+
+Then the 23 files swap:
+
+```tsx
+import { Text } from 'react-native';
+// →
+import { Text } from '@/src/components/ui/AppText';
+```
+
+Identical API, drop-in. Any future component that imports `Text`
+from the new path gets scaling automatically.
+
+### 3. Persistence + hydration
+
+Mirror `ThemeContext` line-for-line:
+
+- AsyncStorage key: `text-size`
+- Persisted values: `'small' | 'medium' | 'large'`
+- `isHydrated` flag — splash stays up until both theme AND text-size
+  preferences are read. Without this, a user with stored `'large'`
+  would see a brief paint at `'small'` before snapping bigger.
+
+---
+
+## Current state
+
+Nothing relevant exists yet:
+
+- No `TextSizeContext` or related hook.
+- No `AppText` wrapper — all 23 files import `Text` directly from
+  `react-native`.
+- No settings UI control. The "Appearance" section in
+  `app/(tabs)/profile.tsx` only has the theme `SegmentedControl`.
+- Splash gating in `app/_layout.tsx` waits on theme hydration only.
+
+---
+
+## Recommended sequence
+
+| # | Step | Outcome |
+| - | ---- | ------- |
+| 1 | Add `src/lib/textSize/TextSizeContext.tsx` mirroring `ThemeContext` | Persistence + hook + `isHydrated` flag |
+| 2 | Wrap `<TextSizeProvider>` around the existing `<ThemeProvider>` in `app/_layout.tsx` | Context available app-wide |
+| 3 | Update splash hide gate to wait on both `isHydrated` flags | No font-size-flash on launch |
+| 4 | Add `src/components/ui/AppText.tsx` | The canonical `<Text>` for the app |
+| 5 | Migrate the 23 files to import `Text` from `AppText` | Scaling applies everywhere |
+| 6 | Add "Text Size" `SegmentedControl` to the Appearance section in `profile.tsx` | User can change the setting |
+| 7 | Visual smoke test on iPhone 14 — toggle S/M/L, confirm MatchupCard / picks / sign-in all scale | Confirms the wrapper is in the right places |
+
+Steps 1–6 are mechanical and low-risk. Step 5 is the bulk of the
+diff but is a global find/replace per file.
+
+---
+
+## Decisions to make before editing config
+
+### 1. Storage key + value convention
+
+- **(a)** Key `text-size`, values `'small' | 'medium' | 'large'`
+- **(b)** Key `font-scale`, values `1.0 | 1.125 | 1.25` (raw multipliers)
+
+Recommendation: **(a)**. Symbolic names match the theme pattern
+(`light` / `dark` / `system`) and stay readable when you grep
+AsyncStorage. The multiplier is an implementation detail derived
+from the symbolic name inside the context.
+
+### 2. Where does the settings UI go?
+
+- **(a)** New "Text Size" section in `profile.tsx`, below "Appearance"
+- **(b)** Same "Appearance" section, second `SegmentedControl`
+  stacked below the theme one
+
+Recommendation: **(b)**. Both controls are visual-preference
+adjusters; grouping them keeps the screen tidy. The "System follows
+your device's light/dark setting" hint already exists in
+Appearance — adding a parallel hint under the text-size control
+("Affects all in-app text. Header brand stays fixed.") fits the
+same pattern.
+
+### 3. `allowFontScaling` behavior
+
+- **(a)** Wrapper sets `allowFontScaling={false}` — our setting is
+  the sole source of truth
+- **(b)** Pass through to props default (`true`) — iOS Dynamic Type
+  compounds with our setting
+
+Recommendation: **(a)**. Compounding is a usability trap; a user on
+iOS "XXL" Dynamic Type who then picks our "L" gets an enormous
+result they didn't expect. Single source of truth is the right
+default; the OS-level setting still affects everything outside our
+app.
+
+### 4. Should the `Wordmark` component scale?
+
+- **(a)** No — brand stays fixed
+- **(b)** Yes — wordmark text grows with the rest of the UI
+
+Recommendation: **(a)**. The Wordmark is brand, not body content.
+Scaling it would shift visual hierarchy on every screen where it
+appears (auth header, tab headers, sign-in). It's intentional that
+brand glyphs hold their relative weight.
+
+---
+
+## What changes when we execute
+
+### New files
+
+```
+src/UI/sd-mobile/src/lib/textSize/TextSizeContext.tsx  (~90 lines)
+src/UI/sd-mobile/src/components/ui/AppText.tsx          (~25 lines)
+```
+
+### Modified
+
+- `app/_layout.tsx` — wrap `<TextSizeProvider>`, expand splash gate
+  to wait on both hydration flags.
+- `app/(tabs)/profile.tsx` — add the new SegmentedControl in the
+  Appearance section.
+- The 23 files listed in the migration section below — change `Text`
+  import path.
+
+### Migration mechanics — 23 files, ~150 declarations
+
+```text
+app/create-league.tsx                                          (6 declarations)
+app/+not-found.tsx                                              (2)
+app/(auth)/sign-in.tsx                                          (7)
+app/(tabs)/_layout.tsx                                          (2)
+app/(tabs)/picks.tsx                                            (2)
+app/(tabs)/profile.tsx                                         (10)
+app/(tabs)/standings.tsx                                        (6)
+app/(tabs)/(details)/_layout.tsx                                (1)
+app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx     (18)
+app/(tabs)/(details)/sport/[sport]/[league]/team/[slug].tsx   (11)
+src/components/ui/SegmentedControl.tsx                          (1)
+src/components/ui/Button.tsx                                    (3)
+src/components/ui/EmptyState.tsx                                (3)
+src/components/ui/LoadingSpinner.tsx                            (1)
+src/components/features/games/GameStatus.tsx                   (13)
+src/components/features/games/InsightModal.tsx                 (14)
+src/components/features/games/MatchupCard.tsx                  (18)
+src/components/features/games/StatsComparisonModal.tsx          (9)
+src/components/features/home/PrimarySlotNewUser.tsx             (3)
+src/components/features/home/PrimarySlotOffSeasonCountdown.tsx  (3)
+src/components/features/home/YourLeaguesCard.tsx                (3)
+src/components/features/selectors/LeagueWeekSelector.tsx        (3)
+src/components/features/settings/TimezonePickerModal.tsx       (11)
+```
+
+The migration is mechanical: per file, change the `Text` import
+from `react-native` to `@/src/components/ui/AppText`. The
+`fontSize:` values stay as-is — they're now scale baselines, not
+final sizes.
+
+Files NOT in the migration:
+
+- `src/components/brand/Wordmark.tsx` — keeps `Text` from
+  `react-native` directly, scales via its own `size` prop. See
+  decision 4 above.
+
+---
+
+## Steady-state usage
+
+Once shipped:
+
+- New components should `import { Text } from '@/src/components/ui/AppText'`
+  by default. Lint rule maybe (deferred — convention first, enforcement
+  if drift becomes a problem).
+- New `fontSize` values declared anywhere in the app are baselines.
+  They get multiplied at render time. The number written in code is
+  what "small" users see.
+- Brand-locked surfaces (Wordmark, eventually badges if we add them)
+  import `Text` from `react-native` directly to opt out.
+
+---
+
+## Gotchas to watch for
+
+1. **Layout overflow at L.** A 25% increase can push fixed-width
+   text into wrap or truncation territory. The Round 3 stack
+   layout is robust (it's vertical) but anything with `numberOfLines={1}`
+   plus a fixed container width is at risk. Visual smoke test should
+   exercise: MatchupCard team rows at L (Cleveland Guardians +
+   3-digit record), Picks selector at L, Standings tables at L.
+2. **Tab bar height.** Tab labels are NOT scaled (out of scope),
+   but if anyone forgets and migrates `_layout.tsx`'s tab styles to
+   AppText, the bottom tabs will distort. The intentional carve-out
+   needs a code comment.
+3. **Modals.** RN modals can clip at the edges if internal text
+   wraps unexpectedly. Test `InsightModal`, `StatsComparisonModal`,
+   `TimezonePickerModal` at L.
+4. **TextInput.** Form inputs (sign-in) won't scale until a follow-up
+   PR. Worth noting in the user-facing hint text under the control
+   ("Affects all in-app text" is slightly aspirational right now).
+5. **iOS Dynamic Type.** Setting `allowFontScaling={false}` is a
+   deliberate trade-off — power users who rely on OS-level Dynamic
+   Type will get less than they expect from our app. Mitigation: our
+   in-app S/M/L gives the same effect; the choice is whether to
+   surface that in the "Affects all in-app text" hint.
+6. **Static rendering / web export.** The `eas update --platform=all`
+   web bundle pass evaluates code paths during static rendering. If
+   `TextSizeContext` is consumed at module-evaluation time anywhere
+   (it shouldn't be — only in render), the web export could choke.
+   Mirror the `Platform.OS === 'web'` defensive pattern from
+   `firebase.ts` (PR #345) if the smoke test trips.
+
+---
+
+## References
+
+- `src/lib/theme/ThemeContext.tsx` — the canonical pattern this
+  feature mirrors line-for-line.
+- `app/(tabs)/profile.tsx` — settings UI placement; the existing
+  theme `SegmentedControl` is the visual model.
+- `docs/ui/matchup-card-blueprint.md` — Round 3 readability bumps
+  context that motivated this feature.
+- `docs/mobile/eas-update.md` — sibling user-preference / settings
+  doc style for tone and structure.
+- Web parity: sd-ui has no font-size preference yet either; if this
+  ships well on mobile we should mirror on web.

--- a/docs/mobile/text-size-setting.md
+++ b/docs/mobile/text-size-setting.md
@@ -150,16 +150,27 @@ Mirror `ThemeContext` line-for-line:
 
 ---
 
-## Current state
+## Current state (as of PR #346, 2026-05-21)
 
-Nothing relevant exists yet:
+All four pieces are wired up:
 
-- No `TextSizeContext` or related hook.
-- No `AppText` wrapper — all 23 files import `Text` directly from
-  `react-native`.
-- No settings UI control. The "Appearance" section in
-  `app/(tabs)/profile.tsx` only has the theme `SegmentedControl`.
-- Splash gating in `app/_layout.tsx` waits on theme hydration only.
+- `TextSizeContext` lives at `src/lib/textSize/TextSizeContext.tsx` —
+  provider, `useTextSize` (mode + setter + `isHydrated`), `useTextScale`
+  (multiplier), AsyncStorage persistence under key `text-size`.
+- `AppText` wrapper at `src/components/ui/AppText.tsx` — drop-in
+  `<Text>` that multiplies `fontSize` by the current scale and sets
+  `allowFontScaling={false}` so iOS Dynamic Type doesn't compound.
+- Settings UI in `app/(tabs)/profile.tsx` — second `SegmentedControl`
+  (S | M | L) in the Appearance section with the hint "Affects all
+  in-app text. Header brand stays fixed."
+- Splash gating in `app/_layout.tsx` — `<TextSizeProvider>` wraps
+  `<RootLayoutNav>`, and `SplashScreen.hideAsync()` waits on both the
+  theme and text-size `isHydrated` flags before revealing the UI.
+
+22 component / screen files were migrated to import `Text` from the
+new `AppText` path. `src/components/brand/Wordmark.tsx` was
+intentionally left importing `Text` directly from `react-native` so
+the brand lockup stays fixed regardless of the user's preference.
 
 ---
 
@@ -234,7 +245,7 @@ brand glyphs hold their relative weight.
 
 ### New files
 
-```
+```text
 src/UI/sd-mobile/src/lib/textSize/TextSizeContext.tsx  (~90 lines)
 src/UI/sd-mobile/src/components/ui/AppText.tsx          (~25 lines)
 ```

--- a/docs/mobile/text-size-setting.md
+++ b/docs/mobile/text-size-setting.md
@@ -1,10 +1,27 @@
 # Text size user setting
 
-Companion to `expo-deployment-model.md`. This doc captures the plan
-for a user-facing text-size preference (S | M | L) layered on top of
-the existing theme setting, before any code lands.
+Companion to `expo-deployment-model.md`. Captures the design for a
+user-facing text-size preference (S | M | L) layered on top of the
+existing theme setting.
 
-Status: **planning** as of 2026-05-21. Nothing wired up yet.
+Status: **implemented** as of 2026-05-21 (PR #346). Forward-looking
+sections below ("Current state", "Recommended sequence") preserve the
+original planning content for posterity — what actually shipped is
+summarized here:
+
+- `src/lib/textSize/TextSizeContext.tsx` — provider, `useTextSize`,
+  `useTextScale`, AsyncStorage persistence, `isHydrated` flag.
+- `src/components/ui/AppText.tsx` — drop-in `<Text>` wrapper that
+  multiplies `fontSize` by the current scale; `allowFontScaling={false}`.
+- `app/_layout.tsx` — `<TextSizeProvider>` wraps `<RootLayoutNav>`;
+  splash `hideAsync()` waits on theme AND text-size hydration.
+- `app/(tabs)/profile.tsx` — second `SegmentedControl` (S | M | L)
+  in the Appearance section with the hint "Affects all in-app text.
+  Header brand stays fixed."
+- 22 component / screen files migrated from
+  `import { Text } from 'react-native'` to
+  `import { Text } from '@/src/components/ui/AppText'`. `Wordmark.tsx`
+  is intentionally excluded.
 
 ---
 

--- a/src/UI/sd-mobile/app/(auth)/sign-in.tsx
+++ b/src/UI/sd-mobile/app/(auth)/sign-in.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   View,
-  Text,
   TextInput,
   StyleSheet,
   KeyboardAvoidingView,
@@ -9,6 +8,7 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';

--- a/src/UI/sd-mobile/app/(tabs)/(details)/_layout.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack, useRouter } from 'expo-router';
-import { TouchableOpacity, Text, StyleSheet, Platform } from 'react-native';
+import { TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { useNavigationState } from '@react-navigation/native';
 import { getTheme } from '@/constants/Colors';

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   View,
-  Text,
   Image,
   StyleSheet,
   ScrollView,
@@ -9,6 +8,7 @@ import {
   Alert,
 } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/team/[slug].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/team/[slug].tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import {
   View,
-  Text,
   Image,
   ScrollView,
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   View,
-  Text,
   FlatList,
   StyleSheet,
   RefreshControl,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
   TouchableOpacity,
   Alert,
@@ -9,7 +8,9 @@ import {
 } from 'react-native';
 import { signOut } from 'firebase/auth';
 import { useQueryClient } from '@tanstack/react-query';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme, useThemeMode, type ThemeMode } from '@/src/lib/theme/ThemeContext';
+import { useTextSize, type TextSize } from '@/src/lib/textSize/TextSizeContext';
 import { getTheme } from '@/constants/Colors';
 import { auth } from '@/src/lib/firebase';
 import { useAuthStore } from '@/src/stores/authStore';
@@ -85,6 +86,12 @@ const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: 'system', label: 'System' },
 ];
 
+const TEXT_SIZE_OPTIONS: { value: TextSize; label: string }[] = [
+  { value: 'small', label: 'S' },
+  { value: 'medium', label: 'M' },
+  { value: 'large', label: 'L' },
+];
+
 // Device default — Hermes exposes Intl.DateTimeFormat().resolvedOptions().
 // We use this to pre-populate the picker when the user hasn't picked a tz
 // yet. We do NOT auto-save the device tz; the user must explicitly confirm.
@@ -102,6 +109,7 @@ export default function ProfileScreen() {
   const { user } = useAuthStore();
   const { data: me } = useCurrentUser();
   const { mode, setMode } = useThemeMode();
+  const { size: textSize, setSize: setTextSize } = useTextSize();
   const queryClient = useQueryClient();
 
   const deviceTz = useMemo(() => detectDeviceTimezone(), []);
@@ -201,6 +209,15 @@ export default function ProfileScreen() {
           />
           <Text style={[styles.sectionHint, { color: theme.textMuted }]}>
             System follows your device's light/dark setting.
+          </Text>
+          <SegmentedControl
+            value={textSize}
+            options={TEXT_SIZE_OPTIONS}
+            onChange={setTextSize}
+            accessibilityLabel="Text size"
+          />
+          <Text style={[styles.sectionHint, { color: theme.textMuted }]}>
+            Affects all in-app text. Header brand stays fixed.
           </Text>
         </View>
       </View>

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {
   View,
-  Text,
   FlatList,
   StyleSheet,
   RefreshControl,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';

--- a/src/UI/sd-mobile/app/+not-found.tsx
+++ b/src/UI/sd-mobile/app/+not-found.tsx
@@ -1,5 +1,6 @@
 import { Link, Stack } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 
 export default function NotFoundScreen() {
   return (

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -16,6 +16,7 @@ import 'react-native-reanimated';
 import { queryClient } from '@/src/lib/queryClient';
 import { useAuthInit, useAuth } from '@/src/hooks/useAuth';
 import { ThemeProvider, useThemeMode } from '@/src/lib/theme/ThemeContext';
+import { TextSizeProvider, useTextSize } from '@/src/lib/textSize/TextSizeContext';
 import { SignalRGate } from '@/src/components/signalR/SignalRGate';
 
 export {
@@ -86,7 +87,9 @@ function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <RootLayoutNav />
+        <TextSizeProvider>
+          <RootLayoutNav />
+        </TextSizeProvider>
       </ThemeProvider>
     </QueryClientProvider>
   );
@@ -99,14 +102,16 @@ export default Sentry.wrap(RootLayout);
 function RootLayoutNav() {
   // Feed the user-resolved scheme into React Navigation so native header
   // transitions and focus rings match the chosen theme.
-  const { resolvedScheme, isHydrated } = useThemeMode();
+  const { resolvedScheme, isHydrated: themeHydrated } = useThemeMode();
+  const { isHydrated: textSizeHydrated } = useTextSize();
 
-  // Second splash gate: fonts loaded + theme hydrated from AsyncStorage.
-  // Keeps the splash visible through the full startup path so the first
-  // painted pixels already reflect the user's stored preference.
+  // Second splash gate: fonts loaded + BOTH user preferences hydrated from
+  // AsyncStorage. Keeps the splash visible through the full startup path
+  // so the first painted pixels already reflect every stored preference
+  // (no theme flash, no font-size flash on launch).
   useEffect(() => {
-    if (isHydrated) SplashScreen.hideAsync();
-  }, [isHydrated]);
+    if (themeHydrated && textSizeHydrated) SplashScreen.hideAsync();
+  }, [themeHydrated, textSizeHydrated]);
 
   return (
     <NavThemeProvider value={resolvedScheme === 'dark' ? DarkTheme : DefaultTheme}>

--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import {
   View,
-  Text,
   TextInput,
   StyleSheet,
   KeyboardAvoidingView,
@@ -11,6 +10,7 @@ import {
   TouchableOpacity,
   Alert,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
+import { View, TouchableOpacity, StyleSheet, Image } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { Matchup } from '@/src/types/models';

--- a/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {
   Modal,
   View,
-  Text,
   ScrollView,
   TouchableOpacity,
   Image,
   StyleSheet,
   ActivityIndicator,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, PreviewResponse } from '@/src/types/models';

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
+import { View, TouchableOpacity, StyleSheet, Image } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, UserPick, PickChoice, PreviewResponse, TeamComparisonData } from '@/src/types/models';

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -2,13 +2,13 @@ import React, { useState } from 'react';
 import {
   Modal,
   View,
-  Text,
   ScrollView,
   TouchableOpacity,
   Image,
   StyleSheet,
   ActivityIndicator,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, TeamComparisonData, TeamStatEntry } from '@/src/types/models';

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotNewUser.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotNewUser.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { Button } from '@/src/components/ui/Button';

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { Button } from '@/src/components/ui/Button';

--- a/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { useRouter } from 'expo-router';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { League } from '@/src/types/models';

--- a/src/UI/sd-mobile/src/components/features/selectors/LeagueWeekSelector.tsx
+++ b/src/UI/sd-mobile/src/components/features/selectors/LeagueWeekSelector.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import {
   View,
-  Text,
   TouchableOpacity,
   StyleSheet,
   LayoutAnimation,
   Platform,
   UIManager,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { League } from '@/src/types/models';

--- a/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   Modal,
   View,
-  Text,
   TouchableOpacity,
   StyleSheet,
   FlatList,
   TextInput,
   ActivityIndicator,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import { DEFAULT_TIMEZONE } from '@/src/utils/timeUtils';

--- a/src/UI/sd-mobile/src/components/ui/AppText.tsx
+++ b/src/UI/sd-mobile/src/components/ui/AppText.tsx
@@ -31,5 +31,9 @@ export function Text(props: TextProps) {
     flat && typeof flat.fontSize === 'number'
       ? { ...flat, fontSize: flat.fontSize * scale }
       : flat;
-  return <RNText allowFontScaling={false} {...props} style={scaled} />;
+  // allowFontScaling={false} sits AFTER the spread so callers can't
+  // reintroduce OS-level font scaling and re-create the compound-scaling
+  // footgun this wrapper exists to prevent. style stays last so it wins
+  // over any style in props (multiplied fontSize is the whole point).
+  return <RNText {...props} allowFontScaling={false} style={scaled} />;
 }

--- a/src/UI/sd-mobile/src/components/ui/AppText.tsx
+++ b/src/UI/sd-mobile/src/components/ui/AppText.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Text as RNText, StyleSheet, type TextProps } from 'react-native';
+import { useTextScale } from '@/src/lib/textSize/TextSizeContext';
+
+/**
+ * Canonical `<Text>` for the app. Drop-in replacement for React Native's
+ * `Text` that multiplies any `fontSize` in `style` by the user's current
+ * text-size preference (S/M/L → 1.0 / 1.125 / 1.25).
+ *
+ * Why this exists: React Native has no parent-to-child font-size cascade,
+ * so retro-fitting a single user setting onto ~150 `fontSize:` declarations
+ * across 23 files requires either a wrapper at render time or a token
+ * migration. The wrapper is mechanical to introduce; the migration would be
+ * a multi-week effort. See docs/mobile/text-size-setting.md for the
+ * decision rationale.
+ *
+ * Why `allowFontScaling={false}`: iOS Settings → Display → Text Size
+ * (Dynamic Type) and our in-app S/M/L would otherwise compound — a user
+ * on iOS "XXL" who picks "L" would get a surprise giant result. Our
+ * setting is the single source of truth for in-app text. The OS-level
+ * setting still scales text outside our app.
+ *
+ * Opt-out: brand surfaces (the `<Wordmark>` lockup, e.g.) import `Text`
+ * directly from `react-native` so their size stays fixed regardless of
+ * the user's preference.
+ */
+export function Text(props: TextProps) {
+  const scale = useTextScale();
+  const flat = StyleSheet.flatten(props.style);
+  const scaled =
+    flat && typeof flat.fontSize === 'number'
+      ? { ...flat, fontSize: flat.fontSize * scale }
+      : flat;
+  return <RNText allowFontScaling={false} {...props} style={scaled} />;
+}

--- a/src/UI/sd-mobile/src/components/ui/Button.tsx
+++ b/src/UI/sd-mobile/src/components/ui/Button.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
   TouchableOpacity,
-  Text,
   ActivityIndicator,
   StyleSheet,
   type ViewStyle,
   type TextStyle,
 } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 

--- a/src/UI/sd-mobile/src/components/ui/EmptyState.tsx
+++ b/src/UI/sd-mobile/src/components/ui/EmptyState.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 

--- a/src/UI/sd-mobile/src/components/ui/LoadingSpinner.tsx
+++ b/src/UI/sd-mobile/src/components/ui/LoadingSpinner.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, ActivityIndicator, Text, StyleSheet } from 'react-native';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { getTheme } from '@/constants/Colors';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 

--- a/src/UI/sd-mobile/src/components/ui/SegmentedControl.tsx
+++ b/src/UI/sd-mobile/src/components/ui/SegmentedControl.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 

--- a/src/UI/sd-mobile/src/lib/textSize/TextSizeContext.tsx
+++ b/src/UI/sd-mobile/src/lib/textSize/TextSizeContext.tsx
@@ -1,0 +1,114 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * User-selected text size. Maps to a font-size multiplier applied by the
+ * canonical `<Text>` wrapper in src/components/ui/AppText. Default is
+ * `small` so existing users see no visual change when the feature ships.
+ *
+ * Mirrors `ThemeContext` line-for-line — persistence, hydration gate,
+ * hook shape, and provider mounting pattern are identical so the two
+ * settings stay structurally interchangeable for future readers.
+ */
+export type TextSize = 'small' | 'medium' | 'large';
+
+const STORAGE_KEY = 'text-size';
+const VALID_SIZES: TextSize[] = ['small', 'medium', 'large'];
+
+/**
+ * Scale multipliers per size. 12.5% / 25% steps mirror web accessibility
+ * conventions ("100/112/125") — tight enough that layouts don't break,
+ * visible enough that the user feels a real difference between steps.
+ */
+const SCALE_FOR: Record<TextSize, number> = {
+  small: 1.0,
+  medium: 1.125,
+  large: 1.25,
+};
+
+interface TextSizeContextValue {
+  size: TextSize;
+  setSize: (size: TextSize) => void;
+  /** Multiplier derived from `size`. Components shouldn't need this directly — use `useTextScale()`. */
+  scale: number;
+  /**
+   * False until the persisted text-size preference has been read from
+   * AsyncStorage. The splash screen controller in app/_layout.tsx waits
+   * on this (alongside the theme `isHydrated`) so the first painted
+   * pixels already reflect the stored preference.
+   */
+  isHydrated: boolean;
+}
+
+const TextSizeContext = createContext<TextSizeContextValue | null>(null);
+
+function isValidSize(value: unknown): value is TextSize {
+  return typeof value === 'string' && (VALID_SIZES as string[]).includes(value);
+}
+
+export function TextSizeProvider({ children }: { children: React.ReactNode }) {
+  const [size, setSizeState] = useState<TextSize>('small');
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  // Load persisted preference on mount. Any parse failure silently falls
+  // back to `small` — corrupt storage shouldn't crash the app. The
+  // `mounted` flag guards setState-after-unmount in tests / HMR teardown.
+  useEffect(() => {
+    let mounted = true;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((raw) => {
+        if (!mounted) return;
+        if (isValidSize(raw)) setSizeState(raw);
+      })
+      .catch(() => {
+        // ignore — keep default
+      })
+      .finally(() => {
+        if (mounted) setIsHydrated(true);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const setSize = useCallback((next: TextSize) => {
+    setSizeState(next);
+    AsyncStorage.setItem(STORAGE_KEY, next).catch(() => {
+      // persistence is best-effort; in-memory state is authoritative for the session
+    });
+  }, []);
+
+  const value = useMemo<TextSizeContextValue>(
+    () => ({ size, setSize, scale: SCALE_FOR[size], isHydrated }),
+    [size, setSize, isHydrated],
+  );
+
+  return <TextSizeContext.Provider value={value}>{children}</TextSizeContext.Provider>;
+}
+
+/** Exposes mode + setter + hydration flag for the settings selector UI. */
+export function useTextSize(): TextSizeContextValue {
+  const ctx = useContext(TextSizeContext);
+  if (!ctx) {
+    throw new Error('useTextSize must be used within a <TextSizeProvider>');
+  }
+  return ctx;
+}
+
+/**
+ * Returns the current font-size multiplier. Used by the `<AppText>`
+ * wrapper. Falls back to 1.0 if the provider isn't mounted (e.g. in
+ * tests rendering a component in isolation) so consumers don't crash
+ * out of context.
+ */
+export function useTextScale(): number {
+  const ctx = useContext(TextSizeContext);
+  return ctx ? ctx.scale : 1.0;
+}


### PR DESCRIPTION
## Summary

Adds a per-user text-size preference (S | M | L) layered on top of the existing theme setting. Same persistence pattern, same Profile-screen settings UI location. Lays groundwork for accessibility and per-user readability tuning that the Round 3 MatchupCard readability bumps (#341) could only address globally.

Full rollout plan + decisions captured in [\`docs/mobile/text-size-setting.md\`](docs/mobile/text-size-setting.md) — worth reading before reviewing.

## Scale

| Option | Multiplier | Effect |
|---|---|---|
| **S** (small) | 1.00× | Current sizes — no change for existing users |
| **M** (medium) | 1.125× | +12.5% |
| **L** (large) | 1.25× | +25% |

Default is **small** so existing users see no visual change. Mirrors web accessibility "100/112/125" conventions — tight enough not to break layouts, visible enough that each step feels real.

## Architecture

### \`TextSizeContext\` — mirrors \`ThemeContext\` line-for-line
- AsyncStorage key: \`text-size\`
- Values: \`'small' | 'medium' | 'large'\`
- \`isHydrated\` flag, splash hide gates on theme AND text-size both hydrated
- \`useTextSize()\` and \`useTextScale()\` hooks

### \`<AppText>\` wrapper (new)
- Drop-in replacement for RN's \`Text\`
- Multiplies any \`fontSize\` in \`style\` by the current scale
- Sets \`allowFontScaling={false}\` — single source of truth (no compounding with iOS Dynamic Type)
- ~25 lines total

### Migration — 22 files
\`import { Text } from 'react-native'\` → \`import { Text } from '@/src/components/ui/AppText'\`. Mechanical, drop-in. **\`Wordmark.tsx\` is intentionally excluded** — brand stays fixed (decision 4 in the doc).

## UI

Profile screen "Appearance" section gets a second \`SegmentedControl\` below the theme one:

\`\`\`
Light  |  Dark  |  System          ← existing
System follows your device's light/dark setting.

S  |  M  |  L                       ← new
Affects all in-app text. Header brand stays fixed.
\`\`\`

## Out of scope (deferred)

- TextInput sizing (sign-in form fields)
- Tab bar label sizing (fixed nav-bar height)
- Wordmark text sizing (brand)
- Server-side sync (AsyncStorage only)
- Line-height, letter-spacing, weight adjustments

See doc Section "Out of scope" for rationale on each.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Open Profile screen, toggle S/M/L — Appearance section shows the new control with the hint
- [ ] Confirm MatchupCard text scales with each step (the original pain point)
- [ ] Confirm contest overview, picks, standings, sign-in all scale at L
- [ ] Confirm Wordmark / app icon / tab labels stay fixed (intentional carve-outs)
- [ ] Cold-launch on iOS with stored \`large\`: no font-size flash on splash hide
- [ ] iOS Settings → Display → Text Size set to XXL: app text does NOT compound (because \`allowFontScaling={false}\`)
- [ ] Visual regression at L on iPhone 14: any text truncation or layout overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adjustable text-size in Profile → Appearance (S/M/L) with persistent storage and restored on startup; splash now waits for text-size + theme hydration.
  * App-wide text scaling applied consistently via a canonical text wrapper.

* **Refactor**
  * App switched to a unified text component across screens and UI elements for consistent sizing.

* **Documentation**
  * Docs updated to mark text-size design as implemented and include migration notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->