### PR TITLE
feat(api): resolve sport per-contest in ContestScoringProcessor

### DIFF
--- a/src/SportsData.Api/Application/Scoring/ContestScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/ContestScoringProcessor.cs
@@ -39,8 +39,45 @@ namespace SportsData.Api.Application.Scoring
 
         public async Task Process(ScoreContestCommand command)
         {
-            // TODO: multi-sport
-            var matchupResultResponse = await _contestClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa).GetMatchupResult(command.ContestId);
+            // Short-circuit: ContestCompleted may re-deliver (at-least-once delivery)
+            // and the cron backstop may enqueue contests whose picks have already
+            // been scored. Skip the Producer round-trip and per-pick iteration when
+            // there is nothing left to do.
+            var hasUnscoredPicks = await _dataContext.UserPicks
+                .AsNoTracking()
+                .AnyAsync(p => p.ContestId == command.ContestId && p.ScoredAt == null);
+
+            if (!hasUnscoredPicks)
+            {
+                _logger.LogInformation(
+                    "Contest already scored or no picks exist. Skipping. ContestId={ContestId}",
+                    command.ContestId);
+                return;
+            }
+
+            // Resolve sport for this contest by joining PickemGroupMatchups to
+            // PickemGroups. A contest belongs to exactly one sport, so any matchup
+            // row that references this contest carries the canonical Sport via its
+            // PickemGroup. The (Sport?) projection disambiguates "no row" from
+            // "row with Sport.All (== 0)".
+            var sport = await _dataContext.PickemGroupMatchups
+                .AsNoTracking()
+                .Where(m => m.ContestId == command.ContestId)
+                .Join(_dataContext.PickemGroups,
+                    m => m.GroupId,
+                    g => g.Id,
+                    (m, g) => (Sport?)g.Sport)
+                .FirstOrDefaultAsync();
+
+            if (sport is null)
+            {
+                _logger.LogWarning(
+                    "Could not resolve sport for contest. No PickemGroupMatchup found. ContestId={ContestId}",
+                    command.ContestId);
+                return;
+            }
+
+            var matchupResultResponse = await _contestClientFactory.Resolve(sport.Value).GetMatchupResult(command.ContestId);
 
             if (!matchupResultResponse.IsSuccess)
             {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringProcessorTests.cs
@@ -18,11 +18,20 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
 {
     private readonly Mock<IProvideContests> _contestClientMock = new();
 
+    // Fixed "now" for any test-seeded timestamps. Using IDateTimeProvider
+    // (via AutoMocker) instead of DateTime.UtcNow keeps test-seeded entities
+    // deterministic per CLAUDE.md guidance.
+    private static readonly DateTime FixedUtcNow = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     public ContestScoringProcessorTests()
     {
         Mocker.GetMock<IContestClientFactory>()
             .Setup(x => x.Resolve(It.IsAny<Sport>()))
             .Returns(_contestClientMock.Object);
+
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedUtcNow);
     }
     [Fact]
     public async Task Process_WithValidMatchupResult_ScoresEachPick()
@@ -244,7 +253,7 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
             .With(x => x.ContestId, contestId)
             .With(x => x.PickemGroupId, groupId)
             .With(x => x.Group, group)
-            .With(x => x.ScoredAt, (DateTime?)DateTime.UtcNow)
+            .With(x => x.ScoredAt, (DateTime?)FixedUtcNow)
             .CreateMany(2)
             .ToList();
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringProcessorTests.cs
@@ -45,10 +45,12 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
         var matchup = Fixture.Build<PickemGroupMatchup>()
             .With(x => x.ContestId, contestId)
             .With(x => x.SeasonWeekId, seasonWeekId)
+            .With(x => x.GroupId, groupId)
             .Create();
 
         var group = Fixture.Build<PickemGroup>()
             .With(x => x.Id, groupId)
+            .With(x => x.Sport, Sport.FootballNcaa)
             .With(x => x.PickType, PickType.StraightUp)
             .With (x => x.Weeks, new List<PickemGroupWeek>
             {
@@ -73,6 +75,7 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
             .With(x => x.PickemGroupId, groupId)
             .With(x => x.Group, group)
             .With(x => x.FranchiseId, result.WinnerFranchiseSeasonId) // make it correct
+            .With(x => x.ScoredAt, (DateTime?)null) // unscored, so the short-circuit doesn't fire
             .CreateMany(3)
             .ToList();
 
@@ -110,6 +113,34 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
     {
         // Arrange
         var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        // Seed a matchup + group so sport resolution succeeds and the test
+        // exercises the GetMatchupResult NotFound path (rather than short-circuiting
+        // on the new sport-resolution guard).
+        var matchup = Fixture.Build<PickemGroupMatchup>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.GroupId, groupId)
+            .Create();
+
+        var group = Fixture.Build<PickemGroup>()
+            .With(x => x.Id, groupId)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.Weeks, new List<PickemGroupWeek>())
+            .Create();
+
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+
+        var pick = Fixture.Build<PickemGroupUserPick>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.PickemGroupId, groupId)
+            .With(x => x.Group, group)
+            .With(x => x.ScoredAt, (DateTime?)null)
+            .Create();
+
+        await DataContext.UserPicks.AddAsync(pick);
+        await DataContext.SaveChangesAsync();
 
         _contestClientMock
             .Setup(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
@@ -137,7 +168,8 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
     {
         // Arrange
         var contestId = Guid.NewGuid();
-        var missingGroupId = Guid.NewGuid();
+        var matchupGroupId = Guid.NewGuid(); // group that owns the matchup (for sport resolution)
+        var missingGroupId = Guid.NewGuid(); // group referenced by the pick — intentionally absent
 
         var result = Fixture.Build<MatchupResult>()
             .With(x => x.WinnerFranchiseSeasonId, Guid.NewGuid())
@@ -147,10 +179,28 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
             .Setup(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<MatchupResult>(result));
 
+        // Seed a matchup + group so sport resolution succeeds. The pick references
+        // a DIFFERENT (missing) group, so the per-pick group lookup later fails as
+        // the original test intends.
+        var matchup = Fixture.Build<PickemGroupMatchup>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.GroupId, matchupGroupId)
+            .Create();
+
+        var matchupGroup = Fixture.Build<PickemGroup>()
+            .With(x => x.Id, matchupGroupId)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.Weeks, new List<PickemGroupWeek>())
+            .Create();
+
+        await DataContext.PickemGroups.AddAsync(matchupGroup);
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+
         var pick = Fixture.Build<PickemGroupUserPick>()
             .With(x => x.ContestId, contestId)
             .With(x => x.PickemGroupId, missingGroupId)
             .With(x => x.Group, null as PickemGroup)
+            .With(x => x.ScoredAt, (DateTime?)null)
             .Create();
 
         await DataContext.UserPicks.AddAsync(pick);
@@ -164,6 +214,91 @@ public class ContestScoringProcessorTests : ApiTestBase<ContestScoringProcessor>
         await sut.Process(command);
 
         // Assert
+        Mocker.GetMock<IPickScoringService>()
+            .Verify(x => x.ScorePick(
+                    It.IsAny<PickemGroup>(),
+                    It.IsAny<double?>(),
+                    It.IsAny<PickemGroupUserPick>(),
+                    It.IsAny<MatchupResult>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenAllPicksAlreadyScored_ShortCircuits()
+    {
+        // Arrange
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        // Seed picks for the contest, all with ScoredAt set (already scored).
+        // The short-circuit should fire before any Producer round-trip happens.
+        var group = Fixture.Build<PickemGroup>()
+            .With(x => x.Id, groupId)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.Weeks, new List<PickemGroupWeek>())
+            .Create();
+
+        await DataContext.PickemGroups.AddAsync(group);
+
+        var picks = Fixture.Build<PickemGroupUserPick>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.PickemGroupId, groupId)
+            .With(x => x.Group, group)
+            .With(x => x.ScoredAt, (DateTime?)DateTime.UtcNow)
+            .CreateMany(2)
+            .ToList();
+
+        await DataContext.UserPicks.AddRangeAsync(picks);
+        await DataContext.SaveChangesAsync();
+
+        var command = new ScoreContestCommand(contestId);
+
+        var sut = Mocker.CreateInstance<ContestScoringProcessor>();
+
+        // Act
+        await sut.Process(command);
+
+        // Assert — no Producer call, no scoring
+        _contestClientMock
+            .Verify(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()), Times.Never);
+
+        Mocker.GetMock<IPickScoringService>()
+            .Verify(x => x.ScorePick(
+                    It.IsAny<PickemGroup>(),
+                    It.IsAny<double?>(),
+                    It.IsAny<PickemGroupUserPick>(),
+                    It.IsAny<MatchupResult>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenSportCannotBeResolved_LogsAndReturns()
+    {
+        // Arrange — unscored picks but NO matchup row, so sport resolution returns null.
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        var pick = Fixture.Build<PickemGroupUserPick>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.PickemGroupId, groupId)
+            .With(x => x.Group, null as PickemGroup)
+            .With(x => x.ScoredAt, (DateTime?)null)
+            .Create();
+
+        await DataContext.UserPicks.AddAsync(pick);
+        await DataContext.SaveChangesAsync();
+
+        var command = new ScoreContestCommand(contestId);
+
+        var sut = Mocker.CreateInstance<ContestScoringProcessor>();
+
+        // Act
+        await sut.Process(command);
+
+        // Assert — no Producer call, no scoring
+        _contestClientMock
+            .Verify(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()), Times.Never);
+
         Mocker.GetMock<IPickScoringService>()
             .Verify(x => x.ScorePick(
                     It.IsAny<PickemGroup>(),


### PR DESCRIPTION
## Summary

**PR-N+1** of the multi-sport scoring refactor (see `docs/multi-sport-scoring-job-refactor.md`, doc PR #356).

Drops the hardcoded `Sport.FootballNcaa` at `ContestScoringProcessor.cs:43` and adds an idempotency short-circuit so the processor is safe to call any number of times — both via the existing cron path and the upcoming `ContestCompleted` event consumer (PR-N+3).

## Changes

**`ContestScoringProcessor.cs`** — two guards added at the top of `Process`, then sport-aware client resolution:

1. **Already-scored short-circuit** — `UserPicks.AnyAsync(p => p.ContestId == X && p.ScoredAt == null)`. If nothing's unscored, log and return. Saves the Producer round-trip + per-pick iteration on re-delivery.
2. **Sport resolution** — `PickemGroupMatchups.Where(m => m.ContestId == X).Join(PickemGroups, ...).Select(g => (Sport?)g.Sport).FirstOrDefault`. The `(Sport?)` cast disambiguates "no row" from "row with `Sport.All = 0`."
3. **Sport-aware client resolve** — `_contestClientFactory.Resolve(sport.Value).GetMatchupResult(...)` replaces the hardcoded `Sport.FootballNcaa`.

## Architectural notes

- Does **not** touch the API-side `Contest` entity (intentionally not in `AppDataContext`).
- Canonical sports data continues to flow through `ContestClient`.
- Only API-local league/pick tables (`PickemGroup`, `PickemGroupMatchup`, `UserPicks`) are read for sport resolution.
- No change to the `ScoreContestCommand` record shape — callers (today's `ContestScoringJob.cs:87` and tomorrow's `ContestCompleted` consumer) pass only `ContestId`.

## Tests

5/5 pass.

- `Process_WithValidMatchupResult_ScoresEachPick` — updated: explicit `Sport.FootballNcaa`, `GroupId`, `ScoredAt = null` so the new guards don't false-trigger.
- `Process_WhenResultNotFound_LogsAndReturns` — updated: now seeds matchup + group + unscored pick so the test reaches the NotFound path.
- `Process_WhenGroupNotFound_LogsAndSkips` — updated: matchup/group seeded for sport resolution; pick references a separate missing group so the original test intent is preserved.
- `Process_WhenAllPicksAlreadyScored_ShortCircuits` — **new**: verifies no Producer call when every pick is already scored.
- `Process_WhenSportCannotBeResolved_LogsAndReturns` — **new**: verifies no Producer call when no matchup row exists for the contestId.

## Test plan

- [x] `dotnet build` SportsData.Api — 0 warnings, 0 errors
- [x] `dotnet test` Api.Tests.Unit `~ContestScoringProcessor` — 5/5 pass
- [ ] Manual post-deploy: confirm football scoring continues to function on the next NCAAFB contest finalization. No behavior change expected for the cron path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contest scoring efficiency by skipping processing when all user picks are already scored, avoiding unnecessary result lookups and scoring work.
  * Enhanced sport resolution to detect and log unresolved contests and return early when sport cannot be determined.

* **Tests**
  * Added tests covering scoring short-circuits and sport-resolution/not-found edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->