### PR TITLE
feat(mobile): swap to dark-mode logo variants in MatchupCard

### DIFF
--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -485,7 +485,33 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
 
   const handleOpenStats = async () => {
     setShowStats(true);
-    if (statsData) return; // already loaded
+
+    // Resolve the logo URI against the live scheme. Same fallback rule as
+    // TeamRow. Computed at the top of the handler so the cache check below
+    // can compare against current values and refresh if the user toggled
+    // themes between opens.
+    const awayLogoUri =
+      scheme === 'dark' ? (matchup.awayLogoUriDark ?? matchup.awayLogoUri) : matchup.awayLogoUri;
+    const homeLogoUri =
+      scheme === 'dark' ? (matchup.homeLogoUriDark ?? matchup.homeLogoUri) : matchup.homeLogoUri;
+
+    // Stats / metrics are cached across opens, but the resolved logo URIs
+    // depend on the active theme. If the user toggled themes between
+    // opens, refresh just the logoUri fields on the existing cache —
+    // don't re-fetch stats.
+    if (statsData) {
+      if (
+        statsData.teamA.logoUri !== awayLogoUri ||
+        statsData.teamB.logoUri !== homeLogoUri
+      ) {
+        setStatsData({
+          teamA: { ...statsData.teamA, logoUri: awayLogoUri },
+          teamB: { ...statsData.teamB, logoUri: homeLogoUri },
+        });
+      }
+      return;
+    }
+
     setStatsLoading(true);
     try {
       const [awayStats, homeStats, awayMetrics, homeMetrics] = await Promise.all([
@@ -494,13 +520,6 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         teamCardApi.getMetrics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId),
         teamCardApi.getMetrics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId),
       ]);
-      // Resolve the logo URI at modal-open time so the StatsComparisonModal
-      // gets the dark-mode variant when appropriate. Same fallback rule as
-      // TeamRow above.
-      const awayLogoUri =
-        scheme === 'dark' ? (matchup.awayLogoUriDark ?? matchup.awayLogoUri) : matchup.awayLogoUri;
-      const homeLogoUri =
-        scheme === 'dark' ? (matchup.homeLogoUriDark ?? matchup.homeLogoUri) : matchup.homeLogoUri;
       setStatsData({
         teamA: { name: matchup.away, logoUri: awayLogoUri, stats: awayStats, metrics: awayMetrics },
         teamB: { name: matchup.home, logoUri: homeLogoUri, stats: homeStats, metrics: homeMetrics },

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -82,7 +82,14 @@ function TeamRow({
   const isHome = side === 'home';
   const name = isHome ? matchup.home : matchup.away;
   const abbr = isHome ? matchup.homeShort : matchup.awayShort;
-  const logoUrl = isHome ? matchup.homeLogoUri : matchup.awayLogoUri;
+  // Dark-mode logo swap: some teams have a *Dark variant for use against
+  // a dark surface (e.g. dark-on-white wordmarks that disappear against
+  // theme.card in dark mode). Falls back to the default variant when no
+  // dark version exists. Mirrors web's pattern in
+  // sd-ui/src/components/matchups/MatchupCard.jsx.
+  const logoUriLight = isHome ? matchup.homeLogoUri : matchup.awayLogoUri;
+  const logoUriDark = isHome ? matchup.homeLogoUriDark : matchup.awayLogoUriDark;
+  const logoUrl = scheme === 'dark' ? (logoUriDark ?? logoUriLight) : logoUriLight;
   const rank = isHome ? matchup.homeRank : matchup.awayRank;
   const score = isHome ? matchup.homeScore : matchup.awayScore;
   const wins = isHome ? matchup.homeWins : matchup.awayWins;
@@ -487,9 +494,16 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         teamCardApi.getMetrics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId),
         teamCardApi.getMetrics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId),
       ]);
+      // Resolve the logo URI at modal-open time so the StatsComparisonModal
+      // gets the dark-mode variant when appropriate. Same fallback rule as
+      // TeamRow above.
+      const awayLogoUri =
+        scheme === 'dark' ? (matchup.awayLogoUriDark ?? matchup.awayLogoUri) : matchup.awayLogoUri;
+      const homeLogoUri =
+        scheme === 'dark' ? (matchup.homeLogoUriDark ?? matchup.homeLogoUri) : matchup.homeLogoUri;
       setStatsData({
-        teamA: { name: matchup.away, logoUri: matchup.awayLogoUri, stats: awayStats, metrics: awayMetrics },
-        teamB: { name: matchup.home, logoUri: matchup.homeLogoUri, stats: homeStats, metrics: homeMetrics },
+        teamA: { name: matchup.away, logoUri: awayLogoUri, stats: awayStats, metrics: awayMetrics },
+        teamB: { name: matchup.home, logoUri: homeLogoUri, stats: homeStats, metrics: homeMetrics },
       });
     } catch (err) {
       console.warn('[MatchupCard] stats fetch error', err);

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -41,6 +41,8 @@ export interface Matchup {
   awaySlug: string;
   awayFranchiseSeasonId: string;
   awayLogoUri?: string | null;
+  /** Dark-theme variant. Falls back to awayLogoUri when null. */
+  awayLogoUriDark?: string | null;
   awayColor?: string | null;
   awayRank?: number | null;
   awayWins?: number;
@@ -54,6 +56,8 @@ export interface Matchup {
   homeSlug: string;
   homeFranchiseSeasonId: string;
   homeLogoUri?: string | null;
+  /** Dark-theme variant. Falls back to homeLogoUri when null. */
+  homeLogoUriDark?: string | null;
   homeColor?: string | null;
   homeRank?: number | null;
   homeWins?: number;


### PR DESCRIPTION
## Summary

Backend's \`MatchupForPickDto\` has carried \`HomeLogoUriDark\` / \`AwayLogoUriDark\` for a while — web's \`MatchupCard.jsx\` uses them via \`useTheme()\`, mobile was just not consuming the fields. Result: teams whose default logo has dark elements (dark wordmarks, brown-on-brown helmets, etc.) rendered with poor contrast against \`theme.card\` in dark mode. Real eyesore on the picks list.

Closes the parent \"Dark-mode logo variants\" drift item from the MatchupCard blueprint. Contest Overview + Team Card surfaces are tracked as follow-ups in \`docs/mobile/working-queue.md\` — both need backend DTO additions before mobile can consume.

## Changes

### \`src/types/models.ts\`
Added two optional, nullable fields to the \`Matchup\` interface:
- \`homeLogoUriDark?: string | null\`
- \`awayLogoUriDark?: string | null\`

### \`src/components/features/games/MatchupCard.tsx\`
- **\`TeamRow\`**: resolves logo URI based on the active color scheme. Falls back to the default variant when a team has no dark version.
  \`\`\`tsx
  const logoUriLight = isHome ? matchup.homeLogoUri : matchup.awayLogoUri;
  const logoUriDark = isHome ? matchup.homeLogoUriDark : matchup.awayLogoUriDark;
  const logoUrl = scheme === 'dark' ? (logoUriDark ?? logoUriLight) : logoUriLight;
  \`\`\`
  Mirrors the web pattern exactly.
- **\`handleOpenStats\`**: applies the same swap to the data passed into \`StatsComparisonModal\` so the modal's team logos pick the right variant.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Visual smoke test on real device — confirmed feature works in dark theme
- [ ] Reviewer: toggle Light → Dark theme on the picks list, confirm teams with known dark variants show different artwork in each scheme
- [ ] Open the Stats comparison modal on a card in dark theme; verify the team logos inside the modal are also dark variants

## Out of scope

- \`ContestOverviewDto\` and \`TeamCardDto\` don't carry dark variants on the wire yet. Backend DTO additions required before the contest overview header and team card screen can swap. Tracked in working-queue.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark-mode support for team logos across the app; matchup cards and stats comparison modals show theme-appropriate logo variants with automatic fallback to standard logos.
  * Stats comparison now updates displayed team logos when you open the modal after switching themes, ensuring consistent visuals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->