### PR TITLE
fix(mobile): use static frameworks for iOS Firebase pod static-linking

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -19,7 +19,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "20"
+      "buildNumber": "21"
     },
     "android": {
       "package": "com.sportdeets.mobile",
@@ -47,7 +47,15 @@
       "@react-native-community/datetimepicker",
       "@react-native-firebase/app",
       "@react-native-firebase/messaging",
-      "expo-notifications"
+      "expo-notifications",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/src/UI/sd-mobile/package-lock.json
+++ b/src/UI/sd-mobile/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.6",
         "expo": "~55.0.24",
+        "expo-build-properties": "~55.0.14",
         "expo-clipboard": "~55.0.13",
         "expo-constants": "~55.0.7",
         "expo-dev-client": "~55.0.34",
@@ -6927,6 +6928,19 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.14.tgz",
+      "integrity": "sha512-5wopuLXlzFpDnCfsIjgAcj4yKnVTYg3XYGnYV5Hqi7u6jJipLG4fwtUqxVIFqBj7vEHXjd4zYCyXjp39AtAD7w==",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.4",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-clipboard": {

--- a/src/UI/sd-mobile/package.json
+++ b/src/UI/sd-mobile/package.json
@@ -50,6 +50,7 @@
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",
     "expo": "~55.0.24",
+    "expo-build-properties": "~55.0.14",
     "expo-clipboard": "~55.0.13",
     "expo-constants": "~55.0.7",
     "expo-dev-client": "~55.0.34",


### PR DESCRIPTION
## Summary

EAS iOS build (from main, after PR #388 merge) fails at \`pod install\` with:

\`\`\`
The Swift pod \`FirebaseCoreInternal\` depends upon \`GoogleUtilities\`,
which does not define modules. To opt into those targets generating
module maps (which is necessary to import them from Swift when
building as static libraries), you may set \`use_modular_headers!\`
globally in your Podfile, or specify \`:modular_headers => true\` for
particular dependencies.
\`\`\`

This is the well-known \`@react-native-firebase\` + CocoaPods conflict — the Firebase iOS SDK ships Swift pods that can't import the Objective-C \`GoogleUtilities\` pod without a Swift module map.

## Fix

Add \`expo-build-properties\` plugin with \`ios.useFrameworks: "static"\`. That configures the generated Podfile to use \`use_frameworks! :linkage => :static\`, which gives the Firebase Swift pods the module map they need.

Only build configuration changes. No application code touched.

## Files

- \`src/UI/sd-mobile/app.json\` — \`expo-build-properties\` plugin entry added with the iOS static-frameworks config.
- \`src/UI/sd-mobile/package.json\` + \`package-lock.json\` — explicit \`expo-build-properties\` dep (already pulled in transitively, now declared via \`npx expo install\` for SDK 55 version alignment).

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [ ] EAS iOS build runs past \`pod install\` and produces an IPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented iOS build number to version 21
  * Added iOS build configuration updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->