### PR TITLE
fix(mobile): silence known third-party dev-console deprecations

### DIFF
--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -1,3 +1,9 @@
+// Suppress known third-party dev-console deprecations BEFORE Sentry's
+// console instrumentation hooks console.warn — otherwise each filtered
+// warning still becomes a Sentry breadcrumb. See the file's header
+// comment for the suppression list and removal triggers.
+import '@/src/lib/silenceKnownWarnings';
+
 // Sentry MUST initialize before any other module that could throw at
 // import time (Firebase, React Query, navigation). Side-effect import
 // kept on its own line, above all other imports, for that reason.

--- a/src/UI/sd-mobile/src/lib/silenceKnownWarnings.ts
+++ b/src/UI/sd-mobile/src/lib/silenceKnownWarnings.ts
@@ -1,0 +1,35 @@
+// Suppress known third-party deprecation noise from the dev console.
+// Loaded as a side-effect import in app/_layout.tsx BEFORE Sentry's
+// console instrumentation kicks in so the filtered messages never
+// become breadcrumbs (otherwise each suppressed warn still wastes a
+// Sentry breadcrumb slot and adds 6+ frames of instrumentation stack
+// to the terminal output).
+//
+// Each entry MUST be a verifiable, harmless upstream warning that we
+// cannot fix in our own code. Add the source library + version + a
+// removal trigger so future maintainers can prune the list when
+// upstream actually fixes it.
+
+const SUPPRESSED_WARNING_FRAGMENTS = [
+  // @react-navigation/elements (currently 2.9.18, pulled in by
+  // expo-router) still passes pointerEvents as a top-level prop on
+  // <View> in Screen.tsx, ResourceSavingView.tsx, Header.tsx, and
+  // HeaderSearchBar.tsx. react-native-web 0.19+ deprecated this in
+  // favor of style.pointerEvents. Fires on every screen render, so
+  // SSR-bundled web reloads get flooded with otherwise-harmless
+  // warnings. Remove this entry once @react-navigation/elements drops
+  // the prop form.
+  'props.pointerEvents is deprecated',
+];
+
+const originalWarn = console.warn;
+console.warn = (...args: unknown[]) => {
+  const first = args[0];
+  if (
+    typeof first === 'string' &&
+    SUPPRESSED_WARNING_FRAGMENTS.some((fragment) => first.includes(fragment))
+  ) {
+    return;
+  }
+  originalWarn(...args);
+};

--- a/src/UI/sd-mobile/src/lib/silenceKnownWarnings.ts
+++ b/src/UI/sd-mobile/src/lib/silenceKnownWarnings.ts
@@ -20,6 +20,20 @@ const SUPPRESSED_WARNING_FRAGMENTS = [
   // warnings. Remove this entry once @react-navigation/elements drops
   // the prop form.
   'props.pointerEvents is deprecated',
+
+  // react-native-web 0.19+ deprecated shadow* style props
+  // (shadowColor, shadowOffset, shadowOpacity, shadowRadius) in favor
+  // of boxShadow on web. shadow* remains the correct styling on
+  // native iOS/Android — RN-Web translates internally and just emits
+  // the deprecation, so functionality is unaffected. Fires from both
+  // @react-navigation/elements (Header / HeaderBackground) and from
+  // our own shadowed surfaces (MatchupCard, Card, sign-in screen).
+  // Rewriting our styles to Platform.select between shadow* and
+  // boxShadow would scatter conditional logic for a purely cosmetic
+  // web warning, so we silence at the source. Remove this entry once
+  // either upstream stops emitting the warning or React Native's
+  // shadow primitive unifies with web's boxShadow.
+  '"shadow*" style props are deprecated',
 ];
 
 const originalWarn = console.warn;

--- a/src/UI/sd-mobile/src/lib/silenceKnownWarnings.ts
+++ b/src/UI/sd-mobile/src/lib/silenceKnownWarnings.ts
@@ -36,14 +36,30 @@ const SUPPRESSED_WARNING_FRAGMENTS = [
   '"shadow*" style props are deprecated',
 ];
 
-const originalWarn = console.warn;
-console.warn = (...args: unknown[]) => {
-  const first = args[0];
-  if (
-    typeof first === 'string' &&
-    SUPPRESSED_WARNING_FRAGMENTS.some((fragment) => first.includes(fragment))
-  ) {
-    return;
-  }
-  originalWarn(...args);
-};
+// Dev-only. The deprecation warnings we're filtering are emitted by
+// react-native-web's warnOnce, which itself only fires under __DEV__,
+// so the shim accomplishes nothing in production builds. Skipping the
+// patch in prod avoids the per-call overhead and eliminates the
+// (small) risk of silently swallowing a real production warn that
+// happens to overlap a suppressed fragment.
+if (__DEV__) {
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    // Scan every string-typed arg, not just args[0]. RN-Web's warnOnce
+    // (the source of our current suppressed warnings) passes the
+    // message as a single string, but React's own warnings use the
+    // format-string pattern console.warn('Warning: %s', detail) — so
+    // a future suppression target's substantive text could live at
+    // args[1+]. Scanning all string args keeps the filter robust
+    // without affecting current cases.
+    const matchesSuppressed = args.some(
+      (arg) =>
+        typeof arg === 'string' &&
+        SUPPRESSED_WARNING_FRAGMENTS.some((fragment) => arg.includes(fragment)),
+    );
+    if (matchesSuppressed) {
+      return;
+    }
+    originalWarn(...args);
+  };
+}


### PR DESCRIPTION
## Summary

The web dev console floods with two third-party deprecation warnings during normal navigation:

1. ``"props.pointerEvents is deprecated. Use style.pointerEvents"``
2. ``"\"shadow*\" style props are deprecated. Use \"boxShadow\""``

Neither is caused by our code (or rather: the ``shadow*`` one fires from our shadowed surfaces too, but only because the legitimate native styling is *also* what RN-Web complains about). Both are cosmetic transitional warnings — RN-Web translates the deprecated form internally and functionality is unaffected.

### Sources

- `@react-navigation/elements@2.9.18` (transitive via `expo-router`) — passes `pointerEvents` as a top-level prop on `<View>` in `Screen.tsx`, `ResourceSavingView.tsx`, `Header.tsx`, `HeaderSearchBar.tsx`. Fires on every screen render.
- Same package's `Header.tsx` / `HeaderBackground.tsx` — uses `shadow*` style props.
- Our own `MatchupCard.tsx`, `Card.tsx`, and `sign-in.tsx` — also use `shadow*`. Rewriting them to `Platform.select` between `shadow*` and `boxShadow` would scatter conditional logic across every shadowed surface for a purely cosmetic web warning. `shadow*` is still the correct primitive on native iOS/Android.

### Why a single warning looks like ~40 lines

Sentry's console instrumentation wraps `console.warn` to capture each call as a breadcrumb. Combined with RN-Web's SSR-style stack dump on `warnOnce`, every fired warning emits ~7 Sentry frames + ~30 React internals.

## Fix

Add `src/lib/silenceKnownWarnings.ts` — a small side-effect module that patches `console.warn` to drop messages whose first arg matches any fragment in a curated suppression list. Wired into `app/_layout.tsx` as the **first import**, **before** the Sentry side-effect import, so filtered messages never reach the breadcrumb capture (otherwise we'd just shift the noise from terminal to Sentry).

Each entry documents source library + version + removal trigger so the list stays prunable as upstream catches up.

## Test plan

- [x] `jest`: 51 / 51 pass.
- [x] `npx tsc --noEmit`: clean.
- [x] Manual (user): ``npx expo start`` on web, navigate tabs, confirm both deprecations are gone from terminal.
- [ ] Manual: trigger a legitimate ``console.warn`` (network error, dev-mode warning) and confirm it still surfaces — filter is fragment-match, not blanket drop.

## Removal triggers

- **`pointerEvents` entry:** delete after bumping `@react-navigation/elements` past the version that drops the prop form (or once `expo-router` ships a newer pinned bundle).
- **`shadow*` entry:** delete when either upstream stops emitting the warning or React Native's shadow primitive unifies with web's `boxShadow`.

If the list ever empties, delete the whole file + remove the side-effect import in `_layout.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Suppress specific third-party deprecation warnings in development to reduce console noise.
  * Ensure these filtered warnings are not captured by error-tracking breadcrumbs, improving signal-to-noise for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->