### PR TITLE
fix(producer,web): refresh canonical Contest on STATUS_FINAL + overview/matchup edge cases

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -264,10 +264,14 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
                     case LiveStartOutcome.AlreadyFinal:
                         _logger.LogInformation("Competition went final while waiting for start. Skipping live polling.");
-                        await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
-                        await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, cancellationToken);
+                        // Finalization writes must not be cancellable by the caller — a token trip
+                        // mid-finalize would leave Contest stuck on Live and skip scoring, defeating
+                        // the whole point of this finalization path. Matches the catch block's
+                        // CancellationToken.None precedent below.
+                        await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, CancellationToken.None);
+                        await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, CancellationToken.None);
                         stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
+                        await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, CancellationToken.None);
                         return;
 
                     case LiveStartOutcome.Timeout:
@@ -283,10 +287,11 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
             case "STATUS_FINAL":
                 _logger.LogInformation("Competition already final. Skipping streaming.");
-                await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
-                await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, cancellationToken);
+                // Finalization writes use CancellationToken.None — see AlreadyFinal block above.
+                await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, CancellationToken.None);
+                await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, CancellationToken.None);
                 stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
-                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, CancellationToken.None);
                 return;
 
             default:
@@ -311,15 +316,16 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
         _logger.LogInformation("Polling loop exited with outcome {Outcome}. Stopping workers gracefully.", pollOutcome);
         if (pollOutcome == PollOutcome.Final)
         {
-            await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
-            await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, cancellationToken);
+            // Finalization writes use CancellationToken.None — see AlreadyFinal block above.
+            await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, CancellationToken.None);
+            await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, CancellationToken.None);
         }
 
         stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
         switch (pollOutcome)
         {
             case PollOutcome.Final:
-                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
+                await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, CancellationToken.None);
                 break;
 
             case PollOutcome.Timeout:

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -265,6 +265,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
                     case LiveStartOutcome.AlreadyFinal:
                         _logger.LogInformation("Competition went final while waiting for start. Skipping live polling.");
                         await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
+                        await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, cancellationToken);
                         stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
                         await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
                         return;
@@ -283,6 +284,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             case "STATUS_FINAL":
                 _logger.LogInformation("Competition already final. Skipping streaming.");
                 await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
+                await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, cancellationToken);
                 stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
                 await UpdateStreamStatusAsync(stream, CompetitionStreamStatus.Completed, cancellationToken);
                 return;
@@ -310,6 +312,7 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
         if (pollOutcome == PollOutcome.Final)
         {
             await PublishContestCompletedAsync(stream.Id, command, competition.Contest!.SeasonWeekId, cancellationToken);
+            await PublishContestRefreshOnFinalAsync(stream.Id, new Uri(externalId.SourceUrl), command, cancellationToken);
         }
 
         stream.StreamEndedUtc = _dateTimeProvider.UtcNow();
@@ -658,6 +661,52 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             Ref: null,
             Sport: command.Sport,
             SeasonYear: command.SeasonYear,
+            CorrelationId: correlationId,
+            CausationId: correlationId
+        ), cancellationToken);
+    }
+
+    /// <summary>
+    /// Re-source the parent Event document at STATUS_FINAL so the canonical
+    /// Contest entity gets its final state (IsFinal, completed status flags,
+    /// final score totals) regardless of whether the in-progress poll loop
+    /// caught the last update tick. Without this, a viewer that leaves the
+    /// picks page open overnight sees stale "Live" status the next morning
+    /// because the canonical entity never received the finalization write.
+    ///
+    /// <c>IncludeLinkedDocumentTypes</c> is intentionally omitted — at
+    /// finalization we want every linked child type re-sourced, not the
+    /// narrowed set used by the manual <c>ContestUpdateProcessor</c> path.
+    /// Provider's re-publish suppression window (~90 min) absorbs the
+    /// inevitable duplicates against documents we already polled during
+    /// the stream, so asking for "everything" here is cheap.
+    ///
+    /// The Event URI is derived from the EventCompetition URI we already
+    /// hold via <see cref="EspnUriMapper.CompetitionRefToContestRef"/>, so
+    /// no extra DB roundtrip for Contest.ExternalIds is needed.
+    /// </summary>
+    private async Task PublishContestRefreshOnFinalAsync(
+        Guid correlationId,
+        Uri competitionRef,
+        StreamCompetitionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var contestUri = EspnUriMapper.CompetitionRefToContestRef(competitionRef);
+
+        _logger.LogInformation(
+            "Publishing final Contest refresh DocumentRequested. ContestId={ContestId}, Uri={Uri}",
+            command.ContestId, contestUri);
+
+        using var _ = _deliveryScope.Use(DeliveryMode.Direct);
+        await _eventBus.Publish(new DocumentRequested(
+            Id: Guid.NewGuid().ToString(),
+            ParentId: null,
+            Uri: contestUri,
+            Ref: null,
+            Sport: command.Sport,
+            SeasonYear: command.SeasonYear,
+            DocumentType: DocumentType.Event,
+            SourceDataProvider: command.DataProvider,
             CorrelationId: correlationId,
             CausationId: correlationId
         ), cancellationToken);

--- a/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
@@ -91,7 +91,7 @@ export default function ContestOverview() {
 
   return (
     <div className="contest-overview-container">
-      <ContestOverviewHeader homeTeam={homeTeam} awayTeam={awayTeam} quarterScores={quarterScores} seasonYear={header.seasonYear} sport={sport} league={league} />
+      <ContestOverviewHeader homeTeam={homeTeam} awayTeam={awayTeam} quarterScores={quarterScores} seasonYear={header.seasonYear} sport={sport} league={league} status={header.status} />
       <div className="contest-overview-grid">
         <div className="contest-overview-col">
           <ContestOverviewLeaders homeTeam={homeTeam} awayTeam={awayTeam} leaders={leaders} />

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewHeader.jsx
@@ -5,7 +5,7 @@ import { teamLink } from '../../utils/sportLinks';
 import BoxScoreTable from "../shared/BoxScoreTable";
 import "./ContestOverview.css";
 
-export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScores, homeTeamColor, awayTeamColor, seasonYear, sport, league }) {
+export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScores, homeTeamColor, awayTeamColor, seasonYear, sport, league, status }) {
   const { theme } = useTheme() ?? {};
   const pickLogo = (t) =>
     theme === 'dark'
@@ -54,7 +54,7 @@ export default function ContestOverviewHeader({ homeTeam, awayTeam, quarterScore
           periodScores={quarterScores}
           awayLabel={awayTeam.displayName.split(' ')[0].toUpperCase()}
           homeLabel={homeTeam.displayName.split(' ')[0].toUpperCase()}
-          statusLabel="Final"
+          statusLabel={status}
         />
         {/* Home Side */}
         <div className="contest-team-score contest-header-team-score-home">{homeTotal}</div>

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewMetrics.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewMetrics.jsx
@@ -38,6 +38,13 @@ export default function ContestOverviewMetrics({ homeMetrics = {}, awayMetrics =
     .filter((k) => !excluded.has(String(k).toLowerCase()))
     .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
 
+  // No metric data on either side (scheduled / postponed / canceled, or just
+  // before stat feeds kick in) — hide the whole section rather than render an
+  // empty Metrics card.
+  if (sortedKeys.length === 0) {
+    return null;
+  }
+
   return (
     <div className="contest-section">
   <div className="contest-section-title">Metrics</div>

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
@@ -58,6 +58,24 @@
   text-align: center;
 }
 
+.make-picks-button {
+  display: block;
+  text-align: center;
+  background-color: var(--accent);
+  color: var(--bg-modal);
+  text-decoration: none;
+  padding: 0.875rem 2rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1.05rem;
+  margin-bottom: 1.5rem;
+  transition: opacity 0.2s ease;
+}
+
+.make-picks-button:hover {
+  opacity: 0.85;
+}
+
 .league-details-list {
   list-style-type: none;
   padding: 0;

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -95,6 +95,9 @@ const LeagueDetail = () => {
       <div className="league-detail-primary">
         <div className="league-info-card">
           <h2>{league.name}</h2>
+          <Link to={`/app/picks/${league.id}`} className="make-picks-button">
+            Make Your Picks
+          </Link>
           <ul className="league-details-list">
             <li><strong>Description:</strong> {league.description}</li>
             <li><strong>Pick Type:</strong> {league.pickType}</li>

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -151,6 +151,16 @@ function GameStatus({
     );
   }
 
+  if (status === 'Postponed') {
+    return (
+      <div className="game-time-location game-time-location-postponed">
+        <div className="result-label">POSTPONED</div>
+        <div className="game-time-original">{gameTime}</div>
+        <div>{venue} | {location}</div>
+      </div>
+    );
+  }
+
   // Scheduled or other status
   return (
     <>

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -245,6 +245,11 @@
   gap: 2px;
 }
 
+.game-time-location-postponed .game-time-original {
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
 /* Game Result Section */
 .game-result {
   text-align: center;

--- a/src/UI/sd-ui/src/components/shared/BoxScoreTable.jsx
+++ b/src/UI/sd-ui/src/components/shared/BoxScoreTable.jsx
@@ -27,6 +27,13 @@ export default function BoxScoreTable({
   homeLabel,
   statusLabel = "Final",
 }) {
+  // No periods means the game hasn't produced any line-score data yet
+  // (scheduled, postponed, canceled). Render nothing so the caller doesn't
+  // get an empty header + bare team labels.
+  if (!periodScores || periodScores.length === 0) {
+    return null;
+  }
+
   const awayTotal = periodScores.reduce((sum, p) => sum + p.awayScore, 0);
   const homeTotal = periodScores.reduce((sum, p) => sum + p.homeScore, 0);
   const wideClass = periodScores.length > 4 ? " wide" : "";


### PR DESCRIPTION
## Summary
- **Producer**: `CompetitionStreamerBase` now publishes a final `DocumentRequested` for the Event URL at every STATUS_FINAL detection site, so the canonical Contest entity flips to Final even if the in-progress poll loop missed the last update tick. Event URL derived from the EventCompetition URI via `EspnUriMapper.CompetitionRefToContestRef`. `IncludeLinkedDocumentTypes` is intentionally omitted (spawn all) — Provider's re-publish suppression window absorbs duplicates against documents already polled.
- **Web — Contest Overview**: boxscore status now reflects `header.status` from the DTO (was hardcoded `"Final"`); `BoxScoreTable` hides itself when `periodScores` is empty; `ContestOverviewMetrics` hides when neither side has metric data.
- **Web — MatchupCard**: new `Postponed` branch on `GameStatus` — `POSTPONED` label above the original `gameTime` struck through, venue retained, broadcasts/stream link dropped.

## Test plan
- [ ] Producer unit tests pass (no changes to existing assertions; lifecycle tests for the new finalize publish are deferred)
- [ ] Live MLB game with STATUS_FINAL → Seq shows the final `Publishing final Contest refresh DocumentRequested` line; Contest entity `IsFinal` flips to true; picks page badge transitions away from "Live"
- [ ] Postponed MLB game on picks page renders `POSTPONED` + struck-through gameTime + venue
- [ ] Scheduled game's Contest Overview no longer renders an empty boxscore wrapper
- [ ] Game with no metric data does not render an empty Metrics card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Triggers an additional final-refresh event when a competition stream reaches finality.
  * Added a “Make Your Picks” link on league pages.

* **UI Improvements**
  * Contest status flows into headers and box score labels (replaces hardcoded status).
  * Adds a visible "POSTPONED" label and styles to indicate postponed games.

* **Bug Fixes**
  * Suppress empty metrics and score tables when no data is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->