### PR TITLE
feat(api,producer,core): event-driven rank-poll matchup refresh (PR-F)

### DIFF
--- a/src/SportsData.Api/Application/Events/SeasonPollWeekCreatedHandler.cs
+++ b/src/SportsData.Api/Application/Events/SeasonPollWeekCreatedHandler.cs
@@ -1,0 +1,143 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Processors;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Eventing.Events.Seasons;
+using SportsData.Core.Processing;
+
+namespace SportsData.Api.Application.Events
+{
+    /// <summary>
+    /// Reacts to <see cref="SeasonPollWeekCreated"/> by re-firing matchup
+    /// generation for every active league whose <c>RankingFilter</c> is set
+    /// and whose window overlaps the affected <c>SeasonWeek</c>.
+    ///
+    /// <para>
+    /// Without this handler, a TOP25-filtered league created before the
+    /// preseason AP poll lands gets its SEC conference matchups at creation
+    /// time but never gets the newly-ranked Top 25 contests added — the
+    /// <c>AreMatchupsGenerated</c> flag is set by the conference pass, and
+    /// the daily <c>MatchupScheduler</c> only re-fires when that flag is
+    /// false. The refresh-variant of
+    /// <see cref="ScheduleGroupWeekMatchupsCommand"/> bypasses that gate so
+    /// the upsert-by-ContestId loop in <see cref="MatchupScheduleProcessor"/>
+    /// adds the newly-eligible ranked contests.
+    /// </para>
+    ///
+    /// <para>
+    /// Preseason / postseason "headline" polls arrive with
+    /// <c>SeasonWeekId = null</c> and are skipped here — they don't map to a
+    /// pickable week.
+    /// </para>
+    /// </summary>
+    public class SeasonPollWeekCreatedHandler : IConsumer<SeasonPollWeekCreated>
+    {
+        private readonly ILogger<SeasonPollWeekCreatedHandler> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IProvideBackgroundJobs _backgroundJobProvider;
+
+        public SeasonPollWeekCreatedHandler(
+            ILogger<SeasonPollWeekCreatedHandler> logger,
+            AppDataContext dataContext,
+            IProvideBackgroundJobs backgroundJobProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _backgroundJobProvider = backgroundJobProvider;
+        }
+
+        public async Task Consume(ConsumeContext<SeasonPollWeekCreated> context)
+        {
+            var evt = context.Message;
+
+            using (_logger.BeginScope(new Dictionary<string, object>
+                   {
+                       ["CorrelationId"] = evt.CorrelationId,
+                       ["Sport"] = evt.Sport,
+                       ["SeasonWeekId"] = evt.SeasonWeekId ?? Guid.Empty,
+                       ["PollSlug"] = evt.PollSlug ?? string.Empty,
+                   }))
+            {
+                if (!evt.SeasonWeekId.HasValue)
+                {
+                    _logger.LogInformation(
+                        "SeasonPollWeekCreated with null SeasonWeekId (preseason/postseason headline poll); nothing to refresh.");
+                    return;
+                }
+
+                if (!evt.SeasonWeekStartDate.HasValue || !evt.SeasonWeekEndDate.HasValue)
+                {
+                    // Producer always populates these when SeasonWeekId is set.
+                    // Defensive log — if this ever fires, the Producer-side
+                    // publish branch is missing the lookup.
+                    _logger.LogWarning(
+                        "SeasonPollWeekCreated carried SeasonWeekId but no date bounds; cannot overlap-test league windows.");
+                    return;
+                }
+
+                var seasonWeekId = evt.SeasonWeekId.Value;
+                var weekStart = evt.SeasonWeekStartDate.Value;
+                var weekEnd = evt.SeasonWeekEndDate.Value;
+
+                // Active leagues that:
+                //   • match the event's sport
+                //   • use a RankingFilter (the only thing this refresh path
+                //     affects — conference-only leagues don't care about new
+                //     polls)
+                //   • aren't deactivated
+                //   • whose window overlaps [weekStart, weekEnd]
+                //   • already have a PickemGroupWeek for the affected
+                //     SeasonWeekId (no shell → nothing to refresh; the daily
+                //     scheduler or creation-time bootstrap will create it
+                //     when its own conditions are met)
+                var affected = await _dataContext.PickemGroups
+                    .AsNoTracking()
+                    .Where(g => g.Sport == evt.Sport
+                                && g.RankingFilter != null
+                                && g.DeactivatedUtc == null
+                                && (g.StartsOn == null || g.StartsOn <= weekEnd)
+                                && (g.EndsOn == null || g.EndsOn >= weekStart))
+                    .Join(
+                        _dataContext.PickemGroupWeeks.Where(w => w.SeasonWeekId == seasonWeekId),
+                        g => g.Id,
+                        w => w.GroupId,
+                        (g, w) => new
+                        {
+                            g.Id,
+                            w.SeasonWeek,
+                            w.SeasonYear,
+                            w.IsNonStandardWeek,
+                        })
+                    .ToListAsync(context.CancellationToken);
+
+                if (affected.Count == 0)
+                {
+                    _logger.LogInformation(
+                        "SeasonPollWeekCreated for SeasonWeek {SeasonWeekId} affects 0 leagues; nothing to enqueue.",
+                        seasonWeekId);
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "SeasonPollWeekCreated for SeasonWeek {SeasonWeekId} affects {Count} league(s); enqueuing refresh.",
+                    seasonWeekId, affected.Count);
+
+                foreach (var league in affected)
+                {
+                    var cmd = new ScheduleGroupWeekMatchupsCommand(
+                        league.Id,
+                        seasonWeekId,
+                        league.SeasonYear,
+                        league.SeasonWeek,
+                        league.IsNonStandardWeek,
+                        evt.CorrelationId,
+                        IsRefresh: true);
+
+                    _backgroundJobProvider.Enqueue<IScheduleGroupWeekMatchups>(p => p.Process(cmd));
+                }
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
+++ b/src/SportsData.Api/Application/Jobs/MatchupScheduler.cs
@@ -163,4 +163,5 @@ public record ScheduleGroupWeekMatchupsCommand(
     int SeasonYear,
     int SeasonWeek,
     bool IsNonStandardWeek,
-    Guid CorrelationId);
+    Guid CorrelationId,
+    bool IsRefresh = false);

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -48,6 +48,7 @@ namespace SportsData.Api.Application.Processors
 
             // at this point, we have a group - but we need to generate matchups for the specified week
             var groupWeek = await _dataContext.PickemGroupWeeks
+                .Include(gw => gw.Matchups)
                 .Where(x => x.GroupId == command.GroupId && x.SeasonWeekId == command.SeasonWeekId)
                 .FirstOrDefaultAsync();
 
@@ -70,7 +71,15 @@ namespace SportsData.Api.Application.Processors
             }
             else
             {
-                if (groupWeek.AreMatchupsGenerated)
+                // Refresh callers (e.g. SeasonPollWeekCreatedHandler — a new
+                // AP poll just landed for this week) explicitly want to re-run
+                // the filter to add newly-eligible matchups, so they bypass the
+                // "already generated" short-circuit. The upsert-by-ContestId
+                // loop below makes the second pass safe — existing matchups get
+                // attribute updates, newly-eligible contests get inserted, and
+                // contests that fell OUT of the filter are left in place because
+                // user picks against them must be preserved.
+                if (groupWeek.AreMatchupsGenerated && !command.IsRefresh)
                 {
                     _logger.LogWarning("Matchups already generated");
                     return;
@@ -145,58 +154,110 @@ namespace SportsData.Api.Application.Processors
                     .ToList();
             }
 
+            // Upsert-by-ContestId. The shape supports both first-pass and
+            // refresh calls:
+            //   • Filter passes a contest already in groupWeek.Matchups →
+            //     update mutable attributes (rank, spread, line, win/loss,
+            //     headline, start time). Lets a post-poll refresh propagate
+            //     newly-published ranks and odds without churning rows.
+            //   • Filter passes a contest NOT yet in groupWeek.Matchups →
+            //     insert. This is how a TOP25+SEC league's "ranked teams"
+            //     get added the first time a poll lands after creation.
+            //   • A contest already in groupWeek.Matchups that the filter
+            //     REJECTS (e.g. Texas fell out of Top 25) is intentionally
+            //     left in place — picks against it must be preserved.
+            var existingByContestId = groupWeek.Matchups
+                .ToDictionary(m => m.ContestId, m => m);
+            var insertedCount = 0;
+
             foreach (var groupMatchup in groupMatchups)
             {
-                groupWeek.Matchups.Add(new PickemGroupMatchup()
+                if (existingByContestId.TryGetValue(groupMatchup.ContestId, out var existing))
                 {
-                    Id = Guid.NewGuid(),
-                    AwayConferenceLosses = groupMatchup.AwayConferenceLosses,
-                    AwayConferenceWins = groupMatchup.AwayConferenceWins,
-                    AwayLosses = groupMatchup.AwayLosses,
-                    AwayRank = groupMatchup.AwayRank,
-                    AwaySpread = groupMatchup.AwaySpread,
-                    AwayWins = groupMatchup.AwayWins,
-                    ContestId = groupMatchup.ContestId,
-                    CreatedBy = Guid.Empty,
-                    CreatedUtc = DateTime.UtcNow,
-                    GroupId = group.Id,
-                    GroupWeek = groupWeek,
-                    Headline = groupMatchup.Headline,
-                    HomeConferenceLosses = groupMatchup.HomeConferenceLosses,
-                    HomeConferenceWins = groupMatchup.HomeConferenceWins,
-                    HomeLosses = groupMatchup.HomeLosses,
-                    HomeRank = groupMatchup.HomeRank,
-                    HomeSpread = groupMatchup.HomeSpread,
-                    HomeWins = groupMatchup.HomeWins,
-                    OverOdds = groupMatchup.OverOdds,
-                    OverUnder = groupMatchup.OverUnder,
-                    SeasonWeek = groupWeek.SeasonWeek,
-                    SeasonWeekId = groupMatchup.SeasonWeekId,
-                    SeasonYear = command.SeasonYear,
-                    Spread = groupMatchup.Spread,
-                    StartDateUtc = groupMatchup.StartDateUtc,
-                    UnderOdds = groupMatchup.UnderOdds
-                });
+                    existing.AwayConferenceLosses = groupMatchup.AwayConferenceLosses;
+                    existing.AwayConferenceWins = groupMatchup.AwayConferenceWins;
+                    existing.AwayLosses = groupMatchup.AwayLosses;
+                    existing.AwayRank = groupMatchup.AwayRank;
+                    existing.AwaySpread = groupMatchup.AwaySpread;
+                    existing.AwayWins = groupMatchup.AwayWins;
+                    existing.Headline = groupMatchup.Headline;
+                    existing.HomeConferenceLosses = groupMatchup.HomeConferenceLosses;
+                    existing.HomeConferenceWins = groupMatchup.HomeConferenceWins;
+                    existing.HomeLosses = groupMatchup.HomeLosses;
+                    existing.HomeRank = groupMatchup.HomeRank;
+                    existing.HomeSpread = groupMatchup.HomeSpread;
+                    existing.HomeWins = groupMatchup.HomeWins;
+                    existing.OverOdds = groupMatchup.OverOdds;
+                    existing.OverUnder = groupMatchup.OverUnder;
+                    existing.Spread = groupMatchup.Spread;
+                    existing.StartDateUtc = groupMatchup.StartDateUtc;
+                    existing.UnderOdds = groupMatchup.UnderOdds;
+                    // Immutable on update: Id, ContestId, GroupId, SeasonWeekId,
+                    // SeasonWeek, SeasonYear, CreatedBy, CreatedUtc.
+                }
+                else
+                {
+                    groupWeek.Matchups.Add(new PickemGroupMatchup()
+                    {
+                        Id = Guid.NewGuid(),
+                        AwayConferenceLosses = groupMatchup.AwayConferenceLosses,
+                        AwayConferenceWins = groupMatchup.AwayConferenceWins,
+                        AwayLosses = groupMatchup.AwayLosses,
+                        AwayRank = groupMatchup.AwayRank,
+                        AwaySpread = groupMatchup.AwaySpread,
+                        AwayWins = groupMatchup.AwayWins,
+                        ContestId = groupMatchup.ContestId,
+                        CreatedBy = Guid.Empty,
+                        CreatedUtc = DateTime.UtcNow,
+                        GroupId = group.Id,
+                        GroupWeek = groupWeek,
+                        Headline = groupMatchup.Headline,
+                        HomeConferenceLosses = groupMatchup.HomeConferenceLosses,
+                        HomeConferenceWins = groupMatchup.HomeConferenceWins,
+                        HomeLosses = groupMatchup.HomeLosses,
+                        HomeRank = groupMatchup.HomeRank,
+                        HomeSpread = groupMatchup.HomeSpread,
+                        HomeWins = groupMatchup.HomeWins,
+                        OverOdds = groupMatchup.OverOdds,
+                        OverUnder = groupMatchup.OverUnder,
+                        SeasonWeek = groupWeek.SeasonWeek,
+                        SeasonWeekId = groupMatchup.SeasonWeekId,
+                        SeasonYear = command.SeasonYear,
+                        Spread = groupMatchup.Spread,
+                        StartDateUtc = groupMatchup.StartDateUtc,
+                        UnderOdds = groupMatchup.UnderOdds
+                    });
+                    insertedCount++;
+                }
             }
 
-            // Mark "generated" only when matchups were actually written.
-            // Empty results leave the flag false so the daily scheduler re-fires
-            // matchup generation on the next pass — the load-bearing piece that
-            // makes the eager-bootstrap path work for NCAAFB+RankingFilter
-            // shells created pre-poll. See docs/league-creation-matrix.md
-            // "Processor change: AreMatchupsGenerated rule".
-            groupWeek.AreMatchupsGenerated = groupMatchups.Count > 0;
+            // Mark "generated" once a first-pass write succeeds. The flag is
+            // a one-way switch that the daily scheduler reads to skip
+            // already-populated weeks — refresh callers (IsRefresh=true)
+            // explicitly bypass that gate at the top of this method.
+            // Empty results leave the flag false so the daily scheduler
+            // re-fires matchup generation on the next pass — the load-bearing
+            // piece that makes the eager-bootstrap path work for
+            // NCAAFB+RankingFilter shells created pre-poll. See
+            // docs/league-creation-matrix.md "Processor change: AreMatchupsGenerated rule".
+            if (groupMatchups.Count > 0)
+            {
+                groupWeek.AreMatchupsGenerated = true;
+            }
 
             // Publish BEFORE SaveChanges so MassTransit's bus-outbox interceptor flushes
             // the captured message into the OutboxMessage table within the same transaction
             // as the entity write. If the save fails, the captured publish is rolled back
             // with it — same atomicity guarantee, correct outbox semantics.
-            // Skip publish when groupMatchups is empty: PickemGroupWeekMatchupsGeneratedHandler
-            // throws on zero rows (treated as transient and retried), which would generate
-            // bogus retries and DLQ entries for a permanently-empty group week.
-            var hasMatchups = groupMatchups.Count > 0;
-            var isWeekCompleted = hasMatchups && groupMatchups.All(m => ContestStatusValues.IsCompleted(m.Status));
-            if (hasMatchups && !isWeekCompleted)
+            // Skip publish when nothing was inserted: the downstream consumer
+            // (PickemGroupWeekMatchupsGeneratedHandler) enqueues preview jobs
+            // for contests without existing previews. On a pure-update refresh
+            // (filter returned matchups but they were all already present)
+            // there are no new contests to preview, so re-publishing the event
+            // would just trigger a query that finds nothing to do.
+            var hasNewMatchups = insertedCount > 0;
+            var isWeekCompleted = hasNewMatchups && groupMatchups.All(m => ContestStatusValues.IsCompleted(m.Status));
+            if (hasNewMatchups && !isWeekCompleted)
             {
                 await _eventBus.Publish(new PickemGroupWeekMatchupsGenerated(
                         group.Id,
@@ -208,10 +269,11 @@ namespace SportsData.Api.Application.Processors
                         Guid.NewGuid()),
                     CancellationToken.None);
             }
-            else if (!hasMatchups)
+            else if (!hasNewMatchups)
             {
-                _logger.LogInformation("Skipping PickemGroupWeekMatchupsGenerated event — no matchups for this group week. GroupId={GroupId}, SeasonYear={SeasonYear}, SeasonWeek={SeasonWeek}",
-                    group.Id, command.SeasonYear, command.SeasonWeek);
+                _logger.LogInformation(
+                    "Skipping PickemGroupWeekMatchupsGenerated event — no new matchups inserted (filter returned {Count}, all already present). GroupId={GroupId}, SeasonYear={SeasonYear}, SeasonWeek={SeasonWeek}, IsRefresh={IsRefresh}",
+                    groupMatchups.Count, group.Id, command.SeasonYear, command.SeasonWeek, command.IsRefresh);
             }
             else
             {

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -21,17 +21,20 @@ namespace SportsData.Api.Application.Processors
         private readonly ILogger<MatchupScheduleProcessor> _logger;
         private readonly IContestClientFactory _contestClientFactory;
         private readonly IEventBus _eventBus;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public MatchupScheduleProcessor(
             AppDataContext dataContext,
             ILogger<MatchupScheduleProcessor> logger,
             IContestClientFactory contestClientFactory,
-            IEventBus eventBus)
+            IEventBus eventBus,
+            IDateTimeProvider dateTimeProvider)
         {
             _dataContext = dataContext;
             _logger = logger;
             _contestClientFactory = contestClientFactory;
             _eventBus = eventBus;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task Process(ScheduleGroupWeekMatchupsCommand command)
@@ -208,7 +211,7 @@ namespace SportsData.Api.Application.Processors
                         AwayWins = groupMatchup.AwayWins,
                         ContestId = groupMatchup.ContestId,
                         CreatedBy = Guid.Empty,
-                        CreatedUtc = DateTime.UtcNow,
+                        CreatedUtc = _dateTimeProvider.UtcNow(),
                         GroupId = group.Id,
                         GroupWeek = groupWeek,
                         Headline = groupMatchup.Headline,

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -238,7 +238,8 @@ namespace SportsData.Api
                     typeof(PickemGroupCreatedHandler),
                     typeof(PickemGroupMatchupAddedHandler),
                     typeof(PickemGroupWeekMatchupsGeneratedHandler),
-                    typeof(PreviewGeneratedHandler)
+                    typeof(PreviewGeneratedHandler),
+                    typeof(SeasonPollWeekCreatedHandler)
                 ]);
 
                 sigRConnString = config["CommonConfig:AzureSignalR:ConnectionString"];

--- a/src/SportsData.Core/Eventing/Events/Seasons/SeasonPollWeekCreated.cs
+++ b/src/SportsData.Core/Eventing/Events/Seasons/SeasonPollWeekCreated.cs
@@ -1,0 +1,39 @@
+using System;
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Seasons
+{
+    /// <summary>
+    /// Fires when a Producer-side <c>SeasonTypeWeekRankingsDocumentProcessor</c>
+    /// creates a new <c>SeasonPollWeek</c> row — i.e. the rankings for a
+    /// specific (poll, week) just landed in the canonical DB. Drives the
+    /// API-side rank-poll refresh path: leagues with a <c>RankingFilter</c>
+    /// whose window overlaps the affected SeasonWeek re-fire matchup
+    /// generation so newly-ranked contests get included.
+    ///
+    /// <para>
+    /// <c>SeasonWeekId</c> is nullable because preseason / postseason
+    /// "headline" polls (e.g. final AP poll of a season) don't map to a
+    /// specific pickable SeasonWeek. The API consumer skips those.
+    /// </para>
+    ///
+    /// <para>
+    /// SeasonWeek bounds are inlined on the payload so the API consumer
+    /// doesn't have to call back to Producer to resolve them — this is the
+    /// hot path on poll publication and a tight inner loop matters.
+    /// </para>
+    /// </summary>
+    public record SeasonPollWeekCreated(
+        Guid SeasonPollWeekId,
+        Guid SeasonPollId,
+        Guid? SeasonWeekId,
+        DateTime? SeasonWeekStartDate,
+        DateTime? SeasonWeekEndDate,
+        int? SeasonYear,
+        string? PollSlug,
+        Uri? Ref,
+        Sport Sport,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessor.cs
@@ -15,6 +15,11 @@ using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 
+// Alias to disambiguate from the sibling SportsData.Producer.Application.SeasonWeek
+// namespace, which name-resolution prefers over the entity type when the bare name
+// is used in this file.
+using SeasonWeekEntity = SportsData.Producer.Infrastructure.Data.Entities.SeasonWeek;
+
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.SeasonTypeWeekRankings)]
@@ -69,7 +74,7 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
 
         // Determine the SeasonWeek for this poll
         // can be null: preseason/postseason polls
-        Guid? seasonWeekId = null;
+        SeasonWeekEntity? seasonWeek = null;
 
         if (dto.Season.Type.Week is not null)
         {
@@ -77,7 +82,7 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
             // Example: Week 9 poll is published on the Sunday after Week 9 games
             // therefore we use it for Week 10
             // TODO:  At the end of the season, correct this data and adjust for next season
-            var seasonWeek = await _dataContext.SeasonWeeks
+            seasonWeek = await _dataContext.SeasonWeeks
                 .Include(x => x.Season)
                 .Include(x => x.ExternalIds)
                 .Include(x => x.Rankings)
@@ -98,8 +103,6 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
 
                 throw new ExternalDocumentNotSourcedException("SeasonWeek not found. Sourcing requested. Will retry.");
             }
-
-            seasonWeekId = seasonWeek.Id;
         }
 
         var dtoIdentity = _externalRefIdentityGenerator.Generate(dto.Ref);
@@ -110,9 +113,9 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
 
         if (pollWeek is null)
         {
-            await ProcessNewEntity(dto, dtoIdentity, seasonPollId, seasonWeekId, command);
+            await ProcessNewEntity(dto, dtoIdentity, seasonPollId, seasonWeek, command);
         }
-        else 
+        else
         {
             await ProcessExistingEntity();
         }
@@ -122,7 +125,7 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
         EspnFootballSeasonTypeWeekRankingsDto dto,
         ExternalRefIdentity dtoIdentity,
         Guid seasonPollId,
-        Guid? seasonWeekId,
+        SeasonWeekEntity? seasonWeek,
         ProcessDocumentCommand command)
     {
         // We need to create a mapping of the Team's season ref to the FranchiseSeasonId
@@ -160,7 +163,7 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
         // Create the entity from the DTO
         var entity = dto.AsEntity(
             seasonPollId,
-            seasonWeekId,
+            seasonWeek?.Id,
             _externalRefIdentityGenerator,
             franchiseDictionary,
             command.CorrelationId);
@@ -193,25 +196,14 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
         // Add to EF and save
         await _dataContext.SeasonPollWeeks.AddAsync(entity);
 
-        // Resolve poll slug + season-week dates for the event payload so the
-        // API-side consumer (rank-poll refresh path) doesn't have to call
-        // back to Producer to overlap-test the affected SeasonWeek against
-        // league windows. Both are cheap PK lookups; only fire on poll
-        // publication (weekly per sport during NCAAFB season).
+        // Resolve poll slug for the event payload. The SeasonWeek row was
+        // already loaded earlier in ProcessInternal and threaded in here, so
+        // we reuse its dates without re-querying. SeasonPoll wasn't loaded
+        // earlier — one cheap PK lookup, only fires on poll publication
+        // (weekly per sport during NCAAFB season).
         var seasonPoll = await _dataContext.SeasonPolls
             .AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id == seasonPollId);
-
-        DateTime? seasonWeekStart = null;
-        DateTime? seasonWeekEnd = null;
-        if (seasonWeekId.HasValue)
-        {
-            var seasonWeek = await _dataContext.SeasonWeeks
-                .AsNoTracking()
-                .FirstOrDefaultAsync(w => w.Id == seasonWeekId.Value);
-            seasonWeekStart = seasonWeek?.StartDate;
-            seasonWeekEnd = seasonWeek?.EndDate;
-        }
 
         // Publish BEFORE SaveChanges so the bus-outbox interceptor captures
         // the message in the same transaction as the entity write — if the
@@ -219,9 +211,9 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
         await _publishEndpoint.Publish(new SeasonPollWeekCreated(
             SeasonPollWeekId: entity.Id,
             SeasonPollId: seasonPollId,
-            SeasonWeekId: seasonWeekId,
-            SeasonWeekStartDate: seasonWeekStart,
-            SeasonWeekEndDate: seasonWeekEnd,
+            SeasonWeekId: seasonWeek?.Id,
+            SeasonWeekStartDate: seasonWeek?.StartDate,
+            SeasonWeekEndDate: seasonWeek?.EndDate,
             SeasonYear: command.SeasonYear,
             PollSlug: seasonPoll?.Slug,
             Ref: null,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessor.cs
@@ -8,6 +8,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Core.Infrastructure.Refs;
+using SportsData.Core.Eventing.Events.Seasons;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Exceptions;
 using SportsData.Producer.Infrastructure.Data.Common;
@@ -191,6 +192,43 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
 
         // Add to EF and save
         await _dataContext.SeasonPollWeeks.AddAsync(entity);
+
+        // Resolve poll slug + season-week dates for the event payload so the
+        // API-side consumer (rank-poll refresh path) doesn't have to call
+        // back to Producer to overlap-test the affected SeasonWeek against
+        // league windows. Both are cheap PK lookups; only fire on poll
+        // publication (weekly per sport during NCAAFB season).
+        var seasonPoll = await _dataContext.SeasonPolls
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == seasonPollId);
+
+        DateTime? seasonWeekStart = null;
+        DateTime? seasonWeekEnd = null;
+        if (seasonWeekId.HasValue)
+        {
+            var seasonWeek = await _dataContext.SeasonWeeks
+                .AsNoTracking()
+                .FirstOrDefaultAsync(w => w.Id == seasonWeekId.Value);
+            seasonWeekStart = seasonWeek?.StartDate;
+            seasonWeekEnd = seasonWeek?.EndDate;
+        }
+
+        // Publish BEFORE SaveChanges so the bus-outbox interceptor captures
+        // the message in the same transaction as the entity write — if the
+        // save fails, the captured publish is rolled back with it.
+        await _publishEndpoint.Publish(new SeasonPollWeekCreated(
+            SeasonPollWeekId: entity.Id,
+            SeasonPollId: seasonPollId,
+            SeasonWeekId: seasonWeekId,
+            SeasonWeekStartDate: seasonWeekStart,
+            SeasonWeekEndDate: seasonWeekEnd,
+            SeasonYear: command.SeasonYear,
+            PollSlug: seasonPoll?.Slug,
+            Ref: null,
+            Sport: command.Sport,
+            CorrelationId: command.CorrelationId,
+            CausationId: Guid.NewGuid()));
+
         await _dataContext.SaveChangesAsync();
 
         _logger.LogInformation("Created SeasonPollWeek entity {@SeasonRankingId}", entity.Id);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Events/SeasonPollWeekCreatedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Events/SeasonPollWeekCreatedHandlerTests.cs
@@ -1,0 +1,306 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.Events;
+using SportsData.Api.Application.Processors;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Seasons;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Events;
+
+/// <summary>
+/// Pins the rank-poll refresh trigger. The consumer queries for active
+/// leagues that:
+///   • match the event's sport
+///   • have a non-null RankingFilter (other leagues don't care about polls)
+///   • are not deactivated
+///   • have a window that overlaps the affected SeasonWeek
+///   • already have a PickemGroupWeek for that SeasonWeekId
+/// and enqueues a refresh-variant <see cref="ScheduleGroupWeekMatchupsCommand"/>
+/// for each match.
+/// </summary>
+public class SeasonPollWeekCreatedHandlerTests : ApiTestBase<SeasonPollWeekCreatedHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 8, 18, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime WeekStart = new(2026, 8, 30, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime WeekEnd = new(2026, 9, 6, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IProvideBackgroundJobs> _backgroundJobsMock;
+
+    public SeasonPollWeekCreatedHandlerTests()
+    {
+        _backgroundJobsMock = Mocker.GetMock<IProvideBackgroundJobs>();
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    [Fact]
+    public async Task NullSeasonWeekId_LogsAndReturns_NoEnqueue()
+    {
+        // Preseason/postseason "headline" polls don't map to a pickable
+        // week — handler short-circuits before querying.
+        var evt = NewEvent(seasonWeekId: null);
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(0);
+    }
+
+    [Fact]
+    public async Task MissingWeekDateBounds_LogsAndReturns_NoEnqueue()
+    {
+        // Defensive: producer always populates dates when SeasonWeekId is
+        // set, but if it ever doesn't we can't overlap-test windows.
+        var evt = NewEvent(seasonWeekId: Guid.NewGuid(), weekStart: null, weekEnd: null);
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(0);
+    }
+
+    [Fact]
+    public async Task NoMatchingLeagues_LogsAndReturns_NoEnqueue()
+    {
+        // Sport matches but no leagues use RankingFilter.
+        var seasonWeekId = Guid.NewGuid();
+        await SeedLeagueAndWeek(
+            sport: Sport.FootballNcaa,
+            rankingFilter: null,
+            startsOn: WeekStart.AddDays(-30),
+            endsOn: WeekEnd.AddDays(30),
+            seasonWeekId: seasonWeekId,
+            deactivatedUtc: null);
+
+        var evt = NewEvent(seasonWeekId: seasonWeekId);
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(0);
+    }
+
+    [Fact]
+    public async Task MatchingLeague_EnqueuesRefreshCommand()
+    {
+        // Happy path: NCAAFB + TOP25 league whose window covers the week.
+        var seasonWeekId = Guid.NewGuid();
+        var groupId = await SeedLeagueAndWeek(
+            sport: Sport.FootballNcaa,
+            rankingFilter: TeamRankingFilter.AP_TOP_25,
+            startsOn: WeekStart.AddDays(-30),
+            endsOn: WeekEnd.AddDays(30),
+            seasonWeekId: seasonWeekId,
+            deactivatedUtc: null);
+
+        ScheduleGroupWeekMatchupsCommand? captured = null;
+        _backgroundJobsMock
+            .Setup(x => x.Enqueue<IScheduleGroupWeekMatchups>(
+                It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()))
+            .Callback<Expression<Func<IScheduleGroupWeekMatchups, Task>>>(expr =>
+                captured = ExtractCommand(expr))
+            .Returns("job-id");
+
+        var evt = NewEvent(seasonWeekId: seasonWeekId);
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(1);
+        captured.Should().NotBeNull();
+        captured!.GroupId.Should().Be(groupId);
+        captured.SeasonWeekId.Should().Be(seasonWeekId);
+        captured.IsRefresh.Should().BeTrue();
+        captured.CorrelationId.Should().Be(evt.CorrelationId);
+    }
+
+    [Fact]
+    public async Task DeactivatedLeague_Skipped()
+    {
+        var seasonWeekId = Guid.NewGuid();
+        await SeedLeagueAndWeek(
+            sport: Sport.FootballNcaa,
+            rankingFilter: TeamRankingFilter.AP_TOP_25,
+            startsOn: WeekStart.AddDays(-30),
+            endsOn: WeekEnd.AddDays(30),
+            seasonWeekId: seasonWeekId,
+            deactivatedUtc: FixedNow);
+
+        var evt = NewEvent(seasonWeekId: seasonWeekId);
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(0);
+    }
+
+    [Fact]
+    public async Task LeagueWindowDoesNotOverlap_Skipped()
+    {
+        // Window ends before the affected week starts.
+        var seasonWeekId = Guid.NewGuid();
+        await SeedLeagueAndWeek(
+            sport: Sport.FootballNcaa,
+            rankingFilter: TeamRankingFilter.AP_TOP_25,
+            startsOn: WeekStart.AddDays(-60),
+            endsOn: WeekStart.AddDays(-1),
+            seasonWeekId: seasonWeekId,
+            deactivatedUtc: null);
+
+        var evt = NewEvent(seasonWeekId: seasonWeekId);
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(0);
+    }
+
+    [Fact]
+    public async Task WrongSport_Skipped()
+    {
+        // NCAAFB poll lands; MLB league with TOP25 (hypothetical) shouldn't
+        // get woken up by an NCAAFB poll.
+        var seasonWeekId = Guid.NewGuid();
+        await SeedLeagueAndWeek(
+            sport: Sport.BaseballMlb,
+            rankingFilter: TeamRankingFilter.AP_TOP_25,
+            startsOn: WeekStart.AddDays(-30),
+            endsOn: WeekEnd.AddDays(30),
+            seasonWeekId: seasonWeekId,
+            deactivatedUtc: null);
+
+        var evt = NewEvent(seasonWeekId: seasonWeekId, sport: Sport.FootballNcaa);
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(0);
+    }
+
+    [Fact]
+    public async Task NoShellForSeasonWeek_Skipped()
+    {
+        // League matches everything but doesn't have a PickemGroupWeek for
+        // the affected SeasonWeek yet (e.g. it's a future window that the
+        // creation-time bootstrap or daily scheduler hasn't reached). Nothing
+        // to refresh; the shell will be created when its own conditions are
+        // met, and the next refresh trigger after that will populate it.
+        var group = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "No-Shell League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            RankingFilter = TeamRankingFilter.AP_TOP_25,
+            CommissionerUserId = Guid.NewGuid(),
+            StartsOn = WeekStart.AddDays(-30),
+            EndsOn = WeekEnd.AddDays(30),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.Empty,
+        };
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+
+        var evt = NewEvent(seasonWeekId: Guid.NewGuid());
+        var sut = Mocker.CreateInstance<SeasonPollWeekCreatedHandler>();
+
+        await sut.Consume(ConsumeContextFor(evt));
+
+        VerifyEnqueueCount(0);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedLeagueAndWeek(
+        Sport sport,
+        TeamRankingFilter? rankingFilter,
+        DateTime? startsOn,
+        DateTime? endsOn,
+        Guid seasonWeekId,
+        DateTime? deactivatedUtc)
+    {
+        var groupId = Guid.NewGuid();
+        var group = new PickemGroup
+        {
+            Id = groupId,
+            Name = "Test",
+            Sport = sport,
+            League = sport == Sport.BaseballMlb ? League.MLB : League.NCAAF,
+            RankingFilter = rankingFilter,
+            CommissionerUserId = Guid.NewGuid(),
+            StartsOn = startsOn,
+            EndsOn = endsOn,
+            DeactivatedUtc = deactivatedUtc,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.Empty,
+        };
+        await DataContext.PickemGroups.AddAsync(group);
+
+        var groupWeek = new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonWeekId = seasonWeekId,
+            SeasonYear = 2026,
+            SeasonWeek = 1,
+            AreMatchupsGenerated = true,
+            IsNonStandardWeek = false,
+        };
+        await DataContext.PickemGroupWeeks.AddAsync(groupWeek);
+        await DataContext.SaveChangesAsync();
+
+        return groupId;
+    }
+
+    private static SeasonPollWeekCreated NewEvent(
+        Guid? seasonWeekId,
+        DateTime? weekStart = null,
+        DateTime? weekEnd = null,
+        Sport sport = Sport.FootballNcaa) =>
+        new(
+            SeasonPollWeekId: Guid.NewGuid(),
+            SeasonPollId: Guid.NewGuid(),
+            SeasonWeekId: seasonWeekId,
+            SeasonWeekStartDate: seasonWeekId.HasValue ? (weekStart ?? WeekStart) : null,
+            SeasonWeekEndDate: seasonWeekId.HasValue ? (weekEnd ?? WeekEnd) : null,
+            SeasonYear: 2026,
+            PollSlug: "ap-top-25",
+            Ref: null,
+            Sport: sport,
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid());
+
+    private static ConsumeContext<SeasonPollWeekCreated> ConsumeContextFor(SeasonPollWeekCreated message) =>
+        Mock.Of<ConsumeContext<SeasonPollWeekCreated>>(ctx => ctx.Message == message);
+
+    private void VerifyEnqueueCount(int expected)
+    {
+        _backgroundJobsMock.Verify(
+            x => x.Enqueue<IScheduleGroupWeekMatchups>(
+                It.IsAny<Expression<Func<IScheduleGroupWeekMatchups, Task>>>()),
+            Times.Exactly(expected));
+    }
+
+    private static ScheduleGroupWeekMatchupsCommand? ExtractCommand(
+        Expression<Func<IScheduleGroupWeekMatchups, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        var arg = call.Arguments.FirstOrDefault();
+        if (arg is null) return null;
+
+        var lambda = Expression.Lambda<Func<ScheduleGroupWeekMatchupsCommand>>(arg).Compile();
+        return lambda.Invoke();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -936,5 +936,317 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             savedGroupWeek!.Matchups.Should().BeEmpty();
             savedGroupWeek.AreMatchupsGenerated.Should().BeFalse();
         }
+
+        /// <summary>
+        /// PR-F refresh path: a SeasonPollWeekCreated event triggers a second
+        /// call with IsRefresh=true. The week is already marked
+        /// AreMatchupsGenerated, so the legacy gate would return early —
+        /// IsRefresh must bypass it so newly-eligible matchups (ranked teams
+        /// from the just-published AP poll) can be inserted.
+        /// </summary>
+        [Fact]
+        public async Task Process_Refresh_BypassesAreMatchupsGeneratedGate_AndInsertsNewMatchup()
+        {
+            // Arrange — a TOP25+SEC NCAAFB league that already has its SEC
+            // matchups in place from creation-time bootstrap; AP poll wasn't
+            // published yet so no ranked-team matchups got in.
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+            var existingSecContestId = Guid.NewGuid();
+            var newRankedContestId = Guid.NewGuid();
+
+            var group = new PickemGroup
+            {
+                Id = groupId,
+                Name = "Test",
+                Sport = Core.Common.Sport.FootballNcaa,
+                League = League.NCAAF,
+                RankingFilter = TeamRankingFilter.AP_TOP_25,
+                CommissionerUserId = Guid.NewGuid(),
+                CreatedUtc = FixedUtcNow,
+                CreatedBy = Guid.Empty,
+                Conferences = new List<PickemGroupConference>
+                {
+                    new() { Id = Guid.NewGuid(), ConferenceSlug = "sec", PickemGroupId = groupId, ConferenceId = Guid.NewGuid(), CreatedUtc = FixedUtcNow, CreatedBy = Guid.Empty }
+                }
+            };
+            await DataContext.PickemGroups.AddAsync(group);
+
+            var groupWeek = new PickemGroupWeek
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = seasonWeekId,
+                SeasonYear = 2024,
+                SeasonWeek = 1,
+                AreMatchupsGenerated = true, // first-pass already ran
+                IsNonStandardWeek = false,
+            };
+            groupWeek.Matchups.Add(new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                ContestId = existingSecContestId,
+                GroupId = groupId,
+                SeasonWeekId = seasonWeekId,
+                SeasonYear = 2024,
+                SeasonWeek = 1,
+                AwayRank = null,
+                HomeRank = null,
+                CreatedUtc = FixedUtcNow,
+                CreatedBy = Guid.Empty,
+            });
+            await DataContext.PickemGroupWeeks.AddAsync(groupWeek);
+            await DataContext.SaveChangesAsync();
+
+            // Second pass: the SEC matchup still passes the filter (conference
+            // match); the newly-ranked AP Top 25 contest is new.
+            var allMatchups = new List<Matchup>
+            {
+                new()
+                {
+                    SeasonWeekId = seasonWeekId,
+                    SeasonYear = 2024,
+                    SeasonWeek = 1,
+                    ContestId = existingSecContestId,
+                    AwaySlug = "ole-miss",
+                    HomeSlug = "lsu",
+                    AwayRank = null,
+                    HomeRank = null,
+                    AwayConferenceSlug = "sec",
+                    HomeConferenceSlug = "sec",
+                    Status = "STATUS_SCHEDULED",
+                    StatusDescription = "Scheduled",
+                    StartDateUtc = new DateTime(2024, 9, 7, 19, 0, 0, DateTimeKind.Utc),
+                },
+                new()
+                {
+                    SeasonWeekId = seasonWeekId,
+                    SeasonYear = 2024,
+                    SeasonWeek = 1,
+                    ContestId = newRankedContestId,
+                    AwaySlug = "michigan",
+                    HomeSlug = "ohio-state",
+                    AwayRank = 3,
+                    HomeRank = 1,
+                    AwayConferenceSlug = "big10",
+                    HomeConferenceSlug = "big10",
+                    Status = "STATUS_SCHEDULED",
+                    StatusDescription = "Scheduled",
+                    StartDateUtc = new DateTime(2024, 9, 7, 12, 0, 0, DateTimeKind.Utc),
+                },
+            };
+            _contestClientMock
+                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId, seasonWeekId, 2024, 1, false, Guid.NewGuid(), IsRefresh: true);
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — both matchups now present; existing SEC row preserved
+            // by ContestId; newly-ranked Big Ten contest inserted.
+            var saved = await DataContext.PickemGroupWeeks
+                .Include(gw => gw.Matchups)
+                .FirstOrDefaultAsync(x => x.Id == groupWeek.Id);
+            saved.Should().NotBeNull();
+            saved!.Matchups.Select(m => m.ContestId).Should().BeEquivalentTo(new[]
+            {
+                existingSecContestId,
+                newRankedContestId,
+            });
+        }
+
+        /// <summary>
+        /// Picks-sacred contract: a refresh call must NOT delete a matchup
+        /// whose contest fell out of the filter (e.g. team dropped out of
+        /// Top 25). User picks against it would be silently invalidated.
+        /// </summary>
+        [Fact]
+        public async Task Process_Refresh_DoesNotDeleteExistingMatchupThatFellOutOfFilter()
+        {
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+            var formerlyRankedContestId = Guid.NewGuid();
+
+            var group = new PickemGroup
+            {
+                Id = groupId,
+                Name = "Test",
+                Sport = Core.Common.Sport.FootballNcaa,
+                League = League.NCAAF,
+                RankingFilter = TeamRankingFilter.AP_TOP_5,  // tight filter
+                CommissionerUserId = Guid.NewGuid(),
+                CreatedUtc = FixedUtcNow,
+                CreatedBy = Guid.Empty,
+                Conferences = new List<PickemGroupConference>(),
+            };
+            await DataContext.PickemGroups.AddAsync(group);
+
+            var groupWeek = new PickemGroupWeek
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = seasonWeekId,
+                SeasonYear = 2024,
+                SeasonWeek = 1,
+                AreMatchupsGenerated = true,
+                IsNonStandardWeek = false,
+            };
+            // Matchup from a prior poll where this team WAS ranked #2.
+            groupWeek.Matchups.Add(new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                ContestId = formerlyRankedContestId,
+                GroupId = groupId,
+                SeasonWeekId = seasonWeekId,
+                SeasonYear = 2024,
+                SeasonWeek = 1,
+                AwayRank = 2,
+                HomeRank = null,
+                CreatedUtc = FixedUtcNow,
+                CreatedBy = Guid.Empty,
+            });
+            await DataContext.PickemGroupWeeks.AddAsync(groupWeek);
+            await DataContext.SaveChangesAsync();
+
+            // New poll — this team is now ranked #15, outside TOP_5.
+            var allMatchups = new List<Matchup>
+            {
+                new()
+                {
+                    SeasonWeekId = seasonWeekId,
+                    SeasonYear = 2024,
+                    SeasonWeek = 1,
+                    ContestId = formerlyRankedContestId,
+                    AwaySlug = "unaffiliated-away",
+                    HomeSlug = "unaffiliated-home",
+                    AwayRank = 15,
+                    HomeRank = null,
+                    AwayConferenceSlug = "x",
+                    HomeConferenceSlug = "y",
+                    Status = "STATUS_SCHEDULED",
+                    StatusDescription = "Scheduled",
+                    StartDateUtc = new DateTime(2024, 9, 7, 19, 0, 0, DateTimeKind.Utc),
+                },
+            };
+            _contestClientMock
+                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId, seasonWeekId, 2024, 1, false, Guid.NewGuid(), IsRefresh: true);
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — the row stays; user picks against it are safe. (No
+            // attribute update either because the contest fell out of the
+            // filter result — only filter-passing contests get upserted.)
+            var saved = await DataContext.PickemGroupWeeks
+                .Include(gw => gw.Matchups)
+                .FirstOrDefaultAsync(x => x.Id == groupWeek.Id);
+            saved!.Matchups.Should().ContainSingle()
+                .Which.ContestId.Should().Be(formerlyRankedContestId);
+        }
+
+        /// <summary>
+        /// Refresh with only-existing matchups (filter result is non-empty
+        /// but every contest is already in the week) must NOT re-fire
+        /// PickemGroupWeekMatchupsGenerated. The downstream preview-spawn
+        /// consumer only enqueues for contests without existing previews
+        /// anyway, but re-firing wastes a query per league per refresh.
+        /// </summary>
+        [Fact]
+        public async Task Process_Refresh_NoNewMatchups_DoesNotPublishGeneratedEvent()
+        {
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+            var existingContestId = Guid.NewGuid();
+
+            var group = new PickemGroup
+            {
+                Id = groupId,
+                Name = "Test",
+                Sport = Core.Common.Sport.FootballNcaa,
+                League = League.NCAAF,
+                RankingFilter = TeamRankingFilter.AP_TOP_25,
+                CommissionerUserId = Guid.NewGuid(),
+                CreatedUtc = FixedUtcNow,
+                CreatedBy = Guid.Empty,
+                Conferences = new List<PickemGroupConference>(),
+            };
+            await DataContext.PickemGroups.AddAsync(group);
+
+            var groupWeek = new PickemGroupWeek
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = seasonWeekId,
+                SeasonYear = 2024,
+                SeasonWeek = 1,
+                AreMatchupsGenerated = true,
+                IsNonStandardWeek = false,
+            };
+            groupWeek.Matchups.Add(new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                ContestId = existingContestId,
+                GroupId = groupId,
+                SeasonWeekId = seasonWeekId,
+                SeasonYear = 2024,
+                SeasonWeek = 1,
+                AwayRank = 5,
+                CreatedUtc = FixedUtcNow,
+                CreatedBy = Guid.Empty,
+            });
+            await DataContext.PickemGroupWeeks.AddAsync(groupWeek);
+            await DataContext.SaveChangesAsync();
+
+            // Filter passes the existing contest (still ranked) but adds
+            // nothing new.
+            var allMatchups = new List<Matchup>
+            {
+                new()
+                {
+                    SeasonWeekId = seasonWeekId,
+                    SeasonYear = 2024,
+                    SeasonWeek = 1,
+                    ContestId = existingContestId,
+                    AwaySlug = "a",
+                    HomeSlug = "b",
+                    AwayRank = 5,
+                    HomeRank = null,
+                    AwayConferenceSlug = "x",
+                    HomeConferenceSlug = "y",
+                    Status = "STATUS_SCHEDULED",
+                    StatusDescription = "Scheduled",
+                    StartDateUtc = new DateTime(2024, 9, 7, 19, 0, 0, DateTimeKind.Utc),
+                },
+            };
+            _contestClientMock
+                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
+
+            var eventBus = Mocker.GetMock<IEventBus>();
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId, seasonWeekId, 2024, 1, false, Guid.NewGuid(), IsRefresh: true);
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            eventBus.Verify(
+                x => x.Publish(It.IsAny<PickemGroupWeekMatchupsGenerated>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -1151,8 +1151,13 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             var saved = await DataContext.PickemGroupWeeks
                 .Include(gw => gw.Matchups)
                 .FirstOrDefaultAsync(x => x.Id == groupWeek.Id);
-            saved!.Matchups.Should().ContainSingle()
-                .Which.ContestId.Should().Be(formerlyRankedContestId);
+            var preserved = saved!.Matchups.Should().ContainSingle().Subject;
+            preserved.ContestId.Should().Be(formerlyRankedContestId);
+            // Pin the "no update" contract: seeded AwayRank=2 must NOT have
+            // been overwritten with the new poll's AwayRank=15. ContestId
+            // alone wouldn't catch an update because it's the upsert key.
+            preserved.AwayRank.Should().Be(2);
+            preserved.HomeRank.Should().BeNull();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Closes the gap surfaced during PR-D testing — a TOP25+SEC NCAAFB league created before the preseason AP poll lands gets its SEC conference matchups populated immediately by the creation-time bootstrap, the `AreMatchupsGenerated` flag flips true, and the daily `MatchupScheduler` never re-fires for that week. When the AP poll finally publishes weeks later, newly-ranked Top 25 contests never get added to the league.

PR-F wires an event-driven refresh path that fixes this.

## The pipeline

```
ESPN publishes AP Top 25 for Week N
   ↓
SeasonTypeWeekRankingsDocumentProcessor.ProcessNewEntity
   ↓ publishes
SeasonPollWeekCreated (new event)
   ↓ consumed by
SeasonPollWeekCreatedHandler (API)
   ↓ queries affected leagues, enqueues per-league
ScheduleGroupWeekMatchupsCommand with IsRefresh=true
   ↓
MatchupScheduleProcessor (now idempotent / upsert-on-membership)
   ↓ inserts newly-ranked contests, updates existing matchups' ranks/spreads,
     leaves picks-sacred contests in place
```

## Pieces

### Producer
`SeasonTypeWeekRankingsDocumentProcessor.ProcessNewEntity` publishes `SeasonPollWeekCreated` after saving the new `SeasonPollWeek`. Event carries:
- `SeasonPollWeekId`, `SeasonPollId`
- Nullable `SeasonWeekId` (null for preseason/postseason "headline" polls)
- Inlined `SeasonWeekStartDate` / `SeasonWeekEndDate` so the API consumer doesn't have to call back to Producer for the overlap test
- `PollSlug`, `Sport`, correlation/causation

### Core
New `SportsData.Core.Eventing.Events.Seasons.SeasonPollWeekCreated` record.

### API
New `SeasonPollWeekCreatedHandler` consumer:
- Skips when `SeasonWeekId` is null (headline polls don't map to pickable weeks)
- Queries `PickemGroup` joined with `PickemGroupWeek` for: Sport match + `RankingFilter != null` + `DeactivatedUtc null` + window overlap + has-shell
- Enqueues a refresh-variant `ScheduleGroupWeekMatchupsCommand` per match

### MatchupScheduleProcessor — made idempotent
- Added `IsRefresh: bool = false` to `ScheduleGroupWeekMatchupsCommand`
- Processor bypasses the `AreMatchupsGenerated` gate when `IsRefresh=true`
- Insert-only loop replaced with **upsert-by-`ContestId`**:
  - Existing matchup matched by `ContestId` → update mutable attributes (rank, spread, line, win/loss, headline, start time)
  - Filter passes a contest NOT yet present → insert
  - Contest fell OUT of filter → leave the existing row. **Picks are sacred** — silently invalidating a user's pick because a team dropped out of Top 25 is not acceptable.
- `PickemGroupWeekMatchupsGenerated` event now gated on `insertedCount > 0` instead of total filter result count, so a pure-update refresh doesn't trigger preview-spawn for contests that already have previews.

## Scope deferred (follow-up)

**`SeasonPollWeekUpdated`** for mid-week ranking changes — requires implementing the `SeasonTypeWeekRankingsDocumentProcessor.ProcessExistingEntity` no-op stub. The infrastructure on the API side (consumer, processor, command shape) is identical; the follow-up is small.

## Test plan

- [x] 3 new `MatchupScheduleProcessor` tests: refresh bypasses gate + inserts new matchup; picks-sacred no-delete on filter dropout; no publish when only-existing matchups were touched.
- [x] 8 new `SeasonPollWeekCreatedHandler` tests: null SeasonWeekId short-circuit, missing date bounds defensive log, no matching leagues, happy-path enqueue + correlation id threading + IsRefresh flag, deactivated/non-overlapping/wrong-sport/no-shell skip cases.
- [x] API unit suite: **381/381** (was 369).
- [x] Producer unit suite: **416/416** (no regressions on existing `SeasonTypeWeekRankingsDocumentProcessor` tests despite the publish addition).
- [x] Whole-solution build clean.

Local E2E (yours when convenient):
- [ ] Create an NCAAFB TOP25+SEC league with a week-1 window before the preseason AP poll publishes. Verify SEC matchups land at creation, no ranked matchups.
- [ ] Trigger AP poll sourcing. Verify Seq shows `SeasonPollWeekCreated` from Producer, the API consumer log line about N affected leagues, and the per-league `ScheduleGroupWeekMatchupsCommand` jobs in Hangfire.
- [ ] After the jobs complete, verify the league's `PickemGroupMatchup` rows now include the Top 25 contests, with SEC matchups untouched and `AreMatchupsGenerated` still true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added season-poll event handling to automatically schedule matchup refreshes for affected leagues
  * Matchup scheduling supports configurable "refresh" runs that upsert matchups and preserve existing pick data; refreshes only publish generation events when new matchups are inserted

* **Tests**
  * New unit tests covering season-poll handling and refresh behaviors (including edge cases)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->