### PR TITLE
fix(producer): stop silent data drops in EventCompetitionCompetitorRecord processor

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessor.cs
@@ -19,14 +19,18 @@ namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Co
 public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {
+    private readonly IDateTimeProvider _dateTimeProvider;
+
     public EventCompetitionCompetitorRecordDocumentProcessor(
         ILogger<EventCompetitionCompetitorRecordDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus eventBus,
         IGenerateExternalRefIdentities identityGenerator,
-        IGenerateResourceRefs refs)
+        IGenerateResourceRefs refs,
+        IDateTimeProvider dateTimeProvider)
         : base(logger, dataContext, eventBus, identityGenerator, refs)
     {
+        _dateTimeProvider = dateTimeProvider;
     }
 
     protected override async Task ProcessInternal(ProcessDocumentCommand command)
@@ -219,12 +223,12 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
             Summary = dto.Summary,
             DisplayValue = dto.DisplayValue,
             Value = dto.Value,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = _dateTimeProvider.UtcNow(),
             CreatedBy = command.CorrelationId
         };
 
         // Add stats
-        CreateStatsForRecord(dto.Stats, record, command.CorrelationId);
+        CreateStatsForRecord(dto.Stats, record, command.CorrelationId, _dateTimeProvider.UtcNow());
 
         await _dataContext.CompetitionCompetitorRecords.AddAsync(record);
 
@@ -235,7 +239,7 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
             record.Stats.Count);
     }
 
-    private async Task ProcessUpdate(
+    private Task ProcessUpdate(
         ProcessDocumentCommand command,
         EspnEventCompetitionCompetitorRecordDto dto,
         CompetitionCompetitorRecord existingRecord)
@@ -250,7 +254,7 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
         existingRecord.Summary = dto.Summary;
         existingRecord.DisplayValue = dto.DisplayValue;
         existingRecord.Value = dto.Value;
-        existingRecord.ModifiedUtc = DateTime.UtcNow;
+        existingRecord.ModifiedUtc = _dateTimeProvider.UtcNow();
 
         // Diff-merge stats by Name (ESPN's natural per-stat identifier).
         // The prior "RemoveRange + re-Add" pattern issued explicit DELETE
@@ -262,7 +266,7 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
         // steady-state case where ESPN ships the same stat keys with new
         // values — UPDATEs don't race the same way, and only orphan
         // removal / new additions hit DELETE / INSERT paths.
-        var now = DateTime.UtcNow;
+        var now = _dateTimeProvider.UtcNow();
         var incoming = (dto.Stats ?? new List<EspnRecordStatDto>())
             .Where(s => !string.IsNullOrEmpty(s.Name))
             .GroupBy(s => s.Name)
@@ -322,18 +326,19 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
             _dataContext.CompetitionCompetitorRecordStats.Remove(orphan);
         }
 
-        await Task.CompletedTask;
-
         _logger.LogInformation(
             "✅ RECORD_UPDATED: CompetitionCompetitorRecord updated. RecordId={RecordId}, Stats={StatCount}",
             existingRecord.Id,
             existingRecord.Stats.Count);
+
+        return Task.CompletedTask;
     }
 
     private static void CreateStatsForRecord(
         IEnumerable<EspnRecordStatDto>? statDtos,
         CompetitionCompetitorRecord record,
-        Guid correlationId)
+        Guid correlationId,
+        DateTime now)
     {
         if (statDtos == null)
             return;
@@ -352,7 +357,7 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
                 Type = statDto.Type,
                 Value = statDto.Value,
                 DisplayValue = statDto.DisplayValue,
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = now,
                 CreatedBy = correlationId
             };
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessor.cs
@@ -110,7 +110,7 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
                         .FirstOrDefaultAsync(r =>
                             r.CompetitionCompetitorId == competitorId &&
                             r.Type == dto.Type);
-                    
+
                     if (existingRecord == null)
                     {
                         _logger.LogWarning(
@@ -121,18 +121,36 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
                             command.CorrelationId);
                         return;
                     }
+
+                    // Jittered backoff before the next attempt. Seq analysis
+                    // of the conflict bursts (single fan-out CorrelationId
+                    // generating dozens of sibling messages within ~160ms)
+                    // showed all 3 attempts firing within ~15ms total — the
+                    // retry was spinning through the contention window. A
+                    // 50-200ms jitter pushes the next attempt past the burst
+                    // window, giving attempt 2/3 a real chance to land
+                    // before escalating to outer-delivery retry.
+                    var backoffMs = Random.Shared.Next(50, 200);
+                    await Task.Delay(backoffMs);
                 }
                 catch (DbUpdateConcurrencyException)
                 {
-                    // Final retry failed - another pod won
+                    // Final retry failed. Previously this swallowed the
+                    // exception with `return;`, which caused Hangfire /
+                    // MassTransit to treat the message as succeeded and
+                    // silently drop the update. Rethrow so the outer
+                    // delivery layer can apply its own exponential backoff
+                    // and retry — by the time the message redelivers, the
+                    // burst window that caused the in-process contention
+                    // will have cleared.
                     _logger.LogWarning(
-                        "Concurrency conflict after {MaxRetries} retries. Another process owns this update. " +
+                        "Concurrency conflict after {MaxRetries} retries. Rethrowing for outer-delivery retry. " +
                         "CompetitorId={CompetitorId}, Type={Type}, CorrelationId={CorrelationId}",
                         maxRetries,
                         competitorId,
                         dto.Type,
                         command.CorrelationId);
-                    return;
+                    throw;
                 }
             }
         }
@@ -234,12 +252,77 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
         existingRecord.Value = dto.Value;
         existingRecord.ModifiedUtc = DateTime.UtcNow;
 
-        // Remove old stats
-        _dataContext.CompetitionCompetitorRecordStats.RemoveRange(existingRecord.Stats);
-        existingRecord.Stats.Clear();
+        // Diff-merge stats by Name (ESPN's natural per-stat identifier).
+        // The prior "RemoveRange + re-Add" pattern issued explicit DELETE
+        // statements for every stat row; under burst-fan-out contention a
+        // sibling worker could DELETE the same rows first, causing EF to
+        // throw DbUpdateConcurrencyException on the row-count mismatch
+        // (the entity has no IsRowVersion token, so EF only verifies
+        // 1 row affected per DELETE). Diff-merge emits UPDATEs for the
+        // steady-state case where ESPN ships the same stat keys with new
+        // values — UPDATEs don't race the same way, and only orphan
+        // removal / new additions hit DELETE / INSERT paths.
+        var now = DateTime.UtcNow;
+        var incoming = (dto.Stats ?? new List<EspnRecordStatDto>())
+            .Where(s => !string.IsNullOrEmpty(s.Name))
+            .GroupBy(s => s.Name)
+            .ToDictionary(g => g.Key, g => g.First());
+        var existingByName = existingRecord.Stats
+            .Where(s => !string.IsNullOrEmpty(s.Name))
+            .GroupBy(s => s.Name)
+            .ToDictionary(g => g.Key, g => g.First());
 
-        // Add new stats
-        CreateStatsForRecord(dto.Stats, existingRecord, command.CorrelationId);
+        // Update existing + insert new
+        foreach (var (name, statDto) in incoming)
+        {
+            if (existingByName.TryGetValue(name, out var existingStat))
+            {
+                existingStat.DisplayName = statDto.DisplayName;
+                existingStat.ShortDisplayName = statDto.ShortDisplayName;
+                existingStat.Description = statDto.Description;
+                existingStat.Abbreviation = statDto.Abbreviation;
+                existingStat.Type = statDto.Type;
+                existingStat.Value = statDto.Value;
+                existingStat.DisplayValue = statDto.DisplayValue;
+                existingStat.ModifiedUtc = now;
+            }
+            else
+            {
+                var newStat = new CompetitionCompetitorRecordStat
+                {
+                    Id = Guid.NewGuid(),
+                    CompetitionCompetitorRecordId = existingRecord.Id,
+                    Name = statDto.Name,
+                    DisplayName = statDto.DisplayName,
+                    ShortDisplayName = statDto.ShortDisplayName,
+                    Description = statDto.Description,
+                    Abbreviation = statDto.Abbreviation,
+                    Type = statDto.Type,
+                    Value = statDto.Value,
+                    DisplayValue = statDto.DisplayValue,
+                    CreatedUtc = now,
+                    CreatedBy = command.CorrelationId
+                };
+                existingRecord.Stats.Add(newStat);
+                // Mark on the DbSet too — relying on navigation-collection
+                // auto-detection alone has surfaced as a real failure path
+                // (InMemory provider raised "entity does not exist in the
+                // store" on SaveChanges when only added to the collection).
+                _dataContext.CompetitionCompetitorRecordStats.Add(newStat);
+            }
+        }
+
+        // Remove orphans (stats ESPN no longer ships)
+        var orphans = existingRecord.Stats
+            .Where(s => !string.IsNullOrEmpty(s.Name) && !incoming.ContainsKey(s.Name))
+            .ToList();
+        foreach (var orphan in orphans)
+        {
+            existingRecord.Stats.Remove(orphan);
+            _dataContext.CompetitionCompetitorRecordStats.Remove(orphan);
+        }
+
+        await Task.CompletedTask;
 
         _logger.LogInformation(
             "✅ RECORD_UPDATED: CompetitionCompetitorRecord updated. RecordId={RecordId}, Stats={StatCount}",

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessorTests.cs
@@ -4,6 +4,8 @@ using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using System.Globalization;
+
 using SportsData.Core.Common;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
@@ -43,6 +45,9 @@ public class EventCompetitionCompetitorRecordDocumentProcessorTests
 
     private static string BuildDocumentJson(string type, params (string Name, double Value, string DisplayValue)[] stats)
     {
+        // Numeric values rendered with InvariantCulture so the resulting
+        // JSON is valid on locales with non-dot decimal separators (e.g.
+        // de-DE would otherwise emit "value": 0,667 — invalid JSON).
         var statsJson = string.Join(",", stats.Select(s =>
             $$"""
             {
@@ -52,7 +57,7 @@ public class EventCompetitionCompetitorRecordDocumentProcessorTests
               "description": "{{s.Name}} desc",
               "abbreviation": "{{s.Name}}",
               "type": "{{s.Name}}",
-              "value": {{s.Value}},
+              "value": {{s.Value.ToString(CultureInfo.InvariantCulture)}},
               "displayValue": "{{s.DisplayValue}}"
             }
             """));
@@ -150,9 +155,10 @@ public class EventCompetitionCompetitorRecordDocumentProcessorTests
 
         // Second call ships the same stat NAMES but different VALUES. Under
         // diff-merge this should UPDATE in place — same row Ids. Under the
-        // prior DELETE-INSERT pattern, Ids would be regenerated.
-        // Use a fresh SUT (and thus a fresh DbContext from the test base's
-        // Mocker) to simulate a different worker / message processing.
+        // prior DELETE-INSERT pattern, Ids would be regenerated. The
+        // ChangeTracker.Clear() above simulates the production "fresh DI
+        // scope per message" semantic; reusing the same `sut` here is fine
+        // because the processor is stateless apart from the DbContext.
         var secondDoc = BuildDocumentJson("road",
             ("wins", 11, "11"),
             ("losses", 5, "5"));
@@ -241,7 +247,7 @@ public class EventCompetitionCompetitorRecordDocumentProcessorTests
 
         var anyRecords = await FootballDataContext.CompetitionCompetitorRecords
             .AsNoTracking()
-            .AnyAsync();
+            .AnyAsync(r => r.CompetitionCompetitorId == phantomCompetitorId);
 
         anyRecords.Should().BeFalse();
     }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessorTests.cs
@@ -1,0 +1,248 @@
+using AutoFixture;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using System.Text.Json;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Common;
+
+/// <summary>
+/// Tests for EventCompetitionCompetitorRecordDocumentProcessor.
+///
+/// Focus is on the diff-merge stat update path that replaced the prior
+/// "RemoveRange + re-Add" pattern. The prior pattern issued explicit DELETE
+/// statements for every stat row, which under burst-fan-out contention
+/// would race sibling workers and throw DbUpdateConcurrencyException on
+/// EF's row-count mismatch (the entity has no IsRowVersion token).
+///
+/// Diff-merge emits in-place UPDATEs for the steady-state case (ESPN ships
+/// the same stat keys with new values), eliminating the race for the
+/// common path. Only orphan removal / new stat additions still hit
+/// DELETE / INSERT.
+///
+/// Stat.Id preservation is the load-bearing assertion that proves
+/// diff-merge: under the prior DELETE-INSERT pattern, every SaveChanges
+/// would issue a new Guid for every stat. Diff-merge keeps the same Id
+/// across updates.
+/// </summary>
+public class EventCompetitionCompetitorRecordDocumentProcessorTests
+    : ProducerTestBase<EventCompetitionCompetitorRecordDocumentProcessor<TeamSportDataContext>>
+{
+    private const string DocumentRef = "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401815434/competitions/401815434/competitors/28/records/61534?lang=en&region=us";
+
+    private static string BuildDocumentJson(string type, params (string Name, double Value, string DisplayValue)[] stats)
+    {
+        var statsJson = string.Join(",", stats.Select(s =>
+            $$"""
+            {
+              "name": "{{s.Name}}",
+              "displayName": "{{s.Name}} display",
+              "shortDisplayName": "{{s.Name}}",
+              "description": "{{s.Name}} desc",
+              "abbreviation": "{{s.Name}}",
+              "type": "{{s.Name}}",
+              "value": {{s.Value}},
+              "displayValue": "{{s.DisplayValue}}"
+            }
+            """));
+
+        return $$"""
+        {
+          "$ref": "{{DocumentRef}}",
+          "id": "61534",
+          "name": "Road",
+          "abbreviation": "RD",
+          "displayName": "Road Record",
+          "shortDisplayName": "Road",
+          "description": "Record on the road",
+          "type": "{{type}}",
+          "summary": "10-5",
+          "displayValue": "10-5",
+          "value": 0.667,
+          "stats": [{{statsJson}}]
+        }
+        """;
+    }
+
+    private async Task<Guid> SeedCompetitorAsync()
+    {
+        var competitor = Fixture.Build<FootballCompetitionCompetitor>()
+            .OmitAutoProperties()
+            .With(x => x.Id, Guid.NewGuid())
+            .With(x => x.CompetitionId, Guid.NewGuid())
+            .With(x => x.FranchiseSeasonId, Guid.NewGuid())
+            .With(x => x.HomeAway, "home")
+            .Create();
+        await FootballDataContext.CompetitionCompetitors.AddAsync(competitor);
+        await FootballDataContext.SaveChangesAsync();
+        return competitor.Id;
+    }
+
+    private ProcessDocumentCommand BuildCommand(string parentId, string documentJson) =>
+        Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitorRecord)
+            .With(x => x.Document, documentJson)
+            .With(x => x.ParentId, parentId)
+            .OmitAutoProperties()
+            .Create();
+
+    [Fact]
+    public async Task WhenRecordDoesNotExist_CreatesRecordWithStats()
+    {
+        var competitorId = await SeedCompetitorAsync();
+        var documentJson = BuildDocumentJson("road",
+            ("wins", 10, "10"),
+            ("losses", 5, "5"));
+
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorRecordDocumentProcessor<TeamSportDataContext>>();
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(), documentJson));
+
+        var record = await FootballDataContext.CompetitionCompetitorRecords
+            .AsNoTracking()
+            .Include(r => r.Stats)
+            .FirstOrDefaultAsync(r => r.CompetitionCompetitorId == competitorId);
+
+        record.Should().NotBeNull();
+        record!.Type.Should().Be("road");
+        record.Stats.Should().HaveCount(2);
+        record.Stats.Should().Contain(s => s.Name == "wins" && s.Value == 10);
+        record.Stats.Should().Contain(s => s.Name == "losses" && s.Value == 5);
+    }
+
+    [Fact]
+    public async Task WhenRecordExists_DiffMergePreservesStatIds_OnValueChange()
+    {
+        var competitorId = await SeedCompetitorAsync();
+
+        // First call seeds the record + stats with initial values.
+        var firstDoc = BuildDocumentJson("road",
+            ("wins", 10, "10"),
+            ("losses", 5, "5"));
+
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorRecordDocumentProcessor<TeamSportDataContext>>();
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(), firstDoc));
+        // Simulate production: each message gets a fresh DI scope + DbContext.
+        // Without this, the second ProcessAsync sees cached entities from the
+        // first call's change tracker and EF's InMemory provider misbehaves
+        // on the second SaveChanges.
+        FootballDataContext.ChangeTracker.Clear();
+
+        var statIdsBefore = (await FootballDataContext.CompetitionCompetitorRecordStats
+            .AsNoTracking()
+            .Where(s => s.CompetitionCompetitorRecord.CompetitionCompetitorId == competitorId)
+            .ToListAsync())
+            .ToDictionary(s => s.Name, s => s.Id);
+
+        statIdsBefore.Should().HaveCount(2);
+
+        // Second call ships the same stat NAMES but different VALUES. Under
+        // diff-merge this should UPDATE in place — same row Ids. Under the
+        // prior DELETE-INSERT pattern, Ids would be regenerated.
+        // Use a fresh SUT (and thus a fresh DbContext from the test base's
+        // Mocker) to simulate a different worker / message processing.
+        var secondDoc = BuildDocumentJson("road",
+            ("wins", 11, "11"),
+            ("losses", 5, "5"));
+
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(), secondDoc));
+
+        var statsAfter = await FootballDataContext.CompetitionCompetitorRecordStats
+            .AsNoTracking()
+            .Where(s => s.CompetitionCompetitorRecord.CompetitionCompetitorId == competitorId)
+            .ToListAsync();
+
+        statsAfter.Should().HaveCount(2);
+
+        var winsAfter = statsAfter.Single(s => s.Name == "wins");
+        winsAfter.Id.Should().Be(statIdsBefore["wins"], "diff-merge must update in place, not delete-and-insert");
+        winsAfter.Value.Should().Be(11);
+
+        var lossesAfter = statsAfter.Single(s => s.Name == "losses");
+        lossesAfter.Id.Should().Be(statIdsBefore["losses"], "unchanged stats must keep their Id under diff-merge");
+        lossesAfter.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task WhenRecordExists_AddsNewIncomingStats()
+    {
+        var competitorId = await SeedCompetitorAsync();
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorRecordDocumentProcessor<TeamSportDataContext>>();
+
+        // Seed with two stats.
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(),
+            BuildDocumentJson("road", ("wins", 10, "10"), ("losses", 5, "5"))));
+        FootballDataContext.ChangeTracker.Clear();
+
+        // Second call adds a third stat the DB doesn't know about.
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(),
+            BuildDocumentJson("road",
+                ("wins", 10, "10"),
+                ("losses", 5, "5"),
+                ("winPercent", 0.667, ".667"))));
+
+        var stats = await FootballDataContext.CompetitionCompetitorRecordStats
+            .AsNoTracking()
+            .Where(s => s.CompetitionCompetitorRecord.CompetitionCompetitorId == competitorId)
+            .ToListAsync();
+
+        stats.Should().HaveCount(3);
+        stats.Should().Contain(s => s.Name == "winPercent" && s.Value == 0.667);
+    }
+
+    [Fact]
+    public async Task WhenRecordExists_RemovesOrphanStats_NotInIncoming()
+    {
+        var competitorId = await SeedCompetitorAsync();
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorRecordDocumentProcessor<TeamSportDataContext>>();
+
+        // Seed with three stats.
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(),
+            BuildDocumentJson("road",
+                ("wins", 10, "10"),
+                ("losses", 5, "5"),
+                ("ties", 0, "0"))));
+        FootballDataContext.ChangeTracker.Clear();
+
+        // Second call drops 'ties' — should be removed as an orphan.
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(),
+            BuildDocumentJson("road", ("wins", 10, "10"), ("losses", 5, "5"))));
+
+        var stats = await FootballDataContext.CompetitionCompetitorRecordStats
+            .AsNoTracking()
+            .Where(s => s.CompetitionCompetitorRecord.CompetitionCompetitorId == competitorId)
+            .ToListAsync();
+
+        stats.Should().HaveCount(2);
+        stats.Should().NotContain(s => s.Name == "ties");
+    }
+
+    [Fact]
+    public async Task WhenCompetitorMissing_ReturnsWithoutCreatingRecord()
+    {
+        // No competitor seeded — ParentId references a nonexistent Id.
+        var phantomCompetitorId = Guid.NewGuid();
+        var documentJson = BuildDocumentJson("road", ("wins", 10, "10"));
+
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorRecordDocumentProcessor<TeamSportDataContext>>();
+        await sut.ProcessAsync(BuildCommand(phantomCompetitorId.ToString(), documentJson));
+
+        var anyRecords = await FootballDataContext.CompetitionCompetitorRecords
+            .AsNoTracking()
+            .AnyAsync();
+
+        anyRecords.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
End-to-end fix for the `"Concurrency conflict after 3 retries"` warnings in `EventCompetitionCompetitorRecordDocumentProcessor` that were silently dropping record updates whenever the upstream Competition cascade produced burst sibling messages. Seq surfaced ~50 final-failure events in one 12-minute MLB burst this morning, all sharing one CorrelationId — same upstream fan-out, dozens of sibling CompetitorRecord messages stepping on each other inside the in-process retry window.

## Root cause
The entity has no `IsRowVersion` concurrency token, so `DbUpdateConcurrencyException` was firing on EF's row-count-mismatch check during the prior `RemoveRange(existingRecord.Stats) + re-Add` pattern. When two sibling workers raced the same Record, the second worker's DELETE found 0 rows (the first worker already deleted them) → exception → retry → same race → exhaustion → **silent `return;`** swallowed the failure from Hangfire's perspective. No DLQ, no outer retry, no visible "this got dropped."

## Changes
1. **Rethrow on retry exhaustion** — `return;` → `throw;` in the final catch. Hangfire / MassTransit now apply outer-delivery retry with their own exponential backoff. By the time the message redelivers, the in-burst contention has cleared.
2. **Jittered 50-200ms backoff between in-process retries.** Was zero — all 3 attempts firing within ~15ms total, spinning through the contention window instead of waiting it out. Jitter gives attempt 2/3 a real chance to land post-burst before escalating.
3. **Diff-merge stats by `Name`** (ESPN's stable per-stat identifier) instead of `DELETE then re-INSERT`. The steady-state case (same stat keys with new values) now emits in-place `UPDATE`s — which don't race the row-count-mismatch way. Only orphan removal / new additions hit `DELETE` or `INSERT` paths.
4. **Bug surfaced by the new test**: explicit `_dataContext.CompetitionCompetitorRecordStats.Add(newStat)` alongside the navigation-collection `existingRecord.Stats.Add(newStat)`. The navigation-only add was producing the exact `"Attempted to update or delete an entity that does not exist in the store"` error we'd been chasing in production — caught locally by EF's InMemory provider, would have hit Postgres the same way.

## Test coverage
New test file `EventCompetitionCompetitorRecordDocumentProcessorTests.cs` — 5 tests, all pass:
- `WhenRecordDoesNotExist_CreatesRecordWithStats` — new-record path
- `WhenRecordExists_DiffMergePreservesStatIds_OnValueChange` — load-bearing assertion that diff-merge updates in place rather than delete-and-insert (`Stat.Id` preserved across updates)
- `WhenRecordExists_AddsNewIncomingStats` — new stat path
- `WhenRecordExists_RemovesOrphanStats_NotInIncoming` — orphan deletion
- `WhenCompetitorMissing_ReturnsWithoutCreatingRecord` — early-return guard

The processor previously had **zero** test coverage. Producer suite: 407 pass (+5), 15 skipped, 0 fail.

## What's NOT fixed in this PR (follow-up)
The upstream fan-out emitting duplicate sibling `DocumentRequested` messages from the same Competition cascade. Seq showed every conflict tied to one CorrelationId — strong signal that the same Competition is being re-sourced (or fanned-out twice) in quick succession. The retry hardening here removes the data-loss *consequence* but doesn't fix the underlying fan-out duplication. Worth a separate trace of the parent CorrelationId pattern.

## Test plan
- [x] `dotnet test SportsData.Producer.Tests.Unit` — 407 pass
- [ ] Deploy and watch Seq for "Concurrency conflict after 3 retries" — expect drastic reduction. Any remaining ones should now show outer-delivery retry attempts (Hangfire's `AttemptCount` incrementing) rather than silent drops.
- [ ] Watch for new `"Attempted to update or delete an entity that does not exist in the store"` errors — expect none; if they appear, the diff-merge has another edge case to chase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency handling for competitor record updates with randomized retry delay and surfaced failures for proper upstream retry/backoff.
  * Stat updates now merge changes instead of deleting/recreating, preserving existing rows when values change and correctly adding/removing stats.
  * Record/stat timestamps now come from a consistent time provider for reliable Created/Modified times.

* **Tests**
  * Added comprehensive tests covering create, update (preserve IDs), add/remove stats, and missing-parent scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->