### PR TITLE
chore(producer): resolve 4 image-publish TODOs

### DIFF
--- a/src/SportsData.Producer/Application/Images/Processors/Requests/FranchiseLogoRequestProcessor.cs
+++ b/src/SportsData.Producer/Application/Images/Processors/Requests/FranchiseLogoRequestProcessor.cs
@@ -65,31 +65,10 @@ namespace SportsData.Producer.Application.Images.Processors.Requests
 
             if (logo is not null)
             {
-                _logger.LogWarning("Venue image already exists. Will publish event and exit.");
-
-                // TODO: Do I REALLY need to publish this event? It will just cause more work for downstream
-
-                var outgoingEvt = new ProcessImageResponse(
-                    logo.Uri,
-                    logo.Id.ToString(),
-                    urlHash,
-                    request.ParentEntityId,
-                    request.Name,
-                    null,
-                    request.Sport,
-                    request.SeasonYear,
-                    logoDocType,
-                    request.SourceDataProvider,
-                    request.Height,
-                    request.Width,
-                    request.Rel,
-                    request.CorrelationId,
-                    request.CausationId);
-
-                await _bus.Publish(outgoingEvt);
-                
-                await _dataContext.SaveChangesAsync();
-
+                // FranchiseLogoResponseProcessor performs the same OriginalUrlHash duplicate
+                // check and silent-returns on hit. Republishing here would be a no-op cycle
+                // through broker + Hangfire + 2 DB queries for nothing.
+                _logger.LogInformation("Franchise logo already exists. Skipping publish.");
                 return;
             }
 

--- a/src/SportsData.Producer/Application/Images/Processors/Requests/FranchiseSeasonLogoRequestProcessor.cs
+++ b/src/SportsData.Producer/Application/Images/Processors/Requests/FranchiseSeasonLogoRequestProcessor.cs
@@ -64,9 +64,12 @@ namespace SportsData.Producer.Application.Images.Processors.Requests
 
             if (logo is not null)
             {
-                _logger.LogWarning("franchiseSeason logo already exists. Will publish event and exit.");
-
-                // TODO: Do I REALLY need to publish this event? It will just cause more work for downstream
+                // Unlike the other *LogoRequestProcessors, this one's republish is load-bearing:
+                // FranchiseSeasonLogoResponseProcessor updates Height/Width/Rel/ModifiedUtc on
+                // the existing row when it sees the duplicate. Removing the publish would skip
+                // the metadata refresh path. (In practice ESPN rarely changes these values for
+                // a given URL hash, so this is defensive — revisit if metrics show it's wasted.)
+                _logger.LogInformation("franchiseSeason logo already exists. Publishing for metadata refresh.");
 
                 var outgoingEvt = new ProcessImageResponse(
                     logo.Uri,

--- a/src/SportsData.Producer/Application/Images/Processors/Requests/GroupSeasonLogoRequestProcessor.cs
+++ b/src/SportsData.Producer/Application/Images/Processors/Requests/GroupSeasonLogoRequestProcessor.cs
@@ -71,31 +71,11 @@ namespace SportsData.Producer.Application.Images.Processors.Requests
 
             if (logo is not null)
             {
-                _logger.LogWarning("groupSeason logo already exists. Will publish event and exit.");
-
-                // TODO: Do I REALLY need to publish this event? It will just cause more work for downstream
-
-                var outgoingEvt = new ProcessImageResponse(
-                    logo.Uri,
-                    logo.Id.ToString(),
-                    urlHash,
-                    request.ParentEntityId,
-                    request.Name,
-                    null,
-                    request.Sport,
-                    request.SeasonYear,
-                    logoDocType,
-                    request.SourceDataProvider,
-                    request.Height,
-                    request.Width,
-                    request.Rel,
-                    request.CorrelationId,
-                    request.CausationId);
-
-                await _bus.Publish(outgoingEvt);
-
-                await _dataContext.SaveChangesAsync();
-
+                // GroupSeasonLogoResponseProcessor does NOT check for an existing logo before
+                // INSERT; republishing here with the existing logo's Id would cause a PK
+                // violation in the downstream Hangfire job. Idempotency lives on the request
+                // side: if the GroupSeason already has a logo for this URL hash, we're done.
+                _logger.LogInformation("GroupSeason logo already exists. Skipping publish.");
                 return;
             }
 

--- a/src/SportsData.Producer/Application/Images/Processors/Requests/VenueImageRequestProcessor.cs
+++ b/src/SportsData.Producer/Application/Images/Processors/Requests/VenueImageRequestProcessor.cs
@@ -77,7 +77,10 @@ namespace SportsData.Producer.Application.Images.Processors.Requests
 
             if (img is not null)
             {
-                await HandleExisting(img, urlHash, request, logoDocType);
+                // VenueImageResponseProcessor performs the same OriginalUrlHash duplicate
+                // check and silent-returns on hit. Republishing here would be a no-op cycle
+                // through broker + Hangfire + 2 DB queries for nothing.
+                _logger.LogInformation("Venue image already exists. Skipping publish.");
                 return;
             }
 
@@ -127,36 +130,5 @@ namespace SportsData.Producer.Application.Images.Processors.Requests
             _logger.LogInformation("Published ProcessImageResponse");
         }
 
-        private async Task HandleExisting(
-            VenueImage img,
-            string urlHash,
-            ProcessImageRequest request,
-            DocumentType logoDocType)
-        {
-            _logger.LogWarning("Venue image already exists. Will publish event and exit.");
-
-            // TODO: Do I REALLY need to publish this event? It will just cause more work for downstream
-
-            var outgoingEvt = new ProcessImageResponse(
-                img.Uri,
-                img.Id.ToString(),
-                urlHash,
-                request.ParentEntityId,
-                request.Name,
-                null,
-                request.Sport,
-                request.SeasonYear,
-                logoDocType,
-                request.SourceDataProvider,
-                request.Height,
-                request.Width,
-                request.Rel,
-                request.CorrelationId,
-                request.CausationId);
-
-            await _bus.Publish(outgoingEvt);
-
-            await _dataContext.SaveChangesAsync();
-        }
     }
 }


### PR DESCRIPTION
## Summary

Investigation of the four `// TODO: Do I REALLY need to publish this event?` TODOs in the image request processors. Per-processor analysis:

| Processor | Response handler on duplicate | Verdict |
|-----------|------------------------------|---------|
| `FranchiseLogoRequestProcessor` | silent return | **DELETE** — pure no-op |
| `GroupSeasonLogoRequestProcessor` | unconditional INSERT | **DELETE** — latent PK violation |
| `VenueImageRequestProcessor` | silent return | **DELETE** — pure no-op |
| `FranchiseSeasonLogoRequestProcessor` | updates `Height/Width/Rel/ModifiedUtc` | **KEEP** with explanatory comment |

### Notes

- The `GroupSeasonLogo` case was a latent bug: `GroupSeasonLogoResponseProcessor` does not check for an existing logo before `AddAsync` with `Id = Guid.Parse(response.ImageId)`. The duplicate-path publish carried the EXISTING logo's GUID, which would PK-violate downstream. Removing the publish fixes the bug and removes the wasted broker round-trip.
- For `FranchiseSeasonLogo` I kept the publish defensively — the response handler does refresh metadata. In practice ESPN rarely changes `Height/Width` for a given URL hash so this might also be wasted, but I can't prove it never useful from code alone. Flagged for future revisit.
- All four duplicate paths also dropped the trailing `SaveChangesAsync()` (was flushing the outbox after the now-removed publish; no other DB writes pending).
- `VenueImageRequestProcessor` lost its `HandleExisting` helper which had no other call sites.

## Test plan
- [x] `dotnet build src/SportsData.Producer` — clean
- [x] `dotnet test SportsData.Producer.Tests.Unit` — 419 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized image processing to reduce unnecessary operations when duplicate images are detected across multiple handlers.
  * Improved logging consistency for duplicate image scenarios.
  * Enhanced system performance by streamlining redundant event publishing and database operations for existing image records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->