### PR TITLE
feat(api,web,mobile): sport icon + creation-date order on YourLeaguesCard

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,17 @@
       "Bash(npm ls:*)",
       "Bash(npm view:*)",
       "Bash(kubectl logs:*)",
-      "WebFetch(domain:datalust.co)"
+      "WebFetch(domain:datalust.co)",
+      "Bash(echo \"Exit: $?\")",
+      "Bash(npx expo *)",
+      "Bash(npx eas-cli *)",
+      "Bash(awk 'NR==127||NR==128||NR==247||NR==248||NR==287||NR==288{printf \"%d: %s\\\\n\",NR,$0}' docs/mobile/text-size-setting.md)",
+      "PowerShell(dotnet test *)",
+      "PowerShell(Set-Location \"C:/Projects/sports-data/src/UI/sd-mobile\"; npx tsc --noEmit 2>&1 | Select-Object -Last 40; \"EXIT=$LASTEXITCODE\")",
+      "PowerShell(git *)",
+      "PowerShell(dotnet build *)",
+      "PowerShell(npm run *)",
+      "Bash(npm config *)"
     ]
   }
 }

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
+using SportsData.Core.Common;
+
 namespace SportsData.Api.Application.User.Dtos;
 
 public class UserDto
@@ -30,6 +32,13 @@ public class UserDto
         public Guid Id { get; set; }
 
         public required string Name { get; set; }
+
+        /// <summary>
+        /// Sport this league belongs to (FootballNcaa / FootballNfl / BaseballMlb).
+        /// Used by the UI to render a default sport icon next to the league name
+        /// until commissioner-uploaded league icons land.
+        /// </summary>
+        public Sport Sport { get; set; }
 
         /// <summary>
         /// Week numbers that exist for this league, ascending with duplicates removed.

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -60,10 +60,15 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                     // today; a background job will automate it later. A future
                     // "Past Seasons" endpoint can surface the excluded rows.
                     .Where(m => m.Group.DeactivatedUtc == null)
+                    // Newest-first so a just-created league lands at the top of
+                    // YourLeaguesCard on the next /me fetch — matches the
+                    // commissioner's mental model coming out of the create flow.
+                    .OrderByDescending(m => m.Group.CreatedUtc)
                     .Select(m => new UserDto.UserLeagueMembership
                     {
                         Id = m.Group.Id,
                         Name = m.Group.Name,
+                        Sport = m.Group.Sport,
                         // Dedupe: some leagues have multiple PickemGroupWeek rows with
                         // the same SeasonWeek number (e.g. a preseason Week 1 alongside a
                         // regular-season Week 1, or rows carried over across SeasonYears).

--- a/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
@@ -6,6 +6,15 @@ import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { League } from '@/src/types/models';
 
+// Default sport-icon glyphs. Mirrors sd-ui's YourLeaguesCard SPORT_ICON map.
+// Stand-in until commissioner-uploaded league icons land — at that point the
+// per-league icon overrides this map and unknown-sport rows skip the glyph.
+const SPORT_ICON: Record<NonNullable<League['sport']>, string> = {
+  FootballNcaa: '🏈',
+  FootballNfl: '🏈',
+  BaseballMlb: '⚾',
+};
+
 interface Props {
   leagues: League[];
 }
@@ -43,40 +52,39 @@ export function YourLeaguesCard({ leagues }: Props) {
     >
       <Text style={[styles.eyebrow, { color: theme.tint }]}>YOUR LEAGUES</Text>
 
-      <View style={styles.list}>
-        {leagues.map((league, i) => (
-          <TouchableOpacity
-            key={league.id}
-            onPress={() => openLeague(league.id)}
-            activeOpacity={0.6}
-            accessibilityRole="button"
-            accessibilityLabel={`Open ${league.name}`}
-            style={[
-              styles.row,
-              i > 0 && {
-                borderTopColor: theme.separator,
-                borderTopWidth: StyleSheet.hairlineWidth,
-              },
-            ]}
-          >
-            <Text
-              style={[styles.name, { color: theme.text }]}
-              numberOfLines={1}
+      <View style={styles.pillGrid}>
+        {leagues.map((league) => {
+          const icon = league.sport ? SPORT_ICON[league.sport] : undefined;
+          return (
+            <TouchableOpacity
+              key={league.id}
+              onPress={() => openLeague(league.id)}
+              activeOpacity={0.6}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${league.name}`}
+              style={[
+                styles.pill,
+                { backgroundColor: theme.background, borderColor: theme.border },
+              ]}
             >
-              {league.name}
-            </Text>
-            <Text
-              style={[styles.chevron, { color: theme.textMuted }]}
-              // accessibilityElementsHidden is iOS-only; importantForAccessibility
-              // covers Android TalkBack. Pass both so the "›" glyph never reaches
-              // a screen reader alongside the row's accessibilityLabel.
-              accessibilityElementsHidden
-              importantForAccessibility="no-hide-descendants"
-            >
-              ›
-            </Text>
-          </TouchableOpacity>
-        ))}
+              {icon && (
+                <Text
+                  style={styles.pillIcon}
+                  accessibilityElementsHidden
+                  importantForAccessibility="no-hide-descendants"
+                >
+                  {icon}
+                </Text>
+              )}
+              <Text
+                style={[styles.pillName, { color: theme.text }]}
+                numberOfLines={1}
+              >
+                {league.name}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
       </View>
     </View>
   );
@@ -94,23 +102,30 @@ const styles = StyleSheet.create({
     letterSpacing: 1.5,
     marginBottom: 10,
   },
-  list: {
-    gap: 0,
+  pillGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
   },
-  row: {
+  pill: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    gap: 6,
+    // Hard cap so a single very-long league name can't push the pill past
+    // the card width; long names truncate via numberOfLines={1} + flexShrink
+    // on the name Text.
+    maxWidth: '100%',
   },
-  name: {
-    fontSize: 15,
+  pillIcon: {
+    fontSize: 14,
+  },
+  pillName: {
+    fontSize: 14,
     fontWeight: '600',
-    flex: 1,
-  },
-  chevron: {
-    fontSize: 22,
-    fontWeight: '400',
-    marginLeft: 8,
+    flexShrink: 1,
   },
 });

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -13,6 +13,13 @@ export interface League {
   id: string;
   name: string;
   /**
+   * Backend Sport enum (PascalCase). Drives the default sport-icon glyph
+   * shown next to the league name on YourLeaguesCard until commissioner-
+   * uploaded league icons land. Optional — older API builds (pre the
+   * GetMeQueryHandler Sport projection) don't include it.
+   */
+  sport?: 'FootballNcaa' | 'FootballNfl' | 'BaseballMlb';
+  /**
    * Ascending list of week numbers that exist in this league.
    * Custom-window leagues may contain a subset (e.g. [4]) rather than 1..N.
    */

--- a/src/UI/sd-ui/src/components/home/YourLeaguesCard.css
+++ b/src/UI/sd-ui/src/components/home/YourLeaguesCard.css
@@ -52,6 +52,18 @@
   border-radius: 6px;
 }
 
+.your-leagues-card__icon {
+  font-size: 1.15rem;
+  line-height: 1;
+  /* Lock width so leagues without an icon (unknown future Sport enum
+     value) don't shift the name column inconsistently — the absent-icon
+     case skips rendering this span entirely. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+}
+
 .your-leagues-card__name {
   flex: 1;
   /* Flex items default to min-width: auto, which prevents shrinking

--- a/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
@@ -45,11 +45,14 @@ function YourLeaguesCard() {
                 className="your-leagues-card__row"
                 aria-label={`Open ${league.name}`}
               >
-                {icon && (
-                  <span className="your-leagues-card__icon" aria-hidden="true">
-                    {icon}
-                  </span>
-                )}
+                {/* Always render the icon span — its CSS min-width reserves
+                    the column even when icon is undefined (unknown Sport
+                    enum value, or pre-rollout cached /me without the Sport
+                    field). Skipping the span entirely produces a mid-rollout
+                    visual jitter where mixed rows shift the name column. */}
+                <span className="your-leagues-card__icon" aria-hidden="true">
+                  {icon}
+                </span>
                 <span className="your-leagues-card__name">{league.name}</span>
                 <span className="your-leagues-card__chevron" aria-hidden="true">
                   ›

--- a/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
@@ -2,6 +2,15 @@ import { Link } from "react-router-dom";
 import { useUserDto } from "../../contexts/UserContext";
 import "./YourLeaguesCard.css";
 
+// Default sport-icon glyphs. Stand-in until commissioner-uploaded league
+// icons land — at that point the per-league icon overrides this map and
+// the unknown-sport branch becomes the fallback for legacy rows.
+const SPORT_ICON = {
+  FootballNcaa: "🏈",
+  FootballNfl: "🏈",
+  BaseballMlb: "⚾",
+};
+
 /**
  * Tier 2 — "Your Leagues" card. Web mirror of sd-mobile's YourLeaguesCard
  * (src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx).
@@ -27,20 +36,28 @@ function YourLeaguesCard() {
     <div className="your-leagues-card">
       <div className="your-leagues-card__eyebrow">YOUR LEAGUES</div>
       <ul className="your-leagues-card__list">
-        {leagues.map((league) => (
-          <li key={league.id} className="your-leagues-card__item">
-            <Link
-              to={`/app/picks/${league.id}`}
-              className="your-leagues-card__row"
-              aria-label={`Open ${league.name}`}
-            >
-              <span className="your-leagues-card__name">{league.name}</span>
-              <span className="your-leagues-card__chevron" aria-hidden="true">
-                ›
-              </span>
-            </Link>
-          </li>
-        ))}
+        {leagues.map((league) => {
+          const icon = SPORT_ICON[league.sport];
+          return (
+            <li key={league.id} className="your-leagues-card__item">
+              <Link
+                to={`/app/picks/${league.id}`}
+                className="your-leagues-card__row"
+                aria-label={`Open ${league.name}`}
+              >
+                {icon && (
+                  <span className="your-leagues-card__icon" aria-hidden="true">
+                    {icon}
+                  </span>
+                )}
+                <span className="your-leagues-card__name">{league.name}</span>
+                <span className="your-leagues-card__chevron" aria-hidden="true">
+                  ›
+                </span>
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Backend**: `UserDto.UserLeagueMembership` gains a `Sport` field (Core.Common.Sport enum); `GetMeQueryHandler` projects `m.Group.Sport` and orders leagues by `m.Group.CreatedUtc DESC` so a just-created league lands at the top of `/me`. Single ordering decision in the BE keeps web and mobile in sync.
- **Web `YourLeaguesCard.jsx`**: `SPORT_ICON` lookup (`FootballNcaa`/`FootballNfl` → 🏈, `BaseballMlb` → ⚾) renders a leading sport glyph on each row. Unknown future Sport enum values skip the icon span rather than break layout. `.icon` style locks `min-width: 1.5rem` so present/absent rows don't shift the name column.
- **Mobile `YourLeaguesCard.tsx`**: same `SPORT_ICON` map, plus a layout swap from stacked-rows-with-hairlines to a flex-wrap pill grid. Many-league users no longer waste screen height on a one-pill-per-row stack. Long names truncate via `numberOfLines + flexShrink`; `maxWidth: '100%'` caps a single oversized pill at the card width.
- **`League` type (mobile)** gains an optional `sport?: 'FootballNcaa' | 'FootballNfl' | 'BaseballMlb'`.

Stand-in defaults until commissioner-uploaded league icons land — at that point a per-league `iconUrl` field overrides this map and the unknown-sport branch becomes the legacy fallback.

## Test plan
- [ ] `dotnet test` API: 339 tests pass (verified locally).
- [ ] Mobile `npx tsc --noEmit` + Jest: 39 tests pass (verified locally).
- [ ] Web YourLeaguesCard renders `🏈 League Name ›` / `⚾ League Name ›`; unknown-sport leagues render without the icon, name column not shifted.
- [ ] Mobile YourLeaguesCard renders pills that wrap to multiple rows when the user has many leagues; long names truncate inside the pill; tapping any pill routes to the picks tab with that leagueId preselected.
- [ ] Newly-created league appears at the top of `/me` → top of YourLeaguesCard on both web and mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * League cards now show sport icons (football, baseball, etc.) on web and mobile.
  * User league lists are ordered newest-first.
  * Mobile “Your Leagues” displays leagues as wrapped pill buttons with icons and improved touch navigation.
  * UI styling updated so icons render consistently without layout shifts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->