### PR TITLE
fix(producer): catch unique-violation on CompetitionPlay insert race

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionPlayDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionPlayDocumentProcessorBase.cs
@@ -117,11 +117,49 @@ public abstract class EventCompetitionPlayDocumentProcessorBase<TDataContext, TD
             }
 
             await _dataContext.CompetitionPlays.AddAsync(play);
-            await _dataContext.SaveChangesAsync();
 
-            _logger.LogInformation(
-                "Persisted CompetitionPlay. CompetitionId={CompId}, PlayId={PlayId}, Sequence={Sequence}",
-                competition.Id, play.Id, play.SequenceNumber);
+            try
+            {
+                await _dataContext.SaveChangesAsync();
+
+                _logger.LogInformation(
+                    "Persisted CompetitionPlay. CompetitionId={CompId}, PlayId={PlayId}, Sequence={Sequence}",
+                    competition.Id, play.Id, play.SequenceNumber);
+            }
+            catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
+            {
+                // Two workers raced on the SELECT-then-INSERT for the same play
+                // (at-least-once delivery + parallel Hangfire workers fanning out
+                // play documents for the same live game). The winner's row is
+                // already canonical; the loser detaches and treats this as
+                // idempotent success.
+                //
+                // Confirm the conflict is on the expected play Id — if not, the
+                // unique violation is on an unrelated constraint and must rethrow.
+                var alreadyExists = await _dataContext.CompetitionPlays
+                    .AsNoTracking()
+                    .AnyAsync(p => p.Id == play.Id);
+
+                // Detach regardless so the failed Add can't be retried by EF.
+                _dataContext.Entry(play).State = EntityState.Detached;
+                foreach (var externalId in play.ExternalIds.ToList())
+                    _dataContext.Entry(externalId).State = EntityState.Detached;
+
+                if (!alreadyExists)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Unique constraint violation on CompetitionPlay insert but no matching row found by Id — " +
+                        "unrelated data-integrity issue. PlayId={PlayId}, CorrelationId={CorrelationId}",
+                        play.Id, command.CorrelationId);
+                    throw;
+                }
+
+                _logger.LogWarning(
+                    "Duplicate key on CompetitionPlay insert — another worker won the race. " +
+                    "Treating as idempotent success. PlayId={PlayId}, CorrelationId={CorrelationId}",
+                    play.Id, command.CorrelationId);
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary

Producer-side sibling to PR #382. Two parallel Hangfire workers fanning out play documents for the same live MLB game raced on the `SELECT`-then-`INSERT` in `EventCompetitionPlayDocumentProcessorBase.ProcessInternal`: both saw no row, both built, both `Add` + `SaveChanges`, second one hit `23505` on `PK_CompetitionPlay`.

Caught during 24h Seq triage on 2026-05-31:

```
Npgsql.PostgresException 23505: duplicate key value violates unique constraint "PK_CompetitionPlay"
DETAIL: Key ("Id")=(5b2dded5-b7f0-320b-49fa-d546e2cad6c1) already exists.
SourceRef: .../v2/sports/baseball/leagues/mlb/events/401815563/competitions/401815563/plays/4018155631609060024
```

Same shape as PR #382, different table, different service.

## Fix

Wrap the new-play insert in try/catch following the established pattern in `SeasonTypeWeekDocumentProcessor`, `AthleteSeasonStatisticsDocumentProcessor`, and `AthleteCareerStatisticsDocumentProcessor`:

- Try `SaveChanges`
- On `DbUpdateException.IsUniqueConstraintViolation()`:
  - Confirm the conflict is on the **expected play Id** — if not, rethrow to surface real data-integrity issues on unrelated constraints
  - Detach the failed `Add` (play + `ExternalIds`) so EF can't retry it
  - Log warning and return — winner's row is canonical

Sport-specific navs (e.g. baseball `Participants`) are left in `Added` state on the loser; the DbContext disposes at request-end so they never get a second `SaveChanges`. Matches the `SeasonTypeWeek` precedent which also only detaches what the base knows about.

## Bonus behavior

Status quo published `*PlayCompleted` *before* `SaveChanges`. On the current code, both racers publish before either saves, and MT redelivery of the loser's failed batch causes a second publish. After this fix, the loser's outbox-tracked publish rolls away with the tracker detach — **exactly one `*PlayCompleted` per play, from the winner.**

## Out of scope

UPDATE-path `DbUpdateConcurrencyException` cluster (also flagged in triage) is transient and self-heals via MassTransit redelivery — already known/expected per project memory. Not touched.

## Test plan

- [x] `dotnet build src/SportsData.Producer` — 0 warnings / 0 errors
- [x] Existing 13 `EventCompetitionPlay` unit tests pass (4 pre-existing skips, unrelated)
- [ ] **Not adding** a unit test for the catch block: InMemoryDB enforces PK uniqueness but throws a different exception shape that bypasses `IsUniqueConstraintViolation()` entirely. A genuine race test would need a Testcontainers Postgres harness. Matches the testing posture of the four other processors that use this exact pattern.
- [ ] Verify in prod: post-deploy, watch Seq for `"another worker won the race"` warnings (positive signal — fix is firing) and absence of `23505 ... PK_CompetitionPlay` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of concurrent data insertion scenarios to prevent processing errors when multiple workers simultaneously attempt to insert identical data entries, treating duplicates as successfully processed to enhance system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->