### PR TITLE
fix(web,mobile): reject past dates in league creation (PR-C league-creation hardening)

### DIFF
--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -162,6 +162,13 @@ const schema = z
     if (data.startsOn && data.endsOn && data.endsOn < data.startsOn) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['endsOn'], message: 'End date must be on or after the start date' });
     }
+    // Mirror of the server `EffectiveEndsOn > now` rule. Recomputes today
+    // at validation time so a long-running form session can't sneak through
+    // a now-stale date.
+    const today = getTodayIsoDate();
+    if (data.endsOn && data.endsOn < today) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['endsOn'], message: "End date can't be in the past" });
+    }
   });
 
 type FormData = z.infer<typeof schema>;
@@ -220,6 +227,13 @@ const dateToIsoDateOnly = (d: Date): string => {
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
 };
+
+// Today as 'YYYY-MM-DD' anchored at the user's local calendar day. Used for
+// the date-picker `minimumDate` floor and the Zod `superRefine` rule. The
+// server-side `EffectiveEndsOn > now` validator is the trust boundary —
+// these UI guards just prevent users from constructing an invalid window in
+// the first place.
+const getTodayIsoDate = (): string => dateToIsoDateOnly(new Date());
 
 // Mirrors web's toStartOfDayIso / toEndOfDayIso. Anchored at the caller's
 // local timezone — appending 'Z' would wrongly treat the local calendar
@@ -375,6 +389,15 @@ export default function CreateLeagueScreen() {
       setValue('endsOn', startsOn, { shouldDirty: true, shouldValidate: true });
     }
   }, [durationMode, startsOn, endsOn, setValue]);
+
+  // Today as 'YYYY-MM-DD' for the date-picker floors. Memoized so re-renders
+  // during the form session don't create a new Date object per render, but
+  // intentionally NOT recomputed at midnight — the Zod superRefine catches
+  // a stale "today" on submit if the user leaves the form open overnight.
+  const todayIsoDate = useMemo(() => getTodayIsoDate(), []);
+  const endsOnMinIsoDate =
+    startsOn && startsOn > todayIsoDate ? startsOn : todayIsoDate;
+
   const copy = SPORT_COPY[sport];
   const isNcaa = sport === 'FootballNcaa';
 
@@ -690,6 +713,7 @@ export default function CreateLeagueScreen() {
                         accessibilityLabel="Start Date"
                         theme={theme}
                         error={errors.startsOn?.message}
+                        minimumDate={parseDateOnly(todayIsoDate)}
                       />
                     )}
                   />
@@ -707,7 +731,7 @@ export default function CreateLeagueScreen() {
                         accessibilityLabel="End Date"
                         theme={theme}
                         error={errors.endsOn?.message}
-                        minimumDate={startsOn ? parseDateOnly(startsOn) : undefined}
+                        minimumDate={parseDateOnly(endsOnMinIsoDate)}
                       />
                     )}
                   />

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -107,6 +107,18 @@ const LeagueCreatePage = () => {
 
   const navigate = useNavigate();
 
+  // Today as a `YYYY-MM-DD` string for the date-input `min` attribute and
+  // the pre-submit guard. Anchored at the user's local calendar day so the
+  // picker rejects yesterday in the user's timezone (the server-side
+  // EffectiveEndsOn > now check is the trust boundary; this is just UX).
+  const todayIsoDate = useMemo(() => {
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, "0");
+    const d = String(now.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }, []);
+
   const isNcaa = sport === SPORT_NCAA;
   const isMlbAvailable = userDto?.isAdmin === true;
   const copy = SPORT_COPY[sport];
@@ -164,6 +176,23 @@ const LeagueCreatePage = () => {
 
   const handleFormSubmit = (e) => {
     e.preventDefault();
+
+    // Mirror of the server `EffectiveEndsOn > now` rule. The `min` attribute
+    // on the date inputs handles the native-picker UX, but the keyboard /
+    // paste path can bypass it — guard before opening the confirm dialog so
+    // the user gets a clear message instead of a confirmed-then-rejected
+    // round-trip.
+    if (durationMode === DURATION_DATES) {
+      if (endsOn && endsOn < todayIsoDate) {
+        alert("End date can't be in the past.");
+        return;
+      }
+      if (startsOn && endsOn && endsOn < startsOn) {
+        alert("End date must be on or after the start date.");
+        return;
+      }
+    }
+
     setShowConfirmDialog(true);
   };
 
@@ -435,6 +464,7 @@ const LeagueCreatePage = () => {
                     type="date"
                     id="startsOn"
                     value={startsOn}
+                    min={todayIsoDate}
                     onChange={(e) => setStartsOn(e.target.value)}
                   />
                 </div>
@@ -444,6 +474,7 @@ const LeagueCreatePage = () => {
                     type="date"
                     id="endsOn"
                     value={endsOn}
+                    min={startsOn || todayIsoDate}
                     onChange={(e) => setEndsOn(e.target.value)}
                   />
                 </div>


### PR DESCRIPTION
## Summary

**PR-C** of the league-creation hardening plan documented at `docs/league-creation-hardening.md`. Tightens the date pickers on both create-league surfaces so users can't construct a league window whose end date has already passed.

Independent of PR-A; the corresponding server-side validator lands in PR-B.

## Why this is necessary

The most common symptom in prod (motivating bug, see design doc): single-day MLB leagues end up with **two** `PickemGroupWeek` rows in `/user/me` — an orphan empty one created at league-creation time, plus the real one created days later by `MatchupScheduler`. UI defaults to the first → zero matchups → reads as broken.

The root cause is the server-side handler ignoring `StartsOn` (fixed in PR-B), but the UI also let users *construct* the bad input. This PR closes that door from the client side. PR-B closes it from the server side. Defense-in-depth.

## What changed

**Web** (`src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx`):
- `min={todayIsoDate}` on the start-date input; `min={startsOn || todayIsoDate}` on the end-date input. Native date pickers gray out earlier days.
- Pre-confirm guard in `handleFormSubmit` rejecting `endsOn < today` with an alert before the confirmation dialog opens. Catches keyboard/paste input that bypasses the `min` attribute.

**Mobile** (`src/UI/sd-mobile/app/create-league.tsx`):
- `minimumDate` on both date pickers (start = today; end = `max(startsOn, today)` to defend against a stale `startsOn`).
- New Zod `superRefine` rule mirroring the server `EffectiveEndsOn > now` check. Today is recomputed at validation time so a long-running form session can't sneak through a stale date.

## What is intentionally *not* changed

- The dead `DURATION_WEEKS` mode on web still shows weeks 1..maxWeeks unfiltered, but `finalizeLeagueCreation` short-circuits with an "isn't wired up yet" alert before submission — no user-visible impact, no bug.
- No `SeasonYear` picker exists on either UI (both implicitly use the current year). The server-side rule from PR-B is the only defense; it's there for a future admin tool / direct-API caller.

## Test plan

- [ ] Web: open `/create-league`, select Date Range, try to pick yesterday for start date → native picker should reject. Open devtools, set `startsOn` input value to `2026-01-01` programmatically and submit → alert fires before confirm dialog opens.
- [ ] Web: set startsOn to a future date, then move endsOn to a date before startsOn via keyboard input → alert fires.
- [ ] Mobile: open Create League, select Date Range. Open the start picker → today should be the earliest selectable day. Open end picker without setting start → today should be the floor. Set start to next week, end picker should floor to next week.
- [ ] Mobile: leave the form open overnight (or mock `Date`), confirm Zod superRefine catches a now-stale `endsOn` on submit even if it was valid when picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * League end dates can no longer be set to past dates.
  * Date range validation now enforces that end dates cannot be earlier than start dates, preventing invalid date range submissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->