### PR TITLE
fix(mobile): plist for fresh Firebase iOS app (full re-register, new GOOGLE_APP_ID)

### DIFF
--- a/src/UI/sd-mobile/GoogleService-Info.plist
+++ b/src/UI/sd-mobile/GoogleService-Info.plist
@@ -29,6 +29,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:812654295319:ios:124e10809ef6bee99a1f52</string>
+	<string>1:812654295319:ios:b944b1d0e5f0ed139a1f52</string>
 </dict>
 </plist>

--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -22,7 +22,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "30"
+      "buildNumber": "31"
     },
     "android": {
       "package": "com.sportdeets.mobile",


### PR DESCRIPTION
## Summary

Second attempt at the iOS-app-re-register fix. PR #403 bumped \`buildNumber\` against a plist that hadn't actually changed (Firebase reused the \`GOOGLE_APP_ID\` on the first re-register). This time the full delete + re-add cycle produced a genuinely new iOS app entry — confirmed by the differing \`GOOGLE_APP_ID\` in the freshly-downloaded plist.

## What changed in the plist

| Field | Before (PR #403's plist) | After (this PR) |
|---|---|---|
| \`GOOGLE_APP_ID\` | \`1:812654295319:ios:124e10809ef6bee99a1f52\` | \`1:812654295319:ios:b944b1d0e5f0ed139a1f52\` |
| \`API_KEY\` (iOS-app-specific) | old | \`AIzaSyD76-Gj0Ite3YgMZQivuxUu32m-oMnMuJU\` |
| \`REVERSED_CLIENT_ID\` | unchanged (Apple reused the iOS OAuth client → no \`app.json\` update needed for Google Sign-In's \`iosUrlScheme\`) | — |
| \`PROJECT_ID\` / \`BUNDLE_ID\` | unchanged | — |

\`buildNumber\` bumped 30 → 31 for the EAS rebuild (the 30 attempt under PR #403 used the stale plist).

## Companion config on Firebase (already done outside this PR)

- New iOS app entry created in Firebase Console for the \`sportdeets\` project (bundle ID \`com.sportdeets.mobile\`, generated this plist)
- APNs Auth Key (\`3TBZ5TJ957\`, Production) re-uploaded to both Development and Production slots under the new iOS app's Cloud Messaging configuration
- Team ID \`J3P72XEPJP\`, FCM API v1 still enabled

## Test plan

- [ ] Merge → \`eas build -p ios --profile production\`.
- [ ] **Uninstall** SportDeets from the iPhone first (forces FCM token re-registration against the new iOS app entry; old tokens from prior installs are not migrated by Firebase).
- [ ] Reinstall from TestFlight, sign in, grab the fresh FCM token from Profile → Developer → Push Token.
- [ ] Firebase Console → Messaging → Send test message to that token.
- [ ] If it works: this was the resolution. Round-trip via our API \`/admin/notifications/test-push\` should also work.
- [ ] If it still fails after a token sourced from this build: we're out of self-service options and the next step is opening a Firebase support ticket with project / bundle / token details.

## Affected sign-in flows

Verified none of these break with the iOS app re-register:
- **Apple Sign-In**: provider lives at project level, iOS app entry just declares bundle ID. Same bundle ID = no impact.
- **Google Sign-In**: \`REVERSED_CLIENT_ID\` in the plist unchanged (Apple reused the iOS OAuth client), so \`app.json\`'s \`iosUrlScheme\` is still correct. \`webClientId\` passed to \`GoogleSignin.configure()\` is the Web OAuth client (separate, unaffected).
- **Email/password**: project-level, unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated Firebase/Google app credentials for iOS platform
- Incremented iOS application build number to version 31

<!-- end of auto-generated comment: release notes by coderabbit.ai -->