### PR TITLE
fix(mobile): make React-Core modular for RNFB framework header includes

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -19,7 +19,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "21"
+      "buildNumber": "22"
     },
     "android": {
       "package": "com.sportdeets.mobile",
@@ -52,7 +52,10 @@
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "static"
+            "useFrameworks": "static",
+            "extraPods": [
+              { "name": "React-Core", "modular_headers": true }
+            ]
           }
         }
       ]


### PR DESCRIPTION
## Summary

Round 2 of the RN-Firebase + iOS static-frameworks build fallout. PR #389 enabled \`useFrameworks: "static"\` to satisfy \`FirebaseCoreInternal\`'s Swift-pod requirements. The build progressed further but now fails at \`xcodebuild\` compiling RNFBApp:

\`\`\`
include of non-modular header inside framework module
'RNFBApp.RCTConvert_FIRApp':
'Pods/Headers/Public/React-Core/React/RCTConvert.h'
[-Werror,-Wnon-modular-include-in-framework-module]
\`\`\`

Six errors total in build log lines 1437-1497 — all React-Core public headers (RCTConvert.h, RCTBridgeModule.h, RCTEventEmitter.h) being included from inside RNFBApp's framework module.

### Why this happens

Under static linkage, RNFBApp is built as a framework module. Clang requires every header transitively included by a framework module to also be modular (i.e., declare a Swift module map). React-Core's public Objective-C headers don't, and the framework-module strict mode (\`-Werror\`) blows up.

## Fix

Declare React-Core with \`modular_headers => true\` via \`expo-build-properties\`'s \`extraPods\` option. That generates \`pod 'React-Core', :modular_headers => true\` in the Podfile alongside the existing react-native entry, giving the headers the module map RNFBApp needs to include them.

## Files

- \`src/UI/sd-mobile/app.json\` — \`extraPods\` array added under \`expo-build-properties.ios\`.

Only build configuration changes. No application code touched.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [ ] EAS iOS build runs past the xcodebuild step and produces an IPA.

## Out of scope

If more pods surface non-modular include errors after this fix, they can be added to the same \`extraPods\` list. \`@react-native-firebase/messaging\` (and any future Firebase RN modules) typically only need \`React-Core\` modular for this category of error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build configuration and incremented build number for the mobile application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->