### PR TITLE
feat(api): consume ContestCompleted to enqueue ContestScoringProcessor

### DIFF
--- a/src/SportsData.Api/Application/Events/ContestCompletedHandler.cs
+++ b/src/SportsData.Api/Application/Events/ContestCompletedHandler.cs
@@ -1,0 +1,54 @@
+using MassTransit;
+
+using SportsData.Api.Application.Scoring;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Processing;
+
+namespace SportsData.Api.Application.Events
+{
+    /// <summary>
+    /// Closes the live-scoring loop. Producer's
+    /// <see cref="ContestStreamerBase{T}"/> publishes
+    /// <see cref="ContestCompleted"/> the moment STATUS_FINAL is detected; this
+    /// thin shim enqueues a <see cref="ScoreContestCommand"/> via Hangfire so
+    /// the existing <see cref="ContestScoringProcessor"/> path runs as soon as
+    /// possible rather than waiting on the daily cron backstop.
+    ///
+    /// Per the "ingest consumers must be thin Hangfire-spawn shims" convention,
+    /// this consumer does no inline DB work. The processor handles all the
+    /// actual scoring work, including idempotency via its already-scored
+    /// short-circuit — safe against at-least-once redelivery (broker
+    /// redelivery, admin replay of a completed game, pod restart, etc.).
+    /// </summary>
+    public class ContestCompletedHandler : IConsumer<ContestCompleted>
+    {
+        private readonly ILogger<ContestCompletedHandler> _logger;
+        private readonly IProvideBackgroundJobs _backgroundJobProvider;
+
+        public ContestCompletedHandler(
+            ILogger<ContestCompletedHandler> logger,
+            IProvideBackgroundJobs backgroundJobProvider)
+        {
+            _logger = logger;
+            _backgroundJobProvider = backgroundJobProvider;
+        }
+
+        public Task Consume(ConsumeContext<ContestCompleted> context)
+        {
+            var msg = context.Message;
+
+            _logger.LogInformation(
+                "ContestCompleted consume: received. ContestId={ContestId}, CompetitionId={CompetitionId}, Sport={Sport}, CausationId={CausationId}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.CompetitionId, msg.Sport, msg.CausationId, msg.CorrelationId, context.MessageId);
+
+            var cmd = new ScoreContestCommand(msg.ContestId, msg.CorrelationId);
+            _backgroundJobProvider.Enqueue<IScoreContests>(p => p.Process(cmd));
+
+            _logger.LogInformation(
+                "ContestCompleted consume: ScoreContestCommand enqueued. ContestId={ContestId}, CorrelationId={CorrelationId}",
+                msg.ContestId, msg.CorrelationId);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -227,6 +227,7 @@ namespace SportsData.Api
                 services.AddMessaging<AppDataContext>(config,
                 [
                     typeof(BaseballPlayCompletedHandler),
+                    typeof(ContestCompletedHandler),
                     typeof(ContestOddsUpdatedHandler),
                     typeof(ContestRecapArticlePublishedHandler),
                     typeof(ContestRefreshRequestedHandler),

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestCompletedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestCompletedHandlerTests.cs
@@ -1,0 +1,52 @@
+using MassTransit;
+
+using Moq;
+
+using SportsData.Api.Application.Events;
+using SportsData.Api.Application.Scoring;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Events
+{
+    public class ContestCompletedHandlerTests : ApiTestBase<ContestCompletedHandler>
+    {
+        [Fact]
+        public async Task Consume_EnqueuesScoreContestCommandForContestId()
+        {
+            // Arrange
+            var contestId = Guid.NewGuid();
+            var competitionId = Guid.NewGuid();
+            var correlationId = Guid.NewGuid();
+
+            var message = new ContestCompleted(
+                ContestId: contestId,
+                CompetitionId: competitionId,
+                SeasonWeekId: Guid.NewGuid(),
+                Ref: null,
+                Sport: Sport.BaseballMlb,
+                SeasonYear: 2026,
+                CorrelationId: correlationId,
+                CausationId: correlationId);
+
+            var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+            var context = Mock.Of<ConsumeContext<ContestCompleted>>(ctx =>
+                ctx.Message == message);
+
+            var sut = Mocker.CreateInstance<ContestCompletedHandler>();
+
+            // Act
+            await sut.Consume(context);
+
+            // Assert
+            background.Verify(x => x.Enqueue<IScoreContests>(
+                It.IsAny<Expression<Func<IScoreContests, Task>>>()), Times.Once);
+        }
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestCompletedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestCompletedHandlerTests.cs
@@ -44,9 +44,34 @@ namespace SportsData.Api.Tests.Unit.Application.Events
             // Act
             await sut.Consume(context);
 
-            // Assert
+            // Assert — verify the enqueued expression invokes Process(cmd) with
+            // a ScoreContestCommand carrying the expected ContestId and the
+            // CorrelationId propagated from the event. Catches regressions in
+            // the method call shape, command type, or field wiring.
             background.Verify(x => x.Enqueue<IScoreContests>(
-                It.IsAny<Expression<Func<IScoreContests, Task>>>()), Times.Once);
+                It.Is<Expression<Func<IScoreContests, Task>>>(expr =>
+                    ScoreContestCommandFromExpression(expr) != null
+                    && ScoreContestCommandFromExpression(expr)!.ContestId == contestId
+                    && ScoreContestCommandFromExpression(expr)!.CorrelationId == correlationId
+                )),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Compiles and evaluates the single argument of a
+        /// <c>p =&gt; p.Process(cmd)</c> expression to extract the captured
+        /// <see cref="ScoreContestCommand"/> instance. Returns null when the
+        /// expression isn't shaped as expected (wrong method, wrong arity, or
+        /// non-<see cref="ScoreContestCommand"/> argument).
+        /// </summary>
+        private static ScoreContestCommand? ScoreContestCommandFromExpression(
+            Expression<Func<IScoreContests, Task>> expr)
+        {
+            if (expr.Body is not MethodCallExpression call) return null;
+            if (call.Method.Name != nameof(IScoreContests.Process)) return null;
+            if (call.Arguments.Count != 1) return null;
+
+            return Expression.Lambda<Func<ScoreContestCommand>>(call.Arguments[0]).Compile()();
         }
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestCompletedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestCompletedHandlerTests.cs
@@ -50,28 +50,33 @@ namespace SportsData.Api.Tests.Unit.Application.Events
             // the method call shape, command type, or field wiring.
             background.Verify(x => x.Enqueue<IScoreContests>(
                 It.Is<Expression<Func<IScoreContests, Task>>>(expr =>
-                    ScoreContestCommandFromExpression(expr) != null
-                    && ScoreContestCommandFromExpression(expr)!.ContestId == contestId
-                    && ScoreContestCommandFromExpression(expr)!.CorrelationId == correlationId
-                )),
+                    EnqueueInvokesProcessWith(expr, contestId, correlationId))),
                 Times.Once);
         }
 
         /// <summary>
-        /// Compiles and evaluates the single argument of a
-        /// <c>p =&gt; p.Process(cmd)</c> expression to extract the captured
-        /// <see cref="ScoreContestCommand"/> instance. Returns null when the
-        /// expression isn't shaped as expected (wrong method, wrong arity, or
-        /// non-<see cref="ScoreContestCommand"/> argument).
+        /// True iff <paramref name="expr"/> is shaped as
+        /// <c>p =&gt; p.Process(cmd)</c> where <c>cmd</c> is a
+        /// <see cref="ScoreContestCommand"/> whose <c>ContestId</c> and
+        /// <c>CorrelationId</c> match the expected values. The argument
+        /// expression is compiled and evaluated exactly once so the predicate
+        /// inside <c>It.Is&lt;...&gt;</c> stays a single helper call (the
+        /// expression-tree form of <c>It.Is</c> can't host a block-bodied
+        /// lambda with a local).
         /// </summary>
-        private static ScoreContestCommand? ScoreContestCommandFromExpression(
-            Expression<Func<IScoreContests, Task>> expr)
+        private static bool EnqueueInvokesProcessWith(
+            Expression<Func<IScoreContests, Task>> expr,
+            Guid expectedContestId,
+            Guid expectedCorrelationId)
         {
-            if (expr.Body is not MethodCallExpression call) return null;
-            if (call.Method.Name != nameof(IScoreContests.Process)) return null;
-            if (call.Arguments.Count != 1) return null;
+            if (expr.Body is not MethodCallExpression call) return false;
+            if (call.Method.Name != nameof(IScoreContests.Process)) return false;
+            if (call.Arguments.Count != 1) return false;
 
-            return Expression.Lambda<Func<ScoreContestCommand>>(call.Arguments[0]).Compile()();
+            var cmd = Expression.Lambda<Func<ScoreContestCommand>>(call.Arguments[0]).Compile()();
+            return cmd != null
+                && cmd.ContestId == expectedContestId
+                && cmd.CorrelationId == expectedCorrelationId;
         }
     }
 }


### PR DESCRIPTION
## Summary

**PR-N+3** of the multi-sport scoring refactor (see `docs/multi-sport-scoring-job-refactor.md`, doc PR #356). Closes the live-scoring loop that PR-N+2 (#358) opened.

## What ships

### `ContestCompletedHandler`

`IConsumer<ContestCompleted>` shim in `SportsData.Api.Application.Events`. Receives the event Producer publishes at `STATUS_FINAL` detection, then enqueues a `ScoreContestCommand` via Hangfire. The `CorrelationId` from the event flows through into the command for correlation tracing.

Per the *"ingest consumers must be thin Hangfire-spawn shims"* convention, this consumer does no inline DB work. All actual scoring runs in `ContestScoringProcessor` (Worker role), which already short-circuits when no `UserPicks` for the contest are unscored — making the path safe under at-least-once redelivery (broker, admin replay, pod restart).

### Wiring

- `Program.cs:230` — `typeof(ContestCompletedHandler)` added to the `AddMessaging` consumer list, alphabetically.
- `ContestCompletedHandlerTests.cs` — verifies `Enqueue<IScoreContests>` with the expected `Func<IScoreContests, Task>` shape. Mirrors `PickemGroupWeekMatchupsGeneratedHandlerTests` style.

## Full live-scoring loop now wired

```
Streamer STATUS_FINAL detection
  → publishes ContestCompleted (PR-N+2 / #358)
  → ContestCompletedHandler (this PR) enqueues ScoreContestCommand
  → ContestScoringProcessor (PR-N+1 / #357) scores picks + tail-triggers
     LeagueWeekScoringService
```

The cron path is still in place untouched; PR-N+4 rewrites it as a sport-agnostic daily backstop for events lost in transit.

## Test plan

- [x] `dotnet build` SportsData.Api — 0 warnings, 0 errors
- [x] `dotnet test` Api.Tests.Unit `~ContestCompletedHandler` — 1/1 passes
- [ ] Manual post-deploy: tail Seq for the next baseball contest finalization. Expect to see in order:
  - Producer: `Publishing ContestCompleted for ContestId=...`
  - API: `ContestCompleted consume: received. ContestId=...`
  - API: `ContestCompleted consume: ScoreContestCommand enqueued.`
  - Worker: Hangfire-spawned `ContestScoringProcessor` execution
  - Leaderboard updates within a minute of finalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contest completion events now enqueue background scoring jobs so scoring runs asynchronously. This improves responsiveness of event handling and prevents inline scoring from delaying processing.

* **Tests**
  * Added unit tests to verify that contest completion events trigger the enqueueing of background scoring jobs with the correct identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->