### PR TITLE
docs: multi-sport scoring job refactor plan

### DIFF
--- a/docs/multi-sport-scoring-job-refactor.md
+++ b/docs/multi-sport-scoring-job-refactor.md
@@ -1,0 +1,185 @@
+# Multi-Sport Scoring Job Refactor
+
+**Status:** Draft for review. No code yet.
+**Owner:** sports-data-core
+**Created:** 2026-05-22
+**Related code:** `src/SportsData.Api/Application/Jobs/*`, `src/SportsData.Api/Application/Scoring/*`
+
+## Problem
+
+Four recurring jobs in `SportsData.Api` were built last season for `Sport.FootballNcaa` and hardcode that sport when resolving sport-routed clients. With MLB live and NFL on deck (and more sports eventually), the current shape produces wrong behavior for non-football leagues:
+
+| File | Lines | What's hardcoded |
+|---|---|---|
+| `Jobs/LeagueWeekScoringJob.cs` | 45, 74 | `_seasonClientFactory.Resolve(Sport.FootballNcaa)`, `_contestClientFactory.Resolve(Sport.FootballNcaa)` |
+| `Jobs/ContestScoringJob.cs` | 52, 71 | Same pattern |
+| `Jobs/MatchupScheduler.cs` | 36 | `_seasonClientFactory.Resolve(Sport.FootballNcaa).GetCurrentSeasonWeek()` |
+| `Scoring/ContestScoringProcessor.cs` | 43 | `_contestClientFactory.Resolve(Sport.FootballNcaa).GetMatchupResult(contestId)` |
+
+Each is annotated with a `// TODO: multi-sport` comment. Downstream of these calls, `LeagueWeekScoringService`, `PickScoringService`, and the `PickemGroup*` data layer are already sport-agnostic — they operate on entities that carry `Sport` as data, not as a code-path branch.
+
+## What's already sport-tagged at the data layer
+
+- `PickemGroup.Sport` — **required**, populated at league creation.
+- `Contest.Sport` (API-side) — populated when contest is recorded.
+- `PickemGroupMatchup` — joins to `PickemGroup`, so league sport is one join away.
+
+So we are not missing data. We are just not reading it.
+
+## Why this isn't a one-line factory swap
+
+Four concerns make a "loop over all sports inside the existing single job" approach awkward:
+
+1. **Cadence differs significantly.**
+   - Football: most contests finalize Sunday night. Hourly during weekends is plenty; daily otherwise is fine.
+   - Baseball: contests finalize nightly, ~15 games/day. Daily-or-better is the floor; every 30 minutes during the in-season evening window is more appropriate.
+   - Today all four jobs are registered as `Cron.Weekly` in `ServiceRegistration.cs:272/277/282/292`, which is a placeholder pace inherited from the football-only world and is too slow even for football.
+
+2. **"Season week" semantics differ.**
+   - Football: weeks 1–15+ with well-defined calendar boundaries, NCAAFB has bowl postseason which uses non-standard-week ordinals.
+   - Baseball: custom date-range windows. The mobile `League.seasonWeeks` JSDoc explicitly notes *"Custom-window leagues may contain a subset (e.g. [4]) rather than 1..N."*
+   - A single `_seasonClientFactory.Resolve(Sport).GetCurrentAndLastSeasonWeeks()` returns very different shapes per sport. There's no clean way to fold them into one loop without sport-conditional logic.
+
+3. **Season calendars overlap, sometimes don't.**
+   - Spring/early summer: MLB only.
+   - Fall: MLB tail + NCAAF + NFL.
+   - Winter: NCAAF bowls + NFL playoffs.
+   - A single job iterating over all sports has to coordinate three independent "what's active right now?" answers and gracefully skip sports out of season.
+
+4. **Failure isolation matters in production.**
+   - If MLB's Producer hangs on a 100s HttpClient.Timeout (we saw this on 2026-05-22, PR #354), football scoring should not block behind it.
+   - Per-sport jobs fail per-sport; one job per all sports cascades the blast radius.
+
+## Recommendation: sport-specific subclasses with shared sport-agnostic core
+
+Three flavors of change. None of them touch the actual scoring math.
+
+### 1. `ContestScoringProcessor` — resolve sport from the contest itself
+
+This processor runs once per `contestId`. The contest knows its own sport (`Contest.Sport` in `AppDataContext.Contests`). No subclass needed:
+
+```csharp
+// Before
+var matchupResultResponse = await _contestClientFactory
+    .Resolve(Sport.FootballNcaa)
+    .GetMatchupResult(command.ContestId);
+
+// After
+var contest = await _dataContext.Contests.AsNoTracking()
+    .FirstOrDefaultAsync(c => c.ContestId == command.ContestId);
+if (contest is null)
+{
+    _logger.LogWarning("Contest not found for scoring: {ContestId}", command.ContestId);
+    return;
+}
+var matchupResultResponse = await _contestClientFactory
+    .Resolve(contest.Sport)
+    .GetMatchupResult(command.ContestId);
+```
+
+Pure refactor. One method, two new lines, no new file.
+
+### 2. `LeagueWeekScoringJob` + `ContestScoringJob` + `MatchupScheduler` — sport-specific subclasses
+
+Extract sport-neutral logic into an abstract base (or a shared service consumed by thin wrappers — open question, see §"Naming and shape" below). Concrete types per sport:
+
+```
+ContestScoringJobBase            (abstract)
+├── FootballNcaaContestScoringJob
+└── BaseballMlbContestScoringJob
+
+LeagueWeekScoringJobBase         (abstract)
+├── FootballNcaaLeagueWeekScoringJob
+└── BaseballMlbLeagueWeekScoringJob
+
+MatchupSchedulerBase             (abstract)
+├── FootballNcaaMatchupScheduler
+└── BaseballMlbMatchupScheduler
+```
+
+Each concrete type:
+- Declares `protected abstract Sport Sport { get; }`
+- Inherits the orchestration loop from the base
+- Is registered as its own Hangfire recurring job with its own cron
+
+When NFL goes live: add `FootballNflContestScoringJob` (and friends). When NBA: same pattern. The growth shape is linear.
+
+### 3. Sport-filter the matchup queries
+
+Both job bases currently query `PickemGroupMatchups.Where(m => SeasonYear == X && SeasonWeek == Y)` — this picks up *all* leagues regardless of sport. Add the filter:
+
+```csharp
+var leagueWeeks = await _dataContext.PickemGroupMatchups
+    .Where(m => m.SeasonYear == seasonWeek.SeasonYear
+             && m.SeasonWeek == seasonWeek.WeekNumber)
+    .Join(_dataContext.PickemGroups,
+        m => m.GroupId,
+        g => g.Id,
+        (m, g) => new { m, g.Sport })
+    .Where(x => x.Sport == Sport) // ← the per-sport filter from the subclass
+    .Select(x => new { x.m.GroupId, x.m.SeasonYear, x.m.SeasonWeek })
+    .Distinct()
+    .ToListAsync();
+```
+
+Without this filter, the baseball job would process football leagues' matchups (and vice versa), applying the wrong week semantics in the process.
+
+## Cron schedule (proposed)
+
+Today all four jobs are `Cron.Weekly` — wrong for both sports. Proposed:
+
+| Job | Football (NCAA/NFL) | Baseball (MLB) | Rationale |
+|---|---|---|---|
+| MatchupScheduler | `0 6 * * 2` (Tue 06:00 UTC = Mon evening US) | `0 9 * * *` (daily 09:00 UTC = early-morning US) | Football schedule firms up early week; MLB schedules game-by-game. |
+| ContestScoringJob | `0 */2 * * 0` (every 2h on Sundays) + `0 6 * * 1` (Mon 06:00 UTC catch-up) | `0 6,15 * * *` (06:00 UTC + 15:00 UTC) | Football: most finalize during US Sunday afternoon/evening. Baseball: most finalize US evening into early morning. |
+| LeagueWeekScoringJob | Same as ContestScoringJob + 15 min offset | Same + 15 min offset | Runs after ContestScoringJob so picks are scored before leaderboards aggregate. |
+
+The 15-min offset between ContestScoringJob and LeagueWeekScoringJob is best-effort, not strict — the LeagueWeekScoringJob already has self-correcting "score if not scored recently" logic, so even if it runs first it'll backfill on the next pass.
+
+NFL crons are identical to NCAA initially — NFL games run Thursday/Sunday/Monday so the Sunday-anchored schedule fits both.
+
+Open question on whether MLB needs in-game scoring cadence (every 30 min during games) vs the once-per-day model proposed here. The once-per-day model is sufficient for next-day leaderboard freshness but won't update live during a game. Given baseball picks are typically a series-level commitment (not in-game), once-per-day is probably fine for Phase 1.
+
+## Naming and shape
+
+Two structural choices to make before coding. Both are deferred to the implementation PR — flagging them here for awareness.
+
+### Choice A: prefix vs suffix
+
+- `FootballNcaaContestScoringJob` (sport-as-prefix)
+- `ContestScoringJobFootballNcaa` (sport-as-suffix)
+
+Codebase has both patterns: `BaseballEventCompetitionPlayDocumentProcessor` uses sport-as-prefix; `MatchupForPickDtoMapper` uses no sport tag at all. Prefix reads more naturally in alphabetical file listings (all football files cluster). Recommendation: **prefix**, pending user confirmation.
+
+### Choice B: abstract base class vs shared service
+
+- **Abstract base.** `ContestScoringJobBase` holds the orchestration loop; concrete subclasses override `Sport` and the per-sport `GetCurrentWeekAsync` virtual.
+- **Shared service.** Thin sport-specific job wrappers (`FootballNcaaContestScoringJob` is a 10-line class that calls `_scoringWorkflow.RunAsync(Sport.FootballNcaa)`). The workflow object holds the logic.
+
+Both are valid. Abstract base is the more conventional pattern and matches existing `EventCompetitionPlayDocumentProcessorBase<TDataContext, TDto>`. Shared service is friendlier to unit testing and avoids inheritance constraints. Recommendation: **abstract base**, mirroring the processor-base pattern already in the codebase.
+
+## Migration path
+
+Suggested order, each step shippable independently:
+
+1. **PR-N+0 (this doc)** — design doc only. Land for review.
+2. **PR-N+1** — refactor `ContestScoringProcessor.cs:43` to use `contest.Sport`. Independent of the job split; unblocks per-contest sport handling.
+3. **PR-N+2** — introduce `ContestScoringJobBase` + `FootballNcaaContestScoringJob`. Register new job with football cadence. Delete the old `ContestScoringJob`. Verify scoring still works for the active football season.
+4. **PR-N+3** — same shape for `LeagueWeekScoringJob`. Verify leaderboards still update for football.
+5. **PR-N+4** — same shape for `MatchupScheduler`. Verify matchup generation still produces football matchups on the new cadence.
+6. **PR-N+5** — add `BaseballMlbContestScoringJob`, `BaseballMlbLeagueWeekScoringJob`, `BaseballMlbMatchupScheduler`. Verify against an existing MLB league with finalized contests.
+
+Steps 3–5 are deliberately one-sport-at-a-time so we can verify the refactor didn't regress football before adding baseball. The base class is fully exercised by step 3 — adding baseball in step 6 is then a confidence check, not a discovery exercise.
+
+## Open questions for user
+
+1. **MLB cadence** — once-daily (proposed) or in-game polling (every 30 min during active games)? Picks-product question, not implementation.
+2. **Prefix vs suffix naming** — recommendation is prefix; user override?
+3. **Abstract base vs shared service** — recommendation is abstract base; user override?
+4. **Should MatchupScheduler also split now**, or defer until baseball matchup generation is needed? Today MatchupScheduler only produces football matchups; baseball picks may use a different generation path entirely (e.g., manual commissioner setup for series-based leagues). Need to confirm baseball league shape before deciding.
+
+## Out of scope
+
+- The scoring math itself. `LeagueWeekScoringService.ScoreLeagueWeekAsync` and `PickScoringService.ScorePick` stay as-is — they're sport-agnostic and operate on already-finalized data.
+- KEDA / pod-count tuning. These jobs run inside the existing API pod; no infrastructure change.
+- Game Center wallboard work. The runner-on-base data populated for the Game Center vision is unrelated to scoring cadence; tracked separately.

--- a/docs/multi-sport-scoring-job-refactor.md
+++ b/docs/multi-sport-scoring-job-refactor.md
@@ -1,13 +1,13 @@
-# Multi-Sport Scoring Job Refactor
+# Multi-Sport Scoring Refactor
 
 **Status:** Draft for review. No code yet.
 **Owner:** sports-data-core
 **Created:** 2026-05-22
-**Related code:** `src/SportsData.Api/Application/Jobs/*`, `src/SportsData.Api/Application/Scoring/*`
+**Related code:** `src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs`, `src/SportsData.Api/Application/Jobs/*`, `src/SportsData.Api/Application/Scoring/*`
 
 ## Problem
 
-Four recurring jobs in `SportsData.Api` were built last season for `Sport.FootballNcaa` and hardcode that sport when resolving sport-routed clients. With MLB live and NFL on deck (and more sports eventually), the current shape produces wrong behavior for non-football leagues:
+Three recurring jobs in `SportsData.Api` plus the per-contest `ContestScoringProcessor` were built last season for `Sport.FootballNcaa` and hardcode that sport when resolving sport-routed clients:
 
 | File | Lines | What's hardcoded |
 |---|---|---|
@@ -16,47 +16,84 @@ Four recurring jobs in `SportsData.Api` were built last season for `Sport.Footba
 | `Jobs/MatchupScheduler.cs` | 36 | `_seasonClientFactory.Resolve(Sport.FootballNcaa).GetCurrentSeasonWeek()` |
 | `Scoring/ContestScoringProcessor.cs` | 43 | `_contestClientFactory.Resolve(Sport.FootballNcaa).GetMatchupResult(contestId)` |
 
-Each is annotated with a `// TODO: multi-sport` comment. Downstream of these calls, `LeagueWeekScoringService`, `PickScoringService`, and the `PickemGroup*` data layer are already sport-agnostic — they operate on entities that carry `Sport` as data, not as a code-path branch.
+Each has a `// TODO: multi-sport` comment.
 
-## What's already sport-tagged at the data layer
+Underneath the hardcoded sport, the bigger architectural issue is that scoring today is **pull-based** — the cron polls every week (currently `Cron.Weekly` for all four jobs in `DependencyInjection/ServiceRegistration.cs:272-292`) asking Producer "is anything finalized yet?" — instead of being **push-based** from the streamer that already knows the moment a game ends.
 
-- `PickemGroup.Sport` — **required**, populated at league creation.
-- `Contest.Sport` (API-side) — populated when contest is recorded.
-- `PickemGroupMatchup` — joins to `PickemGroup`, so league sport is one join away.
+## What's already in place
 
-So we are not missing data. We are just not reading it.
+- **`PickemGroup.Sport`** — required, populated at league creation.
+- **`Contest.Sport`** (API-side) — required, populated when contest is recorded.
+- **`CompetitionStreamerBase` already detects `STATUS_FINAL`** in three places, each currently only flipping `CompetitionStream.Status` to `Completed` without publishing a domain event:
+  - `:208` — `LiveStartOutcome.AlreadyFinal` (game was final before we started watching)
+  - `:231` — initial status switch (game was final on our first status check)
+  - `:267` — `PollOutcome.Final` from in-game polling (game went final mid-watch)
+- **`ContestScoringProcessor` already triggers league week scoring** at the tail (`:151`) — picks scoring naturally chains into leaderboard scoring within the same processor invocation. No separate orchestration needed.
+- **The downstream scoring math** (`LeagueWeekScoringService`, `PickScoringService`) is fully sport-agnostic — operates on generic `PickemGroup*` entities that carry `Sport` as data rather than branching on it in code.
 
-## Why this isn't a one-line factory swap
+So we are not missing data and not missing chaining. We are missing the trigger and the sport-correct factory resolution.
 
-Four concerns make a "loop over all sports inside the existing single job" approach awkward:
+## Recommendation: event-driven primary, daily cron backstop
 
-1. **Cadence differs significantly.**
-   - Football: most contests finalize Sunday night. Hourly during weekends is plenty; daily otherwise is fine.
-   - Baseball: contests finalize nightly, ~15 games/day. Daily-or-better is the floor; every 30 minutes during the in-season evening window is more appropriate.
-   - Today all four jobs are registered as `Cron.Weekly` in `ServiceRegistration.cs:272/277/282/292`, which is a placeholder pace inherited from the football-only world and is too slow even for football.
+### Primary path (live)
 
-2. **"Season week" semantics differ.**
-   - Football: weeks 1–15+ with well-defined calendar boundaries, NCAAFB has bowl postseason which uses non-standard-week ordinals.
-   - Baseball: custom date-range windows. The mobile `League.seasonWeeks` JSDoc explicitly notes *"Custom-window leagues may contain a subset (e.g. [4]) rather than 1..N."*
-   - A single `_seasonClientFactory.Resolve(Sport).GetCurrentAndLastSeasonWeeks()` returns very different shapes per sport. There's no clean way to fold them into one loop without sport-conditional logic.
+```
+Streamer detects STATUS_FINAL
+  → publishes ContestCompleted (new event)
+  → API consumer enqueues ContestScoringProcessor
+  → ContestScoringProcessor scores picks (using contest.Sport, not hardcoded)
+  → tail invokes LeagueWeekScoringService.ScoreLeagueWeekAsync
+  → leaderboard updates
+```
 
-3. **Season calendars overlap, sometimes don't.**
-   - Spring/early summer: MLB only.
-   - Fall: MLB tail + NCAAF + NFL.
-   - Winter: NCAAF bowls + NFL playoffs.
-   - A single job iterating over all sports has to coordinate three independent "what's active right now?" answers and gracefully skip sports out of season.
+Latency from game end to leaderboard update: seconds to single-digit minutes (bounded by the in-game polling interval + MassTransit delivery).
 
-4. **Failure isolation matters in production.**
-   - If MLB's Producer hangs on a 100s HttpClient.Timeout (we saw this on 2026-05-22, PR #354), football scoring should not block behind it.
-   - Per-sport jobs fail per-sport; one job per all sports cascades the blast radius.
+### Backstop path (catch-up)
 
-## Recommendation: sport-specific subclasses with shared sport-agnostic core
+A single daily cron pass for each of `ContestScoringJob` and `LeagueWeekScoringJob` looks for unscored picks against finalized contests and processes them. This catches:
+- Events lost to RabbitMQ outage or consumer pod restart during the broadcast
+- Contests finalized via paths other than the streamer (admin replay, bulk finalize)
+- Anything else the primary path missed
 
-Three flavors of change. None of them touch the actual scoring math.
+The backstop is sport-agnostic: querying `UserPicks.Where(ScoredAt == null)` against the list of finalized contests doesn't require sport-specific factory resolution at the job level — `ContestScoringProcessor` resolves sport per-contest.
 
-### 1. `ContestScoringProcessor` — resolve sport from the contest itself
+### Why this is simpler than per-sport subclasses
 
-This processor runs once per `contestId`. The contest knows its own sport (`Contest.Sport` in `AppDataContext.Contests`). No subclass needed:
+With the primary path live-driven, the cron's job collapses to "find anything that slipped through" instead of "iterate season weeks, resolve current week, fetch finalized contests, cross-reference." No sport-specific week semantics. No per-sport cadence. No abstract-base / concrete-per-sport class hierarchy. A single daily run across all sports is sufficient because the live path already handles the time-sensitive case.
+
+## Concrete changes
+
+### 1. `ContestCompleted` domain event (new)
+
+New record in `SportsData.Core.Eventing.Events.Contests` (or sibling location). At minimum:
+
+```csharp
+public record ContestCompleted(
+    Guid ContestId,
+    Guid CompetitionId,
+    Sport Sport,
+    int SeasonYear,
+    Guid? SeasonWeekId,
+    Guid CorrelationId,
+    Guid CausationId
+);
+```
+
+Sport is on the event so the consumer can route without a DB lookup. SeasonYear and SeasonWeekId help the consumer make idempotency / locality decisions if needed.
+
+### 2. `CompetitionStreamerBase` — publish at the three completion sites
+
+All three sites listed under "What's already in place" publish `ContestCompleted` before (or after — order doesn't matter; both happen in the same SaveChangesAsync transaction with bus-outbox semantics) the `UpdateStreamStatusAsync(stream, Completed, ...)` call. Includes the existing log scope (Sport, ContestId, CompetitionId, CorrelationId) so the publish carries clean context.
+
+At-least-once delivery means the consumer may see `ContestCompleted` multiple times per contest (e.g., admin re-broadcasts a completed game). The consumer must be idempotent.
+
+### 3. API consumer for `ContestCompleted` (new)
+
+A MassTransit consumer in `SportsData.Api` that receives `ContestCompleted` and enqueues `IScoreContests.Process(new ScoreContestCommand(ContestId))` via the existing `IProvideBackgroundJobs`. Thin shim per the codebase convention — no DB work inline.
+
+Idempotency: if the contest is already fully scored, the existing `ContestScoringProcessor` should short-circuit. Today it does not short-circuit — it re-iterates all `UserPicks` for the contest. Add an "already-scored" guard inside the processor in this PR (cheap check: `UserPicks.Any(p => p.ContestId == X && p.ScoredAt == null)`).
+
+### 4. `ContestScoringProcessor` — resolve sport from the contest
 
 ```csharp
 // Before
@@ -67,119 +104,79 @@ var matchupResultResponse = await _contestClientFactory
 // After
 var contest = await _dataContext.Contests.AsNoTracking()
     .FirstOrDefaultAsync(c => c.ContestId == command.ContestId);
-if (contest is null)
-{
-    _logger.LogWarning("Contest not found for scoring: {ContestId}", command.ContestId);
-    return;
-}
+if (contest is null) { /* log + return */ }
 var matchupResultResponse = await _contestClientFactory
     .Resolve(contest.Sport)
     .GetMatchupResult(command.ContestId);
 ```
 
-Pure refactor. One method, two new lines, no new file.
+Two new lines. The processor remains a single class — sport is data, not a class-level distinction.
 
-### 2. `LeagueWeekScoringJob` + `ContestScoringJob` + `MatchupScheduler` — sport-specific subclasses
+### 5. `ContestScoringJob` — sport-agnostic daily backstop
 
-Extract sport-neutral logic into an abstract base (or a shared service consumed by thin wrappers — open question, see §"Naming and shape" below). Concrete types per sport:
+Rewrite to:
 
 ```
-ContestScoringJobBase            (abstract)
-├── FootballNcaaContestScoringJob
-└── BaseballMlbContestScoringJob
-
-LeagueWeekScoringJobBase         (abstract)
-├── FootballNcaaLeagueWeekScoringJob
-└── BaseballMlbLeagueWeekScoringJob
-
-MatchupSchedulerBase             (abstract)
-├── FootballNcaaMatchupScheduler
-└── BaseballMlbMatchupScheduler
+For each Sport in {FootballNcaa, BaseballMlb, ...}:
+    finalizedIds = _contestClientFactory.Resolve(Sport).GetFinalizedContestIds(...)
+    unscoredContestIds = UserPicks.Where(ScoredAt == null).Select(ContestId).Distinct()
+    For each contest in (unscored ∩ finalized):
+        Enqueue ContestScoringProcessor
 ```
 
-Each concrete type:
-- Declares `protected abstract Sport Sport { get; }`
-- Inherits the orchestration loop from the base
-- Is registered as its own Hangfire recurring job with its own cron
+Discover the active sport list at runtime from `PickemGroups.Select(g => g.Sport).Distinct()` so adding a new sport doesn't require touching this job. Daily cadence.
 
-When NFL goes live: add `FootballNflContestScoringJob` (and friends). When NBA: same pattern. The growth shape is linear.
+### 6. `LeagueWeekScoringJob` — sport-agnostic daily backstop
 
-### 3. Sport-filter the matchup queries
+Rewrite to:
 
-Both job bases currently query `PickemGroupMatchups.Where(m => SeasonYear == X && SeasonWeek == Y)` — this picks up *all* leagues regardless of sport. Add the filter:
-
-```csharp
-var leagueWeeks = await _dataContext.PickemGroupMatchups
-    .Where(m => m.SeasonYear == seasonWeek.SeasonYear
-             && m.SeasonWeek == seasonWeek.WeekNumber)
-    .Join(_dataContext.PickemGroups,
-        m => m.GroupId,
-        g => g.Id,
-        (m, g) => new { m, g.Sport })
-    .Where(x => x.Sport == Sport) // ← the per-sport filter from the subclass
-    .Select(x => new { x.m.GroupId, x.m.SeasonYear, x.m.SeasonWeek })
-    .Distinct()
-    .ToListAsync();
+```
+unscoredLeagueWeeks = PickemGroupMatchups
+    .Join(PickemGroupWeekResults — null OR stale, i.e. older than max(UserPick.ScoredAt))
+    .Select(GroupId, SeasonYear, SeasonWeek)
+For each: ScoreLeagueWeekAsync
 ```
 
-Without this filter, the baseball job would process football leagues' matchups (and vice versa), applying the wrong week semantics in the process.
+The exact predicate is: a league week needs scoring if any pick for that league+year+week was scored after the last `PickemGroupWeekResult.CalculatedUtc` for that league+year+week (or if no result row exists). This catches league weeks where contest scoring succeeded but the tail leaderboard scoring failed.
 
-## Cron schedule (proposed)
+### 7. `MatchupScheduler` — loop over sports
 
-Today all four jobs are `Cron.Weekly` — wrong for both sports. Proposed:
+MatchupScheduler is not in the eventing path (matchups must be generated *before* games happen). Rewrite the body to iterate over the active sport list and call the per-sport `GetCurrentSeasonWeek()`. Single job, daily cadence, no subclass hierarchy.
 
-| Job | Football (NCAA/NFL) | Baseball (MLB) | Rationale |
-|---|---|---|---|
-| MatchupScheduler | `0 6 * * 2` (Tue 06:00 UTC = Mon evening US) | `0 9 * * *` (daily 09:00 UTC = early-morning US) | Football schedule firms up early week; MLB schedules game-by-game. |
-| ContestScoringJob | `0 */2 * * 0` (every 2h on Sundays) + `0 6 * * 1` (Mon 06:00 UTC catch-up) | `0 6,15 * * *` (06:00 UTC + 15:00 UTC) | Football: most finalize during US Sunday afternoon/evening. Baseball: most finalize US evening into early morning. |
-| LeagueWeekScoringJob | Same as ContestScoringJob + 15 min offset | Same + 15 min offset | Runs after ContestScoringJob so picks are scored before leaderboards aggregate. |
+## Cron schedule
 
-The 15-min offset between ContestScoringJob and LeagueWeekScoringJob is best-effort, not strict — the LeagueWeekScoringJob already has self-correcting "score if not scored recently" logic, so even if it runs first it'll backfill on the next pass.
+All four jobs become daily. Currently `Cron.Weekly` placeholders.
 
-NFL crons are identical to NCAA initially — NFL games run Thursday/Sunday/Monday so the Sunday-anchored schedule fits both.
+| Job | Cadence | Role |
+|---|---|---|
+| MatchupScheduler | Daily 06:00 UTC | Primary — schedules upcoming matchups |
+| ContestScoringJob | Daily 09:00 UTC | Backstop — catches contests where ContestCompleted was missed |
+| LeagueWeekScoringJob | Daily 09:15 UTC | Backstop — catches league weeks where contest-tail leaderboard scoring failed |
 
-Open question on whether MLB needs in-game scoring cadence (every 30 min during games) vs the once-per-day model proposed here. The once-per-day model is sufficient for next-day leaderboard freshness but won't update live during a game. Given baseball picks are typically a series-level commitment (not in-game), once-per-day is probably fine for Phase 1.
-
-## Naming and shape
-
-Two structural choices to make before coding. Both are deferred to the implementation PR — flagging them here for awareness.
-
-### Choice A: prefix vs suffix
-
-- `FootballNcaaContestScoringJob` (sport-as-prefix)
-- `ContestScoringJobFootballNcaa` (sport-as-suffix)
-
-Codebase has both patterns: `BaseballEventCompetitionPlayDocumentProcessor` uses sport-as-prefix; `MatchupForPickDtoMapper` uses no sport tag at all. Prefix reads more naturally in alphabetical file listings (all football files cluster). Recommendation: **prefix**, pending user confirmation.
-
-### Choice B: abstract base class vs shared service
-
-- **Abstract base.** `ContestScoringJobBase` holds the orchestration loop; concrete subclasses override `Sport` and the per-sport `GetCurrentWeekAsync` virtual.
-- **Shared service.** Thin sport-specific job wrappers (`FootballNcaaContestScoringJob` is a 10-line class that calls `_scoringWorkflow.RunAsync(Sport.FootballNcaa)`). The workflow object holds the logic.
-
-Both are valid. Abstract base is the more conventional pattern and matches existing `EventCompetitionPlayDocumentProcessorBase<TDataContext, TDto>`. Shared service is friendlier to unit testing and avoids inheritance constraints. Recommendation: **abstract base**, mirroring the processor-base pattern already in the codebase.
+15-min stagger between ContestScoringJob and LeagueWeekScoringJob is best-effort. Both are self-correcting.
 
 ## Migration path
 
-Suggested order, each step shippable independently:
+Each step is shippable independently and exercises a piece of the architecture before the next builds on it.
 
-1. **PR-N+0 (this doc)** — design doc only. Land for review.
-2. **PR-N+1** — refactor `ContestScoringProcessor.cs:43` to use `contest.Sport`. Independent of the job split; unblocks per-contest sport handling.
-3. **PR-N+2** — introduce `ContestScoringJobBase` + `FootballNcaaContestScoringJob`. Register new job with football cadence. Delete the old `ContestScoringJob`. Verify scoring still works for the active football season.
-4. **PR-N+3** — same shape for `LeagueWeekScoringJob`. Verify leaderboards still update for football.
-5. **PR-N+4** — same shape for `MatchupScheduler`. Verify matchup generation still produces football matchups on the new cadence.
-6. **PR-N+5** — add `BaseballMlbContestScoringJob`, `BaseballMlbLeagueWeekScoringJob`, `BaseballMlbMatchupScheduler`. Verify against an existing MLB league with finalized contests.
+1. **PR-N+0 (this doc)** — design doc only.
+2. **PR-N+1** — `ContestScoringProcessor.cs:43` uses `contest.Sport`. Add the "already scored" short-circuit guard. Small, unblocks both event-driven and cron-driven paths.
+3. **PR-N+2** — define `ContestCompleted` event. Publish from the three `CompetitionStreamerBase` sites. **No consumer yet** — publishing into the void is safe (RabbitMQ retains until consumed; if no consumer is registered, the event is discarded per MassTransit's default behavior, which is what we want until step 3).
+4. **PR-N+3** — API `ContestCompleted` consumer that enqueues `ContestScoringProcessor`. Closes the live-scoring loop. Verify against an MLB contest finalizing.
+5. **PR-N+4** — rewrite `ContestScoringJob` + `LeagueWeekScoringJob` as sport-agnostic daily backstops. Both files change in one PR (similar shape, similar testing). Bump Hangfire cron to daily.
+6. **PR-N+5** — rewrite `MatchupScheduler` to loop over sports. Separate from scoring; can land before or after step 4 without coupling.
 
-Steps 3–5 are deliberately one-sport-at-a-time so we can verify the refactor didn't regress football before adding baseball. The base class is fully exercised by step 3 — adding baseball in step 6 is then a confidence check, not a discovery exercise.
+## Open questions
 
-## Open questions for user
+1. **Where to source the active sport list at runtime** — `PickemGroups.Select(g => g.Sport).Distinct()` is the data-driven option. Alternative: hardcode a small static `[FootballNcaa, BaseballMlb]` list and update on each sport launch. Recommendation: data-driven. New sports get picked up the moment their first league is created.
 
-1. **MLB cadence** — once-daily (proposed) or in-game polling (every 30 min during active games)? Picks-product question, not implementation.
-2. **Prefix vs suffix naming** — recommendation is prefix; user override?
-3. **Abstract base vs shared service** — recommendation is abstract base; user override?
-4. **Should MatchupScheduler also split now**, or defer until baseball matchup generation is needed? Today MatchupScheduler only produces football matchups; baseball picks may use a different generation path entirely (e.g., manual commissioner setup for series-based leagues). Need to confirm baseball league shape before deciding.
+2. **Should the "already scored" short-circuit also live in the consumer, or only in the processor?** Recommendation: only in the processor. Keeping the guard at the lowest level means both event and cron triggers benefit, and the consumer stays trivially thin.
+
+3. **`ContestCompleted` payload — anything beyond ContestId + Sport + ids needed?** The consumer currently only needs `ContestId` to enqueue the processor (which then fetches everything else). Including SeasonYear / SeasonWeekId is cheap and helps tracing.
 
 ## Out of scope
 
-- The scoring math itself. `LeagueWeekScoringService.ScoreLeagueWeekAsync` and `PickScoringService.ScorePick` stay as-is — they're sport-agnostic and operate on already-finalized data.
-- KEDA / pod-count tuning. These jobs run inside the existing API pod; no infrastructure change.
-- Game Center wallboard work. The runner-on-base data populated for the Game Center vision is unrelated to scoring cadence; tracked separately.
+- The scoring math itself. `LeagueWeekScoringService.ScoreLeagueWeekAsync` and `PickScoringService.ScorePick` stay as-is.
+- KEDA / pod-count tuning.
+- Game Center wallboard work — separate effort.
+- Per-contest sport-routing for any other consumer (e.g., admin replay). If those grow `// TODO: multi-sport` markers, same `contest.Sport` lookup pattern applies; not blocking on this refactor.


### PR DESCRIPTION
## Summary

Design doc for splitting four `SportsData.Api` jobs out of the football-only assumption they were built under last season.

In scope (all four covered in the doc):
- `LeagueWeekScoringJob` — sport-specific subclasses
- `ContestScoringJob` — sport-specific subclasses
- `MatchupScheduler` — sport-specific subclasses
- `ContestScoringProcessor` — simpler treatment: resolve sport from `Contest.Sport` rather than splitting the processor itself

Out of scope: the scoring math (`LeagueWeekScoringService`, `PickScoringService`) — already sport-agnostic. KEDA / pod tuning — no infra change needed.

## Highlights

- Four files hardcode `Sport.FootballNcaa` with `// TODO: multi-sport` markers
- `PickemGroup.Sport` and `Contest.Sport` are already required + populated — no schema work needed
- Recommendation: abstract `*JobBase` per job family + concrete `FootballNcaa*` / `BaseballMlb*` subclasses
- Separate Hangfire cron entries per concrete type → independent cadences per sport
- Each subclass adds the `PickemGroupMatchup → PickemGroup` sport filter to prevent cross-sport bleed
- All four current registrations are `Cron.Weekly` placeholders — doc proposes Football and Baseball cadences in a table

## Migration path

Six PRs proposed, each shippable independently:

1. PR-N+0: this doc
2. PR-N+1: `ContestScoringProcessor` per-contest sport resolution
3. PR-N+2: split `ContestScoringJob` (football only first)
4. PR-N+3: split `LeagueWeekScoringJob` (football only first)
5. PR-N+4: split `MatchupScheduler` (football only first)
6. PR-N+5: add all three `BaseballMlb*` subclasses

Football-first sequencing is deliberate — exercises the base class against the active season before baseball lands as a confidence check.

## Open questions for reviewer

Spelled out at the bottom of the doc; quoted here for visibility:

1. **MLB cadence** — once-daily (proposed) or in-game polling every 30 min?
2. **Prefix vs suffix naming** — `FootballNcaaContestScoringJob` or `ContestScoringJobFootballNcaa`?
3. **Abstract base vs shared service** — recommendation is abstract base, matching `EventCompetitionPlayDocumentProcessorBase` precedent.
4. **MatchupScheduler split timing** — split now or wait for baseball matchup-generation design?

## Test plan

- [x] Doc is internally consistent (no contradictory recommendations between sections)
- [x] All four affected files cited by name + line number
- [ ] User review of recommendation choices before any implementation PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design draft for multi-sport scoring refactor: move from weekly polling to an event-driven primary path with a daily backstop, make scoring and scheduling sport-agnostic at runtime, update daily cron timings, and provide a phased migration plan plus open questions for future work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->