### PR TITLE
feat(api,producer,web): on-demand full play log endpoint + "Show all plays" wiring

### DIFF
--- a/src/SportsData.Api/Application/UI/Contest/ContestController.cs
+++ b/src/SportsData.Api/Application/UI/Contest/ContestController.cs
@@ -5,6 +5,7 @@ using SportsData.Api.Application.UI.Contest.Commands.FinalizeContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContestMedia;
 using SportsData.Api.Application.UI.Contest.Queries.GetContestOverview;
+using SportsData.Api.Application.UI.Contest.Queries.GetContestPlayLog;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Mapping;
 using SportsData.Core.Dtos.Canonical;
@@ -27,6 +28,27 @@ public class ContestController : ApiControllerBase
     {
         var mode = ModeMapper.ResolveMode(sport, league);
         var query = new GetContestOverviewQuery { ContestId = id, Sport = mode };
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// On-demand full play log for the Contest Overview page's "Show all
+    /// plays" toggle. The default overview endpoint trims to key/scoring
+    /// plays to keep its payload small (~10 rows); this endpoint returns
+    /// every play (~500 for MLB, ~150 for football).
+    /// </summary>
+    [HttpGet("{id}/playlog")]
+    public async Task<ActionResult<PlayLogDto>> GetContestPlayLog(
+        [FromRoute] Guid id,
+        [FromQuery] string sport = "football",
+        [FromQuery] string league = "ncaa",
+        [FromServices] IGetContestPlayLogQueryHandler handler = default!,
+        CancellationToken cancellationToken = default)
+    {
+        var mode = ModeMapper.ResolveMode(sport, league);
+        var query = new GetContestPlayLogQuery { ContestId = id, Sport = mode };
         var result = await handler.ExecuteAsync(query, cancellationToken);
 
         return result.ToActionResult();

--- a/src/SportsData.Api/Application/UI/Contest/Queries/GetContestPlayLog/GetContestPlayLogQuery.cs
+++ b/src/SportsData.Api/Application/UI/Contest/Queries/GetContestPlayLog/GetContestPlayLogQuery.cs
@@ -1,0 +1,10 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.UI.Contest.Queries.GetContestPlayLog;
+
+public class GetContestPlayLogQuery
+{
+    public required Guid ContestId { get; init; }
+
+    public required Sport Sport { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Contest/Queries/GetContestPlayLog/GetContestPlayLogQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Contest/Queries/GetContestPlayLog/GetContestPlayLogQueryHandler.cs
@@ -1,0 +1,59 @@
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.UI.Contest.Queries.GetContestPlayLog;
+
+public interface IGetContestPlayLogQueryHandler
+{
+    Task<Result<PlayLogDto>> ExecuteAsync(
+        GetContestPlayLogQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// API-side proxy for the Producer's full-play-log endpoint. Mirrors
+/// <see cref="GetContestOverview.GetContestOverviewQueryHandler"/> in shape —
+/// resolves the sport-keyed contest client, calls the matching method, logs
+/// failure for diagnostics. The Producer side does the actual DB work.
+/// </summary>
+public class GetContestPlayLogQueryHandler : IGetContestPlayLogQueryHandler
+{
+    private readonly ILogger<GetContestPlayLogQueryHandler> _logger;
+    private readonly IContestClientFactory _contestClientFactory;
+
+    public GetContestPlayLogQueryHandler(
+        ILogger<GetContestPlayLogQueryHandler> logger,
+        IContestClientFactory contestClientFactory)
+    {
+        _logger = logger;
+        _contestClientFactory = contestClientFactory;
+    }
+
+    public async Task<Result<PlayLogDto>> ExecuteAsync(
+        GetContestPlayLogQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var contestClient = _contestClientFactory.Resolve(query.Sport);
+
+        var correlationId = ActivityExtensions.GetCorrelationId();
+
+        _logger.LogInformation(
+            "GetContestPlayLog requested. ContestId={ContestId}, CorrelationId={CorrelationId}",
+            query.ContestId,
+            correlationId);
+
+        var result = await contestClient.GetContestPlayLogByContestId(query.ContestId, cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            _logger.LogWarning(
+                "Failed to get contest play log. ContestId={ContestId}, CorrelationId={CorrelationId}",
+                query.ContestId,
+                correlationId);
+        }
+
+        return result;
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -35,6 +35,7 @@ using SportsData.Api.Application.UI.Contest.Commands.RefreshContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContestMedia;
 using SportsData.Api.Application.UI.Contest.Commands.SubmitContestPredictions;
 using SportsData.Api.Application.UI.Contest.Queries.GetContestOverview;
+using SportsData.Api.Application.UI.Contest.Queries.GetContestPlayLog;
 using SportsData.Api.Application.UI.Leaderboard.Queries.GetLeaderboard;
 using SportsData.Api.Application.UI.Leaderboard.Queries.GetLeaderboardWidget;
 using SportsData.Api.Application.UI.Leagues.Commands.AddMatchup;
@@ -168,6 +169,7 @@ namespace SportsData.Api.DependencyInjection
 
             // Contest Queries
             services.AddScoped<IGetContestOverviewQueryHandler, GetContestOverviewQueryHandler>();
+            services.AddScoped<IGetContestPlayLogQueryHandler, GetContestPlayLogQueryHandler>();
 
             // Season Queries
             services.AddScoped<IGetSeasonOverviewQueryHandler, GetSeasonOverviewQueryHandler>();

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
@@ -31,6 +31,14 @@ public interface IProvideContests : IProvideHealthChecks
 
     Task<Result<ContestOverviewDto>> GetContestOverviewByContestId(Guid contestId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Full play-by-play log for a contest. Companion to the overview
+    /// endpoint, which trims plays to key/scoring only — this returns the
+    /// complete list (up to ~500 rows for an MLB game). Backs the
+    /// on-demand "Show all plays" expansion in the UI.
+    /// </summary>
+    Task<Result<PlayLogDto>> GetContestPlayLogByContestId(Guid contestId, CancellationToken cancellationToken = default);
+
     Task<Result<bool>> RefreshContest(Guid contestId, CancellationToken cancellationToken = default);
 
     Task<Result<bool>> RefreshContestMediaByContestId(Guid contestId, CancellationToken cancellationToken = default);
@@ -136,6 +144,25 @@ public class ContestClient : ClientBase, IProvideContests
             overview => overview,
             default!,
             "Contest overview",
+            ResultStatus.NotFound,
+            cancellationToken);
+    }
+
+    public async Task<Result<PlayLogDto>> GetContestPlayLogByContestId(Guid contestId, CancellationToken cancellationToken = default)
+    {
+        if (contestId == Guid.Empty)
+        {
+            return new Failure<PlayLogDto>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure("contestId", "Contest ID cannot be empty")]);
+        }
+
+        return await GetAsync<PlayLogDto, PlayLogDto>(
+            $"contests/{contestId}/playlog",
+            playLog => playLog,
+            default!,
+            "Contest play log",
             ResultStatus.NotFound,
             cancellationToken);
     }

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -14,6 +14,7 @@ using SportsData.Producer.Application.Competitions.Commands.RefreshCompetitionMe
 using SportsData.Producer.Application.Contests.Commands;
 using SportsData.Producer.Application.Contests.Queries.GetContestById;
 using SportsData.Producer.Application.Contests.Queries.GetContestOverview;
+using SportsData.Producer.Application.Contests.Queries.GetContestPlayLog;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 
@@ -188,6 +189,25 @@ namespace SportsData.Producer.Application.Contests
             CancellationToken cancellationToken = default)
         {
             var query = new GetContestOverviewQuery(id);
+            var result = await handler.ExecuteAsync(query, cancellationToken);
+
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Full play-by-play log for a contest. The overview endpoint above
+        /// trims plays to key/scoring only to keep the typical "Contest
+        /// Overview" page payload manageable; this endpoint backs the
+        /// on-demand "Show all plays" expansion in the UI (e.g., 500+ MLB
+        /// plays).
+        /// </summary>
+        [HttpGet("{id}/playlog")]
+        public async Task<ActionResult<PlayLogDto>> GetContestPlayLog(
+            [FromServices] IGetContestPlayLogQueryHandler handler,
+            [FromRoute] Guid id,
+            CancellationToken cancellationToken = default)
+        {
+            var query = new GetContestPlayLogQuery(id);
             var result = await handler.ExecuteAsync(query, cancellationToken);
 
             return result.ToActionResult();

--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
@@ -529,7 +529,7 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
         var plays = await _dbContext.CompetitionPlays
             .AsNoTracking()
             .Include(p => p.Competition)
-            .Where(p => p.Competition.ContestId == contestId)
+            .Where(p => p.Competition.ContestId == contestId && (p.Priority || p.ScoringPlay)) // return only significant plays (scoring or marked key plays) to limit payload size; adjust as needed
             .OrderBy(p => p.SequenceNumber)
             .ToListAsync(cancellationToken);
 

--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestOverview/GetContestOverviewQueryHandler.cs
@@ -123,6 +123,7 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
                 awayTeamLogoUri,
                 homeTeamLogoUri,
                 awayTeamFranchiseSeasonId,
+                homeTeamFranchiseSeasonId,
                 cancellationToken),
             TeamStats = await GetTeamStatsAsync(query.ContestId, cancellationToken),
             Info = await GetGameInfoAsync(query.ContestId, cancellationToken),
@@ -524,6 +525,7 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
         Uri? awayTeamLogoUri,
         Uri? homeTeamLogoUri,
         Guid awayTeamFranchiseSeasonId,
+        Guid homeTeamFranchiseSeasonId,
         CancellationToken cancellationToken)
     {
         var plays = await _dbContext.CompetitionPlays
@@ -537,14 +539,20 @@ public partial class GetContestOverviewQueryHandler : IGetContestOverviewQueryHa
         {
             // Use StartFranchiseSeasonId (shared) — for football this is the start team,
             // for baseball this is the batting team. Both serve as the "team on play".
+            // Neutral plays (no attribution, or attribution to a third party we
+            // don't recognize) get Team = null so the UI renders no logo rather
+            // than mis-attributing to home.
             var teamId = p.StartFranchiseSeasonId ?? Guid.Empty;
+            string? teamSlug = null;
+            if (teamId == awayTeamFranchiseSeasonId) teamSlug = awayTeamSlug;
+            else if (teamId == homeTeamFranchiseSeasonId) teamSlug = homeTeamSlug;
 
             return new PlayDto
             {
                 Ordinal = x,
                 Quarter = p.PeriodNumber,
                 FranchiseSeasonId = teamId,
-                Team = teamId == awayTeamFranchiseSeasonId ? awayTeamSlug : homeTeamSlug,
+                Team = teamSlug,
                 Description = p.ShortAlternativeText ?? p.Text,
                 TimeRemaining = (p as FootballCompetitionPlay)?.ClockDisplayValue,
                 IsScoringPlay = p.ScoringPlay,

--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQuery.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQuery.cs
@@ -1,0 +1,9 @@
+namespace SportsData.Producer.Application.Contests.Queries.GetContestPlayLog;
+
+/// <summary>
+/// Full play-by-play log for a contest. The overview endpoint trims to
+/// key/scoring plays only to keep its payload small; this endpoint exists
+/// as the on-demand "Show all plays" expansion (typically 500+ rows for an
+/// MLB game).
+/// </summary>
+public record GetContestPlayLogQuery(Guid ContestId);

--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQueryHandler.cs
@@ -99,19 +99,27 @@ public class GetContestPlayLogQueryHandler : IGetContestPlayLogQueryHandler
             .OrderBy(p => p.SequenceNumber)
             .ToListAsync(cancellationToken);
 
+        var homeTeamFranchiseSeasonId = contest.HomeTeamFranchiseSeasonId;
+
         var playDtos = plays.Select((p, x) =>
         {
             // Mirrors the mapping in GetContestOverviewQueryHandler.GetPlayLogAsync.
             // StartFranchiseSeasonId is the start team (football) / batting team
-            // (baseball) — both serve as "team on play" for display.
+            // (baseball) — both serve as "team on play" for display. Neutral
+            // plays (no attribution, or attribution to a third party we don't
+            // recognize) get Team = null so the UI renders no logo rather than
+            // mis-attributing to home.
             var teamId = p.StartFranchiseSeasonId ?? Guid.Empty;
+            string? teamSlug = null;
+            if (teamId == awayTeamFranchiseSeasonId) teamSlug = awayTeamSlug;
+            else if (teamId == homeTeamFranchiseSeasonId) teamSlug = homeTeamSlug;
 
             return new PlayDto
             {
                 Ordinal = x,
                 Quarter = p.PeriodNumber,
                 FranchiseSeasonId = teamId,
-                Team = teamId == awayTeamFranchiseSeasonId ? awayTeamSlug : homeTeamSlug,
+                Team = teamSlug,
                 Description = p.ShortAlternativeText ?? p.Text,
                 TimeRemaining = (p as FootballCompetitionPlay)?.ClockDisplayValue,
                 IsScoringPlay = p.ScoringPlay,

--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQueryHandler.cs
@@ -1,0 +1,133 @@
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Application.Services;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+namespace SportsData.Producer.Application.Contests.Queries.GetContestPlayLog;
+
+public interface IGetContestPlayLogQueryHandler
+{
+    Task<Result<PlayLogDto>> ExecuteAsync(GetContestPlayLogQuery query, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Returns every <see cref="CompetitionPlay"/> for a contest, ordered by
+/// <c>SequenceNumber</c>. Companion to the overview handler — the overview
+/// endpoint filters plays to <c>(Priority || ScoringPlay)</c> to keep its
+/// payload manageable; this endpoint serves the on-demand "Show all plays"
+/// expansion in the UI.
+/// </summary>
+public class GetContestPlayLogQueryHandler : IGetContestPlayLogQueryHandler
+{
+    private readonly TeamSportDataContext _dbContext;
+    private readonly ILogoSelectionService _logoSelectionService;
+    private readonly IValidator<GetContestPlayLogQuery> _validator;
+    private readonly ILogger<GetContestPlayLogQueryHandler> _logger;
+
+    public GetContestPlayLogQueryHandler(
+        TeamSportDataContext dbContext,
+        ILogoSelectionService logoSelectionService,
+        IValidator<GetContestPlayLogQuery> validator,
+        ILogger<GetContestPlayLogQueryHandler> logger)
+    {
+        _dbContext = dbContext;
+        _logoSelectionService = logoSelectionService;
+        _validator = validator;
+        _logger = logger;
+    }
+
+    public async Task<Result<PlayLogDto>> ExecuteAsync(
+        GetContestPlayLogQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var validationResult = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return new Failure<PlayLogDto>(
+                default!,
+                ResultStatus.Validation,
+                validationResult.Errors);
+        }
+
+        var contest = await _dbContext.Contests
+            .AsNoTracking()
+            .Include(x => x.AwayTeamFranchiseSeason!)
+            .ThenInclude(x => x.Franchise)
+            .ThenInclude(x => x.Logos)
+            .Include(x => x.HomeTeamFranchiseSeason!)
+            .ThenInclude(x => x.Franchise)
+            .ThenInclude(x => x.Logos)
+            .Include(x => x.AwayTeamFranchiseSeason!)
+            .ThenInclude(x => x.Logos!)
+            .Include(x => x.HomeTeamFranchiseSeason!)
+            .ThenInclude(x => x.Logos!)
+            .AsSplitQuery()
+            .FirstOrDefaultAsync(c => c.Id == query.ContestId, cancellationToken);
+
+        if (contest is null)
+        {
+            return new Failure<PlayLogDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new FluentValidation.Results.ValidationFailure(
+                    nameof(query.ContestId),
+                    $"Contest with ID {query.ContestId} not found")]);
+        }
+
+        var awayTeamSlug = contest.AwayTeamFranchiseSeason!.Franchise!.Slug!;
+        var homeTeamSlug = contest.HomeTeamFranchiseSeason!.Franchise!.Slug!;
+
+        var awayTeamLogoUri = _logoSelectionService.SelectLogoForDarkBackground(contest.AwayTeamFranchiseSeason?.Logos)
+                              ?? _logoSelectionService.SelectLogoForDarkBackground(contest.AwayTeamFranchiseSeason?.Franchise?.Logos);
+        var homeTeamLogoUri = _logoSelectionService.SelectLogoForDarkBackground(contest.HomeTeamFranchiseSeason?.Logos)
+                              ?? _logoSelectionService.SelectLogoForDarkBackground(contest.HomeTeamFranchiseSeason?.Franchise?.Logos);
+
+        var awayTeamFranchiseSeasonId = contest.AwayTeamFranchiseSeasonId;
+
+        // Full set — no Priority/ScoringPlay filter. For an MLB game this can
+        // be ~500 rows; for football typically ~150. Caller has opted into
+        // the larger payload via the "Show all plays" UI toggle.
+        var plays = await _dbContext.CompetitionPlays
+            .AsNoTracking()
+            .Include(p => p.Competition)
+            .Where(p => p.Competition.ContestId == query.ContestId)
+            .OrderBy(p => p.SequenceNumber)
+            .ToListAsync(cancellationToken);
+
+        var playDtos = plays.Select((p, x) =>
+        {
+            // Mirrors the mapping in GetContestOverviewQueryHandler.GetPlayLogAsync.
+            // StartFranchiseSeasonId is the start team (football) / batting team
+            // (baseball) — both serve as "team on play" for display.
+            var teamId = p.StartFranchiseSeasonId ?? Guid.Empty;
+
+            return new PlayDto
+            {
+                Ordinal = x,
+                Quarter = p.PeriodNumber,
+                FranchiseSeasonId = teamId,
+                Team = teamId == awayTeamFranchiseSeasonId ? awayTeamSlug : homeTeamSlug,
+                Description = p.ShortAlternativeText ?? p.Text,
+                TimeRemaining = (p as FootballCompetitionPlay)?.ClockDisplayValue,
+                IsScoringPlay = p.ScoringPlay,
+                IsKeyPlay = p.Priority
+            };
+        }).ToList();
+
+        var dto = new PlayLogDto
+        {
+            AwayTeamSlug = awayTeamSlug,
+            HomeTeamSlug = homeTeamSlug,
+            AwayTeamLogoUrl = awayTeamLogoUri is null ? string.Empty : awayTeamLogoUri.OriginalString,
+            HomeTeamLogoUrl = homeTeamLogoUri is null ? string.Empty : homeTeamLogoUri.OriginalString,
+            Plays = playDtos
+        };
+
+        return new Success<PlayLogDto>(dto);
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/GetContestPlayLogQueryValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace SportsData.Producer.Application.Contests.Queries.GetContestPlayLog;
+
+public class GetContestPlayLogQueryValidator : AbstractValidator<GetContestPlayLogQuery>
+{
+    public GetContestPlayLogQueryValidator()
+    {
+        RuleFor(x => x.ContestId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("ContestId must be provided");
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -18,6 +18,7 @@ using SportsData.Producer.Application.Contests;
 using SportsData.Producer.Application.Contests.Commands;
 using SportsData.Producer.Application.Contests.Queries.GetContestById;
 using SportsData.Producer.Application.Contests.Queries.GetContestOverview;
+using SportsData.Producer.Application.Contests.Queries.GetContestPlayLog;
 using SportsData.Producer.Application.Contests.Queries.Matchups.GetCompletedFbsContestIds;
 using SportsData.Producer.Application.Contests.Queries.Matchups.GetContestResults;
 using SportsData.Producer.Application.Contests.Queries.Matchups.GetFinalizedContestIds;
@@ -293,9 +294,11 @@ namespace SportsData.Producer.DependencyInjection
             // Contest Queries
             services.AddScoped<IGetContestByIdQueryHandler, GetContestByIdQueryHandler>();
             services.AddScoped<IGetContestOverviewQueryHandler, GetContestOverviewQueryHandler>();
+            services.AddScoped<IGetContestPlayLogQueryHandler, GetContestPlayLogQueryHandler>();
 
             // Contest Query Validators
             services.AddScoped<FluentValidation.IValidator<GetContestOverviewQuery>, GetContestOverviewQueryValidator>();
+            services.AddScoped<FluentValidation.IValidator<GetContestPlayLogQuery>, GetContestPlayLogQueryValidator>();
 
             services.AddScoped<IGroupSeasonsService, GroupSeasonsService>();
             services.AddScoped<ILogoSelectionService, LogoSelectionService>();

--- a/src/UI/sd-ui/src/api/contestApi.js
+++ b/src/UI/sd-ui/src/api/contestApi.js
@@ -6,6 +6,13 @@ const ContestApi = {
     apiClient.get(`/ui/contest/${contestId}/overview`, {
       params: { sport, league }
     }),
+  // On-demand full play log. The overview endpoint above returns only the
+  // significant plays (scoring + priority); this fetches every play and
+  // backs the "Show all plays" toggle.
+  getContestPlayLog: (contestId, sport, league) =>
+    apiClient.get(`/ui/contest/${contestId}/playlog`, {
+      params: { sport, league }
+    }),
   refresh: (contestId, sport, league) =>
     apiClient.post(`/ui/contest/${contestId}/refresh`, null, {
       params: { sport, league }

--- a/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
@@ -105,7 +105,7 @@ export default function ContestOverview() {
           <ContestOverviewInfo info={info} />
         </div>
         <div className="contest-overview-col">
-          <ContestOverviewPlaylog playLog={playLog} sport={sport} />
+          <ContestOverviewPlaylog playLog={playLog} sport={sport} contestId={contestId} league={league} />
         </div>
       </div>
       {isAdmin && (

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { getPeriodPrefix } from "../../utils/periodLabel";
 import apiWrapper from "../../api/apiWrapper";
 import "./ContestOverview.css";
@@ -20,6 +20,19 @@ export default function ContestOverviewPlaylog({ playLog, sport, contestId, leag
   const [fullPlayLog, setFullPlayLog] = useState(null);
   const [loadingFull, setLoadingFull] = useState(false);
   const [fullError, setFullError] = useState(null);
+
+  // Reset lazy-load state when the contest context changes. The parent
+  // page (ContestOverview) is rendered by a React Router route that
+  // matches the same definition for every contest id, so navigating
+  // between contests re-renders this component instance with new props
+  // rather than remounting it — without this effect the cached
+  // fullPlayLog from a prior contest would leak into the next one.
+  useEffect(() => {
+    setShowAll(false);
+    setFullPlayLog(null);
+    setLoadingFull(false);
+    setFullError(null);
+  }, [contestId, sport, league]);
 
   if (!playLog || !playLog.plays) return null;
 

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
@@ -1,13 +1,55 @@
 import React, { useState } from "react";
 import { getPeriodPrefix } from "../../utils/periodLabel";
+import apiWrapper from "../../api/apiWrapper";
 import "./ContestOverview.css";
 
-export default function ContestOverviewPlaylog({ playLog, sport }) {
+/**
+ * Renders the "Play Log" panel on the Contest Overview page.
+ *
+ * The `playLog` prop carries only the *significant* plays (scoring or
+ * marked-priority) that the backend's overview endpoint returns by default
+ * to keep the payload small (~10 rows vs. 500+ for MLB). When the user
+ * checks "Show all plays" we fetch the full log from `/ui/contest/:id/playlog`
+ * on demand and cache it in component state so subsequent toggles don't
+ * re-fetch.
+ */
+export default function ContestOverviewPlaylog({ playLog, sport, contestId, league }) {
   const periodPrefix = getPeriodPrefix(sport);
   const [showAll, setShowAll] = useState(false);
+  // Lazy-loaded full play log. Null until the user first opts in.
+  const [fullPlayLog, setFullPlayLog] = useState(null);
+  const [loadingFull, setLoadingFull] = useState(false);
+  const [fullError, setFullError] = useState(null);
+
   if (!playLog || !playLog.plays) return null;
-  const { plays, awayTeamSlug, homeTeamSlug, awayTeamLogoUrl, homeTeamLogoUrl } = playLog;
-  const filteredPlays = !showAll ? plays.filter(p => p.isScoringPlay) : plays;
+
+  const handleToggle = () => {
+    const next = !showAll;
+    setShowAll(next);
+
+    // First time turning on → fetch. Cached on subsequent toggles so
+    // bouncing the checkbox doesn't re-hit the API.
+    if (next && !fullPlayLog && !loadingFull) {
+      setLoadingFull(true);
+      setFullError(null);
+      apiWrapper.Contest.getContestPlayLog(contestId, sport, league)
+        .then((result) => {
+          const dto = result?.data || result;
+          setFullPlayLog(dto);
+          setLoadingFull(false);
+        })
+        .catch((err) => {
+          setFullError(err);
+          setLoadingFull(false);
+        });
+    }
+  };
+
+  // While the full-log fetch is in flight, keep showing the
+  // significant-plays subset so the user has continuous context. Swap to
+  // the full log once it arrives.
+  const activePlayLog = showAll && fullPlayLog ? fullPlayLog : playLog;
+  const { plays, awayTeamSlug, homeTeamSlug, awayTeamLogoUrl, homeTeamLogoUrl } = activePlayLog;
 
   // Helper to get logo URL for a play
   const getLogoUrl = (teamSlug) => {
@@ -16,9 +58,8 @@ export default function ContestOverviewPlaylog({ playLog, sport }) {
     return null;
   };
 
-
   // Group plays by quarter
-  const playsByQuarter = filteredPlays.reduce((acc, play) => {
+  const playsByQuarter = plays.reduce((acc, play) => {
     const q = play.quarter || "Other";
     if (!acc[q]) acc[q] = [];
     acc[q].push(play);
@@ -31,17 +72,23 @@ export default function ContestOverviewPlaylog({ playLog, sport }) {
     <div className="contest-section">
       <div className="contest-section-title" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <span>Play Log</span>
-        <label style={{ fontSize: 14, fontWeight: 400, cursor: 'pointer', userSelect: 'none' }}>
+        <label style={{ fontSize: 14, fontWeight: 400, cursor: loadingFull ? 'wait' : 'pointer', userSelect: 'none' }}>
           <input
             type="checkbox"
             checked={showAll}
-            onChange={() => setShowAll(v => !v)}
+            onChange={handleToggle}
+            disabled={loadingFull}
             style={{ marginRight: 6 }}
           />
-          Show all plays
+          {loadingFull ? 'Loading all plays…' : 'Show all plays'}
         </label>
       </div>
       <div className="contest-scoring-summary-section">
+        {fullError && showAll && (
+          <div className="contest-scoring-summary-item" style={{ color: 'var(--danger, #d32f2f)', marginBottom: 8 }}>
+            Failed to load full play log. Showing significant plays only.
+          </div>
+        )}
         {quarterOrder.length > 0 ? (
           quarterOrder.map((quarter) => (
             <div


### PR DESCRIPTION
## Summary

The Contest Overview page's play log component used to render every play from `/overview` and filter client-side to scoring-only when "Show all plays" was unchecked. For MLB that meant shipping **500+ plays** in the overview payload for ~10 that anyone actually views by default.

This PR splits the responsibilities:

- **`/overview`** now trims server-side to `(Priority || ScoringPlay)` so the default contest view sees only the significant plays.
- **New `/playlog` endpoint** returns every play and backs the on-demand "Show all plays" toggle.
- **Web component** fetches the full log on first toggle activation, caches it in component state, and swaps the active list.

## What changed

### Producer
- `GetContestOverviewQueryHandler.GetPlayLogAsync` filter: `(p.Priority || p.ScoringPlay)`. Drops MLB overview payload from ~500 rows to ~10.
- New `GetContestPlayLogQuery` + `GetContestPlayLogQueryHandler` + validator at `src/SportsData.Producer/Application/Contests/Queries/GetContestPlayLog/`. Returns the full `PlayLogDto` with team slugs + logos + every `CompetitionPlay` ordered by `SequenceNumber`. Mirrors the overview handler's resolution shape.
- `GET /api/contests/{id}/playlog` on `ContestController`.
- DI registered.

### Core
- `IProvideContests.GetContestPlayLogByContestId` on `SeasonClient` proxying via the sport-keyed factory. `BadRequest` on empty contestId; `NotFound` on miss.

### API
- `GET /ui/contest/{id}/playlog?sport=&league=` on the existing `ContestController`.
- Thin proxy handler at `src/SportsData.Api/Application/UI/Contest/Queries/GetContestPlayLog/` mirroring `GetContestOverviewQueryHandler`'s shape.
- DI registered.

### Web
- `contestApi.getContestPlayLog(contestId, sport, league)` added; auto-surfaced via `apiWrapper.Contest`.
- `ContestOverviewPlaylog` reworked:
  - Removed the client-side `plays.filter(p => p.isScoringPlay)` — server owns the trim now.
  - On first toggle-on: fetches the full log, caches it in component state, swaps the active play list.
  - Toggling off and back on doesn't re-fetch (cache hit).
  - Loading state on the checkbox label (`"Loading all plays…"`, checkbox disabled).
  - Continuous-context UX: significant plays remain visible during the fetch rather than blanking out.
  - Inline error fallback: red message above the plays + the existing significant set still rendered.
- `ContestOverview` passes `contestId` and `league` down to the playlog child.

## Test plan

- [ ] Open an MLB contest overview page (e.g., `/app/sport/baseball/mlb/contest/<id>`). Verify the default Play Log panel shows only significant plays (scoring + priority) — should be ~10 entries.
- [ ] Check "Show all plays". Verify checkbox label shows "Loading all plays…" briefly, then the full log (500+ entries for MLB) renders.
- [ ] Uncheck. Verify the panel returns to the significant subset instantly (no flash).
- [ ] Re-check. Verify the full log returns instantly (no network call — cache hit).
- [ ] Confirm same flow on an NCAA football and NFL contest (~150 plays full, ~3-5 significant).
- [ ] Force a 500 on `/playlog` (kill Producer mid-fetch). Verify the red inline error appears and the significant set remains visible.

## Builds + tests

- `dotnet build SportsData.Api` + `SportsData.Producer` — clean (0 warnings, 0 errors).
- API unit suite: 369/369 passing (plus the known-flaky `DisplayNameGenerator` test that re-passes on rerun).
- Producer unit suite: 416/416 passing.
- No new unit tests for `GetContestPlayLogQueryHandler` — same pattern as `GetContestOverviewQueryHandler` which is also untested at the unit level. Worth a follow-up if we ever start unit-testing this family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Show all plays" toggle in contest overview to lazy-load the full play-by-play on demand.
  * Shows loading state and disables the toggle while fetching; displays inline error if fetch fails and continues showing significant plays.
  * Full/filtered plays are grouped by quarter based on the currently active play log; supports contest/sport/league context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->