### PR TITLE
feat(api): reject past-window leagues + bootstrap-mode dispatch (PR-B)

### DIFF
--- a/docs/league-creation-hardening.md
+++ b/docs/league-creation-hardening.md
@@ -1,0 +1,470 @@
+# League Creation Hardening (2026-05-28)
+
+Tighten the league-creation eager-bootstrap path so leagues with a
+non-trivial `[StartsOn, EndsOn]` window don't silently mis-populate
+their first `PickemGroupWeek`. Surfaced while testing MLB league
+creation: a league with `StartsOn = today + 10 days` produces an
+orphan empty `PickemGroupWeek` row pointing at the *current* week
+(which has nothing to do with the league).
+
+**Motivating bug.** Single-day MLB leagues (`StartsOn = EndsOn = some
+future date`) end up with **two** `PickemGroupWeek` rows in prod —
+the orphan empty one created at league-creation time, and the real
+one created days later by `MatchupScheduler` once the current
+`SeasonWeek` window reaches `StartsOn`. `/user/me` projects
+`seasonWeeks` straight off `PickemGroupWeek.SeasonWeek` values, so
+both show up in the league's ascending week list. The PicksPage UI
+defaults to the first week → zero matchups → reads as broken.
+
+**Status:** drafted 2026-05-28. Not yet executed. Implementation
+expected to land in 2–3 PRs (factory extraction → handler dispatch
+→ scheduler gate); backfill is explicitly deferred.
+
+---
+
+## What "current week" is trying to do
+
+The intent of `PickemGroupCreatedHandler` is **eager bootstrap**:
+populate the league's first `PickemGroupWeek` + schedule matchups
+synchronously off the `PickemGroupCreated` event so the
+commissioner can immediately go make picks after creating the
+league. The implicit assumption is *"league created → user wants
+to pick this week's games right now."*
+
+That assumption holds for one case — a season-long league
+created during the season. It mismatches every other case:
+
+- League starts in the future (most common during preseason
+  signup window).
+- League window is entirely in the past (backfill / replay).
+- League explicitly targets a non-current `SeasonYear`.
+- League created during postseason where the "current" week is
+  non-standard (CFP, MLB playoffs, NFL postseason).
+
+---
+
+## Current state
+
+### Files involved
+
+- `src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs`
+- `src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs`
+- `src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs`
+- `src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs`
+- `src/SportsData.Api/Application/Jobs/MatchupScheduler.cs`
+- `src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs`
+- `src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBase.cs`
+- `src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs`
+
+### Flow today
+
+1. **Command handler** (`CreateBaseballMlbLeagueCommandHandler:50-158`):
+   creates the `PickemGroup` with `StartsOn`/`EndsOn` from the
+   request, adds conferences + commissioner + synthetic member,
+   publishes `PickemGroupCreated`, saves. Sport-agnostic except
+   for the divisions step. Three near-identical copies exist
+   (NCAA / NFL / MLB).
+
+2. **Event handler** (`PickemGroupCreatedHandler.CreateCurrentWeekInternal:46-101`):
+   unconditionally calls
+   `ISeasonClientFactory.Resolve(sport).GetCurrentSeasonWeek()`,
+   creates a `PickemGroupWeek` for that week, enqueues
+   `ScheduleGroupWeekMatchupsCommand`. Ignores `StartsOn`,
+   `EndsOn`, and the `SeasonYear` on the event itself.
+
+3. **Matchup processor** (`MatchupScheduleProcessor:37-180`):
+   fetches matchups for `(sport, year, week)`, applies the
+   `[StartsOn, EndsOn]` window filter (lines 101-112), filters
+   by ranking/conference, writes `PickemGroupMatchup` rows,
+   publishes `PickemGroupWeekMatchupsGenerated` *only if at least
+   one matchup survived* (lines 191-199). Empty-week early-return
+   is deliberate — see comment at 188-190.
+
+4. **Daily recurring job** (`MatchupScheduler.ExecuteAsync:48-69`):
+   for every sport with at least one league, gets current week,
+   for every league of that sport creates a `PickemGroupWeek` for
+   the current week if missing, enqueues
+   `ScheduleGroupWeekMatchupsCommand`. Also ignores
+   `[StartsOn, EndsOn]`.
+
+### What this produces today
+
+Concrete scenarios with the current code:
+
+| Scenario | What happens |
+| --- | --- |
+| Season-long, created mid-season | ✅ Works as designed. First week populates immediately. |
+| Future-start (`StartsOn = today + 10`) | ⚠️ Orphan empty `PickemGroupWeek` row at *today's* week. No matchups (processor's window filter drops them). No event published. Daily scheduler creates a fresh orphan empty week every day until `StartsOn` lands. Eventually self-corrects when current-week ≥ `StartsOn`. |
+| Past-only backfill (window entirely in past) | ❌ Should never have been accepted in the first place. No validator rule prevents it today. PR-B adds one. |
+| Non-current `SeasonYear` | ❌ Same — no validator rule today. PR-B adds one. Handler currently ignores `SeasonYear` and uses real-time current week regardless. |
+| Created during postseason | ⚠️ Handler doesn't adjust `SeasonWeek` ordinal for postseason or set `IsNonStandardWeek`. Daily scheduler does both (`MatchupScheduler:101-117`). Two creation sites have drifted. |
+
+The functional case (#1) covers ~all production usage today
+because MLB is the only active sport and the test pattern has
+been "create league now, season is live." Holes show up the
+moment we start testing realistic signup windows.
+
+---
+
+## Holes
+
+Numbered for cross-reference. Severity = personal call.
+
+1. **`StartsOn` ignored at creation** (high). Causes scenario rows
+   2–3 above. The handler should at least *not* create a
+   `PickemGroupWeek` for a week that falls outside the league's
+   window.
+
+2. **`EndsOn` ignored at creation** (medium). Same shape as #1.
+   Less impactful in practice because most leagues either have
+   `EndsOn = null` (full season) or `EndsOn` far enough away that
+   the current week is in-window.
+
+3. **`SeasonYear` from the event is dropped** (medium).
+   `PickemGroupCreated.SeasonYear` exists on the record
+   (`src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupCreated.cs:6-13`),
+   gets a value from the handler (`CreateBaseballMlbLeagueCommandHandler:143`),
+   and is never read by the consumer. Adding a 2024 backfill flag
+   today does nothing.
+
+4. **`PickemGroupWeek` initialization drift between creation sites**
+   (medium). `PickemGroupCreatedHandler:75-83` doesn't set
+   `IsNonStandardWeek` and doesn't adjust the `SeasonWeek` ordinal
+   for postseason. `MatchupScheduler:108-117` does both. A league
+   created during postseason via the eager path gets a wrong week
+   row; one created the next day via the scheduler gets a right
+   one. Two sites must construct the same entity the same way.
+
+5. **`MatchupScheduler` is current-week-only** (medium).
+   No mechanism to walk `[StartsOn, EndsOn]` and bootstrap missed
+   weeks. Backfill is structurally impossible without code change.
+
+6. **`MatchupScheduler` doesn't gate on the league window** (low).
+   Once running daily, it'll happily create empty
+   `PickemGroupWeek` rows for a future-start league every day
+   until `StartsOn`. Rows accumulate even though they're harmless.
+
+7. **Entity fields not wired through requests** (low):
+   - `PickemGroup.MaxUsers` exists on the entity, no request field.
+   - `PickemGroup.NonStandardWeekGroupSeasonMapFilter` is read by
+     `MatchupScheduleProcessor:116-122` for NCAA postseason
+     filtering but isn't on any request — currently only
+     populated by direct DB edit.
+   - `RankingFilter` is read by the processor (`MatchupScheduleProcessor:83`)
+     and is on the NCAA request only. Fine — it's NCAA-specific.
+
+8. **Exception handling treats permanent failures as transient**
+   (low). `PickemGroupCreatedHandler:55-57` throws on
+   `group is null`. The message would retry / DLQ forever for a
+   group that genuinely doesn't exist (race on outbox flush could
+   theoretically cause this, but a permanent absence shouldn't
+   loop). Same at lines 65-69 for "current week could not be
+   found" — for an offseason MLB sport, that's permanent until
+   the season starts. Different failure modes deserve different
+   responses.
+
+9. **Three near-identical sport-specific command handlers**
+   (cosmetic but compounds drift risk). NCAA / NFL / MLB handlers
+   share ~90% of their code (only the `DivisionSlugs` resolution
+   differs meaningfully). Any fix from this doc has to be applied
+   in three places. Worth extracting a shared
+   `CreateLeagueCommandHandlerBase<TRequest>` while we're in
+   here — bounds the blast radius for the rest of the fixes.
+
+---
+
+## Decisions
+
+### Reject past / wrong-year at the validator
+
+Backfill and replay leagues are **never** valid user input. A
+league overlapping already-played games has no pickable surface
+(the games are over) and corrupts the time-based assumptions in
+the picks pipeline. Reject at the request boundary, not silently
+absorb in the handler.
+
+One new rule in `CreateLeagueRequestBaseValidator` (PR-B):
+
+**`EffectiveEndsOn > now`** (using `IDateTimeProvider.UtcNow()`).
+Rejects only the unambiguous case: window entirely in the past,
+no pickable games possible. **Windows that straddle `now` are
+allowed** — e.g., a single-day league created at noon where
+morning games are done but afternoon games are still scheduled is
+a legitimate use case. The processor's `[StartsOn, EndsOn]`
+window filter still grabs the in-window games; the existing
+pick-lock logic handles per-game pickability. `EndsOn`-only check
+is sufficient because the existing `StartsOn < EffectiveEndsOn`
+rule already prevents a degenerate window.
+
+Deferred — **`SeasonYear` == current** rule. Originally listed as
+a second PR-B validator rule. Pulled out because neither UI
+surfaces a `SeasonYear` picker (both implicitly use the current
+year), so the rule only defends a hypothetical admin tool /
+direct-API caller. Adding `ISeasonClientFactory` to the
+command-handler chain (or the validator) purely for that guard
+isn't worth it today. Can land alongside whatever admin tool
+eventually exposes the field, or as a follow-up if direct-API
+attacks become a concern.
+
+### What does "bootstrap mode" actually mean?
+
+After the validator rejects past / wrong-year inputs, the
+handler's mode dispatch shrinks to two:
+
+| Mode | When | Action |
+| --- | --- | --- |
+| `Immediate` | `(StartsOn ?? -∞) <= now`. | Bootstrap *current week* (today's behavior, narrowed). |
+| `Future` | `StartsOn > now`. | **No-op.** Don't create any `PickemGroupWeek`. Daily scheduler will pick it up once `now >= StartsOn`. |
+
+`Immediate` fires for:
+- Full-season leagues (`StartsOn` null).
+- Today-or-earlier-start leagues whose window still extends into
+  the future (the validator allows these; the half-played
+  single-day case fits here).
+- Leagues whose `StartsOn` was just-barely-future at validation
+  time but the event-handler clock has since rolled past.
+
+`Future` fires for leagues whose `StartsOn` is still strictly
+in the future at consume time. The daily scheduler picks them
+up when the calendar reaches `StartsOn`.
+
+### UI hardening (web + mobile)
+
+The API-side validator is the trust boundary; the UI is the UX
+layer. Both required — the validator catches malicious / direct-
+API requests, the UI prevents users from constructing invalid
+requests in the first place.
+
+**Web** (`src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx`):
+
+- Add `min={todayIsoDate}` to both `<input type="date">` (start
+  + end). `<input type="date">` respects `min` and grays out
+  earlier days in native date pickers — free UX.
+- Client-side check before submit: reject if `endsOn < today`.
+  Mirrors the server `EffectiveEndsOn > now` rule.
+- `DURATION_WEEKS` mode is dead UI today
+  (`finalizeLeagueCreation:171-176` short-circuits with an
+  alert). Either remove the tab or, when it's wired up, filter
+  the week dropdowns to current + future weeks only. Pending —
+  tracked here so it doesn't reintroduce the bug when activated.
+
+**Mobile** (`src/UI/sd-mobile/app/create-league.tsx`):
+
+- Add `minimumDate={today}` on the `startsOn` date picker
+  (~line 684-692).
+- Update the `endsOn` picker's `minimumDate` to
+  `max(startsOn ?? today, today)` so the end date can never be
+  before today, regardless of whether `startsOn` is set yet.
+- Add a `superRefine` rule: `endsOn` (when set) must be `>=`
+  today. Same shape as the server rule.
+
+Neither platform's UI work covers the `SeasonYear` mismatch case
+because neither UI surfaces a `SeasonYear` picker — both
+implicitly use the current year. The server rule is the only
+defense, and it's there for a future admin tool / direct-API
+caller, not for the standard UI flow.
+
+### `MatchupScheduler` window gate
+
+Add a per-league window check before creating the current-week
+`PickemGroupWeek`:
+
+```csharp
+if (group.StartsOn.HasValue && currentWeek.EndDate < group.StartsOn.Value) continue;
+if (group.EndsOn.HasValue && currentWeek.StartDate > group.EndsOn.Value) continue;
+```
+
+(Exact column names depend on the `SeasonWeek` DTO returned by
+`GetCurrentSeasonWeek` — verify before writing.) Stops the
+daily orphan-row accumulation for future-start leagues.
+
+Also handles `DeactivatedUtc` while we're there — currently
+nothing in `MatchupScheduler` filters out inactive leagues.
+
+### `PickemGroupWeek` factory
+
+Extract a single `PickemGroupWeekFactory.CreateForCurrentWeek(
+  PickemGroup group,
+  CurrentSeasonWeekDto currentWeek)`
+that handles:
+
+- `SeasonWeek` ordinal adjustment for postseason (today only in
+  `MatchupScheduler:101-106`).
+- `IsNonStandardWeek` flag.
+- `SeasonWeekId`, `SeasonYear`, `GroupId`, default
+  `AreMatchupsGenerated = false`.
+
+Both `PickemGroupCreatedHandler` and `MatchupScheduler` call it.
+Fixes hole #4 and stops the two sites from drifting again.
+
+### Command handler base
+
+Extract `CreateLeagueCommandHandlerBase<TRequest>` covering:
+
+- Validation, enum parsing, year defaulting, division resolution
+  (via virtual hook), group construction, member adds, synthetic
+  user lookup, event publish, save.
+
+Sport-specific handlers shrink to ~10 lines each: a constructor
+forwarding deps + a `Task<Dictionary<Guid, string>>
+ResolveDivisionsAsync(...)` override (or null if the sport has
+no divisions concept). Fixes hole #9.
+
+### Exception handling differentiation
+
+In `PickemGroupCreatedHandler`:
+
+- `group is null` → `LogError + return`. Permanent. Don't DLQ.
+  If outbox replays this later, the handler is idempotent (the
+  next condition handles "already populated").
+- `currentWeek is null` for an active in-window sport → keep
+  `throw`. Transient. Worth retry.
+- `currentWeek is null` because the sport is offseason → don't
+  throw; log and return. This shows up as
+  `weekResult.IsSuccess == true with Value == null` vs
+  `IsSuccess == false`. Need to confirm the API contract;
+  currently both paths collapse into the same null check.
+
+### Wire fields through
+
+- Add `MaxUsers` to `CreateLeagueRequestBase`. Plumb to entity.
+- Add `NonStandardWeekGroupSeasonMapFilter` to the NCAA request
+  only. (Cosmetic for MLB.)
+- `RankingFilter`: already NCAA-only, no change.
+
+---
+
+## Plan
+
+Four PRs:
+
+1. **PR-A: `PickemGroupWeekFactory` extraction.** Pure refactor.
+   Both call sites switch over, identical observable behavior,
+   tests pin the factory output. Smallest risk; lays the
+   foundation for PR-B and PR-D.
+
+2. **PR-B: Server validator + handler dispatch.** Two halves:
+   - Validator: add the `EffectiveEndsOn > now` rule in
+     `CreateLeagueRequestBaseValidator`. `IDateTimeProvider`
+     injected through the base ctor; all three derived
+     validators thread the parameter. The
+     `SeasonYear == current` rule originally listed here is
+     deferred — see *Decisions* above for the reasoning.
+   - Handler: compute bootstrap mode (`Immediate` / `Future`),
+     route to `BootstrapImmediate` (current path, using the
+     factory from PR-A) or a `Future`-mode no-op with a
+     `LogInformation` line for Seq trail. Differentiate
+     `group is null` (permanent, log + return) from
+     `currentWeek is null` (transient, throw).
+
+3. **PR-C: UI hardening (web + mobile).** Tighten the date
+   pickers so users can't construct invalid windows in the first
+   place:
+   - Web `LeagueCreatePage.jsx`: `min={todayIsoDate}` on both
+     `<input type="date">` plus a pre-submit guard rejecting
+     `endsOn < today`.
+   - Mobile `create-league.tsx`: `minimumDate` on both pickers
+     plus a `superRefine` Zod rule mirroring the server check.
+   - Defense-in-depth — the server validator from PR-B is the
+     trust boundary. Ships independently of PR-B (UI is more
+     restrictive in what it allows; safe regardless of server
+     state).
+
+4. **PR-D: `MatchupScheduler` window gate + handler base
+   extraction.** Add the `[StartsOn, EndsOn]` and `DeactivatedUtc`
+   gates in the scheduler. Collapse the three sport-specific
+   create-league handlers into a shared base. Wire `MaxUsers` /
+   `NonStandardWeekGroupSeasonMapFilter` through.
+
+Dependency graph: PR-A blocks PR-B and PR-D (both use the
+factory). PR-B and PR-C are independent. PR-D depends only on
+PR-A. Sensible order: A → C in parallel with B → D.
+
+---
+
+## Out of scope
+
+- **Backfill / historical replay leagues.** Explicitly rejected
+  at the validator after PR-B. If a real product use case for
+  historical replay ever surfaces, it's an admin-only operational
+  tool — not a public create-league input. That tool would need
+  its own design: how to surface progress, idempotency on partial
+  completion, behavior when a past `SeasonWeek` has no data,
+  whether to auto-`DeactivatedUtc` on completion. None of which
+  is being built here.
+
+- **Eager bootstrap of *future* weeks.** Today the system is
+  reactive — daily scheduler picks up next week's row when the
+  week boundary moves. For a future-start league we considered
+  pre-creating the first week at creation time. Decision:
+  **don't.** Adds complexity for no user-visible benefit (the
+  commissioner can't pick games for a future week anyway), and
+  the daily scheduler is the right place for week-rollover
+  logic.
+
+- **`MatchupScheduler` → event-driven.** Memory notes call this
+  out as "the only scheduling job NOT in the event-driven primary
+  path." There's a real argument for switching to a
+  `SeasonWeekRolledOver`-style event, but it's a separate
+  architectural call and orthogonal to this cleanup.
+
+- **NCAA / NFL handler equivalents.** Same code shape, same
+  holes. PR-C's base extraction fixes all three at once. Don't
+  fix NCAA/NFL in isolation.
+
+---
+
+## Prod data remediation
+
+The code fix prevents *new* orphan rows. Existing orphans are
+already in the prod DB for every single-day / future-start league
+created so far. They need to be cleaned up explicitly — a
+`PickemGroupWeek` with zero `PickemGroupMatchup` children and
+`AreMatchupsGenerated = false` is the diagnostic signature, but
+"empty for legitimate reasons" (sourcing in flight, future week
+not reached yet) overlaps with that signature.
+
+Safer query for cleanup candidates:
+
+```sql
+-- PickemGroupWeek rows that are empty AND fall outside the
+-- league's [StartsOn, EndsOn] window. The window check is what
+-- distinguishes orphan from "real but not yet populated."
+SELECT pgw."Id", pgw."GroupId", pgw."SeasonWeek", pgw."SeasonYear",
+       pg."Name", pg."StartsOn", pg."EndsOn"
+FROM "PickemGroupWeek" pgw
+JOIN "PickemGroup" pg ON pg."Id" = pgw."GroupId"
+LEFT JOIN "PickemGroupMatchup" pgm ON pgm."GroupWeekId" = pgw."Id"
+LEFT JOIN public."SeasonWeek" sw ON sw."Id" = pgw."SeasonWeekId"
+WHERE pgm."Id" IS NULL
+  AND pgw."AreMatchupsGenerated" = false
+  AND (
+    (pg."StartsOn" IS NOT NULL AND sw."EndDate" < pg."StartsOn") OR
+    (pg."EndsOn" IS NOT NULL AND sw."StartDate" > pg."EndsOn")
+  );
+```
+
+Eyeball the result before deleting. Once PR-B ships, this
+becomes a one-shot manual cleanup; no recurring need.
+
+---
+
+## Validation
+
+For PR-B in particular, the bootstrap-mode dispatch is the
+behavioral change that has to be exercised. Test plan:
+
+- Unit tests on `PickemGroupCreatedHandler` covering each mode
+  (`Immediate` / `Future` / `Past` / `WrongYear`), asserting
+  whether `PickemGroupWeek` was created and whether
+  `ScheduleGroupWeekMatchupsCommand` was enqueued.
+- Local E2E: create an MLB league with `StartsOn = today + 10`,
+  confirm no `PickemGroupWeek` rows materialize. Re-run the
+  daily scheduler at `StartsOn + 1`, confirm a row appears.
+- Local E2E: create an MLB league with `StartsOn = today`,
+  confirm the current-week row appears and matchups populate
+  (current happy-path regression check).
+
+For PR-C, the scheduler window gate: spin up two leagues — one
+future-start, one current — let the scheduler run, confirm only
+the current-start league gets a new `PickemGroupWeek` row.

--- a/docs/league-creation-hardening.md
+++ b/docs/league-creation-hardening.md
@@ -16,9 +16,24 @@ one created days later by `MatchupScheduler` once the current
 both show up in the league's ascending week list. The PicksPage UI
 defaults to the first week → zero matchups → reads as broken.
 
-**Status:** drafted 2026-05-28. Not yet executed. Implementation
-expected to land in 2–3 PRs (factory extraction → handler dispatch
-→ scheduler gate); backfill is explicitly deferred.
+**Status:** drafted 2026-05-28. Partially executed — three of four
+PRs:
+
+- **PR-A** (factory extraction) — **merged** in #372.
+- **PR-C** (UI date-picker guards on web + mobile) — **merged** in
+  #373. Note: originally listed third in the plan; reordered to
+  ship in parallel with PR-A since it's independent of all
+  backend work.
+- **PR-B** (server validator + bootstrap-mode dispatch) — **in
+  flight** as the PR that introduces this doc.
+- **PR-D** (`MatchupScheduler` window gate + handler base
+  extraction) — **not started**. The motivating bug (single-day
+  leagues producing two `PickemGroupWeek` rows in `/user/me`) is
+  only fully closed once PR-D lands; PR-B alone removes the
+  eager-bootstrap orphan but leaves the daily-scheduler orphan
+  intact.
+
+Backfill is explicitly deferred (see *Out of scope*).
 
 ---
 

--- a/docs/league-creation-hardening.md
+++ b/docs/league-creation-hardening.md
@@ -424,7 +424,7 @@ PR-A. Sensible order: A → C in parallel with B → D.
   architectural call and orthogonal to this cleanup.
 
 - **NCAA / NFL handler equivalents.** Same code shape, same
-  holes. PR-C's base extraction fixes all three at once. Don't
+  holes. PR-D's base extraction fixes all three at once. Don't
   fix NCAA/NFL in isolation.
 
 ---
@@ -480,6 +480,6 @@ behavioral change that has to be exercised. Test plan:
   confirm the current-week row appears and matchups populate
   (current happy-path regression check).
 
-For PR-C, the scheduler window gate: spin up two leagues — one
+For PR-D, the scheduler window gate: spin up two leagues — one
 future-start, one current — let the scheduler run, confirm only
 the current-start league gets a new `PickemGroupWeek` row.

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
@@ -105,9 +105,8 @@ namespace SportsData.Api.Application.PickemGroups
             // ESPN provides native week boundaries for all three via SeasonType, so
             // the Producer-side GetCurrentSeasonWeek endpoint works uniformly.
             var weekResult = await _seasonClientFactory.Resolve(group.Sport).GetCurrentSeasonWeek();
-            var currentWeek = weekResult.IsSuccess ? weekResult.Value : null;
 
-            if (currentWeek is null)
+            if (!weekResult.IsSuccess)
             {
                 // Transient: the current-week endpoint is offline / sport is briefly
                 // between seasons. Throw so MassTransit retries the message. If the
@@ -120,6 +119,8 @@ namespace SportsData.Api.Application.PickemGroups
                 throw new InvalidOperationException(
                     $"Current week unavailable for sport {group.Sport}.");
             }
+
+            var currentWeek = weekResult.Value;
 
             var groupWeek = group.Weeks.FirstOrDefault(x => x.SeasonWeekId == currentWeek.Id);
 

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
@@ -1,9 +1,11 @@
-﻿using MassTransit;
+using MassTransit;
 
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Processors;
 using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Season;
 using SportsData.Core.Processing;
@@ -16,17 +18,20 @@ namespace SportsData.Api.Application.PickemGroups
         private readonly AppDataContext _dataContext;
         private readonly ISeasonClientFactory _seasonClientFactory;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public PickemGroupCreatedHandler(
             ILogger<PickemGroupCreatedHandler> logger,
             AppDataContext dataContext,
             ISeasonClientFactory seasonClientFactory,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
             _seasonClientFactory = seasonClientFactory;
             _backgroundJobProvider = backgroundJobProvider;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupCreated> context)
@@ -37,12 +42,20 @@ namespace SportsData.Api.Application.PickemGroups
                    }))
             {
                 _logger.LogInformation("New pickem group created event received: {@Message}", context.Message);
-                
-                await CreateCurrentWeekInternal(context.Message);
+
+                await DispatchAsync(context.Message);
             }
         }
 
-        private async Task CreateCurrentWeekInternal(PickemGroupCreated @event)
+        /// <summary>
+        /// Route the just-created league to the appropriate bootstrap path based on
+        /// its <see cref="PickemGroup.StartsOn"/> relative to now. Without this
+        /// dispatch the handler would eagerly create a <c>PickemGroupWeek</c> for
+        /// the sport's *current* week regardless of when the league actually starts,
+        /// producing an orphan empty row for any future-start league
+        /// (the motivating bug — see docs/league-creation-hardening.md).
+        /// </summary>
+        private async Task DispatchAsync(PickemGroupCreated @event)
         {
             var group = await _dataContext.PickemGroups
                 .Include(x => x.Weeks)
@@ -51,10 +64,43 @@ namespace SportsData.Api.Application.PickemGroups
 
             if (group is null)
             {
-                _logger.LogError("Group not found");
-                throw new Exception("Group not found");
+                // Permanent failure: a missing group doesn't fix itself on retry.
+                // Log and return rather than throw — throwing would land the
+                // message in the DLQ for a state that will never become valid.
+                _logger.LogError(
+                    "PickemGroupCreated received for unknown group {GroupId}; skipping bootstrap.",
+                    @event.GroupId);
+                return;
             }
 
+            var mode = ResolveBootstrapMode(group);
+            switch (mode)
+            {
+                case BootstrapMode.Future:
+                    _logger.LogInformation(
+                        "League {GroupId} starts at {StartsOn}; deferring bootstrap to MatchupScheduler.",
+                        group.Id, group.StartsOn);
+                    return;
+
+                case BootstrapMode.Immediate:
+                    await BootstrapImmediateAsync(@event, group);
+                    return;
+
+                default:
+                    throw new InvalidOperationException($"Unhandled bootstrap mode: {mode}");
+            }
+        }
+
+        /// <summary>
+        /// Current-week bootstrap path: fetch the sport's current
+        /// <see cref="CanonicalSeasonWeekDto"/>, ensure a <see cref="PickemGroupWeek"/>
+        /// exists for it, and enqueue matchup generation. Unchanged from the
+        /// pre-PR-B behavior except for the (1) <see cref="BootstrapMode.Future"/>
+        /// gate above and (2) transient-vs-permanent exception split for the
+        /// current-week lookup.
+        /// </summary>
+        private async Task BootstrapImmediateAsync(PickemGroupCreated @event, PickemGroup group)
+        {
             // get the current week for the league's sport (NCAA, NFL, or MLB).
             // ESPN provides native week boundaries for all three via SeasonType, so
             // the Producer-side GetCurrentSeasonWeek endpoint works uniformly.
@@ -63,8 +109,16 @@ namespace SportsData.Api.Application.PickemGroups
 
             if (currentWeek is null)
             {
-                _logger.LogError("Current week could not be found");
-                throw new Exception("Current week could not be found");
+                // Transient: the current-week endpoint is offline / sport is briefly
+                // between seasons. Throw so MassTransit retries the message. If the
+                // sport is permanently offseason, the retry policy will eventually
+                // DLQ — that's the correct outcome (a human will reschedule via the
+                // daily MatchupScheduler once the new season starts).
+                _logger.LogError(
+                    "Current week could not be resolved for {Sport} (group {GroupId}); will retry.",
+                    group.Sport, group.Id);
+                throw new InvalidOperationException(
+                    $"Current week unavailable for sport {group.Sport}.");
             }
 
             var groupWeek = group.Weeks.FirstOrDefault(x => x.SeasonWeekId == currentWeek.Id);
@@ -89,6 +143,26 @@ namespace SportsData.Api.Application.PickemGroups
                 // kick off a process to create the PickemGroupWeek and matchups for the current week
                 _backgroundJobProvider.Enqueue<IScheduleGroupWeekMatchups>(p => p.Process(cmd));
             }
+        }
+
+        /// <summary>
+        /// Decide whether to bootstrap now or wait for <c>MatchupScheduler</c>.
+        /// Null <see cref="PickemGroup.StartsOn"/> = full-season league → Immediate.
+        /// StartsOn at-or-before now (validator already rejected the
+        /// EndsOn-in-past case) → Immediate. StartsOn strictly future → Future.
+        /// </summary>
+        private BootstrapMode ResolveBootstrapMode(PickemGroup group)
+        {
+            if (!group.StartsOn.HasValue) return BootstrapMode.Immediate;
+            return group.StartsOn.Value <= _dateTimeProvider.UtcNow()
+                ? BootstrapMode.Immediate
+                : BootstrapMode.Future;
+        }
+
+        private enum BootstrapMode
+        {
+            Immediate,
+            Future,
         }
     }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueRequestValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueRequestValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
 
 using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague.Dtos;
+using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague;
 
 public class CreateBaseballMlbLeagueRequestValidator
     : CreateLeagueRequestBaseValidator<CreateBaseballMlbLeagueRequest>
 {
-    public CreateBaseballMlbLeagueRequestValidator()
+    public CreateBaseballMlbLeagueRequestValidator(IDateTimeProvider dateTimeProvider)
+        : base(dateTimeProvider)
     {
         // Empty DivisionSlugs is allowed (means "include all divisions"); but when the
         // caller provides entries they must be unique. Duplicates almost always indicate

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueRequestValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueRequestValidator.cs
@@ -2,13 +2,15 @@ using FluentValidation;
 
 using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague.Dtos;
+using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague;
 
 public class CreateFootballNcaaLeagueRequestValidator
     : CreateLeagueRequestBaseValidator<CreateFootballNcaaLeagueRequest>
 {
-    public CreateFootballNcaaLeagueRequestValidator()
+    public CreateFootballNcaaLeagueRequestValidator(IDateTimeProvider dateTimeProvider)
+        : base(dateTimeProvider)
     {
         // RankingFilter is optional — only validate when the caller supplied a value.
         RuleFor(x => x.RankingFilter)

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueRequestValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueRequestValidator.cs
@@ -1,13 +1,15 @@
 using FluentValidation;
 
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague.Dtos;
+using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague;
 
 public class CreateFootballNflLeagueRequestValidator
     : CreateLeagueRequestBaseValidator<CreateFootballNflLeagueRequest>
 {
-    public CreateFootballNflLeagueRequestValidator()
+    public CreateFootballNflLeagueRequestValidator(IDateTimeProvider dateTimeProvider)
+        : base(dateTimeProvider)
     {
         // Empty DivisionSlugs is allowed (means "include all divisions"); but when the
         // caller provides entries they must be unique. Duplicates almost always indicate

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 
 using SportsData.Api.Application.Common.Enums;
+using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands;
 
@@ -13,8 +14,10 @@ namespace SportsData.Api.Application.UI.Leagues.Commands;
 public abstract class CreateLeagueRequestBaseValidator<TRequest> : AbstractValidator<TRequest>
     where TRequest : CreateLeagueRequestBase
 {
-    protected CreateLeagueRequestBaseValidator()
+    protected CreateLeagueRequestBaseValidator(IDateTimeProvider dateTimeProvider)
     {
+        ArgumentNullException.ThrowIfNull(dateTimeProvider);
+
         RuleFor(x => x.Name)
             .NotEmpty()
             .WithMessage("League name is required.");
@@ -41,6 +44,21 @@ public abstract class CreateLeagueRequestBaseValidator<TRequest> : AbstractValid
                 || x.StartsOn.Value < x.EffectiveEndsOn.Value)
             .WithName(nameof(CreateLeagueRequestBase.EndsOn))
             .WithMessage("EndsOn must be after StartsOn.");
+
+        // Reject windows whose end has already passed — no pickable games can
+        // exist in such a window. Windows that straddle "now" (e.g. a single-day
+        // league created at noon where the morning games already started) are
+        // allowed: the matchup processor's [StartsOn, EndsOn] filter still grabs
+        // the in-window games and the pick-lock logic handles per-game
+        // pickability. EndsOn-only check is sufficient because the existing
+        // StartsOn < EffectiveEndsOn rule above already prevents a degenerate
+        // window. UI sibling guards in PR-C (web `min={today}` + mobile Zod
+        // superRefine) prevent users from constructing this from the form; this
+        // is the trust boundary for admin / direct-API callers.
+        RuleFor(x => x)
+            .Must(x => !x.EffectiveEndsOn.HasValue || x.EffectiveEndsOn.Value > dateTimeProvider.UtcNow())
+            .WithName(nameof(CreateLeagueRequestBase.EndsOn))
+            .WithMessage("EndsOn can't be in the past.");
     }
 
     /// <summary>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
@@ -1,0 +1,197 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.PickemGroups;
+using SportsData.Api.Application.Processors;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Core.Infrastructure.Clients.Season;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.PickemGroups;
+
+/// <summary>
+/// Pins the PR-B bootstrap-mode dispatch on <see cref="PickemGroupCreatedHandler"/>.
+/// Three behavioral contracts:
+///   1. Missing group is permanent, not transient — log and return, don't throw.
+///   2. Future-start league (<see cref="PickemGroup.StartsOn"/> &gt; now) defers
+///      to MatchupScheduler — no PickemGroupWeek row, no matchup enqueue.
+///   3. Immediate path (StartsOn null or already past) hits the current-week
+///      bootstrap and enqueues matchup generation, OR throws transient when
+///      the season client can't resolve current week.
+/// </summary>
+public class PickemGroupCreatedHandlerTests : ApiTestBase<PickemGroupCreatedHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 5, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<ISeasonClientFactory> _seasonClientFactoryMock;
+    private readonly Mock<IProvideSeasons> _seasonClientMock;
+    private readonly Mock<IProvideBackgroundJobs> _backgroundJobsMock;
+
+    public PickemGroupCreatedHandlerTests()
+    {
+        _seasonClientFactoryMock = Mocker.GetMock<ISeasonClientFactory>();
+        _seasonClientMock = new Mock<IProvideSeasons>();
+        _seasonClientFactoryMock
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_seasonClientMock.Object);
+
+        _backgroundJobsMock = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    [Fact]
+    public async Task GroupNotFound_LogsAndReturns_DoesNotThrow()
+    {
+        // Permanent failure: don't DLQ. The group will never materialize on
+        // retry. Log + return is the correct response.
+        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
+        var context = ConsumeContextFor(new PickemGroupCreated(
+            Guid.NewGuid(), null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
+
+        var act = async () => await sut.Consume(context);
+
+        await act.Should().NotThrowAsync();
+        _backgroundJobsMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task FutureStartLeague_NoBootstrap_NoEnqueue()
+    {
+        // Motivating bug regression test: a league starting in the future
+        // must not produce an orphan PickemGroupWeek for *today's* current
+        // week, and must not enqueue matchup generation. The daily
+        // MatchupScheduler picks the league up once now >= StartsOn (gated
+        // in PR-D).
+        var groupId = await SeedGroup(startsOn: FixedNow.AddDays(10));
+
+        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
+        var context = ConsumeContextFor(new PickemGroupCreated(
+            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
+
+        await sut.Consume(context);
+
+        (await DataContext.PickemGroupWeeks.AnyAsync(x => x.GroupId == groupId))
+            .Should().BeFalse();
+        _backgroundJobsMock.Verify(
+            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NullStartsOnLeague_CreatesWeek_AndEnqueues()
+    {
+        // Full-season league — Immediate path.
+        var groupId = await SeedGroup(startsOn: null);
+        SetupCurrentWeek(NewCurrentWeek());
+
+        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
+        var context = ConsumeContextFor(new PickemGroupCreated(
+            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
+
+        await sut.Consume(context);
+
+        (await DataContext.PickemGroupWeeks.AnyAsync(x => x.GroupId == groupId))
+            .Should().BeTrue();
+        _backgroundJobsMock.Verify(
+            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task StartsOnInPastLeague_CreatesWeek_AndEnqueues()
+    {
+        // Validator already rejected the "ends-in-past" case; this exercises
+        // the half-played single-day scenario where StartsOn was earlier
+        // today (or the validator-allowed boundary race where StartsOn was
+        // just-barely-future at validation time but the event-handler clock
+        // has rolled past it).
+        var groupId = await SeedGroup(startsOn: FixedNow.AddHours(-2));
+        SetupCurrentWeek(NewCurrentWeek());
+
+        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
+        var context = ConsumeContextFor(new PickemGroupCreated(
+            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
+
+        await sut.Consume(context);
+
+        (await DataContext.PickemGroupWeeks.AnyAsync(x => x.GroupId == groupId))
+            .Should().BeTrue();
+        _backgroundJobsMock.Verify(
+            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CurrentWeekUnavailable_ThrowsForRetry()
+    {
+        // Transient failure: throw so MassTransit retries. A briefly-between-
+        // seasons sport will eventually DLQ via retry policy, at which point
+        // a human re-enqueues via MatchupScheduler.
+        var groupId = await SeedGroup(startsOn: null);
+        _seasonClientMock
+            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<CanonicalSeasonWeekDto>(null!));
+
+        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
+        var context = ConsumeContextFor(new PickemGroupCreated(
+            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
+
+        var act = async () => await sut.Consume(context);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _backgroundJobsMock.Verify(
+            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            Times.Never);
+    }
+
+    private async Task<Guid> SeedGroup(DateTime? startsOn)
+    {
+        var group = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Sport = Sport.BaseballMlb,
+            League = League.MLB,
+            StartsOn = startsOn,
+        };
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+        return group.Id;
+    }
+
+    private static CanonicalSeasonWeekDto NewCurrentWeek() => new()
+    {
+        Id = Guid.NewGuid(),
+        SeasonId = Guid.NewGuid(),
+        SeasonYear = 2026,
+        WeekNumber = 9,
+        SeasonPhase = "regularseason",
+        IsNonStandardWeek = false,
+    };
+
+    private void SetupCurrentWeek(CanonicalSeasonWeekDto week)
+    {
+        _seasonClientMock
+            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<CanonicalSeasonWeekDto>(week));
+    }
+
+    private static ConsumeContext<PickemGroupCreated> ConsumeContextFor(PickemGroupCreated message) =>
+        Mock.Of<ConsumeContext<PickemGroupCreated>>(ctx => ctx.Message == message);
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 
+using FluentValidation.Results;
+
 using MassTransit;
 
 using Microsoft.EntityFrameworkCore;
@@ -142,11 +144,18 @@ public class PickemGroupCreatedHandlerTests : ApiTestBase<PickemGroupCreatedHand
     {
         // Transient failure: throw so MassTransit retries. A briefly-between-
         // seasons sport will eventually DLQ via retry policy, at which point
-        // a human re-enqueues via MatchupScheduler.
+        // a human re-enqueues via MatchupScheduler. The season client expresses
+        // unavailability as a Failure result (see SeasonClient.GetCurrentSeasonWeek
+        // which returns Failure<...>(default!, ResultStatus.NotFound, ...) on
+        // upstream miss) — the handler checks !IsSuccess rather than a null
+        // Value payload.
         var groupId = await SeedGroup(startsOn: null);
         _seasonClientMock
             .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<CanonicalSeasonWeekDto>(null!));
+            .ReturnsAsync(new Failure<CanonicalSeasonWeekDto>(
+                default!,
+                ResultStatus.NotFound,
+                new List<ValidationFailure>()));
 
         var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
         var context = ConsumeContextFor(new PickemGroupCreated(

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandlerTests.cs
@@ -26,10 +26,15 @@ public class CreateBaseballMlbLeagueCommandHandlerTests : ApiTestBase<CreateBase
             .Setup(x => x.Resolve(It.IsAny<Sport>()))
             .Returns(_franchiseClientMock.Object);
 
+        // Fixed clock far enough in the past that the validator's
+        // EndsOn-in-future rule doesn't fire for the (null EndsOn) test requests.
+        var dateTimeProviderMock = Mocker.GetMock<IDateTimeProvider>();
+        dateTimeProviderMock.Setup(x => x.UtcNow()).Returns(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
         // Use the real validator so Name/enum/date-window assertions exercise the
         // production rules rather than AutoMocker's default IsValid=true stub.
         Mocker.Use<IValidator<CreateBaseballMlbLeagueRequest>>(
-            new CreateBaseballMlbLeagueRequestValidator());
+            new CreateBaseballMlbLeagueRequestValidator(dateTimeProviderMock.Object));
     }
 
     private CreateBaseballMlbLeagueRequest BuildValidRequest() => new()

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
@@ -24,10 +24,16 @@ public class CreateFootballNcaaLeagueCommandHandlerTests : ApiTestBase<CreateFoo
             .Setup(x => x.Resolve(It.IsAny<Sport>()))
             .Returns(_franchiseClientMock.Object);
 
+        // Fixed clock for the validator's EndsOn-in-future rule. Test
+        // requests use a null EndsOn so the rule is a no-op; setup is just
+        // to satisfy the constructor dependency.
+        var dateTimeProviderMock = Mocker.GetMock<IDateTimeProvider>();
+        dateTimeProviderMock.Setup(x => x.UtcNow()).Returns(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
         // Use the real validator so Name/enum/date-window assertions exercise the
         // production rules rather than AutoMocker's default IsValid=true stub.
         Mocker.Use<FluentValidation.IValidator<CreateFootballNcaaLeagueRequest>>(
-            new CreateFootballNcaaLeagueRequestValidator());
+            new CreateFootballNcaaLeagueRequestValidator(dateTimeProviderMock.Object));
     }
 
     private CreateFootballNcaaLeagueRequest BuildValidRequest() => new()

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandlerTests.cs
@@ -26,10 +26,16 @@ public class CreateFootballNflLeagueCommandHandlerTests : ApiTestBase<CreateFoot
             .Setup(x => x.Resolve(It.IsAny<Sport>()))
             .Returns(_franchiseClientMock.Object);
 
+        // Fixed clock for the validator's EndsOn-in-future rule. Test
+        // requests use a null EndsOn so the rule is a no-op; setup is just
+        // to satisfy the constructor dependency.
+        var dateTimeProviderMock = Mocker.GetMock<IDateTimeProvider>();
+        dateTimeProviderMock.Setup(x => x.UtcNow()).Returns(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
         // Use the real validator so Name/enum/date-window assertions exercise the
         // production rules rather than AutoMocker's default IsValid=true stub.
         Mocker.Use<FluentValidation.IValidator<CreateFootballNflLeagueRequest>>(
-            new CreateFootballNflLeagueRequestValidator());
+            new CreateFootballNflLeagueRequestValidator(dateTimeProviderMock.Object));
     }
 
     private CreateFootballNflLeagueRequest BuildValidRequest() => new()

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidatorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidatorTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague;
+using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague.Dtos;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Commands;
+
+/// <summary>
+/// Pins the EndsOn-in-future rule on <see cref="CreateLeagueRequestBaseValidator{TRequest}"/>.
+/// Exercised via the MLB derived validator since the rule lives in the base —
+/// NCAA and NFL inherit identical behavior. Companion to the PR-C UI guards on
+/// web (`min={today}` + submit guard) and mobile (Zod superRefine); this is the
+/// server-side trust boundary for admin / direct-API callers.
+/// </summary>
+public class CreateLeagueRequestBaseValidatorTests
+{
+    private static readonly DateTime FixedNow = new(2026, 5, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    private static CreateBaseballMlbLeagueRequestValidator NewValidator()
+    {
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.Setup(x => x.UtcNow()).Returns(FixedNow);
+        return new CreateBaseballMlbLeagueRequestValidator(dateTimeProvider.Object);
+    }
+
+    private static CreateBaseballMlbLeagueRequest ValidBaseRequest() => new()
+    {
+        Name = "League",
+        PickType = "StraightUp",
+        TiebreakerType = "TotalPoints",
+        TiebreakerTiePolicy = "EarliestSubmission",
+    };
+
+    [Fact]
+    public async Task EndsOn_Null_Passes()
+    {
+        // Full-season leagues — no window constraint, rule is a no-op.
+        var validator = NewValidator();
+        var request = ValidBaseRequest();
+        request.EndsOn = null;
+
+        var result = await validator.ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EndsOn_FarFuture_Passes()
+    {
+        var validator = NewValidator();
+        var request = ValidBaseRequest();
+        request.StartsOn = FixedNow.AddDays(1);
+        request.EndsOn = FixedNow.AddDays(30);
+
+        var result = await validator.ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EndsOn_TodayMidnightAligned_Passes()
+    {
+        // Midnight-aligned EndsOn normalizes to end-of-day via EffectiveEndsOn,
+        // so "today" stays valid for the rest of the calendar day. Matches the
+        // half-played single-day scenario the design doc calls out.
+        var validator = NewValidator();
+        var request = ValidBaseRequest();
+        var todayMidnightUtc = new DateTime(FixedNow.Year, FixedNow.Month, FixedNow.Day, 0, 0, 0, DateTimeKind.Utc);
+        request.StartsOn = todayMidnightUtc;
+        request.EndsOn = todayMidnightUtc;
+
+        var result = await validator.ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EndsOn_Yesterday_Fails()
+    {
+        var validator = NewValidator();
+        var request = ValidBaseRequest();
+        request.StartsOn = FixedNow.AddDays(-7);
+        request.EndsOn = FixedNow.AddDays(-1);
+
+        var result = await validator.ValidateAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CreateBaseballMlbLeagueRequest.EndsOn) &&
+            e.ErrorMessage == "EndsOn can't be in the past.");
+    }
+
+    [Fact]
+    public async Task EndsOn_ExactlyNow_Fails()
+    {
+        // Boundary: rule is strictly EffectiveEndsOn > now. A window ending
+        // at the exact moment of validation has zero remaining pickable time.
+        var validator = NewValidator();
+        var request = ValidBaseRequest();
+        request.StartsOn = FixedNow.AddDays(-1);
+        request.EndsOn = FixedNow;
+
+        var result = await validator.ValidateAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreateBaseballMlbLeagueRequest.EndsOn));
+    }
+}


### PR DESCRIPTION
## Summary

**PR-B** of the league-creation hardening plan documented at `docs/league-creation-hardening.md` (committed in this PR for the first time). Two halves:

1. **Validator** rejects past-window leagues at the API edge.
2. **Handler** computes a bootstrap mode and skips the eager bootstrap for future-start leagues.

Half-fixes the motivating bug — single-day MLB leagues with `StartsOn` in the future no longer produce an orphan `PickemGroupWeek` at league-creation time. The daily `MatchupScheduler` still creates a current-week orphan until PR-D's scheduler window gate ships.

## Server validator

`CreateLeagueRequestBaseValidator` gets a single new rule: `EffectiveEndsOn > IDateTimeProvider.UtcNow()`. Rejects only the unambiguous "window entirely in the past" case. **Half-played single-day leagues are still allowed** — a window that straddles `now` (morning games over, afternoon games still scheduled) is legitimate. The processor's existing `[StartsOn, EndsOn]` window filter handles the rest; pick-lock handles per-game pickability.

Base constructor takes `IDateTimeProvider` now; all three derived validators (NCAA / NFL / MLB) thread it through `base()`.

## Deferred — `SeasonYear == current` rule

Originally listed in PR-B per the doc. Pulled out because neither UI surface (web nor mobile) exposes a `SeasonYear` picker today — both implicitly use the current year. The guard would only defend a hypothetical admin tool / direct-API caller, and adding `ISeasonClientFactory` to the validator or handler chain purely for that isn't worth the cost. Doc updated to reflect the deferral. Can land alongside whatever admin tool eventually exposes the field.

## Handler dispatch

`PickemGroupCreatedHandler` now:

1. Loads the group.
2. **Missing group → log + return** (permanent, don't DLQ — won't fix itself on retry).
3. Computes bootstrap mode from `(group.StartsOn, now)`:
   - `Immediate` — StartsOn null OR `<= now`. Current path unchanged.
   - `Future` — StartsOn `> now`. `LogInformation` line for Seq trail, return. No `PickemGroupWeek` created, no matchup enqueue. `MatchupScheduler` picks up once `now >= StartsOn` (gate in PR-D).
4. In the Immediate path, `currentWeek is null` now throws `InvalidOperationException` (transient — MassTransit retries; eventual DLQ is the correct outcome for an offseason sport).

## Tests

**Validator** (`CreateLeagueRequestBaseValidatorTests.cs`, 5 cases):
- `EndsOn` null → passes (full-season leagues)
- `EndsOn` far future → passes
- `EndsOn` today midnight-aligned → passes (`EffectiveEndsOn` normalizes to end-of-day)
- `EndsOn` yesterday → fails with the expected error message
- `EndsOn` exactly `now` → fails (boundary)

**Handler** (`PickemGroupCreatedHandlerTests.cs`, 5 cases):
- Group not found → does not throw, no enqueue
- Future-start league → no `PickemGroupWeek` row, no enqueue
- Null `StartsOn` (full-season) → creates week + enqueues
- Past `StartsOn` (validator-allowed straddle) → creates week + enqueues
- `currentWeek` unavailable → throws `InvalidOperationException`, no enqueue

**Existing test updates**: 3 sport-specific command-handler tests (NCAA / NFL / MLB) thread the new `IDateTimeProvider` through their inline validator construction.

Full API unit suite: **357/357 passing** (one pre-existing flaky `DisplayNameGenerator` test self-resolves on rerun; unrelated to this PR).

## What's next

- **PR-D** (separately): `MatchupScheduler` window gate so the daily run also respects `[StartsOn, EndsOn]` and `DeactivatedUtc`. Closes the second half of the orphan bug. Three sport-specific create-league handlers collapsed into a shared base while we're in there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred immediate bootstrap for leagues that start in the future to prevent orphan current-week pickem groups
  * Validator now rejects leagues whose effective end date is in the past

* **Documentation**
  * Added a comprehensive league-creation hardening spec with remediation and cleanup/testing guidance

* **Tests**
  * Added unit tests for bootstrap-mode dispatch and the validator’s date-range rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->