### PR TITLE
Android deployment guide + Play-Store-ready privacy policy

### DIFF
--- a/docs/mobile/android-deployment.md
+++ b/docs/mobile/android-deployment.md
@@ -5,14 +5,17 @@ This doc focuses on the Android side: getting builds onto a physical
 test device, then onto the Google Play Console for friend testers and
 eventually production users.
 
-Status: **Android Firebase wiring complete** as of 2026-06-04 (PR #405
-landed `google-services.json` and `android.googleServicesFile` in
-`app.json`, unblocking EAS Android builds). iOS path is shipped end-
-to-end (TestFlight builds + Firebase Auth + Apple Sign-In + push
-notifications round-trip validated). Android first-build is now
-mechanically possible; remaining work is **EAS profile config**,
-**Play Console listing**, and **distribution-track setup**. Google
-Play Developer account ($25) paid and verified 2026-05-18, dedicated
+Status: **Play Console app created, Internal Testing prep in flight**
+as of 2026-06-04. PR #405 landed `google-services.json` and
+`android.googleServicesFile` in `app.json` (Firebase Android wiring).
+Play Console app registered with package `com.sportdeets.mobile` the
+same day. iOS path is shipped end-to-end (TestFlight builds +
+Firebase Auth + Apple Sign-In + push notifications round-trip
+validated). Remaining work for friend-tester distribution: **four
+App-content forms** (content rating / target audience / data safety
+/ privacy policy URL), **manual first AAB upload** through Play
+Console UI, **service account JSON** for `eas submit`. Google Play
+Developer account ($25) paid and verified 2026-05-18, dedicated
 Android test device acquired the same day.
 
 ---
@@ -30,17 +33,46 @@ What's already in place:
 - `eas.json` defines `development` / `preview` / `production` build
   profiles, but only iOS resource classes are configured. There is no
   Android-specific build config and no `submit` section.
+- **Play Console app registered** (2026-06-04): app name SportDeets,
+  package `com.sportdeets.mobile`, free, country list configured.
+  Status: "You can start testing your app right away using internal
+  testing." Closed test + production access apply for later graduation.
 
-What's missing:
+What's missing for Internal Testing (friend distribution):
+
+- **App content forms**, all four required:
+  - Content rating questionnaire (~10 min)
+  - Target audience declaration (~2 min)
+  - Data safety form (~15 min — declare Firebase Auth, Sentry, FCM
+    collection)
+  - Privacy policy URL — required because we collect personal data
+    via Firebase Auth (user IDs, emails). Cheap fix: a static page on
+    sportdeets.com.
+- **Manual first `.aab` upload** through Play Console UI (initializes
+  Play App Signing — `eas submit` cannot do this).
+- **Internal testing track** populated with tester Google account
+  emails + share link sent to friends.
+
+What's missing for `eas submit` automation:
 
 - Android-specific build configuration in `eas.json` (`buildType` per
   profile, `resourceClass` if we want anything other than the default).
 - `submit` section in `eas.json` for automated Play Console pushes.
 - Google Cloud service account JSON for EAS Submit to authenticate
-  against the Play Console API.
-- Play Console store listing (app name, description, screenshots,
-  content rating questionnaire).
-- Internal Testing track configured with tester Google accounts.
+  against the Play Console API (also referenced from `eas.json`'s
+  `submit.production.android.serviceAccountKeyPath`).
+
+What's missing for Production (eventual public release):
+
+- Full store listing: screenshots (phone + tablet), feature graphic,
+  short description, long description, categorization.
+- **Closed test completion** before Google grants production access.
+  Play Console explicitly requires this gate now: complete a closed
+  test (typically 12+ testers for 14+ days) and apply for production
+  access — it's no longer enough to just submit to production.
+
+What's missing for Google Sign-In on Android (separate from Play):
+
 - **SHA-1 debug fingerprint registered in Firebase Console** for the
   Android app — required for Google Sign-In on Android (Firebase
   needs to verify which client signed the OAuth request). Get the
@@ -76,12 +108,19 @@ testing tracks, testers install through the Play Store on their
 devices. Path B has **four tracks** of progressively wider audience,
 and you escalate through them as you gain confidence:
 
-| Track | Audience | Review time | Typical use |
-|---|---|---|---|
-| **Internal testing** | Up to 100 testers added by Google account email | **Minutes** (no human review) | Friends, early validation, the TestFlight-Internal equivalent |
-| **Closed testing** | Specific tester list / Google Groups (larger) | Hours to ~1 day | Wider beta, still gated, structured QA |
-| **Open testing** | Anyone with the opt-in URL | Hours to ~1 day | Public beta — appears in Play Store as "beta" |
-| **Production** | Public | **Days** (full review, multiple cycles common) | App-Store equivalent — slow, deliberate release |
+| Track | Audience | Review time | Listing requirements | Typical use |
+|---|---|---|---|---|
+| **Internal testing** | Up to 100 testers added by Google account email | **Minutes** (no human review) | Minimal — four App-content forms + privacy policy URL. No screenshots, no description copy required. | Friends, early validation, the TestFlight-Internal equivalent |
+| **Closed testing** | Specific tester list / Google Groups (larger) | Hours to ~1 day | Full store listing required (screenshots, description, feature graphic) | Wider beta, structured QA, **also the production-access gate** (see below) |
+| **Open testing** | Anyone with the opt-in URL | Hours to ~1 day | Full store listing required | Public beta — appears in Play Store as "beta" |
+| **Production** | Public | **Days** (full review, multiple cycles common) | Full store listing + completed closed test + apply for production access | App-Store equivalent — slow, deliberate release |
+
+**Production is gated by a closed test.** Google's current policy (in
+the Play Console UI verbatim): *"To publish to everyone, you need to
+finish setting up your app, complete a closed test, and apply for
+production access."* In practice this means a closed test with 12+
+testers active for 14+ days before you can apply. Plan the timeline
+accordingly — production access is not a same-day operation.
 
 For "friends bang on it before public" — **Internal testing** is the
 right track. Some advantages over TestFlight worth knowing:
@@ -106,33 +145,61 @@ during early dev and graduate to Path B once the build is solid.
 
 **Google requires the very first `.aab` of a new app to be uploaded
 manually through the Play Console UI** — not via the API, not via
-`eas submit`. This is one-time setup that associates Google Play App
-Signing with your app.
+`eas submit`. This is one-time setup that initializes Google Play App
+Signing for your app. Since Internal Testing setup happens through
+the Play Console UI anyway (you create the release and pick the AAB
+from a file dialog), this requirement is satisfied naturally on the
+first Internal Testing release. The gotcha is only painful if you
+try `eas submit` as your *literal* first action without ever having
+touched the Play Console UI — which will fail with cryptic errors.
 
 After that initial manual upload, subsequent `eas submit` calls work
-on autopilot. Plan for it in the sequence below.
+on autopilot.
 
 ---
 
 ## Recommended sequence
 
-Numbered for execution order. Time estimates are rough.
+Numbered for execution order. Time estimates are rough. The sequence
+splits into two phases: **Internal Testing** (friend distribution,
+~2 hours total) and **Production graduation** (much later, weeks of
+gated steps).
+
+### Phase 1 — Internal Testing (friend distribution)
 
 | # | Step | Time | Outcome |
 | - | ---- | ---- | ------- |
 | 1 | EAS Android build config + first APK build | ~30 min | APK lands on the dev device; daily dev unblocked |
-| 2 | Play Console store listing + Internal Testing track | ~1 hr | App exists in Play Console; tester list configured |
-| 3 | Manual upload of first `.aab` to Internal Testing | ~15 min | Play App Signing initialized; tester install link live |
-| 4 | Service account JSON + `eas.json` `submit` profile | ~15 min | `eas submit --platform android` works |
-| 5 | Steady state: `eas build && eas submit` | ongoing | Each release ships to Internal Testing automatically |
+| 2 | Play Console app created (DONE 2026-06-04) | — | App exists in Play Console |
+| 3 | Privacy policy URL hosted on sportdeets.com | ~30 min | Required field for Data Safety form |
+| 4 | App-content forms: content rating + target audience + data safety + privacy URL | ~45 min | Internal Testing track unblocked |
+| 5 | Manual upload of first `.aab` to Internal Testing via Play Console UI | ~15 min | Play App Signing initialized; tester install link live |
+| 6 | Add tester Google emails to Internal track + send share link | ~5 min | Friends can install |
+| 7 | Service account JSON + `eas.json` `submit` profile | ~15 min | `eas submit -p android --latest --track internal` works |
+| 8 | Steady state: `eas build && eas submit` | ongoing | Each release ships to Internal Testing automatically |
 
-Steps 1 alone unblocks dev iteration. Steps 2–5 are sequenced for
-when distribution to friend testers becomes relevant.
+Step 1 alone unblocks dev iteration on the test device. Steps 3–7
+are the friend-distribution path. **Total budget: ~2 hours.**
 
-The tedious step is **#2** — Play Console listing requirements
-(screenshots at multiple resolutions, description text, content
-rating questionnaire, target audience declaration, data safety form).
-Budget for that one accordingly.
+### Phase 2 — Production graduation (weeks later)
+
+| # | Step | Time | Outcome |
+| - | ---- | ---- | ------- |
+| 9 | Full store listing: screenshots, descriptions, feature graphic, categorization | ~2-4 hrs | Required for Closed/Open/Production tracks |
+| 10 | Closed test with 12+ testers, run for 14+ days | 2+ weeks calendar time | Required gate for production access |
+| 11 | Apply for production access through Play Console | ~1 hr forms + days of waiting | Google reviews and grants production capability |
+| 12 | First production release | ~1-3 days review | App live in Play Store |
+
+Phase 2 is not on the critical path until we're ready to leave beta.
+Don't pre-do it — Google's policies for the production-access
+application change and the screenshots you need will likely have
+evolved by then.
+
+The tedious step in Phase 1 is **#4** — the Data Safety form, which
+requires honest declarations about Firebase Auth, Sentry, FCM, and
+any other data-collecting SDKs. The honest-declaration part matters:
+Google audits, and misdeclaration gets your app yanked. Budget the
+~15 minutes accordingly and don't rush it.
 
 ---
 
@@ -193,7 +260,7 @@ session.
 
 ## What changes when we execute
 
-### `eas.json` additions (Step 1)
+### `eas.json` additions (Phase 1, Step 1)
 
 Each profile grows an `android` section. Example for `preview`:
 
@@ -223,7 +290,7 @@ And `production` (AAB for Play Console):
 `versionCode` on the Android side just like it handles `buildNumber`
 on iOS.
 
-### `eas.json` `submit` section (Step 4)
+### `eas.json` `submit` section (Phase 1, Step 7)
 
 ```json
 "submit": {
@@ -241,7 +308,7 @@ on iOS.
 `alpha` / `beta` / `production` when you graduate from Internal
 Testing.
 
-### Environment variables (Steps 1–5)
+### Environment variables
 
 Android builds consume the same `EXPO_PUBLIC_*` env vars as iOS — no
 duplication needed. Firebase config lives in the same env block
@@ -256,7 +323,7 @@ Native bundle-side config (`GoogleService-Info.plist` for iOS,
 and is wired through `app.json`'s `ios.googleServicesFile` /
 `android.googleServicesFile` declarations.
 
-### Google Cloud service account (Step 4)
+### Google Cloud service account (Phase 1, Step 7)
 
 One-time setup:
 
@@ -277,7 +344,7 @@ is the preferred storage for production setups.
 
 ---
 
-## Per-build workflow (steady state, post-Step 5)
+## Per-build workflow (steady state, post-Phase 1)
 
 ```bash
 # Bump versionCode (handled by autoIncrement on production profile,
@@ -348,10 +415,26 @@ EAS Update is not currently wired up for this project (per
    until you declare what user data your app collects (Firebase Auth
    counts; Sentry counts). Be honest; users see this in the listing.
 6. **Adaptive icon background color must match.** `app.json` sets
-   `android.adaptiveIcon.backgroundColor` (currently `#1B3A6B` — the
-   navy brand color). Verify this renders correctly on the test
+   `android.adaptiveIcon.backgroundColor` (currently `#0d1117` — the
+   dark brand color). Verify this renders correctly on the test
    device's launcher before submitting; some launchers crop
    aggressively.
+7. **Production access requires a completed closed test.** Google's
+   current policy: you can't ship to Production directly. Must run a
+   closed test (typically 12+ testers, 14+ day window) and apply for
+   production access through the Play Console. Plan ~2 weeks of
+   calendar time for the gate alone, separate from the actual review.
+8. **Internal Testing has reduced listing requirements.** You do NOT
+   need screenshots, feature graphic, or long description to ship to
+   Internal Testing — only the four App-content forms (content
+   rating, target audience, data safety, privacy policy URL). Don't
+   pre-do the full listing when all you want is friends installing
+   the app. (Closed/Open/Production require the full listing.)
+9. **Free apps cannot be converted to Paid post-publish.** The Play
+   Console toggle is one-way. Pick Free; monetize via in-app
+   purchases / subscriptions through Google Play Billing instead.
+   This is the universal mobile monetization pattern (Spotify,
+   Netflix, etc. are all Free apps with paid tiers).
 
 ---
 

--- a/docs/mobile/android-deployment.md
+++ b/docs/mobile/android-deployment.md
@@ -1,0 +1,376 @@
+# Android deployment via EAS
+
+Companion to `expo-deployment-model.md`, which covers iOS / TestFlight.
+This doc focuses on the Android side: getting builds onto a physical
+test device, then onto the Google Play Console for friend testers and
+eventually production users.
+
+Status: **Android Firebase wiring complete** as of 2026-06-04 (PR #405
+landed `google-services.json` and `android.googleServicesFile` in
+`app.json`, unblocking EAS Android builds). iOS path is shipped end-
+to-end (TestFlight builds + Firebase Auth + Apple Sign-In + push
+notifications round-trip validated). Android first-build is now
+mechanically possible; remaining work is **EAS profile config**,
+**Play Console listing**, and **distribution-track setup**. Google
+Play Developer account ($25) paid and verified 2026-05-18, dedicated
+Android test device acquired the same day.
+
+---
+
+## Current state
+
+What's already in place:
+
+- `app.json` declares `android.package: com.sportdeets.mobile`, the
+  adaptive icon asset set, AND `android.googleServicesFile` pointing
+  at `./google-services.json` (landed in PR #405).
+- `src/UI/sd-mobile/google-services.json` — Firebase Android app
+  registered in the `sportdeets` project with package name
+  `com.sportdeets.mobile`; config file committed to the repo.
+- `eas.json` defines `development` / `preview` / `production` build
+  profiles, but only iOS resource classes are configured. There is no
+  Android-specific build config and no `submit` section.
+
+What's missing:
+
+- Android-specific build configuration in `eas.json` (`buildType` per
+  profile, `resourceClass` if we want anything other than the default).
+- `submit` section in `eas.json` for automated Play Console pushes.
+- Google Cloud service account JSON for EAS Submit to authenticate
+  against the Play Console API.
+- Play Console store listing (app name, description, screenshots,
+  content rating questionnaire).
+- Internal Testing track configured with tester Google accounts.
+- **SHA-1 debug fingerprint registered in Firebase Console** for the
+  Android app — required for Google Sign-In on Android (Firebase
+  needs to verify which client signed the OAuth request). Get the
+  SHA-1 via `eas credentials -p android` after the first build, then
+  paste into Firebase Console → Project Settings → Your apps → Android
+  app → "Add fingerprint". Not required for FCM or email/password
+  sign-in.
+
+---
+
+## Two distribution paths
+
+Android has two parallel paths, useful at different stages:
+
+### Path A — Direct APK install
+
+Build a `.apk` (single-file Android Package), download via the EAS
+build URL on the device's browser, sideload directly. **No Play
+Console involvement at all.**
+
+- **Fast.** No store listing required, no review, no propagation
+  delay.
+- **Dev-only.** Sideloaded APKs don't auto-update; each new build is
+  a fresh install.
+- **Right for.** Daily dev validation on the dedicated test device.
+  Sanity-checking that EAS builds for Android, that the app launches,
+  that Firebase / SignalR / Sentry all wire up correctly on Android.
+
+### Path B — Google Play Console testing tracks
+
+Build an `.aab` (Android App Bundle), upload to one of Play Console's
+testing tracks, testers install through the Play Store on their
+devices. Path B has **four tracks** of progressively wider audience,
+and you escalate through them as you gain confidence:
+
+| Track | Audience | Review time | Typical use |
+|---|---|---|---|
+| **Internal testing** | Up to 100 testers added by Google account email | **Minutes** (no human review) | Friends, early validation, the TestFlight-Internal equivalent |
+| **Closed testing** | Specific tester list / Google Groups (larger) | Hours to ~1 day | Wider beta, still gated, structured QA |
+| **Open testing** | Anyone with the opt-in URL | Hours to ~1 day | Public beta — appears in Play Store as "beta" |
+| **Production** | Public | **Days** (full review, multiple cycles common) | App-Store equivalent — slow, deliberate release |
+
+For "friends bang on it before public" — **Internal testing** is the
+right track. Some advantages over TestFlight worth knowing:
+
+- **Review is effectively instant.** Apple's TestFlight Internal still
+  goes through a beta review (hours to days). Play Console Internal
+  Testing has no human review at all — submit, available in minutes.
+- **100 testers without the split.** TestFlight allocates 25 internal
+  testers + 10,000 external (with separate review processes). Play's
+  Internal track is a flat 100, all on the fast path.
+- **Auto-update behaves like prod.** Once a tester opts in via the
+  share link, the app appears in their Play Store as if installed
+  normally. Updates auto-deliver — no separate "TestFlight app"
+  intermediary.
+
+The two paths are not mutually exclusive — most projects use Path A
+during early dev and graduate to Path B once the build is solid.
+
+---
+
+## The first-build-is-special gotcha
+
+**Google requires the very first `.aab` of a new app to be uploaded
+manually through the Play Console UI** — not via the API, not via
+`eas submit`. This is one-time setup that associates Google Play App
+Signing with your app.
+
+After that initial manual upload, subsequent `eas submit` calls work
+on autopilot. Plan for it in the sequence below.
+
+---
+
+## Recommended sequence
+
+Numbered for execution order. Time estimates are rough.
+
+| # | Step | Time | Outcome |
+| - | ---- | ---- | ------- |
+| 1 | EAS Android build config + first APK build | ~30 min | APK lands on the dev device; daily dev unblocked |
+| 2 | Play Console store listing + Internal Testing track | ~1 hr | App exists in Play Console; tester list configured |
+| 3 | Manual upload of first `.aab` to Internal Testing | ~15 min | Play App Signing initialized; tester install link live |
+| 4 | Service account JSON + `eas.json` `submit` profile | ~15 min | `eas submit --platform android` works |
+| 5 | Steady state: `eas build && eas submit` | ongoing | Each release ships to Internal Testing automatically |
+
+Steps 1 alone unblocks dev iteration. Steps 2–5 are sequenced for
+when distribution to friend testers becomes relevant.
+
+The tedious step is **#2** — Play Console listing requirements
+(screenshots at multiple resolutions, description text, content
+rating questionnaire, target audience declaration, data safety form).
+Budget for that one accordingly.
+
+---
+
+## Decisions to make before editing config
+
+### 1. Profile naming
+
+Current iOS-flavored profiles: `preview` = TestFlight Internal,
+`production` = App Store.
+
+Android parallel: `preview` = direct-install APK,
+`production` = Play Console AAB.
+
+Options:
+
+- **(a)** Same profile names, platform-flag at build time.
+  `eas build --profile preview --platform android` produces APK;
+  `--platform ios` produces the iOS TestFlight build. Same env vars
+  apply to both.
+- **(b)** Separate profiles per platform: `android-preview` /
+  `android-production` alongside `preview` / `production`.
+
+Recommendation: **(a)** — same profile names. Keeps env vars in one
+place, keeps `eas.json` smaller, matches Expo's expected pattern.
+
+### 2. APK vs AAB for the `preview` profile
+
+- **APK**: Single file, sideloads cleanly via a browser download
+  link. Easy direct-install on the test device.
+- **AAB**: Required for Play Console upload, but can't be sideloaded
+  without `bundletool` gymnastics.
+
+Options:
+
+- **(a)** `preview` = APK, `production` = AAB. Distinct artifacts for
+  distinct purposes.
+- **(b)** Both = AAB. Use Path B (Play Console Internal Testing) for
+  all distribution including dev.
+
+Recommendation: **(a)** — APK for `preview`, AAB for `production`.
+Path A is just faster for daily dev; once we've validated the build
+works, we don't need to keep using it for ourselves.
+
+### 3. Where to start
+
+Options:
+
+- **(a)** Step 1 only — APK direct-install. Validate end-to-end on
+  the dedicated device before fighting Play Console's listing forms.
+- **(b)** Full sequence in one pass.
+
+Recommendation: **(a)** — Step 1 first. Cheaper to discover that
+Firebase / SignalR / Sentry have an Android-specific config issue
+through a 5-minute APK install than through a 90-minute Play Console
+session.
+
+---
+
+## What changes when we execute
+
+### `eas.json` additions (Step 1)
+
+Each profile grows an `android` section. Example for `preview`:
+
+```json
+"preview": {
+  "distribution": "internal",
+  "android": {
+    "buildType": "apk"
+  },
+  "env": { ... unchanged ... }
+}
+```
+
+And `production` (AAB for Play Console):
+
+```json
+"production": {
+  "autoIncrement": true,
+  "android": {
+    "buildType": "app-bundle"
+  },
+  "env": { ... unchanged ... }
+}
+```
+
+`autoIncrement: true` already exists on `production` and handles
+`versionCode` on the Android side just like it handles `buildNumber`
+on iOS.
+
+### `eas.json` `submit` section (Step 4)
+
+```json
+"submit": {
+  "production": {
+    "android": {
+      "serviceAccountKeyPath": "./google-play-service-account.json",
+      "track": "internal",
+      "releaseStatus": "completed"
+    }
+  }
+}
+```
+
+`track: internal` ships to the Internal Testing track. Move to
+`alpha` / `beta` / `production` when you graduate from Internal
+Testing.
+
+### Environment variables (Steps 1–5)
+
+Android builds consume the same `EXPO_PUBLIC_*` env vars as iOS — no
+duplication needed. Firebase config lives in the same env block
+already configured for iOS preview/production builds.
+
+The `sportdeets` Firebase project is in use for both iOS and Android,
+preview and production. The iOS app, Android app, and Web app are all
+registered under the same Firebase project, so a single set of
+`EXPO_PUBLIC_FIREBASE_*` env vars works for every build target.
+Native bundle-side config (`GoogleService-Info.plist` for iOS,
+`google-services.json` for Android) lives in `src/UI/sd-mobile/`
+and is wired through `app.json`'s `ios.googleServicesFile` /
+`android.googleServicesFile` declarations.
+
+### Google Cloud service account (Step 4)
+
+One-time setup:
+
+1. Open Google Cloud Console for the project linked to your Play
+   Developer account (or create a new project).
+2. Create a service account with no special role.
+3. Grant the service account access to your Play Console:
+   - Play Console → Setup → API access → Link service account
+   - Grant **Release apps to testing tracks** + **Manage production
+     releases** permissions.
+4. Create + download a JSON key for the service account.
+5. Save the JSON outside the repo (do **not** commit). Reference it
+   from `eas.json` via `serviceAccountKeyPath` (local path) or
+   `serviceAccountKey` (an EAS secret).
+
+The JSON file is sensitive — treat it like a credential. EAS Secret
+is the preferred storage for production setups.
+
+---
+
+## Per-build workflow (steady state, post-Step 5)
+
+```bash
+# Bump versionCode (handled by autoIncrement on production profile,
+# manual otherwise). Make code changes. Then:
+
+eas build -p android --profile production
+# ... wait for cloud build to finish, ~10-20 min ...
+
+eas submit -p android --latest --track internal
+# ... pushes the most-recent production AAB to the Internal Testing
+# track. --latest skips the interactive build-picker; --track
+# internal is the explicit override even if eas.json defaults the
+# track elsewhere.
+
+# Testers see the update in Play Store within ~15 min.
+```
+
+A few `eas submit` variants worth knowing:
+
+- `eas submit -p android --latest --track internal` — most common
+  during friend-tester phase. Pushes the freshest production AAB.
+- `eas submit -p android --id <build-id> --track internal` — pick a
+  specific older build (e.g. roll back to last-known-good).
+- `eas submit -p android --latest --track production` — graduate to
+  the live Play Store track. Subject to full review.
+
+The `--track` flag overrides whatever is in `eas.json`'s `submit`
+config, which is helpful when the same profile needs to ship to
+different tracks at different times.
+
+For dev iteration without going through Play Console:
+
+```bash
+eas build -p android --profile preview
+# ... wait for build ...
+# EAS prints a QR code / URL. Open on the test device's browser,
+# download the APK, install. Done.
+```
+
+---
+
+## Hotfixes between builds
+
+EAS Update (OTA JS updates) works the same on Android as on iOS —
+the same `eas update` commands apply once we configure it. Native
+changes still require a new build; JS-only changes can ship as OTA.
+
+EAS Update is not currently wired up for this project (per
+`expo-deployment-model.md`). When it is, Android comes along for free.
+
+---
+
+## Gotchas to watch for
+
+1. **First `.aab` upload must be manual.** Don't try `eas submit`
+   before the manual upload through the Play Console UI — it will
+   fail in a confusing way.
+2. **`versionCode` is an integer, monotonically increasing.** Unlike
+   iOS `buildNumber` (which is a string), Android `versionCode` must
+   be a strict integer. EAS `autoIncrement` handles this.
+3. **`com.sportdeets.mobile` is the immutable package identifier.**
+   Once an app is created in Play Console with a package name, you
+   cannot change it. Different package = different app.
+4. **Play Console requires a privacy policy URL** as part of listing
+   setup. Even if you have nothing fancy, you need *something* hosted
+   at a public URL. (Cheap fix: a static page on `sportdeets.com`.)
+5. **Data Safety form is mandatory.** Play Console will block release
+   until you declare what user data your app collects (Firebase Auth
+   counts; Sentry counts). Be honest; users see this in the listing.
+6. **Adaptive icon background color must match.** `app.json` sets
+   `android.adaptiveIcon.backgroundColor` (currently `#1B3A6B` — the
+   navy brand color). Verify this renders correctly on the test
+   device's launcher before submitting; some launchers crop
+   aggressively.
+
+---
+
+## Pricing
+
+- **Google Play Developer account**: $25 one-time. Already paid
+  (2026-05-18).
+- **EAS Build**: same as iOS — included in the EAS plan tier already
+  used. No additional cost per-platform.
+- **EAS Submit**: same as build — included in plan.
+
+---
+
+## References
+
+- `expo-deployment-model.md` — iOS / TestFlight equivalent of this
+  doc. Steady-state workflows mirror each other closely.
+- `firebase-config-in-eas-builds.md` — Firebase env-var setup for EAS
+  builds. The same env block applies to Android.
+- `eas.json` — actual config we'll be editing in Steps 1 and 4.
+- `app.json` — Android package, adaptive icon, versioning declared
+  here.

--- a/src/UI/sd-ui/src/components/legal/LegalPages.css
+++ b/src/UI/sd-ui/src/components/legal/LegalPages.css
@@ -19,8 +19,71 @@
   line-height: 1.6;
 }
 
+/* Long-form policy layout — left-aligned body for readability, with
+   section spacing and link/list styling that the short placeholder
+   variant doesn't need. Applied via the .legal-page--policy modifier
+   so the original centered look still applies elsewhere. */
+.legal-page--policy {
+  text-align: left;
+}
+
+.legal-page--policy h2 {
+  text-align: center;
+}
+
+.legal-page--policy .legal-page__meta {
+  max-width: 800px;
+  margin: 0 auto 40px;
+  text-align: center;
+  font-size: 0.95rem;
+  color: var(--text-tertiary, var(--text-secondary));
+  opacity: 0.8;
+}
+
+.legal-page--policy section {
+  max-width: 800px;
+  margin: 0 auto 32px;
+}
+
+.legal-page--policy h3 {
+  font-size: 1.4rem;
+  margin: 24px 0 12px;
+  color: var(--accent);
+}
+
+.legal-page--policy h4 {
+  font-size: 1.1rem;
+  margin: 20px 0 8px;
+  color: var(--text-primary, var(--text-secondary));
+}
+
+.legal-page--policy ul {
+  max-width: 800px;
+  margin: 0 auto 20px;
+  padding-left: 24px;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.legal-page--policy li {
+  margin-bottom: 8px;
+}
+
+.legal-page--policy a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.legal-page--policy a:hover {
+  color: var(--accent-hover);
+}
+
 .back-home-link {
   margin-top: 30px;
+}
+
+.legal-page--policy .back-home-link {
+  text-align: center;
 }
 
 .back-home-link a {

--- a/src/UI/sd-ui/src/components/legal/PrivacyPage.jsx
+++ b/src/UI/sd-ui/src/components/legal/PrivacyPage.jsx
@@ -3,23 +3,328 @@ import { Link } from "react-router-dom";
 
 function PrivacyPage() {
   return (
-    <div className="legal-page">
+    <div className="legal-page legal-page--policy">
       <h2>Privacy Policy</h2>
-      <p>
-        This is a placeholder Privacy Policy for sportDeets. Final policies
-        regarding data collection and usage will be published prior to launch.
-      </p>
-      <p>
-        Your personal information will never be sold, and will only be used to
-        enhance your sportDeets experience.
-      </p>
-      <p>
-        Thank you for trusting us to protect your data.
+      <p className="legal-page__meta">
+        Effective date: June 4, 2026
       </p>
 
-<div className="back-home-link">
-  <Link to="/">← Back to Home</Link>
-</div>
+      <section>
+        <h3>Overview</h3>
+        <p>
+          sportDeets (&ldquo;sportDeets,&rdquo; &ldquo;we,&rdquo;
+          &ldquo;us,&rdquo; or &ldquo;our&rdquo;) provides a sports
+          pick&apos;em platform delivered through mobile applications and
+          our website at sportdeets.com. This Privacy Policy describes
+          what information we collect, how we use it, who we share it
+          with, and the choices you have. It applies to your use of
+          sportDeets through the iOS app, Android app, and web product.
+        </p>
+        <p>
+          We do not sell your personal information.
+        </p>
+      </section>
+
+      <section>
+        <h3>Information We Collect</h3>
+        <p>We collect the following categories of information:</p>
+
+        <h4>Account information</h4>
+        <p>
+          When you create an account, we collect your email address and
+          a display name. Depending on how you sign in, we also receive
+          a unique user identifier from your authentication provider:
+        </p>
+        <ul>
+          <li>
+            <strong>Email and password:</strong> handled by Google
+            Firebase Authentication. We do not see or store your
+            password.
+          </li>
+          <li>
+            <strong>Sign in with Apple:</strong> we receive your name
+            (if you choose to share it) and a private relay email or
+            your real email (your choice), via Apple&apos;s OAuth flow.
+          </li>
+          <li>
+            <strong>Sign in with Google:</strong> we receive your name,
+            email address, and profile picture URL via Google&apos;s
+            OAuth flow.
+          </li>
+        </ul>
+
+        <h4>Product usage data</h4>
+        <p>
+          To run the pick&apos;em features, we store information you
+          create and actions you take in the app, including:
+        </p>
+        <ul>
+          <li>Leagues you create or join, and your role in each.</li>
+          <li>Picks you submit for each game or contest.</li>
+          <li>Comments, messages, or other content you post in leagues.</li>
+          <li>Preferences such as theme, text size, and favorite teams.</li>
+        </ul>
+
+        <h4>Device and diagnostic data</h4>
+        <p>
+          We collect a limited set of device and diagnostic data to keep
+          the app working and to investigate crashes:
+        </p>
+        <ul>
+          <li>
+            <strong>Push notification tokens:</strong> when you enable
+            notifications, your device generates a token we store so we
+            can send you reminders and league updates. The token is
+            issued by Apple Push Notification service or Firebase Cloud
+            Messaging.
+          </li>
+          <li>
+            <strong>Crash reports and error logs:</strong> if the app
+            crashes or encounters an error, we collect a stack trace,
+            device model, operating system version, and a sequence of
+            recent in-app actions (&ldquo;breadcrumbs&rdquo;). Crash
+            reports may include your user identifier and email so we
+            can correlate the report with your account, but we
+            deliberately exclude notification content, pick contents,
+            and other product data from log payloads.
+          </li>
+          <li>
+            <strong>Server logs:</strong> our backend records standard
+            request metadata, including IP address, user agent string,
+            timestamp, and the API endpoint accessed. These logs are
+            used for security, debugging, and abuse prevention.
+          </li>
+        </ul>
+
+        <h4>Information we do not collect</h4>
+        <ul>
+          <li>
+            We do not collect precise geolocation, contacts,
+            microphone, camera, calendar, or health data.
+          </li>
+          <li>
+            We do not use third-party advertising SDKs, and we do not
+            collect advertising identifiers (IDFA, GAID).
+          </li>
+          <li>We do not currently process payment information.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>How We Use Information</h3>
+        <p>We use the information we collect to:</p>
+        <ul>
+          <li>Create and authenticate your account.</li>
+          <li>
+            Provide the core product: leagues, picks, contests,
+            leaderboards, and reminders.
+          </li>
+          <li>
+            Send push notifications you have opted in to (game
+            reminders, league activity, contest results).
+          </li>
+          <li>
+            Diagnose crashes, fix bugs, and improve product
+            reliability.
+          </li>
+          <li>
+            Detect, investigate, and prevent fraud, abuse, and
+            violations of our Terms of Service.
+          </li>
+          <li>
+            Comply with legal obligations and respond to lawful
+            requests.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Third-Party Services</h3>
+        <p>
+          sportDeets relies on a small number of third-party services
+          to deliver the product. Each receives only the data needed
+          for its function:
+        </p>
+        <ul>
+          <li>
+            <strong>Google (Firebase Authentication, Firebase Cloud
+            Messaging, Google Sign-In):</strong> account
+            authentication and push notification delivery. Governed
+            by{" "}
+            <a
+              href="https://policies.google.com/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Google&apos;s Privacy Policy
+            </a>
+            .
+          </li>
+          <li>
+            <strong>Apple (Sign in with Apple, Apple Push Notification
+            service):</strong> account authentication and push
+            notification delivery on iOS. Governed by{" "}
+            <a
+              href="https://www.apple.com/legal/privacy/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Apple&apos;s Privacy Policy
+            </a>
+            .
+          </li>
+          <li>
+            <strong>Functional Software, Inc. (Sentry):</strong> crash
+            reporting and error monitoring. Receives crash reports
+            including the diagnostic data described above. Governed
+            by{" "}
+            <a
+              href="https://sentry.io/privacy/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Sentry&apos;s Privacy Policy
+            </a>
+            .
+          </li>
+        </ul>
+        <p>
+          We do not sell personal information to data brokers,
+          advertisers, or any other third party.
+        </p>
+      </section>
+
+      <section>
+        <h3>Data Retention and Deletion</h3>
+        <p>
+          We retain account information and product usage data for as
+          long as your account is active. Server logs and crash reports
+          are retained for up to 90 days, then deleted or anonymized.
+        </p>
+        <p>
+          You can delete your sportDeets account at any time from the
+          Profile screen in the mobile app. Account deletion removes
+          your account record, your picks, your league memberships,
+          and your push notification tokens within 30 days. We may
+          retain a limited record of the deletion request (without
+          personal data) for fraud prevention and legal compliance.
+        </p>
+        <p>
+          To request deletion if you cannot access the app, email{" "}
+          <a href="mailto:privacy@sportdeets.com">
+            privacy@sportdeets.com
+          </a>{" "}
+          from the email address associated with your account.
+        </p>
+      </section>
+
+      <section>
+        <h3>Children&apos;s Privacy</h3>
+        <p>
+          sportDeets is not directed to children under 13, and we do
+          not knowingly collect personal information from anyone under
+          13. If you believe a child under 13 has provided us with
+          personal information, please contact us at{" "}
+          <a href="mailto:privacy@sportdeets.com">
+            privacy@sportdeets.com
+          </a>{" "}
+          and we will take steps to delete it.
+        </p>
+      </section>
+
+      <section>
+        <h3>Security</h3>
+        <p>
+          We use industry-standard measures to protect your information,
+          including HTTPS for all network traffic, encrypted storage of
+          credentials by Firebase Authentication, and access controls
+          on our backend systems. No method of transmission or storage
+          is 100% secure, and we cannot guarantee absolute security.
+        </p>
+      </section>
+
+      <section>
+        <h3>Your Rights</h3>
+        <p>
+          Depending on where you live, you may have specific rights
+          regarding your personal information:
+        </p>
+        <ul>
+          <li>
+            <strong>Access and portability:</strong> request a copy of
+            the personal data we hold about you.
+          </li>
+          <li>
+            <strong>Correction:</strong> request that we correct
+            inaccurate information.
+          </li>
+          <li>
+            <strong>Deletion:</strong> request that we delete your
+            personal information (see &ldquo;Data Retention and
+            Deletion&rdquo; above).
+          </li>
+          <li>
+            <strong>Objection and restriction:</strong> object to or
+            restrict certain processing of your personal information.
+          </li>
+        </ul>
+        <p>
+          Residents of the European Economic Area, the United Kingdom,
+          and Switzerland have rights under the General Data Protection
+          Regulation (GDPR). Residents of California have rights under
+          the California Consumer Privacy Act (CCPA), including the
+          right to know what personal information we collect and the
+          right to request deletion. sportDeets does not sell personal
+          information as defined by the CCPA.
+        </p>
+        <p>
+          To exercise any of these rights, email{" "}
+          <a href="mailto:privacy@sportdeets.com">
+            privacy@sportdeets.com
+          </a>
+          . We will respond within the timeframe required by
+          applicable law.
+        </p>
+      </section>
+
+      <section>
+        <h3>International Users</h3>
+        <p>
+          sportDeets is operated from the United States. If you access
+          the service from outside the United States, you understand
+          that your information will be transferred to, stored, and
+          processed in the United States, where data protection laws
+          may differ from those in your country.
+        </p>
+      </section>
+
+      <section>
+        <h3>Changes to This Policy</h3>
+        <p>
+          We may update this Privacy Policy from time to time. When we
+          do, we will update the &ldquo;Effective date&rdquo; at the
+          top of this page and, for material changes, notify you
+          through the app or by email. Your continued use of
+          sportDeets after the effective date constitutes acceptance
+          of the updated policy.
+        </p>
+      </section>
+
+      <section>
+        <h3>Contact</h3>
+        <p>
+          If you have questions about this Privacy Policy or our
+          handling of your personal information, please contact us at{" "}
+          <a href="mailto:privacy@sportdeets.com">
+            privacy@sportdeets.com
+          </a>
+          .
+        </p>
+      </section>
+
+      <div className="back-home-link">
+        <Link to="/">← Back to Home</Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Unblocks Google Play Internal Testing distribution for the sd-mobile Android build. Two coordinated changes:

- **`docs/mobile/android-deployment.md`** — full guide for the Android path, written to mirror the iOS / TestFlight coverage in `expo-deployment-model.md`. Splits the work into Phase 1 (Internal Testing, ~2 hours, friend distribution) and Phase 2 (Production graduation, weeks of calendar time). Four-track comparison table makes the Internal vs Closed/Open/Production listing-requirement delta explicit, and calls out Google's current Production-access gate (closed test with 12+ testers for 14+ days, then apply).
- **`src/UI/sd-ui/src/components/legal/PrivacyPage.jsx`** + CSS — replaces the three-paragraph placeholder with a policy structured against Google's Data Safety form questions. Declares actual third parties (Firebase, Apple, Sentry) with linked policies, deletion mechanism, retention windows, COPPA/GDPR/CCPA. Contact via `privacy@sportdeets.com` (catch-all routes to user's existing inbox). `LegalPages.css` gains a `.legal-page--policy` modifier for long-form left-aligned layout; the original centered styling still applies to `TermsPage` which remains a placeholder.

Coverage is intentionally production-grade rather than Internal-Testing-minimum because the alternative is rewriting the policy in 6 weeks at closed-test graduation. Google does not perform human content review of privacy policies at Internal Testing tier, but Data-Safety-form consistency with the policy text is checked at Production review and on abuse reports.

Deferred to follow-up (not blocking Internal Testing):
- Legal entity name / physical mailing address in the policy
- EAS `submit` profile + service account JSON (manual AAB upload through Play Console UI is fine for the first few builds)
- Full store listing for Closed/Open/Production tracks

## Test plan

- [ ] `sd-ui` builds without errors
- [ ] Local dev server renders `/privacy` cleanly: section headings spaced, links readable on dark background, mobile width holds up
- [ ] Local dev server renders `/terms` unchanged (still uses the centered placeholder layout)
- [ ] All third-party privacy policy links in the policy open correctly (Google, Apple, Sentry)
- [ ] `mailto:privacy@sportdeets.com` links open the user's mail client
- [ ] After merge + sd-ui deploy: `https://www.sportdeets.com/privacy` returns the new content (Play Console's Data Safety form fetches this URL automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Android app deployment guide with setup instructions, internal testing procedures, and production release workflow.
  * Updated privacy policy with detailed information sections covering data collection, usage, retention, and user rights.

* **Style**
  * Enhanced visual design of legal and policy pages with improved typography, spacing, and content alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->