### PR TITLE
fix(producer): bump Hangfire InvisibilityTimeout to 6h for long stream jobs

### DIFF
--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -239,6 +239,18 @@ namespace SportsData.Core.DependencyInjection
                 x.UsePostgreSqlStorage(options =>
                 {
                     options.UseNpgsqlConnection(connString);
+                }, new PostgreSqlStorageOptions
+                {
+                    // Long-running stream jobs (BaseballCompetitionStreamer, up to 5h
+                    // per CompetitionStreamerBase.MaxStreamDuration) must outlive
+                    // Hangfire's invisibility window or the storage layer re-fetches
+                    // the "abandoned" job and cancels the in-flight worker via its
+                    // linked CancellationToken. The default (30 min) caused every
+                    // baseball live-stream to be reaped mid-game on 2026-05-21 (see
+                    // Seq CorrelationId 1a80a1e6-02a3-4fa0-9ed9-291ed363beb9). Setting
+                    // this above MaxStreamDuration with margin keeps streaming jobs
+                    // owned by their original worker for the full game.
+                    InvisibilityTimeout = TimeSpan.FromHours(6)
                 });
                 x.UseTagsWithPostgreSql();
 


### PR DESCRIPTION
## Summary

Hot-fix: Hangfire.PostgreSql's default `InvisibilityTimeout` (30 min) was reaping every in-flight `BaseballCompetitionStreamer` job mid-game. The streamer is designed to run up to 5 hours (`CompetitionStreamerBase.MaxStreamDuration`), so the storage layer treated the long-running worker as abandoned at the 30-min mark, re-fetched the same job for another worker, and cancelled the original via its linked `CancellationToken`. **Result: zero `BaseballPlayCompleted` events published all day on 2026-05-21**.

## Evidence (Seq, 2026-05-21)

All five MLB contests today showed an identical 30:00 ± 1s delta between first job start and cancel/refire, with the same `CorrelationId` on both events (the storage-layer re-fetch fingerprint):

| Contest | Job #1 start | Cancel/refire | Δ |
|---|---|---|---|
| ebe3b05a | 00:30:01Z | 01:00:01Z | 30:00 |
| b5b82920 | 01:28:03Z | 01:58:05Z | 30:02 |
| 85303bb0 | 17:00:11Z | 17:30:11Z | 30:00 |
| 3673f855 | 17:05:11Z | 17:35:11Z | 30:00 |
| 9397392e | 19:55:10Z | 20:25:10Z | 30:00 |

Anchor event: `CorrelationId 1a80a1e6-02a3-4fa0-9ed9-291ed363beb9` / `ContestId 9397392e-1791-d9a3-9445-c96c40b80e08`, log template `Streaming cancelled by external request` (`@i: 4209a3c2`).

Cancellation site: `CompetitionStreamerBase.cs:257-264` (catches `OperationCanceledException when (cancellationToken.IsCancellationRequested)`).

## Fix

Set `PostgreSqlStorageOptions.InvisibilityTimeout` to `TimeSpan.FromHours(6)` in `SportsData.Core.DependencyInjection.ServiceRegistration.AddHangfire`. Exceeds `MaxStreamDuration` with one hour of safety margin. All other storage defaults preserved.

## Out of scope (follow-up PR)

A secondary bug in `CompetitionStreamerBase` causes the first poll cycle after `Live start detected` to log `Skipping worker for {DocumentType} - URI is null` for all 4 polling workers, ending in `Active workers: 0`. Even with this hot-fix, that bug would cost the first ~30 min of every game (until the next re-fetch grabs a populated `competitionDto`). Will be addressed in a separate PR — likely a `competitionDto` re-fetch between `WaitForLiveStartAsync` and `StartPollingWorkers`.

## Test plan

- [x] `dotnet build` Core + Producer — 0 warnings, 0 errors
- [x] `dotnet test` Core.Tests.Unit — 221/221 pass
- [ ] Manual verification post-deploy: tail Seq for `BaseballCompetitionStreamer` during tonight's late game. Confirm no `Streaming cancelled by external request` at the 30-min mark; confirm `BaseballPlayCompleted` events flow to the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of background job processing by extending timeout configuration for long-running operations. This prevents unexpected job termination and ensures critical background tasks complete successfully without interruptions, enhancing overall system stability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->