### PR TITLE
feat(api): sport-iteration in MatchupScheduler + AsNoTracking cleanup

### DIFF
--- a/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
+++ b/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Processors;
 using SportsData.Api.Infrastructure.Data;
@@ -10,6 +10,22 @@ using SportsData.Core.Processing;
 
 namespace SportsData.Api.Application.Jobs
 {
+    /// <summary>
+    /// Generates next-week PickemGroupWeek + matchup-schedule jobs for every
+    /// active league.
+    ///
+    /// Sport-agnostic by construction: discovers the active sport list at
+    /// runtime from <c>PickemGroups.Select(g => g.Sport).Distinct()</c>, then
+    /// resolves each sport's current week through its own
+    /// <see cref="ISeasonClientFactory"/>-routed client. Sports with no active
+    /// leagues are skipped; sports whose Producer can't report a current week
+    /// (offseason, transient failure) are skipped with a warning.
+    ///
+    /// This is the only scoring/scheduling job NOT in the event-driven primary
+    /// path — matchups must be generated BEFORE games happen, so this stays a
+    /// cron-driven primary. Daily cadence is sufficient since week boundaries
+    /// move at most once per week per sport.
+    /// </summary>
     public class MatchupScheduler : IAmARecurringJob
     {
         private readonly ILogger<MatchupScheduler> _logger;
@@ -31,20 +47,45 @@ namespace SportsData.Api.Application.Jobs
 
         public async Task ExecuteAsync()
         {
-            // get the current week
-            // TODO: multi-sport — resolve sport from context instead of defaulting
-            var result = await _seasonClientFactory.Resolve(Sport.FootballNcaa).GetCurrentSeasonWeek();
-            var currentWeek = result.IsSuccess ? result.Value : null;
+            _logger.LogInformation("{JobName} Began", nameof(MatchupScheduler));
+
+            // Discover sports with at least one league. Adding a new sport
+            // becomes "create a league" — no code change to this job.
+            var activeSports = await _dataContext.PickemGroups
+                .Select(g => g.Sport)
+                .Distinct()
+                .ToListAsync();
+
+            _logger.LogInformation(
+                "Found {Count} active sport(s) with leagues: {Sports}",
+                activeSports.Count, string.Join(", ", activeSports));
+
+            foreach (var sport in activeSports)
+            {
+                await ScheduleForSportAsync(sport);
+            }
+
+            _logger.LogInformation("{JobName} Ended", nameof(MatchupScheduler));
+        }
+
+        private async Task ScheduleForSportAsync(Sport sport)
+        {
+            var weekResult = await _seasonClientFactory.Resolve(sport).GetCurrentSeasonWeek();
+            var currentWeek = weekResult.IsSuccess ? weekResult.Value : null;
 
             if (currentWeek is null)
             {
-                _logger.LogWarning("Current week could not be found; skipping matchup scheduling");
+                _logger.LogWarning(
+                    "Current week could not be resolved for {Sport}; skipping matchup scheduling for this sport.",
+                    sport);
                 return;
             }
 
-            // find all PickemGroup entities who do not yet have a PickemGroupWeek for this week
+            // Only this sport's leagues. Loading Weeks for the ordinal lookup
+            // below + the existence check.
             var groups = await _dataContext.PickemGroups
                 .Include(x => x.Weeks)
+                .Where(x => x.Sport == sport)
                 .OrderBy(x => x.CreatedUtc)
                 .ToListAsync();
 

--- a/src/SportsData.Api/Application/Scoring/ContestScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/ContestScoringProcessor.cs
@@ -44,7 +44,6 @@ namespace SportsData.Api.Application.Scoring
             // been scored. Skip the Producer round-trip and per-pick iteration when
             // there is nothing left to do.
             var hasUnscoredPicks = await _dataContext.UserPicks
-                .AsNoTracking()
                 .AnyAsync(p => p.ContestId == command.ContestId && p.ScoredAt == null);
 
             if (!hasUnscoredPicks)
@@ -61,7 +60,6 @@ namespace SportsData.Api.Application.Scoring
             // PickemGroup. The (Sport?) projection disambiguates "no row" from
             // "row with Sport.All (== 0)".
             var sport = await _dataContext.PickemGroupMatchups
-                .AsNoTracking()
                 .Where(m => m.ContestId == command.ContestId)
                 .Join(_dataContext.PickemGroups,
                     m => m.GroupId,

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -293,10 +293,13 @@ namespace SportsData.Api.DependencyInjection
                 job => job.ExecuteAsync(),
                 Cron.Weekly);
 
+            // Daily primary trigger. Can't be event-driven — matchups must
+            // be generated BEFORE games happen. Daily is sufficient since
+            // week boundaries move at most once per week per sport.
             recurringJobManager.AddOrUpdate<MatchupScheduler>(
                 nameof(MatchupScheduler),
                 job => job.ExecuteAsync(),
-                Cron.Weekly);
+                Cron.Daily(6));
 
             return services;
         }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/MatchupSchedulerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/MatchupSchedulerTests.cs
@@ -1,0 +1,193 @@
+using AutoFixture;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.Jobs;
+using SportsData.Api.Application.Processors;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Season;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Jobs;
+
+/// <summary>
+/// Tests for the sport-agnostic MatchupScheduler. Validates iteration over
+/// distinct sports in PickemGroups, per-sport SeasonClient resolution, and
+/// the existing per-league week-creation + enqueue behavior.
+/// </summary>
+public class MatchupSchedulerTests : ApiTestBase<MatchupScheduler>
+{
+    private readonly Mock<IProvideSeasons> _footballSeasonClientMock = new();
+    private readonly Mock<IProvideSeasons> _baseballSeasonClientMock = new();
+
+    public MatchupSchedulerTests()
+    {
+        Mocker.GetMock<ISeasonClientFactory>()
+            .Setup(x => x.Resolve(Sport.FootballNcaa))
+            .Returns(_footballSeasonClientMock.Object);
+        Mocker.GetMock<ISeasonClientFactory>()
+            .Setup(x => x.Resolve(Sport.BaseballMlb))
+            .Returns(_baseballSeasonClientMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Iterates_Sports_With_Active_Leagues()
+    {
+        // Arrange — one league per sport.
+        var footballLeagueId = Guid.NewGuid();
+        var baseballLeagueId = Guid.NewGuid();
+        var footballWeekId = Guid.NewGuid();
+        var baseballWeekId = Guid.NewGuid();
+
+        await SeedLeagueAsync(footballLeagueId, Sport.FootballNcaa, League.NCAAF);
+        await SeedLeagueAsync(baseballLeagueId, Sport.BaseballMlb, League.MLB);
+
+        SetupCurrentWeek(_footballSeasonClientMock, footballWeekId, 2026, 1, false, "regular");
+        SetupCurrentWeek(_baseballSeasonClientMock, baseballWeekId, 2026, 5, false, "regular");
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert — each sport's client was asked for its current week, and one
+        // ScheduleGroupWeekMatchupsCommand was enqueued per league.
+        _footballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Once);
+        _baseballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Once);
+
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Skips_Sport_When_Current_Week_Unresolvable()
+    {
+        // Arrange — a baseball league but the baseball SeasonClient reports
+        // no current week (offseason or transient failure).
+        var leagueId = Guid.NewGuid();
+        await SeedLeagueAsync(leagueId, Sport.BaseballMlb, League.MLB);
+
+        _baseballSeasonClientMock
+            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<CanonicalSeasonWeekDto>(default!, ResultStatus.NotFound, []));
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert — no week created, no command enqueued.
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Skips_League_When_Week_Already_Generated()
+    {
+        // Arrange — a football league that already has a PickemGroupWeek for
+        // the current SeasonWeek with AreMatchupsGenerated = true.
+        var leagueId = Guid.NewGuid();
+        var weekId = Guid.NewGuid();
+
+        var group = BuildPickemGroup(leagueId, Sport.FootballNcaa, League.NCAAF);
+        group.Weeks.Add(new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = leagueId,
+            SeasonWeekId = weekId,
+            SeasonYear = 2026,
+            SeasonWeek = 1,
+            AreMatchupsGenerated = true,
+        });
+
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+
+        SetupCurrentWeek(_footballSeasonClientMock, weekId, 2026, 1, false, "regular");
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Does_Nothing_When_No_Active_Leagues()
+    {
+        // Arrange — empty database (no PickemGroups).
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert — no SeasonClient call, no enqueue.
+        _footballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Never);
+        _baseballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Never);
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Never);
+    }
+
+    private async Task SeedLeagueAsync(Guid leagueId, Sport sport, League league)
+    {
+        var group = BuildPickemGroup(leagueId, sport, league);
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+    }
+
+    private PickemGroup BuildPickemGroup(Guid leagueId, Sport sport, League league)
+    {
+        return new PickemGroup
+        {
+            Id = leagueId,
+            Name = $"Test {sport} League",
+            Sport = sport,
+            League = league,
+            PickType = PickType.StraightUp,
+            TiebreakerType = TiebreakerType.None,
+            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
+            CommissionerUserId = Guid.NewGuid(),
+            CreatedUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CreatedBy = Guid.Empty,
+        };
+    }
+
+    private static void SetupCurrentWeek(
+        Mock<IProvideSeasons> seasonClient,
+        Guid weekId,
+        int seasonYear,
+        int weekNumber,
+        bool isNonStandardWeek,
+        string seasonPhase)
+    {
+        seasonClient
+            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<CanonicalSeasonWeekDto>(new CanonicalSeasonWeekDto
+            {
+                Id = weekId,
+                SeasonId = Guid.NewGuid(),
+                SeasonYear = seasonYear,
+                WeekNumber = weekNumber,
+                IsNonStandardWeek = isNonStandardWeek,
+                SeasonPhase = seasonPhase,
+            }));
+    }
+}


### PR DESCRIPTION
## Summary

**PR-N+5 (final)** of the multi-sport scoring refactor (see `docs/multi-sport-scoring-job-refactor.md`, doc PR #356). With this, **no `Sport.FootballNcaa` hardcodes remain** in the scoring/scheduling pipeline. New sports get picked up by creating a `PickemGroup` with that sport — zero code changes required at the job layer.

## Changes

### `MatchupScheduler` — sport-iteration

- Discovers active sports at runtime from `PickemGroups.Select(g => g.Sport).Distinct()` per the design doc's data-driven convention.
- Per-sport iteration in new `ScheduleForSportAsync(Sport sport)` private method: resolves that sport's `SeasonClient`, fetches its current week, processes only that sport's `PickemGroups`.
- Sports whose Producer can't report a current week (offseason or transient failure) log a warning and are skipped — doesn't block other sports.
- Postseason ordinal calculation kept as-is (sport-neutral logic).
- Job stays a single class — no per-sport subclass hierarchy.

### Cron cadence

`Cron.Weekly` (placeholder) → `Cron.Daily(6)` at 06:00 UTC. `MatchupScheduler` is the only scoring/scheduling job NOT in the event-driven primary path — matchups must exist before games happen — so it stays cron-driven. Daily is sufficient since week boundaries move at most once per week per sport.

### `ContestScoringProcessor` cleanup

Removed two `AsNoTracking()` calls that were flagged after PR-N+1. Both project away from entity types (`AnyAsync` returns `bool`, the `(Sport?)` projection returns a scalar), so the change tracker doesn't engage regardless. Matches the convention from PR-N+4.

### Tests (4 new in `MatchupSchedulerTests`)

| Test | Verifies |
|---|---|
| `Iterates_Sports_With_Active_Leagues` | Both football + baseball SeasonClients called; one enqueue per league |
| `Skips_Sport_When_Current_Week_Unresolvable` | `Failure<>` from SeasonClient → no enqueue, no crash |
| `Skips_League_When_Week_Already_Generated` | Existing `PickemGroupWeek` with `AreMatchupsGenerated=true` left alone |
| `Does_Nothing_When_No_Active_Leagues` | Empty DB → SeasonClient not called at all |

## Refactor complete

| PR | Status |
|---|---|
| #356 | docs |
| #357 | ContestScoringProcessor sport-resolution |
| #358 | ContestCompleted publish |
| #359 | ContestCompleted consumer |
| #360 | sport-agnostic backstop (cron jobs) |
| **#361 (this)** | **MatchupScheduler sport-iteration** |

## Test plan

- [x] `dotnet build` SportsData.Api — 0 warnings, 0 errors
- [x] `dotnet test` Api.Tests.Unit across the full refactor surface — 17/17 pass
- [ ] Manual post-deploy: confirm `MatchupScheduler` runs at 06:00 UTC tomorrow. Watch Seq for `Found N active sport(s) with leagues: ...` log line and confirm both NCAAF (if in season) and MLB show up. Confirm only sport-appropriate leagues are processed per sport iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded matchup scheduling system with independent per-sport support for enhanced coverage across all active sports.

* **Improvements**
  * Matchup scheduler frequency increased from weekly to daily for more timely matchup generation.
  * Optimized contest scoring processor performance through streamlined database operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->