### PR TITLE
fix(api): bump + split AppData/Hangfire pool sizing (10 → 20/30)

### DIFF
--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -221,9 +221,13 @@ namespace SportsData.Api
 
             // Per-pool sizing. Two distinct pools live on this pod:
             //   - AppData: serves HTTP requests via AppDataContext.
-            //   - Hangfire: client-side enqueue calls (no Hangfire server runs in-process
-            //     on the API; recurring cron triggers and POST-driven enqueues both
-            //     check out a connection per enqueue).
+            //   - Hangfire: a Hangfire server DOES run in-process here (AddHangfire
+            //     defaults includeServer: true). The API hosts five recurring jobs —
+            //     ContestRecapJob, PickScoringJob, LeagueWeekScoringJob,
+            //     MatchupPreviewGenerator, MatchupScheduler — plus the
+            //     PickScoringProcessor / LeagueWeekScoringProcessor that fan out
+            //     downstream enqueues from inside those jobs. This pool sees both
+            //     server-side state transitions and client-side enqueue bursts.
             //
             // Both default sizes are tunable via Azure App Config —
             //   SportsData.Api:ConnectionPool:AppData

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -219,17 +219,39 @@ namespace SportsData.Api
             services.AddScoped<IProvideAiCommunication>(sp => sp.GetRequiredService<DeepSeekClient>());
             /* End AI */
 
-            // API is a single pod — keep pool small to leave headroom for Producer/Provider
-            const int apiPoolSize = 10;
+            // Per-pool sizing. Two distinct pools live on this pod:
+            //   - AppData: serves HTTP requests via AppDataContext.
+            //   - Hangfire: client-side enqueue calls (no Hangfire server runs in-process
+            //     on the API; recurring cron triggers and POST-driven enqueues both
+            //     check out a connection per enqueue).
+            //
+            // Both default sizes are tunable via Azure App Config —
+            //   SportsData.Api:ConnectionPool:AppData
+            //   SportsData.Api:ConnectionPool:Hangfire
+            // — matching the Producer's per-role pattern. PostgreSQL max_connections is
+            // 500 on sdprod-data-01 so these numbers are well within capacity.
+            //
+            // Defaults bumped from 10 (hardcoded) → 20 / 30 after a 2026-06-15 prod
+            // incident where the Hangfire pool exhausted at 10 connections during a
+            // cron-driven scoring burst (LeagueWeekScoringJob → PickScoringProcessor
+            // enqueues many ScorePicksCommand in a tight loop). The hardcoded 10 was
+            // not load-tested against burst patterns; the Hangfire default is sized
+            // to absorb cron-fired multi-job enqueue waves comfortably.
+            var apiAppDataPoolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "AppData", defaultPoolSize: 20);
+            var apiHangfirePoolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "Hangfire", defaultPoolSize: 30);
+            Console.WriteLine($"Api ConnectionPool sizes — AppData: {apiAppDataPoolSize}, Hangfire: {apiHangfirePoolSize}");
+
             if (!isTestingEnv)
             {
-                services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, apiPoolSize);
+                services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, apiAppDataPoolSize);
             }
 
             string? sigRConnString = null;
             if (!isTestingEnv)
             {
-                services.AddHangfire(config, builder.Environment.ApplicationName, mode, maxPoolSize: apiPoolSize);
+                services.AddHangfire(config, builder.Environment.ApplicationName, mode, maxPoolSize: apiHangfirePoolSize);
 
                 services.AddMessaging<AppDataContext>(config,
                 [


### PR DESCRIPTION
## Summary

The API connection pool was hardcoded at `const int apiPoolSize = 10` for **both** `AppDataContext` and the Hangfire client pool. That ceiling exhausted on 2026-06-15 09:00:17Z when a cron-driven scoring burst (`LeagueWeekScoringJob` → `PickScoringProcessor` enqueuing many `ScorePicksCommand` jobs in a tight loop) collided with in-flight HTTP traffic. Hangfire surfaced it as:

```
Hangfire.BackgroundJobClientException → 
  Npgsql.NpgsqlException: The connection pool has been exhausted, 
  either raise 'Max Pool Size' (currently 10) or 'Timeout' (currently 15 seconds)
```

7 league-week scoring enqueues failed in a 4-second window.

## Why 10 was wrong

PostgreSQL `max_connections` is 500 on sdprod-data-01. The 10-per-pod limit was ~5% of capacity and load-testing-naive. The original code comment ("keep pool small to leave headroom for Producer/Provider") reasoned about it wrong — Producer/Provider have their own per-pod pools to their own DBs, so the API's pool ceiling has no effect on their headroom.

## Changes

- **Split into two distinct pools** so HTTP and Hangfire can be tuned independently. Hangfire is the burst-prone one (cron-fired enqueue waves); AppData scales with concurrent HTTP requests.
- **Defaults bumped:** AppData `10 → 20`, Hangfire `10 → 30`.
- **Per-pool override via Azure App Config:** `SportsData.Api:ConnectionPool:AppData` and `SportsData.Api:ConnectionPool:Hangfire`. Matches the Producer's per-role `ResolvePoolSize` pattern. Future tuning is config-only — no redeploy.
- **Comment block** documents the why so this doesn't get shrunk again.

## Test plan

- [x] `dotnet build src/SportsData.Api` — clean
- [x] Api unit tests: **392 passing**
- [ ] **Post-deploy:** confirm Seq startup banner shows `Api ConnectionPool sizes — AppData: 20, Hangfire: 30`
- [ ] **Post-deploy:** monitor the next `LeagueWeekScoringJob` / `PickScoringJob` cron fire window in Seq — no more pool-exhaustion exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved production database connection pooling by using separate, configuration-driven pool sizes (instead of a single fixed value), with sensible defaults.
  * Updated startup diagnostics to output the resolved connection pool sizing values, making it easier to confirm runtime configuration.
  * Ensures the enhanced pool configuration and diagnostics apply only outside the testing environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->