### PR TITLE
refactor(api): extract CreateLeagueCommandHandlerBase (PR-E)

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
@@ -26,8 +26,9 @@ public class CreateBaseballMlbLeagueCommandHandler
         AppDataContext dbContext,
         IEventBus eventBus,
         IFranchiseClientFactory franchiseClientFactory,
-        IValidator<CreateBaseballMlbLeagueRequest> validator)
-        : base(logger, dbContext, eventBus, franchiseClientFactory, validator)
+        IValidator<CreateBaseballMlbLeagueRequest> validator,
+        IDateTimeProvider dateTimeProvider)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, validator, dateTimeProvider)
     {
     }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
@@ -1,15 +1,10 @@
 using FluentValidation;
-using FluentValidation.Results;
-
-using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague.Dtos;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
-using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague;
@@ -22,138 +17,26 @@ public interface ICreateBaseballMlbLeagueCommandHandler
         CancellationToken cancellationToken = default);
 }
 
-public class CreateBaseballMlbLeagueCommandHandler : ICreateBaseballMlbLeagueCommandHandler
+public class CreateBaseballMlbLeagueCommandHandler
+    : CreateLeagueCommandHandlerBase<CreateBaseballMlbLeagueRequest>,
+      ICreateBaseballMlbLeagueCommandHandler
 {
-    private const Sport SportMode = Sport.BaseballMlb;
-    private const League LeagueMode = League.MLB;
-
-    private readonly ILogger<CreateBaseballMlbLeagueCommandHandler> _logger;
-    private readonly AppDataContext _dbContext;
-    private readonly IEventBus _eventBus;
-    private readonly IFranchiseClientFactory _franchiseClientFactory;
-    private readonly IValidator<CreateBaseballMlbLeagueRequest> _validator;
-
     public CreateBaseballMlbLeagueCommandHandler(
         ILogger<CreateBaseballMlbLeagueCommandHandler> logger,
         AppDataContext dbContext,
         IEventBus eventBus,
         IFranchiseClientFactory franchiseClientFactory,
         IValidator<CreateBaseballMlbLeagueRequest> validator)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, validator)
     {
-        _logger = logger;
-        _dbContext = dbContext;
-        _eventBus = eventBus;
-        _franchiseClientFactory = franchiseClientFactory;
-        _validator = validator;
     }
 
-    public async Task<Result<Guid>> ExecuteAsync(
-        CreateBaseballMlbLeagueRequest request,
-        Guid currentUserId,
-        CancellationToken cancellationToken = default)
-    {
-        var validation = await _validator.ValidateAsync(request, cancellationToken);
-        if (!validation.IsValid)
-            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+    protected override Sport SportMode => Sport.BaseballMlb;
+    protected override League LeagueMode => League.MLB;
 
-        // Enum parsing is guaranteed by the validator above.
-        var pickType = Enum.Parse<PickType>(request.PickType, ignoreCase: true);
-        var tiebreakerType = Enum.Parse<TiebreakerType>(request.TiebreakerType, ignoreCase: true);
-        var tiebreakerTiePolicy = Enum.Parse<TiebreakerTiePolicy>(request.TiebreakerTiePolicy, ignoreCase: true);
+    protected override IReadOnlyList<string> GetGroupingSlugs(CreateBaseballMlbLeagueRequest request) =>
+        request.DivisionSlugs;
 
-        var seasonYear = request.SeasonYear ?? DateTime.UtcNow.Year;
-        var divisionIds = request.DivisionSlugs.Count > 0
-            ? await _franchiseClientFactory
-                .Resolve(SportMode)
-                .GetConferenceIdsBySlugs(seasonYear, request.DivisionSlugs)
-            : new Dictionary<Guid, string>();
-
-        var unresolved = request.DivisionSlugs
-            .Except(divisionIds.Values, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (unresolved.Count > 0)
-            return new Failure<Guid>(
-                default!,
-                ResultStatus.Validation,
-                [new ValidationFailure(nameof(request.DivisionSlugs), $"Unknown division slugs: {string.Join(", ", unresolved)}")]);
-
-        var group = new PickemGroup
-        {
-            Id = Guid.NewGuid(),
-            CommissionerUserId = currentUserId,
-            CreatedBy = currentUserId,
-            Description = request.Description?.Trim(),
-            IsPublic = request.IsPublic,
-            League = LeagueMode,
-            Name = request.Name.Trim(),
-            PickType = pickType,
-            Sport = SportMode,
-            TiebreakerTiePolicy = tiebreakerTiePolicy,
-            TiebreakerType = tiebreakerType,
-            UseConfidencePoints = request.UseConfidencePoints,
-            DropLowWeeksCount = request.DropLowWeeksCount,
-            StartsOn = request.StartsOn,
-            EndsOn = request.EffectiveEndsOn
-        };
-
-        foreach (var kvp in divisionIds)
-        {
-            group.Conferences.Add(new PickemGroupConference
-            {
-                ConferenceSlug = kvp.Value,
-                ConferenceId = kvp.Key,
-                PickemGroupId = group.Id
-            });
-        }
-
-        group.Members.Add(new PickemGroupMember
-        {
-            CreatedBy = currentUserId,
-            PickemGroupId = group.Id,
-            Role = LeagueRole.Commissioner,
-            UserId = currentUserId,
-        });
-
-        var synthetic = await _dbContext.Users
-            .Where(x => x.IsSynthetic == true)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (synthetic != null)
-        {
-            group.Members.Add(new PickemGroupMember
-            {
-                CreatedBy = currentUserId,
-                PickemGroupId = group.Id,
-                Role = LeagueRole.Member,
-                UserId = synthetic.Id,
-            });
-        }
-
-        await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
-
-        // Publish BEFORE the commit: with the EF outbox, Publish enqueues the
-        // message into the DbContext tracker and only SaveChangesAsync persists
-        // both the aggregate and the outbox row atomically. Publishing AFTER
-        // SaveChangesAsync silently loses the event when the DI scope disposes.
-        var evt = new PickemGroupCreated(
-            group.Id,
-            null,
-            group.Sport,
-            seasonYear,
-            Guid.NewGuid(),
-            Guid.NewGuid());
-        await _eventBus.Publish(evt, cancellationToken);
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; PickemGroupCreated enqueued to outbox",
-            SportMode,
-            group.Id,
-            group.Name,
-            currentUserId);
-
-        return new Success<Guid>(group.Id);
-    }
+    protected override string SlugRequestFieldName => nameof(CreateBaseballMlbLeagueRequest.DivisionSlugs);
+    protected override string SlugDisplayLabel => "division";
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
@@ -27,8 +27,9 @@ public class CreateFootballNcaaLeagueCommandHandler
         AppDataContext dbContext,
         IEventBus eventBus,
         IFranchiseClientFactory franchiseClientFactory,
-        IValidator<CreateFootballNcaaLeagueRequest> validator)
-        : base(logger, dbContext, eventBus, franchiseClientFactory, validator)
+        IValidator<CreateFootballNcaaLeagueRequest> validator,
+        IDateTimeProvider dateTimeProvider)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, validator, dateTimeProvider)
     {
     }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
@@ -1,7 +1,4 @@
 using FluentValidation;
-using FluentValidation.Results;
-
-using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague.Dtos;
@@ -9,7 +6,6 @@ using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
-using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague;
@@ -22,143 +18,33 @@ public interface ICreateFootballNcaaLeagueCommandHandler
         CancellationToken cancellationToken = default);
 }
 
-public class CreateFootballNcaaLeagueCommandHandler : ICreateFootballNcaaLeagueCommandHandler
+public class CreateFootballNcaaLeagueCommandHandler
+    : CreateLeagueCommandHandlerBase<CreateFootballNcaaLeagueRequest>,
+      ICreateFootballNcaaLeagueCommandHandler
 {
-    private const Sport SportMode = Sport.FootballNcaa;
-    private const League LeagueMode = League.NCAAF;
-
-    private readonly ILogger<CreateFootballNcaaLeagueCommandHandler> _logger;
-    private readonly AppDataContext _dbContext;
-    private readonly IEventBus _eventBus;
-    private readonly IFranchiseClientFactory _franchiseClientFactory;
-    private readonly IValidator<CreateFootballNcaaLeagueRequest> _validator;
-
     public CreateFootballNcaaLeagueCommandHandler(
         ILogger<CreateFootballNcaaLeagueCommandHandler> logger,
         AppDataContext dbContext,
         IEventBus eventBus,
         IFranchiseClientFactory franchiseClientFactory,
         IValidator<CreateFootballNcaaLeagueRequest> validator)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, validator)
     {
-        _logger = logger;
-        _dbContext = dbContext;
-        _eventBus = eventBus;
-        _franchiseClientFactory = franchiseClientFactory;
-        _validator = validator;
     }
 
-    public async Task<Result<Guid>> ExecuteAsync(
-        CreateFootballNcaaLeagueRequest request,
-        Guid currentUserId,
-        CancellationToken cancellationToken = default)
+    protected override Sport SportMode => Sport.FootballNcaa;
+    protected override League LeagueMode => League.NCAAF;
+
+    protected override IReadOnlyList<string> GetGroupingSlugs(CreateFootballNcaaLeagueRequest request) =>
+        request.ConferenceSlugs;
+
+    protected override string SlugRequestFieldName => nameof(CreateFootballNcaaLeagueRequest.ConferenceSlugs);
+    protected override string SlugDisplayLabel => "conference";
+
+    protected override void ApplySportSpecific(PickemGroup group, CreateFootballNcaaLeagueRequest request)
     {
-        var validation = await _validator.ValidateAsync(request, cancellationToken);
-        if (!validation.IsValid)
-            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
-
-        // Enum parsing is guaranteed by the validator above.
-        var pickType = Enum.Parse<PickType>(request.PickType, ignoreCase: true);
-        var tiebreakerType = Enum.Parse<TiebreakerType>(request.TiebreakerType, ignoreCase: true);
-        var tiebreakerTiePolicy = Enum.Parse<TiebreakerTiePolicy>(request.TiebreakerTiePolicy, ignoreCase: true);
-
-        var rankingFilter = string.IsNullOrWhiteSpace(request.RankingFilter)
-            ? (TeamRankingFilter?)null
+        group.RankingFilter = string.IsNullOrWhiteSpace(request.RankingFilter)
+            ? null
             : Enum.Parse<TeamRankingFilter>(request.RankingFilter, ignoreCase: true);
-
-        var seasonYear = request.SeasonYear ?? DateTime.UtcNow.Year;
-        var conferenceIds = request.ConferenceSlugs.Count > 0
-            ? await _franchiseClientFactory
-                .Resolve(SportMode)
-                .GetConferenceIdsBySlugs(seasonYear, request.ConferenceSlugs)
-            : new Dictionary<Guid, string>();
-
-        var unresolved = request.ConferenceSlugs
-            .Except(conferenceIds.Values, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (unresolved.Count > 0)
-            return new Failure<Guid>(
-                default!,
-                ResultStatus.Validation,
-                [new ValidationFailure(nameof(request.ConferenceSlugs), $"Unknown conference slugs: {string.Join(", ", unresolved)}")]);
-
-        var group = new PickemGroup
-        {
-            Id = Guid.NewGuid(),
-            CommissionerUserId = currentUserId,
-            CreatedBy = currentUserId,
-            Description = request.Description?.Trim(),
-            IsPublic = request.IsPublic,
-            League = LeagueMode,
-            Name = request.Name.Trim(),
-            PickType = pickType,
-            RankingFilter = rankingFilter,
-            Sport = SportMode,
-            TiebreakerTiePolicy = tiebreakerTiePolicy,
-            TiebreakerType = tiebreakerType,
-            UseConfidencePoints = request.UseConfidencePoints,
-            DropLowWeeksCount = request.DropLowWeeksCount,
-            StartsOn = request.StartsOn,
-            EndsOn = request.EffectiveEndsOn
-        };
-
-        foreach (var kvp in conferenceIds)
-        {
-            group.Conferences.Add(new PickemGroupConference
-            {
-                ConferenceSlug = kvp.Value,
-                ConferenceId = kvp.Key,
-                PickemGroupId = group.Id
-            });
-        }
-
-        group.Members.Add(new PickemGroupMember
-        {
-            CreatedBy = currentUserId,
-            PickemGroupId = group.Id,
-            Role = LeagueRole.Commissioner,
-            UserId = currentUserId,
-        });
-
-        var synthetic = await _dbContext.Users
-            .Where(x => x.IsSynthetic == true)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (synthetic != null)
-        {
-            group.Members.Add(new PickemGroupMember
-            {
-                CreatedBy = currentUserId,
-                PickemGroupId = group.Id,
-                Role = LeagueRole.Member,
-                UserId = synthetic.Id,
-            });
-        }
-
-        await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
-
-        // Publish BEFORE the commit: with the EF outbox, Publish enqueues the
-        // message into the DbContext tracker and only SaveChangesAsync persists
-        // both the aggregate and the outbox row atomically. Publishing AFTER
-        // SaveChangesAsync silently loses the event when the DI scope disposes.
-        var evt = new PickemGroupCreated(
-            group.Id,
-            null,
-            group.Sport,
-            seasonYear,
-            Guid.NewGuid(),
-            Guid.NewGuid());
-        await _eventBus.Publish(evt, cancellationToken);
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; PickemGroupCreated enqueued to outbox",
-            SportMode,
-            group.Id,
-            group.Name,
-            currentUserId);
-
-        return new Success<Guid>(group.Id);
     }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
@@ -1,15 +1,10 @@
 using FluentValidation;
-using FluentValidation.Results;
-
-using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague.Dtos;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
-using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague;
@@ -22,138 +17,26 @@ public interface ICreateFootballNflLeagueCommandHandler
         CancellationToken cancellationToken = default);
 }
 
-public class CreateFootballNflLeagueCommandHandler : ICreateFootballNflLeagueCommandHandler
+public class CreateFootballNflLeagueCommandHandler
+    : CreateLeagueCommandHandlerBase<CreateFootballNflLeagueRequest>,
+      ICreateFootballNflLeagueCommandHandler
 {
-    private const Sport SportMode = Sport.FootballNfl;
-    private const League LeagueMode = League.NFL;
-
-    private readonly ILogger<CreateFootballNflLeagueCommandHandler> _logger;
-    private readonly AppDataContext _dbContext;
-    private readonly IEventBus _eventBus;
-    private readonly IFranchiseClientFactory _franchiseClientFactory;
-    private readonly IValidator<CreateFootballNflLeagueRequest> _validator;
-
     public CreateFootballNflLeagueCommandHandler(
         ILogger<CreateFootballNflLeagueCommandHandler> logger,
         AppDataContext dbContext,
         IEventBus eventBus,
         IFranchiseClientFactory franchiseClientFactory,
         IValidator<CreateFootballNflLeagueRequest> validator)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, validator)
     {
-        _logger = logger;
-        _dbContext = dbContext;
-        _eventBus = eventBus;
-        _franchiseClientFactory = franchiseClientFactory;
-        _validator = validator;
     }
 
-    public async Task<Result<Guid>> ExecuteAsync(
-        CreateFootballNflLeagueRequest request,
-        Guid currentUserId,
-        CancellationToken cancellationToken = default)
-    {
-        var validation = await _validator.ValidateAsync(request, cancellationToken);
-        if (!validation.IsValid)
-            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+    protected override Sport SportMode => Sport.FootballNfl;
+    protected override League LeagueMode => League.NFL;
 
-        // Enum parsing is guaranteed by the validator above.
-        var pickType = Enum.Parse<PickType>(request.PickType, ignoreCase: true);
-        var tiebreakerType = Enum.Parse<TiebreakerType>(request.TiebreakerType, ignoreCase: true);
-        var tiebreakerTiePolicy = Enum.Parse<TiebreakerTiePolicy>(request.TiebreakerTiePolicy, ignoreCase: true);
+    protected override IReadOnlyList<string> GetGroupingSlugs(CreateFootballNflLeagueRequest request) =>
+        request.DivisionSlugs;
 
-        var seasonYear = request.SeasonYear ?? DateTime.UtcNow.Year;
-        var divisionIds = request.DivisionSlugs.Count > 0
-            ? await _franchiseClientFactory
-                .Resolve(SportMode)
-                .GetConferenceIdsBySlugs(seasonYear, request.DivisionSlugs)
-            : new Dictionary<Guid, string>();
-
-        var unresolved = request.DivisionSlugs
-            .Except(divisionIds.Values, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (unresolved.Count > 0)
-            return new Failure<Guid>(
-                default!,
-                ResultStatus.Validation,
-                [new ValidationFailure(nameof(request.DivisionSlugs), $"Unknown division slugs: {string.Join(", ", unresolved)}")]);
-
-        var group = new PickemGroup
-        {
-            Id = Guid.NewGuid(),
-            CommissionerUserId = currentUserId,
-            CreatedBy = currentUserId,
-            Description = request.Description?.Trim(),
-            IsPublic = request.IsPublic,
-            League = LeagueMode,
-            Name = request.Name.Trim(),
-            PickType = pickType,
-            Sport = SportMode,
-            TiebreakerTiePolicy = tiebreakerTiePolicy,
-            TiebreakerType = tiebreakerType,
-            UseConfidencePoints = request.UseConfidencePoints,
-            DropLowWeeksCount = request.DropLowWeeksCount,
-            StartsOn = request.StartsOn,
-            EndsOn = request.EffectiveEndsOn
-        };
-
-        foreach (var kvp in divisionIds)
-        {
-            group.Conferences.Add(new PickemGroupConference
-            {
-                ConferenceSlug = kvp.Value,
-                ConferenceId = kvp.Key,
-                PickemGroupId = group.Id
-            });
-        }
-
-        group.Members.Add(new PickemGroupMember
-        {
-            CreatedBy = currentUserId,
-            PickemGroupId = group.Id,
-            Role = LeagueRole.Commissioner,
-            UserId = currentUserId,
-        });
-
-        var synthetic = await _dbContext.Users
-            .Where(x => x.IsSynthetic == true)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (synthetic != null)
-        {
-            group.Members.Add(new PickemGroupMember
-            {
-                CreatedBy = currentUserId,
-                PickemGroupId = group.Id,
-                Role = LeagueRole.Member,
-                UserId = synthetic.Id,
-            });
-        }
-
-        await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
-
-        // Publish BEFORE the commit: with the EF outbox, Publish enqueues the
-        // message into the DbContext tracker and only SaveChangesAsync persists
-        // both the aggregate and the outbox row atomically. Publishing AFTER
-        // SaveChangesAsync silently loses the event when the DI scope disposes.
-        var evt = new PickemGroupCreated(
-            group.Id,
-            null,
-            group.Sport,
-            seasonYear,
-            Guid.NewGuid(),
-            Guid.NewGuid());
-        await _eventBus.Publish(evt, cancellationToken);
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        _logger.LogInformation(
-            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; PickemGroupCreated enqueued to outbox",
-            SportMode,
-            group.Id,
-            group.Name,
-            currentUserId);
-
-        return new Success<Guid>(group.Id);
-    }
+    protected override string SlugRequestFieldName => nameof(CreateFootballNflLeagueRequest.DivisionSlugs);
+    protected override string SlugDisplayLabel => "division";
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
@@ -26,8 +26,9 @@ public class CreateFootballNflLeagueCommandHandler
         AppDataContext dbContext,
         IEventBus eventBus,
         IFranchiseClientFactory franchiseClientFactory,
-        IValidator<CreateFootballNflLeagueRequest> validator)
-        : base(logger, dbContext, eventBus, franchiseClientFactory, validator)
+        IValidator<CreateFootballNflLeagueRequest> validator,
+        IDateTimeProvider dateTimeProvider)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, validator, dateTimeProvider)
     {
     }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -1,0 +1,217 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Core.Infrastructure.Clients.Franchise;
+
+namespace SportsData.Api.Application.UI.Leagues.Commands;
+
+/// <summary>
+/// Shared body for the three sport-specific create-league handlers
+/// (NCAA / NFL / MLB). The flow is identical across all three:
+/// validate, parse enums, resolve grouping slugs, build the
+/// <see cref="PickemGroup"/>, add commissioner + synthetic member,
+/// publish <see cref="PickemGroupCreated"/> into the outbox, save.
+///
+/// <para>
+/// Sport-specific bits surface through three abstract members and
+/// one virtual hook — see the members below for the exact seam.
+/// </para>
+///
+/// <para>
+/// <b>Naming note — grouping vs conference vs division.</b> The
+/// <c>PickemGroup.Conferences</c> collection (entity
+/// <see cref="PickemGroupConference"/>) is a misnomer: NCAA stores
+/// conferences (Big 10, SEC), NFL stores divisions (AFC East, NFC
+/// West), MLB stores divisions (AL East, NL Central). The base
+/// deliberately uses sport-neutral language ("grouping slugs") and
+/// leaves the entity name as-is. A future PR is expected to rename
+/// the entity + Franchise client method and decide per-sport which
+/// hierarchy level(s) the DTO exposes.
+/// </para>
+/// </summary>
+public abstract class CreateLeagueCommandHandlerBase<TRequest>
+    where TRequest : CreateLeagueRequestBase
+{
+    /// <summary>
+    /// Hard-coded placeholder. Per-league user caps are not a current
+    /// product feature; the entity column is nullable but we set an
+    /// explicit sentinel so downstream code can read the value without
+    /// null-checking. Revisit when product decides caps are a thing.
+    /// </summary>
+    protected const int DefaultMaxUsers = int.MaxValue;
+
+    private readonly ILogger _logger;
+    private readonly AppDataContext _dbContext;
+    private readonly IEventBus _eventBus;
+    private readonly IFranchiseClientFactory _franchiseClientFactory;
+    private readonly IValidator<TRequest> _validator;
+
+    protected CreateLeagueCommandHandlerBase(
+        ILogger logger,
+        AppDataContext dbContext,
+        IEventBus eventBus,
+        IFranchiseClientFactory franchiseClientFactory,
+        IValidator<TRequest> validator)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+        _eventBus = eventBus;
+        _franchiseClientFactory = franchiseClientFactory;
+        _validator = validator;
+    }
+
+    protected abstract Sport SportMode { get; }
+    protected abstract League LeagueMode { get; }
+
+    /// <summary>
+    /// The grouping slugs the user picked (conferences for NCAA,
+    /// divisions for NFL/MLB). Sport DTOs name the field differently
+    /// per sport vocabulary; this hook lets the base stay agnostic.
+    /// </summary>
+    protected abstract IReadOnlyList<string> GetGroupingSlugs(TRequest request);
+
+    /// <summary>
+    /// The request DTO field name that <see cref="GetGroupingSlugs"/>
+    /// reads from. Used as the <see cref="ValidationFailure"/> property
+    /// name so the FE knows which field to highlight on the
+    /// unresolved-slug failure path.
+    /// </summary>
+    protected abstract string SlugRequestFieldName { get; }
+
+    /// <summary>
+    /// Human-friendly singular label for the grouping concept, used in
+    /// the unresolved-slug failure message ("Unknown {label} slugs:").
+    /// "conference" for NCAA, "division" for NFL/MLB.
+    /// </summary>
+    protected abstract string SlugDisplayLabel { get; }
+
+    /// <summary>
+    /// Hook for fields that exist only on some sports — currently just
+    /// NCAA's <see cref="TeamRankingFilter"/>. Called after the base
+    /// has filled in all shared fields and before the group is added to
+    /// the <see cref="DbContext"/>.
+    /// </summary>
+    protected virtual void ApplySportSpecific(PickemGroup group, TRequest request) { }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        TRequest request,
+        Guid currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validation.IsValid)
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+
+        // Enum parsing is guaranteed by the validator above.
+        var pickType = Enum.Parse<PickType>(request.PickType, ignoreCase: true);
+        var tiebreakerType = Enum.Parse<TiebreakerType>(request.TiebreakerType, ignoreCase: true);
+        var tiebreakerTiePolicy = Enum.Parse<TiebreakerTiePolicy>(request.TiebreakerTiePolicy, ignoreCase: true);
+
+        var seasonYear = request.SeasonYear ?? DateTime.UtcNow.Year;
+        var slugs = GetGroupingSlugs(request);
+        var groupingIds = slugs.Count > 0
+            ? await _franchiseClientFactory
+                .Resolve(SportMode)
+                .GetConferenceIdsBySlugs(seasonYear, slugs.ToList())
+            : new Dictionary<Guid, string>();
+
+        var unresolved = slugs
+            .Except(groupingIds.Values, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (unresolved.Count > 0)
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(SlugRequestFieldName, $"Unknown {SlugDisplayLabel} slugs: {string.Join(", ", unresolved)}")]);
+
+        var group = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            CommissionerUserId = currentUserId,
+            CreatedBy = currentUserId,
+            Description = request.Description?.Trim(),
+            IsPublic = request.IsPublic,
+            League = LeagueMode,
+            MaxUsers = DefaultMaxUsers,
+            Name = request.Name.Trim(),
+            PickType = pickType,
+            Sport = SportMode,
+            TiebreakerTiePolicy = tiebreakerTiePolicy,
+            TiebreakerType = tiebreakerType,
+            UseConfidencePoints = request.UseConfidencePoints,
+            DropLowWeeksCount = request.DropLowWeeksCount,
+            StartsOn = request.StartsOn,
+            EndsOn = request.EffectiveEndsOn
+        };
+
+        ApplySportSpecific(group, request);
+
+        foreach (var kvp in groupingIds)
+        {
+            group.Conferences.Add(new PickemGroupConference
+            {
+                ConferenceSlug = kvp.Value,
+                ConferenceId = kvp.Key,
+                PickemGroupId = group.Id
+            });
+        }
+
+        group.Members.Add(new PickemGroupMember
+        {
+            CreatedBy = currentUserId,
+            PickemGroupId = group.Id,
+            Role = LeagueRole.Commissioner,
+            UserId = currentUserId,
+        });
+
+        var synthetic = await _dbContext.Users
+            .Where(x => x.IsSynthetic == true)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (synthetic != null)
+        {
+            group.Members.Add(new PickemGroupMember
+            {
+                CreatedBy = currentUserId,
+                PickemGroupId = group.Id,
+                Role = LeagueRole.Member,
+                UserId = synthetic.Id,
+            });
+        }
+
+        await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
+
+        // Publish BEFORE the commit: with the EF outbox, Publish enqueues the
+        // message into the DbContext tracker and only SaveChangesAsync persists
+        // both the aggregate and the outbox row atomically. Publishing AFTER
+        // SaveChangesAsync silently loses the event when the DI scope disposes.
+        var evt = new PickemGroupCreated(
+            group.Id,
+            null,
+            group.Sport,
+            seasonYear,
+            Guid.NewGuid(),
+            Guid.NewGuid());
+        await _eventBus.Publish(evt, cancellationToken);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created {Sport} league {LeagueId} with name {LeagueName} by user {UserId}; PickemGroupCreated enqueued to outbox",
+            SportMode,
+            group.Id,
+            group.Name,
+            currentUserId);
+
+        return new Success<Guid>(group.Id);
+    }
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -53,19 +53,22 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
     private readonly IEventBus _eventBus;
     private readonly IFranchiseClientFactory _franchiseClientFactory;
     private readonly IValidator<TRequest> _validator;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     protected CreateLeagueCommandHandlerBase(
         ILogger logger,
         AppDataContext dbContext,
         IEventBus eventBus,
         IFranchiseClientFactory franchiseClientFactory,
-        IValidator<TRequest> validator)
+        IValidator<TRequest> validator,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dbContext = dbContext;
         _eventBus = eventBus;
         _franchiseClientFactory = franchiseClientFactory;
         _validator = validator;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     protected abstract Sport SportMode { get; }
@@ -115,12 +118,12 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
         var tiebreakerType = Enum.Parse<TiebreakerType>(request.TiebreakerType, ignoreCase: true);
         var tiebreakerTiePolicy = Enum.Parse<TiebreakerTiePolicy>(request.TiebreakerTiePolicy, ignoreCase: true);
 
-        var seasonYear = request.SeasonYear ?? DateTime.UtcNow.Year;
+        var seasonYear = request.SeasonYear ?? _dateTimeProvider.UtcNow().Year;
         var slugs = GetGroupingSlugs(request);
         var groupingIds = slugs.Count > 0
             ? await _franchiseClientFactory
                 .Resolve(SportMode)
-                .GetConferenceIdsBySlugs(seasonYear, slugs.ToList())
+                .GetConferenceIdsBySlugs(seasonYear, slugs.ToList(), cancellationToken)
             : new Dictionary<Guid, string>();
 
         var unresolved = slugs

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandlerTests.cs
@@ -2,14 +2,24 @@ using FluentAssertions;
 
 using FluentValidation;
 
+using Microsoft.EntityFrameworkCore;
+
 using Moq;
 
+using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague.Dtos;
+using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 
 using Xunit;
+
+// Alias: SportsData.Api.Tests.Unit.Application.User is a sibling namespace
+// that beats the User entity type in name resolution from this file.
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
 
 namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Commands.CreateBaseballMlbLeague;
 
@@ -70,6 +80,75 @@ public class CreateBaseballMlbLeagueCommandHandlerTests : ApiTestBase<CreateBase
         var result = await sut.ExecuteAsync(request, Guid.NewGuid());
 
         result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldCreateLeague_AndPublishCreatedEvent_OnHappyPath()
+    {
+        // Mirrors the NCAA/NFL happy-path tests against the MLB handler's
+        // SportMode/LeagueMode. Pins the new MaxUsers = int.MaxValue
+        // behavior the base introduced.
+        const int SeasonYear = 2026;
+        var currentUserId = Guid.NewGuid();
+        var divisionId = Guid.NewGuid();
+
+        var request = BuildValidRequest();
+        request.SeasonYear = SeasonYear;
+        request.DivisionSlugs = ["american-league-east"];
+
+        _franchiseClientMock
+            .Setup(x => x.GetConferenceIdsBySlugs(SeasonYear, request.DivisionSlugs, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [divisionId] = "american-league-east" });
+
+        var synthetic = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            FirebaseUid = "synthetic",
+            Email = "synthetic@sportdeets.test",
+            SignInProvider = "synthetic",
+            DisplayName = "Synthetic",
+            IsSynthetic = true,
+            CreatedBy = Guid.Empty,
+        };
+        await DataContext.Users.AddAsync(synthetic);
+        await DataContext.SaveChangesAsync();
+
+        var eventBusMock = Mocker.GetMock<IEventBus>();
+
+        var sut = Mocker.CreateInstance<CreateBaseballMlbLeagueCommandHandler>();
+
+        var result = await sut.ExecuteAsync(request, currentUserId);
+
+        result.IsSuccess.Should().BeTrue();
+        var leagueId = ((Success<Guid>)result).Value;
+
+        var saved = await DataContext.PickemGroups
+            .Include(g => g.Conferences)
+            .Include(g => g.Members)
+            .FirstOrDefaultAsync(g => g.Id == leagueId);
+
+        saved.Should().NotBeNull();
+        saved!.Sport.Should().Be(Sport.BaseballMlb);
+        saved.League.Should().Be(League.MLB);
+        saved.Name.Should().Be("My MLB League");
+        saved.MaxUsers.Should().Be(int.MaxValue);
+        saved.CommissionerUserId.Should().Be(currentUserId);
+
+        saved.Conferences.Should().ContainSingle()
+            .Which.Should().Match<PickemGroupConference>(c =>
+                c.ConferenceId == divisionId && c.ConferenceSlug == "american-league-east");
+
+        saved.Members.Should().HaveCount(2);
+        saved.Members.Should().Contain(m =>
+            m.UserId == currentUserId && m.Role == LeagueRole.Commissioner);
+        saved.Members.Should().Contain(m =>
+            m.UserId == synthetic.Id && m.Role == LeagueRole.Member);
+
+        eventBusMock.Verify(
+            x => x.Publish(
+                It.Is<PickemGroupCreated>(e => e.GroupId == leagueId && e.Sport == Sport.BaseballMlb),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
@@ -1,13 +1,23 @@
 using FluentAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
 using Moq;
 
+using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague.Dtos;
+using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 
 using Xunit;
+
+// Alias: SportsData.Api.Tests.Unit.Application.User is a sibling namespace
+// that beats the User entity type in name resolution from this file.
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
 
 namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Commands.CreateFootballNcaaLeague;
 
@@ -94,6 +104,113 @@ public class CreateFootballNcaaLeagueCommandHandlerTests : ApiTestBase<CreateFoo
         var result = await sut.ExecuteAsync(request, Guid.NewGuid());
 
         result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldCreateLeague_AndPublishCreatedEvent_OnHappyPath()
+    {
+        // Pins the new MaxUsers = int.MaxValue behavior the base introduced
+        // (none of the per-sport handlers set it before PR-E) plus the rest
+        // of the shared body — persistence, member adds, event publish, and
+        // Success result.
+        const int SeasonYear = 2025;
+        var currentUserId = Guid.NewGuid();
+        var conferenceId = Guid.NewGuid();
+
+        var request = BuildValidRequest();
+        request.SeasonYear = SeasonYear;
+        request.Description = "  trimmable  ";
+        request.DropLowWeeksCount = 2;
+        request.ConferenceSlugs = ["sec"];
+
+        _franchiseClientMock
+            .Setup(x => x.GetConferenceIdsBySlugs(SeasonYear, request.ConferenceSlugs, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [conferenceId] = "sec" });
+
+        // Seed a synthetic user so the synthetic-member branch is exercised.
+        var synthetic = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            FirebaseUid = "synthetic",
+            Email = "synthetic@sportdeets.test",
+            SignInProvider = "synthetic",
+            DisplayName = "Synthetic",
+            IsSynthetic = true,
+            CreatedBy = Guid.Empty,
+        };
+        await DataContext.Users.AddAsync(synthetic);
+        await DataContext.SaveChangesAsync();
+
+        var eventBusMock = Mocker.GetMock<IEventBus>();
+
+        var sut = Mocker.CreateInstance<CreateFootballNcaaLeagueCommandHandler>();
+
+        var result = await sut.ExecuteAsync(request, currentUserId);
+
+        result.IsSuccess.Should().BeTrue();
+        var leagueId = ((Success<Guid>)result).Value;
+
+        var saved = await DataContext.PickemGroups
+            .Include(g => g.Conferences)
+            .Include(g => g.Members)
+            .FirstOrDefaultAsync(g => g.Id == leagueId);
+
+        saved.Should().NotBeNull();
+        saved!.Sport.Should().Be(Sport.FootballNcaa);
+        saved.League.Should().Be(League.NCAAF);
+        saved.Name.Should().Be("My League");
+        saved.Description.Should().Be("trimmable");
+        saved.IsPublic.Should().BeTrue();
+        saved.MaxUsers.Should().Be(int.MaxValue);
+        saved.DropLowWeeksCount.Should().Be(2);
+        saved.RankingFilter.Should().BeNull();
+        saved.CommissionerUserId.Should().Be(currentUserId);
+        saved.CreatedBy.Should().Be(currentUserId);
+
+        saved.Conferences.Should().ContainSingle()
+            .Which.Should().Match<PickemGroupConference>(c =>
+                c.ConferenceId == conferenceId && c.ConferenceSlug == "sec");
+
+        saved.Members.Should().HaveCount(2);
+        saved.Members.Should().Contain(m =>
+            m.UserId == currentUserId && m.Role == LeagueRole.Commissioner);
+        saved.Members.Should().Contain(m =>
+            m.UserId == synthetic.Id && m.Role == LeagueRole.Member);
+
+        eventBusMock.Verify(
+            x => x.Publish(
+                It.Is<PickemGroupCreated>(e => e.GroupId == leagueId && e.Sport == Sport.FootballNcaa),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ShouldParseAndPersistRankingFilter_WhenSupplied()
+    {
+        // Pins the NCAA-only ApplySportSpecific hook: a non-null
+        // RankingFilter string must round-trip to the parsed enum on the
+        // saved entity.
+        const int SeasonYear = 2025;
+        var conferenceId = Guid.NewGuid();
+
+        var request = BuildValidRequest();
+        request.SeasonYear = SeasonYear;
+        request.RankingFilter = "AP_TOP_25";
+        request.ConferenceSlugs = ["sec"];
+
+        _franchiseClientMock
+            .Setup(x => x.GetConferenceIdsBySlugs(SeasonYear, request.ConferenceSlugs, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [conferenceId] = "sec" });
+
+        var sut = Mocker.CreateInstance<CreateFootballNcaaLeagueCommandHandler>();
+
+        var result = await sut.ExecuteAsync(request, Guid.NewGuid());
+
+        result.IsSuccess.Should().BeTrue();
+        var leagueId = ((Success<Guid>)result).Value;
+
+        var saved = await DataContext.PickemGroups.FirstAsync(g => g.Id == leagueId);
+        saved.RankingFilter.Should().Be(TeamRankingFilter.AP_TOP_25);
     }
 
     [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandlerTests.cs
@@ -1,15 +1,24 @@
 using FluentAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
 using Moq;
 
+using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague.Dtos;
+using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 
 using Xunit;
 
 using FailureResult = SportsData.Core.Common.Failure<System.Guid>;
+// Alias: SportsData.Api.Tests.Unit.Application.User is a sibling namespace
+// that beats the User entity type in name resolution from this file.
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
 
 namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Commands.CreateFootballNflLeague;
 
@@ -79,6 +88,75 @@ public class CreateFootballNflLeagueCommandHandlerTests : ApiTestBase<CreateFoot
         failure.Errors.Should().ContainSingle()
             .Which.PropertyName.Should().Be(nameof(CreateFootballNflLeagueRequest.PickType));
         failure.Errors.Single().ErrorMessage.Should().Contain("Invalid pick type: Garbage");
+    }
+
+    [Fact]
+    public async Task ShouldCreateLeague_AndPublishCreatedEvent_OnHappyPath()
+    {
+        // Mirrors the NCAA happy-path test against the NFL handler's
+        // SportMode/LeagueMode and division-slug input. Pins the new
+        // MaxUsers = int.MaxValue behavior the base introduced.
+        const int SeasonYear = 2025;
+        var currentUserId = Guid.NewGuid();
+        var divisionId = Guid.NewGuid();
+
+        var request = BuildValidRequest();
+        request.SeasonYear = SeasonYear;
+        request.DivisionSlugs = ["afc-east"];
+
+        _franchiseClientMock
+            .Setup(x => x.GetConferenceIdsBySlugs(SeasonYear, request.DivisionSlugs, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [divisionId] = "afc-east" });
+
+        var synthetic = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            FirebaseUid = "synthetic",
+            Email = "synthetic@sportdeets.test",
+            SignInProvider = "synthetic",
+            DisplayName = "Synthetic",
+            IsSynthetic = true,
+            CreatedBy = Guid.Empty,
+        };
+        await DataContext.Users.AddAsync(synthetic);
+        await DataContext.SaveChangesAsync();
+
+        var eventBusMock = Mocker.GetMock<IEventBus>();
+
+        var sut = Mocker.CreateInstance<CreateFootballNflLeagueCommandHandler>();
+
+        var result = await sut.ExecuteAsync(request, currentUserId);
+
+        result.IsSuccess.Should().BeTrue();
+        var leagueId = ((Success<Guid>)result).Value;
+
+        var saved = await DataContext.PickemGroups
+            .Include(g => g.Conferences)
+            .Include(g => g.Members)
+            .FirstOrDefaultAsync(g => g.Id == leagueId);
+
+        saved.Should().NotBeNull();
+        saved!.Sport.Should().Be(Sport.FootballNfl);
+        saved.League.Should().Be(League.NFL);
+        saved.Name.Should().Be("My NFL League");
+        saved.MaxUsers.Should().Be(int.MaxValue);
+        saved.CommissionerUserId.Should().Be(currentUserId);
+
+        saved.Conferences.Should().ContainSingle()
+            .Which.Should().Match<PickemGroupConference>(c =>
+                c.ConferenceId == divisionId && c.ConferenceSlug == "afc-east");
+
+        saved.Members.Should().HaveCount(2);
+        saved.Members.Should().Contain(m =>
+            m.UserId == currentUserId && m.Role == LeagueRole.Commissioner);
+        saved.Members.Should().Contain(m =>
+            m.UserId == synthetic.Id && m.Role == LeagueRole.Member);
+
+        eventBusMock.Verify(
+            x => x.Publish(
+                It.Is<PickemGroupCreated>(e => e.GroupId == leagueId && e.Sport == Sport.FootballNfl),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Collapses the three sport-specific create-league handlers (NCAA / NFL / MLB) into a generic abstract base. Each concrete handler shrinks from ~160 lines to ~45 (constructor + four overrides); the base owns ~150 lines of shared body. The deferred-hygiene PR-E item from the create-league hardening doc.

Sport-specific seam:
- `SportMode` / `LeagueMode`
- `GetGroupingSlugs` / `SlugRequestFieldName` / `SlugDisplayLabel` — sport-neutral term ("grouping") so the base doesn't claim it's a conference or a division. NCAA stores conferences (Big 10, SEC); NFL/MLB store divisions (AFC East, AL Central). The underlying `PickemGroupConference` entity is a misnomer flagged in the base xmldoc for a future, separate rename.
- `ApplySportSpecific(group, request)` virtual hook — NCAA overrides for `RankingFilter`.

## Behavior changes

- `PickemGroup.MaxUsers = int.MaxValue` set explicitly. Before PR-E, no handler set it (defaulted null). Functional impact is zero today; explicit sentinel removes a future null-check.

## Tests

- 11 existing handler tests pass unchanged — per-sport `SlugRequestFieldName` + `SlugDisplayLabel` overrides are exercised via the unresolved-slug failure tests.
- +4 new happy-path tests close a pre-existing gap: no test previously asserted entity persistence, commissioner + synthetic member adds, or `PickemGroupCreated` publication.
  - NCAA: `ShouldCreateLeague_AndPublishCreatedEvent_OnHappyPath` (pins `MaxUsers == int.MaxValue`)
  - NCAA: `ShouldParseAndPersistRankingFilter_WhenSupplied` (pins `ApplySportSpecific` hook)
  - NFL: `ShouldCreateLeague_AndPublishCreatedEvent_OnHappyPath`
  - MLB: `ShouldCreateLeague_AndPublishCreatedEvent_OnHappyPath`

Final test count: 15/15 in the three handler suites.

## Deferred to follow-up PRs

- Entity rename `PickemGroupConference` → `PickemGroupTeamGrouping` (+ Franchise client method rename) — needs DB migration
- `NonStandardWeekGroupSeasonMapFilter` wiring — source unclear
- Per-sport hierarchy decisions (NCAA division-level, NFL conference-level filter options) — product decision, not refactor

## Test plan

- [x] \`dotnet build src/SportsData.Api/SportsData.Api.csproj\` — zero warnings, zero errors
- [x] All three handler test suites green (15/15)
- [ ] Smoke-test create-league for each sport in dev once branch merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated league-creation logic into a shared handler for MLB, NFL, and NCAA, reducing duplication and standardizing behavior (validation, slug resolution, persistence, event publishing).

* **Tests**
  * Added end-to-end unit tests for MLB, NFL, and NCAA league creation verifying persisted group data, member assignment, ranking-filter parsing, and that creation events are published.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->