### PR TITLE
fix(mobile): drop use_frameworks!, make GoogleUtilities modular instead

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -19,7 +19,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "24"
+      "buildNumber": "25"
     },
     "android": {
       "package": "com.sportdeets.mobile",
@@ -52,7 +52,9 @@
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "dynamic"
+            "extraPods": [
+              { "name": "GoogleUtilities", "modular_headers": true }
+            ]
           }
         }
       ]


### PR DESCRIPTION
## Summary

Round 5 of the RN-Firebase iOS build saga. The last four PRs (#389-#392) tried to make \`use_frameworks!\` work — first static, then with \`modular_headers\` on React-Core, then path-matched, then dynamic — but each attempt reintroduced the original problem in a different form because **RNFBApp is built as a framework module under ANY \`use_frameworks!\` setting** and Clang enforces the modular-include rule for any framework module.

PR #392 (dynamic frameworks) failed identically to #391 (static). Log line 360 of the latest failure confirmed \`RNFBApp.framework\` was still being created. Dynamic doesn't sidestep the restriction — the rule is about **framework modules** in general, not about static linkage specifically.

## Going back to basics

The original CocoaPods error message back in PR #389 prescribed **three** fixes:

> set \`use_modular_headers!\` globally in your Podfile, or specify \`:modular_headers => true\` for particular dependencies.

(The third path was \`use_frameworks!\`, which we tried for four PRs and failed.) This PR takes the second path properly:

- **Remove \`useFrameworks\` entirely** — Pods now build as plain static libraries with no framework module wrapper. The modular-include rule doesn't apply to RNFBApp's \`#import <React/...>\` lines because RNFBApp is no longer a framework module.
- **Add \`extraPods\` entry for \`GoogleUtilities\` with \`modular_headers: true\`** — the original Round 1 problem (Swift's \`FirebaseCoreInternal\` can't import non-modular \`GoogleUtilities\`) is resolved by making \`GoogleUtilities\` modular directly.

Exactly what the original CocoaPods diagnostic recommended, just routed through \`expo-build-properties\`'s \`extraPods\` option.

## Files

- \`src/UI/sd-mobile/app.json\` — \`useFrameworks: "dynamic"\` removed; \`extraPods\` set to make \`GoogleUtilities\` modular.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [ ] EAS iOS build runs past \`pod install\` (FirebaseCoreInternal Swift import resolves) AND past \`xcodebuild\` (no framework-module restriction because no framework modules).

## What if other pods surface modular-import errors?

If \`FirebaseMessaging\` or another Firebase pod fails with a similar Swift-import-modular-header error, add it to the \`extraPods\` array the same way. Each iteration is minimal and targeted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * iOS build version updated to 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->