### PR TITLE
fix(web): swap Firebase web config from sportdeets-dev to sportdeets

### DIFF
--- a/src/UI/sd-ui/src/firebase.js
+++ b/src/UI/sd-ui/src/firebase.js
@@ -3,8 +3,12 @@ import { initializeApp } from "firebase/app";
 import { getAuth, setPersistence, browserLocalPersistence } from "firebase/auth";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyBRkQwtEl3jeqoYKBN-hPv8VxTjUycNJgM",
-  authDomain: "sportdeets-dev.firebaseapp.com",
+  apiKey: "AIzaSyD2z-aIlO1REuGmdiw1Z2kmcUgrpDl4-ko",
+  authDomain: "sportdeets.firebaseapp.com",
+  projectId: "sportdeets",
+  storageBucket: "sportdeets.firebasestorage.app",
+  messagingSenderId: "812654295319",
+  appId: "1:812654295319:web:bb9e42d84312b00c9a1f52",
 };
 
 const firebaseApp = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary

Part of the Firebase project migration documented in \`docs/firebase-project-migration.md\`. The old \`sportdeets-dev\` project was deleted as a "break-fast" surface-the-issues step, so the existing hard-coded Firebase Web API key now returns \`auth/api-key-not-valid\`. This PR swaps in the new \`sportdeets\` project's Web app config.

## Files

- \`src/UI/sd-ui/src/firebase.js\` — replaces the 2-field config with the full 6-field Firebase Web SDK config from the new project's Web app registration.

Newly-populated fields (previously omitted, not strictly required for Auth-only usage but standard for future Firebase feature additions like FCM web push, Storage, Analytics):

- \`projectId\`
- \`storageBucket\`
- \`messagingSenderId\`
- \`appId\`

## Security note

The Firebase Web \`apiKey\` is **not a secret**. It's designed to ship in client code and identifies the project to Google's services. Security is enforced by Firebase Auth + Security Rules server-side, not by hiding the key. Anyone with an installed Web app can extract these values from the browser bundle anyway.

## Test plan

- [ ] Web app deploys with the new config.
- [ ] Sign-in flow works (the previous \`auth/api-key-not-valid\` error is gone).
- [ ] Users who were previously signed in get logged out (their old session's ID token has \`aud = sportdeets-dev\` which no longer exists; clean re-login lands them on \`sportdeets\` with the same UID preserved via the auth user export/import in migration Phase 3).

## Companion changes

- API-side migration (Azure App Config \`CommonConfig:Firebase:*\` swap) — already applied via the \`sports-data-provision\` pipeline.
- Mobile-side migration (\`GoogleService-Info.plist\` swap + EAS build) — separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firebase project configuration credentials to ensure proper service connectivity and authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->