### PR TITLE
chore(producer): drop obsolete unrecognized-participant-type warning

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessor.cs
@@ -55,10 +55,12 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext>
     /// way. Per-play statistics refs are captured verbatim — those
     /// pipelines don't materialize canonical entities yet.
     ///
-    /// Unrecognized participant types are still persisted (we don't drop
-    /// data) but log a warning so Seq surfaces forward-compat work. Null
-    /// AthleteSeasonId is acceptable — the play update path re-resolves on
-    /// each re-ingest, so transient nulls heal naturally without a
+    /// Type strings are stored verbatim (batter, pitcher, onFirst, onSecond,
+    /// onThird, fielder, …). Structural info is captured by the resolved
+    /// AthleteSeasonId + PositionId — the Type string only matters at read
+    /// time when a consumer needs to filter (e.g. ExtractPrimaryAthletes).
+    /// Null AthleteSeasonId is acceptable — the play update path re-resolves
+    /// on each re-ingest, so transient nulls heal naturally without a
     /// throw-retry loop on every play of a freshly-sourced game.
     /// </summary>
     private async Task<List<BaseballCompetitionPlayParticipant>> BuildParticipantsAsync(
@@ -92,27 +94,10 @@ public class BaseballEventCompetitionPlayDocumentProcessor<TDataContext>
                     key: p => p.Id);
             }
 
-            var type = participant.Type;
-            var isPitcher = string.Equals(type, "pitcher", StringComparison.OrdinalIgnoreCase);
-            var isBatter = string.Equals(type, "batter", StringComparison.OrdinalIgnoreCase);
-
-            if (!isPitcher && !isBatter)
-            {
-                // Forward-compat watch: ESPN's play taxonomy can grow (substitution
-                // rows, runner refs, fielders on a play-result, etc.). Surface in
-                // Seq so we notice and can decide whether to add denormalized
-                // columns. The row is still persisted — we don't drop data.
-                _logger.LogWarning(
-                    "Unrecognized baseball participant type '{ParticipantType}' on PlayId={PlayId}, PlayText={PlayText}",
-                    string.IsNullOrEmpty(type) ? "(null)" : type,
-                    dto.Id,
-                    dto.Type?.Text);
-            }
-
             result.Add(new BaseballCompetitionPlayParticipant
             {
                 Order = participant.Order,
-                Type = type ?? string.Empty,
+                Type = participant.Type ?? string.Empty,
                 AthleteSeasonId = athleteSeasonId,
                 PositionId = positionId,
                 StatisticsRef = participant.Statistics?.Ref?.ToString()


### PR DESCRIPTION
## Summary

The forward-compat warning in `BaseballEventCompetitionPlayDocumentProcessor.BuildParticipantsAsync` was scaffolding from when only `batter`/`pitcher` participants were modeled. ESPN now sends additional types (`onFirst`, `onSecond`, `onThird`, `fielder`, etc.) on plays where runners advance or get tagged out, and the warning has been firing as Production noise without indicating a real problem.

## Confirmed: data is fully persisted

Both via Seq + code review:
- Each participant becomes a row in `BaseballCompetitionPlayParticipant` with `Type` stored verbatim
- `AthleteSeasonId` resolves through the athlete ref lookup (line 76-82)
- `PositionId` resolves through the position ref lookup (line 87-93)

The `isPitcher`/`isBatter` check only emitted the warning — it never gated persistence. `ExtractPrimaryAthletes` still works correctly: it matches the `Type` string directly for `batter`/`pitcher` and ignores additional types without conflict.

## Change

Remove the `var type = ...`/`isPitcher`/`isBatter`/`if (...) _logger.LogWarning(...)` block. Use `participant.Type` directly in the row instantiation. XML doc comment updated to reflect that Type strings are stored verbatim and structural info comes from the resolved IDs.

Net: 22 lines removed, 7 added.

## Deferred follow-up (Game Center work)

The published `BaseballPlayCompleted` event hardcodes `RunnerOnFirst/Second/Third = false` in two sites:
- `BaseballEventCompetitionPlayDocumentProcessor.cs:212-214`
- `BaseballContestReplayService.cs:186-188`

The persisted `onFirst`/`onSecond`/`onThird` participants could trivially populate those flags — but the live MatchupCard doesn't render the diamond today. This is parked until the Game Center multi-game wallboard work begins; that surface is what makes the diamond worth building.

## Test plan

- [x] `dotnet build` Producer — 0 warnings, 0 errors
- [x] `dotnet test` Producer.Tests.Unit `~BaseballEventCompetitionPlay` — 9/9 pass
- [ ] Manual verification post-deploy: confirm no `Unrecognized baseball participant type` warnings on subsequent baseball play ingests in Seq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated baseball event participant type processing logic to directly assign participant type values from incoming data sources when creating competition play records.

* **Documentation**
  * Updated documentation for baseball event participant processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->