### PR TITLE
fix(producer): refresh competitionDto after live start detected

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -179,6 +179,25 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                         switch (startOutcome)
                         {
                             case LiveStartOutcome.StartDetected:
+                                // The initial competitionDto fetch above happened while the
+                                // game was still STATUS_SCHEDULED, so ESPN had not yet
+                                // populated the live-data refs (Plays, Probability,
+                                // Situation, Leaders) on the parent EventCompetition
+                                // payload. Re-fetch now that the game is in progress so
+                                // GetPollingTargets returns real URIs instead of nulls.
+                                // Without this refresh, every poller logs "URI is null",
+                                // StartPollingWorkers spawns Active workers: 0, and the
+                                // monitoring loop runs silently for the full game.
+                                competitionDto = await GetCompetitionAsync(new Uri(externalId.SourceUrl), cancellationToken);
+                                if (competitionDto == null)
+                                {
+                                    _logger.LogError("Competition re-fetch after live start failed");
+                                    if (stream != null)
+                                    {
+                                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition re-fetch after live start failed");
+                                    }
+                                    return;
+                                }
                                 break;
 
                             case LiveStartOutcome.AlreadyFinal:


### PR DESCRIPTION
## Summary

Follow-up to #352. The streamer fetches `competitionDto` from ESPN once, up front, while the game is still `STATUS_SCHEDULED`. At that moment ESPN has not yet populated the live-data refs (Plays, Probability, Situation, Leaders) on the parent EventCompetition payload — those URIs are null for not-yet-started games. After `WaitForLiveStartAsync` returns `StartDetected`, `StartPollingWorkers` operates on the **stale** DTO and every polling target hits `URI is null - skipping worker`, leaving `Active workers: 0` for the rest of the stream.

## Why this is urgent post-#352

Pre-#352, this was being accidentally papered over by Hangfire's 30-min `InvisibilityTimeout` re-fetching the same job — the refire ran a fresh `ExecuteAsync` which re-fetched the DTO (now with live URIs) and worked correctly until the next 30-min cancel cycle. With #352's bump to a 6h `InvisibilityTimeout`, **the broken first poll cycle now persists for the full 5h `MaxStreamDuration` with no recovery**. So this fix is load-bearing on streaming actually working post-#352.

## Fix

Re-fetch `competitionDto` inside the `LiveStartOutcome.StartDetected` case-arm of the `STATUS_SCHEDULED` branch, before falling through to `StartPollingWorkers`. Matches the existing fail-fast pattern from the initial fetch — a null result marks the stream Failed and returns.

`STATUS_IN_PROGRESS` and `STATUS_FINAL` switch arms are unaffected: those paths already fetched the DTO from a game that was past the scheduled phase, so live URIs are already populated.

## Test plan

- [x] `dotnet build` Producer — 0 warnings, 0 errors
- [x] `dotnet test` Producer.Tests.Unit `~CompetitionStreamer*` — 19/19 pass
- [ ] Manual verification post-deploy: tail Seq for the next BaseballCompetitionStreamer that goes from `STATUS_SCHEDULED` to `STATUS_IN_PROGRESS`. Confirm `All workers spawned successfully. Active workers: 4` immediately after `Live start detected`, instead of `Active workers: 0`.
- [ ] Manual verification: confirm `BaseballPlayCompleted` events flow on the API side within a few minutes of live start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data synchronization for live sports competitions to ensure users receive current information when games transition from scheduled to active status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->