### PR TITLE
feat(producer): publish ContestCompleted on STATUS_FINAL detection

### DIFF
--- a/src/SportsData.Core/Eventing/Events/Contests/ContestCompleted.cs
+++ b/src/SportsData.Core/Eventing/Events/Contests/ContestCompleted.cs
@@ -1,0 +1,35 @@
+using System;
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Contests
+{
+    /// <summary>
+    /// Sport-neutral lifecycle event. Published by Producer's
+    /// <see cref="Application.Competitions.CompetitionStreamerBase{T}"/> at the
+    /// three sites where it detects STATUS_FINAL:
+    /// LiveStartOutcome.AlreadyFinal, the initial STATUS_FINAL switch arm,
+    /// and PollOutcome.Final after the in-game polling loop exits.
+    ///
+    /// Carries enough context for the API-side scoring consumer to route
+    /// without an extra DB lookup. The consumer is responsible for
+    /// idempotency — at-least-once delivery means this event can re-deliver
+    /// (e.g. admin replay of a completed game, broker redelivery, pod
+    /// restart mid-broadcast). The downstream
+    /// <see cref="Api.Application.Scoring.ContestScoringProcessor"/> already
+    /// short-circuits when no UserPicks for the contest are unscored.
+    ///
+    /// Lifecycle status transitions (Scheduled → InProgress → Final) are
+    /// also surfaced on <see cref="ContestStatusChanged"/>; ContestCompleted
+    /// is a narrower, scoring-trigger-shaped event with the fields the
+    /// scoring path needs.
+    /// </summary>
+    public record ContestCompleted(
+        Guid ContestId,
+        Guid CompetitionId,
+        Guid? SeasonWeekId,
+        Uri? Ref,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn;
@@ -202,6 +203,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
                             case LiveStartOutcome.AlreadyFinal:
                                 _logger.LogInformation("Competition went final while waiting for start. Skipping live polling.");
+                                await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
                                 if (stream != null)
                                 {
                                     stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
@@ -225,6 +227,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
                     case "STATUS_FINAL":
                         _logger.LogInformation("Competition already final. Skipping streaming.");
+                        await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
                         if (stream != null)
                         {
                             stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
@@ -258,6 +261,10 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                 var pollOutcome = await PollWhileInProgressAsync(statusUri, _workerCts.Token);
 
                 _logger.LogInformation("Polling loop exited with outcome {Outcome}. Stopping workers gracefully.", pollOutcome);
+                if (pollOutcome == PollOutcome.Final)
+                {
+                    await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
+                }
                 if (stream != null)
                 {
                     stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
@@ -575,6 +582,46 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             _workerCts?.Dispose();
             _workerCts = null;
         }
+    }
+
+    /// <summary>
+    /// Publish ContestCompleted at any STATUS_FINAL detection point so the API
+    /// scoring path can trigger immediately rather than waiting on the daily
+    /// cron backstop. Uses the same fresh-scope pattern as
+    /// <see cref="PublishDocumentRequestAsync"/> so the MassTransit EF outbox
+    /// interceptor captures the publish and flushes it on the scope's
+    /// SaveChangesAsync within the same transaction.
+    ///
+    /// Idempotency on the consumer side handles at-least-once redelivery and
+    /// the three concurrent publish sites in <see cref="ExecuteAsync"/> —
+    /// downstream ContestScoringProcessor short-circuits when no UserPicks for
+    /// the contest are unscored.
+    /// </summary>
+    private async Task PublishContestCompletedAsync(
+        StreamCompetitionCommand command,
+        Guid? seasonWeekId,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Publishing ContestCompleted for ContestId={ContestId}, CompetitionId={CompetitionId}",
+            command.ContestId, command.CompetitionId);
+
+        using var scope = _scopeFactory.CreateScope();
+        var dataContext = scope.ServiceProvider.GetRequiredService<TeamSportDataContext>();
+        var publishEndpoint = scope.ServiceProvider.GetRequiredService<IEventBus>();
+
+        await publishEndpoint.Publish(new ContestCompleted(
+            ContestId: command.ContestId,
+            CompetitionId: command.CompetitionId,
+            SeasonWeekId: seasonWeekId,
+            Ref: null,
+            Sport: command.Sport,
+            SeasonYear: command.SeasonYear,
+            CorrelationId: command.CorrelationId,
+            CausationId: command.CorrelationId
+        ), cancellationToken);
+
+        await dataContext.SaveChangesAsync(cancellationToken);
     }
 
     private async Task PublishDocumentRequestAsync(


### PR DESCRIPTION
## Summary

**PR-N+2** of the multi-sport scoring refactor (see `docs/multi-sport-scoring-job-refactor.md`, doc PR #356).

Defines a new sport-neutral domain event and emits it from `CompetitionStreamerBase` at the three sites where STATUS_FINAL is detected. **No consumer yet — that ships in PR-N+3.** Behavior change is safe to deploy on its own.

## What's added

### `SportsData.Core.Eventing.Events.Contests.ContestCompleted`

```csharp
public record ContestCompleted(
    Guid ContestId,
    Guid CompetitionId,
    Guid? SeasonWeekId,
    Uri? Ref,
    Sport Sport,
    int? SeasonYear,
    Guid CorrelationId,
    Guid CausationId) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId);
```

Mirrors `ContestStatusChanged` structurally. Carries enough context for the future scoring consumer to route a `ScoreContestCommand` without an extra DB lookup.

### Publish sites in `CompetitionStreamerBase.ExecuteAsync`

| Line | Trigger |
|---|---|
| 208 | `LiveStartOutcome.AlreadyFinal` — game went final while we were waiting for live start |
| 231 | initial `STATUS_FINAL` switch arm — game was already final on our first status check |
| 267 | `PollOutcome.Final` from in-game polling — game finalized mid-broadcast |

All three sites already flip `CompetitionStream.Status` to `Completed`. The publish happens BEFORE the stream-status flip so the publish is captured in the same logical "contest is final" moment.

### `PublishContestCompletedAsync` helper

Mirrors `PublishDocumentRequestAsync` — fresh `IServiceScope`, resolve `DbContext` + `IEventBus` from it, `Publish`, then `SaveChangesAsync` to flush the MassTransit EF outbox interceptor. Keeps the publish transactional with its own scope; if `SaveChangesAsync` fails, the publish is rolled back.

`CorrelationId` and `CausationId` both set to `command.CorrelationId` matching the convention for streamer-originated events (see `PublishDocumentRequestAsync` for precedent).

## Notes per locked design

- **No consumer yet.** PR-N+3 wires that up. MassTransit queues the publish with no subscriber until then — expected steady state for this PR.
- **Payload is minimal as agreed.** Adding optional fields later is non-breaking.
- **Publish on the `pollOutcome.Final` path is gated** so it only fires once per stream-end, not on the `Timeout` path.

## Test plan

- [x] `dotnet build` Core + Producer — 0 warnings, 0 errors
- [x] `dotnet test` Producer.Tests.Unit `~*CompetitionStreamer*` — 19/19 pass
- [ ] Manual post-deploy: tail Seq for `ContestCompleted` publish events on the next baseball contest finalization. The publish should appear in the outbox-flushed timeframe alongside the existing `Stream status updated to Completed` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic contest completion event publishing when contests reach final status, enabling downstream systems to respond in real-time
  * Event-driven notifications eliminate unnecessary database lookups when processing completed contests
  * Enhanced integration capabilities for contest status updates across the platform

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->