### PR TITLE
fix(web,mobile): picks page XHR oscillation + mobile header parity

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -4,7 +4,9 @@ import {
   FlatList,
   StyleSheet,
   RefreshControl,
+  Pressable,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Text } from '@/src/components/ui/AppText';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
@@ -37,6 +39,7 @@ export default function PicksScreen() {
 
   const [leagueId, setLeagueId] = useState<string | null>(null);
   const [selectedWeek, setSelectedWeek] = useState<number | null>(null);
+  const [hidePicked, setHidePicked] = useState(false);
 
   // Latest week = last element of the ascending seasonWeeks list.
   const latestWeek = (l: { seasonWeeks?: number[] } | null | undefined) =>
@@ -111,7 +114,12 @@ export default function PicksScreen() {
 
   const total = entries.length;
   const made = myPicks.length;
-  const remaining = total - made;
+  const allPicked = total > 0 && made >= total;
+
+  const visibleEntries = useMemo(
+    () => (hidePicked ? entries.filter((e) => !e.pick) : entries),
+    [entries, hidePicked],
+  );
 
   // ── Inject pick counter into this tab's header ──────────────────────────────
   useEffect(() => {
@@ -122,18 +130,41 @@ export default function PicksScreen() {
     navigation.setOptions({
       headerRight: () => (
         <View style={headerStyles.pill}>
-          <Text style={[headerStyles.pillText, { color: theme.tint }]}>
-            {made}/{total}
-          </Text>
-          {remaining > 0 && (
-            <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
-              {' '}· {remaining} left
+          {allPicked ? (
+            <Text style={[headerStyles.pillText, { color: theme.tint }]}>
+              All Picks Made
             </Text>
+          ) : (
+            <>
+              <Text style={[headerStyles.pillText, { color: theme.tint }]}>
+                {made}/{total}
+              </Text>
+              <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
+                {' '}Picks Made
+              </Text>
+              <Pressable
+                onPress={() => setHidePicked((v) => !v)}
+                hitSlop={6}
+                style={headerStyles.hideToggle}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: hidePicked }}
+                accessibilityLabel="Hide picked games"
+              >
+                <Ionicons
+                  name={hidePicked ? 'checkbox' : 'square-outline'}
+                  size={18}
+                  color={hidePicked ? theme.tint : theme.textMuted}
+                />
+                <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
+                  {' '}Hide Picked
+                </Text>
+              </Pressable>
+            </>
           )}
         </View>
       ),
     });
-  }, [made, total, remaining, theme]);
+  }, [made, total, allPicked, hidePicked, theme]);
 
   if (meLoading) {
     return <LoadingSpinner message="Loading picks…" fullScreen />;
@@ -166,7 +197,7 @@ export default function PicksScreen() {
         <LoadingSpinner message="Loading picks…" />
       ) : (
         <FlatList
-          data={entries}
+          data={visibleEntries}
           keyExtractor={(item) => item.matchup.contestId}
           renderItem={({ item }) => (
             <MatchupCard
@@ -274,7 +305,7 @@ const styles = StyleSheet.create({
 const headerStyles = StyleSheet.create({
   pill: {
     flexDirection: 'row',
-    alignItems: 'baseline',
+    alignItems: 'center',
     marginRight: 12,
   },
   pillText: {
@@ -284,5 +315,10 @@ const headerStyles = StyleSheet.create({
   pillSub: {
     fontSize: 13,
     fontWeight: '500',
+  },
+  hideToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginLeft: 10,
   },
 });

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -113,7 +113,14 @@ export default function PicksScreen() {
   );
 
   const total = entries.length;
-  const made = myPicks.length;
+  // Count picks that correspond to currently-displayed matchups rather
+  // than myPicks.length directly — picks and matchups load on separate
+  // query cycles, so during a league/week transition (or if myPicks
+  // carries a stale pick for a contest no longer in the matchups list)
+  // raw myPicks.length can briefly exceed entries with picks. Derive
+  // from entries so total / made / allPicked stay aligned with what's
+  // on screen.
+  const made = entries.filter((e) => e.pick !== null).length;
   const allPicked = total > 0 && made >= total;
 
   const visibleEntries = useMemo(

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -207,6 +207,12 @@ function PicksPage() {
   }, [routeLeagueId]);
 
   useEffect(() => {
+    // `cancelled` flips in the cleanup so a late response from the
+    // previous (routeLeagueId, selectedWeek) pair can't stomp newer
+    // state. Without this, a fast A→B switch where A's XHR resolves
+    // after B's clearing effect (or after B's own fetch) would briefly
+    // render A's matchups under B's identity.
+    let cancelled = false;
     async function fetchMatchups() {
       if (!routeLeagueId || selectedWeek === null) return;
       // Skip the request when the current week isn't in the selected
@@ -221,6 +227,7 @@ function PicksPage() {
           routeLeagueId,
           selectedWeek
         );
+        if (cancelled) return;
         setMatchups(response.data.matchups || []);
         setPickType(response.data.pickType);
         setUseConfidencePoints(response.data.useConfidencePoints);
@@ -228,16 +235,22 @@ function PicksPage() {
         setLeagueSeasonYear(response.data.seasonYear);
         setLeagueAsOfDate(response.data.asOfDate ?? null);
       } catch (error) {
+        if (cancelled) return;
         console.error("Failed to fetch matchups:", error);
       } finally {
-        setLoadingMatchups(false);
+        if (!cancelled) setLoadingMatchups(false);
       }
     }
 
     fetchMatchups();
+    return () => {
+      cancelled = true;
+    };
   }, [routeLeagueId, selectedWeek, seasonWeeks]);
 
   useEffect(() => {
+    // Same race guard as fetchMatchups — see comment above.
+    let cancelled = false;
     async function fetchPicks() {
       if (!routeLeagueId || selectedWeek === null) return;
       if (!seasonWeeks.includes(selectedWeek)) return;
@@ -247,6 +260,7 @@ function PicksPage() {
           routeLeagueId,
           selectedWeek
         );
+        if (cancelled) return;
 
         const picksByContest = {};
         for (const pick of response.data) {
@@ -255,11 +269,15 @@ function PicksPage() {
 
         setUserPicks(picksByContest);
       } catch (error) {
+        if (cancelled) return;
         console.error("Failed to fetch user picks:", error);
       }
     }
 
     fetchPicks();
+    return () => {
+      cancelled = true;
+    };
   }, [routeLeagueId, selectedWeek, seasonWeeks]);
 
   async function handlePick(matchup, selectedFranchiseSeasonId, confidencePoints) {

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -1,6 +1,6 @@
 import "./PicksPage.css";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useUserDto } from "../../contexts/UserContext";
 import { useLeagueContext } from "../../contexts/LeagueContext";
@@ -40,7 +40,11 @@ function PicksPage() {
   const [leagueAsOfDate, setLeagueAsOfDate] = useState(null);
   const [loadingMatchups, setLoadingMatchups] = useState(true);
 
-  const [selectedLeagueId, setSelectedLeagueId] = useState(null);
+  // Source of truth for the selected league is the route param
+  // (/app/picks/:leagueId?). The dropdown navigates instead of holding
+  // local state — this kills the prior fight between `selectedLeagueId`
+  // state, the URL sync effect, and the week-snap effect that was
+  // emitting 5 matchups XHRs per league switch.
   const [selectedWeek, setSelectedWeek] = useState(null);
   const viewMode = "card";
 
@@ -54,7 +58,32 @@ function PicksPage() {
     return () => clearInterval(interval);
   }, []);
 
-  const leagues = Object.values(userDto?.leagues || {});
+  // Memoized so the init effect's dep check doesn't fire on every render
+  // (a fresh `Object.values` ref every render previously triggered re-init
+  // and stomped the user's dropdown selection).
+  const leagues = useMemo(
+    () => Object.values(userDto?.leagues || {}),
+    [userDto]
+  );
+
+  // Derive the selected league from the route param. With `leagues`
+  // memoized, `selectedLeague` is a stable reference across renders
+  // (same routeLeagueId → same league object) so downstream effect deps
+  // don't churn.
+  const selectedLeague = useMemo(
+    () => leagues.find((l) => l.id === routeLeagueId) ?? null,
+    [leagues, routeLeagueId]
+  );
+  // Memoized so the `?? []` fallback doesn't hand a fresh array to the
+  // fetch effects' dep arrays on every render.
+  const seasonWeeks = useMemo(
+    () => selectedLeague?.seasonWeeks ?? [],
+    [selectedLeague]
+  );
+  // Default to the latest week the league has (last element of the
+  // ascending list). Custom-window leagues may only have a single entry.
+  const latestSeasonWeek =
+    seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
 
   // Get contest updates for live game data
   const { getContestUpdate, _instanceId: contestCtxInstanceId } = useContestUpdates();
@@ -127,56 +156,55 @@ function PicksPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [matchups, getContestUpdate]);
 
-  // Select default league on load or when leagues change
+  // One-shot init: ensure the URL carries a valid league. When the user
+  // lands on /app/picks with no param (or a stale id) redirect to the
+  // remembered league (LeagueContext, localStorage-backed) or the first
+  // available. Once the URL has a valid league id, subsequent league
+  // switches happen through `handleLeagueChange` (selector → navigate).
   useEffect(() => {
-    if (!userLoading && leagues.length > 0) {
-      // Initialize global context
-      initializeLeagueSelection(leagues);
+    if (userLoading || leagues.length === 0) return;
 
-      const isRouteValid =
-        routeLeagueId && leagues.some((l) => l.id === routeLeagueId);
-      if (isRouteValid) {
-        setSelectedLeagueId(routeLeagueId);
-        setGlobalLeagueId(routeLeagueId); // Sync with global context
-      } else if (!selectedLeagueId) {
-        // Use global context if available, otherwise default to first league
-        const leagueToUse =
-          globalLeagueId && leagues.some((l) => l.id === globalLeagueId)
-            ? globalLeagueId
-            : leagues[0].id;
-        setSelectedLeagueId(leagueToUse);
-        setGlobalLeagueId(leagueToUse);
-      }
+    initializeLeagueSelection(leagues);
+
+    const isRouteValid =
+      routeLeagueId && leagues.some((l) => l.id === routeLeagueId);
+    if (isRouteValid) {
+      // Keep cross-page memory current with the URL-driven selection so
+      // Leaderboard/Messageboard remember the user's league after a tab
+      // switch.
+      setGlobalLeagueId(routeLeagueId);
+      return;
     }
+
+    const fallback =
+      globalLeagueId && leagues.some((l) => l.id === globalLeagueId)
+        ? globalLeagueId
+        : leagues[0].id;
+    setGlobalLeagueId(fallback);
+    navigate(`/app/picks/${fallback}`, { replace: true });
   }, [
     userLoading,
     leagues,
     routeLeagueId,
-    selectedLeagueId,
     globalLeagueId,
     setGlobalLeagueId,
     initializeLeagueSelection,
+    navigate,
   ]);
-
-  // Keep URL in sync with selectedLeagueId and update global context
-  useEffect(
-    () => {
-      if (selectedLeagueId && selectedLeagueId !== routeLeagueId) {
-        navigate(`/app/picks/${selectedLeagueId}`, { replace: true });
-        setGlobalLeagueId(selectedLeagueId); // Update global context
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedLeagueId] // Intentionally omitting routeLeagueId and navigate
-  );
 
   useEffect(() => {
     async function fetchMatchups() {
-      if (!selectedLeagueId || selectedWeek === null) return;
+      if (!routeLeagueId || selectedWeek === null) return;
+      // Skip the request when the current week isn't in the selected
+      // league's week list — happens for one render right after a
+      // league switch, before the week-snap effect below updates
+      // selectedWeek to the new league's latest. Without this gate we
+      // emit a (newLeagueId, oldWeek) XHR that the user never sees.
+      if (!seasonWeeks.includes(selectedWeek)) return;
       setLoadingMatchups(true);
       try {
         const response = await apiWrapper.Matchups.getByLeagueAndWeek(
-          selectedLeagueId,
+          routeLeagueId,
           selectedWeek
         );
         setMatchups(response.data.matchups || []);
@@ -193,15 +221,16 @@ function PicksPage() {
     }
 
     fetchMatchups();
-  }, [selectedLeagueId, selectedWeek]);
+  }, [routeLeagueId, selectedWeek, seasonWeeks]);
 
   useEffect(() => {
     async function fetchPicks() {
-      if (!selectedLeagueId || selectedWeek === null) return;
+      if (!routeLeagueId || selectedWeek === null) return;
+      if (!seasonWeeks.includes(selectedWeek)) return;
 
       try {
         const response = await apiWrapper.Picks.getUserPicksByWeek(
-          selectedLeagueId,
+          routeLeagueId,
           selectedWeek
         );
 
@@ -217,12 +246,12 @@ function PicksPage() {
     }
 
     fetchPicks();
-  }, [selectedLeagueId, selectedWeek]);
+  }, [routeLeagueId, selectedWeek, seasonWeeks]);
 
   async function handlePick(matchup, selectedFranchiseSeasonId, confidencePoints) {
     try {
       const pickPayload = {
-        pickemGroupId: selectedLeagueId,
+        pickemGroupId: routeLeagueId,
         contestId: matchup.contestId,
         pickType: pickType || "StraightUp",
         franchiseSeasonId: selectedFranchiseSeasonId,
@@ -355,29 +384,36 @@ function PicksPage() {
     }
   }
 
-  // Find the selected league's week list (ascending from /user/me)
-  const selectedLeague = leagues.find((l) => l.id === selectedLeagueId) ?? null;
-  const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
-  // Default to the latest week the league has (last element of the ascending list).
-  // Custom-window leagues may only have a single entry; full-season leagues have many.
-  const latestSeasonWeek = seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
+  // Switch league → ensure the URL changes (route is the source of
+  // truth) and persist the choice for cross-page memory. The week-snap
+  // effect below adjusts selectedWeek on the next render; the matchups
+  // fetch is gated on the new league's seasonWeeks so the brief
+  // (newLeagueId, oldWeek) window doesn't emit an XHR.
+  const handleLeagueChange = useCallback(
+    (newLeagueId) => {
+      if (!newLeagueId || newLeagueId === routeLeagueId) return;
+      setGlobalLeagueId(newLeagueId);
+      navigate(`/app/picks/${newLeagueId}`, { replace: true });
+    },
+    [routeLeagueId, navigate, setGlobalLeagueId]
+  );
 
-  // When selectedLeagueId or week list changes, snap selectedWeek to the latest
-  // week in the league. If the league has no weeks defined (latestSeasonWeek
-  // falsy), explicitly clear selectedWeek — otherwise a stale value from the
-  // previously-selected league would carry over and the matchups fetch would
-  // issue an invalid (leagueId, week) pair.
+  // Snap selectedWeek when the URL-driven league changes, or when the
+  // current week falls outside the new league's week list. Respects a
+  // user's manual mid-week selection (deps don't change on week
+  // selection alone, and we only re-snap when the current week is no
+  // longer valid for this league).
   useEffect(() => {
-    if (!selectedLeagueId) return;
+    if (!routeLeagueId) return;
     if (!latestSeasonWeek) {
       if (selectedWeek !== null) setSelectedWeek(null);
       return;
     }
-    if (selectedWeek !== latestSeasonWeek) {
+    if (selectedWeek === null || !seasonWeeks.includes(selectedWeek)) {
       setSelectedWeek(latestSeasonWeek);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedLeagueId, latestSeasonWeek, selectedLeague]);
+  }, [routeLeagueId, latestSeasonWeek, selectedLeague]);
 
   if (userLoading) return <div>Loading user info...</div>;
 
@@ -411,8 +447,8 @@ function PicksPage() {
         <div className="picks-page-header">
           <LeagueWeekSelector
             leagues={leagues}
-            selectedLeagueId={selectedLeagueId}
-            setSelectedLeagueId={setSelectedLeagueId}
+            selectedLeagueId={routeLeagueId}
+            setSelectedLeagueId={handleLeagueChange}
             selectedWeek={selectedWeek}
             setSelectedWeek={setSelectedWeek}
             seasonWeeks={seasonWeeks}

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -192,6 +192,20 @@ function PicksPage() {
     navigate,
   ]);
 
+  // Clear league-scoped state immediately on league change so the UI
+  // doesn't render the previous league's matchups during the brief
+  // window between navigate() and the new matchups fetch resolving.
+  // Also prevents handlePick from racing a click against stale
+  // (newLeagueId, oldContestId) ids — MatchupList reads from `matchups`,
+  // which would otherwise hold the prior league's contests for one or
+  // two renders (and for inbound-link switches the route changes
+  // without remounting PicksPage, so the state survives the transition).
+  useEffect(() => {
+    setMatchups([]);
+    setUserPicks({});
+    setLoadingMatchups(true);
+  }, [routeLeagueId]);
+
   useEffect(() => {
     async function fetchMatchups() {
       if (!routeLeagueId || selectedWeek === null) return;


### PR DESCRIPTION
## Summary

- **Web (PicksPage)**: refactor to make the route param (`/app/picks/:leagueId?`) the single source of truth for the selected league. Eliminates a 3-effect feedback loop that emitted **5 matchups XHRs** (and 5 picks XHRs) on every league switch before settling on the correct render. After: exactly one matchups + one picks XHR per switch.
- **Mobile (picks tab)**: header pill now reads `X/Y Picks Made` / `All Picks Made` to match the web wording (was `X/Y · Z left`), and adds a checkbox-style **Hide Picked** toggle next to the counter that filters picked matchups out of the FlatList — mirrors the existing web behavior.

## Root cause (web)

`PicksPage` held an internal `selectedLeagueId` state in addition to the route param. Three effects fought:

1. An init effect that called `setSelectedLeagueId(routeLeagueId)` whenever its deps changed. Because `leagues = Object.values(userDto?.leagues || {})` produced a new array ref every render, the effect re-ran constantly and stomped the dropdown's selection.
2. A URL-sync effect that called `navigate(...)` whenever `selectedLeagueId !== routeLeagueId`.
3. A week-snap effect that updated `selectedWeek` *after* `selectedLeagueId` changed, causing a second render and a second fetch.

The combined oscillation produced 5 XHRs per league switch (mix of old+new league, old+new week) before converging.

## Fix shape

- Removed internal `selectedLeagueId` state; the dropdown's `onChange` is now `handleLeagueChange` which calls `navigate(/app/picks/<id>)` and updates the cross-page `LeagueContext`.
- Init effect is now a one-shot redirector: only fires when the URL has no league or a stale one.
- Memoized `leagues`, `selectedLeague`, and `seasonWeeks` so downstream effect deps don't churn.
- Matchups + picks fetches are gated on `seasonWeeks.includes(selectedWeek)` so the one render between a league switch and the week-snap effect doesn't emit a stale `(newLeagueId, oldWeek)` XHR.

## Test plan

- [ ] Web: load `/app/picks/<leagueA>`, open devtools network tab, switch dropdown to League B. Confirm exactly one new `leagues/B/matchups/<week>` call and one corresponding picks call.
- [ ] Web: load `/app/picks` (no id) and confirm redirect to the remembered league (or first available).
- [ ] Web: pick a non-latest week in League A, switch to League B, confirm week snaps to B's latest (intended behavior on league change).
- [ ] Web: cross-page navigation (Picks → Leaderboard → Picks) still lands on the same league (LeagueContext / localStorage).
- [ ] Mobile: with mixed pick state, toggle **Hide Picked**, confirm picked matchups hide from the list.
- [ ] Mobile: pick all matchups and confirm header collapses to `All Picks Made` and the toggle disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to hide already-picked games on mobile for cleaner browsing
  * Counter now shows “All Picks Made” when complete; otherwise shows made/total with a hide-picked toggle

* **Improvements**
  * League and week selection now syncs with the URL, preserving selection across navigation
  * More stable behavior when switching leagues/weeks and fewer transient or invalid match requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->