### PR TITLE
fix(api): wrap UpsertMatchupPreview transaction in ExecutionStrategy

### DIFF
--- a/src/SportsData.Api/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandler.cs
@@ -56,23 +56,33 @@ public class UpsertMatchupPreviewCommandHandler : IUpsertMatchupPreviewCommandHa
                     [new ValidationFailure(nameof(command.JsonContent), "Invalid preview content")]);
             }
 
-            // Use explicit transaction to ensure atomicity of the upsert operation
-            await using var transaction = await _dataContext.Database.BeginTransactionAsync(cancellationToken);
+            // Wrap in the DbContext execution strategy: EnableRetryOnFailure is configured
+            // globally for Npgsql (see Core/DependencyInjection/ServiceRegistration.cs),
+            // and raw BeginTransactionAsync under a retry strategy throws at runtime unless
+            // the transaction body is scoped inside strategy.ExecuteAsync so the whole unit
+            // can retry atomically on transient failures. Same fix shape as PR #271
+            // (DeleteLeague). The InMemory provider's no-op execution strategy makes
+            // existing tests still pass; the wrap only changes behavior under Npgsql.
+            var strategy = _dataContext.Database.CreateExecutionStrategy();
+            return await strategy.ExecuteAsync<Result<Guid>>(async () =>
+            {
+                await using var transaction = await _dataContext.Database.BeginTransactionAsync(cancellationToken);
 
-            var existing = await _dataContext.MatchupPreviews
-                .FirstOrDefaultAsync(x => x.ContestId == preview.ContestId, cancellationToken);
+                var existing = await _dataContext.MatchupPreviews
+                    .FirstOrDefaultAsync(x => x.ContestId == preview.ContestId, cancellationToken);
 
-            if (existing is not null)
-                _dataContext.MatchupPreviews.Remove(existing);
+                if (existing is not null)
+                    _dataContext.MatchupPreviews.Remove(existing);
 
-            await _dataContext.MatchupPreviews.AddAsync(preview, cancellationToken);
-            await _dataContext.SaveChangesAsync(cancellationToken);
+                await _dataContext.MatchupPreviews.AddAsync(preview, cancellationToken);
+                await _dataContext.SaveChangesAsync(cancellationToken);
 
-            await transaction.CommitAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
 
-            _logger.LogInformation("Upserted matchup preview for contest {ContestId}", preview.ContestId);
+                _logger.LogInformation("Upserted matchup preview for contest {ContestId}", preview.ContestId);
 
-            return new Success<Guid>(preview.ContestId);
+                return new Success<Guid>(preview.ContestId);
+            });
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

Latent bug fix: `UpsertMatchupPreviewCommandHandler` called `BeginTransactionAsync` outside an `ExecutionStrategy.ExecuteAsync` lambda. Under Npgsql with `EnableRetryOnFailure` (configured globally in `Core/DependencyInjection/ServiceRegistration.cs`), raw `BeginTransactionAsync` throws at runtime the moment the strategy attempts a retry.

Same fix shape as PR #271 (DeleteLeague): wrap the entire transaction body — `BeginTransactionAsync` → existence check → `Remove` / `AddAsync` → `SaveChanges` → `CommitAsync` — in `strategy.ExecuteAsync<Result<Guid>>(async () => { ... })`.

## Why this didn't show up in tests

`ApiTestBase` uses the InMemory provider, whose no-op execution strategy runs the body once with no retries. The wrap is functionally invisible there. Only Npgsql under a transient hiccup triggers the failure. Existing 5 handler tests pass unchanged after the wrap.

## Risk

Low. Pure refactor of the transaction scoping; no behavior change on the happy path, no isolation-level change, no test changes.

## Test plan

- [x] `dotnet build src/SportsData.Api/SportsData.Api.csproj` — zero errors
- [x] `dotnet test ... --filter UpsertMatchupPreviewCommandHandler` — 5/5 pass
- [ ] Verify in dev that an admin-triggered preview upsert still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of matchup preview operations with automatic retry handling for transient database connection issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jrandallsexton/sports-data-core/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->