### PR TITLE
feat(producer): route streamer enqueue to daemon queue (PR C)

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/ICompetitionBroadcastingJob.cs
+++ b/src/SportsData.Producer/Application/Competitions/ICompetitionBroadcastingJob.cs
@@ -1,3 +1,5 @@
+using Hangfire;
+
 namespace SportsData.Producer.Application.Competitions;
 
 /// <summary>
@@ -7,5 +9,19 @@ namespace SportsData.Producer.Application.Competitions;
 /// </summary>
 public interface ICompetitionBroadcastingJob
 {
+    /// <summary>
+    /// Routed to the Hangfire "daemon" queue so only the Producer Daemon role
+    /// (introduced in PR A) picks it up. Worker pods listen on this queue too
+    /// during the PR A–C transition (see docs/contest-finalization-reconcile-
+    /// backstop.md Step 4) so streamers continue to run even before the Daemon
+    /// Deployment is activated; PR D will drop daemon from Worker's queue list
+    /// to complete the cutover.
+    ///
+    /// Hangfire reads [Queue] from the method on the type expression in the
+    /// lambda — since enqueue sites use Enqueue&lt;ICompetitionBroadcastingJob&gt;
+    /// (rather than the concrete streamer type), this attribute belongs on the
+    /// interface, not the implementations.
+    /// </summary>
+    [Queue("daemon")]
     Task ExecuteAsync(StreamCompetitionCommand command, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Summary

Third of six PRs implementing the contest-finalization fix per [`docs/contest-finalization-reconcile-backstop.md`](docs/contest-finalization-reconcile-backstop.md) Step 4.

Adds `[Queue(\"daemon\")]` to `ICompetitionBroadcastingJob.ExecuteAsync` so every `CompetitionStreamerBase` enqueue is routed to the Hangfire `daemon` queue. Both call sites — `CompetitionStreamScheduler` (Schedule) and `ContestController` (Enqueue) — invoke through the interface lambda, so Hangfire's attribute reflection picks this up at the single interface method instead of needing per-implementation duplication.

## Why the interface, not the implementations

Both enqueue sites use `Enqueue<ICompetitionBroadcastingJob>(job => job.ExecuteAsync(...))`. Hangfire reflects the method from the typed lambda parameter — which is the interface method. Putting `[Queue]` on `FootballCompetitionStreamer` / `BaseballCompetitionStreamer` would have no effect because the reflected `MethodInfo` doesn't reach them.

## Transition mode interaction (PR A reminder)

Per PR A's queue routing:

- `Worker` listens on `[\"default\", \"daemon\"]` — transition mode
- `Daemon` listens on `[\"daemon\"]` only

So after this PR merges and a new producer image with PR A + C ships:
- New streamers go to the `daemon` queue
- Both Worker (transition) and Daemon (activated when replicas bump to 2 per PR B) can pick them up
- No gap during the cutover window

PR D will drop `daemon` from Worker once Daemon pods are confirmed healthy in prod, completing the split.

## Test plan
- [x] `dotnet build src/SportsData.Producer` — clean
- [x] Producer unit tests: **420 passed**
- [ ] **Post-deploy verification:** confirm via Hangfire dashboard that new streamer jobs land on the \`daemon\` queue (not \`default\`)
- [ ] **Post-deploy verification:** confirm Seq shows the streamer running on a Daemon-role pod once PR B is activated

## Follow-up PRs

- **PR D**: Worker stops listening on `daemon` queue
- **PR E**: `FinalizationReconcileJob` durable backstop
- **PR F**: One-shot recovery for the 10 stranded 2026-06-13 contests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal background job processing configuration to optimize deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->