### PR TITLE
feat(producer): FinalizationReconcileJob — durable streamer backstop (PR E)

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/Reconcile/FinalizationReconcileJob.cs
+++ b/src/SportsData.Producer/Application/Competitions/Reconcile/FinalizationReconcileJob.cs
@@ -1,0 +1,241 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Producer.Enums;
+using SportsData.Producer.Infrastructure.Data;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Competitions.Reconcile;
+
+public class FinalizationReconcileJob<TDataContext> : IFinalizationReconcileJob
+    where TDataContext : TeamSportDataContext
+{
+    private readonly ILogger<FinalizationReconcileJob<TDataContext>> _logger;
+    private readonly TDataContext _dbContext;
+    private readonly HttpClient _httpClient;
+    private readonly IEventBus _eventBus;
+    private readonly IMessageDeliveryScope _deliveryScope;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IAppMode _appMode;
+
+    // CompetitionStream rows started in the last 48h are candidates.
+    // Older streams are assumed stale enough that publishing ContestCompleted
+    // wouldn't accomplish anything (Contest already finalized via the daily
+    // backstop, or stranded beyond what the consumer cares about). Bounds
+    // ESPN polling cost per pass.
+    private static readonly TimeSpan WindowOfConcern = TimeSpan.FromHours(48);
+
+    // A stream still "in-progress" per ESPN that started > 12h ago is
+    // anomalous (no live game runs that long) and surfaces a warning.
+    private static readonly TimeSpan SuspectThreshold = TimeSpan.FromHours(12);
+
+    public FinalizationReconcileJob(
+        ILogger<FinalizationReconcileJob<TDataContext>> logger,
+        TDataContext dbContext,
+        IHttpClientFactory httpClientFactory,
+        IEventBus eventBus,
+        IMessageDeliveryScope deliveryScope,
+        IDateTimeProvider dateTimeProvider,
+        IAppMode appMode)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+        _httpClient = httpClientFactory.CreateClient();
+        _eventBus = eventBus;
+        _deliveryScope = deliveryScope;
+        _dateTimeProvider = dateTimeProvider;
+        _appMode = appMode;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var correlationId = Guid.NewGuid();
+        using var _ = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId,
+            ["Job"] = nameof(FinalizationReconcileJob<TDataContext>),
+            ["Sport"] = _appMode.CurrentSport
+        });
+
+        var now = _dateTimeProvider.UtcNow();
+        var lowerBound = now - WindowOfConcern;
+
+        _logger.LogInformation(
+            "FinalizationReconcileJob beginning. WindowLowerBound={LowerBound}", lowerBound);
+
+        var stranded = await _dbContext.CompetitionStreams
+            .AsNoTracking()
+            .Include(s => s.Competition).ThenInclude(c => c.Contest)
+            .Include(s => s.Competition).ThenInclude(c => c.ExternalIds)
+            .Where(s => s.StreamStartedUtc != null &&
+                        s.StreamStartedUtc > lowerBound &&
+                        (s.Status == CompetitionStreamStatus.Active ||
+                         s.Status == CompetitionStreamStatus.Failed))
+            .ToListAsync(cancellationToken);
+
+        // IsFinal is a computed property on ContestBase (FinalizedUtc.HasValue),
+        // so it can't be translated to SQL — filter in memory after the
+        // bounded query above.
+        var actionable = stranded
+            .Where(s => s.Competition?.Contest is { IsFinal: false })
+            .ToList();
+
+        _logger.LogInformation(
+            "Found {StrandedCount} stranded streams; {ActionableCount} are unfinalized and require reconciliation.",
+            stranded.Count, actionable.Count);
+
+        var reconciled = 0;
+        foreach (var stream in actionable)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+            if (await TryReconcileAsync(stream, now, cancellationToken)) reconciled++;
+        }
+
+        _logger.LogInformation(
+            "FinalizationReconcileJob complete. Reconciled={Reconciled} Candidates={Candidates}.",
+            reconciled, actionable.Count);
+    }
+
+    private async Task<bool> TryReconcileAsync(
+        CompetitionStream stream,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var externalId = stream.Competition.ExternalIds
+            .FirstOrDefault(x => x.Provider == SourceDataProvider.Espn);
+
+        if (externalId == null)
+        {
+            _logger.LogWarning(
+                "Stranded stream has no ESPN external id; cannot reconcile. StreamId={StreamId}",
+                stream.Id);
+            return false;
+        }
+
+        var competitionRef = new Uri(externalId.SourceUrl);
+        var statusUri = EspnUriMapper.CompetitionRefToCompetitionStatusRef(competitionRef);
+
+        var status = await GetStatusAsync(statusUri, cancellationToken);
+        if (status == null)
+        {
+            _logger.LogWarning(
+                "ESPN status fetch returned null for stranded stream. StreamId={StreamId} StatusUri={StatusUri}",
+                stream.Id, statusUri);
+            return false;
+        }
+
+        if (status.Type?.Name == "STATUS_FINAL")
+        {
+            await PublishFinalizationEventsAsync(stream, competitionRef, cancellationToken);
+            await MarkStreamCompletedAsync(stream.Id, now, cancellationToken);
+
+            _logger.LogInformation(
+                "Reconciled stranded stream → published ContestCompleted. StreamId={StreamId} ContestId={ContestId}",
+                stream.Id, stream.Competition.ContestId);
+            return true;
+        }
+
+        if (stream.StreamStartedUtc.HasValue &&
+            stream.StreamStartedUtc.Value < now - SuspectThreshold)
+        {
+            _logger.LogWarning(
+                "Stranded stream still in-progress per ESPN after {Hours:F1}h — anomalous. StreamId={StreamId} ContestId={ContestId} StatusName={StatusName}",
+                (now - stream.StreamStartedUtc.Value).TotalHours,
+                stream.Id,
+                stream.Competition.ContestId,
+                status.Type?.Name);
+        }
+
+        return false;
+    }
+
+    private async Task<EspnEventCompetitionStatusDtoBase?> GetStatusAsync(
+        Uri statusUri,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync(statusUri, cancellationToken);
+            if (!response.IsSuccessStatusCode) return null;
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            return json.FromJson<EspnEventCompetitionStatusDtoBase>();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fetch ESPN status from {StatusUri}", statusUri);
+            return null;
+        }
+    }
+
+    private async Task PublishFinalizationEventsAsync(
+        CompetitionStream stream,
+        Uri competitionRef,
+        CancellationToken cancellationToken)
+    {
+        // CorrelationId = stream.Id, matching the streamer's own publish path.
+        // Causation = same value (this job is the originating cause in the
+        // backstop chain). Direct delivery — no DbContext write happens here;
+        // the MarkStreamCompletedAsync write is separated below to keep the
+        // outbox interceptor out of the publish path. Same pattern as
+        // CompetitionStreamerBase.PublishContestCompletedAsync.
+        var correlationId = stream.Id;
+
+        using (_deliveryScope.Use(DeliveryMode.Direct))
+        {
+            await _eventBus.Publish(new ContestCompleted(
+                ContestId: stream.Competition.ContestId,
+                CompetitionId: stream.CompetitionId,
+                SeasonWeekId: stream.SeasonWeekId,
+                Ref: null,
+                Sport: _appMode.CurrentSport,
+                SeasonYear: stream.Competition.Contest?.SeasonYear,
+                CorrelationId: correlationId,
+                CausationId: correlationId), cancellationToken);
+
+            var contestUri = EspnUriMapper.CompetitionRefToContestRef(competitionRef);
+            await _eventBus.Publish(new DocumentRequested(
+                Id: Guid.NewGuid().ToString(),
+                ParentId: null,
+                Uri: contestUri,
+                Ref: null,
+                Sport: _appMode.CurrentSport,
+                SeasonYear: stream.Competition.Contest?.SeasonYear,
+                DocumentType: DocumentType.Event,
+                SourceDataProvider: SourceDataProvider.Espn,
+                CorrelationId: correlationId,
+                CausationId: correlationId), cancellationToken);
+        }
+    }
+
+    private async Task MarkStreamCompletedAsync(
+        Guid streamId,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        // The list-level query above is AsNoTracking() to keep memory low;
+        // this scoped re-fetch is the only mutation path. The original
+        // FailureReason is intentionally preserved as diagnostic evidence
+        // for the original streamer miss.
+        var tracked = await _dbContext.CompetitionStreams
+            .FirstOrDefaultAsync(s => s.Id == streamId, cancellationToken);
+        if (tracked == null) return;
+
+        tracked.Status = CompetitionStreamStatus.Completed;
+        tracked.StreamEndedUtc = now;
+        tracked.ModifiedUtc = now;
+        tracked.ModifiedBy = Guid.Empty;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/SportsData.Producer/Application/Competitions/Reconcile/FinalizationReconcileJob.cs
+++ b/src/SportsData.Producer/Application/Competitions/Reconcile/FinalizationReconcileJob.cs
@@ -47,7 +47,13 @@ public class FinalizationReconcileJob<TDataContext> : IFinalizationReconcileJob
     {
         _logger = logger;
         _dbContext = dbContext;
-        _httpClient = httpClientFactory.CreateClient();
+        // Route through the existing EspnHttpClient typed-client registration
+        // (Core/ServiceRegistration.cs::AddClients) so we inherit its retry
+        // policy + SportDeets User-Agent without inventing a parallel named
+        // client. AddHttpClient<EspnHttpClient>(...) registers the configured
+        // HttpClient under nameof(EspnHttpClient), so CreateClient(name) here
+        // returns the same configured instance the EspnHttpClient wrapper uses.
+        _httpClient = httpClientFactory.CreateClient(nameof(EspnHttpClient));
         _eventBus = eventBus;
         _deliveryScope = deliveryScope;
         _dateTimeProvider = dateTimeProvider;

--- a/src/SportsData.Producer/Application/Competitions/Reconcile/IFinalizationReconcileJob.cs
+++ b/src/SportsData.Producer/Application/Competitions/Reconcile/IFinalizationReconcileJob.cs
@@ -1,0 +1,30 @@
+using Hangfire;
+
+namespace SportsData.Producer.Application.Competitions.Reconcile;
+
+/// <summary>
+/// Recurring backstop that recovers stranded <c>CompetitionStream</c>
+/// rows whose streamer process died before publishing <c>ContestCompleted</c>
+/// (KEDA scale-down, pod OOM, the 5h MaxStreamDuration cap, etc.).
+///
+/// For each stranded row, the job re-checks ESPN status directly; on
+/// <c>STATUS_FINAL</c>, it publishes <c>ContestCompleted</c> + a
+/// <c>DocumentRequested(Event)</c> refresh — mirroring the exact
+/// finalization path the streamer would have taken if it had reached
+/// the publish points itself. Idempotency on the consumer side absorbs
+/// any race where a slow streamer also reaches publish.
+///
+/// See docs/contest-finalization-reconcile-backstop.md Step 3.
+/// </summary>
+public interface IFinalizationReconcileJob
+{
+    /// <summary>
+    /// Routed to the Hangfire "daemon" queue so only the Producer Daemon
+    /// role picks it up — same routing rationale as
+    /// <c>ICompetitionBroadcastingJob</c>. Hangfire reads <c>[Queue]</c>
+    /// from the method on the type expression in the lambda, so the
+    /// attribute belongs on the interface, not the implementation.
+    /// </summary>
+    [Queue("daemon")]
+    Task ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -7,6 +7,7 @@ using SportsData.Core.Config;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 using SportsData.Producer.Application.Competitions;
+using SportsData.Producer.Application.Competitions.Reconcile;
 using SportsData.Producer.Application.Consumers;
 using SportsData.Producer.Application.Competitions.Commands.CalculateCompetitionMetrics;
 using SportsData.Producer.Application.Competitions.Commands.EnqueueCompetitionMediaRefresh;
@@ -236,6 +237,19 @@ namespace SportsData.Producer.DependencyInjection
                     break;
             }
 
+            // FinalizationReconcileJob: durable backstop that recovers stranded
+            // CompetitionStream rows when the streamer fails to publish ContestCompleted
+            // (KEDA scale-down mid-game, OOM, 5h MaxStreamDuration). Same closed-generic
+            // pattern as ContestEnrichmentJob; only MLB is wired up initially per the
+            // sequencing in docs/contest-finalization-reconcile-backstop.md. Football
+            // joins when its Daemon Deployments ship pre-season.
+            switch (mode)
+            {
+                case Sport.BaseballMlb:
+                    services.AddScoped<IFinalizationReconcileJob, FinalizationReconcileJob<BaseballDataContext>>();
+                    break;
+            }
+
             // SeasonWeek Commands
             services.AddScoped<IEnqueueSeasonWeekContestsUpdateCommandHandler, EnqueueSeasonWeekContestsUpdateCommandHandler>();
 
@@ -408,6 +422,17 @@ namespace SportsData.Producer.DependencyInjection
                     nameof(CompetitionStreamScheduler),
                     job => job.Execute(),
                     "0 7 * * *"); // Daily at 07:00 UTC
+
+                // FinalizationReconcileJob — durable backstop. Every 15 minutes
+                // it sweeps for CompetitionStream rows whose streamer process
+                // died before publishing ContestCompleted, re-checks ESPN status,
+                // and publishes the finalization events if the game is now FINAL.
+                // [Queue("daemon")] on IFinalizationReconcileJob.ExecuteAsync
+                // routes the trigger to the daemon queue.
+                recurringJobManager.AddOrUpdate<IFinalizationReconcileJob>(
+                    "FinalizationReconcileJob",
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    "*/15 * * * *"); // Every 15 minutes
             }
 
             recurringJobManager.AddOrUpdate<FranchiseSeasonEnrichmentJob>(

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -294,8 +294,12 @@ public class Program
             app.MapPrometheusScrapingEndpoint();
         }
 
-        // Recurring Hangfire jobs — only for Worker role
-        if (role.HasFlag(ProducerRole.Worker))
+        // Recurring Hangfire jobs — for Worker and Daemon roles. Hangfire's
+        // AddOrUpdate is idempotent so duplicate registration across roles is
+        // safe; per-job [Queue(...)] attributes route each trigger to the
+        // appropriate role's queue at run time (e.g. FinalizationReconcileJob
+        // is [Queue("daemon")] so only Daemon pods process it).
+        if (role.HasFlag(ProducerRole.Worker) || role.HasFlag(ProducerRole.Daemon))
         {
             app.Services.ConfigureHangfireJobs(mode);
         }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/Reconcile/FinalizationReconcileJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/Reconcile/FinalizationReconcileJobTests.cs
@@ -1,0 +1,269 @@
+#nullable enable
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+using Moq.Protected;
+
+using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Producer.Application.Competitions.Reconcile;
+using SportsData.Producer.Enums;
+using SportsData.Producer.Infrastructure.Data;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using System.Net;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Competitions.Reconcile;
+
+[Collection("Sequential")]
+public class FinalizationReconcileJobTests : ProducerTestBase<FinalizationReconcileJob<FootballDataContext>>
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 14, 12, 0, 0, DateTimeKind.Utc);
+
+    private const string FinalStatusJson = """
+    { "type": { "name": "STATUS_FINAL" } }
+    """;
+
+    private const string InProgressStatusJson = """
+    { "type": { "name": "STATUS_IN_PROGRESS" } }
+    """;
+
+    private void SetFixedTime()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(p => p.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    private void SetSport(Sport sport)
+    {
+        Mocker.GetMock<IAppMode>()
+            .SetupGet(m => m.CurrentSport)
+            .Returns(sport);
+    }
+
+    private Mock<IMessageDeliveryScope> SetupDeliveryScopeNoop()
+    {
+        var scope = Mocker.GetMock<IMessageDeliveryScope>();
+        scope.Setup(s => s.Use(It.IsAny<DeliveryMode>())).Returns(Mock.Of<IDisposable>());
+        return scope;
+    }
+
+    private void SetupEspnHttp(HttpStatusCode status, string? body)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = status,
+                Content = new StringContent(body ?? string.Empty)
+            });
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+        Mocker.Use(factory.Object);
+    }
+
+    private async Task<(FootballContest contest, FootballCompetition competition, CompetitionStream stream)>
+        SeedStrandedAsync(
+            DateTime streamStartedUtc,
+            CompetitionStreamStatus status = CompetitionStreamStatus.Failed,
+            bool contestFinalized = false)
+    {
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+
+        var contest = new FootballContest
+        {
+            Id = contestId,
+            Name = "Test Game",
+            ShortName = "TG",
+            SeasonYear = 2025,
+            Sport = Sport.FootballNcaa,
+            StartDateUtc = streamStartedUtc,
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            FinalizedUtc = contestFinalized ? FixedNow.AddHours(-1) : null,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = contest.Id,
+            Contest = contest,
+            Date = streamStartedUtc,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds = new List<CompetitionExternalId>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    CompetitionId = competitionId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/1/competitions/1",
+                    SourceUrlHash = "test-hash",
+                    Value = "1",
+                    CreatedUtc = FixedNow,
+                    CreatedBy = Guid.NewGuid()
+                }
+            }
+        };
+
+        var stream = new CompetitionStream
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            Competition = competition,
+            SeasonWeekId = Guid.NewGuid(),
+            ScheduledTimeUtc = streamStartedUtc,
+            BackgroundJobId = "test-job",
+            Status = status,
+            StreamStartedUtc = streamStartedUtc,
+            FailureReason = status == CompetitionStreamStatus.Failed ? "Cancelled by external request" : null,
+            RetryCount = 0,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.Competitions.AddAsync(competition);
+        await FootballDataContext.CompetitionStreams.AddAsync(stream);
+        await FootballDataContext.SaveChangesAsync();
+        FootballDataContext.ChangeTracker.Clear();
+
+        return (contest, competition, stream);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoStreams_CompletesWithoutError()
+    {
+        SetFixedTime();
+        SetSport(Sport.FootballNcaa);
+        SetupDeliveryScopeNoop();
+        SetupEspnHttp(HttpStatusCode.OK, FinalStatusJson);
+
+        var sut = Mocker.CreateInstance<FinalizationReconcileJob<FootballDataContext>>();
+        await sut.ExecuteAsync(CancellationToken.None);
+
+        Mocker.GetMock<IEventBus>()
+            .Verify(b => b.Publish(It.IsAny<ContestCompleted>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StrandedStreamFinalPerEspn_PublishesEventsAndMarksCompleted()
+    {
+        SetFixedTime();
+        SetSport(Sport.FootballNcaa);
+        SetupDeliveryScopeNoop();
+        SetupEspnHttp(HttpStatusCode.OK, FinalStatusJson);
+
+        var (contest, _, stream) = await SeedStrandedAsync(
+            streamStartedUtc: FixedNow.AddHours(-4),
+            status: CompetitionStreamStatus.Failed);
+
+        var sut = Mocker.CreateInstance<FinalizationReconcileJob<FootballDataContext>>();
+        await sut.ExecuteAsync(CancellationToken.None);
+
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(
+                It.Is<ContestCompleted>(e => e.ContestId == contest.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(
+                It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.Event),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var refreshed = await FootballDataContext.CompetitionStreams
+            .FirstAsync(s => s.Id == stream.Id);
+        refreshed.Status.Should().Be(CompetitionStreamStatus.Completed);
+        refreshed.StreamEndedUtc.Should().Be(FixedNow);
+        refreshed.FailureReason.Should().Be("Cancelled by external request",
+            "diagnostic evidence of the original streamer miss is intentionally preserved");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StrandedStreamStillInProgressPerEspn_DoesNothing()
+    {
+        SetFixedTime();
+        SetSport(Sport.FootballNcaa);
+        SetupDeliveryScopeNoop();
+        SetupEspnHttp(HttpStatusCode.OK, InProgressStatusJson);
+
+        var (contest, _, stream) = await SeedStrandedAsync(
+            streamStartedUtc: FixedNow.AddHours(-3),
+            status: CompetitionStreamStatus.Failed);
+
+        var sut = Mocker.CreateInstance<FinalizationReconcileJob<FootballDataContext>>();
+        await sut.ExecuteAsync(CancellationToken.None);
+
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.IsAny<ContestCompleted>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        var refreshed = await FootballDataContext.CompetitionStreams
+            .FirstAsync(s => s.Id == stream.Id);
+        refreshed.Status.Should().Be(CompetitionStreamStatus.Failed,
+            "stream stays Failed until ESPN reports FINAL");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AlreadyFinalizedContest_IsSkipped()
+    {
+        SetFixedTime();
+        SetSport(Sport.FootballNcaa);
+        SetupDeliveryScopeNoop();
+        SetupEspnHttp(HttpStatusCode.OK, FinalStatusJson);
+
+        var (_, _, stream) = await SeedStrandedAsync(
+            streamStartedUtc: FixedNow.AddHours(-4),
+            status: CompetitionStreamStatus.Failed,
+            contestFinalized: true);
+
+        var sut = Mocker.CreateInstance<FinalizationReconcileJob<FootballDataContext>>();
+        await sut.ExecuteAsync(CancellationToken.None);
+
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.IsAny<ContestCompleted>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StreamOlderThan48h_IsOutsideWindowAndSkipped()
+    {
+        SetFixedTime();
+        SetSport(Sport.FootballNcaa);
+        SetupDeliveryScopeNoop();
+        SetupEspnHttp(HttpStatusCode.OK, FinalStatusJson);
+
+        var (_, _, stream) = await SeedStrandedAsync(
+            streamStartedUtc: FixedNow.AddHours(-72),
+            status: CompetitionStreamStatus.Failed);
+
+        var sut = Mocker.CreateInstance<FinalizationReconcileJob<FootballDataContext>>();
+        await sut.ExecuteAsync(CancellationToken.None);
+
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.IsAny<ContestCompleted>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

Fifth of six PRs implementing the contest-finalization fix per [`docs/contest-finalization-reconcile-backstop.md`](docs/contest-finalization-reconcile-backstop.md) Step 3.

Adds a recurring (every 15 min) backstop that recovers stranded `CompetitionStream` rows whose streamer process died before publishing `ContestCompleted` — the exact scenario behind the 2026-06-13 MLB scoring miss. For each candidate, the job re-checks ESPN status directly; on `STATUS_FINAL`, it publishes the same finalization events the streamer would have (`ContestCompleted` + `DocumentRequested(Event)`), then marks the stream `Completed`. The original `FailureReason` is preserved as diagnostic evidence.

This catches everything Steps 2A (rethrow) and 2B–2D (Daemon role, KEDA cooldown) miss — Daemon pod OOM, node failures, the 5h `MaxStreamDuration` cap, etc.

## Scope

MLB only initially, matching the per-sport scoping of the Daemon Deployment shipped in [sports-data-config #1](https://github.com/jrandallsexton/sports-data-config/pull/1). Football joins when its Daemon Deployments ship pre-season.

## Behavior

**Selection predicate:**
- `StreamStartedUtc` within the last 48 hours (bounds ESPN polling cost)
- `Status IN (Active, Failed)`
- `Contest.IsFinal == false` (filtered in-memory since `IsFinal` is a computed property)

**Per stranded row:**
- Fetch ESPN status via `EspnUriMapper.CompetitionRefToCompetitionStatusRef`
- If `STATUS_FINAL`: publish `ContestCompleted` + `DocumentRequested(Event)` (Direct delivery, same pattern as the streamer), mark stream `Completed` with `StreamEndedUtc = now`. **`FailureReason` is intentionally preserved.**
- If not `STATUS_FINAL` AND `StreamStartedUtc > now - 12h`: leave alone (game still in progress)
- If not `STATUS_FINAL` AND `StreamStartedUtc < now - 12h`: log warning (anomalous; surfaces in observability)

## Wiring

- `IFinalizationReconcileJob` interface with `[Queue(\"daemon\")]` on `ExecuteAsync` — routes the recurring trigger to the daemon queue, same attribute pattern as `ICompetitionBroadcastingJob` (PR C).
- `FinalizationReconcileJob<TDataContext>` closed-generic implementation, matching the codebase convention used by `ContestEnrichmentJob`.
- Per-sport DI registration in `ServiceRegistration` (MLB only); MLB-only `AddOrUpdate` registration in `ConfigureHangfireJobs`.
- `Program.cs` now calls `ConfigureHangfireJobs` for both Worker AND Daemon roles. Hangfire's `AddOrUpdate` is idempotent across roles; per-job `[Queue]` attributes handle which role picks each up at run time.

## Test plan

- [x] `dotnet build src/SportsData.Producer` — clean
- [x] Producer unit tests: **425 passed** (was 420 + 5 new):
  - Empty DB → no publishes
  - Happy path (FINAL per ESPN) → publishes both events, marks Completed, preserves FailureReason
  - In-progress per ESPN → no publishes, stream stays Failed
  - Already-finalized contest → skipped (no publishes)
  - Stream older than 48h → outside window, skipped
- [ ] **Post-deploy verification:** confirm via Seq that `\"Reconciled stranded stream → published ContestCompleted\"` fires when expected
- [ ] **Post-deploy verification:** if it fires often, the streamer itself needs a deeper look

## Follow-up PRs

- **PR D**: Worker stops listening on `daemon` queue (final cutover). Safe to ship after Daemon pods are activated and healthy in prod.
- **PR F**: One-shot recovery for the 10 stranded 2026-06-13 contests — the reconcile job's 48h window has long since rolled past them, so they need a manual replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated reconciliation backstop that checks recently started, incomplete competition streams and finalizes them using ESPN status.
  * The recurring job now runs every 15 minutes and is enabled for both Worker and Daemon roles.
* **Bug Fixes**
  * Improved recovery for stranded/in-progress streams by publishing completion and document request outcomes when ESPN reports a final status.
* **Tests**
  * Added unit test coverage for final vs in-progress handling, already-finalized contests, and time-window filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->