### PR TITLE
fix(mobile): keep MatchupCards visible after final pick with Hide Picked on

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -123,9 +123,14 @@ export default function PicksScreen() {
   const made = entries.filter((e) => e.pick !== null).length;
   const allPicked = total > 0 && made >= total;
 
+  // Hide Picked is a no-op once allPicked flips true — the toggle is also
+  // hidden in that branch of the header, so respecting it would strand the
+  // user with an empty FlatList ("No games this week") and no in-UI escape.
+  // Treating the filter as inactive when allPicked === true keeps the cards
+  // visible after the final pick while the header reads "All Picks Made".
   const visibleEntries = useMemo(
-    () => (hidePicked ? entries.filter((e) => !e.pick) : entries),
-    [entries, hidePicked],
+    () => (hidePicked && !allPicked ? entries.filter((e) => !e.pick) : entries),
+    [entries, hidePicked, allPicked],
   );
 
   // ── Inject pick counter into this tab's header ──────────────────────────────


### PR DESCRIPTION
## Summary

Real-device EAS testing surfaced an edge case: when a user toggled **Hide Picked** while working through their picks, the moment they made the final pick the FlatList collapsed to "No games this week" while the header pill correctly switched to "All Picks Made". The toggle lives inside the `!allPicked` branch of the header, so there was no in-UI way to reverse it.

## Root cause

`visibleEntries` filtered out every entry with a non-null pick. Once `allPicked === true`, *every* entry has a pick, so the filter returned an empty array → FlatList renders `ListEmptyComponent`.

## Fix

Make Hide Picked semantically a no-op when `allPicked` is true:

```ts
const visibleEntries = useMemo(
  () => (hidePicked && !allPicked ? entries.filter((e) => !e.pick) : entries),
  [entries, hidePicked, allPicked],
);
```

- No extra state, no extra effect.
- `hidePicked` itself isn't reset — if a future "un-pick" flow ever lands and `allPicked` drops back to false, the filter resumes.
- Matches the visual intent: header says "All Picks Made", body shows all the picked games.

## History

CodeRabbit flagged this exact scenario on the original picks PR (#371). I argued for web/mobile parity at the time and skipped it. EAS testing today proves the case is hit in practice. Web has the same shape; not fixing it here because the user's report is mobile-only and I don't want to ship a parity-divergent fix without explicit ask. Easy follow-up if it matters.

## Test plan

- [ ] Open the Picks tab with a league containing N matchups, no picks yet.
- [ ] Tap Hide Picked → toggle highlights.
- [ ] Make picks one at a time → matchups fade out as they're picked.
- [ ] After the final pick, confirm: header reads "All Picks Made"; the body shows all N picked matchup cards (not "No games this week").
- [ ] Open the Picks tab with a league that's already fully picked → confirm same behavior on cold load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Hide Picked" feature to prevent displaying an empty list after the final item is picked. The filter now automatically disables when all items have been selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->