### PR TITLE
fix(mobile): screenshot polish — picks counter + MatchupCard team-row offset

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -170,9 +170,6 @@ export default function PicksScreen() {
               <Text style={[headerStyles.pillText, { color: theme.tint }]}>
                 {made}/{total}
               </Text>
-              <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
-                {' '}Picks Made
-              </Text>
               <Pressable
                 onPress={() => setHidePicked((v) => !v)}
                 hitSlop={6}

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -142,7 +142,11 @@ function TeamRow({
   }
 
   return (
-    <View style={styles.teamRow}>
+    // Background lives at the call site so the team row gets theme.card,
+    // visually offset from the outer card (which uses theme.background).
+    // Mirrors sd-ui's `.team-row { background: var(--bg-card); }` against
+    // `.matchup-card { background: var(--bg-primary); }`.
+    <View style={[styles.teamRow, { backgroundColor: theme.card }]}>
       {/* Logo */}
       <View style={styles.logoBox}>
         {logoUrl ? (
@@ -707,7 +711,10 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
     <View
       style={[
         styles.card,
-        { backgroundColor: theme.card, borderColor: cardBorderColor },
+        // Outer card uses theme.background (mirrors web's --bg-primary on
+        // .matchup-card). The inner team rows then carry theme.card and
+        // visually pop as inset rows — same layered look the web app has.
+        { backgroundColor: theme.background, borderColor: cardBorderColor },
         isFinal && hasPick && isPickCorrect === true && styles.cardCorrect,
         isFinal && (isPickCorrect === false || !hasPick) && styles.cardIncorrect,
       ]}
@@ -884,13 +891,18 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
-  // Team row
+  // Team row — visual offset from the outer card. Mirrors sd-ui's .team-row:
+  //   background-color: var(--bg-card); border-radius: 8px; margin-bottom: 0.5rem;
+  // Background color is applied at the call site (theme.card) so the
+  // tokens stay consistent across light/dark.
   teamRow: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 14,
     paddingVertical: 10,
     gap: 10,
+    borderRadius: 8,
+    marginBottom: 6,
   },
   logoBox: {
     width: 40,

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -891,8 +891,12 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
-  // Team row — visual offset from the outer card. Mirrors sd-ui's .team-row:
-  //   background-color: var(--bg-card); border-radius: 8px; margin-bottom: 0.5rem;
+  // Team row — visual offset from the outer card. Mirrors sd-ui's .team-row
+  // (background, rounded corners, gap) PLUS the inset created by web's
+  // .matchup-card { padding: 20px; }. On mobile the outer card has no
+  // padding, so we use marginHorizontal here to keep the row off the card
+  // edges. marginVertical creates the spacing between rows AND between the
+  // top row and the headline banner / bottom row and the odds section.
   // Background color is applied at the call site (theme.card) so the
   // tokens stay consistent across light/dark.
   teamRow: {
@@ -902,7 +906,8 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     gap: 10,
     borderRadius: 8,
-    marginBottom: 6,
+    marginHorizontal: 10,
+    marginVertical: 4,
   },
   logoBox: {
     width: 40,


### PR DESCRIPTION
## Summary

Two small mobile parity / screenshot-polish fixes that both fold into the same PR (same surface area, same intent: make the mobile app screenshot-ready).

### 1. Drop \`Picks Made\` label from the picks-counter chip

The header counter on the picks tab read \`X/Y Picks Made\`. The label suffix took real estate, made the chip visually heavy, and crowded marketing screenshots. Dropped the suffix; \`X/Y\` by itself is unambiguous in context (the user is already on the picks tab).

The \`All Picks Made\` celebration text on the completion branch is intentionally untouched — that copy is the success affordance and reads correctly without a counter.

### 2. Match web's inset team-row visual offset in MatchupCard

Web's \`.matchup-card\` uses \`var(--bg-primary)\` as the outer background while the inner \`.team-row\` uses \`var(--bg-card)\`. The team rows visually pop as inset cards inside the bordered outer container. Mobile didn't have that layering — the outer card used \`theme.card\` and team rows were transparent, so the matchup card looked flat next to its web counterpart.

Three coordinated changes:

- Outer card \`backgroundColor\` flipped from \`theme.card\` to \`theme.background\` (matches web's outer \`--bg-primary\`).
- Team row inline gets \`backgroundColor: theme.card\` (matches web's inner \`--bg-card\`).
- \`teamRow\` StyleSheet adds \`borderRadius: 8\` and \`marginBottom: 6\` (matches web's \`border-radius: 8px\` and \`margin-bottom: 0.5rem\`).

Net effect: the matchup card now reads as a bordered container holding two raised team-row cards inside, parity with the web gold standard.

## Test plan

- [ ] Picks tab header shows \`X/Y\` only while picks are in progress
- [ ] Completion banner still shows \`All Picks Made\` after the final pick
- [ ] Hide-picked toggle still renders and toggles correctly
- [ ] MatchupCard's away + home team rows now visually pop as inset cards on both light and dark themes
- [ ] Border / shadow on the outer MatchupCard still reads correctly with the new background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Simplified the Picks header by removing the secondary subtitle so only the numeric "made/total" count is shown for a cleaner, more concise display.
  * Refined matchup card and team row visuals to better follow theme colors and added subtle inset and spacing adjustments for improved readability and visual consistency across cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->