### PR TITLE
fix(web): update CSP frame-src to allow the new Firebase auth domain

### DIFF
--- a/src/UI/sd-ui/security-headers.conf
+++ b/src/UI/sd-ui/security-headers.conf
@@ -1,8 +1,12 @@
 # Security headers
-# TODO: When migrating to a production Firebase project, parameterize the Firebase
-# auth domain (sportdeets-dev.firebaseapp.com) across firebase.js, this CSP config,
-# and Program.cs CORS origins. Use envsubst or nginx variable substitution at
-# container startup so all layers share a single FIREBASE_AUTH_DOMAIN env var.
+# TODO: Parameterize the Firebase auth domain (currently sportdeets.firebaseapp.com)
+# across firebase.js, this CSP config, and Program.cs CORS origins. Use envsubst
+# or nginx variable substitution at container startup so all layers share a single
+# FIREBASE_AUTH_DOMAIN env var. This was felt the hard way during the
+# sportdeets-dev → sportdeets migration (this very value had to be changed manually
+# in N places). See docs/firebase-custom-auth-domain.md — when that work happens,
+# the eventual value will be auth.sportdeets.com, which is a third update across
+# the same three files.
 #
 # CSP: enforcing header only — 'unsafe-inline' was dropped from script-src after
 # a watch period under Content-Security-Policy-Report-Only. Observed during
@@ -19,7 +23,7 @@
 # so no connect-src entry is needed for the Sentry host.
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://analytics.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets-dev.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri https://o4511399352729600.ingest.us.sentry.io/api/4511405062225920/security/?sentry_key=3ff92120e166bebbe395faa904795362;" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://analytics.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri https://o4511399352729600.ingest.us.sentry.io/api/4511405062225920/security/?sentry_key=3ff92120e166bebbe395faa904795362;" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;


### PR DESCRIPTION
## Summary

Part of the Firebase project migration (\`sportdeets-dev\` → \`sportdeets\`). The Google sign-in iframe is now served from \`sportdeets.firebaseapp.com\`, but the CSP \`frame-src\` directive still allowed only the old \`sportdeets-dev.firebaseapp.com\` host, so the browser was blocking the iframe with:

\`\`\`
Framing 'https://sportdeets.firebaseapp.com/' violates the following
Content Security Policy directive: "frame-src 'self'
https://www.youtube.com https://accounts.google.com
https://sportdeets-dev.firebaseapp.com"
\`\`\`

End-user symptom: clicking "Sign in with Google" did nothing (auth iframe silently blocked).

## Fix

Replace the old \`sportdeets-dev.firebaseapp.com\` host in the \`frame-src\` allowlist with the new \`sportdeets.firebaseapp.com\`. Also refreshes the file-header TODO comment — the parameterization warning that was speculative ("if we ever migrate") is now retroactively vindicated by the migration we just did, and a follow-up cleanup (\`auth.sportdeets.com\` per \`docs/firebase-custom-auth-domain.md\`) is queued.

## Files

- \`src/UI/sd-ui/security-headers.conf\` — \`frame-src\` allowlist updated; header comment refreshed to reflect post-migration reality + the upcoming custom auth domain work.

## Test plan

- [ ] Deploy to web.
- [ ] Open the app in a fresh incognito session.
- [ ] Click "Sign in with Google" — the Google OAuth iframe should now load without console violations.
- [ ] Complete sign-in flow successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security headers configuration to reference the production Firebase authentication domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->