### PR TITLE
fix(producer): swallow HttpClient timeout in streamer ESPN fetches

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -313,8 +313,17 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             var json = await response.Content.ReadAsStringAsync(cancellationToken);
             return json.FromJson<TCompetitionDto>();
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Genuine caller-initiated cancellation — propagate so the outer
+            // OperationCanceledException catch in ExecuteAsync runs.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Includes HttpClient.Timeout (TaskCanceledException with no caller-token
+            // cancellation), socket errors, JSON parse failures. Surface as a null
+            // result so the polling loops' consecutiveFailures logic handles it.
             _logger.LogError(ex, "Failed to get competition from {Uri}", uri);
             return null;
         }
@@ -334,8 +343,17 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             var json = await response.Content.ReadAsStringAsync(cancellationToken);
             return json.FromJson<EspnEventCompetitionStatusDtoBase>();
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Genuine caller-initiated cancellation — propagate so the outer
+            // OperationCanceledException catch in ExecuteAsync runs.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Includes HttpClient.Timeout (TaskCanceledException with no caller-token
+            // cancellation), socket errors, JSON parse failures. Surface as a null
+            // result so the polling loops' consecutiveFailures logic handles it.
             _logger.LogError(ex, "Failed to get status from {Uri}", uri);
             return null;
         }


### PR DESCRIPTION
## Summary

Production failure overnight (Seq `CorrelationId cb482fbd-df90-487e-8a5a-53a1f48a8ed0`, `ContestId c74d465c-...`, 2026-05-22T04:09:49Z): a single 100-second `HttpClient.Timeout` on a status fetch during in-game polling killed an entire `BaseballCompetitionStreamer` mid-game. Stream went to `Failed` and never recovered.

## Root cause

`GetCompetitionAsync` and `GetStatusAsync` both used:
```csharp
catch (Exception ex) when (ex is not OperationCanceledException)
```
`HttpClient.Timeout` throws `TaskCanceledException` — which **is** an `OperationCanceledException` — so the timeout escaped the try/catch, bubbled to `ExecuteAsync`'s outer `catch (Exception ex)` (line 268), which logged `Unexpected error during streaming`, marked the stream `Failed`, and re-threw.

The `consecutiveFailures` machinery in `PollWhileInProgressAsync` and `WaitForLiveStartAsync` (designed exactly for transient ESPN hangs, with a 10-strike budget before bailing) never got to count this failure because the exception type wasn't being normalized to a `null` return.

## Fix

Split the catch into two clauses in both methods:

```csharp
catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
{
    throw; // genuine caller cancellation — let outer catch handle
}
catch (Exception ex)
{
    _logger.LogError(ex, "Failed to get status from {Uri}", uri);
    return null; // HttpClient.Timeout, socket errors, JSON parse failures
}
```

The `IsCancellationRequested` check is reliable here: `HttpClient.Timeout` uses its own internal CTS — the caller token is unaffected by the timeout firing.

## Test plan

- [x] `dotnet build` Producer — 0 warnings, 0 errors
- [x] `dotnet test` Producer.Tests.Unit `~CompetitionStreamer*` — 19/19 pass
- [ ] Manual verification post-deploy: tail Seq for slow-ESPN scenarios. Expect to see `Failed to get status from {Uri}` warnings with inner `TaskCanceledException`, followed by retry attempts, instead of `Unexpected error during streaming` → stream Failed.

## Sequencing with #352 and #353

Third in the streaming-recovery chain:
- #352 — bumped Hangfire `InvisibilityTimeout` so the storage layer stops reaping long jobs
- #353 — refresh `competitionDto` after `Live start detected` so first-poll URIs aren't null
- this PR — make transient ESPN hangs survivable instead of stream-killing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for data fetch operations to ensure proper propagation when users initiate cancellation requests, while maintaining existing error handling for other failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->