### PR TITLE
feat(api): MatchupScheduler window + active gate (PR-D)

### DIFF
--- a/docs/league-creation-hardening.md
+++ b/docs/league-creation-hardening.md
@@ -16,24 +16,52 @@ one created days later by `MatchupScheduler` once the current
 both show up in the league's ascending week list. The PicksPage UI
 defaults to the first week → zero matchups → reads as broken.
 
-**Status:** drafted 2026-05-28. Motivating bug fixed; hygiene
-deferred to a follow-up:
+**Status:** drafted 2026-05-28. **Scope and shape of PR-D
+expanded materially on 2026-05-29** — local testing surfaced
+that PR-B's `Future`-mode dispatch was wrong for near-future
+leagues (tomorrow-only), and reflection on the original
+"current-week-only" model showed it was wrong by construction
+for *any* windowed league. PR-D was held open and rebuilt as a
+proper redesign rather than the originally-scoped scheduler-gate
+fix.
 
 - **PR-A** (factory extraction) — **merged** in #372.
-- **PR-C** (UI date-picker guards on web + mobile) — **merged** in
-  #373. Note: originally listed third in the plan; reordered to
+- **PR-C** (UI date-picker guards on web + mobile) — **merged**
+  in #373. Originally listed third in the plan; reordered to
   ship in parallel with PR-A since it's independent of all
   backend work.
-- **PR-B** (server validator + bootstrap-mode dispatch) — **merged**
-  in #375.
-- **PR-D** (`MatchupScheduler` window gate) — **in flight** as the
-  PR landing the scheduler-side daily-orphan fix. Scope reduced
-  vs. the original plan: just the window/active gate, no handler
-  base extraction or `MaxUsers` / `NonStandardWeekGroupSeasonMapFilter`
-  wiring. Those land in a follow-up (`PR-E`) — they're hygiene,
-  not motivating-bug closure. With PR-D's gate in place the
-  motivating bug is fully fixed: no orphan at creation (PR-B),
-  no orphan on subsequent scheduler runs (PR-D).
+- **PR-B** (server validator + Immediate/Future dispatch) —
+  **merged** in #375. The `Future`-mode no-op shipped here is
+  superseded by PR-D below; the validator + permanent-vs-transient
+  exception split stay.
+- **PR-D** (creation-time bootstrap redesign) — **in flight** as
+  the PR you're reading the doc against. Replaces the original
+  "scheduler window gate only" scope with:
+  1. New Producer endpoint that returns SeasonWeeks overlapping
+     a date range (drives windowed-league resolution).
+  2. New `SeasonClient.GetSeasonWeeksOverlapping` consuming it.
+  3. New `BootstrapLeagueMatchupsProcessor` — Hangfire
+     orchestrator that decides full-season vs windowed, resolves
+     target SeasonWeek(s), and fans out one
+     `ScheduleGroupWeekMatchupsCommand` per week to the existing
+     per-week worker.
+  4. `PickemGroupCreatedHandler` slimmed to a thin MassTransit-side
+     fan-out point (existence check + single enqueue). All week
+     resolution and shell creation moved to the new processor.
+  5. `MatchupScheduleProcessor.AreMatchupsGenerated` rule fix:
+     only set `true` when matchups were actually written; empty
+     results leave the flag `false` so the daily scheduler
+     retries (required for the eager-bootstrap path to work for
+     NCAAFB+RankingFilter shells created pre-poll).
+  6. Factory rename `CreateForCurrentWeek` → `Create` to match
+     its post-redesign use (any SeasonWeek, not just current).
+  7. Original `MatchupScheduler` window/active gate stays — it's
+     still useful for the daily refresh path even though
+     creation-time orphans are now prevented upstream.
+
+  Design space the redesign covers is enumerated in
+  `docs/league-creation-matrix.md`.
+
 - **PR-E** (deferred) — handler base extraction collapsing the
   three sport-specific create-league handlers (NCAA / NFL / MLB)
   into a shared base; wire-through of `MaxUsers` and
@@ -231,25 +259,26 @@ attacks become a concern.
 
 ### What does "bootstrap mode" actually mean?
 
-After the validator rejects past / wrong-year inputs, the
-handler's mode dispatch shrinks to two:
+> **Historical — superseded by PR-D.** This section described
+> PR-B's `Immediate` / `Future` dispatch, where the handler did
+> the SeasonWeek lookup and picked one of two paths. Live testing
+> showed `Future` mode (no-op) was wrong for near-future leagues
+> like "tomorrow-only" — the current SeasonWeek usually contains
+> tomorrow, so we should be eagerly populating matchups, not
+> deferring. The actual PR-D dispatch is documented in
+> `docs/league-creation-matrix.md` (rows 1–17). In short: the
+> orchestrator branches on *windowed vs full-season*, not on
+> *future vs now*, and resolves overlapping SeasonWeeks via the
+> new date-range endpoint.
+
+For posterity, the original PR-B dispatch was:
 
 | Mode | When | Action |
 | --- | --- | --- |
-| `Immediate` | `(StartsOn ?? -∞) <= now`. | Bootstrap *current week* (today's behavior, narrowed). |
-| `Future` | `StartsOn > now`. | **No-op.** Don't create any `PickemGroupWeek`. Daily scheduler will pick it up once `now >= StartsOn`. |
+| `Immediate` | `(StartsOn ?? -∞) <= now`. | Bootstrap *current week*. |
+| `Future` | `StartsOn > now`. | **No-op.** Daily scheduler picks it up once `now >= StartsOn`. |
 
-`Immediate` fires for:
-- Full-season leagues (`StartsOn` null).
-- Today-or-earlier-start leagues whose window still extends into
-  the future (the validator allows these; the half-played
-  single-day case fits here).
-- Leagues whose `StartsOn` was just-barely-future at validation
-  time but the event-handler clock has since rolled past.
-
-`Future` fires for leagues whose `StartsOn` is still strictly
-in the future at consume time. The daily scheduler picks them
-up when the calendar reaches `StartsOn`.
+The `Future` no-op is what PR-D removed.
 
 ### UI hardening (web + mobile)
 
@@ -393,13 +422,50 @@ Four PRs:
      restrictive in what it allows; safe regardless of server
      state).
 
-4. **PR-D: `MatchupScheduler` window gate.** Add the
-   `[StartsOn, EndsOn]` and `DeactivatedUtc` gates in the
-   scheduler so the daily run respects per-league windows.
-   Closes the second half of the motivating bug
-   (eager-bootstrap orphan was closed in PR-B). Scope-trimmed
-   from the original plan — handler base extraction and field
-   wiring split out to PR-E (below).
+4. **PR-D: Creation-time bootstrap redesign.** The big one.
+   Originally scoped to just the scheduler window/active gate;
+   expanded mid-flight after PR-B's `Future`-mode dispatch
+   proved wrong for near-future leagues (tomorrow-only) and the
+   underlying "current-week-only" model was shown to be wrong
+   by construction for any windowed league. Ships:
+   - New Producer endpoint
+     `GET /api/seasons/weeks/by-date-range?from=…&to=…` plus
+     query + handler + tests. Returns the SeasonWeeks whose
+     `[StartDate, EndDate]` overlaps the requested range,
+     ordered by `StartDate`. Inclusive on both bounds. Empty
+     result is a Success (row 11 — "no SeasonWeeks defined
+     yet"), `From > To` is a `BadRequest` Failure.
+   - New `IProvideSeasons.GetSeasonWeeksOverlapping(from, to)`
+     method on `SeasonClient`.
+   - New `BootstrapLeagueMatchupsProcessor` (Hangfire,
+     `IBootstrapLeagueMatchups`) — the orchestrator. Resolves
+     full-season vs windowed, calls the appropriate Producer
+     endpoint, fans out one `ScheduleGroupWeekMatchupsCommand`
+     per resolved SeasonWeek to the existing
+     `MatchupScheduleProcessor`. Caps partial windows
+     (`EndsOn = null` or `StartsOn = null`) at `now + 365d` per
+     DP-3 in the matrix doc.
+   - `PickemGroupCreatedHandler` slimmed to ~50 lines: group
+     existence check + single Hangfire enqueue. No more HTTP
+     calls, no more `PickemGroupWeek` writes. Stays as a
+     MassTransit-side fan-out point for future side-effects
+     (invitations, notifications, etc.) per the user's design
+     intent.
+   - `MatchupScheduleProcessor.AreMatchupsGenerated` rule fix:
+     `true` only when matchups were actually written; empty
+     filter results leave the flag `false` so the daily
+     `MatchupScheduler` re-fires. Required for the eager-bootstrap
+     path to work for NCAAFB+`RankingFilter` shells created
+     pre-poll (see "External inputs" appendix in the matrix doc).
+   - `PickemGroupWeekFactory.CreateForCurrentWeek` →
+     `Create`. Two call sites + tests. Cosmetic but worth doing
+     since the factory now creates rows for any SeasonWeek.
+   - `MatchupScheduler` window/active gate (the original PR-D
+     scope) stays as-is. Still useful as a fast-path filter on
+     the daily refresh job — handler-side eager bootstrap means
+     creation-time orphans no longer happen, but the gate keeps
+     the scheduler from doing pointless work on out-of-window
+     leagues.
 
 5. **PR-E (deferred): Handler base extraction + field wiring.**
    Collapse the three sport-specific create-league handlers into
@@ -408,9 +474,10 @@ Four PRs:
    Land whenever the refactor cost feels worth paying.
 
 Dependency graph: PR-A blocks PR-B (use the factory). PR-B and
-PR-C are independent. PR-D is independent of PR-B (could have
-landed in either order). PR-E builds on PR-B's handler shape.
-Shipped order: A → C parallel with B → D, E to follow.
+PR-C are independent. PR-D depends on PR-B (validator stays;
+exception split stays) but supersedes PR-B's `Future`-mode
+dispatch. PR-E builds on PR-D's slimmed handler shape. Shipped
+order: A → C parallel with B → D, E to follow.
 
 ---
 
@@ -483,13 +550,25 @@ becomes a one-shot manual cleanup; no recurring need.
 
 ## Validation
 
-For PR-B in particular, the bootstrap-mode dispatch is the
-behavioral change that has to be exercised. Test plan:
+Unit-test coverage shipped on this branch:
 
-- Unit tests on `PickemGroupCreatedHandler` covering each mode
-  (`Immediate` / `Future`), asserting whether `PickemGroupWeek`
-  was created and whether `ScheduleGroupWeekMatchupsCommand`
-  was enqueued. (PR-B `PickemGroupCreatedHandlerTests`.)
+- `BootstrapLeagueMatchupsProcessorTests` — 9 cases pinning the
+  full-season vs windowed dispatch, the date-range partial-window
+  cap, empty result handling, group-not-found permanence, and
+  transient endpoint failures. This is the load-bearing
+  behavioral test layer for PR-D.
+- `PickemGroupCreatedHandlerTests` — 2 cases for the slimmed
+  handler: existence-check + enqueue, group-not-found permanence.
+- `MatchupScheduleProcessorTests.Process_NoMatchupsAfterFilter_…`
+  — pins the `AreMatchupsGenerated` rule that makes the
+  eager-bootstrap refresh path work.
+- `MatchupSchedulerTests` — existing window/active gate tests
+  still pass (the gate stays as a fast-path filter).
+- `PickemGroupWeekFactoryTests` — existing 8 cases, renamed
+  after the `Create` rename.
+- `GetSeasonWeeksByDateRangeQueryHandlerTests` (Producer side) —
+  7 cases pinning overlap predicate, ordering, boundary
+  inclusion, empty result, and bad-input rejection.
 
 The detailed local E2E matrix below is the pre-merge regression
 checklist for **PR-D** specifically — every scenario exercises
@@ -547,56 +626,67 @@ curl -s http://localhost:5xxx/api/users/me \
 
 ### Scenario matrix
 
-| # | Scenario | Validator | Eager bootstrap | Daily scheduler |
+The PR-D redesign changed the eager-bootstrap behavior for windowed
+leagues. Rather than re-enumerate the design space here, see
+`docs/league-creation-matrix.md` for the full 17-row matrix
+(shell creation × matchup generation × external inputs). The
+local-E2E scenarios below are a representative subset:
+
+| # | Scenario | Validator | Bootstrap (handler → processor) | Daily scheduler |
 | --- | --- | --- | --- | --- |
-| 1 | Future-start single-day league | ✅ accepts | ⛔ no-op (Future) | ⛔ skip (gate) |
+| 1 | Future-start single-day league | ✅ accepts | ✅ shell + matchups for the future SeasonWeek that overlaps StartsOn | ⛔ skip (gate) until window opens |
 | 2 | Past-end league (admin/direct-API) | ⛔ reject | (n/a) | (n/a) |
-| 3 | Half-played single-day league | ✅ accepts | ✅ Immediate | ✅ in-window |
-| 4 | Full-season league (no window) | ✅ accepts | ✅ Immediate | ✅ in-window |
+| 3 | Half-played single-day league | ✅ accepts | ✅ shell + matchups for current SeasonWeek; processor filters to in-window contests | ✅ in-window |
+| 4 | Full-season league (no window) | ✅ accepts | ✅ shell + matchups for current SeasonWeek | ✅ advances weekly |
 | 5 | Closed-window league | (was valid at create) | (was valid at create) | ⛔ skip (gate) |
 | 6 | Deactivated league | (n/a) | (n/a) | ⛔ skip (gate) |
 | 7 | Web UI date picker | rejects past in browser | — | — |
 | 8 | Mobile UI date picker | rejects past in app | — | — |
-| 9 | Mixed-window batch | varies | varies | only in-window processed |
+| 9 | Mixed-window batch | varies | per-league orchestrator decides | only in-window processed |
+| 10 | NCAAFB + `RankingFilter` shell before AP poll | ✅ accepts | ✅ shell only; matchups deferred (filter result is empty) | retries daily until poll lands |
 
 ### Detailed scenarios
 
 #### Scenario 1 — Future-start single-day league (motivating bug)
 
 **Setup:** create an MLB league via the web UI with `StartsOn =
-today + 5 days, EndsOn = today + 5 days`.
+today + 5 days, EndsOn = today + 5 days`. (Same shape works for
+"tomorrow" — the load-bearing case the redesign was driven by.)
 
 **Verify at creation:**
 - API responds `201`.
-- `PickemGroupWeek` for this `GroupId` returns **zero rows**.
-- `/user/me` for the creator shows the league with
-  `seasonWeeks: []`.
-- Seq has a `LogInformation` line containing `"deferring
-  bootstrap to MatchupScheduler"` and the league id. (PR-B
-  `Future` mode.)
+- Seq has handler log line + `BootstrapLeagueMatchupsProcessor`
+  log line `"Bootstrap for group {GroupId} resolved 1 SeasonWeek(s)"`.
+- `PickemGroupWeek` for this `GroupId` returns **exactly one
+  row** — the SeasonWeek whose `[StartDate, EndDate]` contains
+  `today + 5 days` (typically same as the current MLB SeasonWeek
+  in-season, sometimes the next one if the window straddles a
+  Monday boundary).
+- `/user/me` for the creator shows the league with that one
+  week in `seasonWeeks`.
+
+**Verify shortly after creation:**
+- `PickemGroupMatchup` rows for that PickemGroupWeek match the
+  MLB schedule for the league window — i.e., the games on
+  `today + 5 days`. **Not** today's already-played games (the
+  processor's `[StartsOn, EndsOn]` filter drops those).
+- `AreMatchupsGenerated` is `true` for that week.
 
 **Trigger daily scheduler** (Hangfire dashboard → run
 `MatchupScheduler.ExecuteAsync`).
 
 **Verify after scheduler:**
-- Still **zero** `PickemGroupWeek` rows for this league. (PR-D
-  gate skipped the future-start league.)
-- Scheduler did NOT call `seasons/current-week` if this is the
-  only MLB league. (Log line: `Found 0 active sport(s)…`.)
-
-**Time-shift the league** (UPDATE `StartsOn` in Postgres to
-`now() - INTERVAL '1 hour'`).
-
-**Trigger scheduler again. Verify:**
-- One `PickemGroupWeek` row appears for this league for the
-  current `SeasonWeekId`. (Gate now passes; factory creates the
-  row.)
-- A `ScheduleGroupWeekMatchupsCommand` Hangfire job is enqueued.
+- No new `PickemGroupWeek` rows (the one created at bootstrap
+  is the only valid one until the league window arrives at
+  today; the gate skips out-of-window leagues, so the scheduler
+  is a no-op here).
 
 **What this proves:** the motivating bug is closed
-end-to-end — no orphan at creation (PR-B), no orphan on
-subsequent scheduler runs (PR-D), correct behavior when the
-window finally opens (factory + scheduler).
+end-to-end — bootstrap creates the **right** SeasonWeek shell
+at creation (PR-D orchestrator), matchups populate
+immediately because MLB schedules are sourced well in advance
+(PR-D `AreMatchupsGenerated` rule confirms the populated state),
+no orphan rows in `/user/me`.
 
 #### Scenario 2 — Past-end league rejected at validator
 
@@ -624,7 +714,9 @@ the date inputs — they should accept today.
 **Verify at creation:**
 - API responds `201`.
 - One `PickemGroupWeek` row for this league at the current
-  `SeasonWeekId`. (Eager bootstrap, `Immediate` mode.)
+  `SeasonWeekId`. (`BootstrapLeagueMatchupsProcessor` resolves
+  the window to one overlapping SeasonWeek and enqueues a
+  per-week `ScheduleGroupWeekMatchupsCommand`.)
 - `ScheduleGroupWeekMatchupsCommand` enqueued.
 
 **Verify after matchup generation completes:**
@@ -719,19 +811,64 @@ trust boundary mirroring the server validator.
 
 **Setup:** create three MLB leagues:
 - A: `StartsOn = today - 7, EndsOn = today + 7` (in-window).
-- B: `StartsOn = today + 10` (future).
+- B: `StartsOn = today + 10` (future-start).
 - C: same as A but `UPDATE … SET "DeactivatedUtc" = now()`.
 
-**Trigger scheduler. Verify:**
-- Exactly one `ScheduleGroupWeekMatchupsCommand` enqueued (for A).
-- B and C have **zero** new `PickemGroupWeek` rows.
-- Seq log line `Found 1 active sport(s) with in-window
-  leagues: BaseballMlb` (or similar — single sport with the
-  one in-window league).
+**At creation** (verify after each `POST`):
+- A and B both get **one or more** `PickemGroupWeek` rows from
+  the creation-time bootstrap (A's current SeasonWeek for A;
+  the SeasonWeek containing `today + 10` for B).
+- C gets the same as A (deactivation happens after creation).
 
-**What this proves:** the gate filters per-league, not
-per-sport — a single out-of-window league doesn't poison the
-sport's processing.
+**Trigger scheduler. Verify:**
+- Exactly one `ScheduleGroupWeekMatchupsCommand` enqueued
+  (for A, refreshing the current week).
+- B's bootstrap-created week stays untouched (gate skips B
+  because `StartsOn > now`).
+- C's bootstrap-created week stays untouched (gate skips C
+  because `DeactivatedUtc IS NOT NULL`).
+- Seq log line `Found 1 active sport(s) with in-window
+  leagues: BaseballMlb` (the per-sport discovery query also
+  applies the window gate).
+
+**What this proves:** creation-time bootstrap (PR-D
+orchestrator) handles all three leagues correctly; the daily
+scheduler's window/active gate filters per-league for the
+*refresh* path.
+
+#### Scenario 10 — NCAAFB + `RankingFilter` shell pre-poll
+
+**Setup:** create an NCAAFB league with `RankingFilter =
+AP_TOP_25` and `StartsOn = first Saturday of the 2026 season,
+EndsOn = same day`. Pick a date that's before the preseason AP
+poll release (typically mid-August).
+
+**Verify at creation:**
+- API responds `201`.
+- One `PickemGroupWeek` row exists for the SeasonWeek
+  containing the StartsOn date.
+- `AreMatchupsGenerated` is **`false`** for that row (the
+  processor ran, found schedule data for those games, but
+  no ranks were set on any matchup → filter result is empty
+  → flag stays `false` per the PR-D rule).
+- Zero `PickemGroupMatchup` rows.
+
+**Time-shift past the poll publication** (or manually source
+poll data via the existing Producer poll-source flow).
+
+**Trigger daily scheduler. Verify:**
+- The scheduler finds the shell, sees `AreMatchupsGenerated =
+  false`, enqueues `ScheduleGroupWeekMatchupsCommand`.
+- The processor re-runs, now with ranks populated → filter
+  result is non-empty → `PickemGroupMatchup` rows written →
+  `AreMatchupsGenerated` flips to `true`.
+
+**What this proves:** the eager-bootstrap path correctly defers
+matchup materialization for NCAAFB+rank-filter shells until the
+external input (AP poll) lands. The `AreMatchupsGenerated` rule
+is what makes this work — without it the empty pre-poll run
+would mark the shell "done" and the scheduler would never come
+back.
 
 ### Prod-data cleanup checkpoint
 

--- a/docs/league-creation-hardening.md
+++ b/docs/league-creation-hardening.md
@@ -487,16 +487,255 @@ For PR-B in particular, the bootstrap-mode dispatch is the
 behavioral change that has to be exercised. Test plan:
 
 - Unit tests on `PickemGroupCreatedHandler` covering each mode
-  (`Immediate` / `Future` / `Past` / `WrongYear`), asserting
-  whether `PickemGroupWeek` was created and whether
-  `ScheduleGroupWeekMatchupsCommand` was enqueued.
-- Local E2E: create an MLB league with `StartsOn = today + 10`,
-  confirm no `PickemGroupWeek` rows materialize. Re-run the
-  daily scheduler at `StartsOn + 1`, confirm a row appears.
-- Local E2E: create an MLB league with `StartsOn = today`,
-  confirm the current-week row appears and matchups populate
-  (current happy-path regression check).
+  (`Immediate` / `Future`), asserting whether `PickemGroupWeek`
+  was created and whether `ScheduleGroupWeekMatchupsCommand`
+  was enqueued. (PR-B `PickemGroupCreatedHandlerTests`.)
 
-For PR-D, the scheduler window gate: spin up two leagues — one
-future-start, one current — let the scheduler run, confirm only
-the current-start league gets a new `PickemGroupWeek` row.
+The detailed local E2E matrix below is the pre-merge regression
+checklist for **PR-D** specifically — every scenario exercises
+some combination of the four shipped PRs to confirm the
+motivating bug is fully closed end-to-end.
+
+---
+
+## Local E2E test cases
+
+Pre-merge regression matrix for PR-D. Each scenario exercises
+the validator (PR-B), the eager-bootstrap dispatch (PR-B), the
+factory (PR-A), the UI guards (PR-C), the scheduler gate (PR-D),
+or some combination. Run them with a local stack:
+
+### Setup checklist
+
+- API, Producer, Provider, RabbitMQ, Postgres running locally
+  (docker-compose or k8s — whatever your local convention is).
+- Logged-in admin user (MLB league creation is admin-gated; see
+  `LeagueCreatePage` / `create-league.tsx`).
+- MLB current-week data sourced so `GetCurrentSeasonWeek`
+  returns a real `CanonicalSeasonWeekDto`. Out-of-season MLB
+  collapses several scenarios — confirm `seasons/current-week`
+  on Producer returns 200 first.
+- A Hangfire dashboard reachable for manually triggering
+  `MatchupScheduler.ExecuteAsync` (don't wait for the cron).
+
+### Verification queries
+
+Keep these handy in a SQL session against the local Postgres:
+
+```sql
+-- Latest leagues plus their windows
+SELECT "Id", "Name", "Sport", "StartsOn", "EndsOn",
+       "DeactivatedUtc", "CreatedUtc"
+FROM "PickemGroup"
+ORDER BY "CreatedUtc" DESC
+LIMIT 10;
+
+-- PickemGroupWeek rows for a given league
+SELECT pgw."Id", pgw."SeasonYear", pgw."SeasonWeek",
+       pgw."SeasonWeekId", pgw."AreMatchupsGenerated",
+       pgw."IsNonStandardWeek",
+       (SELECT COUNT(*) FROM "PickemGroupMatchup" pgm
+        WHERE pgm."GroupId" = pgw."GroupId"
+          AND pgm."SeasonWeekId" = pgw."SeasonWeekId") AS matchup_count
+FROM "PickemGroupWeek" pgw
+WHERE pgw."GroupId" = '<league-id>';
+
+-- /user/me payload for a logged-in user (substitute auth)
+curl -s http://localhost:5xxx/api/users/me \
+     -H "Authorization: Bearer <token>" | jq '.leagues'
+```
+
+### Scenario matrix
+
+| # | Scenario | Validator | Eager bootstrap | Daily scheduler |
+| --- | --- | --- | --- | --- |
+| 1 | Future-start single-day league | ✅ accepts | ⛔ no-op (Future) | ⛔ skip (gate) |
+| 2 | Past-end league (admin/direct-API) | ⛔ reject | (n/a) | (n/a) |
+| 3 | Half-played single-day league | ✅ accepts | ✅ Immediate | ✅ in-window |
+| 4 | Full-season league (no window) | ✅ accepts | ✅ Immediate | ✅ in-window |
+| 5 | Closed-window league | (was valid at create) | (was valid at create) | ⛔ skip (gate) |
+| 6 | Deactivated league | (n/a) | (n/a) | ⛔ skip (gate) |
+| 7 | Web UI date picker | rejects past in browser | — | — |
+| 8 | Mobile UI date picker | rejects past in app | — | — |
+| 9 | Mixed-window batch | varies | varies | only in-window processed |
+
+### Detailed scenarios
+
+#### Scenario 1 — Future-start single-day league (motivating bug)
+
+**Setup:** create an MLB league via the web UI with `StartsOn =
+today + 5 days, EndsOn = today + 5 days`.
+
+**Verify at creation:**
+- API responds `201`.
+- `PickemGroupWeek` for this `GroupId` returns **zero rows**.
+- `/user/me` for the creator shows the league with
+  `seasonWeeks: []`.
+- Seq has a `LogInformation` line containing `"deferring
+  bootstrap to MatchupScheduler"` and the league id. (PR-B
+  `Future` mode.)
+
+**Trigger daily scheduler** (Hangfire dashboard → run
+`MatchupScheduler.ExecuteAsync`).
+
+**Verify after scheduler:**
+- Still **zero** `PickemGroupWeek` rows for this league. (PR-D
+  gate skipped the future-start league.)
+- Scheduler did NOT call `seasons/current-week` if this is the
+  only MLB league. (Log line: `Found 0 active sport(s)…`.)
+
+**Time-shift the league** (UPDATE `StartsOn` in Postgres to
+`now() - INTERVAL '1 hour'`).
+
+**Trigger scheduler again. Verify:**
+- One `PickemGroupWeek` row appears for this league for the
+  current `SeasonWeekId`. (Gate now passes; factory creates the
+  row.)
+- A `ScheduleGroupWeekMatchupsCommand` Hangfire job is enqueued.
+
+**What this proves:** the motivating bug is closed
+end-to-end — no orphan at creation (PR-B), no orphan on
+subsequent scheduler runs (PR-D), correct behavior when the
+window finally opens (factory + scheduler).
+
+#### Scenario 2 — Past-end league rejected at validator
+
+**Setup:** craft a direct-API POST to
+`/api/leagues/baseball-mlb` (admin token) with `StartsOn =
+yesterday, EndsOn = yesterday`. The UI won't construct this —
+PR-C's `min={today}` blocks it — so use `curl` / Postman to
+bypass.
+
+**Verify:**
+- API responds `400` with `ResultStatus.Validation`.
+- Error payload contains a `EndsOn` violation with message
+  `"EndsOn can't be in the past."` (PR-B validator rule.)
+- No `PickemGroup` row created.
+
+**What this proves:** the server-side trust boundary holds even
+when the UI guards are bypassed.
+
+#### Scenario 3 — Half-played single-day league
+
+**Setup:** create an MLB league via the UI with `StartsOn =
+today (some hours ago)` and `EndsOn = today (end of day)`. Use
+the date inputs — they should accept today.
+
+**Verify at creation:**
+- API responds `201`.
+- One `PickemGroupWeek` row for this league at the current
+  `SeasonWeekId`. (Eager bootstrap, `Immediate` mode.)
+- `ScheduleGroupWeekMatchupsCommand` enqueued.
+
+**Verify after matchup generation completes:**
+- `PickemGroupMatchup` rows exist only for contests with
+  `StartDateUtc` between `StartsOn` and `EndsOn` (i.e., today's
+  games). Morning games already played should still be present
+  (locked picks) — afternoon games still pickable.
+- `/user/me` shows the league with `seasonWeeks` containing the
+  current week number.
+
+**What this proves:** the validator allows mid-day windows
+(the explicit "half-played single-day" carve-out from PR-B),
+and the existing matchup processor's window filter handles
+per-game pickability correctly.
+
+#### Scenario 4 — Full-season league (no window)
+
+**Setup:** create an MLB league via the UI with **Full Season**
+selected (the duration mode that leaves `StartsOn` /
+`EndsOn` null).
+
+**Verify:**
+- One `PickemGroupWeek` row for the current `SeasonWeekId`.
+- Matchups populated.
+- Scheduler picks the league up on subsequent runs and creates
+  rows for newly-current weeks as the season progresses.
+
+**What this proves:** the gate's `StartsOn == null || EndsOn ==
+null` short-circuits do the right thing — full-season leagues
+still flow through the existing happy path.
+
+#### Scenario 5 — Closed-window league + scheduler skip
+
+**Setup:** take a league from Scenario 3 or 4 (or create a
+fresh one) and `UPDATE "PickemGroup" SET "EndsOn" = now() -
+INTERVAL '1 day' WHERE "Id" = '<league-id>'` to simulate the
+window closing.
+
+**Trigger scheduler. Verify:**
+- No new `PickemGroupWeek` rows added.
+- Scheduler did NOT enqueue a `ScheduleGroupWeekMatchupsCommand`
+  for this league.
+- Already-existing `PickemGroupWeek` rows from the in-window
+  period stay intact (the gate prevents *new* rows, doesn't
+  delete old ones).
+
+**What this proves:** PR-D's closed-window branch of the gate.
+
+#### Scenario 6 — Deactivated league + scheduler skip
+
+**Setup:** set an in-window league's `DeactivatedUtc` to
+`now()`.
+
+**Trigger scheduler. Verify:**
+- No new `PickemGroupWeek` rows added.
+- No matchup enqueue for this league.
+
+**What this proves:** PR-D's `DeactivatedUtc` filter.
+
+#### Scenario 7 — Web UI date picker guards
+
+**Setup:** open the web app's Create League page in a browser.
+
+**Verify:**
+- The Start Date `<input type="date">` rejects yesterday in the
+  native picker (`min` attribute).
+- The End Date input rejects dates earlier than either today or
+  the chosen Start Date, whichever is later.
+- In DevTools, override the start input's value to
+  `2020-01-01` programmatically and click submit → an alert
+  fires *before* the confirmation dialog opens (`handleFormSubmit`
+  guard).
+
+**What this proves:** PR-C's web guards.
+
+#### Scenario 8 — Mobile UI date picker guards
+
+**Setup:** open the mobile app's Create League screen.
+
+**Verify:**
+- Both date pickers grey out days before today (`minimumDate`).
+- If you set Start to a future date and then move it back, the
+  End picker's floor follows (`max(startsOn, today)`).
+- Attempting to submit with a manipulated state that yields
+  `endsOn < today` surfaces the Zod `superRefine` error
+  `"End date can't be in the past"`.
+
+**What this proves:** PR-C's mobile guards + the Zod-level
+trust boundary mirroring the server validator.
+
+#### Scenario 9 — Mixed-window batch through scheduler
+
+**Setup:** create three MLB leagues:
+- A: `StartsOn = today - 7, EndsOn = today + 7` (in-window).
+- B: `StartsOn = today + 10` (future).
+- C: same as A but `UPDATE … SET "DeactivatedUtc" = now()`.
+
+**Trigger scheduler. Verify:**
+- Exactly one `ScheduleGroupWeekMatchupsCommand` enqueued (for A).
+- B and C have **zero** new `PickemGroupWeek` rows.
+- Seq log line `Found 1 active sport(s) with in-window
+  leagues: BaseballMlb` (or similar — single sport with the
+  one in-window league).
+
+**What this proves:** the gate filters per-league, not
+per-sport — a single out-of-window league doesn't poison the
+sport's processing.
+
+### Prod-data cleanup checkpoint
+
+After PR-D merges and is deployed, the existing orphan
+`PickemGroupWeek` rows already in prod still need the manual
+SQL cleanup documented in *Prod data remediation* above. The
+gate prevents new orphans but doesn't reach back.

--- a/docs/league-creation-hardening.md
+++ b/docs/league-creation-hardening.md
@@ -16,22 +16,30 @@ one created days later by `MatchupScheduler` once the current
 both show up in the league's ascending week list. The PicksPage UI
 defaults to the first week → zero matchups → reads as broken.
 
-**Status:** drafted 2026-05-28. Partially executed — three of four
-PRs:
+**Status:** drafted 2026-05-28. Motivating bug fixed; hygiene
+deferred to a follow-up:
 
 - **PR-A** (factory extraction) — **merged** in #372.
 - **PR-C** (UI date-picker guards on web + mobile) — **merged** in
   #373. Note: originally listed third in the plan; reordered to
   ship in parallel with PR-A since it's independent of all
   backend work.
-- **PR-B** (server validator + bootstrap-mode dispatch) — **in
-  flight** as the PR that introduces this doc.
-- **PR-D** (`MatchupScheduler` window gate + handler base
-  extraction) — **not started**. The motivating bug (single-day
-  leagues producing two `PickemGroupWeek` rows in `/user/me`) is
-  only fully closed once PR-D lands; PR-B alone removes the
-  eager-bootstrap orphan but leaves the daily-scheduler orphan
-  intact.
+- **PR-B** (server validator + bootstrap-mode dispatch) — **merged**
+  in #375.
+- **PR-D** (`MatchupScheduler` window gate) — **in flight** as the
+  PR landing the scheduler-side daily-orphan fix. Scope reduced
+  vs. the original plan: just the window/active gate, no handler
+  base extraction or `MaxUsers` / `NonStandardWeekGroupSeasonMapFilter`
+  wiring. Those land in a follow-up (`PR-E`) — they're hygiene,
+  not motivating-bug closure. With PR-D's gate in place the
+  motivating bug is fully fixed: no orphan at creation (PR-B),
+  no orphan on subsequent scheduler runs (PR-D).
+- **PR-E** (deferred) — handler base extraction collapsing the
+  three sport-specific create-league handlers (NCAA / NFL / MLB)
+  into a shared base; wire-through of `MaxUsers` and
+  `NonStandardWeekGroupSeasonMapFilter` request fields. No
+  behavior change to in-flight bug, so safe to land whenever the
+  refactor cost feels worth paying.
 
 Backfill is explicitly deferred (see *Out of scope*).
 
@@ -385,15 +393,24 @@ Four PRs:
      restrictive in what it allows; safe regardless of server
      state).
 
-4. **PR-D: `MatchupScheduler` window gate + handler base
-   extraction.** Add the `[StartsOn, EndsOn]` and `DeactivatedUtc`
-   gates in the scheduler. Collapse the three sport-specific
-   create-league handlers into a shared base. Wire `MaxUsers` /
-   `NonStandardWeekGroupSeasonMapFilter` through.
+4. **PR-D: `MatchupScheduler` window gate.** Add the
+   `[StartsOn, EndsOn]` and `DeactivatedUtc` gates in the
+   scheduler so the daily run respects per-league windows.
+   Closes the second half of the motivating bug
+   (eager-bootstrap orphan was closed in PR-B). Scope-trimmed
+   from the original plan — handler base extraction and field
+   wiring split out to PR-E (below).
 
-Dependency graph: PR-A blocks PR-B and PR-D (both use the
-factory). PR-B and PR-C are independent. PR-D depends only on
-PR-A. Sensible order: A → C in parallel with B → D.
+5. **PR-E (deferred): Handler base extraction + field wiring.**
+   Collapse the three sport-specific create-league handlers into
+   a shared base. Wire `MaxUsers` / `NonStandardWeekGroupSeasonMapFilter`
+   through the request DTOs. Pure hygiene; no behavior change.
+   Land whenever the refactor cost feels worth paying.
+
+Dependency graph: PR-A blocks PR-B (use the factory). PR-B and
+PR-C are independent. PR-D is independent of PR-B (could have
+landed in either order). PR-E builds on PR-B's handler shape.
+Shipped order: A → C parallel with B → D, E to follow.
 
 ---
 
@@ -424,7 +441,7 @@ PR-A. Sensible order: A → C in parallel with B → D.
   architectural call and orthogonal to this cleanup.
 
 - **NCAA / NFL handler equivalents.** Same code shape, same
-  holes. PR-D's base extraction fixes all three at once. Don't
+  holes. PR-E's base extraction fixes all three at once. Don't
   fix NCAA/NFL in isolation.
 
 ---

--- a/docs/league-creation-matrix.md
+++ b/docs/league-creation-matrix.md
@@ -139,32 +139,49 @@ runs. Not required for correctness; defer to PR-E or later.
 
 ---
 
-## UX: shell-without-matchups placeholder
+## UX: shell-without-matchups placeholder (proposed follow-up)
 
-A `PickemGroupWeek` row that exists but has zero
-`PickemGroupMatchup` rows needs UI treatment. Today's `MatchupList`
-(web) and FlatList (mobile) just render nothing for the empty case
-— the user sees the week in the selector but a blank body.
+> **Status:** not part of PR-D. PR-D ships backend only — no UI
+> changes. This section is a sketch of the UX direction we'd want
+> *if* and when we wire a placeholder for the shell-without-matchups
+> state. Pinned here so the design space is captured alongside the
+> backend behavior that creates it.
 
-Chosen behavior (option c from prior discussion): show **"Week N
-picks available on X"** placeholder copy. Date is sport+week
-specific:
-- NCAAFB+TOP25 preseason: AP poll drops ~mid-August. Use the
-  expected poll release date if known.
-- NCAAFB+TOP25 in-season: Sunday afternoon after games close.
-- Other sports: never hit this state today.
+**The state in question:** a `PickemGroupWeek` row that exists but
+has zero `PickemGroupMatchup` rows. Today's UI surfaces this as a
+blank body — `MatchupList.jsx` (web) maps `matchups` after loading
+and has no empty-state branch of its own; `picks.tsx` (mobile)
+renders a `ListEmptyComponent` with title `"No games this week"`.
 
-**Implementation:**
-- Web: `MatchupList.jsx` — if `matchups.length === 0` and the week
-  is in the future, render a placeholder card with the copy.
-- Mobile: same shape in the picks tab FlatList's `ListEmptyComponent`
-  or a per-week pre-list check.
-- API: `/user/me` should already expose enough — the week shell
-  exists in `seasonWeeks`; client decides placeholder based on
-  matchup count + sport.
+**Direction (option c from the discussion):** show a placeholder
+indicating *when* picks for that week will become available,
+rather than the current "no games" framing. The exact copy and
+date-source is a UX call that hasn't been made — the discussion
+mentioned strings like *"Week N picks available on X"* as a
+sketch, not a decision.
 
-Specifics are out of scope for PR-D's *backend* but listed here as
-a "what this means for the UI" follow-up to track.
+**Trigger conditions** (still under-specified):
+- NCAAFB + `RankingFilter`, preseason: AP poll release date if
+  known.
+- NCAAFB + `RankingFilter`, in-season: Sunday afternoon after the
+  prior week's games close.
+- Other sports / non-rank-filter leagues: don't hit this state
+  today and may not need the placeholder at all.
+
+**Implementation sketch** (when it's wired):
+- Web: add an empty-state branch in `MatchupList.jsx` keyed on
+  `matchups.length === 0` plus a future-week check.
+- Mobile: replace the `"No games this week"` title in the picks
+  tab's `ListEmptyComponent` with the placeholder copy when the
+  same conditions hold.
+- API: `/user/me` already exposes the week shell via
+  `seasonWeeks` — client decides placeholder based on matchup
+  count + sport.
+
+Bullets above are starting points, not committed copy. A real
+follow-up PR would resolve the exact wording, the date-source for
+"available on X" (poll-publication date isn't in the API contract
+today), and whether to extend this to non-NCAAFB use cases.
 
 ---
 

--- a/docs/league-creation-matrix.md
+++ b/docs/league-creation-matrix.md
@@ -1,0 +1,322 @@
+# League Creation Possibility Matrix (2026-05-29)
+
+Pre-implementation review doc for the PR-D redesign — the
+conversation reveal that the "always look up current SeasonWeek and
+filter" model is wrong by construction for windowed leagues, then
+further refined by recognizing that NFL/NCAAFB/MLB schedules are
+published *months* in advance, so the question isn't "is the date far
+future" but "do we have the inputs the processor needs."
+
+Working alongside `docs/league-creation-hardening.md` (the parent
+plan). This doc is the design-space enumeration that drives the
+PR-D code.
+
+---
+
+## Dimensions
+
+- **Window shape**: `(StartsOn, EndsOn)` — neither / either / both.
+- **Relative to "now"**: past, straddles, near-future (within current
+  SeasonWeek), far-future (next SeasonWeek+), very-far-future
+  (no SeasonWeek defined yet, e.g., next-year leagues).
+- **Span**: zero-day, single-day, multi-day same week, multi-day
+  cross-week, multi-week.
+- **External inputs** (see appendix): SeasonWeek availability,
+  schedule availability, AP poll availability.
+
+**Already gated by PR-B validator** (merged):
+
+- `EffectiveEndsOn <= now` → rejected. No past-only windows.
+- `StartsOn >= EffectiveEndsOn` → rejected. No zero-width windows.
+
+Marked ⛔ in the table.
+
+---
+
+## Matrix
+
+Two outputs per row now — the **shell** (`PickemGroupWeek` row) and
+the **matchups** (`PickemGroupMatchup` rows). They have different
+gates: shells need only the SeasonWeek; matchups additionally need
+schedule data and, for NCAAFB+RankingFilter, an AP poll.
+
+| # | Description | Lookup | Shell at create | Matchups at create | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Full-season, in-season | `GetCurrentSeasonWeek` | ✅ current week | ✅ (or 🟡 if NCAAFB+TOP25 and current week's poll not yet published — unlikely once in-season) | The original "happy path" the legacy code was built for. Scheduler advances weekly. |
+| 2 | Full-season, between weeks (sport idle hours) | `GetCurrentSeasonWeek` | ✅ if a week is current | ✅ | Transient `null` from the endpoint → throw + retry (PR-B behavior). |
+| 3 | Full-season, off-season | `GetCurrentSeasonWeek` | ❌ defer | ❌ defer | `null` is permanent here; DLQ via retry policy. Commissioner re-creates when season starts. |
+| 4 | Partial window, `StartsOn=null`, `EndsOn=future` | date-range or current | ✅ all weeks `[now, EndsOn]` | ✅ where inputs available; 🟡 elsewhere | Bootstrap current + future shells through EndsOn. Scheduler advances weekly within window. |
+| 5 | Partial window, `StartsOn=past`, `EndsOn=null` | date-range or current | ✅ current week | ✅ where inputs available | Already in-window; behaves like row 1 after creation. |
+| 6 | Partial window, `StartsOn=future`, `EndsOn=null` | date-range | ✅ all weeks `[StartsOn, cap]` | ✅ where inputs available; 🟡 elsewhere | Caps at `StartsOn + 1 year` (DP-3). |
+| 7 | Windowed, "now" inside `[StartsOn, EndsOn]` | date-range | ✅ all overlapping weeks | ✅ where inputs available | Mid-window leagues. |
+| 8 | Windowed single-day, tomorrow | date-range | ✅ 1 week (current SeasonWeek) | ✅ schedule known; 🟡 if NCAAFB+TOP25 and poll for current week somehow not yet up | **Motivating bug**. Tomorrow is inside the current SeasonWeek. |
+| 9 | Windowed single-day, next Tuesday | date-range | ✅ 1 week (next SeasonWeek) | ✅ schedule known; 🟡 if NCAAFB+TOP25 and poll for that week not yet published | Current code would have created the wrong week. |
+| 10 | Windowed single-day, next month | date-range | ✅ 1 week (the future SeasonWeek) | ✅ schedule known; 🟡 if NCAAFB+TOP25 and poll for that week not yet published | Same shape, further out. |
+| 11 | Windowed single-day, far enough out that the SeasonWeek isn't in the DB yet (next-year league) | date-range | ❌ defer (empty result) | ❌ defer | Only true "defer" case. Scheduler will pick up once the SeasonWeek is sourced. |
+| 12 | Windowed multi-day, spans 2 SeasonWeeks | date-range | ✅ 2 shells | ✅ where inputs available per week; 🟡 elsewhere | One enqueued `ScheduleGroupWeekMatchupsCommand` per week. |
+| 13 | Windowed multi-week, spans N SeasonWeeks | date-range | ✅ N shells | ✅ where inputs available per week; 🟡 elsewhere | Scales linearly. Realistic multi-week NCAAFB+TOP25 windows would have early weeks waiting on per-week polls. |
+| 14 | Windowed half-played (today morning → today EoD) | date-range or current | ✅ 1 week | ✅ schedule known | Carve-out from PR-B docs; existing pick-lock handles played games. |
+| 15 | Windowed past-end (EndsOn < now) | (n/a) | ⛔ | ⛔ | Validator blocks. |
+| 16 | Windowed zero-width (StartsOn = EndsOn instant) | (n/a) | ⛔ | ⛔ | Validator blocks. |
+| 17 | Week-range mode | (n/a) | ⛔ | ⛔ | Dead UI; `finalizeLeagueCreation` short-circuits. Not part of this PR. |
+
+**Legend**: ✅ produce immediately • ❌ skip / defer • 🟡 shell only, matchups deferred until input lands (existing scheduler refresh path picks them up)
+
+---
+
+## Source-of-truth choice
+
+Once we accept "shell whenever the SeasonWeek exists," every row
+collapses to one of:
+
+- **Current week only** → rows 1, 2, 14 (and degenerate row 8). Uses
+  `GetCurrentSeasonWeek`.
+- **Date range** → rows 4, 5, 6, 7, 8, 9, 10, 11, 12, 13. Uses the
+  new `GetSeasonWeeksOverlapping(from, to)` endpoint.
+
+Cleanest dispatch: **windowed (either bound set) → date-range;
+otherwise (both null) → current week.**
+
+---
+
+## External inputs and their gating
+
+A shell needs:
+
+- **The `SeasonWeek` row exists in canonical DB.** True for the
+  current season year as soon as ESPN's season calendar is sourced.
+  False for next-year leagues (row 11).
+
+Matchups additionally need:
+
+- **Schedule data for the SeasonWeek.** Sourced from ESPN as soon as
+  the league publishes its schedule:
+  - NFL: schedule released mid-May.
+  - NCAAFB: schedule mostly set by Feb–March.
+  - MLB: full season released in late September of the prior year.
+  - So in practice: **if the SeasonWeek exists, schedule data
+    exists too.**
+- **AP poll for that SeasonWeek** (only NCAAFB + `RankingFilter`).
+  Polls release Sunday afternoons in-season; preseason AP poll
+  drops ~mid-August. Outside those windows the filter has nothing
+  to apply against.
+
+This is what makes 🟡 in the matrix: shell-yes, matchups-deferred
+because the poll the rank filter depends on hasn't dropped yet.
+
+---
+
+## Processor change: `AreMatchupsGenerated` rule
+
+Today the processor unconditionally sets
+`groupWeek.AreMatchupsGenerated = true` even when zero matchups
+survived the filter. For the legacy Sunday-cron flow that was fine —
+the cron only ever ran *after* the AP poll dropped, so empty results
+meant "legitimately no qualifying games" and marking them generated
+was correct.
+
+For eager bootstrap pre-poll that rule is wrong: a Week-1 shell
+created in May would get matchup-gen run against it once
+(scheduler's first daily pass), the poll wouldn't be out yet, zero
+matchups would result, and the shell would be marked "generated and
+done." It would never be reconsidered, even after the August poll
+drops.
+
+**New rule:** mark `AreMatchupsGenerated = true` **only when
+`groupMatchups.Count > 0`.** Empty result → leave `false` so the
+scheduler re-fires matchup generation on the next daily pass.
+
+**Cost:** for a true-empty week (rare bye-week situation in a
+full-season league) the scheduler will re-enqueue daily until the
+week is no longer current. Each re-enqueue is a contest-client call
++ filter + 0-write SaveChanges. Small. Acceptable.
+
+**Optimization (deferred):** a short-circuit at the top of the
+processor that checks "does an AP poll exist for this (sport,
+year, week)?" via a Poll table query and bails fast when it
+doesn't. Saves the contest-client roundtrip on doomed-pre-poll
+runs. Not required for correctness; defer to PR-E or later.
+
+---
+
+## UX: shell-without-matchups placeholder
+
+A `PickemGroupWeek` row that exists but has zero
+`PickemGroupMatchup` rows needs UI treatment. Today's `MatchupList`
+(web) and FlatList (mobile) just render nothing for the empty case
+— the user sees the week in the selector but a blank body.
+
+Chosen behavior (option c from prior discussion): show **"Week N
+picks available on X"** placeholder copy. Date is sport+week
+specific:
+- NCAAFB+TOP25 preseason: AP poll drops ~mid-August. Use the
+  expected poll release date if known.
+- NCAAFB+TOP25 in-season: Sunday afternoon after games close.
+- Other sports: never hit this state today.
+
+**Implementation:**
+- Web: `MatchupList.jsx` — if `matchups.length === 0` and the week
+  is in the future, render a placeholder card with the copy.
+- Mobile: same shape in the picks tab FlatList's `ListEmptyComponent`
+  or a per-week pre-list check.
+- API: `/user/me` should already expose enough — the week shell
+  exists in `seasonWeeks`; client decides placeholder based on
+  matchup count + sport.
+
+Specifics are out of scope for PR-D's *backend* but listed here as
+a "what this means for the UI" follow-up to track.
+
+---
+
+## Decision points
+
+Decisions to lock in before code. Each is annotated with my lean
+and the tradeoff.
+
+### DP-1 — Always use date-range when any window value is set?
+
+Rows 4/5/8/14 could technically use `GetCurrentSeasonWeek` (cheaper
+single call) but unifying around "windowed → date-range; full-season
+→ current" is tidier.
+
+- **Lean:** yes, always date-range for windowed.
+
+### DP-2 — Row 11 empty result (no SeasonWeek in DB)
+
+Empty result from the date-range endpoint → log + return; scheduler
+catches up when the SeasonWeek lands.
+
+- **Lean:** yes, treat empty as deferred.
+
+### DP-3 — Partial window with `EndsOn = null` upper bound
+
+If `StartsOn = future date` and `EndsOn = null`, we need a `to`
+bound. Cap at `now + 365d` on the API side as a defensive bound.
+
+- **Lean:** yes, 365-day cap.
+
+### DP-4 — Multi-week bootstrap fan-out
+
+At creation time, enqueue N matchup-schedule jobs (one per
+overlapping SeasonWeek) rather than batching.
+
+- **Lean:** N independent jobs (existing command shape, Hangfire
+  handles concurrency).
+
+### DP-5 — Full-season lookahead
+
+Should the full-season handler eagerly bootstrap the next week (or
+two) so picks are visible early?
+
+- **Lean:** no. Current only; scheduler advances weekly. Adding
+  lookahead is scope creep.
+
+---
+
+## Operational considerations
+
+### Idempotency / outbox replay
+
+`PickemGroupCreated` is at-least-once. The handler must be safe
+to re-fire. Today's "find existing PickemGroupWeek by SeasonWeekId,
+else create" covers single-week. Multi-week version applies the
+same per-week check. The composite PK `(GroupId, SeasonWeekId)`
+enforces DB-layer dedup.
+
+The matchup-schedule command is gated by
+`!groupWeek.AreMatchupsGenerated` — a replay finds the shell, sees
+the flag, and skips re-enqueue. With the new "only mark-generated
+when populated" rule, a replay that hits an empty week would
+re-enqueue, which is fine (processor produces same result).
+
+### Partial-bootstrap failure
+
+When N matchup-schedule jobs are enqueued (rows 12, 13), one can
+fail. Hangfire retry handles per-job; the league lands in a
+half-populated state during retry. Acceptable.
+
+### Multi-week UX on day one
+
+A 4-week windowed league created today shows 4 entries in
+`/user/me`'s `seasonWeeks` immediately. PicksPage / picks tab
+default to "latest" week (`seasonWeeks[seasonWeeks.length - 1]`).
+For a far-future league the user would land on the *furthest*
+week and see the "picks available on X" placeholder. Probably
+OK — the default-to-latest matches what they'd want once games
+are happening, even if it's a placeholder on day one. **Worth
+calling out** in case you'd rather change the default to
+"current SeasonWeek if in window, else earliest."
+
+---
+
+## Open question — factory rename
+
+`PickemGroupWeekFactory.CreateForCurrentWeek(group, week)` was
+named when the only call site was the eager-bootstrap-of-current
+path. After the redesign it creates a `PickemGroupWeek` for *any*
+`CanonicalSeasonWeekDto`. Rename to
+`PickemGroupWeekFactory.Create(group, week)`? Touches two call
+sites + factory tests. Cosmetic but worth doing while in the file.
+
+- **Lean:** yes, rename.
+
+---
+
+## What this changes (implementation outline, post-decisions)
+
+**Producer (new endpoint):**
+- `GET /api/seasons/weeks/by-date-range?from={iso}&to={iso}`
+- `GetSeasonWeeksByDateRangeQuery` + handler
+- SQL overlap predicate: `sw.StartDate <= @to AND sw.EndDate >= @from`,
+  ordered by `StartDate`.
+- Registered alongside existing season query handlers.
+
+**Core (`SeasonClient`):**
+- New `Task<Result<List<CanonicalSeasonWeekDto>>>
+       GetSeasonWeeksOverlapping(DateTime from, DateTime to,
+                                  CancellationToken ct = default)`
+- Routed via the existing sport-resolved factory.
+
+**API (`PickemGroupCreatedHandler`):**
+- Branch: any window set → date-range path; otherwise → current-week.
+- Date-range path: compute `from = StartsOn ?? now`, `to = EndsOn ??
+  StartsOn + 365d`, query, get N SeasonWeeks, per week
+  factory-create the shell + enqueue
+  `ScheduleGroupWeekMatchupsCommand`.
+- Empty result → log + return (row 11).
+- Endpoint failure → throw transient.
+- Idempotent against replay (composite PK + AreMatchupsGenerated
+  gate).
+
+**API (`MatchupScheduleProcessor`):**
+- One-line rule change: `groupWeek.AreMatchupsGenerated = true`
+  becomes `groupWeek.AreMatchupsGenerated = groupMatchups.Count > 0;`.
+- (Optional / deferred) early-out when AP poll for this week
+  doesn't exist yet — query `Poll` table, log + return.
+
+**API (`MatchupScheduler`):** unchanged. Existing "find current
+week shell, enqueue if !AreMatchupsGenerated" logic already
+implements the refresh path the eager-bootstrap needs.
+
+**Factory:** rename `CreateForCurrentWeek` → `Create`. Two call
+sites + tests.
+
+**UI (web + mobile, separate task):** placeholder copy for
+shell-without-matchups state. Out of scope for PR-D backend but
+listed for tracking.
+
+**Tests:**
+- New Producer handler tests for the date-range query (overlap
+  predicate, ordering, empty result).
+- Rewritten API handler tests covering rows 1 (full-season), 7
+  (mid-window), 9 (next-week single-day), 11 (no SeasonWeek), 12
+  (multi-week).
+- Processor: new test for the `AreMatchupsGenerated` rule (empty
+  result → flag stays false).
+- Existing scheduler tests still pass.
+
+**Doc updates:**
+- `docs/league-creation-hardening.md` PR-D plan section updated to
+  reflect the redesign actually shipping.
+- This matrix becomes a permanent reference (not deleted
+  post-merge) so future readers see the decision space.

--- a/docs/league-creation-matrix.md
+++ b/docs/league-creation-matrix.md
@@ -295,15 +295,36 @@ sites + factory tests. Cosmetic but worth doing while in the file.
 - Routed via the existing sport-resolved factory.
 
 **API (`PickemGroupCreatedHandler`):**
-- Branch: any window set → date-range path; otherwise → current-week.
-- Date-range path: compute `from = StartsOn ?? now`, `to = EndsOn ??
-  StartsOn + 365d`, query, get N SeasonWeeks, per week
-  factory-create the shell + enqueue
-  `ScheduleGroupWeekMatchupsCommand`.
-- Empty result → log + return (row 11).
-- Endpoint failure → throw transient.
-- Idempotent against replay (composite PK + AreMatchupsGenerated
-  gate).
+- Slim MassTransit consumer. Performs a single existence check on
+  the `PickemGroup` (permanent log + return if missing) and
+  enqueues exactly one `BootstrapLeagueMatchupsCommand` via
+  Hangfire. No HTTP calls, no SeasonWeek lookup, no
+  `PickemGroupWeek` writes. Stays as a fan-out point for future
+  creation-time side-effects (invitations, notifications, etc.).
+  All dispatch logic moved to the orchestrator below.
+
+**API (`BootstrapLeagueMatchupsProcessor`, new — Hangfire,
+`IBootstrapLeagueMatchups`):**
+- Owns the windowed-vs-full-season branch: any window bound set →
+  date-range path; otherwise → current-week.
+- Date-range path: `from = StartsOn ?? now`, `to = EndsOn ??
+  from + 365d` (DP-3 cap). Inverted result (`from > to`) → permanent
+  error log + return empty (PR-B validator blocks creation-time
+  inversion, but post-creation clock drift or admin edits can
+  still surface it; retrying won't fix it).
+- Calls `SeasonClient.GetSeasonWeeksOverlapping(from, to)` —
+  empty result → log + return (row 11); transient endpoint
+  failure → throw (Hangfire retries).
+- For each resolved SeasonWeek, enqueues a per-week
+  `ScheduleGroupWeekMatchupsCommand` carrying the league id +
+  week ids + correlation id. Per-week shell creation (find-or-
+  create via `PickemGroupWeekFactory.Create`) happens inside the
+  existing `MatchupScheduleProcessor` — single owner of per-week
+  work, called from both this orchestrator and the daily
+  `MatchupScheduler`.
+- Idempotent against replay: the per-week processor's
+  find-or-create on the composite PK `(GroupId, SeasonWeekId)`
+  plus its `!AreMatchupsGenerated` gate handles the dedup.
 
 **API (`MatchupScheduleProcessor`):**
 - One-line rule change: `groupWeek.AreMatchupsGenerated = true`

--- a/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
+++ b/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
@@ -115,7 +115,7 @@ namespace SportsData.Api.Application.Jobs
 
                 if (groupWeek is null)
                 {
-                    groupWeek = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+                    groupWeek = PickemGroupWeekFactory.Create(group, currentWeek);
                     group.Weeks.Add(groupWeek);
                     await _dataContext.SaveChangesAsync();
                 }

--- a/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
+++ b/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
@@ -3,10 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using SportsData.Api.Application.PickemGroups;
 using SportsData.Api.Application.Processors;
 using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Jobs;
 using SportsData.Core.Infrastructure.Clients.Season;
 using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
 
 namespace SportsData.Api.Application.Jobs
 {
@@ -32,48 +35,58 @@ namespace SportsData.Api.Application.Jobs
         private readonly AppDataContext _dataContext;
         private readonly ISeasonClientFactory _seasonClientFactory;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public MatchupScheduler(
             ILogger<MatchupScheduler> logger,
             AppDataContext dataContext,
             ISeasonClientFactory seasonClientFactory,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
             _seasonClientFactory = seasonClientFactory;
             _backgroundJobProvider = backgroundJobProvider;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task ExecuteAsync()
         {
             _logger.LogInformation("{JobName} Began", nameof(MatchupScheduler));
 
-            // Discover sports with at least one league. Adding a new sport
-            // becomes "create a league" — no code change to this job.
+            var now = _dateTimeProvider.UtcNow();
+            var inWindow = InWindowPredicate(now);
+
+            // Discover sports with at least one in-window, active league.
+            // Pre-PR-D this picked up every sport that had *any* league,
+            // including future-start ones — which then produced orphan
+            // PickemGroupWeek rows for the sport's current week despite
+            // the league not having started yet (the daily-orphan half
+            // of the motivating bug — see docs/league-creation-hardening.md).
             var activeSports = await _dataContext.PickemGroups
+                .Where(inWindow)
                 .Select(g => g.Sport)
                 .Distinct()
                 .ToListAsync();
 
             _logger.LogInformation(
-                "Found {Count} active sport(s) with leagues: {Sports}",
+                "Found {Count} active sport(s) with in-window leagues: {Sports}",
                 activeSports.Count, string.Join(", ", activeSports));
 
             foreach (var sport in activeSports)
             {
-                await ScheduleForSportAsync(sport);
+                await ScheduleForSportAsync(sport, inWindow);
             }
 
             _logger.LogInformation("{JobName} Ended", nameof(MatchupScheduler));
         }
 
-        private async Task ScheduleForSportAsync(Sport sport)
+        private async Task ScheduleForSportAsync(Sport sport, Expression<Func<PickemGroup, bool>> inWindow)
         {
             var weekResult = await _seasonClientFactory.Resolve(sport).GetCurrentSeasonWeek();
-            var currentWeek = weekResult.IsSuccess ? weekResult.Value : null;
 
-            if (currentWeek is null)
+            if (!weekResult.IsSuccess)
             {
                 _logger.LogWarning(
                     "Current week could not be resolved for {Sport}; skipping matchup scheduling for this sport.",
@@ -81,11 +94,18 @@ namespace SportsData.Api.Application.Jobs
                 return;
             }
 
-            // Only this sport's leagues. Loading Weeks for the ordinal lookup
-            // below + the existence check.
+            var currentWeek = weekResult.Value;
+
+            // In-window + active leagues for this sport. Loading Weeks for
+            // the postseason ordinal lookup in the factory + the existence
+            // check below. Window filter mirrors the active-sport
+            // discovery above so a sport with leagues that all fell out of
+            // window between calls is a safe no-op (rather than a NPE on
+            // currentWeek and an unnecessary HTTP call to Producer).
             var groups = await _dataContext.PickemGroups
                 .Include(x => x.Weeks)
                 .Where(x => x.Sport == sport)
+                .Where(inWindow)
                 .OrderBy(x => x.CreatedUtc)
                 .ToListAsync();
 
@@ -113,6 +133,27 @@ namespace SportsData.Api.Application.Jobs
                 }
             }
         }
+
+        /// <summary>
+        /// A league is "in window" — eligible for matchup-scheduling — when:
+        /// <list type="bullet">
+        ///   <item><c>DeactivatedUtc</c> is null (not closed by a commissioner
+        ///         or auto-deactivated after all contests finalized)</item>
+        ///   <item><c>StartsOn</c> is null or already past (future-start
+        ///         leagues defer to this gate; eager-bootstrap is PR-B's job)</item>
+        ///   <item><c>EndsOn</c> is null or still in the future (closed-window
+        ///         leagues stop accepting new <c>PickemGroupWeek</c> rows)</item>
+        /// </list>
+        /// Built as an <see cref="Expression{TDelegate}"/> so EF Core
+        /// translates it into SQL — embedding the same shape inline in both
+        /// the sport-discovery query and the per-sport groups query keeps
+        /// the gate single-sourced without a static helper that EF can't
+        /// parse.
+        /// </summary>
+        private static Expression<Func<PickemGroup, bool>> InWindowPredicate(DateTime now) =>
+            g => g.DeactivatedUtc == null
+                && (g.StartsOn == null || g.StartsOn <= now)
+                && (g.EndsOn == null || g.EndsOn >= now);
     }
 }
 

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupCreatedHandler.cs
@@ -4,34 +4,42 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Processors;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Api.Infrastructure.Data.Entities;
-using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.PickemGroups;
-using SportsData.Core.Infrastructure.Clients.Season;
 using SportsData.Core.Processing;
 
 namespace SportsData.Api.Application.PickemGroups
 {
+    /// <summary>
+    /// Creation-time fan-out point for post-PickemGroupCreated work. Today it
+    /// kicks off matchup bootstrap via <see cref="IBootstrapLeagueMatchups"/>;
+    /// future side-effects (invitations from a prior league, notifications,
+    /// etc.) get layered in here without disturbing the matchup pipeline.
+    ///
+    /// <para>
+    /// The handler itself does **no** SeasonWeek lookup or
+    /// <c>PickemGroupWeek</c> creation — that responsibility moved into the
+    /// Hangfire-side <c>BootstrapLeagueMatchupsProcessor</c>, which owns the
+    /// "decide windowed vs full-season, resolve SeasonWeek(s), fan out
+    /// per-week jobs" dispatch. Splitting the work this way means the
+    /// MassTransit consumer stays fast (single DB existence check + enqueue)
+    /// and the heavy lifting runs under Hangfire's retry/persistence model.
+    /// See <c>docs/league-creation-matrix.md</c> for the design space.
+    /// </para>
+    /// </summary>
     public class PickemGroupCreatedHandler : IConsumer<PickemGroupCreated>
     {
         private readonly ILogger<PickemGroupCreatedHandler> _logger;
         private readonly AppDataContext _dataContext;
-        private readonly ISeasonClientFactory _seasonClientFactory;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
-        private readonly IDateTimeProvider _dateTimeProvider;
 
         public PickemGroupCreatedHandler(
             ILogger<PickemGroupCreatedHandler> logger,
             AppDataContext dataContext,
-            ISeasonClientFactory seasonClientFactory,
-            IProvideBackgroundJobs backgroundJobProvider,
-            IDateTimeProvider dateTimeProvider)
+            IProvideBackgroundJobs backgroundJobProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
-            _seasonClientFactory = seasonClientFactory;
             _backgroundJobProvider = backgroundJobProvider;
-            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupCreated> context)
@@ -41,129 +49,36 @@ namespace SportsData.Api.Application.PickemGroups
                        ["CorrelationId"] = context.Message.CorrelationId
                    }))
             {
-                _logger.LogInformation("New pickem group created event received: {@Message}", context.Message);
+                _logger.LogInformation(
+                    "New pickem group created event received: {@Message}",
+                    context.Message);
 
                 await DispatchAsync(context.Message);
             }
         }
 
-        /// <summary>
-        /// Route the just-created league to the appropriate bootstrap path based on
-        /// its <see cref="PickemGroup.StartsOn"/> relative to now. Without this
-        /// dispatch the handler would eagerly create a <c>PickemGroupWeek</c> for
-        /// the sport's *current* week regardless of when the league actually starts,
-        /// producing an orphan empty row for any future-start league
-        /// (the motivating bug — see docs/league-creation-hardening.md).
-        /// </summary>
         private async Task DispatchAsync(PickemGroupCreated @event)
         {
-            var group = await _dataContext.PickemGroups
-                .Include(x => x.Weeks)
-                .Where(x => x.Id == @event.GroupId)
-                .FirstOrDefaultAsync();
+            var groupExists = await _dataContext.PickemGroups
+                .AsNoTracking()
+                .AnyAsync(x => x.Id == @event.GroupId);
 
-            if (group is null)
+            if (!groupExists)
             {
-                // Permanent failure: a missing group doesn't fix itself on retry.
-                // Log and return rather than throw — throwing would land the
-                // message in the DLQ for a state that will never become valid.
+                // Permanent failure: a missing group doesn't fix itself on
+                // retry. Log and return rather than throw — throwing would
+                // land the message in the DLQ for a state that will never
+                // become valid.
                 _logger.LogError(
                     "PickemGroupCreated received for unknown group {GroupId}; skipping bootstrap.",
                     @event.GroupId);
                 return;
             }
 
-            var mode = ResolveBootstrapMode(group);
-            switch (mode)
-            {
-                case BootstrapMode.Future:
-                    _logger.LogInformation(
-                        "League {GroupId} starts at {StartsOn}; deferring bootstrap to MatchupScheduler.",
-                        group.Id, group.StartsOn);
-                    return;
-
-                case BootstrapMode.Immediate:
-                    await BootstrapImmediateAsync(@event, group);
-                    return;
-
-                default:
-                    throw new InvalidOperationException($"Unhandled bootstrap mode: {mode}");
-            }
-        }
-
-        /// <summary>
-        /// Current-week bootstrap path: fetch the sport's current
-        /// <see cref="CanonicalSeasonWeekDto"/>, ensure a <see cref="PickemGroupWeek"/>
-        /// exists for it, and enqueue matchup generation. Unchanged from the
-        /// pre-PR-B behavior except for the (1) <see cref="BootstrapMode.Future"/>
-        /// gate above and (2) transient-vs-permanent exception split for the
-        /// current-week lookup.
-        /// </summary>
-        private async Task BootstrapImmediateAsync(PickemGroupCreated @event, PickemGroup group)
-        {
-            // get the current week for the league's sport (NCAA, NFL, or MLB).
-            // ESPN provides native week boundaries for all three via SeasonType, so
-            // the Producer-side GetCurrentSeasonWeek endpoint works uniformly.
-            var weekResult = await _seasonClientFactory.Resolve(group.Sport).GetCurrentSeasonWeek();
-
-            if (!weekResult.IsSuccess)
-            {
-                // Transient: the current-week endpoint is offline / sport is briefly
-                // between seasons. Throw so MassTransit retries the message. If the
-                // sport is permanently offseason, the retry policy will eventually
-                // DLQ — that's the correct outcome (a human will reschedule via the
-                // daily MatchupScheduler once the new season starts).
-                _logger.LogError(
-                    "Current week could not be resolved for {Sport} (group {GroupId}); will retry.",
-                    group.Sport, group.Id);
-                throw new InvalidOperationException(
-                    $"Current week unavailable for sport {group.Sport}.");
-            }
-
-            var currentWeek = weekResult.Value;
-
-            var groupWeek = group.Weeks.FirstOrDefault(x => x.SeasonWeekId == currentWeek.Id);
-
-            if (groupWeek is null)
-            {
-                groupWeek = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
-                group.Weeks.Add(groupWeek);
-                await _dataContext.SaveChangesAsync();
-            }
-
-            if (!groupWeek.AreMatchupsGenerated)
-            {
-                var cmd = new ScheduleGroupWeekMatchupsCommand(
-                    group.Id,
-                    currentWeek.Id,
-                    currentWeek.SeasonYear,
-                    currentWeek.WeekNumber,
-                    currentWeek.IsNonStandardWeek,
-                    @event.CorrelationId);
-
-                // kick off a process to create the PickemGroupWeek and matchups for the current week
-                _backgroundJobProvider.Enqueue<IScheduleGroupWeekMatchups>(p => p.Process(cmd));
-            }
-        }
-
-        /// <summary>
-        /// Decide whether to bootstrap now or wait for <c>MatchupScheduler</c>.
-        /// Null <see cref="PickemGroup.StartsOn"/> = full-season league → Immediate.
-        /// StartsOn at-or-before now (validator already rejected the
-        /// EndsOn-in-past case) → Immediate. StartsOn strictly future → Future.
-        /// </summary>
-        private BootstrapMode ResolveBootstrapMode(PickemGroup group)
-        {
-            if (!group.StartsOn.HasValue) return BootstrapMode.Immediate;
-            return group.StartsOn.Value <= _dateTimeProvider.UtcNow()
-                ? BootstrapMode.Immediate
-                : BootstrapMode.Future;
-        }
-
-        private enum BootstrapMode
-        {
-            Immediate,
-            Future,
+            var cmd = new BootstrapLeagueMatchupsCommand(
+                @event.GroupId,
+                @event.CorrelationId);
+            _backgroundJobProvider.Enqueue<IBootstrapLeagueMatchups>(p => p.Process(cmd));
         }
     }
 }

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekFactory.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekFactory.cs
@@ -14,30 +14,33 @@ namespace SportsData.Api.Application.PickemGroups;
 public static class PickemGroupWeekFactory
 {
     /// <summary>
-    /// Build a <see cref="PickemGroupWeek"/> for the league's current week.
+    /// Build a <see cref="PickemGroupWeek"/> for the given
+    /// <see cref="CanonicalSeasonWeekDto"/>. Used at both creation time
+    /// (any SeasonWeek the league window overlaps) and from the daily
+    /// scheduler (the sport's then-current SeasonWeek).
     /// </summary>
     /// <param name="group">
     /// The league. <see cref="PickemGroup.Weeks"/> must be loaded — the
     /// postseason ordinal adjustment reads existing weeks to compute the
     /// next sequential <see cref="PickemGroupWeek.SeasonWeek"/> value.
     /// </param>
-    /// <param name="currentWeek">Sport-resolved current season week.</param>
-    public static PickemGroupWeek CreateForCurrentWeek(
+    /// <param name="week">Sport-resolved season week DTO.</param>
+    public static PickemGroupWeek Create(
         PickemGroup group,
-        CanonicalSeasonWeekDto currentWeek)
+        CanonicalSeasonWeekDto week)
     {
         ArgumentNullException.ThrowIfNull(group);
-        ArgumentNullException.ThrowIfNull(currentWeek);
+        ArgumentNullException.ThrowIfNull(week);
 
         return new PickemGroupWeek
         {
             Id = Guid.NewGuid(),
             AreMatchupsGenerated = false,
             GroupId = group.Id,
-            SeasonWeek = ResolveOrdinal(group, currentWeek),
-            SeasonYear = currentWeek.SeasonYear,
-            SeasonWeekId = currentWeek.Id,
-            IsNonStandardWeek = currentWeek.IsNonStandardWeek,
+            SeasonWeek = ResolveOrdinal(group, week),
+            SeasonYear = week.SeasonYear,
+            SeasonWeekId = week.Id,
+            IsNonStandardWeek = week.IsNonStandardWeek,
         };
     }
 
@@ -47,18 +50,18 @@ public static class PickemGroupWeekFactory
     /// the postseason ordinal off the league's highest existing week instead
     /// so the list stays monotonically increasing (used by ascending
     /// <c>seasonWeeks</c> projections on /user/me and the week selector).
-    /// Falls back to <c>currentWeek.WeekNumber</c> for a league with no prior
+    /// Falls back to <c>week.WeekNumber</c> for a league with no prior
     /// weeks (first run of the recurring scheduler hits this).
     /// </summary>
-    private static int ResolveOrdinal(PickemGroup group, CanonicalSeasonWeekDto currentWeek)
+    private static int ResolveOrdinal(PickemGroup group, CanonicalSeasonWeekDto week)
     {
-        if (!currentWeek.IsPostSeason)
-            return currentWeek.WeekNumber;
+        if (!week.IsPostSeason)
+            return week.WeekNumber;
 
         var highestExisting = group.Weeks
             .OrderByDescending(x => x.SeasonWeek)
             .FirstOrDefault();
 
-        return (highestExisting?.SeasonWeek + 1) ?? currentWeek.WeekNumber;
+        return (highestExisting?.SeasonWeek + 1) ?? week.WeekNumber;
     }
 }

--- a/src/SportsData.Api/Application/Processors/BootstrapLeagueMatchupsProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/BootstrapLeagueMatchupsProcessor.cs
@@ -141,6 +141,24 @@ namespace SportsData.Api.Application.Processors
             }
 
             var (from, to) = ResolveDateRange(group);
+
+            if (from > to)
+            {
+                // Permanent input error: the league's window resolved to an
+                // inverted range. The PR-B validator blocks this at creation
+                // (EffectiveEndsOn > now AND StartsOn < EffectiveEndsOn) but
+                // it can still surface here if EndsOn was set, StartsOn was
+                // null, and the clock rolled past EndsOn before the Hangfire
+                // job ran — or if an admin edited the entity into a bad
+                // state post-creation. Retrying won't help; log and return
+                // an empty list so the caller treats it like row 11
+                // ("nothing to bootstrap") rather than DLQ'ing the job.
+                _logger.LogError(
+                    "Inverted date range for {Sport} (group {GroupId}, [{From}, {To}]); skipping bootstrap.",
+                    group.Sport, group.Id, from, to);
+                return [];
+            }
+
             var rangeResult = await seasonClient.GetSeasonWeeksOverlapping(from, to);
 
             if (!rangeResult.IsSuccess)

--- a/src/SportsData.Api/Application/Processors/BootstrapLeagueMatchupsProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/BootstrapLeagueMatchupsProcessor.cs
@@ -1,0 +1,176 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Season;
+using SportsData.Core.Processing;
+
+namespace SportsData.Api.Application.Processors
+{
+    public interface IBootstrapLeagueMatchups
+    {
+        Task Process(BootstrapLeagueMatchupsCommand command);
+    }
+
+    /// <summary>
+    /// Creation-time orchestrator for a newly-created league. Resolves which
+    /// <see cref="SeasonWeek"/>(s) the league overlaps and fans out one
+    /// <see cref="ScheduleGroupWeekMatchupsCommand"/> per resolved week to the
+    /// existing per-week worker (<see cref="MatchupScheduleProcessor"/>).
+    ///
+    /// <para>
+    /// Replaces the prior model where the
+    /// <c>PickemGroupCreatedHandler</c> looked up "current week" directly and
+    /// created a single <c>PickemGroupWeek</c> for it — which produced orphan
+    /// empty rows for any windowed league whose <c>[StartsOn, EndsOn]</c>
+    /// didn't overlap the current SeasonWeek. See
+    /// <c>docs/league-creation-matrix.md</c> for the design space this
+    /// dispatch covers.
+    /// </para>
+    ///
+    /// <para>
+    /// Owns the dispatch only; per-week work (find-or-create shell, fetch
+    /// matchups, filter, write) stays in <c>MatchupScheduleProcessor</c>,
+    /// which the daily <c>MatchupScheduler</c> also drives. One per-week
+    /// worker, two upstream producers (this and the scheduler).
+    /// </para>
+    /// </summary>
+    public class BootstrapLeagueMatchupsProcessor : IBootstrapLeagueMatchups
+    {
+        // Defensive upper bound on the date-range query for partial windows
+        // with `EndsOn = null`. Realistic leagues don't span more than a year;
+        // capping at 365 days bounds the result size and the
+        // SeasonWeek-overlap query's worst case.
+        private static readonly TimeSpan PartialWindowMaxSpan = TimeSpan.FromDays(365);
+
+        private readonly ILogger<BootstrapLeagueMatchupsProcessor> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly ISeasonClientFactory _seasonClientFactory;
+        private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public BootstrapLeagueMatchupsProcessor(
+            ILogger<BootstrapLeagueMatchupsProcessor> logger,
+            AppDataContext dataContext,
+            ISeasonClientFactory seasonClientFactory,
+            IProvideBackgroundJobs backgroundJobProvider,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _seasonClientFactory = seasonClientFactory;
+            _backgroundJobProvider = backgroundJobProvider;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task Process(BootstrapLeagueMatchupsCommand command)
+        {
+            var group = await _dataContext.PickemGroups
+                .Where(x => x.Id == command.GroupId)
+                .FirstOrDefaultAsync();
+
+            if (group is null)
+            {
+                _logger.LogError(
+                    "Bootstrap requested for unknown group {GroupId}; nothing to do.",
+                    command.GroupId);
+                return;
+            }
+
+            var weeks = await ResolveTargetWeeksAsync(group);
+
+            if (weeks.Count == 0)
+            {
+                _logger.LogInformation(
+                    "Bootstrap for group {GroupId} resolved to zero SeasonWeeks ({StartsOn} → {EndsOn}); deferring to MatchupScheduler.",
+                    group.Id, group.StartsOn, group.EndsOn);
+                return;
+            }
+
+            _logger.LogInformation(
+                "Bootstrap for group {GroupId} resolved {Count} SeasonWeek(s); enqueuing per-week matchup scheduling.",
+                group.Id, weeks.Count);
+
+            foreach (var week in weeks)
+            {
+                var perWeekCommand = new ScheduleGroupWeekMatchupsCommand(
+                    group.Id,
+                    week.Id,
+                    week.SeasonYear,
+                    week.WeekNumber,
+                    week.IsNonStandardWeek,
+                    command.CorrelationId);
+
+                _backgroundJobProvider.Enqueue<IScheduleGroupWeekMatchups>(
+                    p => p.Process(perWeekCommand));
+            }
+        }
+
+        /// <summary>
+        /// Decide which <see cref="CanonicalSeasonWeekDto"/>(s) the league
+        /// needs. Full-season leagues (both window bounds null) bootstrap the
+        /// current week only and let the daily scheduler advance weekly.
+        /// Windowed leagues hit the date-range endpoint with effective
+        /// from/to derived from <c>StartsOn</c> / <c>EndsOn</c> and the
+        /// 365-day partial-window cap.
+        /// </summary>
+        private async Task<List<CanonicalSeasonWeekDto>> ResolveTargetWeeksAsync(PickemGroup group)
+        {
+            var seasonClient = _seasonClientFactory.Resolve(group.Sport);
+
+            if (!group.StartsOn.HasValue && !group.EndsOn.HasValue)
+            {
+                var currentResult = await seasonClient.GetCurrentSeasonWeek();
+                if (!currentResult.IsSuccess)
+                {
+                    // Transient (between weeks) or permanent (off-season) — let
+                    // Hangfire's retry policy handle. If the sport is permanently
+                    // off-season the retry budget will eventually exhaust and the
+                    // job lands in failed state; a human re-enqueues once the
+                    // new season starts.
+                    _logger.LogError(
+                        "Current week unavailable for {Sport} (group {GroupId}); throwing to retry.",
+                        group.Sport, group.Id);
+                    throw new InvalidOperationException(
+                        $"Current week unavailable for sport {group.Sport}.");
+                }
+
+                return [currentResult.Value];
+            }
+
+            var (from, to) = ResolveDateRange(group);
+            var rangeResult = await seasonClient.GetSeasonWeeksOverlapping(from, to);
+
+            if (!rangeResult.IsSuccess)
+            {
+                _logger.LogError(
+                    "Date-range lookup failed for {Sport} (group {GroupId}, [{From}, {To}]); throwing to retry.",
+                    group.Sport, group.Id, from, to);
+                throw new InvalidOperationException(
+                    $"Season-week range unavailable for sport {group.Sport}.");
+            }
+
+            return rangeResult.Value;
+        }
+
+        /// <summary>
+        /// Convert the league's nullable <c>(StartsOn, EndsOn)</c> into a
+        /// concrete <c>[from, to]</c> range usable against the date-range
+        /// endpoint. Open bounds resolve to "now" (lower) or "from + 365d"
+        /// (upper) per DP-3.
+        /// </summary>
+        private (DateTime From, DateTime To) ResolveDateRange(PickemGroup group)
+        {
+            var now = _dateTimeProvider.UtcNow();
+            var from = group.StartsOn ?? now;
+            var to = group.EndsOn ?? from + PartialWindowMaxSpan;
+            return (from, to);
+        }
+    }
+}
+
+public record BootstrapLeagueMatchupsCommand(
+    Guid GroupId,
+    Guid CorrelationId);

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -179,7 +179,13 @@ namespace SportsData.Api.Application.Processors
                 });
             }
 
-            groupWeek.AreMatchupsGenerated = true;
+            // Mark "generated" only when matchups were actually written.
+            // Empty results leave the flag false so the daily scheduler re-fires
+            // matchup generation on the next pass — the load-bearing piece that
+            // makes the eager-bootstrap path work for NCAAFB+RankingFilter
+            // shells created pre-poll. See docs/league-creation-matrix.md
+            // "Processor change: AreMatchupsGenerated rule".
+            groupWeek.AreMatchupsGenerated = groupMatchups.Count > 0;
 
             // Publish BEFORE SaveChanges so MassTransit's bus-outbox interceptor flushes
             // the captured message into the OutboxMessage table within the same transaction

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -204,6 +204,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IProvideCanonicalAdminData, CanonicalAdminDataProvider>();
             services.AddSingleton<CanonicalAdminDataQueryProvider>();
             services.AddScoped<IScheduleGroupWeekMatchups, MatchupScheduleProcessor>();
+            services.AddScoped<IBootstrapLeagueMatchups, BootstrapLeagueMatchupsProcessor>();
             services.AddScoped<IScoreContests, ContestScoringProcessor>();
             
             // HATEOAS Ref Generator (external API)

--- a/src/SportsData.Core/Infrastructure/Clients/Season/SeasonClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Season/SeasonClient.cs
@@ -21,6 +21,7 @@ public interface IProvideSeasons : IProvideHealthChecks
     Task<Result<CanonicalSeasonWeekDto>> GetCurrentSeasonWeek(CancellationToken ct = default);
     Task<Result<List<CanonicalSeasonWeekDto>>> GetCurrentAndLastSeasonWeeks(CancellationToken ct = default);
     Task<Result<List<CanonicalSeasonWeekDto>>> GetCompletedSeasonWeeks(int seasonYear, CancellationToken ct = default);
+    Task<Result<List<CanonicalSeasonWeekDto>>> GetSeasonWeeksOverlapping(DateTime from, DateTime to, CancellationToken ct = default);
     Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, CancellationToken ct = default);
 }
 
@@ -116,6 +117,29 @@ public class SeasonClient : ClientBase, IProvideSeasons
             $"seasons/{seasonYear}/completed-weeks",
             new List<CanonicalSeasonWeekDto>(),
             "Completed season weeks",
+            ResultStatus.NotFound,
+            ct);
+    }
+
+    public async Task<Result<List<CanonicalSeasonWeekDto>>> GetSeasonWeeksOverlapping(
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (from > to)
+        {
+            return new Failure<List<CanonicalSeasonWeekDto>>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(from), "from must be on or before to")]);
+        }
+
+        // ISO 8601 round-trip ("o") is the canonical wire format ASP.NET's
+        // [FromQuery] DateTime model binder reads back without timezone drift.
+        return await GetAsync<List<CanonicalSeasonWeekDto>>(
+            $"seasons/weeks/by-date-range?from={Uri.EscapeDataString(from.ToString("o"))}&to={Uri.EscapeDataString(to.ToString("o"))}",
+            new List<CanonicalSeasonWeekDto>(),
+            "Season weeks by date range",
             ResultStatus.NotFound,
             ct);
     }

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQuery.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQuery.cs
@@ -1,0 +1,11 @@
+namespace SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
+
+/// <summary>
+/// Returns the <see cref="SportsData.Core.Dtos.Canonical.CanonicalSeasonWeekDto"/>s
+/// whose <c>[StartDate, EndDate]</c> overlaps the requested
+/// <c>[From, To]</c> range. Used by the API to resolve which
+/// <c>SeasonWeek</c>(s) a windowed pick'em league should bootstrap, replacing
+/// the prior "always use the current week" assumption that produced orphan
+/// empty <c>PickemGroupWeek</c> rows for windowed leagues.
+/// </summary>
+public record GetSeasonWeeksByDateRangeQuery(DateTime From, DateTime To);

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
+
+public interface IGetSeasonWeeksByDateRangeQueryHandler
+{
+    Task<Result<List<CanonicalSeasonWeekDto>>> ExecuteAsync(
+        GetSeasonWeeksByDateRangeQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Returns every <see cref="CanonicalSeasonWeekDto"/> whose
+/// <c>[StartDate, EndDate]</c> overlaps the requested <c>[From, To]</c>
+/// range, ordered by <c>StartDate</c> ascending.
+/// </summary>
+/// <remarks>
+/// Overlap predicate: <c>StartDate &lt;= To AND EndDate &gt;= From</c>.
+/// Inclusive on both bounds — a SeasonWeek that starts exactly on
+/// <c>To</c> or ends exactly on <c>From</c> still overlaps.
+///
+/// <para>
+/// Empty result is a legitimate <see cref="Success{T}"/> (not a
+/// failure). The most common reason for an empty list is "no
+/// SeasonWeeks are sourced yet for the requested date range" — e.g.
+/// a 2027 league created in 2026 before next year's season calendar
+/// has landed in the canonical DB. The API-side caller treats that
+/// as "defer; the daily MatchupScheduler will pick it up once the
+/// SeasonWeeks exist."
+/// </para>
+/// </remarks>
+public class GetSeasonWeeksByDateRangeQueryHandler : IGetSeasonWeeksByDateRangeQueryHandler
+{
+    private readonly TeamSportDataContext _dbContext;
+
+    public GetSeasonWeeksByDateRangeQueryHandler(TeamSportDataContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Result<List<CanonicalSeasonWeekDto>>> ExecuteAsync(
+        GetSeasonWeeksByDateRangeQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        // Reject malformed input outright — a flipped range (From > To)
+        // would silently return nothing and look the same as the legitimate
+        // empty case. Better to fail fast at the API boundary.
+        if (query.From > query.To)
+        {
+            return new Failure<List<CanonicalSeasonWeekDto>>(
+                [],
+                ResultStatus.BadRequest,
+                [new FluentValidation.Results.ValidationFailure(
+                    nameof(query.From),
+                    "From must be on or before To.")]);
+        }
+
+        var weeks = await _dbContext.SeasonWeeks
+            .AsNoTracking()
+            .Include(sw => sw.Season)
+            .Include(sw => sw.SeasonPhase)
+            .Where(sw => sw.StartDate <= query.To && sw.EndDate >= query.From)
+            .OrderBy(sw => sw.StartDate)
+            .Select(sw => new CanonicalSeasonWeekDto
+            {
+                Id = sw.Id,
+                SeasonId = sw.SeasonId,
+                SeasonYear = sw.Season!.Year,
+                WeekNumber = sw.Number,
+                SeasonPhase = sw.SeasonPhase!.Name,
+                IsNonStandardWeek = sw.IsNonStandardWeek
+            })
+            .ToListAsync(cancellationToken);
+
+        return new Success<List<CanonicalSeasonWeekDto>>(weeks);
+    }
+}

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
@@ -52,7 +52,7 @@ public class GetSeasonWeeksByDateRangeQueryHandler : IGetSeasonWeeksByDateRangeQ
         if (query.From > query.To)
         {
             return new Failure<List<CanonicalSeasonWeekDto>>(
-                [],
+                default!,
                 ResultStatus.Validation,
                 [new FluentValidation.Results.ValidationFailure(
                     nameof(query.From),

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
@@ -53,7 +53,7 @@ public class GetSeasonWeeksByDateRangeQueryHandler : IGetSeasonWeeksByDateRangeQ
         {
             return new Failure<List<CanonicalSeasonWeekDto>>(
                 [],
-                ResultStatus.BadRequest,
+                ResultStatus.Validation,
                 [new FluentValidation.Results.ValidationFailure(
                     nameof(query.From),
                     "From must be on or before To.")]);

--- a/src/SportsData.Producer/Application/Seasons/SeasonController.cs
+++ b/src/SportsData.Producer/Application/Seasons/SeasonController.cs
@@ -7,6 +7,7 @@ using SportsData.Producer.Application.Seasons.Queries.GetCompletedSeasonWeeks;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentAndLastSeasonWeeks;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentSeasonWeek;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonOverview;
+using SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
 
 namespace SportsData.Producer.Application.Seasons;
 
@@ -50,6 +51,26 @@ public class SeasonController : ControllerBase
         CancellationToken cancellationToken = default)
     {
         var result = await handler.ExecuteAsync(new GetCompletedSeasonWeeksQuery(seasonYear), cancellationToken);
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Resolves the SeasonWeek(s) overlapping the requested date range.
+    /// Drives the API-side league-creation handler for windowed leagues
+    /// (single-day, multi-day, multi-week), replacing the prior "always
+    /// use the current week" model that produced orphan empty
+    /// <c>PickemGroupWeek</c> rows.
+    /// </summary>
+    [HttpGet("weeks/by-date-range")]
+    public async Task<ActionResult<List<CanonicalSeasonWeekDto>>> GetSeasonWeeksByDateRange(
+        [FromQuery] DateTime from,
+        [FromQuery] DateTime to,
+        [FromServices] IGetSeasonWeeksByDateRangeQueryHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await handler.ExecuteAsync(
+            new GetSeasonWeeksByDateRangeQuery(from, to),
+            cancellationToken);
         return result.ToActionResult();
     }
 }

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -59,6 +59,7 @@ using SportsData.Producer.Application.Seasons.Queries.GetCompletedSeasonWeeks;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentAndLastSeasonWeeks;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentSeasonWeek;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonOverview;
+using SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
 using SportsData.Producer.Application.SeasonWeek.Commands.EnqueueSeasonWeekContestsUpdate;
 using SportsData.Producer.Application.Services;
 using SportsData.Producer.Application.Venues;
@@ -320,6 +321,7 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IGetCurrentSeasonWeekQueryHandler, GetCurrentSeasonWeekQueryHandler>();
             services.AddScoped<IGetCurrentAndLastSeasonWeeksQueryHandler, GetCurrentAndLastSeasonWeeksQueryHandler>();
             services.AddScoped<IGetCompletedSeasonWeeksQueryHandler, GetCompletedSeasonWeeksQueryHandler>();
+            services.AddScoped<IGetSeasonWeeksByDateRangeQueryHandler, GetSeasonWeeksByDateRangeQueryHandler>();
 
             // Contest Matchup Queries
             services.AddScoped<IGetMatchupsForCurrentWeekQueryHandler, GetMatchupsForCurrentWeekQueryHandler>();

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/MatchupSchedulerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/MatchupSchedulerTests.cs
@@ -24,6 +24,12 @@ namespace SportsData.Api.Tests.Unit.Application.Jobs;
 /// </summary>
 public class MatchupSchedulerTests : ApiTestBase<MatchupScheduler>
 {
+    // Fixed "now" for the in-window predicate. All seeded leagues default to
+    // null StartsOn/EndsOn (full-season) so the gate is a no-op for legacy
+    // assertions; the PR-D regression tests below seed explicit window bounds
+    // relative to this anchor.
+    private static readonly DateTime FixedNow = new(2026, 5, 28, 12, 0, 0, DateTimeKind.Utc);
+
     private readonly Mock<IProvideSeasons> _footballSeasonClientMock = new();
     private readonly Mock<IProvideSeasons> _baseballSeasonClientMock = new();
 
@@ -35,6 +41,10 @@ public class MatchupSchedulerTests : ApiTestBase<MatchupScheduler>
         Mocker.GetMock<ISeasonClientFactory>()
             .Setup(x => x.Resolve(Sport.BaseballMlb))
             .Returns(_baseballSeasonClientMock.Object);
+
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
     }
 
     [Fact]
@@ -144,6 +154,134 @@ public class MatchupSchedulerTests : ApiTestBase<MatchupScheduler>
         _baseballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Never);
         background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
             It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Never);
+    }
+
+    // ── PR-D window/active gate regression tests ─────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Skips_FutureStart_League()
+    {
+        // Daily-orphan regression. Pre-PR-D, a league with StartsOn in the
+        // future still received a PickemGroupWeek for the sport's *current*
+        // week on every scheduler run until StartsOn arrived, producing the
+        // empty extra-week row visible in /user/me. The window gate now
+        // skips the league entirely; SeasonClient isn't even consulted for
+        // a sport whose only league is future-start.
+        var leagueId = Guid.NewGuid();
+        var group = BuildPickemGroup(leagueId, Sport.BaseballMlb, League.MLB);
+        group.StartsOn = FixedNow.AddDays(10);
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        await sut.ExecuteAsync();
+
+        _baseballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Never);
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Skips_ClosedWindow_League()
+    {
+        // Mirror of the future-start case for an EndsOn-in-past league.
+        // The matchup processor's window filter already drops new matchups
+        // post-EndsOn, but creating a PickemGroupWeek row for a closed
+        // league is still noise — gate it here.
+        var leagueId = Guid.NewGuid();
+        var group = BuildPickemGroup(leagueId, Sport.BaseballMlb, League.MLB);
+        group.StartsOn = FixedNow.AddDays(-30);
+        group.EndsOn = FixedNow.AddDays(-1);
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        await sut.ExecuteAsync();
+
+        _baseballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Never);
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Skips_Deactivated_League()
+    {
+        // DeactivatedUtc is the commissioner-closed / auto-completed flag.
+        // Inactive leagues shouldn't produce new PickemGroupWeek rows even
+        // if their date window technically still covers now.
+        var leagueId = Guid.NewGuid();
+        var group = BuildPickemGroup(leagueId, Sport.BaseballMlb, League.MLB);
+        group.DeactivatedUtc = FixedNow.AddDays(-1);
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        await sut.ExecuteAsync();
+
+        _baseballSeasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Never);
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Processes_InWindow_League()
+    {
+        // Mid-window happy path: StartsOn in past, EndsOn in future,
+        // DeactivatedUtc null. League is processed normally.
+        var leagueId = Guid.NewGuid();
+        var weekId = Guid.NewGuid();
+        var group = BuildPickemGroup(leagueId, Sport.BaseballMlb, League.MLB);
+        group.StartsOn = FixedNow.AddDays(-7);
+        group.EndsOn = FixedNow.AddDays(7);
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+
+        SetupCurrentWeek(_baseballSeasonClientMock, weekId, 2026, 9, false, "regular");
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        await sut.ExecuteAsync();
+
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MixedWindow_OnlyProcesses_InWindow_League()
+    {
+        // Two MLB leagues, one in-window and one future-start. Confirms the
+        // window gate filters per-league rather than per-sport — the
+        // future-start league mustn't poison the sport's processing.
+        var inWindowId = Guid.NewGuid();
+        var futureStartId = Guid.NewGuid();
+        var weekId = Guid.NewGuid();
+
+        var inWindow = BuildPickemGroup(inWindowId, Sport.BaseballMlb, League.MLB);
+        inWindow.StartsOn = FixedNow.AddDays(-7);
+        inWindow.EndsOn = FixedNow.AddDays(7);
+
+        var futureStart = BuildPickemGroup(futureStartId, Sport.BaseballMlb, League.MLB);
+        futureStart.StartsOn = FixedNow.AddDays(10);
+
+        await DataContext.PickemGroups.AddRangeAsync(inWindow, futureStart);
+        await DataContext.SaveChangesAsync();
+
+        SetupCurrentWeek(_baseballSeasonClientMock, weekId, 2026, 9, false, "regular");
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<MatchupScheduler>();
+
+        await sut.ExecuteAsync();
+
+        background.Verify(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+            It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()), Times.Once);
     }
 
     private async Task SeedLeagueAsync(Guid leagueId, Sport sport, League league)

--- a/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
@@ -1,10 +1,6 @@
 using FluentAssertions;
 
-using FluentValidation.Results;
-
 using MassTransit;
-
-using Microsoft.EntityFrameworkCore;
 
 using Moq;
 
@@ -13,9 +9,7 @@ using SportsData.Api.Application.PickemGroups;
 using SportsData.Api.Application.Processors;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
-using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Eventing.Events.PickemGroups;
-using SportsData.Core.Infrastructure.Clients.Season;
 using SportsData.Core.Processing;
 
 using System.Linq.Expressions;
@@ -25,43 +19,25 @@ using Xunit;
 namespace SportsData.Api.Tests.Unit.Application.PickemGroups;
 
 /// <summary>
-/// Pins the PR-B bootstrap-mode dispatch on <see cref="PickemGroupCreatedHandler"/>.
-/// Three behavioral contracts:
-///   1. Missing group is permanent, not transient — log and return, don't throw.
-///   2. Future-start league (<see cref="PickemGroup.StartsOn"/> &gt; now) defers
-///      to MatchupScheduler — no PickemGroupWeek row, no matchup enqueue.
-///   3. Immediate path (StartsOn null or already past) hits the current-week
-///      bootstrap and enqueues matchup generation, OR throws transient when
-///      the season client can't resolve current week.
+/// The handler is now a thin fan-out point: existence-check + enqueue.
+/// Per-league bootstrap logic moved into
+/// <see cref="BootstrapLeagueMatchupsProcessor"/>. Tests pin two contracts:
+///   1. Missing group is permanent — log + return, no enqueue, no throw.
+///   2. Valid group → exactly one BootstrapLeagueMatchupsCommand enqueued,
+///      carrying through the event's CorrelationId.
 /// </summary>
 public class PickemGroupCreatedHandlerTests : ApiTestBase<PickemGroupCreatedHandler>
 {
-    private static readonly DateTime FixedNow = new(2026, 5, 28, 12, 0, 0, DateTimeKind.Utc);
-
-    private readonly Mock<ISeasonClientFactory> _seasonClientFactoryMock;
-    private readonly Mock<IProvideSeasons> _seasonClientMock;
     private readonly Mock<IProvideBackgroundJobs> _backgroundJobsMock;
 
     public PickemGroupCreatedHandlerTests()
     {
-        _seasonClientFactoryMock = Mocker.GetMock<ISeasonClientFactory>();
-        _seasonClientMock = new Mock<IProvideSeasons>();
-        _seasonClientFactoryMock
-            .Setup(x => x.Resolve(It.IsAny<Sport>()))
-            .Returns(_seasonClientMock.Object);
-
         _backgroundJobsMock = Mocker.GetMock<IProvideBackgroundJobs>();
-
-        Mocker.GetMock<IDateTimeProvider>()
-            .Setup(x => x.UtcNow())
-            .Returns(FixedNow);
     }
 
     [Fact]
-    public async Task GroupNotFound_LogsAndReturns_DoesNotThrow()
+    public async Task GroupNotFound_LogsAndReturns_DoesNotThrow_NoEnqueue()
     {
-        // Permanent failure: don't DLQ. The group will never materialize on
-        // retry. Log + return is the correct response.
         var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
         var context = ConsumeContextFor(new PickemGroupCreated(
             Guid.NewGuid(), null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
@@ -69,107 +45,43 @@ public class PickemGroupCreatedHandlerTests : ApiTestBase<PickemGroupCreatedHand
         var act = async () => await sut.Consume(context);
 
         await act.Should().NotThrowAsync();
-        _backgroundJobsMock.VerifyNoOtherCalls();
-    }
-
-    [Fact]
-    public async Task FutureStartLeague_NoBootstrap_NoEnqueue()
-    {
-        // Motivating bug regression test: a league starting in the future
-        // must not produce an orphan PickemGroupWeek for *today's* current
-        // week, and must not enqueue matchup generation. The daily
-        // MatchupScheduler picks the league up once now >= StartsOn (gated
-        // in PR-D).
-        var groupId = await SeedGroup(startsOn: FixedNow.AddDays(10));
-
-        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
-        var context = ConsumeContextFor(new PickemGroupCreated(
-            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
-
-        await sut.Consume(context);
-
-        (await DataContext.PickemGroupWeeks.AnyAsync(x => x.GroupId == groupId))
-            .Should().BeFalse();
         _backgroundJobsMock.Verify(
-            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            x => x.Enqueue<IBootstrapLeagueMatchups>(It.IsAny<Expression<Func<IBootstrapLeagueMatchups, Task>>>()),
             Times.Never);
     }
 
     [Fact]
-    public async Task NullStartsOnLeague_CreatesWeek_AndEnqueues()
+    public async Task ValidGroup_EnqueuesBootstrap_WithEventCorrelationId()
     {
-        // Full-season league — Immediate path.
-        var groupId = await SeedGroup(startsOn: null);
-        SetupCurrentWeek(NewCurrentWeek());
+        var groupId = await SeedGroup();
+        var correlationId = Guid.NewGuid();
+
+        BootstrapLeagueMatchupsCommand? captured = null;
+        _backgroundJobsMock
+            .Setup(x => x.Enqueue<IBootstrapLeagueMatchups>(
+                It.IsAny<Expression<Func<IBootstrapLeagueMatchups, Task>>>()))
+            .Callback<Expression<Func<IBootstrapLeagueMatchups, Task>>>(expr =>
+            {
+                captured = ExtractCommand(expr);
+            })
+            .Returns("job-id");
 
         var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
         var context = ConsumeContextFor(new PickemGroupCreated(
-            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
+            groupId, null, Sport.BaseballMlb, 2026, correlationId, Guid.NewGuid()));
 
         await sut.Consume(context);
 
-        (await DataContext.PickemGroupWeeks.AnyAsync(x => x.GroupId == groupId))
-            .Should().BeTrue();
         _backgroundJobsMock.Verify(
-            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            x => x.Enqueue<IBootstrapLeagueMatchups>(It.IsAny<Expression<Func<IBootstrapLeagueMatchups, Task>>>()),
             Times.Once);
+
+        captured.Should().NotBeNull();
+        captured!.GroupId.Should().Be(groupId);
+        captured.CorrelationId.Should().Be(correlationId);
     }
 
-    [Fact]
-    public async Task StartsOnInPastLeague_CreatesWeek_AndEnqueues()
-    {
-        // Validator already rejected the "ends-in-past" case; this exercises
-        // the half-played single-day scenario where StartsOn was earlier
-        // today (or the validator-allowed boundary race where StartsOn was
-        // just-barely-future at validation time but the event-handler clock
-        // has rolled past it).
-        var groupId = await SeedGroup(startsOn: FixedNow.AddHours(-2));
-        SetupCurrentWeek(NewCurrentWeek());
-
-        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
-        var context = ConsumeContextFor(new PickemGroupCreated(
-            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
-
-        await sut.Consume(context);
-
-        (await DataContext.PickemGroupWeeks.AnyAsync(x => x.GroupId == groupId))
-            .Should().BeTrue();
-        _backgroundJobsMock.Verify(
-            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task CurrentWeekUnavailable_ThrowsForRetry()
-    {
-        // Transient failure: throw so MassTransit retries. A briefly-between-
-        // seasons sport will eventually DLQ via retry policy, at which point
-        // a human re-enqueues via MatchupScheduler. The season client expresses
-        // unavailability as a Failure result (see SeasonClient.GetCurrentSeasonWeek
-        // which returns Failure<...>(default!, ResultStatus.NotFound, ...) on
-        // upstream miss) — the handler checks !IsSuccess rather than a null
-        // Value payload.
-        var groupId = await SeedGroup(startsOn: null);
-        _seasonClientMock
-            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Failure<CanonicalSeasonWeekDto>(
-                default!,
-                ResultStatus.NotFound,
-                new List<ValidationFailure>()));
-
-        var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
-        var context = ConsumeContextFor(new PickemGroupCreated(
-            groupId, null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
-
-        var act = async () => await sut.Consume(context);
-
-        await act.Should().ThrowAsync<InvalidOperationException>();
-        _backgroundJobsMock.Verify(
-            x => x.Enqueue<IScheduleGroupWeekMatchups>(It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
-            Times.Never);
-    }
-
-    private async Task<Guid> SeedGroup(DateTime? startsOn)
+    private async Task<Guid> SeedGroup()
     {
         var group = new PickemGroup
         {
@@ -177,30 +89,23 @@ public class PickemGroupCreatedHandlerTests : ApiTestBase<PickemGroupCreatedHand
             Name = "Test",
             Sport = Sport.BaseballMlb,
             League = League.MLB,
-            StartsOn = startsOn,
         };
         await DataContext.PickemGroups.AddAsync(group);
         await DataContext.SaveChangesAsync();
         return group.Id;
     }
 
-    private static CanonicalSeasonWeekDto NewCurrentWeek() => new()
-    {
-        Id = Guid.NewGuid(),
-        SeasonId = Guid.NewGuid(),
-        SeasonYear = 2026,
-        WeekNumber = 9,
-        SeasonPhase = "regularseason",
-        IsNonStandardWeek = false,
-    };
-
-    private void SetupCurrentWeek(CanonicalSeasonWeekDto week)
-    {
-        _seasonClientMock
-            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<CanonicalSeasonWeekDto>(week));
-    }
-
     private static ConsumeContext<PickemGroupCreated> ConsumeContextFor(PickemGroupCreated message) =>
         Mock.Of<ConsumeContext<PickemGroupCreated>>(ctx => ctx.Message == message);
+
+    private static BootstrapLeagueMatchupsCommand? ExtractCommand(
+        Expression<Func<IBootstrapLeagueMatchups, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        var arg = call.Arguments.FirstOrDefault();
+        if (arg is null) return null;
+
+        var lambda = Expression.Lambda<Func<BootstrapLeagueMatchupsCommand>>(arg).Compile();
+        return lambda.Invoke();
+    }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupWeekFactoryTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupWeekFactoryTests.cs
@@ -19,12 +19,12 @@ namespace SportsData.Api.Tests.Unit.Application.PickemGroups;
 public class PickemGroupWeekFactoryTests
 {
     [Fact]
-    public void CreateForCurrentWeek_RegularSeason_UsesWeekNumberAsOrdinal()
+    public void Create_RegularSeason_UsesWeekNumberAsOrdinal()
     {
         var group = NewGroup();
         var currentWeek = NewWeek(weekNumber: 7, isPostSeason: false);
 
-        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+        var result = PickemGroupWeekFactory.Create(group, currentWeek);
 
         result.SeasonWeek.Should().Be(7);
         result.SeasonYear.Should().Be(currentWeek.SeasonYear);
@@ -35,12 +35,12 @@ public class PickemGroupWeekFactoryTests
     }
 
     [Fact]
-    public void CreateForCurrentWeek_RegularSeason_PropagatesIsNonStandardWeek()
+    public void Create_RegularSeason_PropagatesIsNonStandardWeek()
     {
         var group = NewGroup();
         var currentWeek = NewWeek(weekNumber: 8, isPostSeason: false, isNonStandardWeek: true);
 
-        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+        var result = PickemGroupWeekFactory.Create(group, currentWeek);
 
         // Bug being prevented: PickemGroupCreatedHandler used to omit this
         // field, so a non-standard regular-season week (rare but possible)
@@ -49,7 +49,7 @@ public class PickemGroupWeekFactoryTests
     }
 
     [Fact]
-    public void CreateForCurrentWeek_Postseason_WithNoExistingWeeks_FallsBackToWeekNumber()
+    public void Create_Postseason_WithNoExistingWeeks_FallsBackToWeekNumber()
     {
         // Scheduler's first run for a sport that started in postseason
         // (degenerate but possible — fresh data, recurring job firing for
@@ -58,13 +58,13 @@ public class PickemGroupWeekFactoryTests
         var group = NewGroup();
         var currentWeek = NewWeek(weekNumber: 1, isPostSeason: true);
 
-        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+        var result = PickemGroupWeekFactory.Create(group, currentWeek);
 
         result.SeasonWeek.Should().Be(1);
     }
 
     [Fact]
-    public void CreateForCurrentWeek_Postseason_WithExistingWeeks_SequencesOffHighest()
+    public void Create_Postseason_WithExistingWeeks_SequencesOffHighest()
     {
         // Common case: league played a full regular season (ordinals 1..18
         // for an NFL league say), now in postseason. ESPN restarts
@@ -74,31 +74,31 @@ public class PickemGroupWeekFactoryTests
         var group = NewGroup(existingWeekOrdinals: [1, 2, 3, 17, 18]);
         var currentWeek = NewWeek(weekNumber: 1, isPostSeason: true);
 
-        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+        var result = PickemGroupWeekFactory.Create(group, currentWeek);
 
         result.SeasonWeek.Should().Be(19);
     }
 
     [Fact]
-    public void CreateForCurrentWeek_Postseason_IgnoresWeekOrderingInGroupWeeks()
+    public void Create_Postseason_IgnoresWeekOrderingInGroupWeeks()
     {
         // Defensive: the factory must not assume group.Weeks is sorted.
         var group = NewGroup(existingWeekOrdinals: [18, 1, 17, 3, 2]);
         var currentWeek = NewWeek(weekNumber: 2, isPostSeason: true);
 
-        var result = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+        var result = PickemGroupWeekFactory.Create(group, currentWeek);
 
         result.SeasonWeek.Should().Be(19);
     }
 
     [Fact]
-    public void CreateForCurrentWeek_AssignsNewIdEachCall()
+    public void Create_AssignsNewIdEachCall()
     {
         var group = NewGroup();
         var currentWeek = NewWeek(weekNumber: 1, isPostSeason: false);
 
-        var first = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
-        var second = PickemGroupWeekFactory.CreateForCurrentWeek(group, currentWeek);
+        var first = PickemGroupWeekFactory.Create(group, currentWeek);
+        var second = PickemGroupWeekFactory.Create(group, currentWeek);
 
         first.Id.Should().NotBe(Guid.Empty);
         second.Id.Should().NotBe(Guid.Empty);
@@ -106,23 +106,23 @@ public class PickemGroupWeekFactoryTests
     }
 
     [Fact]
-    public void CreateForCurrentWeek_NullGroup_Throws()
+    public void Create_NullGroup_Throws()
     {
         var currentWeek = NewWeek(weekNumber: 1, isPostSeason: false);
 
-        var act = () => PickemGroupWeekFactory.CreateForCurrentWeek(null!, currentWeek);
+        var act = () => PickemGroupWeekFactory.Create(null!, currentWeek);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("group");
     }
 
     [Fact]
-    public void CreateForCurrentWeek_NullCurrentWeek_Throws()
+    public void Create_NullCurrentWeek_Throws()
     {
         var group = NewGroup();
 
-        var act = () => PickemGroupWeekFactory.CreateForCurrentWeek(group, null!);
+        var act = () => PickemGroupWeekFactory.Create(group, null!);
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("currentWeek");
+        act.Should().Throw<ArgumentNullException>().WithParameterName("week");
     }
 
     private static PickemGroup NewGroup(int[]? existingWeekOrdinals = null)

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/BootstrapLeagueMatchupsProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/BootstrapLeagueMatchupsProcessorTests.cs
@@ -167,6 +167,31 @@ public class BootstrapLeagueMatchupsProcessorTests : ApiTestBase<BootstrapLeague
     }
 
     [Fact]
+    public async Task InvertedDateRange_LogsAndReturns_NoEndpointCall_NoEnqueues()
+    {
+        // Permanent input error: window resolved to from > to. The PR-B
+        // validator blocks this at creation but it can surface here if
+        // EndsOn was set, StartsOn was null, and the clock rolled past
+        // EndsOn before the Hangfire job ran. Verify the processor
+        // short-circuits without calling the date-range endpoint and
+        // without throwing (which would burn Hangfire retry budget on a
+        // state that can't be fixed by retrying).
+        var groupId = await SeedGroup(startsOn: null, endsOn: FixedNow.AddDays(-1));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        var act = async () => await sut.Process(command);
+
+        await act.Should().NotThrowAsync();
+        _seasonClientMock.Verify(
+            x => x.GetSeasonWeeksOverlapping(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        VerifyNoEnqueues();
+    }
+
+    [Fact]
     public async Task EmptyDateRangeResult_LogsAndReturns_NoEnqueues()
     {
         // Row 11: very-far-future league whose SeasonWeeks aren't sourced

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/BootstrapLeagueMatchupsProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/BootstrapLeagueMatchupsProcessorTests.cs
@@ -1,0 +1,317 @@
+using FluentAssertions;
+
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.Processors;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Season;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Processors;
+
+/// <summary>
+/// Pins the dispatch behavior on the creation-time orchestrator. Each row in
+/// docs/league-creation-matrix.md collapses to one of these test cases:
+///   • Full-season → GetCurrentSeasonWeek → 1 enqueue (rows 1, 2, 14).
+///   • Windowed   → GetSeasonWeeksOverlapping → N enqueues (rows 7-13).
+///   • Empty range result → 0 enqueues (row 11).
+///   • Group not found → 0 enqueues, no exception.
+///   • Endpoint failure → throw (transient).
+///   • Partial window (EndsOn=null) → 365-day cap applied to `to`.
+/// </summary>
+public class BootstrapLeagueMatchupsProcessorTests : ApiTestBase<BootstrapLeagueMatchupsProcessor>
+{
+    private static readonly DateTime FixedNow = new(2026, 5, 29, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<ISeasonClientFactory> _seasonClientFactoryMock;
+    private readonly Mock<IProvideSeasons> _seasonClientMock;
+    private readonly Mock<IProvideBackgroundJobs> _backgroundJobsMock;
+
+    public BootstrapLeagueMatchupsProcessorTests()
+    {
+        _seasonClientFactoryMock = Mocker.GetMock<ISeasonClientFactory>();
+        _seasonClientMock = new Mock<IProvideSeasons>();
+        _seasonClientFactoryMock
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_seasonClientMock.Object);
+
+        _backgroundJobsMock = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    [Fact]
+    public async Task GroupNotFound_LogsAndReturns_DoesNotThrow()
+    {
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        var act = async () => await sut.Process(command);
+
+        await act.Should().NotThrowAsync();
+        VerifyNoEnqueues();
+    }
+
+    [Fact]
+    public async Task FullSeasonLeague_HitsCurrentWeekEndpoint_AndEnqueuesOne()
+    {
+        // Row 1: StartsOn=null, EndsOn=null → GetCurrentSeasonWeek path.
+        var groupId = await SeedGroup(startsOn: null, endsOn: null);
+        var week = SeasonWeek(weekNumber: 5);
+        _seasonClientMock
+            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<CanonicalSeasonWeekDto>(week));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        await sut.Process(command);
+
+        _seasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Once);
+        _seasonClientMock.Verify(x => x.GetSeasonWeeksOverlapping(
+            It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+        VerifyEnqueueCount(1);
+    }
+
+    [Fact]
+    public async Task WindowedLeague_HitsDateRangeEndpoint_AndEnqueuesPerWeek()
+    {
+        // Rows 12/13: windowed multi-week. 3 SeasonWeeks → 3 enqueues.
+        var startsOn = FixedNow.AddDays(30);
+        var endsOn = FixedNow.AddDays(50);
+        var groupId = await SeedGroup(startsOn: startsOn, endsOn: endsOn);
+
+        _seasonClientMock
+            .Setup(x => x.GetSeasonWeeksOverlapping(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>(new List<CanonicalSeasonWeekDto>
+            {
+                SeasonWeek(weekNumber: 1),
+                SeasonWeek(weekNumber: 2),
+                SeasonWeek(weekNumber: 3),
+            }));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        await sut.Process(command);
+
+        _seasonClientMock.Verify(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()), Times.Never);
+        _seasonClientMock.Verify(x => x.GetSeasonWeeksOverlapping(
+            startsOn, endsOn, It.IsAny<CancellationToken>()), Times.Once);
+        VerifyEnqueueCount(3);
+    }
+
+    [Fact]
+    public async Task WindowedLeague_PartialWindow_StartsOnOnly_AppliesPartialWindowCap()
+    {
+        // Row 6: StartsOn=future, EndsOn=null. `to` must be capped at
+        // StartsOn + 365d per DP-3.
+        var startsOn = FixedNow.AddDays(30);
+        var groupId = await SeedGroup(startsOn: startsOn, endsOn: null);
+
+        _seasonClientMock
+            .Setup(x => x.GetSeasonWeeksOverlapping(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>([SeasonWeek(weekNumber: 1)]));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        await sut.Process(command);
+
+        _seasonClientMock.Verify(
+            x => x.GetSeasonWeeksOverlapping(
+                startsOn,
+                startsOn.AddDays(365),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task WindowedLeague_PartialWindow_EndsOnOnly_FromBoundDefaultsToNow()
+    {
+        // Row 4: StartsOn=null, EndsOn=future. `from` defaults to now.
+        var endsOn = FixedNow.AddDays(60);
+        var groupId = await SeedGroup(startsOn: null, endsOn: endsOn);
+
+        _seasonClientMock
+            .Setup(x => x.GetSeasonWeeksOverlapping(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>([SeasonWeek(weekNumber: 1)]));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        await sut.Process(command);
+
+        _seasonClientMock.Verify(
+            x => x.GetSeasonWeeksOverlapping(
+                FixedNow,
+                endsOn,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EmptyDateRangeResult_LogsAndReturns_NoEnqueues()
+    {
+        // Row 11: very-far-future league whose SeasonWeeks aren't sourced
+        // yet. Endpoint returns empty Success; we log + return; daily
+        // scheduler picks up later.
+        var groupId = await SeedGroup(startsOn: FixedNow.AddYears(1), endsOn: FixedNow.AddYears(1).AddDays(1));
+        _seasonClientMock
+            .Setup(x => x.GetSeasonWeeksOverlapping(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>([]));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        var act = async () => await sut.Process(command);
+
+        await act.Should().NotThrowAsync();
+        VerifyNoEnqueues();
+    }
+
+    [Fact]
+    public async Task FullSeasonLeague_CurrentWeekFailure_Throws()
+    {
+        // Row 2/3: current-week lookup fails. Throw so Hangfire retries.
+        var groupId = await SeedGroup(startsOn: null, endsOn: null);
+        _seasonClientMock
+            .Setup(x => x.GetCurrentSeasonWeek(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<CanonicalSeasonWeekDto>(
+                default!, ResultStatus.NotFound, new List<ValidationFailure>()));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        var act = async () => await sut.Process(command);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        VerifyNoEnqueues();
+    }
+
+    [Fact]
+    public async Task WindowedLeague_DateRangeFailure_Throws()
+    {
+        // Date-range endpoint failure is also transient; Hangfire retries.
+        var groupId = await SeedGroup(startsOn: FixedNow.AddDays(10), endsOn: FixedNow.AddDays(20));
+        _seasonClientMock
+            .Setup(x => x.GetSeasonWeeksOverlapping(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<List<CanonicalSeasonWeekDto>>(
+                default!, ResultStatus.NotFound, new List<ValidationFailure>()));
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, Guid.NewGuid());
+
+        var act = async () => await sut.Process(command);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        VerifyNoEnqueues();
+    }
+
+    [Fact]
+    public async Task EnqueuedCommandsCarryCorrelationId()
+    {
+        // The CorrelationId on the bootstrap command threads through to each
+        // per-week command so the whole chain shows up under one trace.
+        var groupId = await SeedGroup(startsOn: FixedNow.AddDays(10), endsOn: FixedNow.AddDays(20));
+        var correlationId = Guid.NewGuid();
+
+        _seasonClientMock
+            .Setup(x => x.GetSeasonWeeksOverlapping(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<CanonicalSeasonWeekDto>>([SeasonWeek(weekNumber: 1)]));
+
+        ScheduleGroupWeekMatchupsCommand? captured = null;
+        _backgroundJobsMock
+            .Setup(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+                It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()))
+            .Callback<Expression<Func<IScheduleGroupWeekMatchups, Task>>>(expr =>
+            {
+                captured = ExtractCommand(expr);
+            })
+            .Returns("job-id");
+
+        var sut = Mocker.CreateInstance<BootstrapLeagueMatchupsProcessor>();
+        var command = new BootstrapLeagueMatchupsCommand(groupId, correlationId);
+
+        await sut.Process(command);
+
+        captured.Should().NotBeNull();
+        captured!.CorrelationId.Should().Be(correlationId);
+        captured.GroupId.Should().Be(groupId);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedGroup(DateTime? startsOn, DateTime? endsOn)
+    {
+        var group = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Sport = Sport.BaseballMlb,
+            League = League.MLB,
+            StartsOn = startsOn,
+            EndsOn = endsOn,
+        };
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+        return group.Id;
+    }
+
+    private static CanonicalSeasonWeekDto SeasonWeek(int weekNumber) => new()
+    {
+        Id = Guid.NewGuid(),
+        SeasonId = Guid.NewGuid(),
+        SeasonYear = 2026,
+        WeekNumber = weekNumber,
+        SeasonPhase = "regularseason",
+        IsNonStandardWeek = false,
+    };
+
+    private void VerifyEnqueueCount(int expected)
+    {
+        _backgroundJobsMock.Verify(
+            x => x.Enqueue<IScheduleGroupWeekMatchups>(
+                It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            Times.Exactly(expected));
+    }
+
+    private void VerifyNoEnqueues() => VerifyEnqueueCount(0);
+
+    /// <summary>
+    /// Inspects the captured <c>p =&gt; p.Process(cmd)</c> expression tree
+    /// to pull out the constructed command, so per-week command fields can
+    /// be asserted (correlation id, week number, etc.).
+    /// </summary>
+    private static ScheduleGroupWeekMatchupsCommand? ExtractCommand(
+        Expression<Func<IScheduleGroupWeekMatchups, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        var arg = call.Arguments.FirstOrDefault();
+        if (arg is null) return null;
+
+        // The argument is a closure over the local `perWeekCommand` variable —
+        // compile + invoke to materialize the constructed record.
+        var lambda = Expression.Lambda<Func<ScheduleGroupWeekMatchupsCommand>>(arg).Compile();
+        return lambda.Invoke();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -862,5 +862,79 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 sameDayEveningKickoff,
             });
         }
+
+        /// <summary>
+        /// AreMatchupsGenerated rule: empty result must leave the flag false so
+        /// the daily scheduler retries. This is the load-bearing piece for the
+        /// eager-bootstrap path — NCAAFB+RankingFilter shells created pre-poll
+        /// would otherwise mark themselves done with 0 rows and never get
+        /// reconsidered after the AP poll lands.
+        /// </summary>
+        [Fact]
+        public async Task Process_NoMatchupsAfterFilter_LeavesAreMatchupsGeneratedFalse()
+        {
+            // Arrange — direct group construction (AutoFixture's int? Matchup
+            // generation has been flaky in this file; bypass it for the
+            // filter assertion to stay deterministic).
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+
+            var group = new PickemGroup
+            {
+                Id = groupId,
+                Name = "Test",
+                Sport = Core.Common.Sport.FootballNcaa,
+                League = League.NCAAF,
+                RankingFilter = TeamRankingFilter.AP_TOP_5,
+                CommissionerUserId = Guid.NewGuid(),
+                CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
+                CreatedBy = Guid.Empty,
+            };
+            await DataContext.PickemGroups.AddAsync(group);
+            await DataContext.SaveChangesAsync();
+
+            // Direct Matchup construction — no AutoFixture for these so the
+            // rank values stay exactly what the test sets.
+            var allMatchups = new List<Matchup>
+            {
+                new()
+                {
+                    SeasonWeekId = seasonWeekId,
+                    SeasonYear = 2024,
+                    SeasonWeek = 1,
+                    ContestId = Guid.NewGuid(),
+                    AwaySlug = "team-a",
+                    HomeSlug = "team-b",
+                    AwayRank = 20,
+                    HomeRank = null,
+                    AwayConferenceSlug = "unaffiliated-1",
+                    HomeConferenceSlug = "unaffiliated-2",
+                    Status = "STATUS_SCHEDULED",
+                    StatusDescription = "Scheduled",
+                    StartDateUtc = new DateTime(2024, 9, 7, 19, 0, 0, DateTimeKind.Utc),
+                },
+            };
+
+            _contestClientMock
+                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId, seasonWeekId, 2024, 1, false, Guid.NewGuid());
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — shell persisted, but flag stays false so the scheduler
+            // re-fires this week on its next pass.
+            var savedGroupWeek = await DataContext.PickemGroupWeeks
+                .Include(gw => gw.Matchups)
+                .FirstOrDefaultAsync(x => x.GroupId == groupId);
+            savedGroupWeek.Should().NotBeNull();
+            savedGroupWeek!.Matchups.Should().BeEmpty();
+            savedGroupWeek.AreMatchupsGenerated.Should().BeFalse();
+        }
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandlerTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 
+using Moq;
+
 using SportsData.Core.Common;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -19,6 +21,19 @@ public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSe
     private static readonly Guid SeasonId = Guid.NewGuid();
     private static readonly Guid SeasonPhaseId = Guid.NewGuid();
     private const int SeasonYear = 2026;
+    private static readonly DateTime FixedUtcNow = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public GetSeasonWeeksByDateRangeQueryHandlerTests()
+    {
+        // The handler under test doesn't consume IDateTimeProvider, but the
+        // seed helpers set CreatedUtc via the provider so test fixtures stay
+        // deterministic (per CLAUDE.md guidance — DateTime.UtcNow is banned
+        // in tests). Centralized setup keeps every entity's CreatedUtc equal
+        // to FixedUtcNow.
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedUtcNow);
+    }
 
     [Fact]
     public async Task ExecuteAsync_SingleWeekFullyInsideRange_ReturnsThatWeek()
@@ -172,7 +187,7 @@ public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSe
         // Assert
         result.IsSuccess.Should().BeFalse();
         var failure = (Failure<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result;
-        failure.Status.Should().Be(ResultStatus.BadRequest);
+        failure.Status.Should().Be(ResultStatus.Validation);
         failure.Errors.Should().ContainSingle()
             .Which.PropertyName.Should().Be(nameof(GetSeasonWeeksByDateRangeQuery.From));
     }
@@ -188,7 +203,7 @@ public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSe
             Name = $"{SeasonYear} Season",
             StartDate = new DateTime(SeasonYear, 8, 1, 0, 0, 0, DateTimeKind.Utc),
             EndDate = new DateTime(SeasonYear + 1, 2, 1, 0, 0, 0, DateTimeKind.Utc),
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
             CreatedBy = Guid.NewGuid()
         };
         var phase = new SeasonPhase
@@ -201,7 +216,7 @@ public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSe
             Year = SeasonYear,
             StartDate = season.StartDate,
             EndDate = season.EndDate,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
             CreatedBy = Guid.NewGuid()
         };
 
@@ -220,7 +235,7 @@ public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSe
             Number = weekNumber,
             StartDate = startDate,
             EndDate = endDate,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
             CreatedBy = Guid.NewGuid()
         });
         await FootballDataContext.SaveChangesAsync();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandlerTests.cs
@@ -1,0 +1,228 @@
+using FluentAssertions;
+
+using SportsData.Core.Common;
+using SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
+
+/// <summary>
+/// Pins the overlap predicate + ordering + boundary-inclusion + empty/bad-input
+/// behavior on the new date-range query handler. This endpoint is the
+/// load-bearing dependency for the API-side league-creation redesign — windowed
+/// leagues hit this to resolve which SeasonWeek(s) to bootstrap.
+/// </summary>
+public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSeasonWeeksByDateRangeQueryHandler>
+{
+    private static readonly Guid SeasonId = Guid.NewGuid();
+    private static readonly Guid SeasonPhaseId = Guid.NewGuid();
+    private const int SeasonYear = 2026;
+
+    [Fact]
+    public async Task ExecuteAsync_SingleWeekFullyInsideRange_ReturnsThatWeek()
+    {
+        // Arrange — one week, query range strictly encloses it.
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(
+            weekNumber: 1,
+            startDate: new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            endDate: new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+        var query = new GetSeasonWeeksByDateRangeQuery(
+            From: new DateTime(2026, 8, 25, 0, 0, 0, DateTimeKind.Utc),
+            To: new DateTime(2026, 9, 14, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var weeks = ((Success<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result).Value;
+        weeks.Should().HaveCount(1);
+        weeks[0].WeekNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleOverlappingWeeks_ReturnsAllOrderedByStartDate()
+    {
+        // Arrange — three weeks; query covers them all.
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(1, new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc));
+        await SeedWeekAsync(3, new DateTime(2026, 9, 15, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 21, 0, 0, 0, DateTimeKind.Utc));
+        await SeedWeekAsync(2, new DateTime(2026, 9, 8, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 14, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+        var query = new GetSeasonWeeksByDateRangeQuery(
+            From: new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            To: new DateTime(2026, 9, 21, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert — defensive: insertion order was scrambled but query orders by StartDate.
+        result.IsSuccess.Should().BeTrue();
+        var weeks = ((Success<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result).Value;
+        weeks.Select(w => w.WeekNumber).Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RangeStraddlesWeekStart_IncludesPartialOverlap()
+    {
+        // Arrange — query ends mid-week.
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(1, new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+        var query = new GetSeasonWeeksByDateRangeQuery(
+            From: new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Utc),
+            To: new DateTime(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        ((Success<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result).Value.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RangeEndsExactlyOnWeekStart_IncludesWeek()
+    {
+        // Boundary check: inclusive overlap. A week starting at the exact
+        // `To` instant still overlaps and must be returned.
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(1, new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+        var query = new GetSeasonWeeksByDateRangeQuery(
+            From: new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            To: new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        ((Success<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result).Value.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RangeStartsExactlyOnWeekEnd_IncludesWeek()
+    {
+        // Mirror of the previous boundary case.
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(1, new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+        var query = new GetSeasonWeeksByDateRangeQuery(
+            From: new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc),
+            To: new DateTime(2026, 9, 30, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        ((Success<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result).Value.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RangeOutsideAllWeeks_ReturnsEmptySuccess()
+    {
+        // Row 11 in the matrix: very-far-future league whose SeasonWeeks
+        // aren't sourced yet. Empty list, but Success — not Failure — so
+        // the API caller can distinguish "no weeks for that range" from
+        // "Producer is down."
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(1, new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+        var query = new GetSeasonWeeksByDateRangeQuery(
+            From: new DateTime(2027, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            To: new DateTime(2027, 6, 30, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        ((Success<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result).Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FromGreaterThanTo_ReturnsBadRequestFailure()
+    {
+        // Flipped range is a client bug — fail fast at the boundary rather
+        // than silently returning nothing (which would look identical to a
+        // legitimate empty result and mask the typo).
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(1, new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+        var query = new GetSeasonWeeksByDateRangeQuery(
+            From: new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc),
+            To: new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        var failure = (Failure<List<Core.Dtos.Canonical.CanonicalSeasonWeekDto>>)result;
+        failure.Status.Should().Be(ResultStatus.BadRequest);
+        failure.Errors.Should().ContainSingle()
+            .Which.PropertyName.Should().Be(nameof(GetSeasonWeeksByDateRangeQuery.From));
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private async Task SeedSeasonScaffoldingAsync()
+    {
+        var season = new Season
+        {
+            Id = SeasonId,
+            Year = SeasonYear,
+            Name = $"{SeasonYear} Season",
+            StartDate = new DateTime(SeasonYear, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(SeasonYear + 1, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        var phase = new SeasonPhase
+        {
+            Id = SeasonPhaseId,
+            SeasonId = SeasonId,
+            Name = "Regular Season",
+            Abbreviation = "REG",
+            Slug = "regular-season",
+            Year = SeasonYear,
+            StartDate = season.StartDate,
+            EndDate = season.EndDate,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        await FootballDataContext.Seasons.AddAsync(season);
+        await FootballDataContext.SeasonPhases.AddAsync(phase);
+        await FootballDataContext.SaveChangesAsync();
+    }
+
+    private async Task SeedWeekAsync(int weekNumber, DateTime startDate, DateTime endDate)
+    {
+        await FootballDataContext.SeasonWeeks.AddAsync(new SeasonWeek
+        {
+            Id = Guid.NewGuid(),
+            SeasonId = SeasonId,
+            SeasonPhaseId = SeasonPhaseId,
+            Number = weekNumber,
+            StartDate = startDate,
+            EndDate = endDate,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

**PR-D** of the league-creation hardening plan. Adds a per-league window + DeactivatedUtc gate to `MatchupScheduler` so the daily run respects league start/end dates and inactive status. With PR-B's eager-bootstrap dispatch already in main, this closes the second half of the motivating bug — a single-day MLB league with `StartsOn` in the future no longer produces an orphan `PickemGroupWeek` at creation **or** on subsequent scheduler runs.

## Scope trim

The original PR-D listed three things: scheduler gate + handler base extraction + field wiring. This PR ships only the first. The other two move to a deferred **PR-E** (documented in the plan section) — they're pure hygiene and benefit from independent review:

- Handler base extraction (collapsing NCAA / NFL / MLB into a shared base) is a meaningful refactor with no behavior change.
- `MaxUsers` / `NonStandardWeekGroupSeasonMapFilter` wiring is independent of the bug fix.

Splitting keeps PR-D focused and reviewable. PR-E can land whenever.

## Implementation

- `MatchupScheduler` gains `IDateTimeProvider`.
- New `InWindowPredicate(now)` returns an `Expression<Func<PickemGroup, bool>>` so EF Core translates it into SQL. Predicate:
  ```
  DeactivatedUtc == null
  AND (StartsOn == null OR StartsOn <= now)
  AND (EndsOn == null OR EndsOn >= now)
  ```
- Applied at **both** query sites:
  1. The sport-discovery query — so a sport whose only league is out-of-window doesn't trigger an unnecessary `GetCurrentSeasonWeek` call to Producer (and doesn't NPE on a then-null `currentWeek`).
  2. The per-sport groups query — the actual gate that prevents the orphan row.
- Drive-by: switched the season-client result handling from the legacy `IsSuccess ? Value : null` pattern to a direct `!IsSuccess` guard, matching the cleanup landed in PR-B's handler.

## Tests

5 new scheduler tests:
- `Skips_FutureStart_League` — daily-orphan regression for the motivating bug.
- `Skips_ClosedWindow_League` — `EndsOn`-in-past mirror.
- `Skips_Deactivated_League` — `DeactivatedUtc` filter.
- `Processes_InWindow_League` — mid-window happy path.
- `MixedWindow_OnlyProcesses_InWindow_League` — per-league gate; a future-start league mustn't poison the sport's processing.

4 existing scheduler tests still pass (null `StartsOn` / `EndsOn` → new gate is a no-op). Constructor now sets a fixed `IDateTimeProvider.UtcNow()` to keep them deterministic.

Full API unit suite: **362/362 passing**.

## Test plan (local E2E)

- [ ] Create an MLB league with `StartsOn = today + 10`. Confirm no `PickemGroupWeek` row appears.
- [ ] Fast-forward `IDateTimeProvider` (or wait) past `StartsOn`. Run the scheduler. Confirm a `PickemGroupWeek` row appears.
- [ ] Manually set a league's `DeactivatedUtc` and `EndsOn = future`. Run the scheduler. Confirm no row.
- [ ] Confirm an in-window league still gets weeks created normally (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bootstrap orchestration that fans out per-week scheduling for new leagues and a date-range season-week lookup endpoint for windowed leagues; created a lightweight event fan-out to trigger bootstrapping.

* **Bug Fixes**
  * Scheduler now skips out-of-window or deactivated leagues and leaves empty weeks marked ungenerated so they can be retried; includes prod-data cleanup guidance for orphaned league-week rows.

* **Tests**
  * Expanded unit tests for time-window gating, bootstrap dispatch, factory behavior, and matchup-generation edge cases.

* **Documentation**
  * Updated hardening plan, validation checklist, possibility matrix, and E2E regression steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->