### PR TITLE
fix(mobile): match React-Core path so CocoaPods merges modular_headers

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -19,7 +19,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "22"
+      "buildNumber": "23"
     },
     "android": {
       "package": "com.sportdeets.mobile",
@@ -54,7 +54,11 @@
           "ios": {
             "useFrameworks": "static",
             "extraPods": [
-              { "name": "React-Core", "modular_headers": true }
+              {
+                "name": "React-Core",
+                "path": "../node_modules/react-native/",
+                "modular_headers": true
+              }
             ]
           }
         }


### PR DESCRIPTION
## Summary

Round 3 of the RN-Firebase iOS build saga. PR #390 added an \`extraPods\` entry for \`React-Core\` with \`modular_headers: true\`, but CocoaPods then refused to install:

\`\`\`
[!] There are multiple dependencies with different sources for \`React-Core\` in \`Podfile\`:
- React-Core
- React-Core (from \`../node_modules/react-native/\`)
- React-Core/RCTWebSocket (from \`../node_modules/react-native/\`)
\`\`\`

CocoaPods sees the bare \`React-Core\` entry from \`extraPods\` as having a different source from react-native's path-specified declaration and refuses to merge them.

## Fix

Add the matching \`path: "../node_modules/react-native/"\` to the \`extraPods\` entry. CocoaPods then recognizes both declarations as the same pod (matching source) and merges them into a single entry that carries the \`modular_headers: true\` flag we need to satisfy RNFBApp's framework-module header includes (the original issue from PR #390).

## Files

- \`src/UI/sd-mobile/app.json\` — \`path\` added to the React-Core \`extraPods\` entry.

Only build configuration changes. No application code touched.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [ ] EAS iOS build runs past \`pod install\` (no source-conflict error) and past \`xcodebuild\` (no framework-module include error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build version number and configured React-Core path settings for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->