### PR TITLE
chore(ci): bump producer-mlb-daemon image in auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -148,6 +148,7 @@ jobs:
           # Update all producer role patch files (worker, ingest, api, daemon) for NCAA, NFL, and MLB.
           # Daemon patches are present per-sport once that sport's daemon Deployment ships in sports-data-config
           # (MLB only as of PR B in the contest-finalization-reconcile-backstop workstream).
+          # Must stay in sync with deploy-services-prod.yml.
           for patch in producer-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
             FILE="app/overlays/04_prod/$patch"
             if [ ! -f "$FILE" ]; then

--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -145,8 +145,10 @@ jobs:
             echo "::error::producer_tag contains invalid characters: $TAG"
             exit 1
           fi
-          # Update all producer role patch files (worker, ingest, api) for NCAA, NFL, and MLB
-          for patch in producer-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml; do
+          # Update all producer role patch files (worker, ingest, api, daemon) for NCAA, NFL, and MLB.
+          # Daemon patches are present per-sport once that sport's daemon Deployment ships in sports-data-config
+          # (MLB only as of PR B in the contest-finalization-reconcile-backstop workstream).
+          for patch in producer-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
             FILE="app/overlays/04_prod/$patch"
             if [ ! -f "$FILE" ]; then
               echo "::error::Missing producer patch file: $FILE"

--- a/.github/workflows/deploy-services-prod.yml
+++ b/.github/workflows/deploy-services-prod.yml
@@ -55,8 +55,11 @@ jobs:
             echo "::error::producer_tag contains invalid characters: $TAG"
             exit 1
           fi
-          # Update all producer role patch files (worker, ingest, api) for NCAA, NFL, and MLB
-          for patch in producer-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml; do
+          # Update all producer role patch files (worker, ingest, api, daemon) for NCAA, NFL, and MLB.
+          # Daemon patches are present per-sport once that sport's daemon Deployment ships in sports-data-config
+          # (MLB only as of PR B in the contest-finalization-reconcile-backstop workstream).
+          # Must stay in sync with deploy-services-prod-auto.yml.
+          for patch in producer-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
             FILE="app/overlays/04_prod/$patch"
             if [ ! -f "$FILE" ]; then
               echo "::error::Missing producer patch file: $FILE"


### PR DESCRIPTION
## Summary

The `deploy-services-prod-auto` workflow iterates a hardcoded list of producer patch files to update their image tags. The MLB daemon patch shipped in [sports-data-config PR #1](https://github.com/jrandallsexton/sports-data-config/pull/1) (contest-finalization-reconcile-backstop workstream) was missed from that list — so triggering a Producer deploy bumps every other producer patch (worker / ingest / api across NCAA, NFL, MLB) but leaves the daemon stuck at its placeholder `:4689` tag.

Adds `producer-mlb-daemon-patch.yaml` to the iteration.

## Why NCAAFB / NFL daemon patches are NOT in the list

Their manifests don't exist yet — we deliberately deferred them until those seasons approach. The workflow has an existence check (`if [ ! -f "$FILE" ]; then echo "::error::Missing producer patch file" && exit 1`) that would fail the build if a non-existent patch were referenced. Easy follow-up to add them when those manifests ship.

## Test plan
- [ ] Trigger workflow with `deploy_producer: true` and confirm log line `Updated producer-mlb-daemon-patch.yaml to tag: <new>` appears
- [ ] Confirm the committed config-repo change touches the daemon patch alongside the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved production deployment automation so producer image tags are updated for an additional daemon patch component.
  * Updated the related workflow comments to reflect the expanded coverage and keep documentation aligned across production deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->