### PR TITLE
fix(mobile): explicitly set ios.entitlements.aps-environment = production

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -16,10 +16,13 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.sportdeets.mobile",
       "googleServicesFile": "./GoogleService-Info.plist",
+      "entitlements": {
+        "aps-environment": "production"
+      },
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "26"
+      "buildNumber": "29"
     },
     "android": {
       "package": "com.sportdeets.mobile",


### PR DESCRIPTION
## Summary

Diagnostic PR for the persistent FCM \`Unregistered\` issue. After ruling out every other configuration layer (token freshness, Firebase project, APNs key correctness, Team ID, FCM API enablement, IPA entitlement existence), the most plausible remaining cause is **EAS auto-deriving \`aps-environment\` to \`development\`** even though we're building with \`--profile production\`.

If the IPA is signed with \`aps-environment: development\`, the device registers with APNs Sandbox rather than Production. The Production-only APNs Auth Key (\`3TBZ5TJ957\`) uploaded to Firebase can't authenticate Sandbox APNs sends — Firebase silently rejects the send and marks the token \`Unregistered\`. Symptom matches exactly what we're seeing.

The \`expo-notifications\` plugin is supposed to set this entitlement automatically based on build profile, but explicitly declaring it in \`app.json\` overrides any auto-detection misconfiguration.

## Diagnostic checklist (what's been ruled out)

- ✅ IPA has APNs entitlement (iOS permission prompt fires on fresh install)
- ✅ Fresh FCM token from current build (verified via uninstall + reinstall)
- ✅ Firebase Console's own test send returns the same \`Unregistered\` (rules out the API)
- ✅ Both APNs Auth Key slots in Firebase have the Production key
- ✅ Team ID \`J3P72XEPJP\` configured for both slots
- ✅ Firebase Cloud Messaging API (V1) enabled in the new \`sportdeets\` project
- ✅ Mobile app on the migrated project (\`PROJECT_ID = sportdeets\`)
- ✅ API service account is for the same project (verified \`ClientEmail\`)
- ❌ Verification of actual \`aps-environment\` value baked into the signed IPA (requires Mac to extract; this PR sidesteps that by explicitly setting it)

## Fix

\`src/UI/sd-mobile/app.json\`:

\`\`\`json
"ios": {
  ...
  "entitlements": {
    "aps-environment": "production"
  },
  ...
  "buildNumber": "29"
}
\`\`\`

Also bumps \`buildNumber\` 28 → 29 for the EAS rebuild that picks this up.

## Outcomes

- **If next build + reinstall + retry succeeds:** EAS was misconfiguring the entitlement. This is the long-term fix; keep the entitlement override in place.
- **If it still fails:** entitlement wasn't the issue. Next move is revoking and regenerating the APNs Auth Key in Apple Developer Console, on the theory that the \`.p8\` got corrupted during download (Apple's one-shot download policy means we can't re-fetch — only re-create).

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [ ] EAS \`eas build -p ios --profile production\` succeeds with no entitlement-related errors.
- [ ] EAS provisioning profile shows \`aps-environment: production\` in build output / build artifact.
- [ ] On-device: uninstall existing build → install new one from TestFlight → fresh notification permission prompt → grab fresh FCM token from dev screen.
- [ ] Firebase Console → Messaging → Send test message → that token → notification arrives.
- [ ] If yes: round-trip via our API's \`/admin/notifications/test-push\` endpoint also delivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS app build number and configuration settings.
  * Modified iOS entitlements configuration for Apple services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->