### PR TITLE
feat(web): dark/light logo swap for ContestOverviewHeader

### DIFF
--- a/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useTheme } from "../../contexts/ThemeContext";
 import { teamLink } from '../../utils/sportLinks';
 import BoxScoreTable from "../shared/BoxScoreTable";
 import "./ContestOverview.css";
 
 export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScores, homeTeamColor, awayTeamColor, seasonYear, sport, league }) {
+  const { theme } = useTheme() ?? {};
+  const pickLogo = (t) =>
+    theme === 'dark'
+      ? (t.logoUrlDark || t.logoUrl)
+      : (t.logoUrlLight || t.logoUrl);
   // Normalize and muted color helpers (small subset copied from TeamComparison)
   const normalizeColor = (color) => {
     if (typeof color === 'string' && color.length === 6 && !color.startsWith('#')) return `#${color}`;
@@ -35,7 +41,7 @@ export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScore
       <div className="contest-header-row contest-header-flex">
         {/* Away Side */}
         <div className="contest-team-logo-wrap" style={awayTeamColor ? { background: normAwayBg, borderColor: 'rgba(255,255,255,0.06)' } : {}}>
-          <img src={awayTeam.logoUrl} alt={awayTeam.displayName} className="contest-team-logo" />
+          <img src={pickLogo(awayTeam)} alt={awayTeam.displayName} className="contest-team-logo" />
         </div>
         <Link
           to={teamLink(awayTeam.slug, seasonYear, sport, league)}
@@ -59,7 +65,7 @@ export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScore
           {homeTeam.displayName}
         </Link>
         <div className="contest-team-logo-wrap" style={homeTeamColor ? { background: normHomeBg, borderColor: 'rgba(255,255,255,0.06)' } : {}}>
-          <img src={homeTeam.logoUrl} alt={homeTeam.displayName} className="contest-team-logo" />
+          <img src={pickLogo(homeTeam)} alt={homeTeam.displayName} className="contest-team-logo" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Follow-up to #349. With `TeamScoreDto.LogoUrlDark` and
`TeamScoreDto.LogoUrlLight` now on the wire, the web
`ContestOverviewHeader` can finally swap logos by theme like
`TeamCard.jsx` already does. Closes the dark-mode logo eyesore on the
web contest-overview surface.

## Change

- `useTheme()` import + hook
- `pickLogo(team)` helper prefers `logoUrlDark`/`logoUrlLight` and
  falls back to `logoUrl`
- Both away and home `<img>` use it

Mirrors `TeamCard.jsx` line 71 exactly.

## Test plan

- [x] `npm run lint` — clean
- [ ] Manual: open a completed game on web in light + dark, verify
      logos swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team logos now automatically adjust based on the active theme, ensuring optimal visibility in both dark and light modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->