### PR TITLE
feat(web,mobile): mini-schedule newest-first + sport-aware limit + mobile parity

### DIFF
--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -74,6 +74,7 @@ function TeamRow({
   isFinal,
   isScheduleOpen,
   onToggleSchedule,
+  canShowSchedule,
 }: {
   matchup: Matchup;
   side: 'home' | 'away';
@@ -83,6 +84,7 @@ function TeamRow({
   isFinal: boolean;
   isScheduleOpen: boolean;
   onToggleSchedule: () => void;
+  canShowSchedule: boolean;
 }) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -141,9 +143,11 @@ function TeamRow({
           {rank != null ? <Text style={[styles.rankText, { color: theme.tint }]}>#{rank} </Text> : null}
           {name}
         </Text>
-        {record !== '' && (
-          <View style={styles.recordRow}>
+        <View style={styles.recordRow}>
+          {record !== '' && (
             <Text style={[styles.recordText, { color: theme.textMuted }]}>{record}</Text>
+          )}
+          {canShowSchedule && (
             <TouchableOpacity
               onPress={onToggleSchedule}
               hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
@@ -155,8 +159,8 @@ function TeamRow({
                 color={theme.tint}
               />
             </TouchableOpacity>
-          </View>
-        )}
+          )}
+        </View>
         {probablePitcher?.displayName ? (
           <View style={styles.probablePitcherRow}>
             {probablePitcher.headshotUrl ? (
@@ -512,19 +516,22 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   const year = seasonYear ?? new Date(matchup.startDateUtc).getFullYear();
   const sportLeague = resolveSportLeague(leagueSport);
 
+  // Only fetch when the sport enum resolves — otherwise we'd issue a
+  // football/ncaa request for a slug that lives in a different sport
+  // (resolveSportLeague returns null for unmapped/unknown enums by design).
   const awayTeamCard = useTeamCard(
     matchup.awaySlug ?? null,
     year,
     sportLeague?.sport ?? 'football',
     sportLeague?.league ?? 'ncaa',
-    showAwaySchedule,
+    showAwaySchedule && !!sportLeague,
   );
   const homeTeamCard = useTeamCard(
     matchup.homeSlug ?? null,
     year,
     sportLeague?.sport ?? 'football',
     sportLeague?.league ?? 'ncaa',
-    showHomeSchedule,
+    showHomeSchedule && !!sportLeague,
   );
 
   const handleOpenStats = async () => {
@@ -659,6 +666,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
             isFinal={isFinal}
             isScheduleOpen={showAwaySchedule}
             onToggleSchedule={() => setShowAwaySchedule((v) => !v)}
+            canShowSchedule={!!sportLeague}
           />
         </TouchableOpacity>
         {showAwaySchedule && (
@@ -689,6 +697,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
             isFinal={isFinal}
             isScheduleOpen={showHomeSchedule}
             onToggleSchedule={() => setShowHomeSchedule((v) => !v)}
+            canShowSchedule={!!sportLeague}
           />
         </TouchableOpacity>
         {showHomeSchedule && (

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { View, TouchableOpacity, StyleSheet, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
@@ -8,9 +9,12 @@ import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
 import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
 import { useCurrentUser } from '@/src/hooks/useStandings';
+import { useTeamCard } from '@/src/hooks/useTeamCard';
+import { resolveSportLeague } from '@/src/utils/sportLinks';
 import { InsightModal } from './InsightModal';
 import { StatsComparisonModal } from './StatsComparisonModal';
 import { GameStatus } from './GameStatus';
+import { MiniSchedule } from './MiniSchedule';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -68,6 +72,8 @@ function TeamRow({
   isPicked,
   isPickCorrect,
   isFinal,
+  isScheduleOpen,
+  onToggleSchedule,
 }: {
   matchup: Matchup;
   side: 'home' | 'away';
@@ -75,6 +81,8 @@ function TeamRow({
   isPicked: boolean;
   isPickCorrect: boolean | null;
   isFinal: boolean;
+  isScheduleOpen: boolean;
+  onToggleSchedule: () => void;
 }) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -134,7 +142,20 @@ function TeamRow({
           {name}
         </Text>
         {record !== '' && (
-          <Text style={[styles.recordText, { color: theme.textMuted }]}>{record}</Text>
+          <View style={styles.recordRow}>
+            <Text style={[styles.recordText, { color: theme.textMuted }]}>{record}</Text>
+            <TouchableOpacity
+              onPress={onToggleSchedule}
+              hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+              accessibilityLabel={isScheduleOpen ? 'Hide recent games' : 'Show recent games'}
+            >
+              <Ionicons
+                name={isScheduleOpen ? 'chevron-up' : 'chevron-down'}
+                size={16}
+                color={theme.tint}
+              />
+            </TouchableOpacity>
+          </View>
         )}
         {probablePitcher?.displayName ? (
           <View style={styles.probablePitcherRow}>
@@ -481,7 +502,30 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
 
+  // ── Mini-schedule state ────────────────────────────────────────────────────
+  // Each team's schedule expands independently. Lazy-fetched via useTeamCard
+  // with an `enabled` gate so cards in the feed don't burn requests for
+  // schedules the user never opens.
+  const [showAwaySchedule, setShowAwaySchedule] = useState(false);
+  const [showHomeSchedule, setShowHomeSchedule] = useState(false);
+
   const year = seasonYear ?? new Date(matchup.startDateUtc).getFullYear();
+  const sportLeague = resolveSportLeague(leagueSport);
+
+  const awayTeamCard = useTeamCard(
+    matchup.awaySlug ?? null,
+    year,
+    sportLeague?.sport ?? 'football',
+    sportLeague?.league ?? 'ncaa',
+    showAwaySchedule,
+  );
+  const homeTeamCard = useTeamCard(
+    matchup.homeSlug ?? null,
+    year,
+    sportLeague?.sport ?? 'football',
+    sportLeague?.league ?? 'ncaa',
+    showHomeSchedule,
+  );
 
   const handleOpenStats = async () => {
     setShowStats(true);
@@ -597,37 +641,67 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         </View>
       )}
 
-      {/* Away team — taps go to the team page, not the contest overview. */}
-      <TouchableOpacity
-        onPress={onPressTeam ? () => onPressTeam('away') : undefined}
-        activeOpacity={onPressTeam ? 0.6 : 1}
-        disabled={!onPressTeam}
-      >
-        <TeamRow
-          matchup={enrichedMatchup}
-          side="away"
-          isWinning={!homeIsWinning}
-          isPicked={pickedAway}
-          isPickCorrect={isPickCorrect}
-          isFinal={isFinal}
-        />
-      </TouchableOpacity>
+      {/* Away team — taps go to the team page, not the contest overview.
+          MiniSchedule sits outside the touchable so taps within the schedule
+          don't navigate to the team page. */}
+      <View>
+        <TouchableOpacity
+          onPress={onPressTeam ? () => onPressTeam('away') : undefined}
+          activeOpacity={onPressTeam ? 0.6 : 1}
+          disabled={!onPressTeam}
+        >
+          <TeamRow
+            matchup={enrichedMatchup}
+            side="away"
+            isWinning={!homeIsWinning}
+            isPicked={pickedAway}
+            isPickCorrect={isPickCorrect}
+            isFinal={isFinal}
+            isScheduleOpen={showAwaySchedule}
+            onToggleSchedule={() => setShowAwaySchedule((v) => !v)}
+          />
+        </TouchableOpacity>
+        {showAwaySchedule && (
+          <MiniSchedule
+            schedule={awayTeamCard.data?.schedule}
+            seasonYear={year}
+            leagueSport={leagueSport}
+            loading={awayTeamCard.isLoading}
+            error={awayTeamCard.isError ? 'Failed to load schedule' : null}
+            teamName={matchup.away}
+          />
+        )}
+      </View>
 
       {/* Home team */}
-      <TouchableOpacity
-        onPress={onPressTeam ? () => onPressTeam('home') : undefined}
-        activeOpacity={onPressTeam ? 0.6 : 1}
-        disabled={!onPressTeam}
-      >
-        <TeamRow
-          matchup={enrichedMatchup}
-          side="home"
-          isWinning={homeIsWinning}
-          isPicked={pickedHome}
-          isPickCorrect={isPickCorrect}
-          isFinal={isFinal}
-        />
-      </TouchableOpacity>
+      <View>
+        <TouchableOpacity
+          onPress={onPressTeam ? () => onPressTeam('home') : undefined}
+          activeOpacity={onPressTeam ? 0.6 : 1}
+          disabled={!onPressTeam}
+        >
+          <TeamRow
+            matchup={enrichedMatchup}
+            side="home"
+            isWinning={homeIsWinning}
+            isPicked={pickedHome}
+            isPickCorrect={isPickCorrect}
+            isFinal={isFinal}
+            isScheduleOpen={showHomeSchedule}
+            onToggleSchedule={() => setShowHomeSchedule((v) => !v)}
+          />
+        </TouchableOpacity>
+        {showHomeSchedule && (
+          <MiniSchedule
+            schedule={homeTeamCard.data?.schedule}
+            seasonYear={year}
+            leagueSport={leagueSport}
+            loading={homeTeamCard.isLoading}
+            error={homeTeamCard.isError ? 'Failed to load schedule' : null}
+            teamName={matchup.home}
+          />
+        )}
+      </View>
 
       {/* Spread & O/U — tap goes to the contest overview. */}
       <TouchableOpacity
@@ -754,6 +828,11 @@ const styles = StyleSheet.create({
   },
   rankText: {
     fontWeight: '700',
+  },
+  recordRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
   },
   recordText: {
     fontSize: 13,

--- a/src/UI/sd-mobile/src/components/features/games/MiniSchedule.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MiniSchedule.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { resolveSportLeague } from '@/src/utils/sportLinks';
+import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
+import { formatToMonthDay } from '@/src/utils/timeUtils';
+import type { TeamCardScheduleGame } from '@/src/types/models';
+
+interface MiniScheduleProps {
+  schedule: TeamCardScheduleGame[] | null | undefined;
+  seasonYear: number;
+  leagueSport?: string | null;
+  loading?: boolean;
+  error?: string | null;
+  teamName: string;
+}
+
+function formatGameResult(game: TeamCardScheduleGame): string {
+  if (!game.finalizedUtc) return 'TBD';
+  const score = `${game.awayScore ?? 0}-${game.homeScore ?? 0}`;
+  const resultText = game.wasWinner ? 'W' : 'L';
+  return `${resultText} | ${score}`;
+}
+
+export function MiniSchedule({ schedule, seasonYear, leagueSport, loading, error, teamName }: MiniScheduleProps) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const userTz = useUserTimeZone();
+  const sportLeague = resolveSportLeague(leagueSport);
+
+  if (loading) {
+    return (
+      <View style={[styles.container, { borderTopColor: theme.separator }]}>
+        <ActivityIndicator size="small" color={theme.tint} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.container, { borderTopColor: theme.separator }]}>
+        <Text style={[styles.emptyText, { color: theme.error }]}>{error}</Text>
+      </View>
+    );
+  }
+
+  if (!Array.isArray(schedule) || schedule.length === 0) {
+    return (
+      <View style={[styles.container, { borderTopColor: theme.separator }]}>
+        <Text style={[styles.emptyText, { color: theme.textMuted }]}>No recent games</Text>
+      </View>
+    );
+  }
+
+  const limit = sportLeague?.sport === 'football' ? schedule.length : 10;
+  const games = [...schedule].reverse().slice(0, limit);
+
+  return (
+    <View style={[styles.container, { borderTopColor: theme.separator }]}>
+      {games.map((game, idx) => {
+        const opponentLabel = game.opponent ?? 'Opponent';
+        const resultColor = !game.finalizedUtc
+          ? theme.textMuted
+          : game.wasWinner
+          ? theme.success
+          : theme.error;
+        const isLast = idx === games.length - 1;
+
+        return (
+          <View
+            key={game.contestId ?? `${game.date}-${idx}`}
+            style={[
+              styles.row,
+              !isLast && { borderBottomColor: theme.separator, borderBottomWidth: StyleSheet.hairlineWidth },
+            ]}
+          >
+            <Text style={[styles.dateCell, { color: theme.textMuted }]} numberOfLines={1}>
+              {formatToMonthDay(game.date, userTz)}
+            </Text>
+
+            <View style={styles.opponentCell}>
+              {game.opponentSlug && sportLeague ? (
+                <TouchableOpacity
+                  onPress={() =>
+                    router.push(
+                      {
+                        pathname: '/sport/[sport]/[league]/team/[slug]',
+                        params: {
+                          sport: sportLeague.sport,
+                          league: sportLeague.league,
+                          slug: game.opponentSlug!,
+                          season: String(seasonYear),
+                          backTitle: teamName,
+                        },
+                      } as never,
+                    )
+                  }
+                  activeOpacity={0.6}
+                >
+                  <Text style={[styles.opponentText, { color: theme.tint }]} numberOfLines={1}>
+                    {opponentLabel}
+                  </Text>
+                </TouchableOpacity>
+              ) : (
+                <Text style={[styles.opponentText, { color: theme.text }]} numberOfLines={1}>
+                  {opponentLabel}
+                </Text>
+              )}
+              {game.location ? (
+                <Text style={[styles.locationText, { color: theme.textMuted }]} numberOfLines={1}>
+                  {game.location}
+                </Text>
+              ) : null}
+            </View>
+
+            {game.finalizedUtc && game.contestId && sportLeague ? (
+              <TouchableOpacity
+                onPress={() =>
+                  router.push(
+                    {
+                      pathname: '/sport/[sport]/[league]/game/[id]',
+                      params: {
+                        sport: sportLeague.sport,
+                        league: sportLeague.league,
+                        id: game.contestId!,
+                        backTitle: teamName,
+                      },
+                    } as never,
+                  )
+                }
+                activeOpacity={0.6}
+                style={styles.resultCell}
+              >
+                <Text style={[styles.resultText, { color: resultColor }]}>{formatGameResult(game)}</Text>
+              </TouchableOpacity>
+            ) : (
+              <View style={styles.resultCell}>
+                <Text style={[styles.resultText, { color: resultColor }]}>{formatGameResult(game)}</Text>
+              </View>
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 14,
+    paddingVertical: 4,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    gap: 10,
+  },
+  dateCell: {
+    width: 48,
+    fontSize: 12,
+  },
+  opponentCell: {
+    flex: 1,
+  },
+  opponentText: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  locationText: {
+    fontSize: 11,
+    marginTop: 1,
+  },
+  resultCell: {
+    minWidth: 70,
+    alignItems: 'flex-end',
+  },
+  resultText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  emptyText: {
+    fontSize: 13,
+    textAlign: 'center',
+    paddingVertical: 6,
+  },
+});

--- a/src/UI/sd-mobile/src/components/features/games/MiniSchedule.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MiniSchedule.tsx
@@ -21,7 +21,9 @@ interface MiniScheduleProps {
 function formatGameResult(game: TeamCardScheduleGame): string {
   if (!game.finalizedUtc) return 'TBD';
   const score = `${game.awayScore ?? 0}-${game.homeScore ?? 0}`;
-  const resultText = game.wasWinner ? 'W' : 'L';
+  // wasWinner is nullable — a finalized game with unknown outcome (canceled,
+  // tied, backend gap) shouldn't silently render as a loss.
+  const resultText = game.wasWinner === true ? 'W' : game.wasWinner === false ? 'L' : '—';
   return `${resultText} | ${score}`;
 }
 
@@ -65,9 +67,11 @@ export function MiniSchedule({ schedule, seasonYear, leagueSport, loading, error
         const opponentLabel = game.opponent ?? 'Opponent';
         const resultColor = !game.finalizedUtc
           ? theme.textMuted
-          : game.wasWinner
+          : game.wasWinner === true
           ? theme.success
-          : theme.error;
+          : game.wasWinner === false
+          ? theme.error
+          : theme.textMuted;
         const isLast = idx === games.length - 1;
 
         return (

--- a/src/UI/sd-mobile/src/hooks/useTeamCard.ts
+++ b/src/UI/sd-mobile/src/hooks/useTeamCard.ts
@@ -18,6 +18,7 @@ export function useTeamCard(
   seasonYear: number | null | undefined,
   sport: string = 'football',
   league: string = 'ncaa',
+  enabled: boolean = true,
 ) {
   return useQuery<TeamCardDto>({
     queryKey: teamCardKeys.bySlugAndSeason(sport, league, slug ?? '', seasonYear ?? 0),
@@ -27,7 +28,7 @@ export function useTeamCard(
         const wrapped = body as { data?: TeamCardDto };
         return wrapped.data ?? (body as TeamCardDto);
       }),
-    enabled: !!slug && !!seasonYear,
+    enabled: enabled && !!slug && !!seasonYear,
     staleTime: 1000 * 60 * 5, // 5 min — schedule data doesn't change rapidly
   });
 }

--- a/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
@@ -10,13 +10,17 @@ import "./MiniScheduleDrilldown.css";
 function formatGameResult(game) {
   if (!game.finalizedUtc) return "TBD";
   const score = `${game.awayScore}-${game.homeScore}`;
-  const resultText = game.wasWinner ? "W" : "L";
+  // wasWinner is nullable — a finalized game with unknown outcome (canceled,
+  // tied, backend gap) shouldn't silently render as a loss.
+  const resultText = game.wasWinner === true ? "W" : game.wasWinner === false ? "L" : "—";
   return `${resultText} | ${score}`;
 }
 
 function getResultClass(game) {
   if (!game.finalizedUtc) return "result-tbd";
-  return game.wasWinner ? "result-win" : "result-loss";
+  if (game.wasWinner === true) return "result-win";
+  if (game.wasWinner === false) return "result-loss";
+  return "result-tbd";
 }
 
 export default function MiniSchedule({ schedule = [], seasonYear, leagueSport }) {

--- a/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MiniSchedule.jsx
@@ -25,7 +25,8 @@ export default function MiniSchedule({ schedule = [], seasonYear, leagueSport })
   const sportLeague = resolveSportLeague(leagueSport);
   const userTz = useUserTimeZone();
   // TODO: create new endpoint that only returns completed games
-  const games = schedule.slice(0, 13);
+  const limit = sportLeague?.sport === 'football' ? schedule.length : 10;
+  const games = [...schedule].reverse().slice(0, limit);
   // Drilldown state: which row is open, and its data
   const [drillIndex, setDrillIndex] = useState(null);
   const [drillSchedule, setDrillSchedule] = useState([]);
@@ -53,7 +54,7 @@ export default function MiniSchedule({ schedule = [], seasonYear, leagueSport })
       // Use current seasonYear for opponent
       const res = await import("../../api/apiWrapper").then(m =>
         m.default.TeamCard.getBySlugAndSeason(sportLeague.sport, sportLeague.league, opponentSlug, seasonYear));
-      setDrillSchedule(Array.isArray(res.data?.schedule) ? res.data.schedule.slice(0, 13) : []);
+      setDrillSchedule(Array.isArray(res.data?.schedule) ? res.data.schedule : []);
     } catch (e) {
       setDrillError("Failed to load schedule");
     } finally {


### PR DESCRIPTION
## Summary

The MatchupCard mini-schedule is core to the picking flow — users need to review a team's recent form without leaving the card. This PR ships two coordinated improvements:

- **Web (`MiniSchedule.jsx`)** — reverse sort so the most recent game is on top, and replace the hard-coded 13-row cap with a sport-aware rule: football shows the full schedule (NCAA: 12 reg-season, NFL: 17), other sports cap at 10 most recent.
- **Mobile (`MatchupCard.tsx` + new `MiniSchedule.tsx`)** — build the embedded mini-schedule that previously only existed on web. Chevron toggle next to each team's record expands a panel below the row, same sort/limit rule as web. Lazy-fetched via `useTeamCard` with an added `enabled` gate so feed cards don't burn requests for schedules the user never opens.

## Behavior

| | Football (NCAA/NFL) | Baseball/other sports |
|---|---|---|
| Sort | Newest first | Newest first |
| Limit | Full schedule | 10 most recent |
| Drilldown (web only) | Same rule applied to opponent's schedule via recursive component |

Mobile v1 intentionally omits the nested opponent-drilldown that web has — keeps the affordance light. Easy to add later if it earns its keep.

## Implementation notes

- `useTeamCard` gained an optional `enabled: boolean = true` parameter to support lazy fetching from feed cards without breaking the team-detail page which always fetches. React Query's 5-min staleTime means re-opens are instant.
- MiniSchedule renders **outside** the team-tap touchable in MatchupCard so taps within the schedule (opponent name, result row) navigate correctly without bubbling up to the team-page tap target.
- Opponent name → existing team detail nav. Result row → existing contest nav. Both mirror the team detail page's `ScheduleRow` patterns.
- Ionicons chevron (`chevron-down` / `chevron-up`) instead of mirroring web's `FaSearchPlus`/`Minus`. Reads cleaner on mobile — chevron signals "expand below" rather than "search."

## Test plan

- [x] `npx tsc --noEmit` clean on sd-mobile
- [x] Existing `MatchupCard.live.test.tsx` (6 tests) still pass
- [x] Web visual check — sort + limit verified locally for NCAA football and MLB
- [x] Mobile visual check — chevron expand/collapse confirmed clean on real device
- [ ] CodeRabbit review
- [ ] Verify lazy fetch — opening DevTools / network shouldn't see `teamcard` calls on feed scroll, only when chevron is tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matchup cards now support per-team expandable mini-schedules with independent open/close controls and aligned record+chevron layout.
  * Added a compact "Mini Schedule" view showing recent games, navigation to team and game details, and clear loading/error/empty states.
  * Team schedule loading is lazy — data is fetched only when a team's mini-schedule is opened.

* **Bug Fixes**
  * Game results now correctly show unknown outcomes as TBD instead of incorrect win/loss labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->