### PR TITLE
fix(api): align Firebase audience/issuer/authority with sportdeets project

### DIFF
--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -55,13 +55,19 @@ namespace SportsData.Api
                 .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>
                 {
-                    options.Authority = "https://securetoken.google.com/sportdeets-dev";
+                    // Firebase project — migrated from "sportdeets-dev" to
+                    // "sportdeets" during the iOS push notification work
+                    // (see docs/firebase-project-migration.md). Web and
+                    // mobile clients were updated then; the API was missed
+                    // and surfaced as IDX10214 audience-validation errors
+                    // for every authenticated UI request in prod.
+                    options.Authority = "https://securetoken.google.com/sportdeets";
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
                         ValidateIssuer = true,
-                        ValidIssuer = "https://securetoken.google.com/sportdeets-dev",
+                        ValidIssuer = "https://securetoken.google.com/sportdeets",
                         ValidateAudience = true,
-                        ValidAudience = "sportdeets-dev",
+                        ValidAudience = "sportdeets",
                         ValidateLifetime = true,
                         NameClaimType = "user_id",
                         RoleClaimType = "role"


### PR DESCRIPTION
## Summary

Production hotfix. Authenticated UI requests have been failing with IDX10214 audience-validation errors. Surfaced today in Seq:

\`\`\`
Audiences: 'sportdeets'.
Did not match: validationParameters.ValidAudience: 'sportdeets-dev'
\`\`\`

**Root cause:** the Firebase project was migrated from \`sportdeets-dev\` to \`sportdeets\` during the iOS push notification work in early June. Web and mobile clients were updated then; the API's hardcoded JwtBearer config in \`Program.cs\` was missed.

Pre-existing tokens probably masked the issue until they expired and clients started signing in fresh against the new Firebase project.

## What changed

Three string constants in \`Program.cs\` — \`Authority\`, \`ValidIssuer\`, \`ValidAudience\` — flipped from \`sportdeets-dev\` to \`sportdeets\`.

## Follow-up worth considering (not in this PR)

These should probably move to Azure AppConfig so the dev/prod split can pick the right Firebase project per environment without code changes. That's a separate refactor; the immediate need is to stop the prod auth failures.

## Test plan

- [ ] Build clean (verified locally)
- [ ] After merge + deploy: an authenticated UI request (e.g. \`/ui/picks/...\`) returns 200 instead of 401
- [ ] Seq shows no more IDX10214 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authentication token validation errors to restore proper login functionality and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->