### PR TITLE
fix(scoring): block pick scoring against unfinalized contests

### DIFF
--- a/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
@@ -21,6 +21,7 @@ namespace SportsData.Api.Application.Scoring
         private readonly IEventBus _bus;
         private readonly IPickScoringService _pickScoringService;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public PickScoringProcessor(
             ILogger<PickScoringProcessor> logger,
@@ -28,7 +29,8 @@ namespace SportsData.Api.Application.Scoring
             IContestClientFactory contestClientFactory,
             IEventBus bus,
             IPickScoringService pickScoringService,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
@@ -36,6 +38,7 @@ namespace SportsData.Api.Application.Scoring
             _bus = bus;
             _pickScoringService = pickScoringService;
             _backgroundJobProvider = backgroundJobProvider;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task Process(ScorePicksCommand command)
@@ -181,7 +184,7 @@ namespace SportsData.Api.Application.Scoring
                         _logger.LogError(ex, "Error scoring pick {PickId} for group {GroupId}", pick.Id, group.Id);
                     }
 
-                    pick.ModifiedUtc = DateTime.UtcNow;
+                    pick.ModifiedUtc = _dateTimeProvider.UtcNow();
                     pick.ModifiedBy = CausationId.Api.PickScoringProcessor;
 
                     await _dataContext.SaveChangesAsync();

--- a/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
@@ -76,7 +76,9 @@ namespace SportsData.Api.Application.Scoring
                 return;
             }
 
-            var matchupResultResponse = await _contestClientFactory.Resolve(sport.Value).GetMatchupResult(command.ContestId);
+            var matchupResultResponse = await _contestClientFactory
+                .Resolve(sport.Value)
+                .GetMatchupResult(command.ContestId);
 
             if (!matchupResultResponse.IsSuccess)
             {
@@ -91,6 +93,22 @@ namespace SportsData.Api.Application.Scoring
             }
 
             var result = matchupResultResponse.Value;
+
+            // Belt-and-suspenders: GetMatchupResultByContestId.sql already
+            // filters to FinalizedUtc IS NOT NULL, so a finalized=null result
+            // here means either (a) the SQL filter was reverted, or (b) some
+            // future caller path bypasses the producer handler. Refuse to
+            // score either way — the cron backstop will retry once enrichment
+            // lands. See docs/contest-finalization-event-restructure.md and
+            // the 2026-06-16 bug where the cron pulled unfinalized contests
+            // and silently scored picks against Guid.Empty.
+            if (result.FinalizedUtc is null)
+            {
+                _logger.LogWarning(
+                    "Matchup result has no FinalizedUtc — contest is not yet enriched. Skipping scoring. ContestId={ContestId}",
+                    command.ContestId);
+                return;
+            }
 
             // canonical data has the true spread winner, but that is based on the final spread
             // our matchups were generated with the opening spread, so we need to adjust
@@ -164,7 +182,7 @@ namespace SportsData.Api.Application.Scoring
                     }
 
                     pick.ModifiedUtc = DateTime.UtcNow;
-                    pick.ModifiedBy = CausationId.Api.ContestScoringProcessor;
+                    pick.ModifiedBy = CausationId.Api.PickScoringProcessor;
 
                     await _dataContext.SaveChangesAsync();
                 }

--- a/src/SportsData.Api/Application/Scoring/PickScoringService.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 
+using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Api.Infrastructure.Data.Entities;
 
@@ -10,10 +11,14 @@ namespace SportsData.Api.Application.Scoring;
 public class PickScoringService : IPickScoringService
 {
     private readonly ILogger<PickScoringService> _logger;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
-    public PickScoringService(ILogger<PickScoringService> logger)
+    public PickScoringService(
+        ILogger<PickScoringService> logger,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public void ScorePick(
@@ -35,7 +40,7 @@ public class PickScoringService : IPickScoringService
             return;
         }
 
-        var now = DateTime.UtcNow;
+        var now = _dateTimeProvider.UtcNow();
 
         switch (group.PickType)
         {

--- a/src/SportsData.Api/Application/Scoring/PickScoringService.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringService.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Api.Infrastructure.Data.Entities;
 
@@ -7,20 +9,30 @@ namespace SportsData.Api.Application.Scoring;
 
 public class PickScoringService : IPickScoringService
 {
+    private readonly ILogger<PickScoringService> _logger;
+
+    public PickScoringService(ILogger<PickScoringService> logger)
+    {
+        _logger = logger;
+    }
+
     public void ScorePick(
         PickemGroup group,
         double? spread,
         PickemGroupUserPick pick,
         MatchupResult result)
     {
-        // Belt-and-suspenders: PickScoringProcessor already guards on this,
-        // but enforce at the service boundary too so a future caller cannot
-        // accidentally score against pre-enrichment data (Guid.Empty winner,
-        // 0-0 scores) and silently lock the pick as ScoredAt.
+        // PickScoringProcessor already guards on this; the early return here
+        // is observable defense-in-depth for any future caller that bypasses
+        // the processor. Log + return instead of throw — exceptions get
+        // swallowed by the processor's broad catch and surface as the
+        // misleading "Error scoring pick" message.
         if (result.FinalizedUtc is null)
         {
-            throw new InvalidOperationException(
-                $"Cannot score pick for unfinalized contest. ContestId={result.ContestId}, PickId={pick.Id}");
+            _logger.LogWarning(
+                "ScorePick called on unfinalized contest — skipping. ContestId={ContestId}, PickId={PickId}",
+                result.ContestId, pick.Id);
+            return;
         }
 
         var now = DateTime.UtcNow;

--- a/src/SportsData.Api/Application/Scoring/PickScoringService.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringService.cs
@@ -13,6 +13,16 @@ public class PickScoringService : IPickScoringService
         PickemGroupUserPick pick,
         MatchupResult result)
     {
+        // Belt-and-suspenders: PickScoringProcessor already guards on this,
+        // but enforce at the service boundary too so a future caller cannot
+        // accidentally score against pre-enrichment data (Guid.Empty winner,
+        // 0-0 scores) and silently lock the pick as ScoredAt.
+        if (result.FinalizedUtc is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot score pick for unfinalized contest. ContestId={result.ContestId}, PickId={pick.Id}");
+        }
+
         var now = DateTime.UtcNow;
 
         switch (group.PickType)

--- a/src/SportsData.Core/Common/CausationId.cs
+++ b/src/SportsData.Core/Common/CausationId.cs
@@ -6,7 +6,7 @@ namespace SportsData.Core.Common
     {
         public static class Api
         {
-            public static Guid ContestScoringProcessor = new Guid("10000000-2000-0000-0000-000000000001");
+            public static Guid PickScoringProcessor = new Guid("10000000-2000-0000-0000-000000000001");
             public static Guid MatchupPreviewProcessor = new Guid("10000000-3000-0000-0000-000000000001");
             public static readonly Guid SignalRDebugBroadcaster = new Guid("10000000-4000-0000-0000-000000000001");
         }

--- a/src/SportsData.Core/Dtos/Canonical/MatchupResult.cs
+++ b/src/SportsData.Core/Dtos/Canonical/MatchupResult.cs
@@ -17,10 +17,15 @@ using System;
 
         public double? Spread { get; set; }
 
-        public Guid WinnerFranchiseSeasonId { get; set; }
+        // Nullable: unset until Producer's ContestEnrichmentProcessor populates
+        // the winner. Pre-enrichment reads would silently see Guid.Empty if this
+        // were non-nullable, causing every pick to be scored as incorrect.
+        public Guid? WinnerFranchiseSeasonId { get; set; }
 
         public Guid? SpreadWinnerFranchiseSeasonId { get; set; } // nullable if there was no spread
 
-        public DateTime FinalizedUtc { get; set; }
+        // Nullable: NULL until enrichment runs. PickScoringProcessor/Service
+        // gate on this — the canonical "is this contest scoreable" signal.
+        public DateTime? FinalizedUtc { get; set; }
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupResultByContestId.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupResultByContestId.sql
@@ -20,3 +20,9 @@ LEFT JOIN LATERAL (
   LIMIT 1
 ) coo ON TRUE
 WHERE c."Id" = @ContestId
+  -- Scoring callers cannot tolerate pre-enrichment rows. WinnerFranchiseId,
+  -- SpreadWinnerFranchiseId, and the final HomeScore/AwayScore are all
+  -- populated atomically by ContestEnrichmentProcessor alongside
+  -- FinalizedUtc. Returning a row before that point produced silent
+  -- Guid.Empty/0-0 scoring (PickScoringProcessor / PickScoringService).
+  AND c."FinalizedUtc" IS NOT NULL

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringProcessorTests.cs
@@ -281,6 +281,65 @@ public class PickScoringProcessorTests : ApiTestBase<PickScoringProcessor>
     }
 
     [Fact]
+    public async Task Process_WhenMatchupResultNotFinalized_LogsAndReturns()
+    {
+        // Regression: 2026-06-16. The PickScoringJob cron pulled contests with
+        // unscored picks regardless of FinalizedUtc and produced
+        // MatchupResults whose WinnerFranchiseSeasonId silently mapped to
+        // Guid.Empty pre-enrichment. After the SQL filter + DTO nullability
+        // change, the processor must refuse the result whenever
+        // FinalizedUtc is null.
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        var matchup = Fixture.Build<PickemGroupMatchup>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.GroupId, groupId)
+            .Create();
+
+        var group = Fixture.Build<PickemGroup>()
+            .With(x => x.Id, groupId)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.Weeks, new List<PickemGroupWeek>())
+            .Create();
+
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+
+        var pick = Fixture.Build<PickemGroupUserPick>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.PickemGroupId, groupId)
+            .With(x => x.Group, group)
+            .With(x => x.ScoredAt, (DateTime?)null)
+            .Create();
+
+        await DataContext.UserPicks.AddAsync(pick);
+        await DataContext.SaveChangesAsync();
+
+        var result = Fixture.Build<MatchupResult>()
+            .With(x => x.ContestId, contestId)
+            .With(x => x.FinalizedUtc, (DateTime?)null)
+            .Create();
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupResult>(result));
+
+        var command = new ScorePicksCommand(contestId);
+        var sut = Mocker.CreateInstance<PickScoringProcessor>();
+
+        await sut.Process(command);
+
+        Mocker.GetMock<IPickScoringService>()
+            .Verify(x => x.ScorePick(
+                    It.IsAny<PickemGroup>(),
+                    It.IsAny<double?>(),
+                    It.IsAny<PickemGroupUserPick>(),
+                    It.IsAny<MatchupResult>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task Process_WhenSportCannotBeResolved_LogsAndReturns()
     {
         // Arrange — unscored picks but NO matchup row, so sport resolution returns null.

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringServiceTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringServiceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using SportsData.Api.Application;
 using SportsData.Api.Application.Scoring;
+using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Api.Application.Common.Enums;
@@ -12,7 +13,9 @@ namespace SportsData.Api.Tests.Unit.Application.Scoring;
 
 public class PickScoringServiceTests : ApiTestBase<PickScoringService>
 {
-    private readonly PickScoringService _sut = new(NullLogger<PickScoringService>.Instance);
+    private readonly PickScoringService _sut = new(
+        NullLogger<PickScoringService>.Instance,
+        new DateTimeProvider());
 
     #region StraightUp Tests
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringServiceTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringServiceTests.cs
@@ -501,6 +501,36 @@ public class PickScoringServiceTests : ApiTestBase<PickScoringService>
     }
 
     [Fact]
+    public void ScorePick_WhenResultNotFinalized_Throws()
+    {
+        // Regression: 2026-06-16. PickScoringProcessor guards on
+        // FinalizedUtc.HasValue, but this service-level guard catches any
+        // future caller that bypasses the processor (admin endpoints, audit
+        // jobs, etc.) before silently locking the pick with bogus IsCorrect /
+        // ScoredAt.
+        var group = Fixture.Build<PickemGroup>()
+            .With(g => g.PickType, PickType.StraightUp)
+            .Create();
+
+        var matchup = Fixture.Create<PickemGroupMatchup>();
+
+        var pick = Fixture.Build<PickemGroupUserPick>()
+            .With(p => p.FranchiseId, Guid.NewGuid())
+            .With(p => p.ScoredAt, (DateTime?)null)
+            .Create();
+
+        var result = Fixture.Build<MatchupResult>()
+            .With(r => r.FinalizedUtc, (DateTime?)null)
+            .Create();
+
+        _sut.Invoking(s => s.ScorePick(group, matchup.HomeSpread, pick, result))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot score pick for unfinalized contest*");
+
+        pick.ScoredAt.Should().BeNull("the throw must fire before ScoredAt is set");
+    }
+
+    [Fact]
     public void ScorePick_UnknownPickType_Throws()
     {
         var group = Fixture.Build<PickemGroup>()

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringServiceTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringServiceTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using SportsData.Api.Application;
 using SportsData.Api.Application.Scoring;
 using SportsData.Core.Dtos.Canonical;
@@ -11,7 +12,7 @@ namespace SportsData.Api.Tests.Unit.Application.Scoring;
 
 public class PickScoringServiceTests : ApiTestBase<PickScoringService>
 {
-    private readonly PickScoringService _sut = new(); // no dependencies
+    private readonly PickScoringService _sut = new(NullLogger<PickScoringService>.Instance);
 
     #region StraightUp Tests
 
@@ -501,13 +502,14 @@ public class PickScoringServiceTests : ApiTestBase<PickScoringService>
     }
 
     [Fact]
-    public void ScorePick_WhenResultNotFinalized_Throws()
+    public void ScorePick_WhenResultNotFinalized_LogsAndReturns()
     {
         // Regression: 2026-06-16. PickScoringProcessor guards on
         // FinalizedUtc.HasValue, but this service-level guard catches any
         // future caller that bypasses the processor (admin endpoints, audit
         // jobs, etc.) before silently locking the pick with bogus IsCorrect /
-        // ScoredAt.
+        // ScoredAt. Early-return rather than throw so the processor's broad
+        // try/catch doesn't surface this as a misleading "Error scoring pick".
         var group = Fixture.Build<PickemGroup>()
             .With(g => g.PickType, PickType.StraightUp)
             .Create();
@@ -517,6 +519,8 @@ public class PickScoringServiceTests : ApiTestBase<PickScoringService>
         var pick = Fixture.Build<PickemGroupUserPick>()
             .With(p => p.FranchiseId, Guid.NewGuid())
             .With(p => p.ScoredAt, (DateTime?)null)
+            .With(p => p.IsCorrect, (bool?)null)
+            .With(p => p.PointsAwarded, 0)
             .Create();
 
         var result = Fixture.Build<MatchupResult>()
@@ -524,10 +528,11 @@ public class PickScoringServiceTests : ApiTestBase<PickScoringService>
             .Create();
 
         _sut.Invoking(s => s.ScorePick(group, matchup.HomeSpread, pick, result))
-            .Should().Throw<InvalidOperationException>()
-            .WithMessage("*Cannot score pick for unfinalized contest*");
+            .Should().NotThrow();
 
-        pick.ScoredAt.Should().BeNull("the throw must fire before ScoredAt is set");
+        pick.ScoredAt.Should().BeNull("the early return must fire before ScoredAt is set");
+        pick.IsCorrect.Should().BeNull("the early return must fire before IsCorrect is set");
+        pick.PointsAwarded.Should().Be(0, "the early return must fire before PointsAwarded is set");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes a silent corruption mode in the pick-scoring pipeline. `PickScoringJob` (the daily cron backstop) scans `UserPicks` where `ScoredAt IS NULL`, takes distinct `ContestIds`, and enqueues `PickScoringProcessor` for each — **without checking whether the contest has been enriched**. The processor's `GetMatchupResult` SQL had no `FinalizedUtc` filter, so it returned the row even when `WinnerFranchiseId` was still NULL. `MatchupResult.WinnerFranchiseSeasonId` was non-nullable `Guid`, so Dapper silently mapped NULL → `Guid.Empty`. `PickScoringService.ScoreStraightUp` then compared `pick.FranchiseId == Guid.Empty`, marked the pick `IsCorrect=false`, set `ScoredAt`, and the pick was **permanently locked** at the bad value — the cron's `ScoredAt IS NULL` filter never revisits it, even after the contest later enriches.

Three-layer fix:

- **SQL filter** — `GetMatchupResultByContestId.sql` now requires `AND c."FinalizedUtc" IS NOT NULL`. Handler returns `NotFound` for pre-enrichment rows. `PickScoringProcessor`'s existing `NotFound` branch handles it cleanly. Cron enqueues become harmless no-ops until enrichment lands.
- **DTO honesty** — `MatchupResult.WinnerFranchiseSeasonId` → `Guid?`, `FinalizedUtc` → `DateTime?`. Eliminates the silent-default trap.
- **Service guards** — `PickScoringProcessor` explicitly checks `result.FinalizedUtc.HasValue` after `GetMatchupResult` success. `PickScoringService.ScorePick` throws `InvalidOperationException` at the top if `result.FinalizedUtc is null`. Belt-and-suspenders.

Event-driven scoring path (`Producer.ContestFinalized` → `API.ContestFinalizedHandler` → `PickScoringProcessor`) was already correctly gated behind enrichment (per `docs/contest-finalization-event-restructure.md`). This PR closes the cron-backstop gap.

Tie-game semantics preserved: `pick.FranchiseId (Guid?) == result.WinnerFranchiseSeasonId (null Guid?)` → false → `IsCorrect=false`, same as before when the underlying DB column was NULL → `Guid.Empty`.

Also completes the `CausationId.Api.ContestScoringProcessor` → `PickScoringProcessor` rename started in #414 (one rename site at `PickScoringProcessor.cs:185` was already in the working tree and load-bearing for this PR's compile).

A follow-up audit job (designed in `docs/pick-scoring-audit-job.md`) will sweep historical corruption.

## Test plan

- [x] `dotnet build` clean on SportsData.Api + SportsData.Producer
- [x] `dotnet test` clean on SportsData.Api.Tests.Unit (394 pass, +2 new)
- [x] `dotnet test` clean on SportsData.Producer.Tests.Unit (425 pass)
- [x] New `Process_WhenMatchupResultNotFinalized_LogsAndReturns` — processor short-circuits on `FinalizedUtc=null`
- [x] New `ScorePick_WhenResultNotFinalized_Throws` — service throws before mutating pick
- [ ] Manual E2E (local): trigger `PickScoringJob` against a DB with an unfinalized contest — verify cron enqueue is a no-op (NotFound short-circuit) instead of corrupting the pick
- [ ] Prod monitoring post-deploy: Seq query for `"Matchup result has no FinalizedUtc"` LogWarning — frequency tracks how aggressive the cron is hitting pre-enrichment rows; should taper as scoring path stabilizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened scoring safeguards so picks are only scored once the matchup result is fully finalized and enrichment is complete.
  * When results aren’t finalized, scoring is skipped and a warning is logged; scored fields and points are left unchanged.
* **Tests**
  * Added/updated unit tests covering the non-finalized matchup scenario to ensure early exit behavior without exceptions and no unintended scoring updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->