### PR TITLE
feat(mobile): register Android Firebase app for FCM + sign-in support

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -22,15 +22,17 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "31"
+      "buildNumber": "32"
     },
     "android": {
       "package": "com.sportdeets.mobile",
+      "googleServicesFile": "./google-services.json",
       "adaptiveIcon": {
         "backgroundColor": "#0d1117",
         "foregroundImage": "./assets/images/android-icon-foreground.png"
       },
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "versionCode": 2
     },
     "web": {
       "bundler": "metro",

--- a/src/UI/sd-mobile/google-services.json
+++ b/src/UI/sd-mobile/google-services.json
@@ -1,0 +1,46 @@
+{
+  "project_info": {
+    "project_number": "812654295319",
+    "project_id": "sportdeets",
+    "storage_bucket": "sportdeets.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:812654295319:android:b495341435975a099a1f52",
+        "android_client_info": {
+          "package_name": "com.sportdeets.mobile"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "812654295319-dgb618dhnl9oflea534fjgdlipkgoi5f.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDvSKaKzd3TIWaXaKssKawE81-ONPknFgY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "812654295319-dgb618dhnl9oflea534fjgdlipkgoi5f.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "812654295319-fckkt2811fn0sr745366rmh62g5788da.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.sportdeets.mobile"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary

First-ever Android EAS build attempt failed at the prebuild step because the Android Firebase app entry didn't exist in the \`sportdeets\` project yet. \`@react-native-firebase/app\`'s config plugin requires both the iOS \`GoogleService-Info.plist\` AND the Android \`google-services.json\` to be declared in \`app.json\`. We only had the iOS side from the migration work.

\`\`\`
Error: [android.dangerous]: withAndroidDangerousBaseMod: Path to
google-services.json is not defined. Please specify the
\`expo.android.googleServicesFile\` field in app.json.
\`\`\`

## Fix

- **\`src/UI/sd-mobile/google-services.json\`** (new) — downloaded from Firebase Console after registering the Android app in the \`sportdeets\` project (package name: \`com.sportdeets.mobile\`, matching \`app.json\`'s \`android.package\`).
- **\`src/UI/sd-mobile/app.json\`** — added \`android.googleServicesFile: "./google-services.json"\`.

## What this enables on Android

- **FCM tokens** issued by Android builds register against the new Android Firebase app entry and are addressable via the existing API \`Admin SDK\` send path (PR #394's endpoint). No APNs intermediary — FCM → Google Play Services → device, all internal to Google.
- **Email/password sign-in** — works out of the box (Firebase Auth at project level, no Android-specific config needed).
- **Apple Sign-In** — iOS-only by design (\`isAppleSignInAvailable\` short-circuits to \`false\` on Android), so no change.

## Out of scope (deferred)

- **Google Sign-In on Android**: requires registering the SHA-1 debug signing fingerprint on the Android app's settings in Firebase Console — without it, Firebase can't verify which client signed the OAuth request and the credential exchange fails. EAS-managed builds use EAS's keystore, so the SHA-1 to register comes from \`eas credentials -p android\`. Adding this is a 2-minute follow-up when we wire up Google Sign-In for Android, but not blocking the FCM-pipeline build that this PR enables.
- **SHA-256 fingerprint** for App Links (deep linking via HTTPS URLs rather than the custom \`sportdeets://\` scheme) — separate Android-specific surface, also deferred.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [ ] \`eas build -p android --profile production\` runs past the prebuild step.
- [ ] APK / AAB produced.
- [ ] Install on Android device (or emulator). Sign in via email/password. FCM token retrieval works via the existing Profile → Developer → Push Token (FCM) admin screen.
- [ ] Round-trip push notification from API → device, mirroring what we just validated for iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS application build number to version 32
  * Updated Android application version code to 2
  * Configured Firebase services integration for the mobile application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->