### PR TITLE
refactor(api): extract PickemGroupWeekFactory (PR-A league-creation hardening)

### DIFF
--- a/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
+++ b/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
@@ -1,8 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 
+using SportsData.Api.Application.PickemGroups;
 using SportsData.Api.Application.Processors;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Jobs;
 using SportsData.Core.Infrastructure.Clients.Season;
@@ -95,26 +95,7 @@ namespace SportsData.Api.Application.Jobs
 
                 if (groupWeek is null)
                 {
-                    var currentWeekOrdinal = currentWeek.WeekNumber;
-
-                    // if current week is postseason, we need to change the ordinal week number to reflect that
-                    if (currentWeek.IsPostSeason)
-                    {
-                        // we need to get the number of regular season weeks for this season year
-                        currentWeekOrdinal = group.Weeks.OrderByDescending(x => x.SeasonWeek)
-                            .Take(1).FirstOrDefault()?.SeasonWeek + 1 ?? currentWeek.WeekNumber;
-                    }
-
-                    groupWeek = new PickemGroupWeek()
-                    {
-                        Id = Guid.NewGuid(),
-                        AreMatchupsGenerated = false,
-                        GroupId = group.Id,
-                        SeasonWeek = currentWeekOrdinal,
-                        SeasonYear = currentWeek.SeasonYear,
-                        SeasonWeekId = currentWeek.Id,
-                        IsNonStandardWeek = currentWeek.IsNonStandardWeek
-                    };
+                    groupWeek = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
                     group.Weeks.Add(groupWeek);
                     await _dataContext.SaveChangesAsync();
                 }

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
@@ -4,8 +4,6 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Processors;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Api.Infrastructure.Data.Entities;
-using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Season;
 using SportsData.Core.Processing;
@@ -73,15 +71,7 @@ namespace SportsData.Api.Application.PickemGroups
 
             if (groupWeek is null)
             {
-                groupWeek = new PickemGroupWeek()
-                {
-                    Id = Guid.NewGuid(),
-                    AreMatchupsGenerated = false,
-                    GroupId = group.Id,
-                    SeasonWeek = currentWeek.WeekNumber,
-                    SeasonYear = currentWeek.SeasonYear,
-                    SeasonWeekId = currentWeek.Id
-                };
+                groupWeek = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
                 group.Weeks.Add(groupWeek);
                 await _dataContext.SaveChangesAsync();
             }

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekFactory.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekFactory.cs
@@ -1,0 +1,64 @@
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Dtos.Canonical;
+
+namespace SportsData.Api.Application.PickemGroups;
+
+/// <summary>
+/// Single source of truth for building a <see cref="PickemGroupWeek"/> row.
+/// Two call sites previously constructed this entity inline and had drifted —
+/// <c>PickemGroupCreatedHandler</c> omitted <see cref="PickemGroupWeek.IsNonStandardWeek"/>
+/// and didn't adjust the <see cref="PickemGroupWeek.SeasonWeek"/> ordinal for
+/// postseason; <c>MatchupScheduler</c> did both. Centralizing here so the two
+/// paths can't drift again.
+/// </summary>
+public static class PickemGroupWeekFactory
+{
+    /// <summary>
+    /// Build a <see cref="PickemGroupWeek"/> for the league's current week.
+    /// </summary>
+    /// <param name="group">
+    /// The league. <see cref="PickemGroup.Weeks"/> must be loaded — the
+    /// postseason ordinal adjustment reads existing weeks to compute the
+    /// next sequential <see cref="PickemGroupWeek.SeasonWeek"/> value.
+    /// </param>
+    /// <param name="currentWeek">Sport-resolved current season week.</param>
+    public static PickemGroupWeek CreateForCurrentWeek(
+        PickemGroup group,
+        CanonicalSeasonWeekDto currentWeek)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(currentWeek);
+
+        return new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            AreMatchupsGenerated = false,
+            GroupId = group.Id,
+            SeasonWeek = ResolveOrdinal(group, currentWeek),
+            SeasonYear = currentWeek.SeasonYear,
+            SeasonWeekId = currentWeek.Id,
+            IsNonStandardWeek = currentWeek.IsNonStandardWeek,
+        };
+    }
+
+    /// <summary>
+    /// Postseason weeks restart at WeekNumber=1 on the ESPN side, which would
+    /// collide with the league's existing regular-season Week 1 row. Sequence
+    /// the postseason ordinal off the league's highest existing week instead
+    /// so the list stays monotonically increasing (used by ascending
+    /// <c>seasonWeeks</c> projections on /user/me and the week selector).
+    /// Falls back to <c>currentWeek.WeekNumber</c> for a league with no prior
+    /// weeks (first run of the recurring scheduler hits this).
+    /// </summary>
+    private static int ResolveOrdinal(PickemGroup group, CanonicalSeasonWeekDto currentWeek)
+    {
+        if (!currentWeek.IsPostSeason)
+            return currentWeek.WeekNumber;
+
+        var highestExisting = group.Weeks
+            .OrderByDescending(x => x.SeasonWeek)
+            .FirstOrDefault();
+
+        return (highestExisting?.SeasonWeek + 1) ?? currentWeek.WeekNumber;
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupWeekFactoryTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupWeekFactoryTests.cs
@@ -1,0 +1,167 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.PickemGroups;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.PickemGroups;
+
+/// <summary>
+/// Pins <see cref="PickemGroupWeekFactory"/> behavior — the central reason
+/// for extracting it was two call sites (PickemGroupCreatedHandler +
+/// MatchupScheduler) drifting on IsNonStandardWeek and the postseason
+/// ordinal sequence. These tests are the regression net.
+/// </summary>
+public class PickemGroupWeekFactoryTests
+{
+    [Fact]
+    public void CreateForCurrentWeek_RegularSeason_UsesWeekNumberAsOrdinal()
+    {
+        var group = NewGroup();
+        var currentWeek = NewWeek(weekNumber: 7, isPostSeason: false);
+
+        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+
+        result.SeasonWeek.Should().Be(7);
+        result.SeasonYear.Should().Be(currentWeek.SeasonYear);
+        result.SeasonWeekId.Should().Be(currentWeek.Id);
+        result.GroupId.Should().Be(group.Id);
+        result.IsNonStandardWeek.Should().BeFalse();
+        result.AreMatchupsGenerated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CreateForCurrentWeek_RegularSeason_PropagatesIsNonStandardWeek()
+    {
+        var group = NewGroup();
+        var currentWeek = NewWeek(weekNumber: 8, isPostSeason: false, isNonStandardWeek: true);
+
+        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+
+        // Bug being prevented: PickemGroupCreatedHandler used to omit this
+        // field, so a non-standard regular-season week (rare but possible)
+        // landed in DB with IsNonStandardWeek=false.
+        result.IsNonStandardWeek.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateForCurrentWeek_Postseason_WithNoExistingWeeks_FallsBackToWeekNumber()
+    {
+        // Scheduler's first run for a sport that started in postseason
+        // (degenerate but possible — fresh data, recurring job firing for
+        // the first time). No prior weeks to sequence off; use the raw
+        // WeekNumber as the ordinal.
+        var group = NewGroup();
+        var currentWeek = NewWeek(weekNumber: 1, isPostSeason: true);
+
+        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+
+        result.SeasonWeek.Should().Be(1);
+    }
+
+    [Fact]
+    public void CreateForCurrentWeek_Postseason_WithExistingWeeks_SequencesOffHighest()
+    {
+        // Common case: league played a full regular season (ordinals 1..18
+        // for an NFL league say), now in postseason. ESPN restarts
+        // WeekNumber at 1 for the postseason; ordinal must continue the
+        // monotonic sequence so the league's seasonWeeks list doesn't
+        // collide on Week 1.
+        var group = NewGroup(existingWeekOrdinals: [1, 2, 3, 17, 18]);
+        var currentWeek = NewWeek(weekNumber: 1, isPostSeason: true);
+
+        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+
+        result.SeasonWeek.Should().Be(19);
+    }
+
+    [Fact]
+    public void CreateForCurrentWeek_Postseason_IgnoresWeekOrderingInGroupWeeks()
+    {
+        // Defensive: the factory must not assume group.Weeks is sorted.
+        var group = NewGroup(existingWeekOrdinals: [18, 1, 17, 3, 2]);
+        var currentWeek = NewWeek(weekNumber: 2, isPostSeason: true);
+
+        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+
+        result.SeasonWeek.Should().Be(19);
+    }
+
+    [Fact]
+    public void CreateForCurrentWeek_AssignsNewIdEachCall()
+    {
+        var group = NewGroup();
+        var currentWeek = NewWeek(weekNumber: 1, isPostSeason: false);
+
+        var first = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+        var second = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+
+        first.Id.Should().NotBe(Guid.Empty);
+        second.Id.Should().NotBe(Guid.Empty);
+        first.Id.Should().NotBe(second.Id);
+    }
+
+    [Fact]
+    public void CreateForCurrentWeek_NullGroup_Throws()
+    {
+        var currentWeek = NewWeek(weekNumber: 1, isPostSeason: false);
+
+        var act = () => PickemGroupWeekFactory.CreateForCurrentWeek(null!, currentWeek);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("group");
+    }
+
+    [Fact]
+    public void CreateForCurrentWeek_NullCurrentWeek_Throws()
+    {
+        var group = NewGroup();
+
+        var act = () => PickemGroupWeekFactory.CreateForCurrentWeek(group, null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("currentWeek");
+    }
+
+    private static PickemGroup NewGroup(int[]? existingWeekOrdinals = null)
+    {
+        var group = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Sport = Sport.BaseballMlb,
+            League = League.MLB,
+        };
+
+        if (existingWeekOrdinals is not null)
+        {
+            foreach (var ordinal in existingWeekOrdinals)
+            {
+                group.Weeks.Add(new PickemGroupWeek
+                {
+                    GroupId = group.Id,
+                    SeasonWeek = ordinal,
+                    SeasonYear = 2026,
+                    SeasonWeekId = Guid.NewGuid(),
+                });
+            }
+        }
+
+        return group;
+    }
+
+    private static CanonicalSeasonWeekDto NewWeek(
+        int weekNumber,
+        bool isPostSeason,
+        bool isNonStandardWeek = false) => new()
+    {
+        Id = Guid.NewGuid(),
+        SeasonId = Guid.NewGuid(),
+        SeasonYear = 2026,
+        WeekNumber = weekNumber,
+        SeasonPhase = isPostSeason ? "postseason" : "regularseason",
+        IsNonStandardWeek = isNonStandardWeek,
+    };
+}


### PR DESCRIPTION
## Summary

**PR-A** of the league-creation hardening plan documented at `docs/league-creation-hardening.md`. Pure refactor — extracts the inline `PickemGroupWeek` construction from `PickemGroupCreatedHandler` and `MatchupScheduler` into a single `PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek)` so the two call sites can't drift again.

## Why this is necessary

`PickemGroupCreatedHandler:75-83` (pre-PR) and `MatchupScheduler:108-117` (pre-PR) both built a `PickemGroupWeek` row for the league's current week, and the implementations had drifted:

- **`IsNonStandardWeek` propagation**: `PickemGroupCreatedHandler` omitted the field — non-standard / postseason weeks created via the eager-bootstrap path landed in DB with `IsNonStandardWeek = false`. `MatchupScheduler` set it correctly.
- **Postseason ordinal sequence**: ESPN restarts `WeekNumber` at 1 for postseason. Without adjustment the league's `PickemGroupWeek` rows would collide on Week 1 (regular-season Week 1 already exists). `MatchupScheduler` sequenced the new ordinal off the highest existing week (`MAX(SeasonWeek) + 1`); `PickemGroupCreatedHandler` did not.

After this PR both call sites use the factory; the behavior in `PickemGroupCreatedHandler` is a correctness uplift, not a regression. `MatchupScheduler`'s behavior is unchanged.

## Where this fits

Unblocks PR-B (server validator + handler dispatch) and PR-D (scheduler window gate + handler base extraction), which both build on the factory.

The motivating bug (single-day MLB leagues creating orphan empty `PickemGroupWeek` rows visible in `/user/me`) is fixed by PR-B + PR-D, not this PR. PR-A is the foundation step.

## Test plan

- [x] 8 new unit tests pin factory output: regular-season ordinal, postseason fallback (no existing weeks), postseason sequence-off-highest, unsorted `group.Weeks` collection, new Id per call, null-arg guards.
- [x] Full API unit suite: 347/347 passing.
- [x] `dotnet build src/SportsData.Api/SportsData.Api.csproj`: 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized group week creation logic to ensure consistent handling of postseason scheduling and non-standard week configurations across the application.

* **Tests**
  * Added comprehensive unit tests covering regular-season and postseason scenarios, edge cases, and validation of week creation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->