### PR TITLE
feat(producer): rebind CorrelationId to CompetitionStream.Id + observability

### DIFF
--- a/docs/competition-streamer-diagram.md
+++ b/docs/competition-streamer-diagram.md
@@ -44,6 +44,8 @@ Notes:
 
 The entry point. All paths converge on the `finally { StopWorkersAsync(); }` at the bottom.
 
+**Code-structure note**: `ExecuteAsync` handles pre-stream-load validation (Competition load → externalId → CompetitionStream load), then opens a nested log scope that rebinds `CorrelationId` to `CompetitionStream.Id` and delegates to `ExecuteWithStreamAsync` for everything from the first `GetCompetitionAsync` call onward. The diagram below collapses both methods into one logical flow.
+
 ```mermaid
 flowchart TD
     Start([ExecuteAsync entry]) --> Scope[Begin log scope with<br/>Sport, SeasonYear, ContestId,<br/>CorrelationId, CompetitionId]
@@ -263,23 +265,33 @@ Both `catch` blocks dereference `stream` only after a null-check; if the `Compet
 
 ---
 
-## 8. Quick-reference: where each `Publishing` log line lives
+## 8. Quick-reference: where each domain event publish + key log line lives
 
-These are the only places this class emits domain events, useful when grep-ing Seq for proof-of-life.
+These are the places this class emits domain events or key proof-of-life log lines, useful when grep-ing Seq.
 
-| Source line (approx) | Log level | Log template | Conditions |
+| Source method | Log level | Log template | Conditions |
 |---|---|---|---|
-| `PublishContestCompletedAsync:605` | Info | `Publishing ContestCompleted for ContestId={ContestId}, CompetitionId={CompetitionId}` | Fires from three sites: `LiveStartOutcome.AlreadyFinal`, initial `STATUS_FINAL` switch arm, `PollOutcome.Final`. |
-| `PublishDocumentRequestAsync:636` | **Debug** | `Publishing {Type} document request for {Uri}` | Fires once per polling worker tick. **Not visible at default Info filtering** — be aware when searching Seq for streamer proof-of-life. |
+| `PublishContestCompletedAsync` | Info | `Publishing ContestCompleted for ContestId={ContestId}, CompetitionId={CompetitionId}, CorrelationId={CorrelationId}` | Fires from three sites: `LiveStartOutcome.AlreadyFinal`, initial `STATUS_FINAL` switch arm, `PollOutcome.Final`. |
+| `PublishDocumentRequestAsync` | Info | `Publishing {Type} document request for {Uri}` | Fires once per polling worker tick. Promoted from Debug → Info so steady-state worker activity is visible at default filtering. |
+| `PollWhileInProgressAsync` | Info | `Streaming heartbeat. Tick={Tick}, ElapsedMin={ElapsedMin:F1}, Status={Status}, Clock={Clock}` | Heartbeat every 10th tick (≈ every 5 min at 30s polling). 12/hour at default filtering — proof-of-life during long in-game stretches. |
+| `PollWhileInProgressAsync` | Debug | `Competition still in progress. Status: {Status}, Clock: {Clock}` | Every non-heartbeat tick. Verbose-mode only. |
+| `ExecuteAsync` (post stream load) | Info | `CompetitionStream loaded. StreamId={StreamId}; CorrelationId rebound from {PriorCorrelationId} to StreamId for the remainder of this run.` | Once per run, immediately after stream load. Pivot point for Seq searches: switch from `command.CorrelationId` to `stream.Id`. |
 
 ---
 
-## 9. Spots where the streamer is silent at Info level
+## 9. CorrelationId model + log scope
 
-These are the gaps where a healthy stream and a hung stream look identical at the default Seq filter:
+Two layers of log scope wrap the streaming work:
 
-- **Between worker spawn and the first STATUS change** — 3 `Worker started for ...` lines, then nothing until `Competition status is FINAL` minutes-to-hours later. The 30s `PollWhileInProgressAsync` heartbeat is `LogDebug`.
-- **Inside `PublishDocumentRequestAsync`** — `LogDebug` only.
-- **Workers' steady-state poll cycle** — only logs at success completion (`LogDebug`) or on error.
+1. **Outer scope** (whole `ExecuteAsync`): `Sport`, `SeasonYear`, `ContestId`, `CorrelationId = command.CorrelationId`, `CompetitionId`, `RunId = Guid.NewGuid()`. Carries early "Broadcasting job started" logs and the pre-stream-load validation.
+2. **Inner scope** (everything after `CompetitionStream` loads, including `ExecuteWithStreamAsync` and all downstream calls): overrides `CorrelationId` to `stream.Id` and adds `StreamId = stream.Id`. Every subsequent log line + every domain-event publish carries `stream.Id` as the correlation.
 
-Practical implication: any future change that adds an Info-level periodic heartbeat from either `PollWhileInProgressAsync` or `SpawnPollingWorker` would be a meaningful observability improvement. Today there is no Info-level proof-of-life between worker spawn and stream end — exactly why a stuck stream is hard to distinguish from a quiet one.
+`RunId` distinguishes execution boundaries (Hangfire refire, admin replay, pod restart) while `CorrelationId = stream.Id` stays stable across runs — so a single Seq query by `stream.Id` returns every log line for that stream's full lifetime including refires, while `RunId` lets you separate which run produced which line.
+
+Downstream propagation (already wired upstream of this class):
+- `PublishContestCompletedAsync` and `PublishDocumentRequestAsync` set `CorrelationId = stream.Id` on the emitted events.
+- `EventBusAdapter` auto-stamps `X-Correlation-Id` transport header from `EventBase.CorrelationId` (see `EventBus.cs:93-98`) — belt-and-suspenders alongside the body field.
+- Provider's `DocumentRequestedHandler` runs a 5-level fallback resolver (body → header → MT context → Activity TraceId → NewGuid+ERROR) and sets its own `BeginScope` from the resolved id. See `src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs`.
+- Producer's `DocumentProcessorBase.ProcessAsync` opens its scope from `command.ToLogScope()` (carrying `CorrelationId`) and propagates it forward into any child `DocumentRequested` re-publishes.
+
+Net result: querying Seq by `stream.Id` returns the full Producer (streamer) → Provider (handler + ESPN fetch) → Producer (document processors) → API (consumers, e.g., `BaseballPlayCompletedHandler`) chain for the entire lifetime of one CompetitionStream.

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -10,6 +10,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Infrastructure.Data;
 using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Application.Competitions;
 
@@ -96,13 +97,19 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
     public async Task ExecuteAsync(StreamCompetitionCommand command, CancellationToken cancellationToken)
     {
+        // RunId distinguishes individual executions of the same stream (Hangfire
+        // refire, admin replay, pod restart). The CorrelationId rebound below is
+        // CompetitionStream.Id and is stable across runs; RunId is fresh per run.
+        var runId = Guid.NewGuid();
+
         using (_logger.BeginScope(new Dictionary<string, object>
         {
             ["Sport"] = command.Sport,
             ["SeasonYear"] = command.SeasonYear,
             ["ContestId"] = command.ContestId,
             ["CorrelationId"] = command.CorrelationId,
-            ["CompetitionId"] = command.CompetitionId
+            ["CompetitionId"] = command.CompetitionId,
+            ["RunId"] = runId
         }))
         {
             _logger.LogInformation("Broadcasting job started for {@Command}", command);
@@ -142,120 +149,32 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                 stream = await _dataContext.CompetitionStreams
                     .FirstOrDefaultAsync(x => x.CompetitionId == command.CompetitionId, cancellationToken);
 
-                if (stream != null)
-                {
-                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.AwaitingStart, cancellationToken);
-                }
-                else
+                if (stream == null)
                 {
                     _logger.LogError("No CompetitionStream record found for competition. Status tracking will be skipped.");
                     return;
                 }
 
-                var competitionDto = await GetCompetitionAsync(new Uri(externalId.SourceUrl), cancellationToken);
-                if (competitionDto == null)
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.AwaitingStart, cancellationToken);
+
+                // Rebind CorrelationId to stream.Id so a single Seq query finds
+                // every log line across Producer (streamer + document processors)
+                // and Provider (DocumentRequestedHandler + sourcing pipeline) for
+                // this stream's lifetime — including refires/restarts of the
+                // same stream. The DocumentRequested / ContestCompleted publishes
+                // also carry stream.Id as CorrelationId so downstream services
+                // see the same id in their resolved fallback chain.
+                using (_logger.BeginScope(new Dictionary<string, object>
                 {
-                    _logger.LogError("Competition fetch failed from ESPN");
-                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition fetch failed");
-                    return;
-                }
-
-                var statusUri = EspnUriMapper.CompetitionRefToCompetitionStatusRef(new Uri(externalId.SourceUrl));
-
-                var status = await GetStatusAsync(statusUri, cancellationToken);
-                if (status == null)
+                    ["CorrelationId"] = stream.Id,
+                    ["StreamId"] = stream.Id
+                }))
                 {
-                    _logger.LogError("Initial status fetch failed");
-                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Initial status fetch failed");
-                    return;
-                }
+                    _logger.LogInformation(
+                        "CompetitionStream loaded. StreamId={StreamId}; CorrelationId rebound from {PriorCorrelationId} to StreamId for the remainder of this run.",
+                        stream.Id, command.CorrelationId);
 
-                switch (status.Type.Name)
-                {
-                    case "STATUS_SCHEDULED":
-                        _logger.LogInformation("Competition is scheduled. Waiting for competition to start...");
-                        var startOutcome = await WaitForLiveStartAsync(statusUri, cancellationToken);
-                        switch (startOutcome)
-                        {
-                            case LiveStartOutcome.StartDetected:
-                                // The initial competitionDto fetch above happened while the
-                                // game was still STATUS_SCHEDULED, so ESPN had not yet
-                                // populated the live-data refs (Plays, Probability,
-                                // Situation, Leaders) on the parent EventCompetition
-                                // payload. Re-fetch now that the game is in progress so
-                                // GetPollingTargets returns real URIs instead of nulls.
-                                // Without this refresh, every poller logs "URI is null",
-                                // StartPollingWorkers spawns Active workers: 0, and the
-                                // monitoring loop runs silently for the full game.
-                                competitionDto = await GetCompetitionAsync(new Uri(externalId.SourceUrl), cancellationToken);
-                                if (competitionDto == null)
-                                {
-                                    _logger.LogError("Competition re-fetch after live start failed");
-                                    await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition re-fetch after live start failed");
-                                    return;
-                                }
-                                break;
-
-                            case LiveStartOutcome.AlreadyFinal:
-                                _logger.LogInformation("Competition went final while waiting for start. Skipping live polling.");
-                                await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
-                                stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
-                                return;
-
-                            case LiveStartOutcome.Timeout:
-                                _logger.LogWarning("Live start was not detected within max stream duration. Aborting.");
-                                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Live start not detected within max stream duration");
-                                return;
-                        }
-                        break;
-
-                    case "STATUS_IN_PROGRESS":
-                        _logger.LogInformation("Competition already in progress. Starting workers immediately.");
-                        break;
-
-                    case "STATUS_FINAL":
-                        _logger.LogInformation("Competition already final. Skipping streaming.");
-                        await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
-                        stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
-                        return;
-
-                    default:
-                        // An unknown status string is anomalous data — bail rather than
-                        // optimistically spawning live workers against an unverified competition state.
-                        _logger.LogWarning("Unknown status type: {StatusType}. Aborting stream.", status.Type.Name);
-                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, $"Unknown status type: {status.Type.Name}");
-                        return;
-                }
-
-                _logger.LogInformation("Starting polling workers for live competition updates");
-
-                stream.StreamStartedUtc = _dateTimeProvider.UtcNow();
-                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Active, cancellationToken);
-
-                _workerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-                StartPollingWorkers(competitionDto, command, _workerCts.Token);
-
-                var pollOutcome = await PollWhileInProgressAsync(statusUri, _workerCts.Token);
-
-                _logger.LogInformation("Polling loop exited with outcome {Outcome}. Stopping workers gracefully.", pollOutcome);
-                if (pollOutcome == PollOutcome.Final)
-                {
-                    await PublishContestCompletedAsync(command, competition.Contest!.SeasonWeekId, cancellationToken);
-                }
-
-                stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                switch (pollOutcome)
-                {
-                    case PollOutcome.Final:
-                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
-                        break;
-
-                    case PollOutcome.Timeout:
-                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Stream exceeded max duration without STATUS_FINAL");
-                        break;
+                    await ExecuteWithStreamAsync(command, competition, externalId, stream, cancellationToken);
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -281,6 +200,128 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             {
                 await StopWorkersAsync();
             }
+        }
+    }
+
+    /// <summary>
+    /// Post-stream-load streaming lifecycle. Called from inside the nested log
+    /// scope in <see cref="ExecuteAsync"/> that rebinds CorrelationId to
+    /// <c>stream.Id</c>, so every log line written from here forward (including
+    /// from the polling loops + publish helpers) carries the stream-scoped
+    /// CorrelationId. Exceptions propagate to <see cref="ExecuteAsync"/>'s
+    /// outer try/catch.
+    /// </summary>
+    private async Task ExecuteWithStreamAsync(
+        StreamCompetitionCommand command,
+        CompetitionBase competition,
+        CompetitionExternalId externalId,
+        CompetitionStream stream,
+        CancellationToken cancellationToken)
+    {
+        var competitionDto = await GetCompetitionAsync(new Uri(externalId.SourceUrl), cancellationToken);
+        if (competitionDto == null)
+        {
+            _logger.LogError("Competition fetch failed from ESPN");
+            await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition fetch failed");
+            return;
+        }
+
+        var statusUri = EspnUriMapper.CompetitionRefToCompetitionStatusRef(new Uri(externalId.SourceUrl));
+
+        var status = await GetStatusAsync(statusUri, cancellationToken);
+        if (status == null)
+        {
+            _logger.LogError("Initial status fetch failed");
+            await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Initial status fetch failed");
+            return;
+        }
+
+        switch (status.Type.Name)
+        {
+            case "STATUS_SCHEDULED":
+                _logger.LogInformation("Competition is scheduled. Waiting for competition to start...");
+                var startOutcome = await WaitForLiveStartAsync(statusUri, cancellationToken);
+                switch (startOutcome)
+                {
+                    case LiveStartOutcome.StartDetected:
+                        // The initial competitionDto fetch above happened while the
+                        // game was still STATUS_SCHEDULED, so ESPN had not yet
+                        // populated the live-data refs (Plays, Probability,
+                        // Situation, Leaders) on the parent EventCompetition
+                        // payload. Re-fetch now that the game is in progress so
+                        // GetPollingTargets returns real URIs instead of nulls.
+                        // Without this refresh, every poller logs "URI is null",
+                        // StartPollingWorkers spawns Active workers: 0, and the
+                        // monitoring loop runs silently for the full game.
+                        competitionDto = await GetCompetitionAsync(new Uri(externalId.SourceUrl), cancellationToken);
+                        if (competitionDto == null)
+                        {
+                            _logger.LogError("Competition re-fetch after live start failed");
+                            await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Competition re-fetch after live start failed");
+                            return;
+                        }
+                        break;
+
+                    case LiveStartOutcome.AlreadyFinal:
+                        _logger.LogInformation("Competition went final while waiting for start. Skipping live polling.");
+                        await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
+                        stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
+                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
+                        return;
+
+                    case LiveStartOutcome.Timeout:
+                        _logger.LogWarning("Live start was not detected within max stream duration. Aborting.");
+                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Live start not detected within max stream duration");
+                        return;
+                }
+                break;
+
+            case "STATUS_IN_PROGRESS":
+                _logger.LogInformation("Competition already in progress. Starting workers immediately.");
+                break;
+
+            case "STATUS_FINAL":
+                _logger.LogInformation("Competition already final. Skipping streaming.");
+                await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
+                stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
+                return;
+
+            default:
+                // An unknown status string is anomalous data — bail rather than
+                // optimistically spawning live workers against an unverified competition state.
+                _logger.LogWarning("Unknown status type: {StatusType}. Aborting stream.", status.Type.Name);
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, $"Unknown status type: {status.Type.Name}");
+                return;
+        }
+
+        _logger.LogInformation("Starting polling workers for live competition updates");
+
+        stream.StreamStartedUtc = _dateTimeProvider.UtcNow();
+        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Active, cancellationToken);
+
+        _workerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        StartPollingWorkers(competitionDto, stream.Id, command, _workerCts.Token);
+
+        var pollOutcome = await PollWhileInProgressAsync(statusUri, _workerCts.Token);
+
+        _logger.LogInformation("Polling loop exited with outcome {Outcome}. Stopping workers gracefully.", pollOutcome);
+        if (pollOutcome == PollOutcome.Final)
+        {
+            await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
+        }
+
+        stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
+        switch (pollOutcome)
+        {
+            case PollOutcome.Final:
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
+                break;
+
+            case PollOutcome.Timeout:
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Failed, cancellationToken, "Stream exceeded max duration without STATUS_FINAL");
+                break;
         }
     }
 
@@ -400,6 +441,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
     private void StartPollingWorkers(
         TCompetitionDto competitionDto,
+        Guid correlationId,
         StreamCompetitionCommand command,
         CancellationToken cancellationToken)
     {
@@ -416,7 +458,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             }
 
             SpawnPollingWorker(
-                () => PublishDocumentRequestAsync(refUri, docType, requiresParentId, command, cancellationToken),
+                () => PublishDocumentRequestAsync(correlationId, refUri, docType, requiresParentId, command, cancellationToken),
                 intervalSeconds,
                 docType,
                 cancellationToken);
@@ -431,6 +473,12 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
         var startTime = _dateTimeProvider.UtcNow();
         var consecutiveFailures = 0;
+        var tickCount = 0;
+        // Info heartbeat every Nth tick so Seq has proof-of-life during long
+        // in-game stretches without flooding at every 30s poll. At 10 ticks
+        // (~5 min) a healthy stream emits 12 heartbeats per hour — readable
+        // in Seq, distinguishable from a hang.
+        const int HeartbeatEveryNTicks = 10;
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -465,8 +513,21 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                 return PollOutcome.Final;
             }
 
-            _logger.LogDebug("Competition still in progress. Status: {Status}, Clock: {Clock}",
-                status.Type.Name, status.DisplayClock);
+            tickCount++;
+            if (tickCount % HeartbeatEveryNTicks == 0)
+            {
+                _logger.LogInformation(
+                    "Streaming heartbeat. Tick={Tick}, ElapsedMin={ElapsedMin:F1}, Status={Status}, Clock={Clock}",
+                    tickCount,
+                    (_dateTimeProvider.UtcNow() - startTime).TotalMinutes,
+                    status.Type.Name,
+                    status.DisplayClock);
+            }
+            else
+            {
+                _logger.LogDebug("Competition still in progress. Status: {Status}, Clock: {Clock}",
+                    status.Type.Name, status.DisplayClock);
+            }
         }
 
         // Cancellation observed by the while-condition. Treat as timeout-equivalent
@@ -580,13 +641,14 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     /// the contest are unscored.
     /// </summary>
     private async Task PublishContestCompletedAsync(
+        Guid correlationId,
         StreamCompetitionCommand command,
         Guid? seasonWeekId,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation(
-            "Publishing ContestCompleted for ContestId={ContestId}, CompetitionId={CompetitionId}",
-            command.ContestId, command.CompetitionId);
+            "Publishing ContestCompleted for ContestId={ContestId}, CompetitionId={CompetitionId}, CorrelationId={CorrelationId}",
+            command.ContestId, command.CompetitionId, correlationId);
 
         using var _ = _deliveryScope.Use(DeliveryMode.Direct);
         await _eventBus.Publish(new ContestCompleted(
@@ -596,8 +658,8 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             Ref: null,
             Sport: command.Sport,
             SeasonYear: command.SeasonYear,
-            CorrelationId: command.CorrelationId,
-            CausationId: command.CorrelationId
+            CorrelationId: correlationId,
+            CausationId: correlationId
         ), cancellationToken);
     }
 
@@ -616,6 +678,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     /// share the same injected instances without per-call scoping.
     /// </summary>
     private async Task PublishDocumentRequestAsync(
+        Guid correlationId,
         Uri refUri,
         DocumentType type,
         bool requiresParentId,
@@ -624,7 +687,12 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
     {
         var parentId = requiresParentId ? command.CompetitionId.ToString() : null;
 
-        _logger.LogDebug("Publishing {Type} document request for {Uri}", type, refUri);
+        // Promoted from Debug to Info so steady-state worker activity is visible
+        // at default filtering. ~3-6 publishes/min total across all polling
+        // workers — not noisy. Closes the "healthy stream and hung stream look
+        // identical in Seq" observability gap that masked the silent-publish
+        // failure mode prior to PR #362.
+        _logger.LogInformation("Publishing {Type} document request for {Uri}", type, refUri);
 
         using var _ = _deliveryScope.Use(DeliveryMode.Direct);
         await _eventBus.Publish(new DocumentRequested(
@@ -636,8 +704,8 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             SeasonYear: command.SeasonYear,
             DocumentType: type,
             SourceDataProvider: command.DataProvider,
-            CorrelationId: command.CorrelationId,
-            CausationId: command.CorrelationId
+            CorrelationId: correlationId,
+            CausationId: correlationId
         ), cancellationToken);
     }
 


### PR DESCRIPTION
## Summary

Direct follow-up to #362's postmortem. The silent-publish failure was undetectable in Seq because a healthy stream and a hung stream emitted the same (essentially zero) Info-level traffic. This PR closes that visibility gap and gives the entire Producer → Provider → Producer → API chain a single, stable, queryable identifier per stream.

## 1. CorrelationId rebound to `CompetitionStream.Id`

After `stream` loads, `ExecuteAsync` opens a nested `BeginScope` that overrides `CorrelationId = stream.Id` and adds an explicit `StreamId` field. Every log line and every domain-event publish from that point onward carries the stream-scoped id.

**Why `stream.Id`**: it's the stable identifier for the streaming work unit. Hangfire refires, admin replays, and pod restarts of the same stream all share it. A single Seq query by `stream.Id` returns the entire chain for the full lifetime of one stream:

```
Producer streamer  ──publish──▶  Provider DocumentRequestedHandler
                                       │
                                       ▼
                                  ESPN fetch + persist
                                       │
                                       ▼
                                  publish DocumentCreated
                                       │
                                       ▼
                                 Producer document processors
                                       │
                                       ▼
                                  publish *PlayCompleted
                                       │
                                       ▼
                                   API consumer + SignalR fan-out
```

**`RunId = Guid.NewGuid()`** is added to the outer scope to distinguish execution boundaries when refires happen on the same stream — `CorrelationId` stays stable across runs, `RunId` tells you which run produced each line.

A bridge log line right after stream load names both the prior and the rebound CorrelationId so traces from "Broadcasting job started" can pivot cleanly:

```
CompetitionStream loaded. StreamId=<guid>; CorrelationId rebound from <prior> to StreamId for the remainder of this run.
```

Cross-boundary propagation is already wired upstream of this class — verified, no changes needed:
- `EventBusAdapter` auto-stamps `X-Correlation-Id` transport header from `EventBase.CorrelationId`.
- `Provider.DocumentRequestedHandler` runs a 5-level fallback resolver (body → header → MT context → Activity TraceId → NewGuid+ERROR) with ERROR-on-empty.
- `DocumentProcessorBase` propagates via `command.CorrelationId` + `ToLogScope()`.

## 2. Code structure (per direction): `ExecuteWithStreamAsync` extraction

Post-stream-load body is extracted to a new private method called from inside the nested log scope. `ExecuteAsync` keeps validation, stream load, and the try/catch/finally; `ExecuteWithStreamAsync` handles everything from the first `GetCompetitionAsync` through worker spawn and poll outcome dispatch. Exceptions propagate to `ExecuteAsync`'s outer try.

`PublishContestCompletedAsync`, `PublishDocumentRequestAsync`, and `StartPollingWorkers` now take a `Guid correlationId` parameter and use it on both the published event (CorrelationId + CausationId) and the Info log line. `ExecuteWithStreamAsync` always passes `stream.Id`.

## 3. Logging gaps closed

| Change | Site | Why |
|---|---|---|
| `PublishDocumentRequestAsync` log: Debug → **Info** | `~/CompetitionStreamerBase.cs` | ~3-6 publishes/min total — not noisy. Closes the "healthy vs hung" indistinguishability that masked #362's failure mode. |
| **New** Info heartbeat every 10 ticks (~5 min) | `PollWhileInProgressAsync` | `Streaming heartbeat. Tick={Tick}, ElapsedMin={ElapsedMin:F1}, Status={Status}, Clock={Clock}` — 12/hour at default filtering, proof-of-life during long in-game stretches. Per-tick Debug stays for verbose mode. |
| `PublishContestCompletedAsync` log includes CorrelationId | same | Fast Seq pivot directly from the log message body. |

Net: a healthy stream emits visible Info traffic continuously during in-game polling. A silent-publish or hung-pod failure shows up as a clear absence of these signals instead of being indistinguishable from a quiet game.

## 4. Diagram doc updated

`docs/competition-streamer-diagram.md`:
- Section 2 prefaced with `ExecuteAsync` / `ExecuteWithStreamAsync` split note.
- Section 8 rewritten as a fuller log-line catalog (including the heartbeat and bridge line).
- Section 9 rewritten as "CorrelationId model + log scope" — documents outer vs inner scope structure, RunId vs CorrelationId, and the full downstream propagation chain.

## Test plan

- [x] `dotnet build` SportsData.Producer — 0 warnings, 0 errors
- [x] `dotnet test` Producer.Tests.Unit `~CompetitionStreamer*` — 19/19 pass
- [ ] Manual post-deploy: tail Seq on the next baseball game's streamer run. Expect:
  - Outer scope log lines (pre stream load) tagged with `command.CorrelationId`.
  - One `CompetitionStream loaded. ... CorrelationId rebound ...` line at the pivot.
  - All subsequent lines (including polling worker `Publishing ...` Info lines and `Streaming heartbeat ...` Info every ~5 min) tagged with `CorrelationId = stream.Id`.
  - Provider's `DocumentRequested received` lines for this stream's child docs carry the same `CorrelationId`.
  - Producer's `*EventCompetitionPlayDocumentProcessor` lines carry the same `CorrelationId`.
  - API's `BaseballPlayCompletedHandler consume: received` lines carry the same `CorrelationId`.
  - A Seq query for `CorrelationId = <stream.Id>` returns the full end-to-end chain in one result set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated reference documentation with streaming lifecycle diagrams and detailed operational flows

* **Improvements**
  * Enhanced request tracing with correlation IDs and run identifiers
  * Added periodic heartbeat logging during streaming operations for improved status visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->