### PR TITLE
feat(web): pick-mode badge + final-score result indicators on picks page

### DIFF
--- a/src/UI/sd-ui/src/components/matchups/FinalScoreResult.jsx
+++ b/src/UI/sd-ui/src/components/matchups/FinalScoreResult.jsx
@@ -1,0 +1,74 @@
+import { FaCheck } from "react-icons/fa";
+
+// Quick-scan result row appended below the final score for ATS / O/U
+// leagues. SU is NOT rendered here — its checkmark is inline next to
+// the winning team's short directly in GameStatus.jsx's scoreContent
+// (the score line already shows the winning team, so a duplicated
+// "NYY won" suffix would be noise).
+//
+// Pure presentation — does NOT reflect the user's own pick (PickButton
+// handles that). The goal is letting a user glance at a finalized card
+// and confirm the result relevant to the league's pick mode without
+// parsing the score themselves.
+function FinalScoreResult({
+  pickType,
+  awayFranchiseSeasonId,
+  homeFranchiseSeasonId,
+  awayShort,
+  homeShort,
+  spreadWinnerFranchiseSeasonId,
+  overUnderResult,
+  overUnderCurrent,
+}) {
+  const shortFor = (franchiseSeasonId) => {
+    if (!franchiseSeasonId) return null;
+    if (franchiseSeasonId === awayFranchiseSeasonId) return awayShort;
+    if (franchiseSeasonId === homeFranchiseSeasonId) return homeShort;
+    return null;
+  };
+
+  if (pickType === "AgainstTheSpread") {
+    // Null spread-winner = push at the spread (Producer enrichment sets
+    // SpreadWinnerFranchiseId to null when the game lands exactly on the
+    // line, see ContestEnrichmentProcessor).
+    if (!spreadWinnerFranchiseSeasonId) {
+      return (
+        <div className="final-score-result final-score-result-push">Push</div>
+      );
+    }
+    const cover = shortFor(spreadWinnerFranchiseSeasonId);
+    if (!cover) return null;
+    return (
+      <div className="final-score-result">
+        <FaCheck className="final-score-result-icon" />
+        <span>{cover} covered</span>
+      </div>
+    );
+  }
+
+  if (pickType === "OverUnder") {
+    if (!overUnderResult || overUnderResult === "None") {
+      return (
+        <div className="final-score-result final-score-result-push">Push</div>
+      );
+    }
+    const ouValue =
+      overUnderCurrent !== null && overUnderCurrent !== undefined
+        ? ` ${overUnderCurrent}`
+        : "";
+    return (
+      <div className="final-score-result">
+        <FaCheck className="final-score-result-icon" />
+        <span>
+          {overUnderResult}
+          {ouValue}
+        </span>
+      </div>
+    );
+  }
+
+  // StraightUp (and unknown pickType) — no row, handled inline.
+  return null;
+}
+
+export default FinalScoreResult;

--- a/src/UI/sd-ui/src/components/matchups/FinalScoreResult.jsx
+++ b/src/UI/sd-ui/src/components/matchups/FinalScoreResult.jsx
@@ -10,12 +10,19 @@ import { FaCheck } from "react-icons/fa";
 // handles that). The goal is letting a user glance at a finalized card
 // and confirm the result relevant to the league's pick mode without
 // parsing the score themselves.
+//
+// Readiness contract: when status=STATUS_FINAL flips, ContestEnrichment
+// (PR #384) runs with a ~30s delay. During that window, the wire still
+// reports STATUS_FINAL but winnerFranchiseSeasonId / spreadWinnerFranchise
+// SeasonId / overUnderResult are all null. We stay silent in that gap
+// rather than rendering a false "Push".
 function FinalScoreResult({
   pickType,
   awayFranchiseSeasonId,
   homeFranchiseSeasonId,
   awayShort,
   homeShort,
+  winnerFranchiseSeasonId,
   spreadWinnerFranchiseSeasonId,
   overUnderResult,
   overUnderCurrent,
@@ -28,10 +35,17 @@ function FinalScoreResult({
   };
 
   if (pickType === "AgainstTheSpread") {
-    // Null spread-winner = push at the spread (Producer enrichment sets
-    // SpreadWinnerFranchiseId to null when the game lands exactly on the
-    // line, see ContestEnrichmentProcessor).
-    if (!spreadWinnerFranchiseSeasonId) {
+    // Gate on winnerFranchiseSeasonId as the "enrichment ran" signal.
+    // Pre-enrichment all three result fields are null on the wire;
+    // treating a null spread winner as "Push" then would lie about a
+    // game that hasn't been scored yet. We accept missing the ATS
+    // indicator on a true tie (rare in football, impossible in MLB)
+    // rather than showing a false push during the enrichment window.
+    if (winnerFranchiseSeasonId == null) return null;
+
+    // Enrichment ran. A null spread winner now genuinely means push at
+    // the spread (game landed exactly on the line).
+    if (spreadWinnerFranchiseSeasonId == null) {
       return (
         <div className="final-score-result final-score-result-push">Push</div>
       );
@@ -47,24 +61,46 @@ function FinalScoreResult({
   }
 
   if (pickType === "OverUnder") {
-    if (!overUnderResult || overUnderResult === "None") {
+    // Only render when we recognize an explicit O/U verdict. Anything
+    // else (null / undefined / "None") means enrichment hasn't computed
+    // a result and we stay silent rather than showing a false "Push".
+    //
+    // Wire-shape note: API DTO uses OverUnderPick (None/Over/Under) but
+    // Producer's Contest.OverUnder uses OverUnderResult which has Push=3.
+    // MatchupForPickDtoMapper casts the int through, so a real push can
+    // arrive as "Push", 3, or "3" depending on the serializer's behavior
+    // on the unnamed enum value. Match all three; the contract mismatch
+    // itself is a separate change.
+    const isOver = overUnderResult === "Over";
+    const isUnder = overUnderResult === "Under";
+    const isPush =
+      overUnderResult === "Push" ||
+      overUnderResult === 3 ||
+      overUnderResult === "3";
+
+    if (isOver || isUnder) {
+      const ouValue =
+        overUnderCurrent !== null && overUnderCurrent !== undefined
+          ? ` ${overUnderCurrent}`
+          : "";
+      return (
+        <div className="final-score-result">
+          <FaCheck className="final-score-result-icon" />
+          <span>
+            {isOver ? "Over" : "Under"}
+            {ouValue}
+          </span>
+        </div>
+      );
+    }
+
+    if (isPush) {
       return (
         <div className="final-score-result final-score-result-push">Push</div>
       );
     }
-    const ouValue =
-      overUnderCurrent !== null && overUnderCurrent !== undefined
-        ? ` ${overUnderCurrent}`
-        : "";
-    return (
-      <div className="final-score-result">
-        <FaCheck className="final-score-result-icon" />
-        <span>
-          {overUnderResult}
-          {ouValue}
-        </span>
-      </div>
-    );
+
+    return null;
   }
 
   // StraightUp (and unknown pickType) — no row, handled inline.

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -1,8 +1,10 @@
 import { Link } from "react-router-dom";
 import { Webcam } from "lucide-react";
+import { FaCheck } from "react-icons/fa";
 import { contestLink } from '../../utils/sportLinks';
 import FootballGameStatusInProgress from './FootballGameStatusInProgress';
 import BaseballGameStatusInProgress from './BaseballGameStatusInProgress';
+import FinalScoreResult from './FinalScoreResult';
 
 // Mid-game paused states. Game is technically still live (score + period/
 // inning are meaningful), but no play is happening. Render the existing
@@ -85,13 +87,43 @@ function GameStatus({
   sport,
   league,
   streamScheduledTimeUtc,
+  // Pick-mode-aware result indicator inputs. pickType drives which
+  // outcome we summarize ("X covered" / "Over 8.5 ✓" / "✓ NYY"); the
+  // *FranchiseSeasonId fields come off the canonical Contest row and
+  // are null until enrichment runs (PR #384). Indicator renders nothing
+  // in that pre-enrichment window — score still shows.
+  pickType,
+  winnerFranchiseSeasonId,
+  spreadWinnerFranchiseSeasonId,
+  overUnderResult,
+  overUnderCurrent,
 }) {
   if (status === 'STATUS_FINAL') {
+    // SU's quick-scan indicator is just a checkmark hugging the
+    // winning team's short directly in the score line — no duplicated
+    // team name. ATS / O/U handle their indicators on a new row below
+    // via FinalScoreResult, since their result ("BOS covered", "Over
+    // 8.5") doesn't map cleanly to a single side of the score.
+    // Unknown / null pickType defaults to SU treatment.
+    const isSU = !pickType || pickType === 'StraightUp';
+    const awayWonSU = isSU && winnerFranchiseSeasonId &&
+      winnerFranchiseSeasonId === awayFranchiseSeasonId;
+    const homeWonSU = isSU && winnerFranchiseSeasonId &&
+      winnerFranchiseSeasonId === homeFranchiseSeasonId;
+
     const scoreContent = (
       <>
         <span className="result-label">FINAL:</span>
         <span className="score-display">
-          {awayShort} {awayScore} - {homeScore} {homeShort}
+          <span className="score-display-team">
+            {awayWonSU && <FaCheck className="final-score-inline-check" />}
+            {awayShort}
+          </span>
+          {awayScore} - {homeScore}
+          <span className="score-display-team">
+            {homeShort}
+            {homeWonSU && <FaCheck className="final-score-inline-check" />}
+          </span>
         </span>
       </>
     );
@@ -111,6 +143,16 @@ function GameStatus({
           ) : (
             scoreContent
           )}
+          <FinalScoreResult
+            pickType={pickType}
+            awayFranchiseSeasonId={awayFranchiseSeasonId}
+            homeFranchiseSeasonId={homeFranchiseSeasonId}
+            awayShort={awayShort}
+            homeShort={homeShort}
+            spreadWinnerFranchiseSeasonId={spreadWinnerFranchiseSeasonId}
+            overUnderResult={overUnderResult}
+            overUnderCurrent={overUnderCurrent}
+          />
         </div>
       </div>
     );

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -149,6 +149,7 @@ function GameStatus({
             homeFranchiseSeasonId={homeFranchiseSeasonId}
             awayShort={awayShort}
             homeShort={homeShort}
+            winnerFranchiseSeasonId={winnerFranchiseSeasonId}
             spreadWinnerFranchiseSeasonId={spreadWinnerFranchiseSeasonId}
             overUnderResult={overUnderResult}
             overUnderCurrent={overUnderCurrent}

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -379,7 +379,6 @@
 .final-score-result-push {
   color: var(--text-muted);
   font-style: italic;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -342,6 +342,47 @@
   gap: 8px;
 }
 
+/* SU quick-scan indicator: a checkmark hugging the winning team's
+   short directly in the score line. .score-display-team groups the
+   team short + (optional) check so flex gap stays between team groups
+   and score numbers, not between the short and its own check. */
+.score-display-team {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.final-score-inline-check {
+  color: var(--pick-correct);
+  font-size: 0.9rem;
+}
+
+/* ATS / O/U quick-scan indicator: separate row below the final score.
+   .final-score is a flex column so this lands centered beneath the
+   score line. See FinalScoreResult.jsx. */
+.final-score-result {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+  margin-top: 2px;
+}
+
+.final-score-result-icon {
+  color: var(--pick-correct);
+  font-size: 0.85rem;
+}
+
+.final-score-result-push {
+  color: var(--text-muted);
+  font-style: italic;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 .possession-indicator {
   font-size: 0.9rem;
   animation: bounce-football 1s ease-in-out infinite;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -265,6 +265,14 @@ function MatchupCard({
           sport={sportLeague?.sport}
           league={sportLeague?.league}
           streamScheduledTimeUtc={matchup.streamScheduledTimeUtc}
+          // Final-score quick-scan indicator inputs. pickType is the
+          // league's mode; the *FranchiseSeasonId/Result/spread fields
+          // come off the canonical Contest row populated by enrichment.
+          pickType={pickType}
+          winnerFranchiseSeasonId={matchup.winnerFranchiseSeasonId}
+          spreadWinnerFranchiseSeasonId={matchup.spreadWinnerFranchiseSeasonId}
+          overUnderResult={matchup.overUnderResult}
+          overUnderCurrent={matchup.overUnderCurrent}
         />
 
         {/* DeetsMeter - AI Prediction Meters */}

--- a/src/UI/sd-ui/src/components/picks/PicksPage.css
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.css
@@ -87,6 +87,21 @@
   color: var(--text-secondary);
 }
 
+.pick-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  background-color: var(--active-bg);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
 .hide-picked-toggle {
   font-size: 0.95rem;
   color: var(--text-secondary);

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -486,6 +486,23 @@ function PicksPage() {
             seasonWeeks={seasonWeeks}
           />
           <div className="pick-status-toggle-row">
+            {(() => {
+              // Pick-mode badge. PickType enum on the wire serializes as a
+              // string ("StraightUp" / "AgainstTheSpread" / "OverUnder").
+              // Anything else (None / unknown) suppresses the badge so a
+              // misconfigured league doesn't render a stray "?".
+              const label = {
+                StraightUp: { short: "SU", full: "Straight Up" },
+                AgainstTheSpread: { short: "ATS", full: "Against The Spread" },
+                OverUnder: { short: "O/U", full: "Over / Under" },
+              }[pickType];
+              if (!label) return null;
+              return (
+                <span className="pick-mode-badge" title={label.full}>
+                  {label.short}
+                </span>
+              );
+            })()}
             <span className="pick-status">
               {allPicked
                 ? "All Picks Made"


### PR DESCRIPTION
## Summary

Two scan-friendly visual cues on the picks page so a user (and a developer doing a visual sanity check on the scoring pipeline) can read a finalized card without parsing the score.

### Page header
- **SU / ATS / O/U pill** in the existing pick-status-toggle-row, keyed on `LeagueWeekMatchupsDto.PickType`. Unknown modes suppress the badge.

### Final-score cards (`STATUS_FINAL`)
- **SU:** green check hugs the outside of the winning team's short — left of away, right of home. Tie / pre-enrichment renders no check.
- **ATS:** new row below the score reads ``✓ {TEAM} covered`` or ``Push`` when `SpreadWinnerFranchiseId` is null on a real final.
- **O/U:** new row below the score reads ``✓ Over {N}`` / ``✓ Under {N}`` or ``Push`` when `OverUnderResult` is `None`.

### Cross-check side benefit
For any finalized SU card, the inline ✓ at the top must land on the same team as the green `PickButton` at the bottom (for a user who picked correctly). Disagreement = scoring bug, visible without opening a single record. Same property holds for ATS via the row-below indicator.

### No backend changes
All three result fields (`WinnerFranchiseSeasonId`, `SpreadWinnerFranchiseSeasonId`, `OverUnderResult`) were already projected by ``GetMatchupsByContestIds.sql`` and mapped through `MatchupForPickDtoMapper.ApplyCanonical`. Pure UI.

## Files

- ``src/UI/sd-ui/src/components/matchups/FinalScoreResult.jsx`` (new) — ATS / O/U row-below indicator. SU is intentionally NOT here; it's inline in `GameStatus`.
- ``src/UI/sd-ui/src/components/matchups/GameStatus.jsx`` — splits the score line into `score-display-team` wrappers, renders SU checkmark inline, renders `<FinalScoreResult>` below for ATS / O/U.
- ``src/UI/sd-ui/src/components/matchups/MatchupCard.jsx`` — threads `pickType`, `winnerFranchiseSeasonId`, `spreadWinnerFranchiseSeasonId`, `overUnderResult`, `overUnderCurrent` into `GameStatus`.
- ``src/UI/sd-ui/src/components/matchups/MatchupCard.css`` — `.score-display-team`, `.final-score-inline-check`, `.final-score-result`, `.final-score-result-icon`, `.final-score-result-push`.
- ``src/UI/sd-ui/src/components/picks/PicksPage.jsx`` — pill IIFE in `pick-status-toggle-row`.
- ``src/UI/sd-ui/src/components/picks/PicksPage.css`` — `.pick-mode-badge` (accent-bordered pill matching `view-mode-toggle` aesthetic).

## Test plan

- [x] Manual: MLB SU league on ``/app/picks/...`` — header pill reads ``SU``, finalized cards show ✓ on the winning team's outside edge, pick-button color agrees on every card.
- [ ] Manual: Switch to an ATS league — header pill reads ``ATS``, row below score reads ``✓ {short} covered`` on every finalized card; check that the ``covered`` team matches the green `PickButton` color where applicable.
- [ ] Manual: Push scenario (game lands exactly on the spread) — confirm ``Push`` renders, not a stray empty row.
- [ ] Visual: dark theme — ``var(--pick-correct)`` check, ``var(--accent)`` pill border, muted Push text all read.
- [ ] Mobile breakpoints — ATS ``{short} covered`` row doesn't shove the card; ``flex-wrap`` on score-display already keeps it tidy.

## Out of scope

- O/U pick UI is still team-shaped (button row), so the O/U cross-check between row-indicator and button-color only validates the row text, not the user's totals choice. Flagged for a future O/U-pick refactor.
- Pre-existing `pickType` defaulting to ``"StraightUp"`` in `PicksPage.jsx` `handlePick` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pick-mode-aware final score results: show spread coverage, over/under verdicts, or push outcomes.
  * Pick mode badge in the picks page header (SU / ATS / O‑U) with full-label tooltip.
  * Inline checkmarks highlighting teams that won Straight‑Up or covered the spread.

* **Style**
  * New quick-scan final-score and pick-mode badge styling for compact display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->