### PR TITLE
feat(mobile): pick-mode badge + final-score result indicators on picks tab

### DIFF
--- a/src/UI/sd-mobile/__tests__/components/features/games/FinalScoreResult.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/games/FinalScoreResult.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { FinalScoreResult } from '@/src/components/features/games/FinalScoreResult';
+
+const AWAY_ID = 'fs-away';
+const HOME_ID = 'fs-home';
+const baseProps = {
+  awayFranchiseSeasonId: AWAY_ID,
+  homeFranchiseSeasonId: HOME_ID,
+  awayShort: 'NYY',
+  homeShort: 'BOS',
+};
+
+describe('FinalScoreResult — readiness gate', () => {
+  it('renders null when pickType is StraightUp (SU is handled inline by the score line)', () => {
+    const { toJSON } = render(
+      <FinalScoreResult
+        pickType="StraightUp"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null on pre-enrichment ATS (winnerFranchiseSeasonId null) instead of showing false Push', () => {
+    const { toJSON } = render(
+      <FinalScoreResult
+        pickType="AgainstTheSpread"
+        {...baseProps}
+        winnerFranchiseSeasonId={null}
+        spreadWinnerFranchiseSeasonId={null}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null on pre-enrichment O/U (overUnderResult null) instead of showing false Push', () => {
+    const { toJSON } = render(
+      <FinalScoreResult
+        pickType="OverUnder"
+        {...baseProps}
+        winnerFranchiseSeasonId={null}
+        overUnderResult={null}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null on O/U "None" (enrichment ran but no O/U line)', () => {
+    const { toJSON } = render(
+      <FinalScoreResult
+        pickType="OverUnder"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        overUnderResult="None"
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+});
+
+describe('FinalScoreResult — ATS verdicts', () => {
+  it('shows "✓ {short} covered" with the cover team short', () => {
+    render(
+      <FinalScoreResult
+        pickType="AgainstTheSpread"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        spreadWinnerFranchiseSeasonId={AWAY_ID}
+      />,
+    );
+    expect(screen.getByText('NYY covered')).toBeTruthy();
+    expect(screen.getByText('✓')).toBeTruthy();
+  });
+
+  it('shows "Push" when enrichment ran but spreadWinnerFranchiseSeasonId is null', () => {
+    render(
+      <FinalScoreResult
+        pickType="AgainstTheSpread"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        spreadWinnerFranchiseSeasonId={null}
+      />,
+    );
+    expect(screen.getByText('Push')).toBeTruthy();
+  });
+
+  it('returns null when the spread-winner id matches neither team (defensive)', () => {
+    const { toJSON } = render(
+      <FinalScoreResult
+        pickType="AgainstTheSpread"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        spreadWinnerFranchiseSeasonId="stray-id-not-on-card"
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+});
+
+describe('FinalScoreResult — O/U verdicts', () => {
+  it('shows "Over {N}" for a tracked overUnderCurrent', () => {
+    render(
+      <FinalScoreResult
+        pickType="OverUnder"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        overUnderResult="Over"
+        overUnderCurrent={8.5}
+      />,
+    );
+    expect(screen.getByText('Over 8.5')).toBeTruthy();
+  });
+
+  it('shows "Under" without value when overUnderCurrent is missing', () => {
+    render(
+      <FinalScoreResult
+        pickType="OverUnder"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        overUnderResult="Under"
+      />,
+    );
+    expect(screen.getByText('Under')).toBeTruthy();
+  });
+
+  it('shows "Push" when overUnderResult is the string "Push"', () => {
+    render(
+      <FinalScoreResult
+        pickType="OverUnder"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        overUnderResult="Push"
+      />,
+    );
+    expect(screen.getByText('Push')).toBeTruthy();
+  });
+
+  // Wire-shape note in the component: the API DTO uses OverUnderPick
+  // (None/Over/Under) but Producer's Contest.OverUnder uses
+  // OverUnderResult which has Push=3. MatchupForPickDtoMapper casts the
+  // int through, so a real push may arrive as "Push", 3, or "3"
+  // depending on serializer behavior on the unnamed enum value.
+  it('shows "Push" when overUnderResult arrives as numeric 3 (unnamed enum cast)', () => {
+    render(
+      <FinalScoreResult
+        pickType="OverUnder"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        overUnderResult={3}
+      />,
+    );
+    expect(screen.getByText('Push')).toBeTruthy();
+  });
+
+  it('shows "Push" when overUnderResult arrives as the string "3"', () => {
+    render(
+      <FinalScoreResult
+        pickType="OverUnder"
+        {...baseProps}
+        winnerFranchiseSeasonId={HOME_ID}
+        overUnderResult="3"
+      />,
+    );
+    expect(screen.getByText('Push')).toBeTruthy();
+  });
+});

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -133,6 +133,18 @@ export default function PicksScreen() {
     [entries, hidePicked, allPicked],
   );
 
+  // Pick-mode badge label. Mirrors web's pill in PicksPage.jsx; suppressed
+  // when pickType is missing or unrecognized so a misconfigured league
+  // doesn't render a stray "?".
+  const pickModeLabel = useMemo(() => {
+    switch (pickType) {
+      case 'StraightUp': return 'SU';
+      case 'AgainstTheSpread': return 'ATS';
+      case 'OverUnder': return 'O/U';
+      default: return null;
+    }
+  }, [pickType]);
+
   // ── Inject pick counter into this tab's header ──────────────────────────────
   useEffect(() => {
     if (total === 0) {
@@ -142,6 +154,13 @@ export default function PicksScreen() {
     navigation.setOptions({
       headerRight: () => (
         <View style={headerStyles.pill}>
+          {pickModeLabel ? (
+            <View style={[headerStyles.modeBadge, { borderColor: theme.tint }]}>
+              <Text style={[headerStyles.modeBadgeText, { color: theme.tint }]}>
+                {pickModeLabel}
+              </Text>
+            </View>
+          ) : null}
           {allPicked ? (
             <Text style={[headerStyles.pillText, { color: theme.tint }]}>
               All Picks Made
@@ -176,7 +195,7 @@ export default function PicksScreen() {
         </View>
       ),
     });
-  }, [made, total, allPicked, hidePicked, theme]);
+  }, [made, total, allPicked, hidePicked, theme, pickModeLabel]);
 
   if (meLoading) {
     return <LoadingSpinner message="Loading picks…" fullScreen />;
@@ -217,6 +236,7 @@ export default function PicksScreen() {
               pick={item.pick}
               leagueSport={matchupsResponse?.sport ?? null}
               leagueAsOfDate={matchupsResponse?.asOfDate ?? null}
+              pickType={pickType}
               onPress={() => {
                 if (!sportLeague) {
                   // Sport hasn't resolved yet (matchups response still in flight)
@@ -319,6 +339,20 @@ const headerStyles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginRight: 12,
+  },
+  // SU / ATS / O/U pill — accent-bordered chip preceding the picks-made
+  // counter. Mirrors the web .pick-mode-badge pattern.
+  modeBadge: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 1,
+    marginRight: 8,
+  },
+  modeBadgeText: {
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 0.5,
   },
   pillText: {
     fontSize: 15,

--- a/src/UI/sd-mobile/src/components/features/games/FinalScoreResult.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/FinalScoreResult.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import type { PickType } from '@/src/types/models';
+
+// Quick-scan result row appended below the final score for ATS / O/U
+// leagues. SU is NOT rendered here — its checkmark is inline next to
+// the winning team's short directly in GameStatus.tsx's STATUS_FINAL
+// branch (the score line already shows the winning team, so a duplicated
+// "NYY won" suffix would be noise).
+//
+// Pure presentation — does NOT reflect the user's own pick (PickButton
+// handles that). The goal is letting a user glance at a finalized card
+// and confirm the result relevant to the league's pick mode without
+// parsing the score themselves.
+//
+// Readiness contract: when status=STATUS_FINAL flips, Contest enrichment
+// (PR #384) runs with a ~30s delay. During that window the wire still
+// reports STATUS_FINAL but winnerFranchiseSeasonId / spreadWinnerFranchise
+// SeasonId / overUnderResult are all null. We stay silent in that gap
+// rather than rendering a false "Push".
+
+interface FinalScoreResultProps {
+  pickType?: PickType | null;
+  awayFranchiseSeasonId?: string | null;
+  homeFranchiseSeasonId?: string | null;
+  awayShort?: string;
+  homeShort?: string;
+  winnerFranchiseSeasonId?: string | null;
+  spreadWinnerFranchiseSeasonId?: string | null;
+  overUnderResult?: string | number | null;
+  overUnderCurrent?: number | null;
+}
+
+export function FinalScoreResult({
+  pickType,
+  awayFranchiseSeasonId,
+  homeFranchiseSeasonId,
+  awayShort,
+  homeShort,
+  winnerFranchiseSeasonId,
+  spreadWinnerFranchiseSeasonId,
+  overUnderResult,
+  overUnderCurrent,
+}: FinalScoreResultProps) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const shortFor = (franchiseSeasonId: string | null | undefined): string | null => {
+    if (!franchiseSeasonId) return null;
+    if (franchiseSeasonId === awayFranchiseSeasonId) return awayShort ?? null;
+    if (franchiseSeasonId === homeFranchiseSeasonId) return homeShort ?? null;
+    return null;
+  };
+
+  if (pickType === 'AgainstTheSpread') {
+    // Gate on winnerFranchiseSeasonId as the "enrichment ran" signal.
+    // Pre-enrichment all three result fields are null on the wire;
+    // treating a null spread winner as "Push" then would lie about a
+    // game that hasn't been scored yet. We accept missing the ATS
+    // indicator on a true tie (rare in football, impossible in MLB)
+    // rather than showing a false push during the enrichment window.
+    if (winnerFranchiseSeasonId == null) return null;
+
+    // Enrichment ran. A null spread winner now genuinely means push at
+    // the spread (game landed exactly on the line).
+    if (spreadWinnerFranchiseSeasonId == null) {
+      return (
+        <View style={styles.row}>
+          <Text style={[styles.pushText, { color: theme.textMuted }]}>Push</Text>
+        </View>
+      );
+    }
+    const cover = shortFor(spreadWinnerFranchiseSeasonId);
+    if (!cover) return null;
+    return (
+      <View style={styles.row}>
+        <Text style={[styles.checkmark, { color: '#16A34A' }]}>✓</Text>
+        <Text style={[styles.resultText, { color: theme.textMuted }]}>
+          {cover} covered
+        </Text>
+      </View>
+    );
+  }
+
+  if (pickType === 'OverUnder') {
+    // Only render when we recognize an explicit O/U verdict. Anything
+    // else (null / undefined / "None") means enrichment hasn't computed
+    // a result and we stay silent rather than showing a false "Push".
+    //
+    // Wire-shape note: API DTO uses OverUnderPick (None/Over/Under) but
+    // Producer's Contest.OverUnder uses OverUnderResult which has Push=3.
+    // MatchupForPickDtoMapper casts the int through, so a real push can
+    // arrive as "Push", 3, or "3" depending on the serializer's behavior
+    // on the unnamed enum value. Match all three; the contract mismatch
+    // itself is a separate change.
+    const isOver = overUnderResult === 'Over';
+    const isUnder = overUnderResult === 'Under';
+    const isPush =
+      overUnderResult === 'Push' ||
+      overUnderResult === 3 ||
+      overUnderResult === '3';
+
+    if (isOver || isUnder) {
+      const ouValue =
+        overUnderCurrent !== null && overUnderCurrent !== undefined
+          ? ` ${overUnderCurrent}`
+          : '';
+      return (
+        <View style={styles.row}>
+          <Text style={[styles.checkmark, { color: '#16A34A' }]}>✓</Text>
+          <Text style={[styles.resultText, { color: theme.textMuted }]}>
+            {isOver ? 'Over' : 'Under'}
+            {ouValue}
+          </Text>
+        </View>
+      );
+    }
+
+    if (isPush) {
+      return (
+        <View style={styles.row}>
+          <Text style={[styles.pushText, { color: theme.textMuted }]}>Push</Text>
+        </View>
+      );
+    }
+
+    return null;
+  }
+
+  // StraightUp (and unknown pickType) — no row, handled inline by the
+  // score line in GameStatus.tsx.
+  return null;
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    marginTop: 2,
+  },
+  checkmark: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  resultText: {
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+  pushText: {
+    fontSize: 13,
+    fontWeight: '600',
+    fontStyle: 'italic',
+    letterSpacing: 1.0,
+  },
+});

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -3,9 +3,10 @@ import { View, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
-import type { Matchup } from '@/src/types/models';
+import type { Matchup, PickType } from '@/src/types/models';
 import { formatToUserTime } from '@/src/utils/timeUtils';
 import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
+import { FinalScoreResult } from './FinalScoreResult';
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
@@ -21,6 +22,15 @@ interface GameStatusProps {
   leagueSport?: string | null;
   /** If provided, called when the user taps on a FINAL/completed game row (preserves full nav context from caller). */
   onPressGameDetail?: () => void;
+  /**
+   * League pick mode. Drives the STATUS_FINAL quick-scan indicator:
+   *   StraightUp        → inline ✓ next to the winning team's short
+   *   AgainstTheSpread  → row below score reading "✓ {team} covered" or "Push"
+   *   OverUnder         → row below score reading "✓ Over/Under {N}" or "Push"
+   * Null / undefined falls back to StraightUp visuals so the indicator
+   * doesn't silently disappear if a caller hasn't threaded it through.
+   */
+  pickType?: PickType | null;
 }
 
 // Mid-game paused states. Game is technically still live (score + period/
@@ -52,7 +62,7 @@ const TERMINAL_STATUSES = new Set(['STATUS_POSTPONED', 'STATUS_CANCELED']);
  *                            gameTime + venue.
  *   Other                  – raw statusDescription (defensive fallback)
  */
-export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStatusProps) {
+export function GameStatus({ matchup, leagueSport, onPressGameDetail, pickType }: GameStatusProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
   const userTz = useUserTimeZone();
@@ -126,12 +136,47 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail }: GameStat
     const awayScore = matchup.awayScore ?? 0;
     const homeScore = matchup.homeScore ?? 0;
 
+    // SU quick-scan: a checkmark on the OUTSIDE of the winning team's
+    // short (left of away or right of home). Skipped for ATS / O/U
+    // leagues — those render their own indicator on a row below.
+    // Skipped pre-enrichment (winnerFranchiseSeasonId null) and on a
+    // true tie. Unknown / null pickType defaults to SU treatment so
+    // callers that don't yet thread the prop through don't regress.
+    const isSU = !pickType || pickType === 'StraightUp';
+    const awayWonSU =
+      isSU &&
+      matchup.winnerFranchiseSeasonId != null &&
+      matchup.winnerFranchiseSeasonId === matchup.awayFranchiseSeasonId;
+    const homeWonSU =
+      isSU &&
+      matchup.winnerFranchiseSeasonId != null &&
+      matchup.winnerFranchiseSeasonId === matchup.homeFranchiseSeasonId;
+
     return (
       <View style={styles.statusSection}>
         <Text style={[styles.statusLabel, { color: theme.textMuted }]}>FINAL</Text>
-        <Text style={[styles.scoreText, { color: theme.text }]}>
-          {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
-        </Text>
+        <View style={styles.finalScoreRow}>
+          {awayWonSU ? (
+            <Text style={[styles.suCheck, { color: '#16A34A' }]}>✓</Text>
+          ) : null}
+          <Text style={[styles.scoreText, { color: theme.text }]}>
+            {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
+          </Text>
+          {homeWonSU ? (
+            <Text style={[styles.suCheck, { color: '#16A34A' }]}>✓</Text>
+          ) : null}
+        </View>
+        <FinalScoreResult
+          pickType={pickType}
+          awayFranchiseSeasonId={matchup.awayFranchiseSeasonId}
+          homeFranchiseSeasonId={matchup.homeFranchiseSeasonId}
+          awayShort={matchup.awayShort}
+          homeShort={matchup.homeShort}
+          winnerFranchiseSeasonId={matchup.winnerFranchiseSeasonId}
+          spreadWinnerFranchiseSeasonId={matchup.spreadWinnerFranchiseSeasonId}
+          overUnderResult={matchup.overUnderResult as string | number | null | undefined}
+          overUnderCurrent={matchup.overUnderCurrent}
+        />
         <OverviewLink label="Box Score" onPress={onPressGameDetail} theme={theme} />
       </View>
     );
@@ -515,6 +560,19 @@ const styles = StyleSheet.create({
   scoreText: {
     fontSize: 15,
     fontWeight: '700',
+  },
+  // STATUS_FINAL row: flex container for the score text plus the
+  // optional SU checkmark that hugs the outside of the winning team's
+  // short. Gap supplies breathing room between the score and the check
+  // without text concatenation.
+  finalScoreRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  suCheck: {
+    fontSize: 15,
+    fontWeight: '800',
   },
   possessionIcon: {
     fontSize: 14,

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -688,13 +688,20 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         isFinal && (isPickCorrect === false || !hasPick) && styles.cardIncorrect,
       ]}
     >
-      {/* Headline banner — theme-aware accent background matches web's
-          .matchup-headline { background-color: var(--accent); } so the
-          marquee tag (bowl name, conf championship, series-leader
-          summary) reads as a branded chip rather than a static navy bar. */}
+      {/* Headline banner — theme-aware accent background + text-on-accent
+          foreground match web's .matchup-headline { background-color:
+          var(--accent); color: var(--text-on-accent); }. Light → white on
+          blue, dark → dark on cyan. The marquee tag (bowl name, conf
+          championship, series-leader summary) reads as a branded chip
+          rather than a static navy bar. */}
       {matchup.headLine != null && matchup.headLine !== '' && (
         <View style={[styles.headline, { backgroundColor: theme.tint }]}>
-          <Text style={styles.headlineText} numberOfLines={1}>{matchup.headLine}</Text>
+          <Text
+            style={[styles.headlineText, { color: theme.textOnAccent }]}
+            numberOfLines={1}
+          >
+            {matchup.headLine}
+          </Text>
         </View>
       )}
 
@@ -845,7 +852,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
   },
   headlineText: {
-    color: '#fff',
+    // color lives at the call site so it picks up theme.textOnAccent.
     fontSize: 12,
     fontWeight: '700',
     textTransform: 'uppercase',

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
-import type { Matchup, UserPick, PickChoice, PreviewResponse, TeamComparisonData } from '@/src/types/models';
+import type { Matchup, UserPick, PickChoice, PreviewResponse, TeamComparisonData, PickType } from '@/src/types/models';
 import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
 import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
@@ -440,9 +440,16 @@ export interface MatchupCardProps {
    * Week-1 reuse both behave correctly.
    */
   leagueAsOfDate?: string | null;
+  /**
+   * League pick mode (StraightUp / AgainstTheSpread / OverUnder), surfaced
+   * via LeagueWeekMatchupsDto.pickType. Threaded to GameStatus for the
+   * STATUS_FINAL quick-scan indicator (inline ✓ for SU, "covered" / Over /
+   * Under / Push row for ATS / O/U). Optional — falls back to SU visuals.
+   */
+  pickType?: PickType | null;
 }
 
-export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear, leagueSport, leagueAsOfDate }: MatchupCardProps) {
+export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear, leagueSport, leagueAsOfDate, pickType }: MatchupCardProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
 
@@ -740,6 +747,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         matchup={enrichedMatchup}
         leagueSport={leagueSport}
         onPressGameDetail={onPress}
+        pickType={pickType}
       />
 
       {/* Inline pick buttons */}

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -121,13 +121,22 @@ function TeamRow({
   const confLosses = isHome ? matchup.homeConferenceLosses : matchup.awayConferenceLosses;
   const probablePitcher = isHome ? matchup.homeProbablePitcher : matchup.awayProbablePitcher;
 
-  const isActive = !isFinal || isWinning;
+  // On a finalized tie, neither side has isWinning true (parent uses
+  // strict >); without the tie branch both team names would mute.
+  const isTie =
+    matchup.awayScore != null &&
+    matchup.homeScore != null &&
+    matchup.awayScore === matchup.homeScore;
+  const isActive = !isFinal || isWinning || isTie;
   const record = formatRecord(wins, losses, confWins, confLosses);
 
-  // Pick indicator styling
+  // Pick indicator styling — uses the same theme.pickCorrect /
+  // theme.pickIncorrect tokens as PickButton and the card border, so all
+  // three result cues stay in lockstep across themes and match web's
+  // --pick-correct / --pick-incorrect palette.
   let pickIndicatorColor: string | null = null;
   if (isPicked && isFinal) {
-    pickIndicatorColor = isPickCorrect ? '#16A34A' : '#DC2626';
+    pickIndicatorColor = isPickCorrect ? theme.pickCorrect : theme.pickIncorrect;
   } else if (isPicked) {
     pickIndicatorColor = theme.tint;
   }
@@ -643,10 +652,21 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
     }
   };
 
+  // Strict > on each side so a true tie (rare in NFL, impossible in MLB)
+  // leaves BOTH sides' isWinning false — TeamRow's tie-aware isActive
+  // then keeps both team names at full text color and skips the
+  // winner-only tint / fontSize bump. Prior >= treated home as the
+  // winner on a tie, and the away row received !homeIsWinning which
+  // flipped the tie into "away wins" for downstream styling.
   const homeIsWinning =
     enrichedMatchup.homeScore != null &&
     enrichedMatchup.awayScore != null &&
-    enrichedMatchup.homeScore >= enrichedMatchup.awayScore;
+    enrichedMatchup.homeScore > enrichedMatchup.awayScore;
+
+  const awayIsWinning =
+    enrichedMatchup.awayScore != null &&
+    enrichedMatchup.homeScore != null &&
+    enrichedMatchup.awayScore > enrichedMatchup.homeScore;
 
   // Use server pick if available, otherwise optimistic
   const effectiveFranchiseId = pick?.franchiseId ?? optimisticFranchiseId;
@@ -664,13 +684,17 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   // `usePickLocking` hook's `userDto.isReadOnly` consultation.
   const locked = isPickLocked(enrichedMatchup) || !!me?.isReadOnly;
 
-  // Card border color based on pick result (matches web)
+  // Card border color based on pick result — same theme tokens as
+  // PickButton bg and the team-row indicator, so all three result cues
+  // share one palette (mirrors web .matchup-card.pick-correct /
+  // .pick-incorrect / .pick-no-submission borders using --pick-correct
+  // / --pick-incorrect).
   let cardBorderColor = theme.border;
   if (isFinal && hasPick) {
-    if (isPickCorrect === true) cardBorderColor = '#16A34A';
-    else if (isPickCorrect === false) cardBorderColor = '#DC2626';
+    if (isPickCorrect === true) cardBorderColor = theme.pickCorrect;
+    else if (isPickCorrect === false) cardBorderColor = theme.pickIncorrect;
   } else if (isFinal && !hasPick) {
-    cardBorderColor = '#DC2626'; // missed pick
+    cardBorderColor = theme.pickIncorrect; // missed pick
   }
 
   const handlePick = (choice: PickChoice, franchiseSeasonId: string) => {
@@ -717,7 +741,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
           <TeamRow
             matchup={enrichedMatchup}
             side="away"
-            isWinning={!homeIsWinning}
+            isWinning={awayIsWinning}
             isPicked={pickedAway}
             isPickCorrect={isPickCorrect}
             isFinal={isFinal}

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -52,10 +52,23 @@ function formatRecord(wins?: number, losses?: number, confWins?: number, confLos
   return s;
 }
 
-/** Returns true when picks should be locked (5 min before kickoff, or game started/finished). */
+/** Returns true when picks should be locked (5 min before kickoff, or game started/finished).
+ *  Canonical status set mirrors GameStatus.tsx: live, paused-live, and
+ *  terminal-final variants all lock. The prior version lowercased the
+ *  status and matched against bare 'final' / 'inprogress' which never
+ *  matched the wire's STATUS_* shape — picks were only ever locked via
+ *  the time-based fallback. */
+const LOCKED_STATUSES = new Set([
+  'STATUS_IN_PROGRESS',
+  'STATUS_HALFTIME',
+  'STATUS_FINAL',
+  'STATUS_DELAYED',
+  'STATUS_RAIN_DELAY',
+  'STATUS_SUSPENDED',
+]);
+
 function isPickLocked(matchup: Matchup): boolean {
-  const status = matchup.status.toLowerCase();
-  if (status === 'inprogress' || status === 'ongoing' || status === 'halftime' || status === 'final' || status === 'completed') {
+  if (LOCKED_STATUSES.has(matchup.status)) {
     return true;
   }
   const kickoff = new Date(matchup.startDateUtc).getTime();
@@ -305,14 +318,17 @@ function PickButton({
   let teamColor = theme.text;
 
   // Web parity: scored picks render as solid green/red buttons with
-  // white-on-accent text (mirrors .pick-button.result-correct /
-  // .result-incorrect in sd-ui/src/components/matchups/MatchupCard.css).
-  // The prior pale-tint values (#F0FDF4 / #FEF2F2) barely registered
-  // against the card background in either theme.
+  // white text (mirrors .pick-button.result-correct / .result-incorrect
+  // in sd-ui/src/components/matchups/MatchupCard.css). theme.textOnAccent
+  // is NOT used here — it's #111 in dark mode (intended for the bright
+  // cyan accent) and would render as dark-on-dark-green / dark-on-dark-red
+  // for the pick result colors. White holds up against both light-mode
+  // (#1b5e20 / #b71c1c) and dark-mode (#28a745 / #dc3545) palettes.
+  const ON_RESULT_FG = '#ffffff';
   if (isSelected && pickResult === 'correct') {
-    borderColor = theme.pickCorrect; bgColor = theme.pickCorrect; teamColor = theme.textOnAccent;
+    borderColor = theme.pickCorrect; bgColor = theme.pickCorrect; teamColor = ON_RESULT_FG;
   } else if (isSelected && pickResult === 'incorrect') {
-    borderColor = theme.pickIncorrect; bgColor = theme.pickIncorrect; teamColor = theme.textOnAccent;
+    borderColor = theme.pickIncorrect; bgColor = theme.pickIncorrect; teamColor = ON_RESULT_FG;
   } else if (isSelected) {
     borderColor = Colors.brand.navy; bgColor = '#EEF2FF'; teamColor = Colors.brand.navy;
   }
@@ -324,15 +340,16 @@ function PickButton({
       disabled={isLocked}
       activeOpacity={isLocked ? 1 : 0.7}
     >
-      {/* ✓ when selected and not incorrect — uses textOnAccent on the
-          solid green correct-bg, navy on the pale pending-bg. */}
+      {/* ✓ when selected and not incorrect — white on the solid green
+          correct-bg, navy on the pale pending-bg. White is hardcoded
+          (not theme.textOnAccent) so it stays legible against the dark
+          green / red pickCorrect-pickIncorrect palette in both themes. */}
       {isSelected && pickResult !== 'incorrect' && (
-        <Text style={[styles.pickIcon, { color: pickResult === 'correct' ? theme.textOnAccent : Colors.brand.navy }]}>✓</Text>
+        <Text style={[styles.pickIcon, { color: pickResult === 'correct' ? '#ffffff' : Colors.brand.navy }]}>✓</Text>
       )}
-      {/* ✗ when selected + incorrect — white-on-red for legibility on the
-          solid pickIncorrect bg. */}
+      {/* ✗ when selected + incorrect — white on the solid red bg. */}
       {isSelected && pickResult === 'incorrect' && (
-        <Text style={[styles.pickIcon, { color: theme.textOnAccent }]}>✗</Text>
+        <Text style={[styles.pickIcon, { color: '#ffffff' }]}>✗</Text>
       )}
       {/* 🔒 when not selected + locked + no result (missed / pre-game locked) */}
       {!isSelected && isLocked && pickResult === null && (
@@ -513,8 +530,13 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
     };
   }, [matchup, live]);
 
-  const status = enrichedMatchup.status.toLowerCase();
-  const isFinal = status === 'final' || status === 'completed';
+  // Use the canonical ESPN status name directly. The prior version
+  // lowercased and compared against bare 'final' / 'completed', which
+  // never matched the wire's STATUS_FINAL shape — so isFinal was always
+  // false and the entire scored-card visual pipeline (PickButton
+  // green/red, team-row indicator ✓/✗, card border tint, winning-team
+  // score color) silently no-op'd.
+  const isFinal = enrichedMatchup.status === 'STATUS_FINAL';
 
   // Optimistic local pick — shows selection instantly before server confirms
   const [optimisticFranchiseId, setOptimisticFranchiseId] = useState<string | null>(null);

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -688,9 +688,12 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         isFinal && (isPickCorrect === false || !hasPick) && styles.cardIncorrect,
       ]}
     >
-      {/* Headline banner */}
+      {/* Headline banner — theme-aware accent background matches web's
+          .matchup-headline { background-color: var(--accent); } so the
+          marquee tag (bowl name, conf championship, series-leader
+          summary) reads as a branded chip rather than a static navy bar. */}
       {matchup.headLine != null && matchup.headLine !== '' && (
-        <View style={styles.headline}>
+        <View style={[styles.headline, { backgroundColor: theme.tint }]}>
           <Text style={styles.headlineText} numberOfLines={1}>{matchup.headLine}</Text>
         </View>
       )}
@@ -835,9 +838,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.2,
   },
 
-  // Headline
+  // Headline — backgroundColor lives at the call site so it can pick
+  // up theme.tint (accent). See web parity comment above the <View />.
   headline: {
-    backgroundColor: Colors.brand.navy,
     paddingVertical: 6,
     paddingHorizontal: 14,
   },

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -304,10 +304,15 @@ function PickButton({
   let bgColor = theme.background;
   let teamColor = theme.text;
 
+  // Web parity: scored picks render as solid green/red buttons with
+  // white-on-accent text (mirrors .pick-button.result-correct /
+  // .result-incorrect in sd-ui/src/components/matchups/MatchupCard.css).
+  // The prior pale-tint values (#F0FDF4 / #FEF2F2) barely registered
+  // against the card background in either theme.
   if (isSelected && pickResult === 'correct') {
-    borderColor = '#16A34A'; bgColor = '#F0FDF4'; teamColor = '#16A34A';
+    borderColor = theme.pickCorrect; bgColor = theme.pickCorrect; teamColor = theme.textOnAccent;
   } else if (isSelected && pickResult === 'incorrect') {
-    borderColor = '#DC2626'; bgColor = '#FEF2F2'; teamColor = '#DC2626';
+    borderColor = theme.pickIncorrect; bgColor = theme.pickIncorrect; teamColor = theme.textOnAccent;
   } else if (isSelected) {
     borderColor = Colors.brand.navy; bgColor = '#EEF2FF'; teamColor = Colors.brand.navy;
   }
@@ -319,13 +324,15 @@ function PickButton({
       disabled={isLocked}
       activeOpacity={isLocked ? 1 : 0.7}
     >
-      {/* ✓ when selected and not incorrect */}
+      {/* ✓ when selected and not incorrect — uses textOnAccent on the
+          solid green correct-bg, navy on the pale pending-bg. */}
       {isSelected && pickResult !== 'incorrect' && (
-        <Text style={[styles.pickIcon, { color: pickResult === 'correct' ? '#16A34A' : Colors.brand.navy }]}>✓</Text>
+        <Text style={[styles.pickIcon, { color: pickResult === 'correct' ? theme.textOnAccent : Colors.brand.navy }]}>✓</Text>
       )}
-      {/* ✗ when selected + incorrect */}
+      {/* ✗ when selected + incorrect — white-on-red for legibility on the
+          solid pickIncorrect bg. */}
       {isSelected && pickResult === 'incorrect' && (
-        <Text style={[styles.pickIcon, { color: '#DC2626' }]}>✗</Text>
+        <Text style={[styles.pickIcon, { color: theme.textOnAccent }]}>✗</Text>
       )}
       {/* 🔒 when not selected + locked + no result (missed / pre-game locked) */}
       {!isSelected && isLocked && pickResult === null && (

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -121,6 +121,15 @@ export interface Matchup {
   homeScore?: number | null;
   winnerFranchiseSeasonId?: string | null;
   spreadWinnerFranchiseSeasonId?: string | null;
+  /**
+   * Post-enrichment O/U verdict. Wire shape is messy: API DTO type is
+   * OverUnderPick ("None"/"Over"/"Under") but Producer's Contest.OverUnder
+   * uses OverUnderResult which adds Push=3 — the mapper casts an int
+   * through, so a real push can arrive as "Push", 3, or "3" depending on
+   * serializer behavior on the unnamed enum value. Consumers should match
+   * all three (see FinalScoreResult).
+   */
+  overUnderResult?: string | number | null;
   completedUtc?: string | null;
 
   // Odds


### PR DESCRIPTION
## Summary

Mobile parity for web PR #385.

### Page header
- **SU / ATS / O/U pill** injected into the picks-tab's existing `headerRight` View, before `{made}/{total} Picks Made`. Keyed on `LeagueMatchupsResponse.pickType`; suppresses on unknown modes.

### Final-score cards (`STATUS_FINAL`)
- **SU:** green ✓ glyph hugs the OUTSIDE of the winning team's short — left of away, right of home. Pre-enrichment + true-tie render no check.
- **ATS:** row below score reads ``✓ {short} covered`` or ``Push`` when `spreadWinnerFranchiseSeasonId` is null on a real final.
- **O/U:** row below score reads ``✓ Over {N}`` / ``✓ Under {N}`` or ``Push`` for explicit verdicts. `null` / `undefined` / ``"None"`` stay silent (matches the post-PR-385 readiness gate).

### Cross-check side benefit
For any finalized SU card, the inline ✓ at the top must land on the same team as the green `PickButton` at the bottom for a user who picked correctly. Same property holds for ATS via the row-below indicator. Disagreement = scoring bug, visible at a glance — same dev sanity-check property the web PR added.

## Files

- ``src/UI/sd-mobile/src/types/models.ts`` — adds `overUnderResult` to `Matchup` with the wire-shape comment.
- ``src/UI/sd-mobile/src/components/features/games/FinalScoreResult.tsx`` (new) — ATS / O/U row-below indicator. SU is intentionally NOT here; it's inline in `GameStatus`.
- ``src/UI/sd-mobile/src/components/features/games/GameStatus.tsx`` — accepts `pickType`, splits the STATUS_FINAL score line into a flex `View` row with optional SU ✓ on either side, renders `<FinalScoreResult>` between the score and the OverviewLink.
- ``src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx`` — adds `pickType` to `MatchupCardProps`; threads it to `GameStatus`.
- ``src/UI/sd-mobile/app/(tabs)/picks.tsx`` — passes `pickType` into `<MatchupCard>`; injects the SU/ATS/O/U pill into `headerRight`.
- ``src/UI/sd-mobile/__tests__/components/features/games/FinalScoreResult.test.tsx`` (new) — 13 cases.

## Test plan

- [x] Jest: ``npm test`` covering `FinalScoreResult` + existing `MatchupCard.live` — 18 / 18 passing locally.
- [x] TypeScript: ``npx tsc --noEmit`` clean.
- [ ] Device: SU league, finalized card, confirm ✓ pins to winning team short.
- [ ] Device: ATS league, finalized card, confirm row reads ``✓ {short} covered`` and lines up with the green `PickButton` color when picked correctly.
- [ ] Device: Pre-enrichment STATUS_FINAL (force a status flip without enrichment) — confirm no false "Push" renders.
- [ ] Device: Dark theme — ``#16A34A`` check, accent-colored pill border, italic muted Push text all read.

## Wire-shape note (preserved from web PR)

API DTO uses ``OverUnderPick`` (None / Over / Under) but Producer's `Contest.OverUnder` uses `OverUnderResult` which has `Push=3`. ``MatchupForPickDtoMapper`` casts the int through, so a real push lands at the consumer as ``"Push"``, ``3``, or ``"3"`` depending on the serializer's behavior on the unnamed enum value. ``FinalScoreResult`` matches all three. Fixing the contract mismatch itself belongs in a separate change.

## Out of scope

- Game detail screen at `app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx` — web PR only touched picks list; mobile parity matches.
- O/U pick UI is still team-shaped (button row), so the O/U cross-check only validates the row text against itself, not the user's totals choice. Future O/U-pick refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pick-mode badges (SU, ATS, O/U) in tab headers.
  * Enhanced final-score area showing mode-specific verdicts and SU checkmark; O/U shows line values and normalized Push handling.
  * Components now accept pick-mode context to surface mode-specific UI.

* **Bug Fixes**
  * Fixed pick locking/final detection and improved selected-state visuals for correct/incorrect picks.

* **Types**
  * Added over/under result handling for varied backend representations.

* **Tests**
  * Added coverage for final-score readiness and verdict rendering across pick modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->