### PR TITLE
feat(api,producer): live headline + baseball series summary in banner

### DIFF
--- a/docs/mobile/working-queue.md
+++ b/docs/mobile/working-queue.md
@@ -7,7 +7,7 @@ they get picked up.
 Order within each section reflects rough priority, but only the
 **In flight** section is binding; everything else is just on deck.
 
-Last updated: 2026-05-21 (post dark-logo cascade for Contest Overview + Team Card)
+Last updated: 2026-05-21 (post #349 + #350 — dark-logo cascade complete on both platforms)
 
 ---
 
@@ -43,11 +43,10 @@ Last updated: 2026-05-21 (post dark-logo cascade for Contest Overview + Team Car
 - **Postponed / cancelled status handling** — mobile shows the raw
   status string in error color; web falls through to Scheduled
   markup. Pick one and apply on both. See blueprint "Known drift".
-- **Dark-mode logo variants** — MatchupCard, Contest Overview, and
-  Team Card all swap via `useColorScheme()` now. Web parity already
-  in place via `useTheme()`. Remaining surfaces (TeamRow expandable
-  schedule, headline banner, etc.) inherit the same fields when
-  added.
+- **Dark-mode logo variants** — done across MatchupCard, Contest
+  Overview header, Team Card on mobile (#348, #349) and ContestOverviewHeader + TeamCard on web (#350,
+  prior). Future surfaces that render a team logo inherit the
+  pattern via `logoUrlDark` / `logoUrlLight` on the existing DTOs.
 - **TeamRow expandable schedule** — web's TeamRow opens a per-team
   schedule on tap via `useTeamSchedule`; mobile's TeamRow has no
   equivalent.
@@ -55,9 +54,11 @@ Last updated: 2026-05-21 (post dark-logo cascade for Contest Overview + Team Car
   the card; mobile omits the slot entirely.
 - **ConfidencePicker integration** — confidence-points leagues work
   on web; mobile has no path to set a confidence score.
-- **Headline banner population** — confirm server-side that
-  `matchup.headLine` populates consistently across sports + states.
-  Today it appears only for some marquee games.
+- **Headline banner population** — addressed in #351:
+  GetMatchupsByContestIds.sql now joins CompetitionNote.Headline live;
+  API coalesces canonical Headline → baseball CurrentSeriesSummary →
+  frozen PickemGroupMatchup.Headline. Football marquee tags now refresh
+  live; baseball regular-season games show series state in the banner.
 
 ---
 

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -217,9 +217,14 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                     // value (already on matchup.HeadLine from the initial
                     // projection) is the last-resort safety net for historical
                     // leagues whose CompetitionNote may no longer resolve.
-                    matchup.HeadLine = canonical.Headline
-                                       ?? canonical.CurrentSeriesSummary
-                                       ?? matchup.HeadLine;
+                    // Whitespace guard: cn."Headline" is non-null in the schema
+                    // but could be empty/blank; treat empty as missing so the
+                    // fallback chain isn't suppressed.
+                    matchup.HeadLine = !string.IsNullOrWhiteSpace(canonical.Headline)
+                        ? canonical.Headline
+                        : !string.IsNullOrWhiteSpace(canonical.CurrentSeriesSummary)
+                            ? canonical.CurrentSeriesSummary
+                            : matchup.HeadLine;
 
                     var preview = previews
                         .Where(x => x.ContestId == matchup.ContestId &&

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -210,6 +210,17 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                     // Predictions, AiWinner, IsPreview*) stay below.
                     MatchupForPickDtoMapper.ApplyCanonical(matchup, canonical);
 
+                    // Headline priority: live CompetitionNote.Headline (marquee
+                    // tag — bowl/conf championship/postseason designation) wins,
+                    // baseball CurrentSeriesSummary is the regular-season fallback
+                    // (e.g. "BOS leads series 2-0"), frozen PickemGroupMatchup
+                    // value (already on matchup.HeadLine from the initial
+                    // projection) is the last-resort safety net for historical
+                    // leagues whose CompetitionNote may no longer resolve.
+                    matchup.HeadLine = canonical.Headline
+                                       ?? canonical.CurrentSeriesSummary
+                                       ?? matchup.HeadLine;
+
                     var preview = previews
                         .Where(x => x.ContestId == matchup.ContestId &&
                                     x.RejectedUtc == null)

--- a/src/SportsData.Core/Dtos/Canonical/LeagueMatchupDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/LeagueMatchupDto.cs
@@ -14,6 +14,20 @@ public class LeagueMatchupDto
     public string? Status { get; set; }
     public string? Broadcasts { get; set; }
 
+    /// <summary>
+    /// Marquee headline pulled live from CompetitionNote.Headline (Type=event).
+    /// Set for special games (bowl names, conference championships, postseason
+    /// designations). Null otherwise.
+    /// </summary>
+    public string? Headline { get; set; }
+
+    /// <summary>
+    /// Baseball-only series state snapshot (e.g. "BOS leads series 2-0"), pulled
+    /// from BaseballCompetition.CurrentSeriesSummary. Null on non-baseball
+    /// matchups and on baseball games not part of a current series.
+    /// </summary>
+    public string? CurrentSeriesSummary { get; set; }
+
     public string? Venue { get; set; }
     public string? VenueCity { get; set; }
     public string? VenueState { get; set; }

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
@@ -58,6 +58,7 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
 
         var streamTimes = await GetActiveStreamTimesAsync(query.ContestIds, cancellationToken);
         var probables = await GetProbablePitchersAsync(query.ContestIds, cancellationToken);
+        var seriesSummaries = await GetCurrentSeriesSummariesAsync(query.ContestIds, cancellationToken);
         foreach (var matchup in matchups)
         {
             matchup.StreamScheduledTimeUtc = streamTimes.GetValueOrDefault(matchup.ContestId);
@@ -67,9 +68,50 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
                 matchup.HomeProbablePitcher = pair.Home;
                 matchup.AwayProbablePitcher = pair.Away;
             }
+
+            matchup.CurrentSeriesSummary = seriesSummaries.GetValueOrDefault(matchup.ContestId);
         }
 
         return new Success<List<LeagueMatchupDto>>(matchups);
+    }
+
+    /// <summary>
+    /// Stitches MLB CurrentSeriesSummary onto the matchup result. Sport-gated:
+    /// only runs against BaseballDataContext (NFL/NCAAFB no-op without a round
+    /// trip). Mirrors the 2-phase stitch in <see cref="GetProbablePitchersAsync"/>.
+    /// A Contest can host multiple Competitions (doubleheaders); the snapshot is
+    /// locked-at-game-start per-Competition so any non-null value is acceptable
+    /// — first match wins per ContestId.
+    /// </summary>
+    internal async Task<Dictionary<Guid, string>> GetCurrentSeriesSummariesAsync(
+        Guid[] contestIds,
+        CancellationToken cancellationToken)
+    {
+        if (_dbContext is not BaseballDataContext baseballCtx)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var rows = await baseballCtx.Competitions
+            .AsNoTracking()
+            .Where(c => contestIds.Contains(c.ContestId))
+            .Where(c => c.CurrentSeriesSummary != null)
+            .Select(c => new
+            {
+                c.ContestId,
+                c.CurrentSeriesSummary
+            })
+            .ToListAsync(cancellationToken);
+
+        var dict = new Dictionary<Guid, string>();
+        foreach (var r in rows)
+        {
+            if (!dict.ContainsKey(r.ContestId) && !string.IsNullOrWhiteSpace(r.CurrentSeriesSummary))
+            {
+                dict[r.ContestId] = r.CurrentSeriesSummary!;
+            }
+        }
+        return dict;
     }
 
     /// <summary>

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -2,6 +2,7 @@ SELECT
   c."SeasonWeekId" AS "SeasonWeekId",
   c."Id" AS "ContestId",
   c."StartDateUtc" AS "StartDateUtc",
+  cn."Headline" AS "Headline",
   REPLACE(cs."StatusDescription", ' ', '') AS "Status",
   STRING_AGG(cb."MediaName", ' | ') AS "Broadcasts",
   v."Name" AS "Venue", v."City" AS "VenueCity", v."State" AS "VenueState",
@@ -33,6 +34,7 @@ SELECT
 FROM public."Contest" c
 LEFT JOIN public."Venue" v ON v."Id" = c."VenueId"
 INNER JOIN public."Competition" comp ON comp."ContestId" = c."Id"
+LEFT JOIN public."CompetitionNote" cn ON cn."CompetitionId" = comp."Id" AND cn."Type" = 'event'
 LEFT JOIN public."CompetitionBroadcast" cb ON cb."CompetitionId" = comp."Id"
 LEFT JOIN public."CompetitionStatus" cs ON cs."CompetitionId" = comp."Id"
 LEFT JOIN LATERAL (
@@ -114,7 +116,7 @@ LEFT JOIN LATERAL (
 LEFT JOIN public."FranchiseSeasonRankingDetail" fsrdHome ON fsrdHome."FranchiseSeasonRankingId" = fsrHome."Id"
 WHERE c."Id" = ANY(@ContestIds)
 GROUP BY
-  c."SeasonWeekId", c."Id", c."StartDateUtc", cs."StatusDescription",
+  c."SeasonWeekId", c."Id", c."StartDateUtc", cn."Headline", cs."StatusDescription",
   v."Name", v."City", v."State",
   fAway."DisplayName", fAway."DisplayNameShort", fsAway."Id",
   flAway."Uri", fslAway."Uri", flDarkAway."Uri", fslDarkAway."Uri", fAway."Slug",


### PR DESCRIPTION
## Summary

Repurposes the headline banner UI slot:
- **Football**: marquee tags ("AllState Sugar Bowl", "NFC Championship") now refresh live from `CompetitionNote.Headline` instead of being frozen at picks-generation time.
- **Baseball**: when no marquee tag is set, the banner displays the current series state (e.g. "BOS leads series 2-0") from `BaseballCompetition.CurrentSeriesSummary`.

No UI changes — both mobile and web already render `matchup.headLine`.

## Coalesce priority (API)

```
matchup.HeadLine = canonical.Headline               // live CompetitionNote
                   ?? canonical.CurrentSeriesSummary // baseball series state
                   ?? matchup.HeadLine               // frozen PickemGroupMatchup snapshot
```

Marquee CompetitionNote always wins (postseason context like "NLCS Game 5" beats "LAD leads 2-0"). Frozen snapshot survives as the last-resort safety net for historical leagues where a `CompetitionNote` row may no longer resolve.

## Changes

**Producer**
- `GetMatchupsByContestIds.sql` — `LEFT JOIN CompetitionNote (Type=event)`, project `cn."Headline"`, matching `GROUP BY` entry. Mirrors the pattern already in 5 sibling SQL files. `CompetitionNote` is a shared base concept present in both football and baseball DBs.
- `GetMatchupsByContestIdsQueryHandler` — new `GetCurrentSeriesSummariesAsync` 2-phase stitch. Sport-gated to `BaseballDataContext` (NFL/NCAAFB no-op without a round-trip), mirrors the existing `GetProbablePitchersAsync` pattern. First non-null match wins per ContestId (doubleheader-safe).

**Core**
- `LeagueMatchupDto` — add nullable `Headline` and `CurrentSeriesSummary`.

**API**
- `GetLeagueWeekMatchupsQueryHandler` — coalesce in the enrichment loop after `ApplyCanonical`.

**Docs**
- `working-queue.md` — mark "Headline banner population" closed with reference to this PR.

## Test plan

- [x] `dotnet build` Producer + API — 0 warnings, 0 errors
- [x] `dotnet test` Producer.Tests.Unit `~GetMatchupsByContestIds` — 5/5 pass
- [x] `dotnet test` Api.Tests.Unit `~GetLeagueWeekMatchups` — 7/7 pass
- [ ] Manual: open a baseball league/week, confirm series banner appears on regular-season games
- [ ] Manual: open a football league/week with a bowl game, confirm marquee tag still appears
- [ ] Manual: open a baseball league/week with a postseason game (if any in current state) and confirm CompetitionNote.Headline wins over series state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated mobile working-queue: marked dark-mode logo variants complete and clarified headline banner population/status and post-release tracking.

* **Improvements**
  * League matchup headlines and series summaries are now more consistently populated and prioritized; sport-specific series information (MLB) is better included for matchups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->