### PR TITLE
feat(marks): self-generated team marks with MarkDirection wire-through

### DIFF
--- a/docs/team-mark-design-brief.md
+++ b/docs/team-mark-design-brief.md
@@ -1,0 +1,220 @@
+# Team mark design brief (for Claude Design)
+
+This document is a self-contained brief. Paste it into Claude Design
+or any design-ideation surface and it should be enough context to
+produce useful directions.
+
+## Context
+
+sportDeets is a multi-sport pick'em platform — users pick winners,
+spreads, and over/unders across NFL, NCAA football, MLB, with NBA /
+NHL / PGA on the roadmap. The product surfaces team identity heavily
+throughout the UX: matchup cards, standings, live-game tiles, pick
+selection flows, league rosters, profile favorites, and push
+notification thumbnails.
+
+Up to now, the data backend has sourced and stored real team logos
+(NFL, NCAA, MLB, etc.) from ESPN's public asset URLs and rehosted
+them in our own Azure Blob Storage. **We cannot ship this to either
+app store.** The plan needs to change before Apple App Store / Google
+Play submission.
+
+## The constraint
+
+Team logos are trademarked. Sourcing them from ESPN and rehosting
+them doesn't grant us rights — ESPN has licensing deals; we don't.
+Licensing the marks ourselves is not viable:
+
+- **NFL Properties:** ~$100k/yr minimums + revenue share. They
+  generally don't license to small operators at all.
+- **NCAA / CLC (Collegiate Licensing Company):** Power 5 schools
+  bundled, also in the $100k+ range for the bundle.
+- **MLB Advanced Media, NBA Digital, NHL Enterprises:** more
+  approachable historically but still well outside a pre-revenue
+  solo-founder budget.
+
+App store review will flag unlicensed marks. A "show real logos to
+my friends, generic to everyone else" workaround was considered and
+rejected — it doesn't solve the underlying infringement (server is
+still hosting unlicensed assets), and Apple specifically polices
+review-evasion patterns where the app behaves differently for
+review accounts vs. real users.
+
+**Conclusion:** sportDeets needs its own visual marks for teams,
+generated programmatically from data we already have. That's a
+permanent change, not a launch hack.
+
+## What we already have
+
+For every team (we use "Franchise" / "FranchiseSeason" in our
+schema), we store:
+
+- **Primary brand color** (hex / RGB) — sourced from ESPN, which got
+  it from each league's official brand guide. Colors are not
+  trademarked; we can use these forever.
+- **Secondary brand color** (hex / RGB).
+- **Team abbreviation** — 2-4 characters (DAL, NYY, BOS, MTL, ALA,
+  USC).
+- **Team name** — location + nickname ("Dallas Cowboys", "New York
+  Yankees").
+- **Sport / League** — which sport the team plays.
+- **Year** for `FranchiseSeason` — colors and abbreviations can
+  change across seasons (rare but happens, especially in NCAA).
+
+We do NOT have (and don't want to invent):
+
+- Mascot illustrations or silhouettes.
+- Stylized team-specific glyphs.
+- Anything that derives from the real mark, even loosely.
+
+## Where the mark appears
+
+The generated mark needs to work at multiple sizes and in multiple
+contexts:
+
+| Context | Size | Notes |
+|---|---|---|
+| Push notification thumbnail | 24-32px | Must be recognizable at tiny size, low color depth |
+| Standings table row | 24-32px | Often alongside ~20 similar marks; differentiation matters |
+| Matchup card (mobile + web) | 48-72px | The hero placement; this is where most users see the mark |
+| Pick selection flow | 72-96px | Side-by-side comparison: two teams; contrast between them matters |
+| Live game tile (Command Center) | 96-128px | May animate during live updates |
+| Team detail / Franchise page header | 128-256px | Larger, more decorative |
+| Profile favorite team | 96-128px | Single team focus |
+
+Light theme and dark theme are both required. Some teams have
+near-black primaries (Raiders), some near-white (Yankees away
+palette), some pastel — the mark needs to look intentional in both
+themes regardless of palette.
+
+## Multi-sport reality
+
+A helmet shape works beautifully for NFL but feels wrong for MLB or
+NBA. Options:
+
+- **One universal shape** that's sport-agnostic (a roundel, a
+  shield, a hexagon, a custom geometric mark) — works everywhere,
+  no per-sport variant logic.
+- **Sport-specific shape families** (helmet for football, cap for
+  baseball, jersey block for basketball/hockey) — more visually
+  appropriate but more design + engineering work.
+- **Hybrid** — universal shape with subtle sport hint (e.g., a
+  small icon in a corner of the roundel).
+
+We don't have a strong opinion yet; this is exactly what we want
+the design exploration to weigh in on.
+
+## Requirements
+
+1. **Parameterized from data.** Given (primary color, secondary
+   color, abbreviation, sport), the mark generator should produce
+   a deterministic SVG. No per-team manual design work.
+2. **Distinctive at small sizes.** A list of 20 marks should be
+   visually scannable.
+3. **Reads as intentional design**, not "we couldn't afford the
+   real ones." Yahoo Fantasy ran generic marks for years; the
+   visual identity became theirs, not a compromise.
+4. **Accessible contrast.** Some teams have similar colors
+   (Cardinals red + Chiefs red + 49ers red). The mark should
+   include an internal contrast element so it doesn't reduce to a
+   blob of one color.
+5. **Legally clean.** No element traceable to any real team mark.
+   No mascot silhouettes. No protected symbology.
+6. **SVG-first.** Generated at data-sourcing time, cached to blob
+   storage, served from existing URL pattern (drop-in replacement
+   for current logo URLs).
+
+## Non-goals
+
+- We are NOT trying to replicate ESPN's logo treatment.
+- We are NOT designing per-team marks; we're designing a parametric
+  system that produces a mark per team.
+- We are NOT trying to look "official" — looking distinctly
+  sportDeets-y is the goal.
+
+## Real team data for sketching
+
+Below are real teams across sports with their actual color data
+(approximations from ESPN's brand records — real values would be
+pulled from the DB at generation time). Useful for stress-testing a
+design direction against tough cases.
+
+### NFL
+
+| Team | Abbr | Primary | Secondary | Notes |
+|---|---|---|---|---|
+| Dallas Cowboys | DAL | #003594 (navy) | #B0B7BC (silver) | Iconic, common |
+| Pittsburgh Steelers | PIT | #000000 (black) | #FFB612 (gold) | Black primary case |
+| Cleveland Browns | CLE | #311D00 (brown) | #FF3C00 (orange) | Brown is rare and tricky |
+| Las Vegas Raiders | LV | #000000 (black) | #A5ACAF (silver) | Black + silver — both low-saturation |
+| Miami Dolphins | MIA | #008E97 (teal) | #FC4C02 (orange) | High-contrast vibrant pair |
+
+### MLB
+
+| Team | Abbr | Primary | Secondary | Notes |
+|---|---|---|---|---|
+| New York Yankees | NYY | #003087 (navy) | #FFFFFF (white) | Near-white secondary |
+| Los Angeles Dodgers | LAD | #005A9C (blue) | #FFFFFF (white) | Similar to NYY palette |
+| San Diego Padres | SD | #2F241D (brown) | #FFC425 (gold) | Brown again, tough |
+| Boston Red Sox | BOS | #BD3039 (red) | #0C2340 (navy) | Classic two-strong palette |
+
+### NBA
+
+| Team | Abbr | Primary | Secondary | Notes |
+|---|---|---|---|---|
+| Boston Celtics | BOS | #007A33 (green) | #BA9653 (gold) | Green + gold uncommon |
+| LA Lakers | LAL | #552583 (purple) | #FDB927 (gold) | Vibrant pair |
+| Brooklyn Nets | BKN | #000000 (black) | #FFFFFF (white) | Pure mono — tough to differentiate |
+
+### NCAA Football
+
+| Team | Abbr | Primary | Secondary | Notes |
+|---|---|---|---|---|
+| Alabama Crimson Tide | ALA | #9E1B32 (crimson) | #FFFFFF (white) | Crimson family is large in NCAA |
+| Michigan Wolverines | MICH | #00274C (navy) | #FFCB05 (maize) | Navy + yellow, common |
+| Oregon Ducks | ORE | #154733 (green) | #FEE123 (yellow) | Dark green primary |
+
+### Tough cases to design against
+
+- Multiple teams with similar palettes (the 4-5 NFL red teams, the
+  2-3 MLB navy-and-white teams).
+- Teams with monochrome palettes (Brooklyn Nets — black + white).
+- Teams whose primary is near-black or near-white (need internal
+  contrast).
+- Teams whose colors are visually similar but they're rivals (e.g.,
+  Michigan vs. Ohio State both have a yellow component).
+
+## What we'd like back from the design exploration
+
+3-5 distinct visual directions, each with:
+
+1. **The concept** — one paragraph describing the visual idea (e.g.,
+   "Heraldic shield with a horizontal bar of secondary color and the
+   team abbreviation in primary").
+2. **5-8 example renders** using the real color data above, ideally
+   covering multiple sports and at least one tough case (monochrome,
+   similar-palette pair).
+3. **Pros and cons** as you see them.
+4. **Multi-sport handling** — does the direction work universally or
+   does it need sport-specific variants?
+5. **SVG sketch / wireframe** that's clear enough we can implement
+   from it.
+
+After we pick a direction (or a hybrid), we'll define the SVG
+template, wire it into the ingest pipeline, regenerate marks for
+every team in the DB, and swap them into the existing logo URLs.
+The mark system also becomes a sportDeets brand asset, not a
+workaround — controllable, consistent, animatable, accessible.
+
+## References (mention as inspiration, not copy)
+
+- **Yahoo Fantasy** historical generic marks (before they got
+  licensing deals) — heraldic shields with team abbreviations.
+- **SeatGeek** team marks — abstract roundels with letter monograms.
+- **Sleeper** team marks — minimalist mono-color cards.
+- Heraldic / vexillological traditions (flags, crests).
+- Older pro-sports branding eras (1950s-70s) where letter
+  monograms dominated over mascot art.
+
+None of these should be copied. Each is useful as a sketch of
+"things that have worked for unlicensed sports identity."

--- a/docs/team-mark-user-preference-design.md
+++ b/docs/team-mark-user-preference-design.md
@@ -1,0 +1,254 @@
+# Team mark direction preference — design doc
+
+Background: `docs/team-mark-design-brief.md` (why generated marks), and
+`src/marks/batch-generation-plan.md` (how marks land in storage).
+
+This doc covers wiring the back-end to **serve those marks** with a
+selectable direction (Roundel / Shield / Hex). Initial scope is the
+matchup card path used by the web app's league-week view:
+
+`GetLeagueWeekMatchupsQueryHandler` (API)
+→ `IContestClient.GetMatchupsByContestIds` (HTTP)
+→ `GetMatchupsByContestIdsQueryHandler` (Producer)
+→ `GetMatchupsByContestIds.sql` (Postgres lateral joins).
+
+## Scope
+
+In:
+- New `MarkDirection` enum, threaded API → Producer → SQL
+- SQL change to prefer `sportdeets-mark` rows tagged with the
+  requested direction, with a transparent fallback to existing
+  ESPN-sourced rows
+- API handler defaults the direction to `Roundel` (hardcoded —
+  see "Why no user column yet" below)
+
+Out (deferred):
+- Per-user persisted preference (no UI yet)
+- The other ~10 logo-selecting SQL queries (see Cascade)
+- `LogoSelectionService` updates (no callers in this path)
+- Light/dark mark variants (single render handles both today)
+
+## The enum
+
+```csharp
+// SportsData.Core/Common/MarkDirection.cs
+public enum MarkDirection
+{
+    Roundel = 0,
+    Shield  = 1,
+    Hex     = 2
+}
+```
+
+Lives in Core so API client + Producer query + Producer SQL handler
+all reference the same type. Roundel = 0 makes it the default value
+for any uninitialized field, matching the system default.
+
+## Why no `User.PreferredMark` column yet
+
+Considered: add `User.PreferredMark MarkDirection?` (nullable) now
+with default Roundel.
+
+Rejected because:
+- **No UI surface exists yet.** Per the top-down-UI-first project
+  guardrail, until the profile-toggle UX is designed we don't know
+  what the persisted shape needs (real enum vs. string for
+  extensibility, companion fields for analytics, per-sport overrides,
+  etc.).
+- **Speculative schema.** A column whose value is uniformly Roundel
+  until the toggle UI ships is exactly what the "design for hypothetical
+  future requirements" guardrail warns against.
+- **No time saved.** The migration cost is the same whether shipped
+  now or with the UI PR. Swapping a hardcoded constant for a DB lookup
+  is a five-line change.
+
+When the toggle UI happens, that PR ships:
+- EF migration adding `User.PreferredMark`
+- `PATCH /user/preferences` (or extension to the existing endpoint)
+- The 5-line swap in `GetLeagueWeekMatchupsQueryHandler`
+- sd-ui profile-page toggle component
+
+All as one coherent change.
+
+## Wire contract change
+
+### Producer endpoint
+
+`POST /contests/matchups/by-ids` currently accepts a bare `Guid[]`
+body. Wrap it in a request DTO so we can include the direction
+without breaking the body shape on every parameter we add later:
+
+```csharp
+public record GetMatchupsByContestIdsRequest(
+    Guid[] ContestIds,
+    MarkDirection Direction);
+```
+
+Lives in `SportsData.Core.Dtos.Canonical` next to `LeagueMatchupDto`.
+
+### Producer query
+
+```csharp
+public record GetMatchupsByContestIdsQuery(
+    Guid[] ContestIds,
+    MarkDirection Direction);
+```
+
+### Client interface
+
+```csharp
+Task<Result<List<LeagueMatchupDto>>> GetMatchupsByContestIds(
+    List<Guid> contestIds,
+    MarkDirection direction,
+    CancellationToken ct = default);
+```
+
+Three call sites need updating:
+1. `GetLeagueWeekMatchupsQueryHandler` (the target — passes the
+   resolved direction)
+2. `GetMatchupForContestQueryHandler` (admin debug single matchup —
+   defaults to Roundel; admin has no user-pref context)
+3. `AdminController.cs` line ~371 (admin endpoint — defaults to Roundel)
+
+## SQL change
+
+`src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql`
+
+Today, each `FranchiseLogo` / `FranchiseSeasonLogo` lateral picks the
+oldest row by `CreatedUtc ASC`. That means even with our 90 new
+sportdeets-mark rows from the batch script, the ESPN-sourced rows
+still win (older).
+
+Replace `ORDER BY` in each of the eight lateral subqueries with a
+preference-ordered `CASE`:
+
+```sql
+LEFT JOIN LATERAL (
+  SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
+  WHERE fsl."FranchiseSeasonId" = fsAway."Id"
+  ORDER BY
+    CASE
+      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
+      ELSE                                                                2
+    END,
+    fsl."CreatedUtc" ASC
+  LIMIT 1
+) fslAway ON TRUE
+```
+
+Fallback chain:
+1. `sportdeets-mark` row tagged with the requested direction → win
+2. Any `sportdeets-mark` row → win (covers a team that doesn't yet
+   have the requested direction generated)
+3. Anything else → fall back to ESPN behavior (preserves today's
+   visuals for unbackfilled teams)
+
+`@Direction` is bound as a Dapper parameter on the existing
+`CommandDefinition` call, alongside `@ContestIds`. The
+`ProducerSqlQueryProvider` startup placeholder validator (matches
+`{Name}` only) won't trip on `@Direction`.
+
+The eight laterals that need the change: `flAway`, `fslAway`,
+`flDarkAway`, `fslDarkAway`, `flHome`, `fslHome`, `flDarkHome`,
+`fslDarkHome`.
+
+### Dark variants and theme-agnostic marks
+
+The current SQL queries dark logos separately and surfaces them as
+`AwayLogoUriDark` / `HomeLogoUriDark`. Our sportdeets-marks are
+theme-agnostic — we ship one render that works on both backgrounds.
+
+The dark laterals get the same CASE-based ordering. For a team with
+sportdeets-mark rows, the dark lateral returns the same URI as the
+light lateral. The UI's existing light/dark URL selection logic still
+works; both URLs simply point at the same blob. Until/unless we
+generate proper dark variants, this is the correct behavior.
+
+## Default-direction resolution in the API handler
+
+```csharp
+// GetLeagueWeekMatchupsQueryHandler.ExecuteAsync
+
+// TODO: read from user.PreferredMark once the profile-toggle UI ships.
+// For now, every user sees roundels.
+var direction = MarkDirection.Roundel;
+
+var matchupsResult = await _contestClientFactory
+    .Resolve(league.Sport)
+    .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
+```
+
+The TODO is load-bearing — it's the line that gets replaced when the
+profile toggle ships.
+
+## The cascade (flagged, not in scope)
+
+`GetMatchupsByContestIds.sql` is one of ~10 SQLs in
+`ProducerSqlQueryProvider` that surface logo URIs:
+
+- `GetMatchupForPreview.sql`
+- `GetMatchupForPreviewBatch.sql`
+- `GetMatchupsForCurrentWeek.sql`
+- `GetMatchupsForSeasonWeek.sql`
+- `GetMatchupByContestId.sql`
+- `GetTeamCard.sql`
+- `GetTeamCardSchedule.sql`
+- `GetTeamFinalizedGames.sql`
+- `GetTeamSeasons.sql`
+- (possibly others — to be audited)
+
+Each needs the same lateral-join CASE pattern for consistent marks
+across the app. `LogoSelectionService` (used by non-SQL paths via EF)
+also needs a `direction`-aware overload.
+
+**Explicitly not in scope for this PR.** Prove the pattern on one
+SQL, validate visually in the web app, then propagate. The propagation
+pass is mechanical once the shape is locked.
+
+## Idempotency / re-runnability of the batch
+
+The synthetic `OriginalUrlHash` on each sportdeets-mark row encodes
+direction (`SHA256("sportdeets-mark:{direction}:{Id}")`), so re-running
+the batch script overwrites rather than duplicates. If Claude Design
+ships a refined roundel later, we rerun the batch and the existing
+rows update in place — no SQL change needed downstream.
+
+## Backwards-compat
+
+For teams that don't yet have sportdeets-mark rows (everything that's
+not MLB FranchiseSeason 2026 today), the SQL change is a no-op: the
+CASE falls to `ELSE 2`, the `ORDER BY` then breaks the tie on
+`CreatedUtc ASC`, which matches today's behavior exactly. No
+regression for unbackfilled teams.
+
+## Migration story
+
+None. This PR adds no columns, no indexes, no schema changes. EF
+build runs zero migrations.
+
+(The eventual UI PR will add a `User.PreferredMark` migration.)
+
+## Test plan
+
+- Build: `dotnet build` on `SportsData.Core`, `SportsData.Producer`,
+  `SportsData.Api` — zero errors.
+- Local run: bring up Postgres, API, Producer (BaseballMlb).
+- Web app → log in → open a league with MLB matchups for week 1 2026.
+- Verify matchup cards show generated roundels for MLB teams (sourced
+  from `sportdeetssadev.blob.core.windows.net/sportdeets-marks/...`).
+- Verify non-MLB matchups (if any seeded locally) still show ESPN
+  logos — fallback path.
+- Spot-check admin matchup-debug endpoint — should also work with
+  roundels (admin path hardcoded to Roundel).
+- DB sanity: `SELECT "Uri" FROM "FranchiseSeasonLogo"
+  WHERE 'sportdeets-mark' = ANY("Rel") AND 'roundel' = ANY("Rel")` —
+  matches what the SQL is now preferring.
+
+## Open question for follow-up PRs
+
+When the profile-toggle UI lands, the `MarkDirection` enum likely
+deserves a `BlobPathSegment()` extension or similar so the marks
+batch script and the SQL can share the lowercase direction-string
+convention without duplicating it. Out of scope here, but worth a
+note so the eventual refactor target is obvious.

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -368,8 +368,10 @@ namespace SportsData.Api.Application.Admin
             // Canonical statuses come from Producer in one round-trip;
             // .ToList() is for the cast — GetMatchupsByContestIds takes
             // a List<Guid>, contestIds is IReadOnlyList<Guid>.
+            // Direction = Roundel: admin path, no user preference context.
             var matchupsResult = await client.GetMatchupsByContestIds(
                 contestIds.ToList(),
+                MarkDirection.Roundel,
                 cancellationToken);
 
             if (!matchupsResult.IsSuccess)

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupForContest/GetMatchupForContestQueryHandler.cs
@@ -31,9 +31,10 @@ public class GetMatchupForContestQueryHandler : IGetMatchupForContestQueryHandle
         GetMatchupForContestQuery query,
         CancellationToken cancellationToken)
     {
+        // Admin debug endpoint — no user context, so default to Roundel.
         var matchupsResult = await _contestClientFactory
             .Resolve(query.Sport)
-            .GetMatchupsByContestIds(new List<Guid> { query.ContestId }, cancellationToken);
+            .GetMatchupsByContestIds(new List<Guid> { query.ContestId }, MarkDirection.Roundel, cancellationToken);
 
         if (!matchupsResult.IsSuccess)
         {

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -163,7 +163,14 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 query.LeagueId,
                 query.Week);
 
-            var matchupsResult = await _contestClientFactory.Resolve(league.Sport).GetMatchupsByContestIds(contestIds);
+            // TODO: read direction from user.PreferredMark once the profile-
+            // toggle UI ships. For now every user sees roundels. See
+            // docs/team-mark-user-preference-design.md.
+            var direction = MarkDirection.Roundel;
+
+            var matchupsResult = await _contestClientFactory
+                .Resolve(league.Sport)
+                .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
             if (!matchupsResult.IsSuccess)
             {
                 _logger.LogError("Failed to retrieve canonical matchups for leagueId={LeagueId}, week={Week}", query.LeagueId, query.Week);

--- a/src/SportsData.Api/Application/UI/Rankings/Queries/GetRankingsByPollWeek/GetRankingsByPollWeekQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Rankings/Queries/GetRankingsByPollWeek/GetRankingsByPollWeekQueryHandler.cs
@@ -56,7 +56,12 @@ public class GetRankingsByPollWeekQueryHandler : IGetRankingsByPollWeekQueryHand
         {
             // TODO: multi-sport - resolve from context
             var client = _franchiseClientFactory.Resolve(Sport.FootballNcaa);
-            var rankings = await client.GetRankingsByPollByWeek(poll, query.SeasonYear, query.Week, cancellationToken);
+
+            // TODO: read direction from user.PreferredMark once the profile-toggle
+            // UI ships. See docs/team-mark-user-preference-design.md.
+            var direction = MarkDirection.Roundel;
+
+            var rankings = await client.GetRankingsByPollByWeek(poll, query.SeasonYear, query.Week, direction, cancellationToken);
 
             if (rankings == null)
             {

--- a/src/SportsData.Core/Common/MarkDirection.cs
+++ b/src/SportsData.Core/Common/MarkDirection.cs
@@ -1,0 +1,14 @@
+namespace SportsData.Core.Common;
+
+/// <summary>
+/// Identifies which of the generated sportDeets team-mark designs the caller
+/// wants surfaced. See docs/team-mark-design-brief.md for the three directions
+/// and src/marks/ for the engine. Roundel = 0 makes it the default value for
+/// uninitialized fields, matching the system default direction.
+/// </summary>
+public enum MarkDirection
+{
+    Roundel = 0,
+    Shield = 1,
+    Hex = 2
+}

--- a/src/SportsData.Core/Dtos/Canonical/GetMatchupsByContestIdsRequest.cs
+++ b/src/SportsData.Core/Dtos/Canonical/GetMatchupsByContestIdsRequest.cs
@@ -1,0 +1,15 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Dtos.Canonical;
+
+/// <summary>
+/// Wire shape for POST /contests/matchups/by-ids. Carries the contest ids plus
+/// the requested mark direction so Producer's SQL can prefer the matching
+/// generated team-mark rows. Direction defaults to Roundel (the enum's zero
+/// value) for any caller that doesn't set it explicitly.
+/// </summary>
+public record GetMatchupsByContestIdsRequest(
+    Guid[] ContestIds,
+    MarkDirection Direction);

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
@@ -58,7 +58,7 @@ public interface IProvideContests : IProvideHealthChecks
     Task<Result<List<Matchup>>> GetMatchupsForCurrentWeek(CancellationToken ct = default);
     Task<Result<List<Matchup>>> GetMatchupsForSeasonWeek(int year, int week, CancellationToken ct = default);
     Task<Result<Matchup>> GetMatchupByContestId(Guid contestId, CancellationToken ct = default);
-    Task<Result<List<LeagueMatchupDto>>> GetMatchupsByContestIds(List<Guid> contestIds, CancellationToken ct = default);
+    Task<Result<List<LeagueMatchupDto>>> GetMatchupsByContestIds(List<Guid> contestIds, MarkDirection direction, CancellationToken ct = default);
     Task<Result<MatchupForPreviewDto>> GetMatchupForPreview(Guid contestId, CancellationToken ct = default);
     Task<Result<Dictionary<Guid, MatchupForPreviewDto>>> GetMatchupsForPreviewBatch(List<Guid> contestIds, CancellationToken ct = default);
     Task<Result<MatchupResult>> GetMatchupResult(Guid contestId, CancellationToken ct = default);
@@ -258,13 +258,14 @@ public class ContestClient : ClientBase, IProvideContests
             default!, "Matchup", ResultStatus.NotFound, ct);
     }
 
-    public async Task<Result<List<LeagueMatchupDto>>> GetMatchupsByContestIds(List<Guid> contestIds, CancellationToken ct = default)
+    public async Task<Result<List<LeagueMatchupDto>>> GetMatchupsByContestIds(List<Guid> contestIds, MarkDirection direction, CancellationToken ct = default)
     {
         if (contestIds is null || contestIds.Count == 0)
             return new Success<List<LeagueMatchupDto>>(new List<LeagueMatchupDto>());
 
-        var result = await PostOrDefaultAsync<List<LeagueMatchupDto>, Guid[]>(
-            "contests/matchups/by-ids", contestIds.ToArray(), new List<LeagueMatchupDto>(), ct);
+        var request = new GetMatchupsByContestIdsRequest(contestIds.ToArray(), direction);
+        var result = await PostOrDefaultAsync<List<LeagueMatchupDto>, GetMatchupsByContestIdsRequest>(
+            "contests/matchups/by-ids", request, new List<LeagueMatchupDto>(), ct);
         return new Success<List<LeagueMatchupDto>>(result);
     }
 

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -32,7 +32,7 @@ public interface IProvideFranchises : IProvideHealthChecks
     Task<List<FranchiseSeasonCompetitionResultDto>> GetFranchiseSeasonCompetitionResults(Guid franchiseSeasonId, CancellationToken cancellationToken = default);
     Task<List<ConferenceDivisionNameAndSlugDto>> GetConferenceNamesAndSlugs(int seasonYear, CancellationToken cancellationToken = default);
     Task<Dictionary<Guid, string>> GetConferenceIdsBySlugs(int seasonYear, List<string> slugs, CancellationToken cancellationToken = default);
-    Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, CancellationToken cancellationToken = default);
+    Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, MarkDirection direction, CancellationToken cancellationToken = default);
     Task<Result<TeamRosterDto>> GetTeamRoster(string slug, int seasonYear, CancellationToken cancellationToken = default);
     Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default);
     Task<Result<bool>> UpdateLogoDarkBg(Guid logoId, bool isForDarkBg, string logoType, CancellationToken cancellationToken = default);
@@ -226,10 +226,10 @@ public class FranchiseClient : ClientBase, IProvideFranchises
             cancellationToken);
     }
 
-    public async Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, CancellationToken cancellationToken = default)
+    public async Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, MarkDirection direction, CancellationToken cancellationToken = default)
     {
         return await GetOrDefaultAsync(
-            $"franchise-season-rankings/by-poll?poll={poll}&seasonYear={seasonYear}&weekNumber={weekNumber}",
+            $"franchise-season-rankings/by-poll?poll={poll}&seasonYear={seasonYear}&weekNumber={weekNumber}&direction={direction}",
             new RankingsByPollIdByWeekDto
             {
                 PollName = poll,

--- a/src/SportsData.Core/Infrastructure/Clients/Season/SeasonClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Season/SeasonClient.cs
@@ -22,7 +22,7 @@ public interface IProvideSeasons : IProvideHealthChecks
     Task<Result<List<CanonicalSeasonWeekDto>>> GetCurrentAndLastSeasonWeeks(CancellationToken ct = default);
     Task<Result<List<CanonicalSeasonWeekDto>>> GetCompletedSeasonWeeks(int seasonYear, CancellationToken ct = default);
     Task<Result<List<CanonicalSeasonWeekDto>>> GetSeasonWeeksOverlapping(DateTime from, DateTime to, CancellationToken ct = default);
-    Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, CancellationToken ct = default);
+    Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, MarkDirection direction, CancellationToken ct = default);
 }
 
 public class SeasonClient : ClientBase, IProvideSeasons
@@ -144,10 +144,10 @@ public class SeasonClient : ClientBase, IProvideSeasons
             ct);
     }
 
-    public async Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, CancellationToken ct = default)
+    public async Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, MarkDirection direction, CancellationToken ct = default)
     {
         return await GetOrDefaultAsync(
-            $"franchise-season-rankings/by-poll?poll={poll}&seasonYear={seasonYear}&weekNumber={weekNumber}",
+            $"franchise-season-rankings/by-poll?poll={poll}&seasonYear={seasonYear}&weekNumber={weekNumber}&direction={direction}",
             new RankingsByPollIdByWeekDto
             {
                 PollName = poll,

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -380,11 +380,15 @@ namespace SportsData.Producer.Application.Contests
 
         [HttpPost("matchups/by-ids")]
         public async Task<ActionResult<List<LeagueMatchupDto>>> GetMatchupsByContestIds(
-            [FromBody] Guid[] contestIds,
+            [FromBody] GetMatchupsByContestIdsRequest request,
             [FromServices] Queries.Matchups.GetMatchupsByContestIds.IGetMatchupsByContestIdsQueryHandler handler,
             CancellationToken cancellationToken = default)
         {
-            var result = await handler.ExecuteAsync(new Queries.Matchups.GetMatchupsByContestIds.GetMatchupsByContestIdsQuery(contestIds), cancellationToken);
+            var result = await handler.ExecuteAsync(
+                new Queries.Matchups.GetMatchupsByContestIds.GetMatchupsByContestIdsQuery(
+                    request.ContestIds,
+                    request.Direction),
+                cancellationToken);
             return result.ToActionResult();
         }
 

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQuery.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQuery.cs
@@ -1,5 +1,9 @@
 using System;
 
+using SportsData.Core.Common;
+
 namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsByContestIds;
 
-public record GetMatchupsByContestIdsQuery(Guid[] ContestIds);
+public record GetMatchupsByContestIdsQuery(
+    Guid[] ContestIds,
+    MarkDirection Direction);

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
@@ -51,9 +51,17 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
 
         var sql = _sqlProvider.GetMatchupsByContestIds();
 
+        // Direction is the lowercase enum name ("roundel" / "shield" / "hex")
+        // so it matches the Rel-tag convention used by the marks batch script.
+        // The SQL's CASE-based ORDER BY checks Rel @> ARRAY['sportdeets-mark', @Direction].
+        var directionTag = query.Direction.ToString().ToLowerInvariant();
+
         var connection = _dbContext.Database.GetDbConnection();
         var matchups = (await connection.QueryAsync<LeagueMatchupDto>(
-            new CommandDefinition(sql, new { ContestIds = query.ContestIds }, cancellationToken: cancellationToken)))
+            new CommandDefinition(
+                sql,
+                new { ContestIds = query.ContestIds, Direction = directionTag },
+                cancellationToken: cancellationToken)))
             .ToList();
 
         var streamTimes = await GetActiveStreamTimesAsync(query.ContestIds, cancellationToken);

--- a/src/SportsData.Producer/Application/FranchiseSeasonRankings/FranchiseSeasonRankingController.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasonRankings/FranchiseSeasonRankingController.cs
@@ -28,10 +28,11 @@ namespace SportsData.Producer.Application.FranchiseSeasonRankings
             [FromQuery] string poll,
             [FromQuery] int seasonYear,
             [FromQuery] int weekNumber,
+            [FromQuery] MarkDirection direction,
             [FromServices] IGetRankingsByPollByWeekQueryHandler handler,
             CancellationToken cancellationToken = default)
         {
-            var query = new GetRankingsByPollByWeekQuery(poll, seasonYear, weekNumber);
+            var query = new GetRankingsByPollByWeekQuery(poll, seasonYear, weekNumber, direction);
             var result = await handler.ExecuteAsync(query, cancellationToken);
             return result.ToActionResult();
         }

--- a/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetRankingsByPollByWeek/GetRankingsByPollByWeekQuery.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetRankingsByPollByWeek/GetRankingsByPollByWeekQuery.cs
@@ -1,3 +1,5 @@
+using SportsData.Core.Common;
+
 namespace SportsData.Producer.Application.FranchiseSeasonRankings.Queries.GetRankingsByPollByWeek;
 
-public record GetRankingsByPollByWeekQuery(string PollType, int SeasonYear, int WeekNumber);
+public record GetRankingsByPollByWeekQuery(string PollType, int SeasonYear, int WeekNumber, MarkDirection Direction);

--- a/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetRankingsByPollByWeek/GetRankingsByPollByWeekQueryHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetRankingsByPollByWeek/GetRankingsByPollByWeekQueryHandler.cs
@@ -40,10 +40,14 @@ public class GetRankingsByPollByWeekQueryHandler : IGetRankingsByPollByWeekQuery
         var sql = _sqlProvider.GetRankingsByPollByWeek();
         var connection = _dbContext.Database.GetDbConnection();
 
+        // Direction is the lowercase enum name ("roundel" / "shield" / "hex")
+        // matching the Rel-tag convention used by the marks batch script.
+        var directionTag = query.Direction.ToString().ToLowerInvariant();
+
         var entries = (await connection.QueryAsync<RankingsByPollIdByWeekDto.RankingsByPollIdByWeekEntryDto>(
             new CommandDefinition(
                 sql,
-                new { query.PollType, query.WeekNumber, query.SeasonYear },
+                new { query.PollType, query.WeekNumber, query.SeasonYear, Direction = directionTag },
                 cancellationToken: cancellationToken))).ToList();
 
         if (entries.Count == 0)

--- a/src/SportsData.Producer/Application/Services/LogoSelectionService.cs
+++ b/src/SportsData.Producer/Application/Services/LogoSelectionService.cs
@@ -1,9 +1,17 @@
+using SportsData.Core.Common;
 using SportsData.Producer.Infrastructure.Data.Entities.Contracts;
 
 namespace SportsData.Producer.Application.Services;
 
 /// <summary>
 /// Service for intelligently selecting logos optimized for different display contexts.
+///
+/// As of the team-mark rollout (2026-06), the selection cascade prefers sportDeets-generated
+/// marks (Rel = "sportdeets-mark") over ESPN-sourced rows when present. The optional
+/// <see cref="MarkDirection"/> parameter on each selection method picks the matching
+/// direction (Roundel / Shield / Hex) when multiple sportdeets-mark rows exist for a team.
+/// Direction defaults to <see cref="MarkDirection.Roundel"/> until the user-preference UI ships;
+/// see docs/team-mark-user-preference-design.md for the larger plan.
 /// </summary>
 public interface ILogoSelectionService
 {
@@ -11,24 +19,24 @@ public interface ILogoSelectionService
     /// Selects the best logo for display on a dark background by prioritizing manually curated logos,
     /// then falling back to Rel-based heuristics and avoiding white background variants.
     /// </summary>
-    Uri? SelectLogoForDarkBackground(IEnumerable<ILogo>? logos);
+    Uri? SelectLogoForDarkBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel);
 
     /// <summary>
     /// Selects the best logo for display on a light/default background by prioritizing manually curated logos,
     /// then falling back to Rel-based heuristics and preferring white background variants.
     /// </summary>
-    Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos);
+    Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel);
 
     /// <summary>
     /// Selects the best logo with fallback from season logos to franchise logos.
     /// Uses dark background selection by default.
     /// </summary>
-    Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos);
+    Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, MarkDirection direction = MarkDirection.Roundel);
 
     /// <summary>
     /// Selects the best logo with fallback, for the specified background type.
     /// </summary>
-    Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground);
+    Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground, MarkDirection direction = MarkDirection.Roundel);
 }
 
 /// <summary>
@@ -37,7 +45,34 @@ public interface ILogoSelectionService
 /// </summary>
 public class LogoSelectionService : ILogoSelectionService
 {
-    public Uri? SelectLogoForDarkBackground(IEnumerable<ILogo>? logos)
+    // Rel-tag constants for sportDeets-generated marks. The marks batch script
+    // writes rows with Rel = ["sportdeets-mark", "{direction}"]; see
+    // src/marks/batch/upload.js and the team-mark design docs.
+    private const string SportdeetsMarkRel = "sportdeets-mark";
+
+    private static string DirectionRel(MarkDirection direction) =>
+        direction.ToString().ToLowerInvariant();
+
+    /// <summary>
+    /// Picks a sportdeets-mark row. Prefers the row tagged with the requested
+    /// direction; falls back to any sportdeets-mark row if the requested
+    /// direction hasn't been generated for that team yet. Returns null when
+    /// no sportdeets-mark rows exist — caller falls through to ESPN cascade.
+    /// </summary>
+    private static Uri? SelectSportdeetsMark(IReadOnlyList<ILogo> logos, MarkDirection direction)
+    {
+        var dirTag = DirectionRel(direction);
+        var preferred = logos.FirstOrDefault(l =>
+            l.Rel != null && l.Rel.Contains(SportdeetsMarkRel) && l.Rel.Contains(dirTag));
+        if (preferred != null)
+            return preferred.Uri;
+
+        var anyMark = logos.FirstOrDefault(l =>
+            l.Rel != null && l.Rel.Contains(SportdeetsMarkRel));
+        return anyMark?.Uri;
+    }
+
+    public Uri? SelectLogoForDarkBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel)
     {
         if (logos == null)
             return null;
@@ -45,6 +80,14 @@ public class LogoSelectionService : ILogoSelectionService
         var logoList = logos.ToList();
         if (logoList.Count == 0)
             return null;
+
+        // Priority -1: sportdeets-generated mark for the requested direction
+        // (or any sportdeets mark as fallback). When present, this wins over
+        // all ESPN-sourced rows below. The marks are theme-agnostic, so the
+        // same selection serves dark and light contexts.
+        var sportdeetsMark = SelectSportdeetsMark(logoList, direction);
+        if (sportdeetsMark != null)
+            return sportdeetsMark;
 
         // Priority 0: Manually curated logos marked as safe for dark backgrounds
         var curatedDarkLogo = logoList.FirstOrDefault(l => l.IsForDarkBg == true);
@@ -85,7 +128,7 @@ public class LogoSelectionService : ILogoSelectionService
         return logoList.FirstOrDefault()?.Uri;
     }
 
-    public Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos)
+    public Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel)
     {
         if (logos == null)
             return null;
@@ -93,6 +136,13 @@ public class LogoSelectionService : ILogoSelectionService
         var logoList = logos.ToList();
         if (logoList.Count == 0)
             return null;
+
+        // Priority -1: sportdeets-generated mark (see SelectLogoForDarkBackground
+        // for the rationale; the same Rel selection wins here because the
+        // marks are theme-agnostic).
+        var sportdeetsMark = SelectSportdeetsMark(logoList, direction);
+        if (sportdeetsMark != null)
+            return sportdeetsMark;
 
         // Priority 0: Manually curated — IsForDarkBg == false means curated for light
         var curatedLightLogo = logoList.FirstOrDefault(l => l.IsForDarkBg == false);
@@ -127,15 +177,15 @@ public class LogoSelectionService : ILogoSelectionService
         return logoList.FirstOrDefault()?.Uri;
     }
 
-    public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos)
-        => SelectWithFallback(seasonLogos, franchiseLogos, darkBackground: true);
+    public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, MarkDirection direction = MarkDirection.Roundel)
+        => SelectWithFallback(seasonLogos, franchiseLogos, darkBackground: true, direction);
 
-    public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground)
+    public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground, MarkDirection direction = MarkDirection.Roundel)
     {
         var selector = darkBackground
-            ? (Func<IEnumerable<ILogo>?, Uri?>)SelectLogoForDarkBackground
+            ? (Func<IEnumerable<ILogo>?, MarkDirection, Uri?>)SelectLogoForDarkBackground
             : SelectLogoForLightBackground;
 
-        return selector(seasonLogos) ?? selector(franchiseLogos);
+        return selector(seasonLogos, direction) ?? selector(franchiseLogos, direction);
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -49,29 +49,76 @@ LEFT JOIN LATERAL (
 LEFT JOIN public."CompetitionTeamOdds" cto ON cto."CompetitionOddsId" = co."Id" AND cto."Side" = 'Home'
 INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
 INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
+-- Logo selection order (applies to all eight lateral subqueries below):
+--   1. sportdeets-mark row tagged with the requested direction (@Direction)
+--   2. any sportdeets-mark row (fallback when requested direction not yet
+--      generated for this team — e.g. shields not backfilled)
+--   3. anything else (preserves ESPN-sourced behavior for unbackfilled teams)
+-- Tie-breaker stays CreatedUtc ASC to match prior behavior on ties.
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
   WHERE fl."FranchiseId" = fAway."Id"
-  ORDER BY fl."CreatedUtc" ASC LIMIT 1
+  ORDER BY
+    CASE
+      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
+      ELSE                                                               2
+    END,
+    fl."CreatedUtc" ASC
+  LIMIT 1
 ) flAway ON TRUE
 -- FranchiseSeason-level logo is preferred; Franchise-level acts as fallback
 -- (matches LogoSelectionService.SelectWithFallback convention: season -> franchise).
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
   WHERE fsl."FranchiseSeasonId" = fsAway."Id"
-  ORDER BY fsl."CreatedUtc" ASC LIMIT 1
+  ORDER BY
+    CASE
+      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
+      ELSE                                                                2
+    END,
+    fsl."CreatedUtc" ASC
+  LIMIT 1
 ) fslAway ON TRUE
 -- Dark-bg variants for theme-aware UI rendering. Same season -> franchise
--- fallback as the default lateral above, but filtered to IsForDarkBg = true.
+-- fallback as the default lateral above. Note sportdeets-marks are
+-- theme-agnostic (single render serves both backgrounds), so a team with
+-- sportdeets-mark rows will surface the same Uri here as in the light lateral
+-- above — that is the intended behavior until/unless dedicated dark variants
+-- are generated. The IsForDarkBg = TRUE filter only matters for ESPN-sourced
+-- rows in the ELSE branch.
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
-  WHERE fl."FranchiseId" = fAway."Id" AND fl."IsForDarkBg" = TRUE
-  ORDER BY fl."CreatedUtc" ASC LIMIT 1
+  WHERE fl."FranchiseId" = fAway."Id"
+    AND (
+      fl."Rel" @> ARRAY['sportdeets-mark']::text[]
+      OR fl."IsForDarkBg" = TRUE
+    )
+  ORDER BY
+    CASE
+      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
+      ELSE                                                               2
+    END,
+    fl."CreatedUtc" ASC
+  LIMIT 1
 ) flDarkAway ON TRUE
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
-  WHERE fsl."FranchiseSeasonId" = fsAway."Id" AND fsl."IsForDarkBg" = TRUE
-  ORDER BY fsl."CreatedUtc" ASC LIMIT 1
+  WHERE fsl."FranchiseSeasonId" = fsAway."Id"
+    AND (
+      fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
+      OR fsl."IsForDarkBg" = TRUE
+    )
+  ORDER BY
+    CASE
+      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
+      ELSE                                                                2
+    END,
+    fsl."CreatedUtc" ASC
+  LIMIT 1
 ) fslDarkAway ON TRUE
 INNER JOIN public."GroupSeason" gsAway ON gsAway."Id" = fsAway."GroupSeasonId"
 LEFT JOIN LATERAL (
@@ -88,24 +135,60 @@ INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
   WHERE fl."FranchiseId" = fHome."Id"
-  ORDER BY fl."CreatedUtc" ASC LIMIT 1
+  ORDER BY
+    CASE
+      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
+      ELSE                                                               2
+    END,
+    fl."CreatedUtc" ASC
+  LIMIT 1
 ) flHome ON TRUE
 -- FranchiseSeason-level preferred, Franchise fallback — see Away comment above.
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
   WHERE fsl."FranchiseSeasonId" = fsHome."Id"
-  ORDER BY fsl."CreatedUtc" ASC LIMIT 1
+  ORDER BY
+    CASE
+      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
+      ELSE                                                                2
+    END,
+    fsl."CreatedUtc" ASC
+  LIMIT 1
 ) fslHome ON TRUE
 -- Dark-bg variants — see Away comment above.
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
-  WHERE fl."FranchiseId" = fHome."Id" AND fl."IsForDarkBg" = TRUE
-  ORDER BY fl."CreatedUtc" ASC LIMIT 1
+  WHERE fl."FranchiseId" = fHome."Id"
+    AND (
+      fl."Rel" @> ARRAY['sportdeets-mark']::text[]
+      OR fl."IsForDarkBg" = TRUE
+    )
+  ORDER BY
+    CASE
+      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
+      ELSE                                                               2
+    END,
+    fl."CreatedUtc" ASC
+  LIMIT 1
 ) flDarkHome ON TRUE
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
-  WHERE fsl."FranchiseSeasonId" = fsHome."Id" AND fsl."IsForDarkBg" = TRUE
-  ORDER BY fsl."CreatedUtc" ASC LIMIT 1
+  WHERE fsl."FranchiseSeasonId" = fsHome."Id"
+    AND (
+      fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
+      OR fsl."IsForDarkBg" = TRUE
+    )
+  ORDER BY
+    CASE
+      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
+      ELSE                                                                2
+    END,
+    fsl."CreatedUtc" ASC
+  LIMIT 1
 ) fslDarkHome ON TRUE
 INNER JOIN public."GroupSeason" gsHome ON gsHome."Id" = fsHome."GroupSeasonId"
 LEFT JOIN LATERAL (

--- a/src/SportsData.Producer/Infrastructure/Sql/GetRankingsByPollByWeek.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetRankingsByPollByWeek.sql
@@ -14,11 +14,20 @@ SELECT
 FROM public."FranchiseSeasonRankingDetail" fsrd
 INNER JOIN public."FranchiseSeasonRanking" fsr on fsr."Id" = fsrd."FranchiseSeasonRankingId"
 INNER JOIN public."FranchiseSeason" fs on fs."Id" = fsr."FranchiseSeasonId"
+-- Logo selection: prefer sportdeets-mark + requested direction, then any
+-- sportdeets-mark, then anything else. Matches the pattern in
+-- GetMatchupsByContestIds.sql and LogoSelectionService.
 LEFT JOIN LATERAL (
   SELECT fsl."Uri"
   FROM public."FranchiseSeasonLogo" fsl
   WHERE fsl."FranchiseSeasonId" = fs."Id"
-  ORDER BY fsl."Uri"
+  ORDER BY
+    CASE
+      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
+      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
+      ELSE                                                                2
+    END,
+    fsl."Uri"
   LIMIT 1
 ) as fsl on true
 INNER JOIN public."SeasonWeek" sw on sw."Id" = fsr."SeasonWeekId"

--- a/src/marks/app.js
+++ b/src/marks/app.js
@@ -1,0 +1,247 @@
+/* sportDeets mark exploration — team dataset + page rendering (vanilla JS) */
+(function () {
+  'use strict';
+
+  // Curated stress-test set. Weighted toward real two-color teams (the vast
+  // majority: all pro leagues + FBS/FCS). One NULL-secondary case is flagged as
+  // the rare D2/D3 fallback.
+  var TEAMS = [
+    // NFL
+    { abbr: 'DAL', name: 'Dallas Cowboys', sport: 'NFL', primary: '#003594', secondary: '#B0B7BC' },
+    { abbr: 'PIT', name: 'Pittsburgh Steelers', sport: 'NFL', primary: '#000000', secondary: '#FFB612' },
+    { abbr: 'CLE', name: 'Cleveland Browns', sport: 'NFL', primary: '#311D00', secondary: '#FF3C00' },
+    { abbr: 'LV', name: 'Las Vegas Raiders', sport: 'NFL', primary: '#000000', secondary: '#A5ACAF' },
+    { abbr: 'MIA', name: 'Miami Dolphins', sport: 'NFL', primary: '#008E97', secondary: '#FC4C02' },
+    { abbr: 'KC', name: 'Kansas City Chiefs', sport: 'NFL', primary: '#E31837', secondary: '#FFB81C' },
+    { abbr: 'ARI', name: 'Arizona Cardinals', sport: 'NFL', primary: '#97233F', secondary: '#000000' },
+    { abbr: 'SF', name: 'San Francisco 49ers', sport: 'NFL', primary: '#AA0000', secondary: '#B3995D' },
+    // MLB
+    { abbr: 'NYY', name: 'New York Yankees', sport: 'MLB', primary: '#003087', secondary: '#FFFFFF' },
+    { abbr: 'LAD', name: 'Los Angeles Dodgers', sport: 'MLB', primary: '#005A9C', secondary: '#FFFFFF' },
+    { abbr: 'SD', name: 'San Diego Padres', sport: 'MLB', primary: '#2F241D', secondary: '#FFC425' },
+    { abbr: 'BOS', name: 'Boston Red Sox', sport: 'MLB', primary: '#BD3039', secondary: '#0C2340' },
+    // NBA
+    { abbr: 'BOS', name: 'Boston Celtics', sport: 'NBA', primary: '#007A33', secondary: '#BA9653' },
+    { abbr: 'LAL', name: 'Los Angeles Lakers', sport: 'NBA', primary: '#552583', secondary: '#FDB927' },
+    { abbr: 'BKN', name: 'Brooklyn Nets', sport: 'NBA', primary: '#000000', secondary: '#FFFFFF' },
+    // NCAA
+    { abbr: 'ALA', name: 'Alabama Crimson Tide', sport: 'NCAA', primary: '#9E1B32', secondary: '#FFFFFF' },
+    { abbr: 'MICH', name: 'Michigan Wolverines', sport: 'NCAA', primary: '#00274C', secondary: '#FFCB05' },
+    { abbr: 'ORE', name: 'Oregon Ducks', sport: 'NCAA', primary: '#154733', secondary: '#FEE123' },
+    { abbr: 'ALST', name: 'Alabama State Hornets', sport: 'NCAA', primary: '#E9A900', secondary: '#0A0A0A' },
+    { abbr: 'LSU', name: 'LSU Tigers', sport: 'NCAA', primary: '#461D76', secondary: '#FDD023' },
+    { abbr: 'TENN', name: 'Tennessee Volunteers', sport: 'NCAA', primary: '#FF8200', secondary: '#FFFFFF' },
+    { abbr: 'TEX', name: 'Texas Longhorns', sport: 'NCAA', primary: '#AF5C37', secondary: '#FFFFFF' },
+    { abbr: 'MISS', name: 'Ole Miss Rebels', sport: 'NCAA', primary: '#13294B', secondary: '#CF142B' },
+    { abbr: 'ADA', name: 'Adams State Grizzlies', sport: 'NCAA', primary: '#000000', secondary: null }
+  ];
+
+  // Hero row for each direction: spread across sports + tough cases.
+  var HERO = ['DAL|NFL', 'MIA|NFL', 'PIT|NFL', 'NYY|MLB', 'SD|MLB', 'LAL|NBA', 'BKN|NBA', 'MICH|NCAA', 'LSU|NCAA', 'TENN|NCAA', 'TEX|NCAA', 'MISS|NCAA'];
+  // Similar-red stress row — the headline differentiation test.
+  var REDS = ['KC|NFL', 'ARI|NFL', 'SF|NFL', 'BOS|MLB', 'ALA|NCAA'];
+  // Mono / near-black / near-white stress row.
+  var EDGE = ['PIT|NFL', 'LV|NFL', 'BKN|NBA', 'NYY|MLB', 'ADA|NCAA'];
+
+  function find(key) {
+    var parts = key.split('|');
+    return TEAMS.filter(function (t) { return t.abbr === parts[0] && t.sport === parts[1]; })[0];
+  }
+
+  function el(tag, cls, html) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (html != null) n.innerHTML = html;
+    return n;
+  }
+
+  // A single mark rendered on both a light and a dark tile, with caption.
+  function markCell(dirId, team, size, opt) {
+    opt = opt || {};
+    var cell = el('div', 'cell');
+    var tiles = el('div', 'tiles');
+    var light = el('div', 'tile tile-light');
+    var dark = el('div', 'tile tile-dark');
+    light.innerHTML = SDMarks.render(dirId, team, { size: size, theme: 'light' });
+    dark.innerHTML = SDMarks.render(dirId, team, { size: size, theme: 'dark' });
+    tiles.appendChild(light); tiles.appendChild(dark);
+    cell.appendChild(tiles);
+    if (!opt.noCaption) {
+      var cap = el('div', 'cap');
+      cap.innerHTML = '<span class="cap-abbr">' + team.abbr + '</span>' +
+        '<span class="cap-sport">' + team.sport + '</span>';
+      cell.appendChild(cap);
+    }
+    return cell;
+  }
+
+  function row(dirId, keys, size, opt) {
+    var r = el('div', 'mark-row');
+    keys.forEach(function (k) {
+      var t = find(k); if (t) r.appendChild(markCell(dirId, t, size, opt));
+    });
+    return r;
+  }
+
+  /* ---------- build direction sections ---------------------------------- */
+  function buildDirections() {
+    var host = document.getElementById('directions');
+    SDMarks.directions.forEach(function (d, i) {
+      var sec = el('section', 'direction');
+      sec.id = 'dir-' + d.id;
+      sec.setAttribute('data-screen-label', 'Direction ' + String.fromCharCode(65 + i) + ' · ' + d.name);
+
+      // header
+      var head = el('div', 'dir-head');
+      head.innerHTML =
+        '<div class="dir-index">' + String.fromCharCode(65 + i) + '</div>' +
+        '<div class="dir-headtext">' +
+        '<h2>' + d.name + '</h2>' +
+        '<div class="dir-tag">' + d.tag + '</div>' +
+        '</div>';
+      sec.appendChild(head);
+
+      var concept = el('p', 'concept', d.concept);
+      sec.appendChild(concept);
+
+      // hero renders
+      var heroLabel = el('div', 'sub-label', 'Across sports &amp; palettes — light / dark tiles, 72px');
+      sec.appendChild(heroLabel);
+      sec.appendChild(row(d.id, HERO, 72));
+
+      // grid: reds + edges + meta
+      var grid = el('div', 'dir-grid');
+
+      var stress = el('div', 'stress');
+      stress.appendChild(el('div', 'sub-label', 'Similar-palette test — five &ldquo;reds&rdquo; must stay distinct'));
+      stress.appendChild(row(d.id, REDS, 56));
+      stress.appendChild(el('div', 'sub-label', 'Mono / near-black / near-white — must not melt into either tile'));
+      stress.appendChild(row(d.id, EDGE, 56));
+      // size ramp
+      stress.appendChild(el('div', 'sub-label', 'Size ramp — 24 · 32 · 48 · 96 · 128px (dark tile)'));
+      var ramp = el('div', 'ramp');
+      [24, 32, 48, 96, 128].forEach(function (s) {
+        var w = el('div', 'ramp-item');
+        w.innerHTML = SDMarks.render(d.id, find('LAD|MLB'), { size: s, theme: 'dark' }) +
+          '<span class="ramp-px">' + s + '</span>';
+        ramp.appendChild(w);
+      });
+      stress.appendChild(ramp);
+      grid.appendChild(stress);
+
+      // meta panel: pros / cons / multisport
+      var meta = el('div', 'meta');
+      meta.innerHTML =
+        '<div class="meta-block"><div class="meta-h pro">Pros</div><ul>' +
+        d.pros.map(function (x) { return '<li>' + x + '</li>'; }).join('') + '</ul></div>' +
+        '<div class="meta-block"><div class="meta-h con">Cons</div><ul>' +
+        d.cons.map(function (x) { return '<li>' + x + '</li>'; }).join('') + '</ul></div>' +
+        '<div class="meta-block"><div class="meta-h ms">Multi-sport</div><p>' + d.multisport + '</p></div>';
+      grid.appendChild(meta);
+
+      sec.appendChild(grid);
+      host.appendChild(sec);
+    });
+  }
+
+  /* ---------- playground ------------------------------------------------- */
+  var pg = { primary: '#005A9C', secondary: '#FFFFFF', abbr: 'LAD', sport: 'MLB', size: 88, noSec: false };
+
+  function buildPlayground() {
+    var presetSel = document.getElementById('pg-preset');
+    TEAMS.forEach(function (t, i) {
+      var o = el('option'); o.value = i; o.textContent = t.name + '  (' + t.sport + ')';
+      presetSel.appendChild(o);
+    });
+    presetSel.value = '9'; // Dodgers
+
+    function bind(id, fn) { document.getElementById(id).addEventListener('input', fn); }
+
+    presetSel.addEventListener('change', function () {
+      var t = TEAMS[+presetSel.value];
+      if (!t) return;
+      pg.primary = t.primary;
+      pg.secondary = t.secondary || '#FFFFFF';
+      pg.noSec = !t.secondary;
+      pg.abbr = t.abbr; pg.sport = t.sport;
+      syncControls(); renderPlayground();
+    });
+    bind('pg-primary', function (e) { pg.primary = e.target.value; document.getElementById('pg-preset').value = ''; renderPlayground(); });
+    bind('pg-secondary', function (e) { pg.secondary = e.target.value; document.getElementById('pg-preset').value = ''; renderPlayground(); });
+    bind('pg-abbr', function (e) { pg.abbr = e.target.value.toUpperCase().slice(0, 4); document.getElementById('pg-preset').value = ''; renderPlayground(); });
+    bind('pg-size', function (e) { pg.size = +e.target.value; document.getElementById('pg-size-val').textContent = pg.size + 'px'; renderPlayground(); });
+    document.getElementById('pg-sport').addEventListener('change', function (e) { pg.sport = e.target.value; document.getElementById('pg-preset').value = ''; renderPlayground(); });
+    document.getElementById('pg-nosec').addEventListener('change', function (e) { pg.noSec = e.target.checked; renderPlayground(); });
+
+    syncControls();
+    renderPlayground();
+  }
+
+  function syncControls() {
+    document.getElementById('pg-primary').value = pg.primary;
+    document.getElementById('pg-secondary').value = pg.secondary;
+    document.getElementById('pg-abbr').value = pg.abbr;
+    document.getElementById('pg-sport').value = pg.sport;
+    document.getElementById('pg-size').value = pg.size;
+    document.getElementById('pg-size-val').textContent = pg.size + 'px';
+    document.getElementById('pg-nosec').checked = pg.noSec;
+  }
+
+  function renderPlayground() {
+    var team = { abbr: pg.abbr || '--', name: 'Custom', sport: pg.sport, primary: pg.primary, secondary: pg.noSec ? null : pg.secondary };
+    var host = document.getElementById('pg-output');
+    host.innerHTML = '';
+    SDMarks.directions.forEach(function (d) {
+      var card = el('div', 'pg-card');
+      card.innerHTML = '<div class="pg-card-name">' + d.name + '</div>';
+      var tiles = el('div', 'tiles');
+      var light = el('div', 'tile tile-light');
+      var dark = el('div', 'tile tile-dark');
+      light.innerHTML = SDMarks.render(d.id, team, { size: pg.size, theme: 'light' });
+      dark.innerHTML = SDMarks.render(d.id, team, { size: pg.size, theme: 'dark' });
+      tiles.appendChild(light); tiles.appendChild(dark);
+      card.appendChild(tiles);
+      host.appendChild(card);
+    });
+    // palette readout
+    var p = SDMarks.resolvePalette(pg.primary, pg.noSec ? null : pg.secondary);
+    document.getElementById('pg-readout').innerHTML =
+      swatch('base', p.baseHex) + swatch('accent', p.accentHex + (p.secProvided ? '' : ' (derived)')) +
+      swatch('ink', p.inkHex);
+  }
+  function swatch(role, hex) {
+    var color = hex.split(' ')[0];
+    return '<div class="sw"><span class="sw-chip" style="background:' + color + '"></span>' +
+      '<span class="sw-role">' + role + '</span><span class="sw-hex">' + hex + '</span></div>';
+  }
+
+  /* ---------- in-context preview (matchup card mock) -------------------- */
+  function buildContext() {
+    var host = document.getElementById('context-rows');
+    if (!host) return;
+    var matchups = [
+      ['NYY|MLB', 'LAD|MLB'], ['ALA|NCAA', 'MICH|NCAA'], ['KC|NFL', 'SF|NFL'], ['LAL|NBA', 'BKN|NBA']
+    ];
+    SDMarks.directions.forEach(function (d) {
+      var col = el('div', 'ctx-col');
+      col.appendChild(el('div', 'ctx-col-name', d.name));
+      matchups.forEach(function (m) {
+        var a = find(m[0]), b = find(m[1]);
+        var card = el('div', 'ctx-card');
+        card.innerHTML =
+          '<div class="ctx-team"><div class="ctx-mk">' + SDMarks.render(d.id, a, { size: 48, theme: 'dark' }) + '</div>' +
+          '<div class="ctx-name">' + a.name + '</div></div>' +
+          '<div class="ctx-team"><div class="ctx-mk">' + SDMarks.render(d.id, b, { size: 48, theme: 'dark' }) + '</div>' +
+          '<div class="ctx-name">' + b.name + '</div></div>';
+        col.appendChild(card);
+      });
+      host.appendChild(col);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    buildDirections();
+    buildContext();
+    buildPlayground();
+  });
+})();

--- a/src/marks/batch-generation-plan.md
+++ b/src/marks/batch-generation-plan.md
@@ -411,7 +411,17 @@ Dependencies:
   the dev environment's franchise list, which is smaller but
   validates the pipeline)
 - Azure Blob connection string for the test environment, placed
-  in `src/marks/batch/.env` (NEVER commit)
+  in `src/marks/batch/.env` (NEVER commit) — or sourced via
+  `run.ps1` from your canonical secrets file (see below)
+- `SPORTDEETS_SECRETS_PATH` environment variable pointing at your
+  local canonical secrets `.ps1` file (the path stays out of the
+  repo; `run.ps1` reads it at runtime). Set once per machine:
+  ```powershell
+  [Environment]::SetEnvironmentVariable(
+    'SPORTDEETS_SECRETS_PATH',
+    'C:\path\to\_common-variables.ps1',
+    'User')
+  ```
 - Confirmation on the recommendations in the Decisions section
   (PNG, 512px, new rows tagged `sportdeets-mark`, single container,
   skip light/dark variants, run against local first)

--- a/src/marks/batch-generation-plan.md
+++ b/src/marks/batch-generation-plan.md
@@ -1,0 +1,442 @@
+# Team mark batch generation — execution plan
+
+Companion to `marks.js` (the engine) and `app.js` (the demo harness).
+This doc covers how we turn the engine into batch-generated team
+marks stored in Azure Blob and indexed in `FranchiseLogo` /
+`FranchiseSeasonLogo`. Background and the why-not-real-logos context
+live in `docs/team-mark-design-brief.md`.
+
+## Context
+
+We cannot ship real team logos to the app stores (licensing is
+cost-prohibitive and unlicensed marks will be flagged in review).
+Claude Design produced `marks.js` — a deterministic, pure-string
+SVG generator that takes (primary color, secondary color,
+abbreviation, sport) and emits a complete SVG. Selected direction:
+**Roundel** (monogram-on-primary, accent ring, theme-agnostic body).
+
+The end state we want:
+
+- Every active `Franchise` and `FranchiseSeason` row has a
+  generated-mark PNG stored in Azure Blob.
+- That PNG is registered in `FranchiseLogo` / `FranchiseSeasonLogo`
+  as a new row, tagged `Rel: ["sportdeets-mark", "default"]`.
+- A one-line change in the C# logo-selection code prefers
+  `sportdeets-mark` over ESPN-sourced rows.
+- Existing ESPN-sourced logo rows stay in place as a revert path
+  until we confirm the new marks render correctly app-wide.
+
+## What we have to work with
+
+### `marks.js` (in this folder)
+
+Renderers are pure string concatenation — no DOM dependency in the
+renderer functions themselves. Only the IIFE's `window` global
+attachment is browser-coupled. Trivially shimmed for Node.
+
+Public API:
+- `SDMarks.render('roundel' | 'shield' | 'hex' | ...,team, opt)` returns an SVG string
+- `SDMarks.directions` — registry of available directions
+- `SDMarks.resolvePalette(primary, secondary)` — color math, used internally
+
+For batch generation we only call `render('roundel', team, { size: 512, theme: 'light' })`.
+
+### Schema (verified against entity classes 2026-06-05)
+
+`Franchise` (`SportsData.Producer/Infrastructure/Data/Entities/Franchise.cs`):
+- `Id` (Guid), `Sport` (enum), `Abbreviation` (nullable, 10 chars)
+- `DisplayName`, `DisplayNameShort`
+- `ColorCodeHex` (required, 7 chars — e.g. `#FFFFFF`)
+- `ColorCodeAltHex` (nullable, 7 chars)
+- `IsActive` (bool)
+- `Logos` — `ICollection<FranchiseLogo>`
+
+`FranchiseSeason` (same folder):
+- `Id` (Guid), `FranchiseId` (Guid), `SeasonYear` (int)
+- `Abbreviation` (required, 20 chars)
+- `DisplayName`, `DisplayNameShort`
+- `ColorCodeHex` (required, 7 chars), `ColorCodeAltHex` (nullable, 7 chars)
+- `IsActive` (bool)
+- `Logos` — `ICollection<FranchiseSeasonLogo>`
+
+`FranchiseLogo` / `FranchiseSeasonLogo` (both implement `ILogo`):
+- `Id` (Guid), `FranchiseId` / `FranchiseSeasonId` (Guid)
+- `Uri` (required, 256 chars)
+- `OriginalUrlHash` (required, 64 chars, indexed — SHA-256 of source URL historically)
+- `Width`, `Height` (long, nullable)
+- `Rel` — `List<string>` (e.g. `["default"]`, `["scoreboard"]`)
+- `IsForDarkBg` (bool, nullable)
+
+### Blob pipeline (`SportsData.Core/Infrastructure/Blobs/BlobStorageProvider.cs`)
+
+- `UploadImageAsync(stream, containerName, filename)` returns Uri,
+  retries (exponential, 5 attempts), creates container if missing
+  with `PublicAccessType.BlobContainer`.
+- ContentType is **hardcoded to `image/png`** in the provider. PNG
+  output is the path of least resistance.
+- Connection string read from `CommonConfig.AzureBlobStorageConnectionString`.
+- Container naming convention from `DocumentController.cs:282-284`:
+  `{doc-type-kebab}-{sport-kebab}` or `{doc-type-kebab}-{sport-kebab}-{seasonYear}`.
+
+## Approach: standalone Node batch script
+
+Why Node and not a C# port:
+
+1. **`marks.js` stays the source of truth.** Porting to C# creates
+   a maintenance fork — every Claude Design iteration would require
+   parallel C# rewrites.
+2. **No code change in Producer / Provider / API.** Generated marks
+   slot into existing `FranchiseLogo` / `FranchiseSeasonLogo` rows
+   via the existing data model. Only logo *selection* (which Rel
+   wins) needs to change, and that's a one-liner.
+3. **One-time per team / season.** New franchises are rare;
+   new seasons are annual. Not a real-time concern that needs
+   in-process integration.
+4. **Easy to rerun** when Claude Design ships a refined Roundel —
+   no service restart, no migration.
+
+Why not run from C#:
+
+- Means embedding a JS engine (Jint, ClearScript) just for SVG
+  string output. Possible but adds runtime dependencies for a
+  problem Node solves natively.
+
+## Decisions
+
+Decisions made with rationale. Each lists what was considered and
+why we picked what we picked.
+
+### Output format → PNG
+
+Considered SVG (smallest, scales perfectly) and PNG.
+
+Picked **PNG** because:
+- True drop-in for existing ESPN PNG URLs throughout the stack.
+- Existing `BlobStorageProvider` hardcodes `image/png` content type.
+- Mobile (React Native) and web (React) both render PNG out of the
+  box. SVG would require `react-native-svg` integration plus a
+  separate web image component swap — out of scope here.
+- SVG can be added later as an enhancement if PNG fidelity proves
+  insufficient at large sizes.
+
+### Output size → single 512×512
+
+Considered single (512), multi-size (24/64/256/512).
+
+Picked **single 512×512** because:
+- Matches roughly what ESPN logo storage uses today.
+- Downscales fine for mobile cards (48-72px) and standings rows
+  (24-32px); the roundel design is built to read at small sizes.
+- Multi-size is a perf optimization that doesn't matter at our
+  current scale. CDN handles repeated downloads.
+- Simpler pipeline: one render call, one upload per team.
+
+### Row strategy → insert new rows per direction, keep ESPN rows intact
+
+Considered: insert new rows, replace existing rows, in-place URL swap.
+
+Picked **insert three new `sportdeets-mark`-tagged rows per franchise**
+(one per direction — roundel, shield, hex) because:
+- Generation is cheap and blob storage is pennies; producing all
+  three universal-shape directions buys flexibility to switch the
+  active direction later without regeneration.
+- Existing ESPN rows become an instant revert path if the new marks
+  look wrong in production.
+- Logo selection flip (Phase 6) can be A/B'd safely.
+- Cleanup of ESPN rows happens as a follow-up after UI confirmed.
+- In-place URL swap was rejected — any cached client (Cloudflare,
+  RN image cache, browsers) would see stale assets until cache
+  expiry.
+
+### Direction tagging → `Rel: ["sportdeets-mark", "{direction}"]`
+
+Each generated row carries the direction id (`roundel`, `shield`,
+`hex`) in its `Rel` array. Phase 6's C# logo selection picks the
+row whose Rel matches the currently-preferred direction.
+
+How the preferred direction is chosen is intentionally deferred —
+options ordered from simplest to most flexible:
+1. Hard-coded constant in C# (one-line change to swap, requires deploy)
+2. Azure AppConfig value `SportsDeets:PreferredMarkDirection` (config
+   change, no deploy)
+3. Per-user preference (UI setting, requires schema + API surface)
+
+Start with option 1 in Phase 6 — option 2 is a fast follow-up if we
+end up swapping directions during the friend-tester phase.
+
+### Light / dark variants → skip for now
+
+The roundel design is theme-agnostic except for a hairline keyline
+that adjusts based on `theme: 'light' | 'dark'`. The body colors
+(base, accent, ink) don't change.
+
+Single PNG generated with `theme: 'light'`. Add a dark variant only
+if real contrast issues surface in app UI testing.
+
+### Container layout → single container, path-prefixed
+
+Considered: per-sport containers (mirroring existing
+`{doc-type}-{sport}-{year}` convention), single flat container.
+
+Picked **single container `sportdeets-marks`** with paths:
+- `franchise/{direction}/{FranchiseId}.png`
+- `franchise-season/{direction}/{FranchiseSeasonId}.png`
+
+Where `{direction}` is one of `roundel`, `shield`, `hex`.
+
+The per-sport split made sense for ESPN-sourced documents (cache
+invalidation per document type per season). Our marks are flat and
+uniform — no benefit from per-sport split, simpler operationally.
+The direction segment in the path makes it trivial to browse all
+roundels (or shields, or hexes) in Azure Storage Explorer.
+
+### Synthetic `OriginalUrlHash`
+
+`FranchiseLogo.OriginalUrlHash` is required and indexed. Historically
+it's the SHA-256 of the ESPN source URL. For generated marks there is
+no source URL.
+
+Use a deterministic synthetic: `SHA256("sportdeets-mark:{direction}:{Id}")`
+where `{direction}` is `roundel`, `shield`, or `hex`.
+
+Unique per (franchise/franchise-season × direction), deterministic so
+reruns overwrite cleanly, and obviously synthetic so anyone debugging
+recognizes it isn't an ESPN hash. The direction segment in the hash
+input ensures the three rows-per-franchise don't collide on the
+indexed `OriginalUrlHash` column.
+
+### Database run order → local prod-copy first
+
+Don't point the first run at prod. Run against a local copy of the
+prod database, inspect generated marks in a local blob container or
+mock, verify the UI renders them correctly, then point at prod.
+
+## Phases
+
+Time estimates are rough. Phases 1-5 are the batch script itself;
+Phase 6 is the C# selection flip, which is a separate PR.
+
+| # | Phase | Time | Deliverable |
+| - | ----- | ---- | ----------- |
+| 1 | UMD-shim `marks.js` so it loads under Node | ~15 min | `node -e "require('./marks')"` works |
+| 2 | Add `@resvg/resvg-js` for SVG → PNG | ~30 min | A 512px PNG of one sample team on disk |
+| 3 | Postgres data fetch via `pg` | ~30 min | Console-logged list of franchises with color data |
+| 4 | Generate + upload per franchise / season | ~1 hr | Blobs visible in `sportdeets-marks` container |
+| 5 | Insert `FranchiseLogo` / `FranchiseSeasonLogo` rows | ~30 min | New rows tagged `sportdeets-mark` in DB |
+| 6 | C# logo selection prefers `sportdeets-mark` | ~1 hr (separate PR) | Mobile + web UI shows generated marks |
+
+Total: ~3.5 hours of work paced. Phases 1-5 can run as a single PR;
+Phase 6 is its own PR with its own UI testing.
+
+### Phase 1 — UMD-shim `marks.js`
+
+Current IIFE: `(function (global) { ... })(window);`
+
+Change to detect Node:
+
+```js
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.SDMarks = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  // existing engine code, returning the API object at the end
+  return API;
+});
+```
+
+Verify the engine still works in the browser harness (`app.js`).
+
+### Phase 2 — Rasterizer
+
+Install `@resvg/resvg-js` (Rust-based, no headless browser, no
+native build dependencies on Windows).
+
+```js
+const { Resvg } = require('@resvg/resvg-js');
+const svg = SDMarks.render('roundel', team, { size: 512 });
+const png = new Resvg(svg).render().asPng();
+```
+
+Smoke-render to disk for visual inspection before wiring up blob
+upload.
+
+### Phase 3 — Postgres data fetch
+
+`pg` (node-postgres). Connection string from `.env` (do NOT commit).
+
+```sql
+-- Franchises
+SELECT "Id", "Sport", "Abbreviation", "DisplayNameShort",
+       "DisplayName", "ColorCodeHex", "ColorCodeAltHex"
+FROM "Franchise"
+WHERE "IsActive" = true;
+
+-- FranchiseSeasons (join Franchise for Sport context)
+SELECT fs."Id", fs."FranchiseId", fs."SeasonYear", fs."Abbreviation",
+       fs."DisplayNameShort", fs."DisplayName",
+       fs."ColorCodeHex", fs."ColorCodeAltHex", f."Sport"
+FROM "FranchiseSeason" fs
+JOIN "Franchise" f ON f."Id" = fs."FranchiseId"
+WHERE fs."IsActive" = true;
+```
+
+Map `Sport` enum integer → string (`'NFL' | 'MLB' | 'NBA' | 'NHL' | 'NCAA'`)
+for the renderer. Need to read the `Sport` enum definition during
+implementation to get the integer mapping right.
+
+`Franchise.Abbreviation` is nullable; if it's null, fall back to a
+2-3 char monogram derived from `DisplayNameShort` or `Name`.
+
+### Phase 4 — Generate + upload
+
+For each row × each direction:
+
+```js
+const team = {
+  abbr: row.Abbreviation || deriveAbbr(row.DisplayNameShort),
+  name: row.DisplayName,
+  sport: row.Sport,
+  primary: row.ColorCodeHex,
+  secondary: row.ColorCodeAltHex  // may be null — engine handles it
+};
+
+for (const direction of ['roundel', 'shield', 'hex']) {
+  const svg = SDMarks.render(direction, team, { size: 512, theme: 'light' });
+  const png = new Resvg(svg).render().asPng();
+  const blobPath = `franchise/${direction}/${row.Id}.png`;
+  await containerClient.getBlockBlobClient(blobPath).uploadData(png, {
+    blobHTTPHeaders: { blobContentType: 'image/png' }
+  });
+}
+```
+
+`@azure/storage-blob` is the Azure Node SDK. Connection string
+matches the one Producer / Provider use today.
+
+Container: `sportdeets-marks` (one container, franchise / season +
+direction segments make up the blob path).
+
+### Phase 5 — Insert logo rows
+
+For each generated mark (3 directions × N franchises × N
+franchise-seasons), INSERT into `FranchiseLogo` or
+`FranchiseSeasonLogo`:
+
+```sql
+INSERT INTO "FranchiseLogo"
+  ("Id", "FranchiseId", "Uri", "OriginalUrlHash",
+   "Width", "Height", "Rel", "IsForDarkBg",
+   "CreatedUtc", "ModifiedUtc")
+VALUES
+  (@id, @franchiseId, @uri, @hash,
+   512, 512, ARRAY['sportdeets-mark', @direction], false,
+   NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC');
+```
+
+Where:
+- `@id` = `crypto.randomUUID()` (new Guid)
+- `@direction` = one of `'roundel'`, `'shield'`, `'hex'`
+- `@uri` = blob URL returned from Phase 4 (includes direction segment)
+- `@hash` = `sha256("sportdeets-mark:" + direction + ":" + row.Id)`
+  (synthetic, direction-scoped to avoid collisions on the indexed
+  `OriginalUrlHash` column)
+
+Pre-check: if a row with the same synthetic hash already exists,
+UPDATE rather than INSERT (so reruns are idempotent — Claude Design
+iteration on any direction should be safe to re-batch).
+
+Need to verify `CanonicalEntityBase<Guid>` exact column names for
+`CreatedUtc` / `ModifiedUtc` during implementation. There may also
+be additional audit columns.
+
+### Phase 6 — C# logo selection (separate PR)
+
+The current logo selection picks rows from `FranchiseLogo` /
+`FranchiseSeasonLogo`. Change the selection to prefer rows whose
+`Rel` array contains BOTH `"sportdeets-mark"` AND the currently-
+preferred direction (e.g. `"roundel"`).
+
+Likely a small change in either:
+- An API query handler that returns logo URLs
+- A query extension method that picks the "primary" logo for a franchise
+
+Implementation order:
+1. Hard-code the preferred direction as a `const string` in the
+   selection code (one-line swap to change)
+2. Promote to Azure AppConfig as a fast follow-up if we end up
+   switching directions during friend-tester phase
+3. Per-user preference is deferred — only revisit if friend testers
+   actually disagree on direction
+
+Need to grep for the current selection logic during implementation.
+Memory note: FranchiseSeason logo is preferred over Franchise logo
+as fallback — keep that ordering, just change which row within each
+table wins.
+
+## File layout
+
+```
+src/marks/
+  marks.js                       # engine (UMD-shimmed in Phase 1)
+  app.js                         # browser demo harness (unchanged)
+  index.html                     # browser demo (if/when added)
+  batch-generation-plan.md       # this doc
+  batch/
+    package.json                 # Node deps scoped to this folder
+    package-lock.json
+    .env.example                 # connection-string templates
+    .env                         # local secrets — gitignored
+    generate.js                  # the batch script (Phases 1-5)
+    .gitignore                   # excludes .env, node_modules
+```
+
+`src/marks/batch/.gitignore` and the root `.gitignore` together
+must keep `.env` and `node_modules` out of git. Verify before first
+commit.
+
+`package.json` for the batch scoped to `src/marks/batch/` so Node
+dependencies don't bleed into the .NET solution structure or get
+picked up by EAS builds / Azure Pipelines.
+
+Dependencies:
+- `pg` — Postgres driver
+- `@azure/storage-blob` — Azure Blob SDK
+- `@resvg/resvg-js` — SVG → PNG rasterizer
+- `dotenv` — `.env` loader
+
+## What we need before starting
+
+- Local Postgres copy of prod data (or willingness to start with
+  the dev environment's franchise list, which is smaller but
+  validates the pipeline)
+- Azure Blob connection string for the test environment, placed
+  in `src/marks/batch/.env` (NEVER commit)
+- Confirmation on the recommendations in the Decisions section
+  (PNG, 512px, new rows tagged `sportdeets-mark`, single container,
+  skip light/dark variants, run against local first)
+
+## Open follow-ups (deferred)
+
+- **SVG output path.** When mobile / web both have SVG renderers
+  wired up, regenerate as SVG for crispness at every size.
+- **Light/dark variants.** Generate the `theme: 'dark'` variant and
+  tag rows with `IsForDarkBg = true` if real contrast issues
+  surface.
+- **Wire into Producer ingest.** When a new Franchise or
+  FranchiseSeason is sourced, auto-generate the mark instead of
+  needing a manual rerun of this batch script. Low priority —
+  new franchises are rare, manual rerun is fine until it isn't.
+- **Multi-size output.** Pre-render 24/64/256/512 if download size
+  or visual quality at thumbnail sizes becomes an issue.
+- **Cleanup of ESPN-sourced rows.** Once UI confirms the
+  `sportdeets-mark` rows render everywhere correctly, drop the
+  ESPN rows from `FranchiseLogo` / `FranchiseSeasonLogo`. Keep them
+  for at least one full release cycle as a revert path.
+
+## Related docs
+
+- `docs/team-mark-design-brief.md` — the design problem statement
+  and Claude Design brief
+- `marks.js` — the engine
+- `app.js` — browser playground for visual comparison

--- a/src/marks/batch/.env.example
+++ b/src/marks/batch/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env (which is gitignored) and fill in for Phase 4+ (blob upload)
+# and Phase 5+ (Postgres inserts). Not required for Phase 1-3 (local PNG
+# generation from the franchise-colors txt file).
+
+AZURE_BLOB_CONNECTION_STRING=
+PG_CONNECTION_STRING=

--- a/src/marks/batch/.gitignore
+++ b/src/marks/batch/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+output/
+.env

--- a/src/marks/batch/generate.js
+++ b/src/marks/batch/generate.js
@@ -1,0 +1,108 @@
+// Phase 1-3 batch generator: reads franchise-colors-mlb.txt (the prod
+// query result Randall dropped in src/marks/), renders one roundel SVG
+// per row via ../marks.js, rasterizes to a 512x512 PNG via resvg-js,
+// and writes the result to ./output/ for visual inspection.
+//
+// No blob upload, no DB writes — those land in later phases once the
+// visual output is approved.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { Resvg } = require('@resvg/resvg-js');
+
+const SDMarks = require('../marks.js');
+
+const DATA_FILE = path.resolve(__dirname, '..', 'franchise-colors-mlb.txt');
+const OUTPUT_DIR = path.resolve(__dirname, 'output');
+const SIZE = 512;
+const SPORT = 'MLB'; // every row in the file is MLB-scoped per the query
+// All three universal-shape directions from marks.js. Block and equipment
+// are excluded — not in the public DIRECTIONS registry and have sport-
+// specific branching we explicitly de-scoped.
+const DIRECTIONS = ['roundel', 'shield', 'hex'];
+
+// Parse the tab-separated dump. The file is:
+//   line 1-5  : the SQL query (commented context for the reader)
+//   line 6    : blank
+//   line 7    : header row
+//   line 8+   : data rows, tab-separated
+function readTeams(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split(/\r?\n/);
+
+  let headerIdx = lines.findIndex((l) => l.startsWith('FranchiseId\t'));
+  if (headerIdx === -1) {
+    throw new Error(`Could not locate header row in ${filePath}`);
+  }
+  const headers = lines[headerIdx].split('\t').map((h) => h.trim());
+  const dataLines = lines.slice(headerIdx + 1).filter((l) => l.trim().length > 0);
+
+  return dataLines.map((line) => {
+    const cells = line.split('\t');
+    const row = {};
+    headers.forEach((h, i) => { row[h] = (cells[i] || '').trim(); });
+    return row;
+  });
+}
+
+function ensureDir(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function generateOne(direction, team) {
+  const svg = SDMarks.render(direction, team, { size: SIZE, theme: 'light' });
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: 'width', value: SIZE },
+    background: 'transparent'
+  });
+  return resvg.render().asPng();
+}
+
+function main() {
+  ensureDir(OUTPUT_DIR);
+  for (const dir of DIRECTIONS) ensureDir(path.join(OUTPUT_DIR, dir));
+
+  const rows = readTeams(DATA_FILE);
+  console.log(`Loaded ${rows.length} teams from ${path.basename(DATA_FILE)}`);
+  console.log(`Generating directions: ${DIRECTIONS.join(', ')}`);
+
+  const perDir = Object.fromEntries(DIRECTIONS.map((d) => [d, 0]));
+  const failures = [];
+
+  for (const row of rows) {
+    // The data file is FranchiseSeason-scoped. Render the mark using the
+    // season-level color + abbreviation; we'll add a separate Franchise-
+    // level pass once the visual is approved.
+    const team = {
+      abbr: row.Abbreviation,
+      name: row.Slug, // human-readable label in the SVG aria-label
+      sport: SPORT,
+      primary: '#' + row.ColorCodeHex,
+      secondary: row.ColorCodeAltHex ? '#' + row.ColorCodeAltHex : null
+    };
+
+    for (const direction of DIRECTIONS) {
+      try {
+        const png = generateOne(direction, team);
+        const outPath = path.join(OUTPUT_DIR, direction, `${row.Slug}.png`);
+        fs.writeFileSync(outPath, png);
+        perDir[direction]++;
+      } catch (err) {
+        failures.push({ slug: row.Slug, abbr: row.Abbreviation, direction, error: err.message });
+      }
+    }
+  }
+
+  console.log(`\nWrote PNGs to ${OUTPUT_DIR}:`);
+  for (const d of DIRECTIONS) console.log(`  ${d}/  ${perDir[d]} files`);
+
+  if (failures.length) {
+    console.log(`\nFailures (${failures.length}):`);
+    for (const f of failures) {
+      console.log(`  [${f.direction}] ${f.slug} (${f.abbr}): ${f.error}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/src/marks/batch/insert.js
+++ b/src/marks/batch/insert.js
@@ -1,0 +1,136 @@
+// Phase 5: read a manifest produced by upload.js and write FranchiseSeasonLogo
+// rows into Postgres. Idempotent — re-runnable against the same manifest.
+//
+// Usage:
+//   node insert.js                # uses the newest manifest in output/manifests/
+//   node insert.js path/to/manifest.json
+//
+// Idempotency: SELECT by (FranchiseSeasonId, OriginalUrlHash); UPDATE if a
+// row already exists, INSERT otherwise. No schema change required.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { Client } = require('pg');
+
+const MANIFEST_DIR = path.resolve(__dirname, 'output', 'manifests');
+// The "sportDeets admin" user; used for audit columns where there is no
+// human actor (this batch runs server-side, not on behalf of a logged-in
+// user).
+const CREATED_BY = '11111111-1111-1111-1111-111111111111';
+
+function latestManifest() {
+  if (!fs.existsSync(MANIFEST_DIR)) return null;
+  const files = fs.readdirSync(MANIFEST_DIR)
+    .filter((f) => f.startsWith('manifest-') && f.endsWith('.json'))
+    .sort();
+  return files.length ? path.join(MANIFEST_DIR, files[files.length - 1]) : null;
+}
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`${name} is not set. Run via ./run.ps1.`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function main() {
+  const manifestArg = process.argv[2];
+  const manifestPath = manifestArg
+    ? path.resolve(manifestArg)
+    : latestManifest();
+  if (!manifestPath || !fs.existsSync(manifestPath)) {
+    console.error(`Manifest not found. Pass a path or place one in ${MANIFEST_DIR}`);
+    process.exit(1);
+  }
+
+  console.log(`Manifest: ${manifestPath}`);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  console.log(`Env: ${manifest.environment}  Scope: ${manifest.scope}  Entries: ${manifest.entries.length}`);
+
+  const client = new Client({
+    host: requireEnv('PG_HOST'),
+    port: parseInt(process.env.PG_PORT || '5432', 10),
+    user: requireEnv('PG_USER'),
+    password: requireEnv('PG_PASSWORD'),
+    database: requireEnv('PG_DATABASE')
+  });
+
+  await client.connect();
+  console.log(`Connected to ${process.env.PG_DATABASE} @ ${process.env.PG_HOST}\n`);
+
+  let inserted = 0, updated = 0, failed = 0;
+
+  for (const e of manifest.entries) {
+    if (e.kind !== 'franchise-season') {
+      // Franchise-level rows will land in a later batch pass.
+      continue;
+    }
+    try {
+      const existing = await client.query(
+        `SELECT "Id" FROM "FranchiseSeasonLogo"
+         WHERE "FranchiseSeasonId" = $1 AND "OriginalUrlHash" = $2
+         LIMIT 1`,
+        [e.entityId, e.originalUrlHash]
+      );
+
+      if (existing.rowCount > 0) {
+        await client.query(
+          `UPDATE "FranchiseSeasonLogo"
+           SET "Uri" = $1,
+               "Width" = $2,
+               "Height" = $3,
+               "Rel" = $4,
+               "IsForDarkBg" = $5,
+               "ModifiedUtc" = (NOW() AT TIME ZONE 'UTC'),
+               "ModifiedBy" = $6
+           WHERE "Id" = $7`,
+          [e.blobUrl, e.width, e.height, e.rel, false, CREATED_BY, existing.rows[0].Id]
+        );
+        updated++;
+        process.stdout.write('u');
+      } else {
+        await client.query(
+          `INSERT INTO "FranchiseSeasonLogo"
+             ("Id", "FranchiseSeasonId", "Uri", "OriginalUrlHash",
+              "Width", "Height", "Rel", "IsForDarkBg",
+              "CreatedUtc", "CreatedBy", "ModifiedUtc", "ModifiedBy")
+           VALUES
+             ($1, $2, $3, $4,
+              $5, $6, $7, $8,
+              (NOW() AT TIME ZONE 'UTC'), $9, NULL, NULL)`,
+          [
+            crypto.randomUUID(),
+            e.entityId,
+            e.blobUrl,
+            e.originalUrlHash,
+            e.width,
+            e.height,
+            e.rel,
+            false,
+            CREATED_BY
+          ]
+        );
+        inserted++;
+        process.stdout.write('i');
+      }
+    } catch (err) {
+      failed++;
+      process.stdout.write('x');
+      console.error(`\n[${e.direction}] ${e.slug}: ${err.message}`);
+    }
+  }
+  process.stdout.write('\n\n');
+
+  await client.end();
+
+  console.log(`Inserted: ${inserted}  Updated: ${updated}  Failed: ${failed}`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/marks/batch/package-lock.json
+++ b/src/marks/batch/package-lock.json
@@ -1,0 +1,705 @@
+{
+  "name": "sportdeets-marks-batch",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sportdeets-marks-batch",
+      "version": "0.1.0",
+      "dependencies": {
+        "@azure/storage-blob": "^12.27.0",
+        "@resvg/resvg-js": "^2.6.2",
+        "pg": "^8.13.1"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.32.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.32.0.tgz",
+      "integrity": "sha512-80LzSNnFQye2LCCBFghAJS6jJQJ7N4bfgZ6qDMgVGRtugZ7TLDKQZ2hczMigmZH3jAcMRdma/IygsC5+0gT7Tw==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.4.0",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.0.tgz",
+      "integrity": "sha512-kNhJKMxQb374KOVt63CZnGIpDcrKNzJeyANLJymxE9mCJSdRGzb+Iv9oSIiCj6tNMLypr530b9ObOiA/5OvwOg==",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ]
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/src/marks/batch/package.json
+++ b/src/marks/batch/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sportdeets-marks-batch",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Batch generator for sportDeets team marks. Reads franchise color data, renders SVG via ../marks.js, rasterizes to PNG, and (in later phases) uploads to Azure Blob + inserts FranchiseLogo rows.",
+  "scripts": {
+    "generate:local": "node generate.js",
+    "upload": "node upload.js",
+    "insert": "node insert.js"
+  },
+  "dependencies": {
+    "@azure/storage-blob": "^12.27.0",
+    "@resvg/resvg-js": "^2.6.2",
+    "pg": "^8.13.1"
+  }
+}

--- a/src/marks/batch/run.ps1
+++ b/src/marks/batch/run.ps1
@@ -1,8 +1,17 @@
 # PowerShell wrapper for the marks batch pipeline.
 #
-# Dot-sources the canonical secrets file (outside the repo, in Dropbox),
-# maps the variables defined there onto the env vars the Node scripts read,
-# then invokes the requested phase.
+# Dot-sources the canonical secrets file (path read from
+# $env:SPORTDEETS_SECRETS_PATH so the local filesystem location stays out of
+# the repo), maps the variables defined there onto the env vars the Node
+# scripts read, then invokes the requested phase.
+#
+# Prerequisite: set SPORTDEETS_SECRETS_PATH in your user environment to the
+# absolute path of your _common-variables.ps1 (or equivalent) secrets file.
+# Example (PowerShell):
+#   [Environment]::SetEnvironmentVariable(
+#     'SPORTDEETS_SECRETS_PATH',
+#     'C:\path\to\_common-variables.ps1',
+#     'User')
 #
 # Usage:
 #   ./run.ps1 -Environment dev -Phase upload
@@ -25,9 +34,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$SecretsFile = 'D:\Dropbox\Code\sports-data-provision\_secrets\_common-variables.ps1'
+if (-not $env:SPORTDEETS_SECRETS_PATH) {
+  Write-Error "SPORTDEETS_SECRETS_PATH is not set. Point it at your secrets .ps1 file before running this script."
+  exit 1
+}
+$SecretsFile = $env:SPORTDEETS_SECRETS_PATH
 if (-not (Test-Path $SecretsFile)) {
-  Write-Error "Secrets file not found: $SecretsFile"
+  Write-Error "Secrets file not found at SPORTDEETS_SECRETS_PATH: $SecretsFile"
   exit 1
 }
 . $SecretsFile

--- a/src/marks/batch/run.ps1
+++ b/src/marks/batch/run.ps1
@@ -1,0 +1,63 @@
+# PowerShell wrapper for the marks batch pipeline.
+#
+# Dot-sources the canonical secrets file (outside the repo, in Dropbox),
+# maps the variables defined there onto the env vars the Node scripts read,
+# then invokes the requested phase.
+#
+# Usage:
+#   ./run.ps1 -Environment dev -Phase upload
+#   ./run.ps1 -Environment dev -Phase insert
+#   ./run.ps1 -Environment dev -Phase insert -Manifest .\output\manifests\manifest-2026-06-05....json
+#
+# Environment toggles which Azure Blob account we upload to (dev vs prod).
+# Postgres is always local for this batch — no prod-DB write path here.
+
+param(
+  [Parameter(Mandatory=$true)]
+  [ValidateSet('upload','insert')]
+  [string]$Phase,
+
+  [ValidateSet('dev','prod')]
+  [string]$Environment = 'dev',
+
+  [string]$Manifest
+)
+
+$ErrorActionPreference = 'Stop'
+
+$SecretsFile = 'D:\Dropbox\Code\sports-data-provision\_secrets\_common-variables.ps1'
+if (-not (Test-Path $SecretsFile)) {
+  Write-Error "Secrets file not found: $SecretsFile"
+  exit 1
+}
+. $SecretsFile
+
+# Azure Blob — dev vs prod per the -Environment flag.
+if ($Environment -eq 'prod') {
+  $env:AZURE_BLOB_CONNECTION_STRING = $AzureBlobStorageProd
+} else {
+  $env:AZURE_BLOB_CONNECTION_STRING = $AzureBlobStorageDev
+}
+
+# Postgres — always local for this batch. We're writing into the Producer's
+# MLB database (sdProducer.BaseballMlb).
+$env:PG_HOST     = $pgHostLocal
+$env:PG_USER     = $pgUserLocal
+$env:PG_PASSWORD = $pgPasswordLocal
+$env:PG_PORT     = '5432'
+$env:PG_DATABASE = 'sdProducer.BaseballMlb'
+
+$env:SD_TARGET_ENV = $Environment
+
+Write-Host "Phase: $Phase  Environment: $Environment" -ForegroundColor Cyan
+Write-Host "PG: $env:PG_DATABASE @ $env:PG_HOST" -ForegroundColor Cyan
+
+if ($Phase -eq 'upload') {
+  node "$PSScriptRoot\upload.js"
+} elseif ($Phase -eq 'insert') {
+  if ($Manifest) {
+    node "$PSScriptRoot\insert.js" $Manifest
+  } else {
+    node "$PSScriptRoot\insert.js"
+  }
+}

--- a/src/marks/batch/upload.js
+++ b/src/marks/batch/upload.js
@@ -1,0 +1,148 @@
+// Phase 4: render every (team x direction) mark and upload to Azure Blob.
+// Writes a manifest to output/manifests/ describing what was uploaded so the
+// insert phase can run independently (or be re-run safely).
+//
+// Reads the franchise-colors-mlb.txt file as the input dataset for this first
+// pass. Future runs will query Postgres directly.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { Resvg } = require('@resvg/resvg-js');
+const { BlobServiceClient } = require('@azure/storage-blob');
+
+const SDMarks = require('../marks.js');
+
+const DATA_FILE = path.resolve(__dirname, '..', 'franchise-colors-mlb.txt');
+const OUTPUT_DIR = path.resolve(__dirname, 'output');
+const MANIFEST_DIR = path.join(OUTPUT_DIR, 'manifests');
+const CONTAINER = 'sportdeets-marks';
+const SIZE = 512;
+const SPORT = 'MLB';
+const SCOPE = 'franchise-season:2026';
+const DIRECTIONS = ['roundel', 'shield', 'hex'];
+
+function readTeams(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split(/\r?\n/);
+  const headerIdx = lines.findIndex((l) => l.startsWith('FranchiseId\t'));
+  if (headerIdx === -1) throw new Error(`Could not locate header row in ${filePath}`);
+  const headers = lines[headerIdx].split('\t').map((h) => h.trim());
+  const dataLines = lines.slice(headerIdx + 1).filter((l) => l.trim().length > 0);
+  return dataLines.map((line) => {
+    const cells = line.split('\t');
+    const row = {};
+    headers.forEach((h, i) => { row[h] = (cells[i] || '').trim(); });
+    return row;
+  });
+}
+
+function ensureDir(p) { fs.mkdirSync(p, { recursive: true }); }
+
+function syntheticHash(direction, id) {
+  return crypto.createHash('sha256')
+    .update(`sportdeets-mark:${direction}:${id}`)
+    .digest('hex');
+}
+
+function renderPng(direction, team) {
+  const svg = SDMarks.render(direction, team, { size: SIZE, theme: 'light' });
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: 'width', value: SIZE },
+    background: 'transparent'
+  });
+  return resvg.render().asPng();
+}
+
+async function main() {
+  const conn = process.env.AZURE_BLOB_CONNECTION_STRING;
+  if (!conn) {
+    console.error('AZURE_BLOB_CONNECTION_STRING is not set. Run via ./run.ps1.');
+    process.exit(1);
+  }
+  const targetEnv = process.env.SD_TARGET_ENV || 'unknown';
+
+  ensureDir(OUTPUT_DIR);
+  ensureDir(MANIFEST_DIR);
+
+  const blobService = BlobServiceClient.fromConnectionString(conn);
+  const container = blobService.getContainerClient(CONTAINER);
+  // PublicAccessType.BlobContainer matches the existing convention in
+  // BlobStorageProvider.cs so anonymous GETs work the same as ESPN-sourced
+  // logos do today.
+  await container.createIfNotExists({ access: 'blob' });
+
+  const rows = readTeams(DATA_FILE);
+  console.log(`Loaded ${rows.length} teams from ${path.basename(DATA_FILE)}`);
+  console.log(`Target: ${targetEnv} / container "${CONTAINER}" / scope ${SCOPE}`);
+  console.log(`Uploading ${rows.length * DIRECTIONS.length} blobs...\n`);
+
+  const entries = [];
+  const failures = [];
+
+  for (const row of rows) {
+    const team = {
+      abbr: row.Abbreviation,
+      name: row.Slug,
+      sport: SPORT,
+      primary: '#' + row.ColorCodeHex,
+      secondary: row.ColorCodeAltHex ? '#' + row.ColorCodeAltHex : null
+    };
+
+    for (const direction of DIRECTIONS) {
+      const blobPath = `franchise-season/${direction}/${row.FranchiseSeasonId}.png`;
+      try {
+        const png = renderPng(direction, team);
+        const blob = container.getBlockBlobClient(blobPath);
+        await blob.uploadData(png, {
+          blobHTTPHeaders: { blobContentType: 'image/png' }
+        });
+        entries.push({
+          kind: 'franchise-season',
+          direction,
+          entityId: row.FranchiseSeasonId,
+          franchiseId: row.FranchiseId,
+          slug: row.Slug,
+          sport: SPORT,
+          blobPath,
+          blobUrl: blob.url,
+          originalUrlHash: syntheticHash(direction, row.FranchiseSeasonId),
+          width: SIZE,
+          height: SIZE,
+          rel: ['sportdeets-mark', direction]
+        });
+        process.stdout.write('.');
+      } catch (err) {
+        failures.push({ slug: row.Slug, direction, error: err.message });
+        process.stdout.write('x');
+      }
+    }
+  }
+  process.stdout.write('\n\n');
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    environment: targetEnv,
+    container: CONTAINER,
+    sport: SPORT,
+    scope: SCOPE,
+    sourceFile: path.basename(DATA_FILE),
+    entries
+  };
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const manifestPath = path.join(MANIFEST_DIR, `manifest-${ts}.json`);
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+  console.log(`Uploaded ${entries.length} blobs (${failures.length} failures)`);
+  console.log(`Manifest: ${manifestPath}`);
+  if (failures.length) {
+    console.log('\nFailures:');
+    for (const f of failures) console.log(`  [${f.direction}] ${f.slug}: ${f.error}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/marks/franchise-colors-mlb.txt
+++ b/src/marks/franchise-colors-mlb.txt
@@ -1,0 +1,37 @@
+select fr."Id" as "FranchiseId", f."Id" as "FranchiseSeasonId", f."Slug", f."Abbreviation", f."ColorCodeHex", f."ColorCodeAltHex"
+from public."FranchiseSeason" f
+inner join public."Franchise" fr on fr."Id" = f."FranchiseId"
+where f."SeasonYear" = 2026 and f."IsActive" = true
+order by f."Slug";
+
+FranchiseId	FranchiseSeasonId	Slug	Abbreviation	ColorCodeHex	ColorCodeAltHex
+dc2849d9-5e10-a3ac-a57e-0b74f74c6c09	c5a9db8e-a364-abbb-fb04-f645226d10b3	arizona-diamondbacks	ARI	aa182c	000000
+21b8cc0f-6e6a-5284-850c-d602ad3cb8bb	5810cf06-f4d7-7c16-367f-a191ca445771	athletics	ATH	003831	efb21e
+5bfdad78-da67-0998-b9cd-8e451d016299	a0f849f4-b184-f53a-82d7-9e0fe1d3c270	atlanta-braves	ATL	0c2340	ba0c2f
+2feeca7e-8013-deeb-a519-f3361e1df7d9	41e828e9-eb15-2f75-0a86-21686992ca2f	baltimore-orioles	BAL	df4601	000000
+d4a1bcb3-0028-576a-b81c-eb2378336622	4b64d3ac-92d3-6011-fd60-19eed40299e7	boston-red-sox	BOS	0d2b56	bd3039
+04c54daf-2e2f-dd23-7bb2-a82487f10dbe	807a38f3-6e52-be58-7f83-736e626726d7	chicago-cubs	CHC	0e3386	cc3433
+cea2344d-72e5-983d-be9f-3d283a592103	e23df181-22eb-a1a5-9442-edf1d8c6c19e	chicago-white-sox	CHW	000000	c4ced4
+f6e36945-4671-d120-604d-42c4d616060a	29232bf7-e39f-abd8-bb8e-1a2db63b2444	cincinnati-reds	CIN	c6011f	ffffff
+bf12bee0-3c29-7066-0cdd-8ea6907020ab	685b145e-6c60-9796-456c-4c25a81e0873	cleveland-guardians	CLE	002b5c	e31937
+5bef626e-76ec-c244-8a59-3de7c640b70c	ae5acbfc-0913-7cf3-0b62-5ad920f087ec	colorado-rockies	COL	33006f	000000
+4cd8f79d-2f0b-910d-a5a1-375ed8101eef	f501ec08-58c8-5172-0da8-c80690d75d01	detroit-tigers	DET	0a2240	ff4713
+7902f0af-eb3d-79f7-33fc-a813f3644806	75997be5-fab6-f6b9-11cb-d5afa093ae1c	houston-astros	HOU	002d62	eb6e1f
+c8cd7538-6e20-af03-8acc-6322978d9cca	185e1c2c-49e5-5804-313c-4c9831916f46	kansas-city-royals	KC	004687	7ab2dd
+7e865b0e-e5c8-4615-043f-4a1625539acd	919d32e9-a117-7b59-860a-66859ed66969	los-angeles-angels	LAA	ba0021	c4ced4
+aa1a9e9b-f14c-458b-2ddf-6e0397c71d78	9873e5f2-c092-e23c-0b86-2744e5e4461e	los-angeles-dodgers	LAD	005a9c	ffffff
+dec5cbce-245b-d68d-9b3d-bd6237b1564f	cfd671c4-2851-3ea7-4e06-07df98fca36c	miami-marlins	MIA	00a3e0	000000
+d31ee3a8-0c4a-807a-02e2-f018633d57b7	f72c5ddf-6b94-ba12-965d-55a892b5aa9a	milwaukee-brewers	MIL	13294b	ffc72c
+5c26f8d6-b93f-2e66-d6d0-9095d4122e53	91bb345f-72a4-a976-6dc3-428003e87c46	minnesota-twins	MIN	031f40	e20e32
+297446c9-7313-40bb-6248-2f78c0f88b17	1bfeddea-2a40-c500-599e-0ec8e9ae4761	new-york-mets	NYM	002d72	ff5910
+04e80690-ef19-ee97-cea4-848ac4e89293	bb6fe154-9ef6-15ab-ba4a-24abff9a78e2	new-york-yankees	NYY	132448	c4ced4
+3eb82f6d-ca69-2bd6-ddfb-c56cc7425c08	f359f9d6-3d7b-28ef-0b6b-d62b5f153c21	philadelphia-phillies	PHI	e81828	003278
+8c0eddc4-d015-e8f7-e7d6-ac3ca01694a6	e0cc7193-c9c1-b7da-e99c-f350564237f5	pittsburgh-pirates	PIT	000000	fdb827
+c0e4b30c-5580-bc0c-a5d7-983f17997ba2	2cfec554-358d-c7d8-ef67-ae9ffe5f8b3f	san-diego-padres	SD	2f241d	ffc425
+87ca06d5-1fb4-5777-7a19-2ed07f6025e4	3e3481c0-6061-9a63-d944-61efd4d59bcd	san-francisco-giants	SF	000000	fd5a1e
+a354a437-fc32-7800-3aa6-a1686c60751f	8b9c540a-bb08-3ff2-fe92-cb3a7ac36e40	seattle-mariners	SEA	005c5c	0c2c56
+2026e51d-e3e6-e4bb-0af6-f6763d0f154d	adc098fa-8647-1011-23f8-2cb4ac9852f6	st-louis-cardinals	STL	be0a14	001541
+73d1d893-2b38-a1b7-67fc-0c06e754d3a9	9c82230a-7266-3dfd-2560-8d5264ecbe9a	tampa-bay-rays	TB	092c5c	8fbce6
+4f890cb9-8d7f-7cf1-eb88-f4c46c1e78c1	d9e159eb-ee26-b954-3436-5449d182e106	texas-rangers	TEX	003278	c0111f
+0848f93a-d74a-368a-5c23-26cadf06fe7d	262b0a6f-70e2-1258-031d-233c41b5405c	toronto-blue-jays	TOR	134a8e	6cace5
+f965b06f-8a4c-d4d2-4aed-5e775ab145c3	b16fb8c0-cf9f-19ba-f71b-e10b20a9870c	washington-nationals	WSH	ab0003	11225b

--- a/src/marks/marks.js
+++ b/src/marks/marks.js
@@ -54,14 +54,28 @@
                  split). Derived from the palette when secondary is missing/weak.
         ink    — letter color, max contrast on `base`
      Deterministic: no randomness, pure function of the two input colors.
+
+     ACCENT_CONTRAST_MIN is the threshold for "is this secondary visually
+     distinct enough from the primary to use as the accent ring/band." This
+     is NOT WCAG text-contrast (4.5/3.0) — that bar applies to text
+     legibility and informational graphical elements. The accent here is
+     brand-decoration; the bar is "are these two color blocks clearly
+     separate?" Set at 1.7 by empirical validation against real MLB color
+     data: at 2.5+ the threshold rejects authentic navy+red pairs (Guardians,
+     Twins, Braves, Rangers — all ~2.3) and forces a washed-out derived
+     mix instead of the actual brand secondary. Tune downward only with new
+     visual validation; tune upward only if a navy+near-black case slips
+     through.
   ------------------------------------------------------------------------ */
+  var ACCENT_CONTRAST_MIN = 1.7;
+
   function resolvePalette(primaryHex, secondaryHex) {
     var base = parseHex(primaryHex) || { r: 90, g: 95, b: 105 };
     var sec = parseHex(secondaryHex); // may be null
     var baseLight = relLum(base) > 0.42;
 
     var accent;
-    var secUsable = sec && contrast(sec, base) >= 1.7;
+    var secUsable = sec && contrast(sec, base) >= ACCENT_CONTRAST_MIN;
     if (secUsable) {
       accent = sec;
     } else {
@@ -69,7 +83,7 @@
       accent = baseLight ? mix(base, INKBLACK, 0.62) : mix(base, WHITE, 0.74);
     }
     // Guarantee the accent will actually read against base.
-    if (contrast(accent, base) < 1.7) {
+    if (contrast(accent, base) < ACCENT_CONTRAST_MIN) {
       accent = baseLight ? mix(base, INKBLACK, 0.7) : mix(base, WHITE, 0.82);
     }
 
@@ -117,7 +131,24 @@
     if (opt.stroke) attrs.push('stroke="' + opt.stroke + '"', 'stroke-width="' + (opt.strokeW || 0) + '"', 'paint-order="stroke"');
     return '<text ' + attrs.join(' ') + '>' + esc(text) + '</text>';
   }
-  function esc(s) { return String(s).replace(/[<>&]/g, function (c) { return { '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]; }); }
+  // Escapes for BOTH HTML element content (the <text> body) AND attribute
+  // values (the aria-label on <svg>). " and ' aren't needed for element
+  // content, but they ARE needed for attribute safety — if a future caller
+  // passes a team name that contains a double-quote, the unescaped value
+  // would break out of the aria-label attribute. Current callers route only
+  // engine-controlled or DB-slug inputs through here, but the escape is
+  // cheap defense-in-depth for any future reuse with less-trusted data.
+  function esc(s) {
+    return String(s).replace(/[<>&"']/g, function (c) {
+      return {
+        '<': '&lt;',
+        '>': '&gt;',
+        '&': '&amp;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[c];
+    });
+  }
 
   function svg(inner, opt) {
     opt = opt || {};

--- a/src/marks/marks.js
+++ b/src/marks/marks.js
@@ -1,0 +1,352 @@
+/* ============================================================================
+   sportDeets — Parametric Team Mark Engine
+   ----------------------------------------------------------------------------
+   Given (primary color, secondary color | NULL, abbreviation, sport) produce a
+   deterministic, legally-clean SVG. No per-team manual design. No mascots, no
+   protected symbology. Just color + geometry + letterform.
+
+   Everything here is pure: same inputs -> same SVG string. That is what lets us
+   cache the output to blob storage and serve it from the existing logo URLs.
+   ========================================================================== */
+(function (global) {
+  'use strict';
+  // Node-vs-browser shim: attaches to window in the browser (existing behavior)
+  // and exports via module.exports under Node (for batch generation scripts).
+  // See src/marks/batch/ for the Node consumer.
+
+  /* ---------- color math -------------------------------------------------- */
+  function parseHex(c) {
+    if (!c) return null;
+    c = String(c).trim().replace(/^#/, '');
+    if (c.length === 3) c = c.split('').map(function (x) { return x + x; }).join('');
+    if (!/^[0-9a-fA-F]{6}$/.test(c)) return null;
+    var n = parseInt(c, 16);
+    return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+  }
+  function toHex(c) {
+    function h(x) { return Math.max(0, Math.min(255, Math.round(x))).toString(16).padStart(2, '0'); }
+    return '#' + h(c.r) + h(c.g) + h(c.b);
+  }
+  function relLum(c) {
+    function f(x) { x /= 255; return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4); }
+    return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+  }
+  function contrast(a, b) {
+    var l1 = relLum(a), l2 = relLum(b), hi = Math.max(l1, l2), lo = Math.min(l1, l2);
+    return (hi + 0.05) / (lo + 0.05);
+  }
+  function mix(a, b, t) {
+    return { r: a.r + (b.r - a.r) * t, g: a.g + (b.g - a.g) * t, b: a.b + (b.b - a.b) * t };
+  }
+  var WHITE = { r: 255, g: 255, b: 255 };
+  var INKBLACK = { r: 18, g: 19, b: 23 };
+
+  // Best-contrast ink (near-white or near-black) for text/shapes on a given bg.
+  function inkOn(bg) { return contrast(bg, WHITE) >= contrast(bg, INKBLACK) ? WHITE : INKBLACK; }
+
+  /* ---------- palette resolution -----------------------------------------
+     The crux of the whole system. Real data gives us a primary hex and a
+     secondary that is OFTEN NULL, OR so close to the primary it is useless as a
+     contrast device (e.g. navy primary + black secondary). We must always end
+     with three usable roles:
+        base   — the team's primary, the dominant fill
+        accent — a clearly distinct color for the contrast device (band/ring/
+                 split). Derived from the palette when secondary is missing/weak.
+        ink    — letter color, max contrast on `base`
+     Deterministic: no randomness, pure function of the two input colors.
+  ------------------------------------------------------------------------ */
+  function resolvePalette(primaryHex, secondaryHex) {
+    var base = parseHex(primaryHex) || { r: 90, g: 95, b: 105 };
+    var sec = parseHex(secondaryHex); // may be null
+    var baseLight = relLum(base) > 0.42;
+
+    var accent;
+    var secUsable = sec && contrast(sec, base) >= 1.7;
+    if (secUsable) {
+      accent = sec;
+    } else {
+      // Derive an accent that keeps the team hue but separates tonally.
+      accent = baseLight ? mix(base, INKBLACK, 0.62) : mix(base, WHITE, 0.74);
+    }
+    // Guarantee the accent will actually read against base.
+    if (contrast(accent, base) < 1.7) {
+      accent = baseLight ? mix(base, INKBLACK, 0.7) : mix(base, WHITE, 0.82);
+    }
+
+    var ink = inkOn(base);
+    // ink for shapes drawn ON the accent (e.g. knockout letters)
+    var inkOnAccent = inkOn(accent);
+
+    return {
+      base: base, baseHex: toHex(base),
+      sec: sec, secProvided: !!sec,
+      accent: accent, accentHex: toHex(accent),
+      ink: ink, inkHex: toHex(ink),
+      inkOnAccent: inkOnAccent, inkOnAccentHex: toHex(inkOnAccent),
+      baseLight: baseLight
+    };
+  }
+
+  // Hairline that keeps a mark from melting into a same-tone tile.
+  function tileKeyline(theme) {
+    return theme === 'dark' ? 'rgba(255,255,255,0.16)' : 'rgba(15,17,21,0.14)';
+  }
+
+  /* ---------- letterform fitting -----------------------------------------
+     Abbreviations run 2–4 chars. We size by length and clamp width with
+     textLength so 4-char marks never overflow their shape.
+  ------------------------------------------------------------------------ */
+  function letter(text, cx, cy, color, opt) {
+    opt = opt || {};
+    text = String(text || '').toUpperCase();
+    var len = text.length || 2;
+    var size = opt.size || ({ 1: 56, 2: 52, 3: 40, 4: 30 }[Math.min(len, 4)] || 30);
+    var maxW = opt.maxW || 0;
+    var attrs = [
+      'x="' + cx + '"', 'y="' + cy + '"',
+      'text-anchor="middle"', 'dominant-baseline="central"',
+      'fill="' + color + '"',
+      'font-family="' + (opt.font || "'Archivo','Arial Narrow',sans-serif") + '"',
+      'font-weight="' + (opt.weight || 800) + '"',
+      'font-size="' + size + '"',
+      'letter-spacing="' + (opt.tracking != null ? opt.tracking : (len >= 3 ? -1 : 0)) + '"'
+    ];
+    if (maxW && len >= 3) {
+      attrs.push('textLength="' + maxW + '"', 'lengthAdjust="spacingAndGlyphs"');
+    }
+    if (opt.stroke) attrs.push('stroke="' + opt.stroke + '"', 'stroke-width="' + (opt.strokeW || 0) + '"', 'paint-order="stroke"');
+    return '<text ' + attrs.join(' ') + '>' + esc(text) + '</text>';
+  }
+  function esc(s) { return String(s).replace(/[<>&]/g, function (c) { return { '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]; }); }
+
+  function svg(inner, opt) {
+    opt = opt || {};
+    var s = opt.size || 100;
+    return '<svg viewBox="0 0 100 100" width="' + s + '" height="' + s + '" ' +
+      'xmlns="http://www.w3.org/2000/svg" shape-rendering="geometricPrecision" ' +
+      'role="img" aria-label="' + esc(opt.label || '') + '">' + inner + '</svg>';
+  }
+
+  /* =========================================================================
+     DIRECTION A — MONOGRAM ROUNDEL
+     Circle, primary field, inset ring in accent, abbreviation knocked in ink.
+     SeatGeek-adjacent. Monogram-forward, universal across all sports.
+  ========================================================================= */
+  function roundel(team, o) {
+    o = o || {}; var p = resolvePalette(team.primary, team.secondary), key = tileKeyline(o.theme);
+    var inner = '';
+    inner += '<circle cx="50" cy="50" r="47" fill="' + p.baseHex + '" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += '<circle cx="50" cy="50" r="40.5" fill="none" stroke="' + p.accentHex + '" stroke-width="5"/>';
+    inner += letter(team.abbr, 50, 51.5, p.inkHex, { maxW: 56, weight: 800 });
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  /* =========================================================================
+     DIRECTION B — HERALDIC SHIELD
+     Crest silhouette, primary field, accent "chief" band across the top
+     carrying the abbreviation, optional sport pip in the point.
+     Yahoo-Fantasy-adjacent. Classic / heraldic. Abbr supporting.
+  ========================================================================= */
+  var SHIELD_PATH = 'M16,12 H84 V50 C84,72 68,86 50,93 C32,86 16,72 16,50 Z';
+  function shield(team, o) {
+    o = o || {}; var p = resolvePalette(team.primary, team.secondary), key = tileKeyline(o.theme);
+    var cid = 'sh' + uid();
+    var inner = '';
+    inner += '<clipPath id="' + cid + '"><path d="' + SHIELD_PATH + '"/></clipPath>';
+    inner += '<path d="' + SHIELD_PATH + '" fill="' + p.baseHex + '"/>';
+    inner += '<g clip-path="url(#' + cid + ')">';
+    inner += '<rect x="14" y="10" width="72" height="26" fill="' + p.accentHex + '"/>';
+    inner += sportPip(team.sport, 50, 70, p.inkHex, 0.5);
+    inner += '</g>';
+    inner += '<path d="' + SHIELD_PATH + '" fill="none" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += letter(team.abbr, 50, 24, p.inkOnAccentHex, { maxW: 56, size: ({ 2: 22, 3: 19, 4: 15 }[Math.min(String(team.abbr).length, 4)] || 19), weight: 800 });
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  /* =========================================================================
+     DIRECTION C — DIAGONAL SPLIT BLOCK
+     Rounded square (squircle), primary field cut by a bold accent sash from
+     corner to corner, oversized abbreviation riding the split.
+     Sleeper-adjacent but louder. Bold / sporty. Monogram hero.
+  ========================================================================= */
+  function block(team, o) {
+    o = o || {}; var p = resolvePalette(team.primary, team.secondary), key = tileKeyline(o.theme);
+    var cid = 'bk' + uid();
+    var inner = '';
+    inner += '<clipPath id="' + cid + '"><rect x="6" y="6" width="88" height="88" rx="22"/></clipPath>';
+    inner += '<g clip-path="url(#' + cid + ')">';
+    inner += '<rect x="6" y="6" width="88" height="88" fill="' + p.baseHex + '"/>';
+    // diagonal sash (lower-left to upper-right)
+    inner += '<polygon points="6,94 30,94 94,30 94,6 70,6 6,70" fill="' + p.accentHex + '"/>';
+    inner += '</g>';
+    inner += '<rect x="6.75" y="6.75" width="86.5" height="86.5" rx="21.5" fill="none" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += letter(team.abbr, 50, 51, p.inkHex, {
+      maxW: 60, weight: 900,
+      stroke: p.baseHex, strokeW: 3.5
+    });
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  /* =========================================================================
+     DIRECTION D — SPORT EQUIPMENT FAMILY
+     Sport-specific silhouette: football helmet, baseball cap, jersey block
+     (basketball/hockey), pennant (golf/other). Generic equipment shapes — no
+     team-specific geometry. Primary field, accent stripe, abbr on the face.
+  ========================================================================= */
+  function equipment(team, o) {
+    o = o || {}; var p = resolvePalette(team.primary, team.secondary), key = tileKeyline(o.theme);
+    var fam = sportFamily(team.sport);
+    if (fam === 'football') return helmet(team, p, key, o);
+    if (fam === 'baseball') return cap(team, p, key, o);
+    if (fam === 'court') return jersey(team, p, key, o);
+    return pennant(team, p, key, o);
+  }
+
+  function helmet(team, p, key, o) {
+    var cid = 'hm' + uid();
+    // Side-profile shell (facing right): the iconic football-helmet silhouette.
+    var shell = 'M20,56 C15,37 26,18 48,17 C70,16 84,28 84,47 C84,53 81,57 75,58 L66,58 C64,65 58,68 50,68 L40,68 C29,68 23,63 20,56 Z';
+    var inner = '';
+    inner += '<clipPath id="' + cid + '"><path d="' + shell + '"/></clipPath>';
+    inner += '<path d="' + shell + '" fill="' + p.baseHex + '" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += '<g clip-path="url(#' + cid + ')">';
+    // center stripe running crown-to-back
+    inner += '<path d="M26,30 C40,21 60,21 74,30 L74,40 C60,31 40,31 26,40 Z" fill="' + p.accentHex + '"/>';
+    // ear hole
+    inner += '<circle cx="44" cy="50" r="6.5" fill="' + p.accentHex + '"/>';
+    inner += '<circle cx="44" cy="50" r="2.6" fill="' + p.baseHex + '"/>';
+    inner += '</g>';
+    // facemask cage projecting from the front (right)
+    inner += '<g fill="none" stroke="' + p.accentHex + '" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round">';
+    inner += '<path d="M75,58 C84,62 84,73 75,77 L58,77 C54,77 52,74 52,70"/>';
+    inner += '<path d="M74,67 L57,67"/>';
+    inner += '</g>';
+    inner += letter(team.abbr, 47, 40, p.inkHex, { maxW: 34, size: ({ 2: 19, 3: 15, 4: 12 }[Math.min(String(team.abbr).length, 4)] || 15), weight: 800 });
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  function cap(team, p, key, o) {
+    var cid = 'cp' + uid();
+    var dome = 'M20,60 C20,33 35,22 50,22 C65,22 80,33 80,60 Z';
+    var inner = '';
+    inner += '<clipPath id="' + cid + '"><path d="' + dome + '"/></clipPath>';
+    inner += '<path d="' + dome + '" fill="' + p.baseHex + '" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += '<g clip-path="url(#' + cid + ')">';
+    inner += '<rect x="48" y="20" width="4" height="44" fill="' + p.accentHex + '" opacity="0.9"/>';
+    inner += '</g>';
+    inner += '<circle cx="50" cy="24" r="3" fill="' + p.accentHex + '"/>';
+    // brim
+    inner += '<path d="M20,60 C20,67 33,72 50,72 C58,72 64,71 68,69 C74,66 78,62 78,60 Z" fill="' + p.accentHex + '" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += letter(team.abbr, 50, 47, p.inkHex, { maxW: 40, size: ({ 2: 24, 3: 18, 4: 14 }[Math.min(String(team.abbr).length, 4)] || 18), weight: 800 });
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  function jersey(team, p, key, o) {
+    var cid = 'js' + uid();
+    var body = 'M30,24 L42,20 C45,25 55,25 58,20 L70,24 L80,34 L72,44 L66,40 L66,82 L34,82 L34,40 L28,44 L20,34 Z';
+    var inner = '';
+    inner += '<clipPath id="' + cid + '"><path d="' + body + '"/></clipPath>';
+    inner += '<path d="' + body + '" fill="' + p.baseHex + '" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += '<g clip-path="url(#' + cid + ')">';
+    inner += '<rect x="34" y="58" width="32" height="6" fill="' + p.accentHex + '"/>';
+    inner += '<rect x="34" y="72" width="32" height="3" fill="' + p.accentHex + '"/>';
+    inner += '</g>';
+    inner += letter(team.abbr, 50, 47, p.inkHex, { maxW: 28, size: ({ 2: 22, 3: 16, 4: 13 }[Math.min(String(team.abbr).length, 4)] || 16), weight: 900 });
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  function pennant(team, p, key, o) {
+    var inner = '';
+    var flag = 'M22,24 L82,38 L40,52 L40,84 L22,84 Z';
+    inner += '<path d="' + flag + '" fill="' + p.baseHex + '" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += '<path d="M22,30 L70,37 L46,45 L22,40 Z" fill="' + p.accentHex + '"/>';
+    inner += letter(team.abbr, 33, 66, p.inkHex, { maxW: 22, size: 18, weight: 900 });
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  /* =========================================================================
+     DIRECTION E — HEX PATCH (negative-space monogram)
+     Pointed hexagon, primary field, inner accent hex, abbreviation KNOCKED OUT
+     to the primary color so the letter reads as negative space inside the
+     accent. Geometric / modern. Demonstrates the knockout contrast device.
+  ========================================================================= */
+  var HEX_OUT = '50,5 89,27 89,73 50,95 11,73 11,27';
+  var HEX_IN = '50,16 79,32 79,68 50,84 21,68 21,32';
+  function hex(team, o) {
+    o = o || {}; var p = resolvePalette(team.primary, team.secondary), key = tileKeyline(o.theme);
+    var mid = 'hx' + uid();
+    var inner = '';
+    inner += '<mask id="' + mid + '">';
+    inner += '<polygon points="' + HEX_IN + '" fill="#fff"/>';
+    inner += letter(team.abbr, 50, 51.5, '#000', { maxW: 46, weight: 900 });
+    inner += '</mask>';
+    inner += '<polygon points="' + HEX_OUT + '" fill="' + p.baseHex + '" stroke="' + key + '" stroke-width="1.5"/>';
+    inner += '<polygon points="' + HEX_IN + '" fill="' + p.accentHex + '" mask="url(#' + mid + ')"/>';
+    return svg(inner, { size: o.size, label: team.name });
+  }
+
+  /* ---------- sport helpers ---------------------------------------------- */
+  function sportFamily(sport) {
+    var s = String(sport || '').toLowerCase();
+    if (s.indexOf('nfl') >= 0 || s.indexOf('ncaa') >= 0 || s.indexOf('football') >= 0) return 'football';
+    if (s.indexOf('mlb') >= 0 || s.indexOf('baseball') >= 0) return 'baseball';
+    if (s.indexOf('nba') >= 0 || s.indexOf('nhl') >= 0 || s.indexOf('basket') >= 0 || s.indexOf('hockey') >= 0) return 'court';
+    return 'other';
+  }
+  // Tiny sport glyph (abstract, generic) used as a heraldic pip. Geometric only.
+  function sportPip(sport, cx, cy, color, scale) {
+    var fam = sportFamily(sport), s = scale || 1;
+    var g = '<g transform="translate(' + cx + ',' + cy + ') scale(' + s + ')" fill="none" stroke="' + color + '" stroke-width="3.4" stroke-linecap="round" opacity="0.85">';
+    if (fam === 'football') { g += '<ellipse cx="0" cy="0" rx="13" ry="8"/><path d="M-6,0 H6 M-3,-3 V3 M3,-3 V3"/>'; }
+    else if (fam === 'baseball') { g += '<circle cx="0" cy="0" r="10"/><path d="M-7,-7 Q0,0 -7,7 M7,-7 Q0,0 7,7"/>'; }
+    else if (fam === 'court') { g += '<circle cx="0" cy="0" r="10"/><path d="M-10,0 H10 M0,-10 V10"/>'; }
+    else { g += '<circle cx="0" cy="0" r="4" fill="' + color + '"/>'; }
+    g += '</g>';
+    return g;
+  }
+
+  var _u = 0;
+  function uid() { return (_u++).toString(36) + Math.random().toString(36).slice(2, 5); }
+
+  /* ---------- direction registry ----------------------------------------- */
+  var DIRECTIONS = [
+    {
+      id: 'roundel', name: 'Monogram Roundel', render: roundel,
+      tag: 'Clean / modern · monogram-forward · universal',
+      concept: 'A primary-color disc with an inset ring in the secondary color and the team abbreviation knocked through the middle. The ring is the contrast device: even two same-red teams differ by their ring color, and a monochrome team gets a derived ring so it never reads as a flat dot. One shape for every sport — zero variant logic.',
+      multisport: 'Fully universal. No sport-specific geometry; works identically for NFL, MLB, NBA, NCAA and anything on the roadmap.',
+      pros: ['Reads cleanly down to 24px push-notification size', 'Single shape = simplest pipeline, no per-sport branch', 'Ring guarantees a two-tone read even for mono palettes'],
+      cons: ['Most "expected" / least ownably-distinct of the set', 'Circles tessellate less interestingly in a 20-row standings list']
+    },
+    {
+      id: 'shield', name: 'Heraldic Shield', render: shield,
+      tag: 'Classic / heraldic · abbr supporting · universal (+sport pip)',
+      concept: 'A crest silhouette with a secondary-color chief (top band) carrying the abbreviation, and a faint generic sport pip embossed in the field below. Leans into the centuries-old "club crest" language fans already associate with team identity, while staying entirely abstract.',
+      multisport: 'Universal silhouette, with an optional abstract sport pip (football/baseball/court) for a subtle hint — drop the pip for a pure-universal variant.',
+      pros: ['Feels the most "team/club" of the directions — fans read it as identity, not placeholder', 'Chief band gives a strong, consistent home for the abbreviation', 'The pip adds a sport hint without per-sport silhouettes'],
+      cons: ['Shield + small chief text is the hardest to keep legible at 24px', 'Heraldry can read as "old-timey" if the type isn\'t kept modern']
+    },
+    {
+      id: 'hex', name: 'Hex Patch', render: hex,
+      tag: 'Geometric / modern · negative-space monogram · universal',
+      concept: 'A pointed hexagon with a secondary inner hex, the abbreviation knocked out to the primary color so the letters read as negative space. A patch/badge feel that\'s modern and ownable — the knockout is the contrast device, so the mark can never collapse into one flat color.',
+      multisport: 'Fully universal. The hexagon is sport-agnostic and tessellates beautifully in grids.',
+      pros: ['Distinct silhouette — not a circle, square or shield', 'Knockout guarantees internal contrast by construction', 'Patch/badge language feels like a deliberate brand system'],
+      cons: ['Negative-space letters need a large-enough inner area; 4-char is tight', 'Two nested hexes can muddy at the very smallest sizes']
+    }
+  ];
+
+  /* ---------- public api -------------------------------------------------- */
+  var API = {
+    parseHex: parseHex, toHex: toHex, contrast: contrast, relLum: relLum,
+    resolvePalette: resolvePalette, sportFamily: sportFamily,
+    directions: DIRECTIONS,
+    byId: function (id) { return DIRECTIONS.filter(function (d) { return d.id === id; })[0]; },
+    render: function (id, team, opt) {
+      var d = this.byId(id);
+      return d ? d.render(team, opt || {}) : '';
+    }
+  };
+  global.SDMarks = API;
+  if (typeof module === 'object' && module.exports) module.exports = API;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandlerTests.cs
@@ -56,7 +56,7 @@ public class GetLeagueWeekMatchupsQueryHandlerTests : ApiTestBase<GetLeagueWeekM
         await DataContext.SaveChangesAsync();
 
         _contestClientMock
-            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<List<LeagueMatchupDto>>([]));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekMatchupsQueryHandler>();
@@ -100,7 +100,7 @@ public class GetLeagueWeekMatchupsQueryHandlerTests : ApiTestBase<GetLeagueWeekM
         var canonicalMatchup2 = CreateCanonicalMatchup(contestId2);
 
         _contestClientMock
-            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<List<LeagueMatchupDto>>([canonicalMatchup1, canonicalMatchup2]));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekMatchupsQueryHandler>();
@@ -143,7 +143,7 @@ public class GetLeagueWeekMatchupsQueryHandlerTests : ApiTestBase<GetLeagueWeekM
         canonicalMatchup.OverUnderCurrent = 52.5;
 
         _contestClientMock
-            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<List<LeagueMatchupDto>>([canonicalMatchup]));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekMatchupsQueryHandler>();
@@ -183,7 +183,7 @@ public class GetLeagueWeekMatchupsQueryHandlerTests : ApiTestBase<GetLeagueWeekM
         await DataContext.SaveChangesAsync();
 
         _contestClientMock
-            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<List<LeagueMatchupDto>>([]));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekMatchupsQueryHandler>();
@@ -230,7 +230,7 @@ public class GetLeagueWeekMatchupsQueryHandlerTests : ApiTestBase<GetLeagueWeekM
 
         var canonicalMatchup = CreateCanonicalMatchup(contestId);
         _contestClientMock
-            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<List<LeagueMatchupDto>>([canonicalMatchup]));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekMatchupsQueryHandler>();
@@ -278,7 +278,7 @@ public class GetLeagueWeekMatchupsQueryHandlerTests : ApiTestBase<GetLeagueWeekM
 
         var canonicalMatchup = CreateCanonicalMatchup(contestId);
         _contestClientMock
-            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetMatchupsByContestIds(It.IsAny<List<Guid>>(), It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<List<LeagueMatchupDto>>([canonicalMatchup]));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekMatchupsQueryHandler>();

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Rankings/Queries/GetRankingsByPollWeek/GetRankingsByPollWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Rankings/Queries/GetRankingsByPollWeek/GetRankingsByPollWeekQueryHandlerTests.cs
@@ -49,7 +49,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
         };
 
         _franchiseClientMock
-            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(rankings);
 
         var handler = Mocker.CreateInstance<GetRankingsByPollWeekQueryHandler>();
@@ -135,7 +135,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
     {
         // Arrange
         _franchiseClientMock
-            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((RankingsByPollIdByWeekDto)null!);
 
         var handler = Mocker.CreateInstance<GetRankingsByPollWeekQueryHandler>();
@@ -163,7 +163,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
         };
 
         _franchiseClientMock
-            .Setup(x => x.GetRankingsByPollByWeek("usa", 2025, 5, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetRankingsByPollByWeek("usa", 2025, 5, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(rankings);
 
         var handler = Mocker.CreateInstance<GetRankingsByPollWeekQueryHandler>();
@@ -194,7 +194,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
         };
 
         _franchiseClientMock
-            .Setup(x => x.GetRankingsByPollByWeek("cfp", 2025, 10, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetRankingsByPollByWeek("cfp", 2025, 10, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(rankings);
 
         var handler = Mocker.CreateInstance<GetRankingsByPollWeekQueryHandler>();
@@ -225,7 +225,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
         };
 
         _franchiseClientMock
-            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(rankings);
 
         var handler = Mocker.CreateInstance<GetRankingsByPollWeekQueryHandler>();
@@ -253,7 +253,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
         };
 
         _franchiseClientMock
-            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(rankings);
 
         var handler = Mocker.CreateInstance<GetRankingsByPollWeekQueryHandler>();
@@ -265,7 +265,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
         // Assert
         result.IsSuccess.Should().BeTrue();
         _franchiseClientMock.Verify(
-            x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<CancellationToken>()),
+            x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -274,7 +274,7 @@ public class GetRankingsByPollWeekQueryHandlerTests : UnitTestBase<GetRankingsBy
     {
         // Arrange
         _franchiseClientMock
-            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetRankingsByPollByWeek("ap", 2025, 5, It.IsAny<MarkDirection>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("HTTP error"));
 
         var handler = Mocker.CreateInstance<GetRankingsByPollWeekQueryHandler>();


### PR DESCRIPTION
## Summary

Replaces ESPN-sourced real team logos (currently in Azure Blob) with **sportDeets-generated team marks** designed to be legally clean for App Store / Play Store submission, and wires a `MarkDirection` enum (Roundel / Shield / Hex) through the back-end read paths so the eventual user-preference UI can flip the served direction without touching the data plane again.

### Why

Real team logos are trademark-protected. NFL Properties and Power-5 NCAA licensing through CLC are ~$100k/yr+ minimums plus revenue share — well outside a pre-revenue solo-founder budget. App Store / Play Store review will flag unlicensed marks.

Background and design exploration: `docs/team-mark-design-brief.md` and the Claude Design session that produced `src/marks/marks.js`.

User-preference wire design and decisions log: `docs/team-mark-user-preference-design.md`.

### What's in this PR

**Commit 1 — Marks engine + batch upload pipeline**
- `src/marks/marks.js` — pure-string SVG generator parameterized by (primary color, secondary color, abbreviation, sport). UMD-shimmed so it loads in both browser and Node.
- `src/marks/batch/` — Node pipeline: `generate.js` (local PNGs for inspection), `upload.js` (blob + manifest), `insert.js` (idempotent DB inserts from manifest), `run.ps1` (PowerShell wrapper).
- 90 marks generated and uploaded for the 30 MLB FranchiseSeason 2026 rows × Roundel/Shield/Hex. Stored in `sportdeetssadev.blob.core.windows.net/sportdeets-marks/franchise-season/{direction}/{Id}.png`. Inserted into `FranchiseSeasonLogo` with `Rel = ["sportdeets-mark", "{direction}"]`.

**Commit 2 — Wire `MarkDirection` through the matchup SQL path**
- New `MarkDirection` enum in Core (`Roundel = 0`, Shield, Hex). Roundel = 0 makes it the default for uninitialized fields.
- `GetMatchupsByContestIds.sql` — each of the 8 logo lateral subqueries replaces `ORDER BY CreatedUtc ASC` with a preference-ordered CASE that picks `sportdeets-mark + requested direction` first, any `sportdeets-mark` second, falls through to ESPN behavior third. Dark-variant laterals now also accept sportdeets-mark rows (our marks are theme-agnostic — single render works on both backgrounds).
- Direction threaded through `IContestClient.GetMatchupsByContestIds` → Producer endpoint → query record → SQL via Dapper `@Direction`.
- API matchup handler hardcodes `MarkDirection.Roundel` with a TODO marker for the deferred user-preference UI.

**Commit 3 — Cascade through `LogoSelectionService` + rankings**
- `LogoSelectionService` gains a "Priority -1" tier at the top of both light- and dark-background cascades. `MarkDirection direction = MarkDirection.Roundel` default parameter means every existing call site silently prefers sportdeets-marks without signature churn. Handlers that benefit automatically: team card, single-game detail, play log, current polls.
- `GetRankingsByPollByWeek.sql` — same CASE pattern as the matchup SQL.
- Rankings wire change parallels the matchup wire change.

**Commit 4 — Read secrets path from env var**
- `run.ps1` no longer hard-codes the local secrets file path. Reads from `$env:SPORTDEETS_SECRETS_PATH` and fails fast with a clear message if unset. Plan doc updated.

### What's not in this PR (deferred)

- **User-preference UI / `User.PreferredMark` column.** No EF migration here. When the profile-toggle UI lands, that PR adds the column, the PATCH endpoint, and the UI — and swaps the hardcoded `MarkDirection.Roundel` in the API handlers for a DB lookup (one-line change per handler).
- **Marks for sports other than MLB, FranchiseSeason rows other than 2026, and Franchise-level marks.** Same batch script, different input dataset.
- **Dead-code cleanup.** Audit surfaced two registered-but-unused SQL surfaces: `ProducerSqlQueryProvider.GetTeamCard()` (registered, never called — `GetTeamCardQueryHandler` uses EF + `LogoSelectionService`) and `CanonicalDataQueryProvider` (registered in DI with zero consumers).
- **Player headshots.** Same legal posture as team logos for different reasons (publicity rights + photo copyright). Planned approach: parametric player roundels with jersey number on team-color disc. Same engine, different render function. See the discussion comment in the PR.
- **NHL pip in marks.js**. `sportPip()` maps both NBA and NHL to the basketball-style "court" glyph. Wrong for hockey. Not blocking MLB.

### Test plan

- [x] Build clean (`dotnet build` on Core, Producer, Api — zero errors, zero warnings)
- [x] Producer + API unit tests pass (only failure is pre-existing `BaseballContestEnrichmentProcessor` test, unrelated to logos)
- [x] LeagueWeek + Rankings tests explicitly updated for new client signatures (60 passing)
- [x] Visual validation: web app shows generated roundels on league-week matchup cards for all MLB 2026 teams
- [x] Visual validation: NYY / LAD / SD / ATH / PIT all render correctly across all three directions (Roundel / Shield / Hex)
- [ ] Spot-check after merge: team card page renders sportdeets roundel for an MLB 2026 team
- [ ] Spot-check after merge: single-game detail renders roundels for both teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable team mark styles (Roundel, Shield, Hex) and direction-aware handling so matchup/ranking cards surface consistent mark variants.
  * Added an interactive marks exploration UI and batch generation/upload tooling to produce multi-size light/dark mark assets.

* **Documentation**
  * Added comprehensive design briefs and integration notes for deterministic, parametric team marks and a user-preference workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->