### PR TITLE
fix(mobile): bump buildNumber for EAS rebuild after Firebase iOS app re-register

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -22,7 +22,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "29"
+      "buildNumber": "30"
     },
     "android": {
       "package": "com.sportdeets.mobile",


### PR DESCRIPTION
## Summary

Triggers a fresh EAS iOS build to validate whether re-registering the iOS app in Firebase Console resolved the persistent FCM \`Unregistered\` issue. \`buildNumber\` 29 → 30 so EAS won't reject the build as a duplicate.

## Background

While diagnosing the FCM \`Unregistered\` symptom, the iOS app entry in the \`sportdeets\` Firebase project was deleted and re-registered. Firebase **reused** the existing \`GOOGLE_APP_ID\` (\`1:812654295319:ios:124e10809ef6bee99a1f52\`) when the iOS app was re-created — documented but unusual. So the freshly-downloaded \`GoogleService-Info.plist\` matches what was already committed from PR #400; no plist content change in this PR.

What is fresh:
- Server-side iOS app entry in Firebase (newly created, clean internal state)
- APNs Auth Key uploads against the new iOS app entry (re-uploaded to both Development and Production slots after the re-register)
- The Production APNs Auth Key itself, regenerated yesterday after we suspected `.p8` corruption

## Why this could fix it

Any FCM token issued by the device against the **previous** iOS app registration in Firebase would have been silently invalidated when that entry was deleted. Even though the new entry recycles the same `GOOGLE_APP_ID`, Firebase's server-side mapping of tokens to the iOS app entity is by internal handle, not by the ID string — old tokens don't get migrated.

## Test plan

- [ ] Merge → EAS \`eas build -p ios --profile production\`.
- [ ] **Uninstall** SportDeets from the iPhone before installing the new build (critical — forces token re-registration against the new iOS app entry).
- [ ] Reinstall from TestFlight, sign in, navigate to Profile → Developer → Push Token (FCM), grab the fresh token.
- [ ] Firebase Console → Messaging → Send test message to that token. If it arrives: this was the fix.
- [ ] If it does: round-trip via API \`/admin/notifications/test-push\` should also work.

## If it still fails

Fallback is the broader re-creation (delete iOS app from Firebase + re-add it and force a fresh \`GOOGLE_APP_ID\` — Firebase reusing the ID after delete is the unusual case; doing it after a longer interval, or with slightly different metadata, may force a new one). Beyond that, opening a Firebase support ticket with the project ID + bundle ID + a known-failing token would be the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented iOS build number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->