### PR TITLE
feat(api): sport-agnostic daily backstop for scoring jobs

### DIFF
--- a/src/SportsData.Api/Application/Jobs/ContestScoringJob.cs
+++ b/src/SportsData.Api/Application/Jobs/ContestScoringJob.cs
@@ -1,92 +1,71 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Scoring;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Core.Infrastructure.Clients.Season;
-using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common.Jobs;
 using SportsData.Core.Processing;
 
 namespace SportsData.Api.Application.Jobs
 {
+    /// <summary>
+    /// Daily backstop for the live contest-scoring path.
+    ///
+    /// Primary scoring trigger is event-driven (Producer publishes
+    /// <c>ContestCompleted</c> on STATUS_FINAL → API <c>ContestCompletedHandler</c>
+    /// enqueues <see cref="ContestScoringProcessor"/>). This job is the
+    /// safety net for events lost in transit (broker outage, consumer pod
+    /// restart, admin replay races, etc.).
+    ///
+    /// Sport-agnostic by construction: we enqueue a <see cref="ScoreContestCommand"/>
+    /// for every distinct contest that still has unscored picks, regardless of
+    /// sport. The processor (PR-N+1) resolves sport per-contest via
+    /// <c>PickemGroup.Sport</c>, checks finalization through the sport-specific
+    /// <c>ContestClient</c>, and short-circuits cleanly when there's nothing
+    /// to do — so this job stays a thin "enqueue all candidates" pass.
+    /// </summary>
     public class ContestScoringJob : IAmARecurringJob
     {
         private readonly ILogger<ContestScoringJob> _logger;
         private readonly AppDataContext _dataContext;
-        private readonly ISeasonClientFactory _seasonClientFactory;
-        private readonly IContestClientFactory _contestClientFactory;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
         private readonly Guid _correlationId = Guid.NewGuid();
 
         public ContestScoringJob(
             ILogger<ContestScoringJob> logger,
             AppDataContext dataContext,
-            ISeasonClientFactory seasonClientFactory,
-            IContestClientFactory contestClientFactory,
             IProvideBackgroundJobs backgroundJobProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
-            _seasonClientFactory = seasonClientFactory;
-            _contestClientFactory = contestClientFactory;
             _backgroundJobProvider = backgroundJobProvider;
         }
 
         public async Task ExecuteAsync()
         {
             using (_logger.BeginScope(new Dictionary<string, object>
-                   {
-                       ["CorrelationId"] = _correlationId
-                    }))
+            {
+                ["CorrelationId"] = _correlationId
+            }))
             {
                 _logger.LogInformation("{MethodName} Began", nameof(ContestScoringJob));
 
-                await ExecuteInternal();
-            }
-        }
-
-        private async Task ExecuteInternal()
-        {
-            // get the current week
-            // TODO: multi-sport
-            var weeksResult = await _seasonClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa).GetCurrentAndLastSeasonWeeks();
-            if (!weeksResult.IsSuccess)
-            {
-                _logger.LogWarning("Failed to retrieve season weeks from Producer. Will retry on next run.");
-                return;
-            }
-
-            var seasonWeeks = weeksResult.Value;
-
-            foreach (var seasonWeek in seasonWeeks)
-            {
-                // get a distinct list of all contests associated with UserPick records that have not been scored
                 var unscoredContestIds = await _dataContext.UserPicks
                     .Where(p => p.ScoredAt == null)
                     .Select(p => p.ContestId)
                     .Distinct()
                     .ToListAsync();
 
-                // get a list of all contests for the week that have been finalized
-                var finalizedResult = await _contestClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa)
-                    .GetFinalizedContestIds(seasonWeek.Id);
-                if (!finalizedResult.IsSuccess)
-                {
-                    _logger.LogWarning("Failed to retrieve finalized contests for week {WeekId}. Skipping.", seasonWeek.Id);
-                    continue;
-                }
-                var contestIdsReadyToScore = finalizedResult.Value;
+                _logger.LogInformation(
+                    "Found {Count} distinct contests with unscored picks. Enqueuing scoring for each.",
+                    unscoredContestIds.Count);
 
-                // determine if they have been enriched
-                var contestIdsToScore = unscoredContestIds
-                    .Where(x => contestIdsReadyToScore.Contains(x));
-
-                // send them each for scoring (generating UserPick points)
-                foreach (var contestId in contestIdsToScore)
+                foreach (var contestId in unscoredContestIds)
                 {
-                    var cmd = new ScoreContestCommand(contestId);
+                    var cmd = new ScoreContestCommand(contestId, _correlationId);
                     _backgroundJobProvider.Enqueue<IScoreContests>(p => p.Process(cmd));
                 }
+
+                _logger.LogInformation("{MethodName} Ended", nameof(ContestScoringJob));
             }
         }
     }

--- a/src/SportsData.Api/Application/Jobs/LeagueWeekScoringJob.cs
+++ b/src/SportsData.Api/Application/Jobs/LeagueWeekScoringJob.cs
@@ -62,9 +62,15 @@ namespace SportsData.Api.Application.Jobs
                     })
                     .ToListAsync();
 
-                // For each league week with any result row, find the most-recent
-                // calculation. Pairs (league, year, week) → max
-                // PickemGroupWeekResult.CalculatedUtc.
+                // For each league week with any result row, find the OLDEST
+                // calculation timestamp across all user rows.
+                //
+                // PickemGroupWeekResult is one row per user per league-week. Using
+                // Min rather than Max means the league-week is only considered
+                // fresh when every member's row is up to date. If we used Max, a
+                // single recently-updated row (e.g. a new league member whose row
+                // was just created) would mask older rows for other members and
+                // leave them stale.
                 var resultStatusByLeagueWeek = await _dataContext.PickemGroupWeekResults
                     .GroupBy(r => new { r.PickemGroupId, r.SeasonYear, r.SeasonWeek })
                     .Select(g => new
@@ -72,22 +78,22 @@ namespace SportsData.Api.Application.Jobs
                         GroupId = g.Key.PickemGroupId,
                         g.Key.SeasonYear,
                         g.Key.SeasonWeek,
-                        LatestCalc = g.Max(r => (DateTime?)r.CalculatedUtc)
+                        OldestCalc = g.Min(r => (DateTime?)r.CalculatedUtc)
                     })
                     .ToListAsync();
 
                 var resultLookup = resultStatusByLeagueWeek.ToDictionary(
                     r => (r.GroupId, r.SeasonYear, r.SeasonWeek),
-                    r => r.LatestCalc);
+                    r => r.OldestCalc);
 
-                // Stale = pick scored more recently than the last leaderboard
+                // Stale = pick scored more recently than the oldest user's last
                 // calculation, OR no result row exists yet.
                 var staleLeagueWeeks = pickStatusByLeagueWeek
                     .Where(p =>
                     {
-                        var lastCalc = resultLookup.GetValueOrDefault((p.GroupId, p.SeasonYear, p.SeasonWeek));
-                        return lastCalc == null
-                            || (p.LatestPickScored.HasValue && p.LatestPickScored > lastCalc);
+                        var oldestCalc = resultLookup.GetValueOrDefault((p.GroupId, p.SeasonYear, p.SeasonWeek));
+                        return oldestCalc == null
+                            || (p.LatestPickScored.HasValue && p.LatestPickScored > oldestCalc);
                     })
                     .ToList();
 

--- a/src/SportsData.Api/Application/Jobs/LeagueWeekScoringJob.cs
+++ b/src/SportsData.Api/Application/Jobs/LeagueWeekScoringJob.cs
@@ -2,35 +2,40 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Scoring;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Core.Infrastructure.Clients.Season;
-using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common.Jobs;
 
 namespace SportsData.Api.Application.Jobs
 {
     /// <summary>
-    /// Recurring job that ensures all league weeks with finalized contests are scored.
-    /// Automatically detects and fills gaps in league week results.
+    /// Daily backstop for the leaderboard-scoring path.
+    ///
+    /// Primary trigger is the tail call inside
+    /// <see cref="ContestScoringProcessor"/>: after picks for a contest are
+    /// scored, the processor invokes
+    /// <see cref="ILeagueWeekScoringService.ScoreLeagueWeekAsync"/> for each
+    /// (league, year, week) tuple that had picks in that contest. This job
+    /// catches league weeks where the tail call failed (e.g., a transient
+    /// exception or pod restart between contest scoring and league-week
+    /// scoring).
+    ///
+    /// Sport-agnostic by construction: the staleness predicate only looks at
+    /// <c>UserPick.ScoredAt</c> and <c>PickemGroupWeekResult.CalculatedUtc</c>
+    /// — no sport-specific endpoints or week semantics. <see cref="ILeagueWeekScoringService"/>
+    /// itself is already sport-neutral.
     /// </summary>
     public class LeagueWeekScoringJob : IAmARecurringJob
     {
         private readonly ILogger<LeagueWeekScoringJob> _logger;
         private readonly AppDataContext _dataContext;
-        private readonly ISeasonClientFactory _seasonClientFactory;
-        private readonly IContestClientFactory _contestClientFactory;
         private readonly ILeagueWeekScoringService _leagueWeekScoringService;
 
         public LeagueWeekScoringJob(
             ILogger<LeagueWeekScoringJob> logger,
             AppDataContext dataContext,
-            ISeasonClientFactory seasonClientFactory,
-            IContestClientFactory contestClientFactory,
             ILeagueWeekScoringService leagueWeekScoringService)
         {
             _logger = logger;
             _dataContext = dataContext;
-            _seasonClientFactory = seasonClientFactory;
-            _contestClientFactory = contestClientFactory;
             _leagueWeekScoringService = leagueWeekScoringService;
         }
 
@@ -40,113 +45,84 @@ namespace SportsData.Api.Application.Jobs
 
             try
             {
-                // Get current and previous season weeks
-                // TODO: multi-sport
-                var weeksResult = await _seasonClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa).GetCurrentAndLastSeasonWeeks();
-                if (!weeksResult.IsSuccess)
-            {
-                _logger.LogWarning("Failed to retrieve season weeks from Producer. Will retry on next run.");
-                return;
-            }
+                // For each league week with any scored picks, find the most-recently-
+                // scored pick. Pairs (league, year, week) → max UserPick.ScoredAt.
+                var pickStatusByLeagueWeek = await _dataContext.PickemGroupMatchups
+                    .Join(_dataContext.UserPicks.Where(p => p.ScoredAt != null),
+                        m => new { m.ContestId, GroupId = m.GroupId },
+                        p => new { p.ContestId, GroupId = p.PickemGroupId },
+                        (m, p) => new { GroupId = m.GroupId, m.SeasonYear, m.SeasonWeek, p.ScoredAt })
+                    .GroupBy(x => new { x.GroupId, x.SeasonYear, x.SeasonWeek })
+                    .Select(g => new
+                    {
+                        g.Key.GroupId,
+                        g.Key.SeasonYear,
+                        g.Key.SeasonWeek,
+                        LatestPickScored = g.Max(x => x.ScoredAt)
+                    })
+                    .ToListAsync();
 
-            var seasonWeeks = weeksResult.Value;
+                // For each league week with any result row, find the most-recent
+                // calculation. Pairs (league, year, week) → max
+                // PickemGroupWeekResult.CalculatedUtc.
+                var resultStatusByLeagueWeek = await _dataContext.PickemGroupWeekResults
+                    .GroupBy(r => new { r.PickemGroupId, r.SeasonYear, r.SeasonWeek })
+                    .Select(g => new
+                    {
+                        GroupId = g.Key.PickemGroupId,
+                        g.Key.SeasonYear,
+                        g.Key.SeasonWeek,
+                        LatestCalc = g.Max(r => (DateTime?)r.CalculatedUtc)
+                    })
+                    .ToListAsync();
 
-                foreach (var seasonWeek in seasonWeeks)
+                var resultLookup = resultStatusByLeagueWeek.ToDictionary(
+                    r => (r.GroupId, r.SeasonYear, r.SeasonWeek),
+                    r => r.LatestCalc);
+
+                // Stale = pick scored more recently than the last leaderboard
+                // calculation, OR no result row exists yet.
+                var staleLeagueWeeks = pickStatusByLeagueWeek
+                    .Where(p =>
+                    {
+                        var lastCalc = resultLookup.GetValueOrDefault((p.GroupId, p.SeasonYear, p.SeasonWeek));
+                        return lastCalc == null
+                            || (p.LatestPickScored.HasValue && p.LatestPickScored > lastCalc);
+                    })
+                    .ToList();
+
+                _logger.LogInformation(
+                    "Found {Count} stale league weeks needing leaderboard rescore.",
+                    staleLeagueWeeks.Count);
+
+                var successCount = 0;
+                var failureCount = 0;
+
+                foreach (var lw in staleLeagueWeeks)
                 {
-                    _logger.LogInformation(
-                        "Processing season year={Year}, week={Week}",
-                        seasonWeek.SeasonYear,
-                        seasonWeek.WeekNumber);
-
-                    // Get all leagues that have matchups for this week
-                    var leagueWeeks = await _dataContext.PickemGroupMatchups
-                        .Where(m => m.SeasonYear == seasonWeek.SeasonYear && m.SeasonWeek == seasonWeek.WeekNumber)
-                        .Select(m => new { m.GroupId, m.SeasonYear, m.SeasonWeek })
-                        .Distinct()
-                        .ToListAsync();
-
-                    _logger.LogInformation(
-                        "Found {Count} leagues with matchups for week {Week}",
-                        leagueWeeks.Count,
-                        seasonWeek.WeekNumber);
-
-                    // Fetch finalized contests once per season week (shared across all leagues)
-                    var finalizedResult = await _contestClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa)
-                        .GetFinalizedContestIds(seasonWeek.Id);
-                    if (!finalizedResult.IsSuccess)
+                    try
                     {
-                        _logger.LogWarning("Failed to retrieve finalized contests for week {WeekId}. Skipping.", seasonWeek.Id);
-                        continue;
+                        _logger.LogInformation(
+                            "Rescoring league week: leagueId={LeagueId}, year={Year}, week={Week}",
+                            lw.GroupId, lw.SeasonYear, lw.SeasonWeek);
+
+                        await _leagueWeekScoringService.ScoreLeagueWeekAsync(
+                            lw.GroupId, lw.SeasonYear, lw.SeasonWeek);
+                        successCount++;
                     }
-                    var finalizedContestIds = finalizedResult.Value;
-
-                    foreach (var leagueWeek in leagueWeeks)
+                    catch (Exception ex)
                     {
-                        try
-                        {
-                            // Check if this league week has been scored recently
-                            var lastCalculated = await _dataContext.PickemGroupWeekResults
-                                .Where(r =>
-                                    r.PickemGroupId == leagueWeek.GroupId &&
-                                    r.SeasonYear == leagueWeek.SeasonYear &&
-                                    r.SeasonWeek == leagueWeek.SeasonWeek)
-                                .MaxAsync(r => (DateTime?)r.CalculatedUtc);
-
-                            // Check if all contests for this week are finalized
-                            var allContestIds = await _dataContext.PickemGroupMatchups
-                                .Where(m =>
-                                    m.GroupId == leagueWeek.GroupId &&
-                                    m.SeasonYear == leagueWeek.SeasonYear &&
-                                    m.SeasonWeek == leagueWeek.SeasonWeek)
-                                .Select(m => m.ContestId)
-                                .ToListAsync();
-
-                            var allFinalized = allContestIds.All(id => finalizedContestIds.Contains(id));
-
-                            // Score if:
-                            // 1. Never scored (lastCalculated == null), OR
-                            // 2. All contests are finalized and it's been more than 1 hour since last calculation
-                            var shouldScore = lastCalculated == null || 
-                                (allFinalized && lastCalculated < DateTime.UtcNow.AddHours(-1));
-
-                            if (shouldScore)
-                            {
-                                _logger.LogInformation(
-                                    "Scoring league week: leagueId={LeagueId}, year={Year}, week={Week}, reason={Reason}",
-                                    leagueWeek.GroupId,
-                                    leagueWeek.SeasonYear,
-                                    leagueWeek.SeasonWeek,
-                                    lastCalculated == null ? "never scored" : "contests finalized");
-
-                                await _leagueWeekScoringService.ScoreLeagueWeekAsync(
-                                    leagueWeek.GroupId,
-                                    leagueWeek.SeasonYear,
-                                    leagueWeek.SeasonWeek);
-                            }
-                            else
-                            {
-                                _logger.LogDebug(
-                                    "Skipping league week (already scored): leagueId={LeagueId}, year={Year}, week={Week}, lastCalculated={LastCalculated}",
-                                    leagueWeek.GroupId,
-                                    leagueWeek.SeasonYear,
-                                    leagueWeek.SeasonWeek,
-                                    lastCalculated);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(
-                                ex,
-                                "Error scoring league week: leagueId={LeagueId}, year={Year}, week={Week}",
-                                leagueWeek.GroupId,
-                                leagueWeek.SeasonYear,
-                                leagueWeek.SeasonWeek);
-                            // Continue processing other leagues
-                        }
+                        _logger.LogError(
+                            ex,
+                            "Error rescoring league week: leagueId={LeagueId}, year={Year}, week={Week}",
+                            lw.GroupId, lw.SeasonYear, lw.SeasonWeek);
+                        failureCount++;
                     }
                 }
 
-                _logger.LogInformation("Completed {JobName}", nameof(LeagueWeekScoringJob));
+                _logger.LogInformation(
+                    "Completed {JobName}: {Success} successful, {Failure} failed",
+                    nameof(LeagueWeekScoringJob), successCount, failureCount);
             }
             catch (Exception ex)
             {

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -271,15 +271,22 @@ namespace SportsData.Api.DependencyInjection
                 job => job.ExecuteAsync(),
                 Cron.Weekly);
 
+            // Daily backstop. Primary scoring trigger is event-driven
+            // (Producer ContestCompleted → API ContestCompletedHandler enqueues
+            // ContestScoringProcessor); this catches events lost in transit.
             recurringJobManager.AddOrUpdate<ContestScoringJob>(
                 nameof(ContestScoringJob),
                 job => job.ExecuteAsync(),
-                Cron.Weekly);
+                Cron.Daily(9));
 
+            // Daily backstop. Primary trigger is the tail call inside
+            // ContestScoringProcessor; this catches league weeks where the
+            // tail leaderboard scoring failed. 15-min stagger so it runs
+            // after ContestScoringJob's enqueues have had time to process.
             recurringJobManager.AddOrUpdate<LeagueWeekScoringJob>(
                 nameof(LeagueWeekScoringJob),
                 job => job.ExecuteAsync(),
-                Cron.Weekly);
+                Cron.Daily(9, 15));
 
             recurringJobManager.AddOrUpdate<MatchupPreviewGenerator>(
                 nameof(MatchupPreviewGenerator),

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueWeekScoringJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueWeekScoringJobTests.cs
@@ -1,107 +1,40 @@
-using FluentAssertions;
-using SportsData.Api.Application.Common.Enums;
-
-using Microsoft.Extensions.Logging;
-
 using Moq;
 
-using SportsData.Api.Application;
 using SportsData.Api.Application.Jobs;
 using SportsData.Api.Application.Scoring;
-using SportsData.Core.Dtos.Canonical;
 using SportsData.Api.Infrastructure.Data.Entities;
-using SportsData.Core.Common;
-using SportsData.Core.Infrastructure.Clients.Contest;
-using SportsData.Core.Infrastructure.Clients.Season;
 
 using Xunit;
 
 namespace SportsData.Api.Tests.Unit.Application.Jobs;
 
 /// <summary>
-/// Tests for LeagueWeekScoringJob - validates gap detection and backfill logic.
+/// Tests for LeagueWeekScoringJob — the sport-agnostic daily backstop.
+///
+/// The staleness predicate: a league week needs rescoring when any pick for
+/// (league, year, week) was scored more recently than the last
+/// PickemGroupWeekResult.CalculatedUtc for that tuple — or no result row
+/// exists yet. No sport-specific endpoints or week semantics.
 /// </summary>
 public class LeagueWeekScoringJobTests : ApiTestBase<LeagueWeekScoringJob>
 {
-    private readonly Mock<ILogger<LeagueWeekScoringJob>> _loggerMock;
-    private readonly Mock<IProvideSeasons> _seasonClientMock;
-    private readonly Mock<IProvideContests> _contestClientMock;
-    private readonly Mock<ILeagueWeekScoringService> _leagueWeekScoringServiceMock;
-
-    public LeagueWeekScoringJobTests()
-    {
-        _loggerMock = new Mock<ILogger<LeagueWeekScoringJob>>();
-        _seasonClientMock = new Mock<IProvideSeasons>();
-        _contestClientMock = new Mock<IProvideContests>();
-        _leagueWeekScoringServiceMock = new Mock<ILeagueWeekScoringService>();
-
-        Mocker.Use(_loggerMock.Object);
-        Mocker.GetMock<ISeasonClientFactory>()
-            .Setup(x => x.Resolve(It.IsAny<Sport>()))
-            .Returns(_seasonClientMock.Object);
-        Mocker.GetMock<IContestClientFactory>()
-            .Setup(x => x.Resolve(It.IsAny<Sport>()))
-            .Returns(_contestClientMock.Object);
-        Mocker.Use(_leagueWeekScoringServiceMock.Object);
-    }
+    private static readonly DateTime FixedUtcNow = new(2026, 5, 22, 9, 15, 0, DateTimeKind.Utc);
+    private static readonly DateTime PickScoredAt = FixedUtcNow.AddHours(-1);
+    private static readonly DateTime ResultCalculatedAfter = FixedUtcNow;
+    private static readonly DateTime ResultCalculatedBefore = FixedUtcNow.AddHours(-2);
 
     [Fact]
-    public async Task ExecuteAsync_ScoresLeagueWeek_WhenNeverScored()
+    public async Task ExecuteAsync_Rescores_WhenNoResultRowExists()
     {
-        // Arrange
+        // Arrange — picks scored but no PickemGroupWeekResult row at all.
         var leagueId = Guid.NewGuid();
-        var seasonWeekId = Guid.NewGuid();
-        var seasonYear = 2024;
-        var weekNumber = 1;
+        var contestId = Guid.NewGuid();
+        const int seasonYear = 2026;
+        const int seasonWeek = 1;
 
-        var seasonWeeks = new List<CanonicalSeasonWeekDto>
-        {
-            new()
-            {
-                Id = seasonWeekId,
-                SeasonYear = seasonYear,
-                WeekNumber = weekNumber
-            }
-        };
+        await SeedMatchupAndScoredPickAsync(leagueId, contestId, seasonYear, seasonWeek, PickScoredAt);
 
-        var league = new PickemGroup
-        {
-            Id = leagueId,
-            Name = "Test League",
-            Sport = Sport.FootballNcaa,
-            League = League.NCAAF,
-            PickType = PickType.StraightUp,
-            TiebreakerType = TiebreakerType.None,
-            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
-            CommissionerUserId = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow,
-            CreatedBy = Guid.Empty
-        };
-
-        var matchup = new PickemGroupMatchup
-        {
-            Id = Guid.NewGuid(),
-            GroupId = leagueId,
-            SeasonWeekId = seasonWeekId,
-            ContestId = Guid.NewGuid(),
-            SeasonYear = seasonYear,
-            SeasonWeek = weekNumber,
-            StartDateUtc = DateTime.UtcNow.AddDays(-1),
-            CreatedUtc = DateTime.UtcNow,
-            CreatedBy = Guid.Empty
-        };
-
-        await DataContext.PickemGroups.AddAsync(league);
-        await DataContext.PickemGroupMatchups.AddAsync(matchup);
-        await DataContext.SaveChangesAsync();
-
-        _seasonClientMock
-            .Setup(x => x.GetCurrentAndLastSeasonWeeks(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>(seasonWeeks));
-
-        _contestClientMock
-            .Setup(x => x.GetFinalizedContestIds(seasonWeekId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<Guid>>(new List<Guid> { matchup.ContestId }));
+        var service = Mocker.GetMock<ILeagueWeekScoringService>();
 
         var sut = Mocker.CreateInstance<LeagueWeekScoringJob>();
 
@@ -109,87 +42,24 @@ public class LeagueWeekScoringJobTests : ApiTestBase<LeagueWeekScoringJob>
         await sut.ExecuteAsync();
 
         // Assert
-        _leagueWeekScoringServiceMock.Verify(
-            x => x.ScoreLeagueWeekAsync(leagueId, seasonYear, weekNumber, default),
-            Times.Once,
-            "Should score league week when never scored before");
+        service.Verify(x => x.ScoreLeagueWeekAsync(leagueId, seasonYear, seasonWeek, default), Times.Once);
     }
 
     [Fact]
-    public async Task ExecuteAsync_SkipsLeagueWeek_WhenRecentlyScored()
+    public async Task ExecuteAsync_Rescores_WhenPickScoredAfterLastCalculation()
     {
-        // Arrange
+        // Arrange — pick scored AFTER the existing result row's CalculatedUtc.
+        // Catches the "ContestScoringProcessor's tail leaderboard scoring failed
+        // silently after picks were scored" scenario.
         var leagueId = Guid.NewGuid();
-        var userId = Guid.NewGuid();
-        var seasonWeekId = Guid.NewGuid();
-        var seasonYear = 2024;
-        var weekNumber = 1;
+        var contestId = Guid.NewGuid();
+        const int seasonYear = 2026;
+        const int seasonWeek = 1;
 
-        var seasonWeeks = new List<CanonicalSeasonWeekDto>
-        {
-            new()
-            {
-                Id = seasonWeekId,
-                SeasonYear = seasonYear,
-                WeekNumber = weekNumber
-            }
-        };
+        await SeedMatchupAndScoredPickAsync(leagueId, contestId, seasonYear, seasonWeek, PickScoredAt);
+        await SeedResultAsync(leagueId, seasonYear, seasonWeek, ResultCalculatedBefore);
 
-        var league = new PickemGroup
-        {
-            Id = leagueId,
-            Name = "Test League",
-            Sport = Sport.FootballNcaa,
-            League = League.NCAAF,
-            PickType = PickType.StraightUp,
-            TiebreakerType = TiebreakerType.None,
-            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
-            CommissionerUserId = userId,
-            CreatedUtc = DateTime.UtcNow,
-            CreatedBy = Guid.Empty
-        };
-
-        var matchup = new PickemGroupMatchup
-        {
-            Id = Guid.NewGuid(),
-            GroupId = leagueId,
-            SeasonWeekId = seasonWeekId,
-            ContestId = Guid.NewGuid(),
-            SeasonYear = seasonYear,
-            SeasonWeek = weekNumber,
-            StartDateUtc = DateTime.UtcNow.AddDays(-1),
-            CreatedUtc = DateTime.UtcNow,
-            CreatedBy = Guid.Empty
-        };
-
-        // Already scored 30 minutes ago
-        var existingResult = new PickemGroupWeekResult
-        {
-            Id = Guid.NewGuid(),
-            PickemGroupId = leagueId,
-            UserId = userId,
-            SeasonYear = seasonYear,
-            SeasonWeek = weekNumber,
-            TotalPoints = 5,
-            CorrectPicks = 5,
-            TotalPicks = 10,
-            CalculatedUtc = DateTime.UtcNow.AddMinutes(-30),
-            CreatedUtc = DateTime.UtcNow.AddMinutes(-30),
-            CreatedBy = Guid.Empty
-        };
-
-        await DataContext.PickemGroups.AddAsync(league);
-        await DataContext.PickemGroupMatchups.AddAsync(matchup);
-        await DataContext.PickemGroupWeekResults.AddAsync(existingResult);
-        await DataContext.SaveChangesAsync();
-
-        _seasonClientMock
-            .Setup(x => x.GetCurrentAndLastSeasonWeeks(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>(seasonWeeks));
-
-        _contestClientMock
-            .Setup(x => x.GetFinalizedContestIds(seasonWeekId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<Guid>>(new List<Guid>())); // Not all finalized
+        var service = Mocker.GetMock<ILeagueWeekScoringService>();
 
         var sut = Mocker.CreateInstance<LeagueWeekScoringJob>();
 
@@ -197,87 +67,73 @@ public class LeagueWeekScoringJobTests : ApiTestBase<LeagueWeekScoringJob>
         await sut.ExecuteAsync();
 
         // Assert
-        _leagueWeekScoringServiceMock.Verify(
+        service.Verify(x => x.ScoreLeagueWeekAsync(leagueId, seasonYear, seasonWeek, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Skips_WhenResultIsCurrent()
+    {
+        // Arrange — pick scored BEFORE the existing result row's CalculatedUtc.
+        // The leaderboard is fresh; no work to do.
+        var leagueId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        const int seasonYear = 2026;
+        const int seasonWeek = 1;
+
+        await SeedMatchupAndScoredPickAsync(leagueId, contestId, seasonYear, seasonWeek, PickScoredAt);
+        await SeedResultAsync(leagueId, seasonYear, seasonWeek, ResultCalculatedAfter);
+
+        var service = Mocker.GetMock<ILeagueWeekScoringService>();
+
+        var sut = Mocker.CreateInstance<LeagueWeekScoringJob>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert
+        service.Verify(
             x => x.ScoreLeagueWeekAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), default),
-            Times.Never,
-            "Should skip league week when recently scored and not all contests finalized");
+            Times.Never);
     }
 
     [Fact]
-    public async Task ExecuteAsync_RescoresLeagueWeek_WhenAllContestsFinalizedAndOldCalculation()
+    public async Task ExecuteAsync_Skips_WhenNoScoredPicks()
     {
-        // Arrange
+        // Arrange — matchup exists but no UserPicks have ScoredAt set.
+        // Nothing has been scored, so no backstop work is needed.
         var leagueId = Guid.NewGuid();
-        var userId = Guid.NewGuid();
-        var seasonWeekId = Guid.NewGuid();
-        var seasonYear = 2024;
-        var weekNumber = 1;
-
-        var seasonWeeks = new List<CanonicalSeasonWeekDto>
-        {
-            new()
-            {
-                Id = seasonWeekId,
-                SeasonYear = seasonYear,
-                WeekNumber = weekNumber
-            }
-        };
-
-        var league = new PickemGroup
-        {
-            Id = leagueId,
-            Name = "Test League",
-            Sport = Sport.FootballNcaa,
-            League = League.NCAAF,
-            PickType = PickType.StraightUp,
-            TiebreakerType = TiebreakerType.None,
-            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
-            CommissionerUserId = userId,
-            CreatedUtc = DateTime.UtcNow,
-            CreatedBy = Guid.Empty
-        };
+        var contestId = Guid.NewGuid();
+        const int seasonYear = 2026;
+        const int seasonWeek = 1;
 
         var matchup = new PickemGroupMatchup
         {
             Id = Guid.NewGuid(),
             GroupId = leagueId,
-            SeasonWeekId = seasonWeekId,
-            ContestId = Guid.NewGuid(),
+            SeasonWeekId = Guid.NewGuid(),
+            ContestId = contestId,
             SeasonYear = seasonYear,
-            SeasonWeek = weekNumber,
-            StartDateUtc = DateTime.UtcNow.AddDays(-1),
-            CreatedUtc = DateTime.UtcNow,
+            SeasonWeek = seasonWeek,
+            StartDateUtc = FixedUtcNow.AddDays(-1),
+            CreatedUtc = FixedUtcNow,
             CreatedBy = Guid.Empty
         };
 
-        // Scored 2 hours ago, but all contests are now finalized
-        var existingResult = new PickemGroupWeekResult
+        var unscoredPick = new PickemGroupUserPick
         {
             Id = Guid.NewGuid(),
             PickemGroupId = leagueId,
-            UserId = userId,
-            SeasonYear = seasonYear,
-            SeasonWeek = weekNumber,
-            TotalPoints = 5,
-            CorrectPicks = 5,
-            TotalPicks = 10,
-            CalculatedUtc = DateTime.UtcNow.AddHours(-2),
-            CreatedUtc = DateTime.UtcNow.AddHours(-2),
+            ContestId = contestId,
+            ScoredAt = null,
+            CreatedUtc = FixedUtcNow,
             CreatedBy = Guid.Empty
         };
 
-        await DataContext.PickemGroups.AddAsync(league);
         await DataContext.PickemGroupMatchups.AddAsync(matchup);
-        await DataContext.PickemGroupWeekResults.AddAsync(existingResult);
+        await DataContext.UserPicks.AddAsync(unscoredPick);
         await DataContext.SaveChangesAsync();
 
-        _seasonClientMock
-            .Setup(x => x.GetCurrentAndLastSeasonWeeks(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>(seasonWeeks));
-
-        _contestClientMock
-            .Setup(x => x.GetFinalizedContestIds(seasonWeekId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<Guid>>(new List<Guid> { matchup.ContestId })); // All finalized
+        var service = Mocker.GetMock<ILeagueWeekScoringService>();
 
         var sut = Mocker.CreateInstance<LeagueWeekScoringJob>();
 
@@ -285,9 +141,68 @@ public class LeagueWeekScoringJobTests : ApiTestBase<LeagueWeekScoringJob>
         await sut.ExecuteAsync();
 
         // Assert
-        _leagueWeekScoringServiceMock.Verify(
-            x => x.ScoreLeagueWeekAsync(leagueId, seasonYear, weekNumber, default),
-            Times.Once,
-            "Should rescore league week when all contests finalized and last calculation is old");
+        service.Verify(
+            x => x.ScoreLeagueWeekAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), default),
+            Times.Never);
+    }
+
+    private async Task SeedMatchupAndScoredPickAsync(
+        Guid leagueId,
+        Guid contestId,
+        int seasonYear,
+        int seasonWeek,
+        DateTime pickScoredAt)
+    {
+        var matchup = new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = leagueId,
+            SeasonWeekId = Guid.NewGuid(),
+            ContestId = contestId,
+            SeasonYear = seasonYear,
+            SeasonWeek = seasonWeek,
+            StartDateUtc = FixedUtcNow.AddDays(-1),
+            CreatedUtc = FixedUtcNow,
+            CreatedBy = Guid.Empty
+        };
+
+        var pick = new PickemGroupUserPick
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            ContestId = contestId,
+            ScoredAt = pickScoredAt,
+            CreatedUtc = FixedUtcNow,
+            CreatedBy = Guid.Empty
+        };
+
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+        await DataContext.UserPicks.AddAsync(pick);
+        await DataContext.SaveChangesAsync();
+    }
+
+    private async Task SeedResultAsync(
+        Guid leagueId,
+        int seasonYear,
+        int seasonWeek,
+        DateTime calculatedUtc)
+    {
+        var result = new PickemGroupWeekResult
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            UserId = Guid.NewGuid(),
+            SeasonYear = seasonYear,
+            SeasonWeek = seasonWeek,
+            TotalPoints = 0,
+            CorrectPicks = 0,
+            TotalPicks = 0,
+            CalculatedUtc = calculatedUtc,
+            CreatedUtc = calculatedUtc,
+            CreatedBy = Guid.Empty
+        };
+
+        await DataContext.PickemGroupWeekResults.AddAsync(result);
+        await DataContext.SaveChangesAsync();
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueWeekScoringJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueWeekScoringJobTests.cs
@@ -97,6 +97,36 @@ public class LeagueWeekScoringJobTests : ApiTestBase<LeagueWeekScoringJob>
     }
 
     [Fact]
+    public async Task ExecuteAsync_Rescores_WhenAnyResultRowIsStale()
+    {
+        // Arrange — same (PickemGroupId, SeasonYear, SeasonWeek) has two user
+        // result rows: one fresh (after the pick was scored), one stale (before).
+        // The staleness check must compare against the OLDEST row, not the newest,
+        // so the league-week is rescored to bring the lagging user up to date.
+        // Regression test for the Min vs Max ambiguity flagged by CodeRabbit.
+        var leagueId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        const int seasonYear = 2026;
+        const int seasonWeek = 1;
+
+        await SeedMatchupAndScoredPickAsync(leagueId, contestId, seasonYear, seasonWeek, PickScoredAt);
+        await SeedResultAsync(leagueId, seasonYear, seasonWeek, ResultCalculatedBefore); // stale user
+        await SeedResultAsync(leagueId, seasonYear, seasonWeek, ResultCalculatedAfter);  // fresh user
+
+        var service = Mocker.GetMock<ILeagueWeekScoringService>();
+
+        var sut = Mocker.CreateInstance<LeagueWeekScoringJob>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert — must rescore because at least one user's row is stale.
+        // With a Max-based check this would incorrectly skip (false negative);
+        // with Min, the older row dominates and the tuple is correctly stale.
+        service.Verify(x => x.ScoreLeagueWeekAsync(leagueId, seasonYear, seasonWeek, default), Times.Once);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Skips_WhenNoScoredPicks()
     {
         // Arrange — matchup exists but no UserPicks have ScoredAt set.

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringJobTests.cs
@@ -4,11 +4,7 @@ using Moq;
 
 using SportsData.Api.Application.Jobs;
 using SportsData.Api.Application.Scoring;
-using SportsData.Core.Common;
-using SportsData.Core.Dtos.Canonical;
 using SportsData.Api.Infrastructure.Data.Entities;
-using SportsData.Core.Infrastructure.Clients.Contest;
-using SportsData.Core.Infrastructure.Clients.Season;
 using SportsData.Core.Processing;
 
 using System.Linq.Expressions;
@@ -19,58 +15,60 @@ namespace SportsData.Api.Tests.Unit.Application.Scoring;
 
 public class ContestScoringJobTests : ApiTestBase<ContestScoringJob>
 {
-    private readonly Mock<IProvideSeasons> _seasonClientMock = new();
-    private readonly Mock<IProvideContests> _contestClientMock = new();
-
-    public ContestScoringJobTests()
-    {
-        Mocker.GetMock<ISeasonClientFactory>()
-            .Setup(x => x.Resolve(It.IsAny<Sport>()))
-            .Returns(_seasonClientMock.Object);
-        Mocker.GetMock<IContestClientFactory>()
-            .Setup(x => x.Resolve(It.IsAny<Sport>()))
-            .Returns(_contestClientMock.Object);
-    }
-
     [Fact]
-    public async Task Process_Should_Enqueue_ScoreContestCommand_For_Each_Finalized_Unscored_Contest()
+    public async Task Execute_EnqueuesScoreContestCommand_ForEachDistinctUnscoredContest()
     {
-        // Arrange
-        var seasonWeekId = Guid.NewGuid();
-
-        var currentWeek = Fixture.Build<CanonicalSeasonWeekDto>()
-            .With(x => x.Id, seasonWeekId)
-            .Create();
-
-        var background = Mocker.GetMock<IProvideBackgroundJobs>();
-
-        _seasonClientMock
-            .Setup(x => x.GetCurrentAndLastSeasonWeeks(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>([currentWeek]));
-
-        // These are the contest IDs referenced by unscored picks
+        // Arrange — three unscored picks spanning two distinct contests,
+        // plus one already-scored pick that should NOT be enqueued.
         var contestId1 = Guid.NewGuid();
         var contestId2 = Guid.NewGuid();
-        var contestId3 = Guid.NewGuid(); // This one is NOT finalized
+        var contestId3 = Guid.NewGuid();
 
         DataContext.UserPicks.AddRange(
             Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, contestId1)
                 .With(x => x.ScoredAt, (DateTime?)null).Create(),
             Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, contestId1) // duplicate contest — should only enqueue once
+                .With(x => x.ScoredAt, (DateTime?)null).Create(),
+            Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, contestId2)
                 .With(x => x.ScoredAt, (DateTime?)null).Create(),
             Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, contestId3)
-                .With(x => x.ScoredAt, (DateTime?)null).Create()
+                .With(x => x.ScoredAt, (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)) // already scored
+                .Create()
         );
 
         await DataContext.SaveChangesAsync();
 
-        // Contest client returns 2 of the 3 as finalized
-        _contestClientMock
-            .Setup(x => x.GetFinalizedContestIds(seasonWeekId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<Guid>>([contestId1, contestId2]));
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        var sut = Mocker.CreateInstance<ContestScoringJob>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert — exactly two distinct unscored contests enqueued;
+        // the already-scored contest is excluded by the WHERE clause.
+        background.Verify(x => x.Enqueue<IScoreContests>(
+            It.IsAny<Expression<Func<IScoreContests, Task>>>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Execute_DoesNothing_WhenNoUnscoredPicks()
+    {
+        // Arrange — only already-scored picks in the database.
+        DataContext.UserPicks.Add(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, Guid.NewGuid())
+                .With(x => x.ScoredAt, (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                .Create()
+        );
+
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
 
         var sut = Mocker.CreateInstance<ContestScoringJob>();
 
@@ -79,6 +77,6 @@ public class ContestScoringJobTests : ApiTestBase<ContestScoringJob>
 
         // Assert
         background.Verify(x => x.Enqueue<IScoreContests>(
-            It.IsAny<Expression<Func<IScoreContests, Task>>>()), Times.Exactly(2));
+            It.IsAny<Expression<Func<IScoreContests, Task>>>()), Times.Never);
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/ContestScoringJobTests.cs
@@ -42,17 +42,46 @@ public class ContestScoringJobTests : ApiTestBase<ContestScoringJob>
 
         await DataContext.SaveChangesAsync();
 
+        // Capture every enqueued ScoreContestCommand so we can verify the exact
+        // set of ContestIds, not just the call count. The count alone would miss
+        // a regression where the same ContestId is enqueued twice and a distinct
+        // one is dropped.
+        var enqueuedCommands = new List<ScoreContestCommand>();
         var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        background
+            .Setup(x => x.Enqueue<IScoreContests>(It.IsAny<Expression<Func<IScoreContests, Task>>>()))
+            .Callback<Expression<Func<IScoreContests, Task>>>(expr =>
+            {
+                var cmd = ScoreContestCommandFromExpression(expr);
+                if (cmd != null) enqueuedCommands.Add(cmd);
+            });
 
         var sut = Mocker.CreateInstance<ContestScoringJob>();
 
         // Act
         await sut.ExecuteAsync();
 
-        // Assert — exactly two distinct unscored contests enqueued;
-        // the already-scored contest is excluded by the WHERE clause.
-        background.Verify(x => x.Enqueue<IScoreContests>(
-            It.IsAny<Expression<Func<IScoreContests, Task>>>()), Times.Exactly(2));
+        // Assert — exactly two enqueues, one per distinct unscored contest.
+        Assert.Equal(2, enqueuedCommands.Count);
+        Assert.Equal(
+            new HashSet<Guid> { contestId1, contestId2 },
+            enqueuedCommands.Select(c => c.ContestId).ToHashSet());
+    }
+
+    /// <summary>
+    /// Compiles and evaluates the single argument of a
+    /// <c>p =&gt; p.Process(cmd)</c> expression to extract the captured
+    /// <see cref="ScoreContestCommand"/> instance. Returns null when the
+    /// expression isn't shaped as expected.
+    /// </summary>
+    private static ScoreContestCommand? ScoreContestCommandFromExpression(
+        Expression<Func<IScoreContests, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        if (call.Method.Name != nameof(IScoreContests.Process)) return null;
+        if (call.Arguments.Count != 1) return null;
+
+        return Expression.Lambda<Func<ScoreContestCommand>>(call.Arguments[0]).Compile()();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

**PR-N+4** of the multi-sport scoring refactor (see `docs/multi-sport-scoring-job-refactor.md`, doc PR #356). Rewrites `ContestScoringJob` and `LeagueWeekScoringJob` as **sport-agnostic daily backstops** behind the event-driven primary path established in #358 (`ContestCompleted` publish) and #359 (consumer).

## Why simpler than the original doc spec

PR-N+1 (#357) made `ContestScoringProcessor` self-contained — it resolves sport from `PickemGroup.Sport`, calls the right `ContestClient`, handles `NotFound` (contest not finalized yet) gracefully, and short-circuits when there are no unscored picks. That collapsed the doc's per-sport-iteration cron pattern into a much thinner "enqueue everything that might need scoring" pass.

## What changes

### `ContestScoringJob`

- Dropped `ISeasonClientFactory` + `IContestClientFactory` deps entirely.
- Body: query distinct `ContestId`s where `UserPicks.ScoredAt == null`, enqueue `ScoreContestCommand` for each.
- Processor handles sport, finalization, idempotency.

### `LeagueWeekScoringJob`

- Dropped the same client factory deps.
- Body: staleness predicate from the design doc — a `(league, year, week)` needs rescore when any `UserPick.ScoredAt` exceeds the latest `PickemGroupWeekResult.CalculatedUtc` for that tuple, or no result row exists.
- Two EF queries + in-memory join. `LeagueWeekScoringService` itself stays untouched (already sport-neutral).

### Cron cadence (`ServiceRegistration.cs`)

Both jobs flipped from `Cron.Weekly` (placeholder) to daily:
- `ContestScoringJob` → `Cron.Daily(9)` (09:00 UTC)
- `LeagueWeekScoringJob` → `Cron.Daily(9, 15)` (09:15 UTC — 15-min stagger so backstop sees the results of any catch-up enqueues)

### EF perf cleanup

Removed three redundant `AsNoTracking()` calls — they were applied to queries projecting to scalars (`Guid`) or anonymous types, where EF Core's change tracker doesn't engage regardless.

### Tests rewritten

| File | Tests |
|---|---|
| `ContestScoringJobTests` (2) | Distinct unscored ContestIds → exact enqueue count; only-scored → zero enqueues |
| `LeagueWeekScoringJobTests` (4) | No result row → rescore; pick newer than calc → rescore; result current → skip; no scored picks → skip |

`IProvideSeasons` / `IProvideContests` mocks removed throughout.

## Behavior change worth noting

The new `ContestScoringJob` enqueues scoring for **every** distinct unscored contest, regardless of finalization state. The processor handles "not yet finalized" by getting `NotFound` from `GetMatchupResult` and returning silently. Net: more enqueues than the prior week-anchored version, each cheap and idempotent. No contest can fall through.

## Test plan

- [x] `dotnet build` SportsData.Api — 0 warnings, 0 errors
- [x] `dotnet test` Api.Tests.Unit `~ContestScoringJob | ~LeagueWeekScoringJob` — 6/6 pass
- [ ] Manual post-deploy: confirm both jobs appear in Hangfire's recurring-jobs UI at the new daily cron. Watch Seq for `ContestScoringJob Began` at 09:00 UTC tomorrow.

## Remaining

PR-N+5 — `MatchupScheduler` sport-iteration — is the only remaining piece of the refactor plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Job scheduling changed to run daily at 9:00 AM (with a 15-minute stagger) to provide more frequent backstops for scoring and leaderboard recovery.

* **Behavior**
  * Scoring jobs simplified to act as database-staleness backstops that enqueue rescores for stale or unscored contests/weeks, improving reliability of missed or failed scoring.

* **Tests**
  * Test suites refactored to validate daily staleness detection and enqueue/rescore behavior with deterministic scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->