### PR TITLE
feat(mobile): unauthenticated landing screen + web-safe sign-out

### DIFF
--- a/src/UI/sd-mobile/app/(auth)/_layout.tsx
+++ b/src/UI/sd-mobile/app/(auth)/_layout.tsx
@@ -1,8 +1,13 @@
 import { Stack } from 'expo-router';
 
+export const unstable_settings = {
+  initialRouteName: 'welcome',
+};
+
 export default function AuthLayout() {
   return (
     <Stack screenOptions={{ headerShown: false, animation: 'fade' }}>
+      <Stack.Screen name="welcome" />
       <Stack.Screen name="sign-in" />
     </Stack>
   );

--- a/src/UI/sd-mobile/app/(auth)/welcome.tsx
+++ b/src/UI/sd-mobile/app/(auth)/welcome.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  SafeAreaView,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { Text } from '@/src/components/ui/AppText';
+import { Wordmark } from '@/src/components/brand/Wordmark';
+import { Button } from '@/src/components/ui/Button';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+
+// Mobile landing — condensed from the web LandingPage (Hero + Feature
+// Highlights + How It Works + Footer). For the mobile auth stack we
+// only need enough surface to communicate the value prop before the
+// sign-in card. Folds the web's "How It Works" section into the
+// feature value props (the two were largely redundant once trimmed).
+//
+// Single "Get Started" CTA at the bottom routes to the existing
+// sign-in screen, which now handles new-user creation transparently
+// via Google / Apple sign-in — no separate sign-up path needed.
+
+const features: ReadonlyArray<{
+  icon: keyof typeof Ionicons.glyphMap;
+  title: string;
+  body: string;
+}> = [
+  {
+    icon: 'bulb-outline',
+    title: 'Pick Smarter',
+    body: 'Insider stats, matchup breakdowns, and AI-driven insights — every game.',
+  },
+  {
+    icon: 'trophy-outline',
+    title: 'Crush Your Friends',
+    body: 'Dominate your private leagues. Bragging rights guaranteed.',
+  },
+  {
+    icon: 'options-outline',
+    title: 'Pick Your Way',
+    body: 'Straight up, against the spread, over/under — your call, every week.',
+  },
+];
+
+export default function WelcomeScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+
+  return (
+    <SafeAreaView style={[styles.safe, { backgroundColor: theme.background }]}>
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        bounces={false}
+      >
+        {/* Hero */}
+        <View style={styles.hero}>
+          <Wordmark size={36} />
+          <Text style={[styles.tagline, { color: theme.text }]}>
+            Win Your Picks. Crush Your Friends.
+          </Text>
+          <Text style={[styles.subhead, { color: theme.textMuted }]}>
+            Data-driven insights for every matchup.
+          </Text>
+        </View>
+
+        {/* Feature cards — condensed from web's "Why sportDeets?" +
+            "How It Works". Three is the sweet spot for mobile: enough
+            to communicate breadth without forcing a scroll on standard
+            phone heights. */}
+        <View style={styles.features}>
+          {features.map(({ icon, title, body }) => (
+            <View
+              key={title}
+              style={[
+                styles.featureCard,
+                {
+                  backgroundColor: theme.card,
+                  borderColor: theme.border,
+                },
+              ]}
+            >
+              <View style={[styles.iconWrap, { backgroundColor: theme.accentMuted }]}>
+                <Ionicons name={icon} size={22} color={theme.tint} />
+              </View>
+              <View style={styles.featureBody}>
+                <Text style={[styles.featureTitle, { color: theme.text }]}>{title}</Text>
+                <Text style={[styles.featureCopy, { color: theme.textMuted }]}>{body}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        {/* CTA — single primary action. The existing sign-in screen
+            handles Google / Apple / email & password in one place, so
+            new vs. returning user is the same destination. */}
+        <View style={styles.ctaStack}>
+          <Button
+            title="Get Started"
+            onPress={() => router.push('/(auth)/sign-in')}
+            fullWidth
+            size="lg"
+          />
+          <TouchableOpacity
+            style={styles.signInLink}
+            onPress={() => router.push('/(auth)/sign-in')}
+            hitSlop={10}
+          >
+            <Text style={[styles.signInLinkText, { color: theme.textMuted }]}>
+              Already have an account?{' '}
+              <Text style={[styles.signInLinkAccent, { color: theme.tint }]}>Sign in</Text>
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1 },
+  scroll: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 32,
+    gap: 28,
+  },
+  hero: {
+    alignItems: 'center',
+    gap: 12,
+  },
+  tagline: {
+    fontSize: 24,
+    fontWeight: '800',
+    textAlign: 'center',
+    lineHeight: 30,
+    marginTop: 16,
+  },
+  subhead: {
+    fontSize: 15,
+    textAlign: 'center',
+    lineHeight: 21,
+    paddingHorizontal: 8,
+  },
+  features: {
+    gap: 12,
+  },
+  featureCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    padding: 14,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  iconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  featureBody: { flex: 1, gap: 2 },
+  featureTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  featureCopy: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  ctaStack: {
+    gap: 12,
+    alignItems: 'center',
+    marginTop: 'auto',
+    paddingTop: 8,
+  },
+  signInLink: { paddingVertical: 4 },
+  signInLinkText: {
+    fontSize: 14,
+  },
+  signInLinkAccent: {
+    fontWeight: '700',
+  },
+});

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   Alert,
+  Platform,
   ScrollView,
 } from 'react-native';
 import { signOut } from 'firebase/auth';
@@ -126,47 +127,63 @@ export default function ProfileScreen() {
   const effectiveTimezone = me?.timezone || deviceTz;
   const isUserSet = !!me?.timezone;
 
+  const performSignOut = async () => {
+    // Clear the Google native session first so the next "Continue with
+    // Google" tap re-prompts the account picker instead of silently
+    // re-auth'ing the last-used account. Apple Sign-In has no
+    // equivalent client-side session — iOS manages it system-wide via
+    // the user's Apple ID settings, not the app.
+    //
+    // Independent try/catch from the Firebase sign-out below: Google's
+    // clearing is best-effort cosmetic, but Firebase's signOut is the
+    // load-bearing operation that actually flips the auth state and
+    // triggers the redirect. If Google's signOut throws (e.g.,
+    // configure() bridge issue), we still need Firebase's signOut to
+    // run — otherwise the user taps Sign Out, sees no error (or only
+    // the warn-log), and stays signed in.
+    try {
+      await signOutGoogle();
+    } catch (err) {
+      console.warn(
+        '[ProfileScreen] Google sign-out failed (continuing to Firebase sign-out)',
+        err,
+      );
+    }
+    try {
+      await signOut(auth);
+      // Success path: useAuthInit's onAuthStateChanged listener observes
+      // the auth flip → AuthGuard handles the redirect to /(auth)/welcome.
+      // No local state cleanup required.
+    } catch (err) {
+      console.error('[ProfileScreen] Firebase sign-out failed', err);
+      Alert.alert(
+        'Sign Out Failed',
+        'We could not sign you out. Please check your connection and try again.',
+      );
+    }
+  };
+
   const handleSignOut = () => {
+    // Cross-platform confirmation. React Native Web's Alert.alert is a
+    // stub that doesn't reliably fire onPress callbacks from the buttons
+    // array, so the previous Alert.alert(...) confirmation deadlocked
+    // on web — the destructive "Sign Out" button rendered but never
+    // executed performSignOut. Use window.confirm on web (synchronous,
+    // returns boolean) and the native Alert on iOS/Android (where the
+    // buttons array works correctly).
+    if (Platform.OS === 'web') {
+      if (typeof window !== 'undefined' && window.confirm('Are you sure you want to sign out?')) {
+        void performSignOut();
+      }
+      return;
+    }
     Alert.alert('Sign Out', 'Are you sure you want to sign out?', [
       { text: 'Cancel', style: 'cancel' },
       {
         text: 'Sign Out',
         style: 'destructive',
-        onPress: async () => {
-          // Clear the Google native session first so the next "Continue
-          // with Google" tap re-prompts the account picker instead of
-          // silently re-auth'ing the last-used account. Apple Sign-In
-          // has no equivalent client-side session — iOS manages it
-          // system-wide via the user's Apple ID settings, not the app.
-          //
-          // Independent try/catch from the Firebase sign-out below:
-          // Google's clearing is best-effort cosmetic, but Firebase's
-          // signOut is the load-bearing operation that actually flips
-          // the auth state and triggers the redirect. If Google's
-          // signOut throws (e.g., configure() bridge issue), we still
-          // need Firebase's signOut to run — otherwise the user taps
-          // Sign Out, sees no error (or only the warn-log), and stays
-          // signed in.
-          try {
-            await signOutGoogle();
-          } catch (err) {
-            console.warn(
-              '[ProfileScreen] Google sign-out failed (continuing to Firebase sign-out)',
-              err,
-            );
-          }
-          try {
-            await signOut(auth);
-            // Success path: useAuthInit's onAuthStateChanged listener
-            // observes the auth flip → AuthGuard handles the redirect
-            // to /(auth)/sign-in. No local state cleanup required.
-          } catch (err) {
-            console.error('[ProfileScreen] Firebase sign-out failed', err);
-            Alert.alert(
-              'Sign Out Failed',
-              'We could not sign you out. Please check your connection and try again.',
-            );
-          }
+        onPress: () => {
+          void performSignOut();
         },
       },
     ]);

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -75,7 +75,10 @@ function AuthGuard() {
 
     const inAuthGroup = segments[0] === '(auth)';
     if (!user && !inAuthGroup) {
-      router.replace('/(auth)/sign-in');
+      // Cast — Expo Router's typed-routes generator hasn't picked up the
+      // new welcome.tsx file yet at typecheck time; regenerates on next
+      // expo start / build.
+      router.replace('/(auth)/welcome' as never);
     } else if (user && inAuthGroup) {
       router.replace('/(tabs)');
     }

--- a/src/UI/sd-mobile/src/lib/googleSignIn.ts
+++ b/src/UI/sd-mobile/src/lib/googleSignIn.ts
@@ -5,7 +5,18 @@ import {
   statusCodes,
 } from '@react-native-google-signin/google-signin';
 import { GoogleAuthProvider, signInWithCredential } from 'firebase/auth';
+import { Platform } from 'react-native';
 import { auth } from './firebase';
+
+// Native-module-only library: @react-native-google-signin doesn't have a
+// web implementation. On web, any call into GoogleSignin throws (or
+// crashes synchronously if the native bridge is missing entirely),
+// which then breaks the *unrelated* Firebase signOut path that runs
+// right after signOutGoogle in the profile screen's logout flow. Treat
+// the entire module as native-only and short-circuit on web. Web
+// federated sign-in (if ever needed) would route through Firebase's
+// signInWithPopup, a separate code path.
+const isNative = Platform.OS !== 'web';
 
 // Web OAuth Client ID for the sportdeets Firebase project. Public-readable
 // (it ships in the IPA bundle anyway via the plugin's URL scheme config);
@@ -20,6 +31,7 @@ const WEB_CLIENT_ID =
 // library but the guard avoids the noise.
 let configured = false;
 function configureOnce() {
+  if (!isNative) return;
   if (configured) return;
   GoogleSignin.configure({ webClientId: WEB_CLIENT_ID });
   configured = true;
@@ -43,6 +55,9 @@ export class GoogleSignInCancelled extends Error {
  *   - generic Error with a user-readable message for everything else
  */
 export async function signInWithGoogle(): Promise<void> {
+  if (!isNative) {
+    throw new Error('Continue with Google is not yet supported on web.');
+  }
   configureOnce();
 
   let response: Awaited<ReturnType<typeof GoogleSignin.signIn>>;
@@ -91,6 +106,7 @@ export async function signInWithGoogle(): Promise<void> {
  * account picker, which is confusing on shared devices.
  */
 export async function signOutGoogle(): Promise<void> {
+  if (!isNative) return; // no-op on web; nothing to clear here
   configureOnce();
   try {
     await GoogleSignin.signOut();


### PR DESCRIPTION
## Summary

Adds a condensed mobile equivalent of sd-ui's web LandingPage in front of the sign-in card, so first-time visitors get the brand + value prop instead of dropping straight onto the auth form. While building it I also caught two web-side bugs that prevented sign-out from working in the Expo Web preview — fixed both as part of this PR since they blocked validating the new landing flow.

## Landing screen

- **\`app/(auth)/welcome.tsx\`** — new screen at the top of the auth stack. Hero (Wordmark + tagline + subhead), three condensed feature cards combining web's "Why sportDeets?" + "How It Works" sections (the two were largely redundant once trimmed for a single-screen mobile surface), single primary "Get Started" CTA + a subtle "Already have an account? Sign in" link. Both route to the existing sign-in screen — with Google / Apple sign-in landed, Firebase handles new vs. returning user transparently, so the two CTAs target the same destination.

### Copy
- Hero tagline ported from web's \`LandingHero\` ("Win Your Picks. Crush Your Friends.") with the ™ dropped — looked squished at mobile sizes.
- Subhead trimmed from web's "Data-driven insights for every NCAA football matchup" to just "Data-driven insights for every matchup" since MLB is now a real mobile surface and the web copy is the one that's stale.
- Three features distilled: Pick Smarter (insider stats + AI insights), Crush Your Friends (private league dominance), Pick Your Way (SU / ATS / O/U).

### Routing
- \`app/(auth)/_layout.tsx\` — declares \`welcome\` as the auth-group \`initialRouteName\` so expo-router lands here when the auth group activates. \`sign-in\` \`Stack.Screen\` kept so the welcome CTA can push to it.
- \`app/_layout.tsx\` — \`AuthGuard\` redirect changed from \`/(auth)/sign-in\` → \`/(auth)/welcome\`. Cast to \`never\` because Expo Router's typed-routes generator hasn't regenerated at typecheck time; regenerates on next \`expo start\` / build.

## Web sign-out fix (blocked the validation of the above)

Two stacked issues prevented sign-out from running on the Expo Web preview:

1. **\`Alert.alert\` buttons array is a stub on react-native-web.** The dialog renders but the destructive "Sign Out" button's \`onPress\` callback never fires. The whole sign-out chain dead-ended. Use \`window.confirm\` on web (synchronous, returns boolean) and the native \`Alert\` on iOS/Android (where the buttons array works correctly). Extracted the inner sign-out logic into a \`performSignOut\` helper so both confirmation paths target the same dual-try/catch implementation without duplicating it.

2. **\`@react-native-google-signin/google-signin\` is native-only.** \`GoogleSignin.configure()\` can throw synchronously on web because the native bridge isn't there. Defensive \`Platform.OS !== 'web'\` gating in \`src/lib/googleSignIn.ts\` makes \`signInWithGoogle\` throw a clear "not supported on web" error and \`signOutGoogle\` a silent no-op. Eliminates the class of failure and lets Firebase signOut run cleanly on web. Same pattern we used for \`expo-notifications\` yesterday.

## Files

| File | Change |
|---|---|
| \`app/(auth)/welcome.tsx\` | New landing screen. |
| \`app/(auth)/_layout.tsx\` | Adds \`welcome\` to the stack as \`initialRouteName\`. |
| \`app/_layout.tsx\` | \`AuthGuard\` redirects to \`/(auth)/welcome\` (cast as \`never\` pending typed-routes regen). |
| \`app/(tabs)/profile.tsx\` | Cross-platform sign-out confirmation; \`performSignOut\` helper. |
| \`src/lib/googleSignIn.ts\` | Web-safe gating on \`configure\` / \`signIn\` / \`signOut\`. |

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`jest\`: 51 / 51 pass.
- [x] Web: signed-in user taps Sign Out → \`window.confirm\` → confirm → Firebase signs out → AuthGuard redirects to \`/(auth)/welcome\` → landing screen renders cleanly with hero + three feature cards + CTAs.
- [ ] iOS device (next EAS build): same flow but Alert.alert path is exercised instead of \`window.confirm\`.
- [ ] iOS device: tapping "Get Started" or "Sign in" on welcome screen → push transitions to sign-in.
- [ ] iOS device: hero + cards + CTA fit on a standard 6.1" / 6.7" iPhone without scroll; SE / Mini scrolls gently within the visible area.

## Out of scope

- Hero illustration / screenshot. Could land a single illustration above or replacing the Wordmark hero later if you decide the screen needs more visual weight.
- A/B testing infrastructure for the copy. The static screen is a fine starting point; instrument if/when conversion becomes a question.
- "Learn More" deep dive (web has a longer scroll). The mobile audience already chose to install the app — value-prop reinforcement is the role here, not full marketing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a welcome screen displaying app features and benefits for new users before sign-in.
  * Improved sign-out confirmation with platform-specific dialogs (native alerts on mobile, browser confirmation on web).

* **Bug Fixes**
  * Enhanced Google Sign-In with clearer messaging for web platform limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->