### PR TITLE
fix(api): coalesce league-week scoring to prevent 23505 race

### DIFF
--- a/src/SportsData.Api/Application/Scoring/ContestScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/ContestScoringProcessor.cs
@@ -4,6 +4,7 @@ using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
+using SportsData.Core.Processing;
 
 namespace SportsData.Api.Application.Scoring
 {
@@ -19,7 +20,7 @@ namespace SportsData.Api.Application.Scoring
         private readonly IContestClientFactory _contestClientFactory;
         private readonly IEventBus _bus;
         private readonly IPickScoringService _pickScoringService;
-        private readonly ILeagueWeekScoringService _leagueWeekScoringService;
+        private readonly IProvideBackgroundJobs _backgroundJobProvider;
 
         public ContestScoringProcessor(
             ILogger<ContestScoringProcessor> logger,
@@ -27,14 +28,14 @@ namespace SportsData.Api.Application.Scoring
             IContestClientFactory contestClientFactory,
             IEventBus bus,
             IPickScoringService pickScoringService,
-            ILeagueWeekScoringService leagueWeekScoringService)
+            IProvideBackgroundJobs backgroundJobProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
             _contestClientFactory = contestClientFactory;
             _bus = bus;
             _pickScoringService = pickScoringService;
-            _leagueWeekScoringService = leagueWeekScoringService;
+            _backgroundJobProvider = backgroundJobProvider;
         }
 
         public async Task Process(ScoreContestCommand command)
@@ -172,28 +173,36 @@ namespace SportsData.Api.Application.Scoring
                 leaguesNeedingScoring.Add((group.Id, matchup.SeasonYear, matchup.SeasonWeek));
             }
 
-            // After all picks are scored, trigger league week scoring
+            // Enqueue per (league, year, week) instead of calling inline. The
+            // IScoreLeagueWeeks job is DisableConcurrentExecution-decorated and
+            // runs a staleness short-circuit, so a burst of contests finalizing
+            // in the same scoring week (a) cannot race on the
+            // PickemGroupWeekResult unique index and (b) collapses into a
+            // single real rescore rather than N.
             foreach (var (leagueId, seasonYear, weekNumber) in leaguesNeedingScoring)
             {
                 try
                 {
+                    _backgroundJobProvider.Enqueue<IScoreLeagueWeeks>(
+                        p => p.Process(leagueId, seasonYear, weekNumber, command.CorrelationId));
+
                     _logger.LogInformation(
-                        "Triggering league week scoring for leagueId={LeagueId}, seasonYear={SeasonYear}, week={Week} after contest scoring",
+                        "Enqueued league-week scoring. LeagueId={LeagueId}, SeasonYear={SeasonYear}, Week={Week}, CorrelationId={CorrelationId}",
                         leagueId,
                         seasonYear,
-                        weekNumber);
-
-                    await _leagueWeekScoringService.ScoreLeagueWeekAsync(leagueId, seasonYear, weekNumber);
+                        weekNumber,
+                        command.CorrelationId);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(
                         ex,
-                        "Failed to score league week for leagueId={LeagueId}, seasonYear={SeasonYear}, week={Week}",
+                        "Failed to enqueue league-week scoring. LeagueId={LeagueId}, SeasonYear={SeasonYear}, Week={Week}",
                         leagueId,
                         seasonYear,
                         weekNumber);
-                    // Don't throw - we don't want to fail contest scoring if league scoring fails
+                    // Don't throw — the recurring LeagueWeekScoringJob backstop
+                    // catches league weeks where the tail enqueue failed.
                 }
             }
         }

--- a/src/SportsData.Api/Application/Scoring/LeagueWeekScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/LeagueWeekScoringProcessor.cs
@@ -1,0 +1,88 @@
+using Hangfire;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+
+namespace SportsData.Api.Application.Scoring;
+
+public interface IScoreLeagueWeeks
+{
+    Task Process(Guid leagueId, int seasonYear, int seasonWeek, Guid correlationId);
+}
+
+/// <summary>
+/// Per-(league, year, week) Hangfire job. Replaces the inline tail call inside
+/// <see cref="ContestScoringProcessor"/> so a burst of contests finalizing in
+/// the same scoring week cannot fan out into N concurrent
+/// <see cref="ILeagueWeekScoringService.ScoreLeagueWeekAsync"/> invocations
+/// racing on the <c>PickemGroupWeekResult</c> unique index.
+///
+/// Two-layer safety:
+///   1. <see cref="DisableConcurrentExecutionAttribute"/> serializes invocations
+///      of <see cref="Process"/> across the cluster — eliminates the 23505 race.
+///   2. A staleness short-circuit collapses N queued runs into 1 actual rescore:
+///      the first run does the work; the rest find fresh state and exit.
+///
+/// Trade-off: DCE serializes ALL league-week scoring globally, not per tuple.
+/// Acceptable while per-run work is sub-second; revisit with a per-tuple
+/// server filter or pg_advisory lock if contention grows.
+/// </summary>
+[DisableConcurrentExecution(60)]
+public class LeagueWeekScoringProcessor : IScoreLeagueWeeks
+{
+    private readonly ILogger<LeagueWeekScoringProcessor> _logger;
+    private readonly AppDataContext _dataContext;
+    private readonly ILeagueWeekScoringService _leagueWeekScoringService;
+
+    public LeagueWeekScoringProcessor(
+        ILogger<LeagueWeekScoringProcessor> logger,
+        AppDataContext dataContext,
+        ILeagueWeekScoringService leagueWeekScoringService)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _leagueWeekScoringService = leagueWeekScoringService;
+    }
+
+    public async Task Process(Guid leagueId, int seasonYear, int seasonWeek, Guid correlationId)
+    {
+        _logger.LogInformation(
+            "Starting league-week scoring. LeagueId={LeagueId}, SeasonYear={SeasonYear}, Week={Week}, CorrelationId={CorrelationId}",
+            leagueId, seasonYear, seasonWeek, correlationId);
+
+        // Staleness short-circuit: skip if no UserPick.ScoredAt is newer than
+        // the OLDEST PickemGroupWeekResult.CalculatedUtc for this tuple. Min
+        // (not Max) so a brand-new member's freshly-inserted row can't mask a
+        // stale row for someone else. Mirrors the predicate the daily backstop
+        // (LeagueWeekScoringJob) uses.
+        var oldestCalc = await _dataContext.PickemGroupWeekResults
+            .Where(r => r.PickemGroupId == leagueId
+                        && r.SeasonYear == seasonYear
+                        && r.SeasonWeek == seasonWeek)
+            .MinAsync(r => (DateTime?)r.CalculatedUtc);
+
+        if (oldestCalc.HasValue)
+        {
+            var latestPickScored = await _dataContext.PickemGroupMatchups
+                .Where(m => m.GroupId == leagueId
+                            && m.SeasonYear == seasonYear
+                            && m.SeasonWeek == seasonWeek)
+                .Join(_dataContext.UserPicks.Where(p => p.ScoredAt != null && p.PickemGroupId == leagueId),
+                    m => m.ContestId,
+                    p => p.ContestId,
+                    (m, p) => p.ScoredAt)
+                .MaxAsync(s => (DateTime?)s);
+
+            if (!latestPickScored.HasValue || latestPickScored.Value <= oldestCalc.Value)
+            {
+                _logger.LogInformation(
+                    "League-week scoring already current; skipping. LeagueId={LeagueId}, SeasonYear={SeasonYear}, Week={Week}, OldestCalc={OldestCalc}, LatestPickScored={LatestPickScored}, CorrelationId={CorrelationId}",
+                    leagueId, seasonYear, seasonWeek, oldestCalc, latestPickScored, correlationId);
+                return;
+            }
+        }
+
+        await _leagueWeekScoringService.ScoreLeagueWeekAsync(leagueId, seasonYear, seasonWeek);
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -208,6 +208,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IScheduleGroupWeekMatchups, MatchupScheduleProcessor>();
             services.AddScoped<IBootstrapLeagueMatchups, BootstrapLeagueMatchupsProcessor>();
             services.AddScoped<IScoreContests, ContestScoringProcessor>();
+            services.AddScoped<IScoreLeagueWeeks, LeagueWeekScoringProcessor>();
             
             // HATEOAS Ref Generator (external API)
             services.AddSingleton<IGenerateApiResourceRefs, ApiResourceRefGenerator>();

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/LeagueWeekScoringProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/LeagueWeekScoringProcessorTests.cs
@@ -1,0 +1,145 @@
+using Moq;
+
+using SportsData.Api.Application.Scoring;
+using SportsData.Api.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Scoring;
+
+public class LeagueWeekScoringProcessorTests : ApiTestBase<LeagueWeekScoringProcessor>
+{
+    private static readonly DateTime FixedUtcNow = new(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc);
+
+    private const int SeasonYear = 2026;
+    private const int SeasonWeek = 10;
+
+    [Fact]
+    public async Task Process_WhenAllPicksScoredBeforeOldestCalc_SkipsScoring()
+    {
+        // Arrange — every UserPick.ScoredAt is older than the OLDEST
+        // PickemGroupWeekResult.CalculatedUtc for this (league, year, week).
+        // This is the coalesce path: a later-enqueued duplicate job hits the
+        // short-circuit because the first run already brought the leaderboard
+        // current.
+        var leagueId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        await SeedMatchupAndPick(leagueId, contestId, pickScoredAt: FixedUtcNow.AddMinutes(-30));
+        await SeedWeekResult(leagueId, calculatedUtc: FixedUtcNow.AddMinutes(-5));
+
+        var sut = Mocker.CreateInstance<LeagueWeekScoringProcessor>();
+
+        // Act
+        await sut.Process(leagueId, SeasonYear, SeasonWeek, Guid.NewGuid());
+
+        // Assert — staleness short-circuit fired; no rescore.
+        Mocker.GetMock<ILeagueWeekScoringService>()
+            .Verify(s => s.ScoreLeagueWeekAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenPickScoredAfterOldestCalc_InvokesScoring()
+    {
+        // Arrange — UserPick.ScoredAt is newer than the OLDEST
+        // PickemGroupWeekResult.CalculatedUtc. Real work to do.
+        var leagueId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        await SeedMatchupAndPick(leagueId, contestId, pickScoredAt: FixedUtcNow);
+        await SeedWeekResult(leagueId, calculatedUtc: FixedUtcNow.AddMinutes(-10));
+
+        var sut = Mocker.CreateInstance<LeagueWeekScoringProcessor>();
+
+        // Act
+        await sut.Process(leagueId, SeasonYear, SeasonWeek, Guid.NewGuid());
+
+        // Assert
+        Mocker.GetMock<ILeagueWeekScoringService>()
+            .Verify(s => s.ScoreLeagueWeekAsync(
+                leagueId,
+                SeasonYear,
+                SeasonWeek,
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task Process_WhenNoResultRowsYet_InvokesScoring()
+    {
+        // Arrange — no PickemGroupWeekResult rows for this tuple. First-ever
+        // scoring of a (league, year, week) must always run; the staleness
+        // predicate has nothing to compare against.
+        var leagueId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        await SeedMatchupAndPick(leagueId, contestId, pickScoredAt: FixedUtcNow);
+
+        var sut = Mocker.CreateInstance<LeagueWeekScoringProcessor>();
+
+        // Act
+        await sut.Process(leagueId, SeasonYear, SeasonWeek, Guid.NewGuid());
+
+        // Assert
+        Mocker.GetMock<ILeagueWeekScoringService>()
+            .Verify(s => s.ScoreLeagueWeekAsync(
+                leagueId,
+                SeasonYear,
+                SeasonWeek,
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+    }
+
+    private async Task SeedMatchupAndPick(Guid leagueId, Guid contestId, DateTime? pickScoredAt)
+    {
+        var matchup = new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = leagueId,
+            ContestId = contestId,
+            SeasonYear = SeasonYear,
+            SeasonWeek = SeasonWeek,
+            StartDateUtc = FixedUtcNow.AddDays(-1),
+            CreatedUtc = FixedUtcNow,
+            CreatedBy = Guid.Empty
+        };
+
+        var pick = new PickemGroupUserPick
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            UserId = Guid.NewGuid(),
+            ContestId = contestId,
+            ScoredAt = pickScoredAt,
+            CreatedUtc = FixedUtcNow,
+            CreatedBy = Guid.Empty
+        };
+
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+        await DataContext.UserPicks.AddAsync(pick);
+        await DataContext.SaveChangesAsync();
+    }
+
+    private async Task SeedWeekResult(Guid leagueId, DateTime calculatedUtc)
+    {
+        var result = new PickemGroupWeekResult
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            UserId = Guid.NewGuid(),
+            SeasonYear = SeasonYear,
+            SeasonWeek = SeasonWeek,
+            CalculatedUtc = calculatedUtc,
+            CreatedUtc = FixedUtcNow,
+            CreatedBy = Guid.Empty
+        };
+
+        await DataContext.PickemGroupWeekResults.AddAsync(result);
+        await DataContext.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

`ContestScoringProcessor`'s tail call to `ScoreLeagueWeekAsync` ran inline per contest. When multiple contests in the same `(league, year, week)` finalized in a burst, parallel Hangfire workers raced on the `PickemGroupWeekResult` unique index — both reading null from the upsert `FirstOrDefault`, both inserting, second insert `23505`'d.

Caught in prod log (2026-05-31 09:00 UTC) after an MLB game finalized:
```
duplicate key value violates unique constraint "IX_PickemGroupWeekResult_PickemGroupId_SeasonYear_SeasonWeek_U~"
Key ("PickemGroupId", "SeasonYear", "SeasonWeek", "UserId")=(a7239c29-..., 2026, 10, 5fa4c116-...) already exists.
```

## Fix

Replace the inline call with a Hangfire enqueue of a new per-tuple `IScoreLeagueWeeks` job:

- **`LeagueWeekScoringProcessor`** (new) — implements `IScoreLeagueWeeks.Process(leagueId, year, week, correlationId)`. Two layers:
  1. `[DisableConcurrentExecution(60)]` serializes invocations across the cluster — eliminates the 23505.
  2. Staleness short-circuit: if no `UserPick.ScoredAt` is newer than the OLDEST `PickemGroupWeekResult.CalculatedUtc` for the tuple, skip. Collapses N enqueued runs into 1 real rescore. Mirrors the predicate the daily `LeagueWeekScoringJob` backstop uses.
- **`ContestScoringProcessor`** — drops `ILeagueWeekScoringService` from ctor, adds `IProvideBackgroundJobs`; tail loop enqueues `IScoreLeagueWeeks.Process(...)` per `(league, year, week)` tuple it touched.
- **`ServiceRegistration`** — one-line scoped registration next to `IScoreContests`.

Daily `LeagueWeekScoringJob` backstop unchanged (runs 09:15, no realistic collision with event-driven path).

## Trade-off

Vanilla Hangfire `[DisableConcurrentExecution]` locks per-method, not per-args, so all league-week scoring is globally serialized. Acceptable at current sub-second per-run work. If contention ever grows the upgrade path is a custom `IServerFilter` keyed on `(leagueId, year, week)`, or wrapping `ScoreLeagueWeekAsync` in `pg_advisory_xact_lock`. Not pre-built.

## Test plan

- [x] `dotnet build src/SportsData.Api` — 0 warnings, 0 errors
- [x] `dotnet test test/unit/SportsData.Api.Tests.Unit --filter Application.Scoring` — 39/39 pass
- [x] 3 new `LeagueWeekScoringProcessorTests`:
  - `Process_WhenAllPicksScoredBeforeOldestCalc_SkipsScoring` — coalesce path
  - `Process_WhenPickScoredAfterOldestCalc_InvokesScoring` — real-work path
  - `Process_WhenNoResultRowsYet_InvokesScoring` — first-ever scoring of a tuple
- [x] Existing `ContestScoringProcessorTests` pass against the ctor swap (AutoMocker absorbed the dependency change transparently)
- [ ] Verify in prod logs: contest completed → "Enqueued league-week scoring" log → either "Starting league-week scoring" or "already current; skipping" — no `23505`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scoring operations now use asynchronous background job processing for improved scalability.

* **Improvements**
  * Non-blocking scoring workflow for better application performance.
  * Graceful error handling for scoring job processing failures.
  * Enhanced logging for improved visibility into scoring execution.

* **Tests**
  * Added unit tests for the new background job-based scoring processor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->