### PR TITLE
fix(producer): direct-publish streamer events; require CompetitionStream

### DIFF
--- a/docs/competition-streamer-diagram.md
+++ b/docs/competition-streamer-diagram.md
@@ -1,0 +1,285 @@
+# Competition Streamer — Logic Diagram
+
+Reference for `src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs` (~680 LOC).
+
+`CompetitionStreamerBase<TCompetitionDto>` drives the live ESPN polling lifecycle for a single contest, fans out per-child-doc polling workers, and emits domain events as the contest transitions between states. Sport-specific subclasses (`BaseballCompetitionStreamer`, `FootballCompetitionStreamer`) supply the typed DTO and the polling target list. Runs as a Hangfire job in the Producer Worker role pod.
+
+Key constants:
+
+| Name | Value | Notes |
+|---|---|---|
+| `MaxStreamDuration` | 5 hours | Hard ceiling on both pre-game wait and in-game polling. |
+| `MaxConsecutiveFailures` | 10 | Triggers `InvalidOperationException` from either polling loop. |
+| Pre-game status poll | every 20s | `WaitForLiveStartAsync` |
+| In-game status poll | every 30s | `PollWhileInProgressAsync` |
+| Per-doc worker poll | per-target (see `GetPollingTargets`) | Spawned by `StartPollingWorkers` |
+| `StopWorkersAsync` grace | 10s | Wait for workers to drain after cancellation. |
+
+---
+
+## 1. `CompetitionStream.Status` state machine
+
+The persisted `CompetitionStream.Status` row in PostgreSQL is the externally-visible lifecycle. Every state transition is committed by `UpdateStreamStatusAsync`. `Completed` and `Failed` are terminal.
+
+```mermaid
+stateDiagram-v2
+    [*] --> AwaitingStart : enter try { } block
+    AwaitingStart --> Active : STATUS_IN_PROGRESS detected\n(workers spawn)
+    AwaitingStart --> Completed : STATUS_FINAL pre-spawn\n(AlreadyFinal or initial STATUS_FINAL)
+    AwaitingStart --> Failed : DTO/status fetch null,\nunknown status,\nWait timeout,\nrefetch-after-live-start null
+    Active --> Completed : PollOutcome.Final
+    Active --> Failed : PollOutcome.Timeout\nor unexpected exception\nor caller cancellation
+
+    Completed --> [*]
+    Failed --> [*]
+```
+
+Notes:
+- `Failed` is also written by both `catch` blocks in `ExecuteAsync` — `OperationCanceledException` (caller cancel) and the generic `Exception` (anything else).
+- The `Failed` write from the `OperationCanceledException` catch uses `CancellationToken.None` so the status update isn't itself cancelled.
+
+---
+
+## 2. `ExecuteAsync` — main flow
+
+The entry point. All paths converge on the `finally { StopWorkersAsync(); }` at the bottom.
+
+```mermaid
+flowchart TD
+    Start([ExecuteAsync entry]) --> Scope[Begin log scope with<br/>Sport, SeasonYear, ContestId,<br/>CorrelationId, CompetitionId]
+    Scope --> LoadComp[Load Competition + Contest +<br/>ExternalIds + Competitors]
+    LoadComp -->|not found| RetNotFound([log error → return])
+    LoadComp -->|Contest.IsFinal == true| RetAlreadyFinal([log info → return])
+    LoadComp -->|ok| FindEspn{ESPN ExternalId<br/>present?}
+    FindEspn -->|no| RetNoExtId([log error → return])
+    FindEspn -->|yes| LoadStream[Load CompetitionStream row]
+    LoadStream --> MarkAwaiting[stream → AwaitingStart]
+    MarkAwaiting --> FetchDto1[GetCompetitionAsync<br/>ESPN HTTP fetch]
+    FetchDto1 -->|null| FailFetchDto[stream → Failed<br/>reason: Competition fetch failed<br/>return]
+    FetchDto1 -->|dto| StatusUri[map competition ref to<br/>status ref via EspnUriMapper]
+    StatusUri --> FetchStatus[GetStatusAsync<br/>ESPN HTTP fetch]
+    FetchStatus -->|null| FailFetchStatus[stream → Failed<br/>reason: Initial status fetch failed<br/>return]
+    FetchStatus -->|status| Dispatch{status.Type.Name}
+
+    Dispatch -->|STATUS_SCHEDULED| Wait[WaitForLiveStartAsync<br/>see diagram 3]
+    Dispatch -->|STATUS_IN_PROGRESS| SpawnPath[log: starting workers immediately]
+    Dispatch -->|STATUS_FINAL| PubF1[PublishContestCompleted]
+    Dispatch -->|unknown| FailUnknown[stream → Failed<br/>reason: Unknown status type<br/>return]
+
+    PubF1 --> Done1[stream → Completed<br/>StreamEndedUtc = now<br/>return]
+
+    Wait -->|StartDetected| Refetch[GetCompetitionAsync again<br/>PR #353: refresh DTO so child<br/>refs Plays/Probability/Situation/<br/>Leaders are populated]
+    Wait -->|AlreadyFinal| PubF2[PublishContestCompleted]
+    Wait -->|Timeout| FailWait[stream → Failed<br/>reason: Live start not detected<br/>within max stream duration<br/>return]
+
+    Refetch -->|null| FailRefetch[stream → Failed<br/>reason: refetch after live start<br/>return]
+    Refetch -->|dto| SpawnPath
+    PubF2 --> Done2[stream → Completed<br/>StreamEndedUtc = now<br/>return]
+
+    SpawnPath --> MarkActive[StreamStartedUtc = now<br/>stream → Active]
+    MarkActive --> LinkedCts[_workerCts = CreateLinkedTokenSource]
+    LinkedCts --> StartW[StartPollingWorkers<br/>see diagram 4]
+    StartW --> Monitor[await PollWhileInProgressAsync<br/>see diagram 3]
+    Monitor -->|PollOutcome.Final| PubF3[PublishContestCompleted]
+    Monitor -->|PollOutcome.Timeout| FailTimeout[stream → Failed<br/>reason: Stream exceeded max<br/>duration without STATUS_FINAL]
+    PubF3 --> DoneFinal[stream → Completed<br/>StreamEndedUtc = now]
+
+    DoneFinal --> Fin
+    FailTimeout --> Fin
+    Done1 --> Fin
+    Done2 --> Fin
+
+    Fin[finally:<br/>StopWorkersAsync<br/>see diagram 5]
+    Fin --> End([exit ExecuteAsync])
+
+    %% Exception edges drawn dashed
+    LoadComp -.->|OperationCanceledException<br/>and token cancelled| Cancelled[log warn<br/>stream → Failed via<br/>CancellationToken.None<br/>reason: Cancelled by external request]
+    LoadComp -.->|other Exception| Threw[log error<br/>stream → Failed via<br/>CancellationToken.None<br/>rethrow]
+    Cancelled --> Fin
+    Threw --> Fin
+```
+
+---
+
+## 3. `WaitForLiveStartAsync` and `PollWhileInProgressAsync` — the two status polling loops
+
+Same shape; different cadences, different terminal conditions. Both share the `consecutiveFailures` failure budget.
+
+```mermaid
+flowchart TD
+    subgraph WLS["WaitForLiveStartAsync — 20s polling, returns LiveStartOutcome"]
+        WStart([entry]) --> WLogStart[/Log: Polling for live start<br/>every 20 seconds.../]
+        WLogStart --> WLoop{cancellation<br/>requested?}
+        WLoop -->|yes| WLoopOutTimeout([return Timeout])
+        WLoop -->|no| WAgeCheck{elapsed ><br/>MaxStreamDuration?}
+        WAgeCheck -->|yes| WAgeOutTimeout([log warn<br/>return Timeout])
+        WAgeCheck -->|no| WDelay[await Task.Delay 20s<br/>token-aware]
+        WDelay --> WFetch[GetStatusAsync]
+        WFetch -->|null| WInc[consecutiveFailures++]
+        WFetch -->|status| WReset[consecutiveFailures = 0]
+        WInc --> WCheckBudget{>= MaxConsecutiveFailures?}
+        WCheckBudget -->|yes| WThrow([throw InvalidOperationException])
+        WCheckBudget -->|no| WLoop
+        WReset --> WBranch{status.Type.Name}
+        WBranch -->|STATUS_IN_PROGRESS| WStart_([return StartDetected])
+        WBranch -->|STATUS_FINAL| WFinal([log warn<br/>return AlreadyFinal])
+        WBranch -->|other| WLoop
+    end
+
+    subgraph PWP["PollWhileInProgressAsync — 30s polling, returns PollOutcome"]
+        PStart([entry]) --> PLogStart[/Log: Monitoring competition status<br/>every 30 seconds.../]
+        PLogStart --> PLoop{cancellation<br/>requested?}
+        PLoop -->|yes| PLoopOutTimeout([return Timeout])
+        PLoop -->|no| PAgeCheck{elapsed ><br/>MaxStreamDuration?}
+        PAgeCheck -->|yes| PAgeOutTimeout([log warn<br/>return Timeout])
+        PAgeCheck -->|no| PDelay[await Task.Delay 30s<br/>token-aware]
+        PDelay --> PFetch[GetStatusAsync]
+        PFetch -->|null| PInc[consecutiveFailures++<br/>log warn N/Max]
+        PFetch -->|status| PReset[consecutiveFailures = 0]
+        PInc --> PCheckBudget{>= MaxConsecutiveFailures?}
+        PCheckBudget -->|yes| PThrow([log error<br/>throw InvalidOperationException])
+        PCheckBudget -->|no| PLoop
+        PReset --> PBranch{status.Type.Name == STATUS_FINAL?}
+        PBranch -->|yes| PFinal([log info<br/>return Final])
+        PBranch -->|no| PLogDebug[log debug:<br/>still in progress] --> PLoop
+    end
+```
+
+`PollWhileInProgressAsync` runs on the main `ExecuteAsync` thread while the per-doc workers from diagram 4 run concurrently. Both branches share the `_workerCts.Token` so cancelling `_workerCts` (in `StopWorkersAsync`) collapses both at once.
+
+---
+
+## 4. `StartPollingWorkers` + `SpawnPollingWorker` — concurrent fire-and-forget tasks
+
+`StartPollingWorkers` iterates the per-sport `GetPollingTargets(competitionDto)` list and spins up one `Task.Run` per non-null URI. Each task owns its own poll loop.
+
+```mermaid
+flowchart TD
+    Entry([StartPollingWorkers]) --> GetTargets[GetPollingTargets<br/>sport-specific tuples<br/>RefUri, DocumentType,<br/>IntervalSeconds, RequiresParentId]
+    GetTargets --> LogSpawn[/Log: Spawning N polling workers/]
+    LogSpawn --> ForEach{for each target}
+    ForEach -->|RefUri == null| LogSkip[/Log warn:<br/>Skipping worker - URI is null/]
+    ForEach -->|RefUri ok| Spawn[SpawnPollingWorker<br/>captures lambda for<br/>PublishDocumentRequestAsync]
+    Spawn --> AddTask[_activeWorkers.Add task]
+    LogSkip --> ForEach
+    AddTask --> ForEach
+    ForEach -->|done| LogDone[/Log: All workers spawned<br/>Active workers: N/]
+
+    subgraph WT["Each spawned worker (Task.Run, runs concurrently)"]
+        WEntry([Task.Run lambda<br/>per DocumentType]) --> WLog[/Log info:<br/>Worker started for DocType/]
+        WLog --> WLoop{cancellation<br/>requested?}
+        WLoop -->|yes| WStopped[/finally: Log info<br/>Worker for DocType stopped/]
+        WLoop -->|no| WCallFactory["await taskFactory<br/>= PublishDocumentRequestAsync"]
+        WCallFactory -->|throws non-OCE| WInnerErr[/log error:<br/>Worker for DocType<br/>failed during execution/]
+        WCallFactory -->|completed| WDelay[await Task.Delay<br/>intervalSeconds, token]
+        WInnerErr --> WDelay
+        WDelay -->|OperationCanceledException| WGraceful[/Log info:<br/>Worker for DocType<br/>cancelled gracefully/]
+        WGraceful --> WStopped
+        WDelay -->|completed| WLoop
+        WCallFactory -.->|outer Exception<br/>escapes inner catch?| WTerminated[/log error:<br/>Worker for DocType<br/>terminated unexpectedly/] --> WStopped
+    end
+
+    Spawn -.spawns.-> WT
+    WStopped --> End([task ends — caller<br/>awaits via _activeWorkers<br/>in StopWorkersAsync])
+```
+
+Key behavior notes:
+- The inner `catch (Exception ex) when (ex is not OperationCanceledException)` swallows publish-time failures so the loop keeps polling.
+- `OperationCanceledException` from `Task.Delay` is the *expected* exit path on cancellation — caught and logged as "cancelled gracefully".
+- An `OperationCanceledException` raised by `taskFactory()` itself (i.e. by an HTTP call inside the publish path) is NOT caught by the inner handler — it propagates out to the outer `catch` and logs "terminated unexpectedly". This kills that worker but the others keep running.
+- `_activeWorkers` is the list `StopWorkersAsync` awaits.
+
+---
+
+## 5. `StopWorkersAsync` — finally-block cleanup
+
+Always runs. Bounded by a 10-second grace timeout so a hung worker doesn't block the job's exit indefinitely.
+
+```mermaid
+flowchart TD
+    Entry([StopWorkersAsync<br/>called from finally]) --> CheckEmpty{any active workers?}
+    CheckEmpty -->|no| ReturnEarly([log debug<br/>return])
+    CheckEmpty -->|yes| LogStop[/Log: Stopping N active workers/]
+    LogStop --> Cancel[_workerCts.Cancel]
+    Cancel --> Race[Task.WhenAny<br/>WhenAll active workers vs<br/>Task.Delay 10s]
+    Race -->|workers drained| LogOk[/Log: All workers stopped<br/>successfully/]
+    Race -->|10s timeout| LogTimeout[/Log warn:<br/>Not all workers stopped<br/>within timeout/]
+    LogOk --> Cleanup
+    LogTimeout --> Cleanup
+    Race -.->|exception during wait| LogErr[/log error:<br/>Error while stopping workers/] --> Cleanup
+    Cleanup[finally:<br/>_activeWorkers.Clear<br/>_workerCts.Dispose<br/>_workerCts = null]
+    Cleanup --> End([return])
+```
+
+---
+
+## 6. Publish helpers — direct delivery (bypass outbox)
+
+Both `PublishContestCompletedAsync` and `PublishDocumentRequestAsync` use `IMessageDeliveryScope.Use(DeliveryMode.Direct)` and call `IEventBus.Publish` straight through — no DbContext involvement.
+
+Why direct: these helpers are **stateless publishes**. No entity write happens inside them, so MassTransit's EF-outbox interceptor (which hooks `SaveChangesAsync`) has no `SavingChanges` event to ride. An outbox-mode publish without a backing entity write would sit captured in the in-memory pending list and never reach the broker. Direct delivery sidesteps that gap entirely.
+
+`IEventBus` (`EventBusAdapter`) and `IMessageDeliveryScope` (`MessageDeliveryPolicy`) are thread-safe — the underlying `IBus`/`IPublishEndpoint` are MassTransit's thread-safe primitives, and the policy is an `AsyncLocal`-scoped flag. All polling workers share the same injected instances; no per-call DI scoping is needed.
+
+```mermaid
+sequenceDiagram
+    participant W as Worker / ExecuteAsync
+    participant DS as IMessageDeliveryScope<br/>(AsyncLocal flag)
+    participant EB as IEventBus<br/>(EventBusAdapter)
+    participant Bus as MassTransit IBus<br/>(direct)
+    participant B as RabbitMQ broker
+
+    W->>DS: Use(DeliveryMode.Direct)
+    Note over DS: AsyncLocal _current = Direct
+    W->>EB: Publish(ContestCompleted or DocumentRequested)
+    EB->>DS: policy.Mode
+    DS-->>EB: Direct
+    Note over EB: Direct branch:<br/>skip IPublishEndpoint (outbox)
+    EB->>Bus: _bus.Publish(message)
+    Bus->>B: send on wire
+    B-->>Bus: ack
+    Bus-->>EB: complete
+    EB-->>W: Publish returns
+    W->>DS: using-block disposes
+    Note over DS: AsyncLocal _current restored
+```
+
+Why this matters operationally:
+- The publish reaches the broker on the same thread as the `await Publish` call — no outbox-flush dependency on a downstream `SaveChangesAsync`.
+- `IEventBus.Publish` honours `cancellationToken` but does not impose its own broker-side timeout. A genuinely stuck broker connection would still hang the call until the client library's heartbeat timer fires (typically minutes). Worth a future enhancement: wrap publishes in a per-call `CancelAfter` so a stuck publish surfaces as a `Worker for X failed during execution` Error rather than freezing the worker.
+- The precedent for this direct-publish pattern lives in `BaseballContestReplayService` (admin replay tool, same architectural shape — stateless publish of a recorded event sequence).
+
+---
+
+## 7. Exception handling — outer `try`/`catch`/`finally` summary
+
+| Catch | Trigger | Behavior |
+|---|---|---|
+| `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)` | Caller-initiated cancellation (Hangfire job cancel, host shutdown) | Log warn `Streaming cancelled by external request`. Write `stream → Failed` using `CancellationToken.None` so the status update itself isn't cancelled. Do NOT rethrow. |
+| `catch (Exception ex)` | Anything else that bubbles out of the try block (incl. `InvalidOperationException` from polling-loop failure budget, EF errors, etc.) | Log error `Unexpected error during streaming`. Write `stream → Failed` using `CancellationToken.None`. Rethrow so Hangfire sees the failure. |
+| `finally { StopWorkersAsync(); }` | Always | Cancel `_workerCts`, await active workers up to 10s, dispose. |
+
+Both `catch` blocks dereference `stream` only after a null-check; if the `CompetitionStream` row didn't exist at all (warning logged at startup), the status update is simply skipped.
+
+---
+
+## 8. Quick-reference: where each `Publishing` log line lives
+
+These are the only places this class emits domain events, useful when grep-ing Seq for proof-of-life.
+
+| Source line (approx) | Log level | Log template | Conditions |
+|---|---|---|---|
+| `PublishContestCompletedAsync:605` | Info | `Publishing ContestCompleted for ContestId={ContestId}, CompetitionId={CompetitionId}` | Fires from three sites: `LiveStartOutcome.AlreadyFinal`, initial `STATUS_FINAL` switch arm, `PollOutcome.Final`. |
+| `PublishDocumentRequestAsync:636` | **Debug** | `Publishing {Type} document request for {Uri}` | Fires once per polling worker tick. **Not visible at default Info filtering** — be aware when searching Seq for streamer proof-of-life. |
+
+---
+
+## 9. Spots where the streamer is silent at Info level
+
+These are the gaps where a healthy stream and a hung stream look identical at the default Seq filter:
+
+- **Between worker spawn and the first STATUS change** — 3 `Worker started for ...` lines, then nothing until `Competition status is FINAL` minutes-to-hours later. The 30s `PollWhileInProgressAsync` heartbeat is `LogDebug`.
+- **Inside `PublishDocumentRequestAsync`** — `LogDebug` only.
+- **Workers' steady-state poll cycle** — only logs at success completion (`LogDebug`) or on error.
+
+Practical implication: any future change that adds an Info-level periodic heartbeat from either `PollWhileInProgressAsync` or `SpawnPollingWorker` would be a meaningful observability improvement. Today there is no Info-level proof-of-life between worker spawn and stream end — exactly why a stuck stream is hard to distinguish from a quiet one.

--- a/src/SportsData.Producer/Application/Competitions/BaseballCompetitionStreamer.cs
+++ b/src/SportsData.Producer/Application/Competitions/BaseballCompetitionStreamer.cs
@@ -1,6 +1,5 @@
-using Microsoft.Extensions.DependencyInjection;
-
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Producer.Infrastructure.Data.Baseball;
 
@@ -19,9 +18,10 @@ public class BaseballCompetitionStreamer : CompetitionStreamerBase<EspnBaseballE
         ILogger<BaseballCompetitionStreamer> logger,
         BaseballDataContext dataContext,
         IHttpClientFactory httpClientFactory,
-        IServiceScopeFactory scopeFactory,
+        IEventBus eventBus,
+        IMessageDeliveryScope deliveryScope,
         IDateTimeProvider dateTimeProvider)
-        : base(logger, dataContext, httpClientFactory, scopeFactory, dateTimeProvider)
+        : base(logger, dataContext, httpClientFactory, eventBus, deliveryScope, dateTimeProvider)
     {
     }
 

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -27,7 +27,8 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     private readonly ILogger _logger;
     private readonly TeamSportDataContext _dataContext;
     private readonly HttpClient _httpClient;
-    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IEventBus _eventBus;
+    private readonly IMessageDeliveryScope _deliveryScope;
     private readonly IDateTimeProvider _dateTimeProvider;
 
     private readonly List<Task> _activeWorkers = new();
@@ -64,13 +65,15 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
         ILogger logger,
         TeamSportDataContext dataContext,
         IHttpClientFactory httpClientFactory,
-        IServiceScopeFactory scopeFactory,
+        IEventBus eventBus,
+        IMessageDeliveryScope deliveryScope,
         IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
         _httpClient = httpClientFactory.CreateClient();
-        _scopeFactory = scopeFactory;
+        _eventBus = eventBus;
+        _deliveryScope = deliveryScope;
         _dateTimeProvider = dateTimeProvider;
     }
 
@@ -145,17 +148,15 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                 }
                 else
                 {
-                    _logger.LogWarning("No CompetitionStream record found for competition. Status tracking will be skipped.");
+                    _logger.LogError("No CompetitionStream record found for competition. Status tracking will be skipped.");
+                    return;
                 }
 
                 var competitionDto = await GetCompetitionAsync(new Uri(externalId.SourceUrl), cancellationToken);
                 if (competitionDto == null)
                 {
                     _logger.LogError("Competition fetch failed from ESPN");
-                    if (stream != null)
-                    {
-                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition fetch failed");
-                    }
+                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition fetch failed");
                     return;
                 }
 
@@ -165,10 +166,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                 if (status == null)
                 {
                     _logger.LogError("Initial status fetch failed");
-                    if (stream != null)
-                    {
-                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Initial status fetch failed");
-                    }
+                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Initial status fetch failed");
                     return;
                 }
 
@@ -193,10 +191,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                                 if (competitionDto == null)
                                 {
                                     _logger.LogError("Competition re-fetch after live start failed");
-                                    if (stream != null)
-                                    {
-                                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition re-fetch after live start failed");
-                                    }
+                                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition re-fetch after live start failed");
                                     return;
                                 }
                                 break;
@@ -204,19 +199,13 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                             case LiveStartOutcome.AlreadyFinal:
                                 _logger.LogInformation("Competition went final while waiting for start. Skipping live polling.");
                                 await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
-                                if (stream != null)
-                                {
-                                    stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
-                                }
+                                stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
+                                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
                                 return;
 
                             case LiveStartOutcome.Timeout:
                                 _logger.LogWarning("Live start was not detected within max stream duration. Aborting.");
-                                if (stream != null)
-                                {
-                                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Live start not detected within max stream duration");
-                                }
+                                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Live start not detected within max stream duration");
                                 return;
                         }
                         break;
@@ -228,31 +217,22 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                     case "STATUS_FINAL":
                         _logger.LogInformation("Competition already final. Skipping streaming.");
                         await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
-                        if (stream != null)
-                        {
-                            stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                            await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
-                        }
+                        stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
+                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
                         return;
 
                     default:
                         // An unknown status string is anomalous data — bail rather than
                         // optimistically spawning live workers against an unverified competition state.
                         _logger.LogWarning("Unknown status type: {StatusType}. Aborting stream.", status.Type.Name);
-                        if (stream != null)
-                        {
-                            await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, $"Unknown status type: {status.Type.Name}");
-                        }
+                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, $"Unknown status type: {status.Type.Name}");
                         return;
                 }
 
                 _logger.LogInformation("Starting polling workers for live competition updates");
 
-                if (stream != null)
-                {
-                    stream.StreamStartedUtc = _dateTimeProvider.UtcNow();
-                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Active, cancellationToken);
-                }
+                stream.StreamStartedUtc = _dateTimeProvider.UtcNow();
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Active, cancellationToken);
 
                 _workerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
@@ -265,19 +245,17 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                 {
                     await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
                 }
-                if (stream != null)
-                {
-                    stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                    switch (pollOutcome)
-                    {
-                        case PollOutcome.Final:
-                            await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
-                            break;
 
-                        case PollOutcome.Timeout:
-                            await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Stream exceeded max duration without STATUS_FINAL");
-                            break;
-                    }
+                stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
+                switch (pollOutcome)
+                {
+                    case PollOutcome.Final:
+                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
+                        break;
+
+                    case PollOutcome.Timeout:
+                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Stream exceeded max duration without STATUS_FINAL");
+                        break;
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -587,10 +565,14 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     /// <summary>
     /// Publish ContestCompleted at any STATUS_FINAL detection point so the API
     /// scoring path can trigger immediately rather than waiting on the daily
-    /// cron backstop. Uses the same fresh-scope pattern as
-    /// <see cref="PublishDocumentRequestAsync"/> so the MassTransit EF outbox
-    /// interceptor captures the publish and flushes it on the scope's
-    /// SaveChangesAsync within the same transaction.
+    /// cron backstop.
+    ///
+    /// Uses <see cref="DeliveryMode.Direct"/> because this is a stateless
+    /// publish — no entity write happens inside this method, so the EF outbox
+    /// interceptor wouldn't have a SaveChangesAsync hook to ride. Direct
+    /// delivery sidesteps the outbox entirely and hands the message to the
+    /// broker immediately. Same pattern as
+    /// <see cref="Application.Contests.BaseballContestReplayService"/>.
     ///
     /// Idempotency on the consumer side handles at-least-once redelivery and
     /// the three concurrent publish sites in <see cref="ExecuteAsync"/> —
@@ -606,11 +588,8 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             "Publishing ContestCompleted for ContestId={ContestId}, CompetitionId={CompetitionId}",
             command.ContestId, command.CompetitionId);
 
-        using var scope = _scopeFactory.CreateScope();
-        var dataContext = scope.ServiceProvider.GetRequiredService<TeamSportDataContext>();
-        var publishEndpoint = scope.ServiceProvider.GetRequiredService<IEventBus>();
-
-        await publishEndpoint.Publish(new ContestCompleted(
+        using var _ = _deliveryScope.Use(DeliveryMode.Direct);
+        await _eventBus.Publish(new ContestCompleted(
             ContestId: command.ContestId,
             CompetitionId: command.CompetitionId,
             SeasonWeekId: seasonWeekId,
@@ -620,10 +599,22 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             CorrelationId: command.CorrelationId,
             CausationId: command.CorrelationId
         ), cancellationToken);
-
-        await dataContext.SaveChangesAsync(cancellationToken);
     }
 
+    /// <summary>
+    /// Fan out one DocumentRequested per polling worker tick.
+    ///
+    /// Stateless — no entity write — so we use <see cref="DeliveryMode.Direct"/>
+    /// for the same reason as <see cref="PublishContestCompletedAsync"/>. The
+    /// outbox interceptor only flushes on SaveChangesAsync against a non-empty
+    /// change set; without that anchor, an outbox-mode publish would sit
+    /// captured in the in-memory pending list and never reach the broker.
+    ///
+    /// <see cref="IEventBus"/> and <see cref="IMessageDeliveryScope"/> are
+    /// thread-safe (MassTransit's IBus/IPublishEndpoint internals + an
+    /// AsyncLocal-scoped policy respectively), so all polling workers can
+    /// share the same injected instances without per-call scoping.
+    /// </summary>
     private async Task PublishDocumentRequestAsync(
         Uri refUri,
         DocumentType type,
@@ -635,18 +626,8 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
         _logger.LogDebug("Publishing {Type} document request for {Uri}", type, refUri);
 
-        // Workers run concurrently with each other and with the main thread that
-        // owns _dataContext. EF Core DbContext is not thread-safe, so each poll
-        // resolves its own scope (and therefore its own DbContext + IEventBus
-        // pair). The MassTransit EF outbox interceptor flushes pending publishes
-        // on SaveChangesAsync within this scope's DbContext — so resolving the
-        // bus from the same scope as the context is required for transactional
-        // outbox semantics.
-        using var scope = _scopeFactory.CreateScope();
-        var dataContext = scope.ServiceProvider.GetRequiredService<TeamSportDataContext>();
-        var publishEndpoint = scope.ServiceProvider.GetRequiredService<IEventBus>();
-
-        await publishEndpoint.Publish(new DocumentRequested(
+        using var _ = _deliveryScope.Use(DeliveryMode.Direct);
+        await _eventBus.Publish(new DocumentRequested(
             Id: Guid.NewGuid().ToString(),
             ParentId: parentId,
             Uri: refUri,
@@ -658,8 +639,6 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             CorrelationId: command.CorrelationId,
             CausationId: command.CorrelationId
         ), cancellationToken);
-
-        await dataContext.SaveChangesAsync(cancellationToken);
     }
 
     private async Task UpdateStreamStatusAsync(

--- a/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamer.cs
+++ b/src/SportsData.Producer/Application/Competitions/FootballCompetitionStreamer.cs
@@ -1,6 +1,5 @@
-using Microsoft.Extensions.DependencyInjection;
-
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Infrastructure.Data.Football;
 
@@ -18,9 +17,10 @@ public class FootballCompetitionStreamer : CompetitionStreamerBase<EspnFootballE
         ILogger<FootballCompetitionStreamer> logger,
         FootballDataContext dataContext,
         IHttpClientFactory httpClientFactory,
-        IServiceScopeFactory scopeFactory,
+        IEventBus eventBus,
+        IMessageDeliveryScope deliveryScope,
         IDateTimeProvider dateTimeProvider)
-        : base(logger, dataContext, httpClientFactory, scopeFactory, dateTimeProvider)
+        : base(logger, dataContext, httpClientFactory, eventBus, deliveryScope, dateTimeProvider)
     {
     }
 

--- a/test/integration/SportsData.Producer.Tests.Integration/Application/Competitions/FootballCompetitionStreamer_LiveGameTests.cs
+++ b/test/integration/SportsData.Producer.Tests.Integration/Application/Competitions/FootballCompetitionStreamer_LiveGameTests.cs
@@ -104,16 +104,19 @@ public class FootballCompetitionStreamer_LiveGameTests : IClassFixture<Integrati
             CorrelationId = Guid.NewGuid()
         };
 
-        // Create the streamer with test dependencies
+        // Create the streamer with test dependencies. IEventBus is the
+        // test-provided instance so the test can observe published messages;
+        // IMessageDeliveryScope comes from the DI container as normal
+        // (AsyncLocal-backed, thread-safe).
         var logger = _serviceProvider.GetRequiredService<ILogger<FootballCompetitionStreamer>>();
-        var baseScopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
-        var scopeFactory = new EventBusOverrideScopeFactory(baseScopeFactory, eventBus);
+        var deliveryScope = _serviceProvider.GetRequiredService<IMessageDeliveryScope>();
         var dateTimeProvider = _serviceProvider.GetRequiredService<IDateTimeProvider>();
         var sut = new FootballCompetitionStreamer(
             logger,
             _dataContext,
             httpFactory,
-            scopeFactory,
+            eventBus,
+            deliveryScope,
             dateTimeProvider);
         
         // Act - Run the complete game stream
@@ -404,57 +407,6 @@ public class TestHttpClientFactory : IHttpClientFactory
     }
     
     public HttpClient CreateClient(string name) => _httpClient;
-}
-
-/// <summary>
-/// Wraps an existing IServiceScopeFactory so every scope it produces resolves
-/// IEventBus to a test-provided instance, while delegating all other service
-/// resolution to the underlying scope. This lets a test observe publishes that
-/// CompetitionStreamerBase performs from inside per-poll DI scopes — a local
-/// TestEventBus instance is otherwise invisible to scoped resolution.
-/// </summary>
-public sealed class EventBusOverrideScopeFactory : IServiceScopeFactory
-{
-    private readonly IServiceScopeFactory _inner;
-    private readonly IEventBus _eventBusOverride;
-
-    public EventBusOverrideScopeFactory(IServiceScopeFactory inner, IEventBus eventBusOverride)
-    {
-        _inner = inner;
-        _eventBusOverride = eventBusOverride;
-    }
-
-    public IServiceScope CreateScope() => new OverrideScope(_inner.CreateScope(), _eventBusOverride);
-
-    private sealed class OverrideScope : IServiceScope
-    {
-        private readonly IServiceScope _inner;
-
-        public OverrideScope(IServiceScope inner, IEventBus eventBusOverride)
-        {
-            _inner = inner;
-            ServiceProvider = new OverrideProvider(inner.ServiceProvider, eventBusOverride);
-        }
-
-        public IServiceProvider ServiceProvider { get; }
-
-        public void Dispose() => _inner.Dispose();
-    }
-
-    private sealed class OverrideProvider : IServiceProvider
-    {
-        private readonly IServiceProvider _inner;
-        private readonly IEventBus _eventBusOverride;
-
-        public OverrideProvider(IServiceProvider inner, IEventBus eventBusOverride)
-        {
-            _inner = inner;
-            _eventBusOverride = eventBusOverride;
-        }
-
-        public object? GetService(Type serviceType)
-            => serviceType == typeof(IEventBus) ? _eventBusOverride : _inner.GetService(serviceType);
-    }
 }
 
 /// <summary>

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/BaseballCompetitionStreamerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/BaseballCompetitionStreamerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Producer.Application.Competitions;
@@ -44,9 +45,10 @@ public class BaseballCompetitionStreamerTests
             ILogger<BaseballCompetitionStreamer> logger,
             BaseballDataContext dataContext,
             IHttpClientFactory httpClientFactory,
-            IServiceScopeFactory scopeFactory,
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope,
             IDateTimeProvider dateTimeProvider)
-            : base(logger, dataContext, httpClientFactory, scopeFactory, dateTimeProvider)
+            : base(logger, dataContext, httpClientFactory, eventBus, deliveryScope, dateTimeProvider)
         {
         }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamerTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using Moq.Protected;
 
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Application.Competitions;
@@ -488,9 +489,10 @@ public class FootballCompetitionStreamerTests : ProducerTestBase<FootballCompeti
             ILogger<FootballCompetitionStreamer> logger,
             FootballDataContext dataContext,
             IHttpClientFactory httpClientFactory,
-            IServiceScopeFactory scopeFactory,
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope,
             IDateTimeProvider dateTimeProvider)
-            : base(logger, dataContext, httpClientFactory, scopeFactory, dateTimeProvider)
+            : base(logger, dataContext, httpClientFactory, eventBus, deliveryScope, dateTimeProvider)
         {
         }
 


### PR DESCRIPTION
## Summary

`CompetitionStreamerBase` was silently dropping every `DocumentRequested` and `ContestCompleted` it tried to publish. Workers spawned, polling loops ran, no errors, no logs — but the broker never saw a single message and Provider never made an ESPN fetch for any contest the streamer was watching.

## Root cause

`PublishContestCompletedAsync` and `PublishDocumentRequestAsync` followed this shape:

```csharp
using var scope = _scopeFactory.CreateScope();
var dataContext = scope.ServiceProvider.GetRequiredService<TeamSportDataContext>();
var publishEndpoint = scope.ServiceProvider.GetRequiredService<IEventBus>();
await publishEndpoint.Publish(message, ct);
await dataContext.SaveChangesAsync(ct);  // ← no tracked entity changes
```

The intent was for MassTransit's EF outbox interceptor to capture the publish and flush it on `SaveChangesAsync`. But these helpers don't write any entity — `SaveChangesAsync` on an empty change set returns immediately without firing the interceptor's `SavingChanges` hook. The captured publish sat in the in-memory pending list and never reached the broker.

A previous in-flight attempt to fix this by mutating `stream.ModifiedUtc` inside the publish helpers didn't work either — the `stream` reference was tracked by the streamer's class-level `_dataContext`, not the fresh-scope `dataContext` doing the `SaveChangesAsync`. The mutation never registered as a tracked change in the scope that was saving.

## Fix

Use `IMessageDeliveryScope.Use(DeliveryMode.Direct)` and call `IEventBus.Publish` directly. Direct delivery routes through `IBus.Publish`, bypassing the outbox entirely — no entity write needed, no scope dance.

```csharp
using var _ = _deliveryScope.Use(DeliveryMode.Direct);
await _eventBus.Publish(message, ct);
```

Precedent: `BaseballContestReplayService` already uses this pattern for the same architectural reason (stateless publish, no entity to ride). Project memory has the convention documented as *"Direct publish when no DbContext write."*

## Other changes in this PR

- **`CompetitionStream` is required.** Missing row at startup now logs error + returns rather than silently continuing with status tracking disabled. All the `if (stream != null)` clutter through the main flow is gone.
- **`IServiceScopeFactory` dropped from the streamer.** No DbContext-per-publish means no scope-per-publish. `IEventBus` and `IMessageDeliveryScope` are both thread-safe, so polling workers share the class-level instances.
- **`stream` parameter removed from `StartPollingWorkers` and both publish helpers.** Only there for the broken entity-mutation hack.
- **Tests updated:** `TestableBaseballCompetitionStreamer` / `TestableFootballCompetitionStreamer` constructors swapped. Integration test drops the `EventBusOverrideScopeFactory` workaround (~50 lines of dead code) since the streamer now takes `IEventBus` directly.
- **New diagram:** `docs/competition-streamer-diagram.md` with Mermaid flowcharts for `ExecuteAsync`, both polling loops, the worker spawn tree, `StopWorkersAsync`, the direct-publish sequence, and a catalog of where each `Publishing` log line fires + at what level.

## Test plan

- [x] `dotnet build` SportsData.Producer + integration test project — 0 warnings, 0 errors
- [x] `dotnet test` Producer.Tests.Unit `~CompetitionStreamer*` — 19/19 pass
- [ ] Manual verification post-deploy: tail Seq on the next baseball game's streamer run. Expect to see `Publishing EventCompetitionPlay document request for ...` (Debug) lines from Producer Worker, followed shortly by `EventCompetitionPlayDocumentProcessor` activity (Info), followed by `BaseballPlayCompletedHandler` SignalR fan-out (Info) on the API side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation detailing competition streaming state machine flows, status polling loops, concurrent worker management, and event publishing patterns.

* **Refactor**
  * Improved event delivery architecture by streamlining dependency injection patterns across competition streaming services. Optimized event publishing for direct delivery and eliminated unnecessary service scope wrapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->