### PR TITLE
feat(scoring): per-sport pick scoring audit job

### DIFF
--- a/docs/pick-scoring-audit-job.md
+++ b/docs/pick-scoring-audit-job.md
@@ -1,0 +1,173 @@
+# Pick Scoring Audit Job
+
+**Status:** Proposed
+**Date:** 2026-06-16
+**Driver:** Historical pick-scoring corruption from the pre-2026-06-16 race where `PickScoringJob` enqueued unfinalized contests and `PickScoringService` silently scored picks against `Guid.Empty` winners (see [contest-finalization-event-restructure](contest-finalization-event-restructure.md) for the upstream fix).
+
+## Problem
+
+The race fixed today only blocks **future** corruption. Picks that were already scored against pre-enrichment data carry permanent wrong values:
+
+- `IsCorrect = false` (compared against `Guid.Empty`)
+- `PointsAwarded = 0` (a confidence-points pick worth 12 awarded 0)
+- `ScoredAt != null` — so no future `PickScoringJob` cron will revisit them
+
+The downstream effect cascades to `PickemGroupWeekResult` aggregates, which the leaderboard reads from.
+
+Two corruption modes that should both be detectable post-fact:
+
+1. **Scored-then-finalized:** pick scored against an unfinalized contest, which later enriched. The contest now has valid `WinnerFranchiseId` / `FinalizedUtc`, but the stored pick result is the bad pre-enrichment computation. **This is invisible to any "is the contest finalized?" check at audit time** because by then it is.
+2. **Scored-and-still-unfinalized:** pick scored against a contest that hasn't enriched. Edge case but possible if upstream is broken. Detection signal: `GetMatchupResult` returns `NotFound` (the new SQL filter rejects unfinalized rows).
+
+Plus a third concern: future scoring-logic bugs we don't yet know about. A periodic re-score-and-compare audit catches **any** divergence between current PickScoringService output and what's stored, regardless of root cause.
+
+User expectation: "I _highly_ imagine there are likely some NCAAFB picks that were scored incorrectly last season." Long-term value is unclear; near-term value is repairing back-to-2024 corruption.
+
+## Proposed flow
+
+```text
+PickScoringAuditJob(Sport)   [CRON, one schedule per active sport, staggered]
+  │
+  ├─ Load distinct ContestIds where any UserPick.ScoredAt != null
+  │   AND the pick's PickemGroup.Sport == this job's Sport
+  │   (no time-window filter — audit is exhaustive by design)
+  │
+  ├─ For each ContestId:
+  │   ├─ Sport is known up-front from the job parameter — no per-contest resolution needed
+  │   ├─ HTTP GET Producer.GetMatchupResult(contestId)  via ContestClientFactory.Resolve(sport)
+  │   │
+  │   ├─ IF NotFound  (contest not finalized — stuck-pick mode)
+  │   │   ├─ Load all scored picks for the contest
+  │   │   ├─ Reset ScoredAt = null, IsCorrect = null, PointsAwarded = 0
+  │   │   ├─ LogError per pick: "Pick scored against unfinalized contest"
+  │   │   └─ Track affected (LeagueId, SeasonYear, SeasonWeek) for fan-out
+  │   │
+  │   └─ IF Success   (contest finalized — re-score and compare)
+  │       ├─ Load all scored picks for the contest (with PickemGroup + matchup)
+  │       ├─ For each pick:
+  │       │   ├─ Capture stored (IsCorrect, PointsAwarded)
+  │       │   ├─ Re-run PickScoringService.ScorePick on a working copy
+  │       │   ├─ Compare against stored values
+  │       │   └─ IF mismatch:
+  │       │       ├─ Overwrite IsCorrect / PointsAwarded in place
+  │       │       ├─ LogError with before/after snapshot
+  │       │       └─ Track affected (LeagueId, SeasonYear, SeasonWeek)
+  │       └─ SaveChangesAsync (one commit per contest)
+  │
+  └─ For each distinct affected (LeagueId, SeasonYear, SeasonWeek):
+      └─ Enqueue IScoreLeagueWeeks  (Hangfire — same fan-out PickScoringProcessor uses)
+```
+
+## Decisions
+
+### D1. Audit re-runs `PickScoringService.ScorePick` directly
+
+No re-implementation of scoring logic. The audit calls the same service the live path uses, on a throwaway clone of the pick, then compares the result to the stored row. This guarantees by construction that audit and live scoring stay in sync — if scoring rules change, the audit picks up the new rules without a code change.
+
+The clone is necessary because `ScorePick` mutates the pick in place (sets `IsCorrect`, `PointsAwarded`, `ScoredAt`, `WasAgainstSpread`). Cloning lets us read the proposed result and decide whether to apply it.
+
+### D2. Correct in place, do not reset+rescore
+
+For finalized-contest mismatches: overwrite `IsCorrect` and `PointsAwarded` directly. `ScoredAt` stays at the original timestamp (it correctly marks "when scoring decided this pick") and gets a sibling `ScoredAt` ModifiedUtc update for audit-trail.
+
+Alternatives considered: reset `ScoredAt = null` and let `PickScoringJob` re-score on its next run. Rejected because it (a) adds latency to user-visible correction, (b) loses the audit's point-of-comparison, and (c) splits responsibility — the audit job already loaded the data and computed the answer; deferring the write is wasteful.
+
+For unfinalized-contest stuck picks: do reset `ScoredAt = null` and clear `IsCorrect` / `PointsAwarded`. The pick should not have been scored at all; clearing it lets the normal path re-score once enrichment lands.
+
+### D3. Fan out league-week rescoring
+
+After per-contest correction, audit collects a `HashSet<(Guid LeagueId, int SeasonYear, int SeasonWeek)>` of affected league-weeks (same idiom `PickScoringProcessor` uses today, lines 117 + 175). At the tail of the job, enqueue `IScoreLeagueWeeks.Process` for each via `IProvideBackgroundJobs.Enqueue` — Hangfire absorbs the burst and `DisableConcurrentExecution` collapses duplicates per (league, year, week).
+
+If the enqueue itself throws, log the failure and continue — `LeagueWeekScoringJob`'s nightly cron (D6 fallback) catches anything we missed.
+
+### D4. Daily schedule at 02:00 UTC, before `PickScoringJob` at 09:00 UTC
+
+Audit runs first so unfinalized-contest resets land in time for the daily `PickScoringJob` cron to re-score them via the normal path. Off-peak for the cluster either way.
+
+`DisableConcurrentExecution(timeoutInSeconds: 0)` per-sport-job to prevent overlap with itself if a previous run runs long. With ~tens of thousands of picks at MLB+NCAAFB+NFL scale, expected runtime is dominated by Producer HTTP roundtrips — one per distinct contest. Estimated <5 min per sport at current scale; flag for re-evaluation if any single sport grows past 30 min.
+
+Per-sport stagger so the three audits don't all hammer different Producer pods at the same instant: FootballNcaa 02:00, FootballNfl 02:15, BaseballMlb 02:30 UTC. The pods are separate so concurrent execution wouldn't actually collide, but staggering keeps Seq output cleaner and makes "which sport's audit is misbehaving" trivial to identify.
+
+### D4a. One job class, one registration per sport
+
+`PickScoringAuditJob.ExecuteAsync(Sport sport)` takes the sport as a parameter. `IRecurringJobManager.AddOrUpdate<PickScoringAuditJob>(...)` registers it once per active sport with a distinct job name (`PickScoringAudit-FootballNcaa`, etc.). Hangfire serializes the `Sport` enum into the recurring job definition and re-injects it on each fire.
+
+Doesn't implement `IAmARecurringJob` because that interface requires a parameterless `ExecuteAsync()`. The marker has no other consumers in the codebase (only declared, never queried), so dropping it costs nothing.
+
+User requirement: "I don't want MLB audits trying to review NCAAFB or NFL." Sport-scoping aligns with the per-sport Producer pod boundary, gives operational isolation (a failing MLB audit doesn't block NCAAFB), and makes Seq queries naturally sport-segmented.
+
+### D5. Exhaustive scope, no time-window filter
+
+`UserPick.ScoredAt != null` is the only filter. The corruption could date back to early-MLB testing or NCAAFB 2025; a sliding-window filter would silently let old corruption persist as it ages out.
+
+Cost analysis: one HTTP `GetMatchupResult` per distinct ContestId regardless of pick count on that contest. At MLB+NCAAFB+NFL season scale this is bounded by the number of finalized contests, not by pick count. Acceptable.
+
+### D6. Tail safety net
+
+The audit job is itself a backstop. If audit fails partway through, the next nightly run picks up where it left off — no resumption state needed because the detection logic is idempotent (re-runs of audit produce the same correction or no correction). Existing `LeagueWeekScoringJob` cron at 09:15 UTC catches any fan-out enqueue that didn't fire.
+
+### D7. Structured logging schema
+
+Every correction event:
+
+```text
+LogError "PickScoringAudit correction: ContestId={ContestId} PickId={PickId}
+         StoredIsCorrect={StoredIsCorrect} ComputedIsCorrect={ComputedIsCorrect}
+         StoredPoints={StoredPoints} ComputedPoints={ComputedPoints}
+         LeagueId={LeagueId} SeasonYear={SeasonYear} Week={Week}
+         Mode={Mode}"
+```
+
+`Mode = "Mismatch"` or `"Unfinalized"`. Single message per pick keeps Seq aggregations simple — count by Mode, group by LeagueId, etc.
+
+Per-contest summary as LogInformation; per-run summary at the end (LogInformation): contests audited, picks examined, mismatches corrected, unfinalized resets, league-weeks enqueued.
+
+## File-by-file plan
+
+| File | Change |
+|---|---|
+| `src/SportsData.Api/Application/Jobs/PickScoringAuditJob.cs` | **New** — cron entry point. Loads distinct ContestIds, delegates per-contest work to a processor. |
+| `src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs` | **New** — per-contest audit. Mirrors `PickScoringProcessor` shape: resolve sport, fetch MatchupResult, iterate picks, write corrections, collect fan-out targets. Constructor takes `AppDataContext`, `IContestClientFactory`, `IPickScoringService`, `IProvideBackgroundJobs`, `IDateTimeProvider`, `ILogger`. |
+| `src/SportsData.Api/Application/Scoring/IPickScoringAudit.cs` | **New** — interface for Hangfire enqueueing (mirrors `IScorePicks`). Single `Process(AuditContestCommand)` method. |
+| `src/SportsData.Api/Application/Scoring/AuditContestCommand.cs` | **New** — record `(Guid ContestId, Sport Sport, Guid CorrelationId)`. Sport is captured up-front so the processor doesn't repeat the resolution join. |
+| `src/SportsData.Core/Common/CausationId.cs` | Add `Api.PickScoringAuditProcessor` GUID so audit-corrected `ModifiedBy` writes are traceable. |
+| `src/SportsData.Api/DependencyInjection/ServiceRegistration.cs` | Wire `IPickScoringAudit` → `PickScoringAuditProcessor`. Register **one** recurring cron per active sport: `PickScoringAudit-FootballNcaa` at `0 2 * * *`, `PickScoringAudit-FootballNfl` at `15 2 * * *`, `PickScoringAudit-BaseballMlb` at `30 2 * * *`. |
+| `test/unit/SportsData.Api.Tests.Unit/Application/Jobs/PickScoringAuditJobTests.cs` | **New** — cover the enqueue-per-contest behavior. |
+| `test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditProcessorTests.cs` | **New** — cover: (a) finalized + matches → no write, (b) finalized + mismatch → correct in place + enqueue league-week, (c) NotFound → reset ScoredAt + log, (d) finalized + no scored picks → no-op, (e) sport unresolvable → log + skip. |
+
+Total: ~7 file touches. No DB migration. No DTO/contract change.
+
+## Sequencing
+
+The audit job is non-coupled to any other deploy. Ship after the today's bug-fix PR (SQL filter + nullable DTO + service guards) so the audit's NotFound-detection path matches the new SQL semantics. Roll out, watch first nightly run.
+
+## Operating procedure
+
+After first deploy:
+
+1. Watch the 02:00 UTC run on day 1. Expect a large initial sweep of corrections — back-corruption from MLB testing and NCAAFB 2025.
+2. Aggregate `LogError "PickScoringAudit correction"` in Seq, group by `Mode`. Sanity-check sample picks manually.
+3. After steady state (subsequent nightly runs should find few or zero mismatches), reassess D5 — could narrow scope to last N days if cost grows. Reassess every quarter; deprecate the job entirely if it goes 90 consecutive days with zero corrections AND we have higher confidence in the upstream scoring path.
+
+## Test plan
+
+- [ ] Unit: `PickScoringAuditJob` enqueues `IPickScoringAudit.Process` once per distinct ContestId with `ScoredAt != null` picks.
+- [ ] Unit: `PickScoringAuditProcessor` correctly identifies mismatch and corrects in place when finalized contest stored result differs from re-computed.
+- [ ] Unit: `PickScoringAuditProcessor` resets `ScoredAt`, `IsCorrect`, `PointsAwarded` when `GetMatchupResult` returns `NotFound`.
+- [ ] Unit: `PickScoringAuditProcessor` enqueues `IScoreLeagueWeeks` exactly once per affected `(LeagueId, SeasonYear, Week)` tuple per run.
+- [ ] Unit: `PickScoringAuditProcessor` does NOT write when stored values match re-computed values (no churn on healthy picks).
+- [ ] Manual E2E (local with prod DB snapshot): one bad pick, one healthy pick, observe correction + enqueue + LogError.
+- [ ] Prod monitoring after first run: Seq query for `PickScoringAudit correction` count by Mode + LeagueId. Verify leaderboard for affected leagues reflects corrections within minutes (LeagueWeekScoringProcessor fanout).
+
+## Out of scope
+
+- **Configurable schedule** via Azure App Config. Hardcode `Cron.Daily(2)` initially; only externalize if we end up tuning it frequently.
+- **Audit history table**. The LogError stream IS the audit trail. Adding a `PickemGroupUserPickAuditLog` table is a separate decision (would also need retention policy, indexing strategy, etc.).
+- **Self-deprecation**. The job stays forever in code; we just stop scheduling it when we trust the upstream path. Don't build automation for that until we know the cadence of trust.
+- **Cross-contest checks** (e.g. consistency between contest score and a pick's IsCorrect across the schema). Per-pick audit only.
+
+## Open items
+
+- Confirm `IProvideBackgroundJobs.Enqueue<IPickScoringAudit>(p => p.Process(cmd))` works with the existing Hangfire job activator the API uses (same as `IScorePicks` enqueue path).
+- Decide whether `PickScoringAuditJob` should `DisableConcurrentExecution` at the job level or at the per-contest processor level. Job-level is sufficient given the cron only runs once nightly.
+- Confirm correlation ID propagation through the audit → service → enqueue chain matches the live scoring path so Seq traces stay readable.

--- a/src/SportsData.Api/Application/Jobs/PickScoringAuditJob.cs
+++ b/src/SportsData.Api/Application/Jobs/PickScoringAuditJob.cs
@@ -71,12 +71,14 @@ public class PickScoringAuditJob
                 "Found {Count} distinct contests to audit for {Sport}.",
                 contestIds.Count, sport);
 
+            var enqueuedCount = 0;
             foreach (var contestId in contestIds)
             {
                 try
                 {
                     var cmd = new AuditContestCommand(contestId, sport, correlationId);
                     _backgroundJobProvider.Enqueue<IPickScoringAudit>(p => p.Process(cmd));
+                    enqueuedCount++;
                 }
                 catch (Exception ex)
                 {
@@ -89,7 +91,7 @@ public class PickScoringAuditJob
 
             _logger.LogInformation(
                 "{JobName} ended. EnqueuedCount={Count}.",
-                nameof(PickScoringAuditJob), contestIds.Count);
+                nameof(PickScoringAuditJob), enqueuedCount);
         }
     }
 }

--- a/src/SportsData.Api/Application/Jobs/PickScoringAuditJob.cs
+++ b/src/SportsData.Api/Application/Jobs/PickScoringAuditJob.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Scoring;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+
+namespace SportsData.Api.Application.Jobs;
+
+/// <summary>
+/// Nightly per-sport audit of historical pick scoring. Re-runs scoring
+/// against current canonical data for every previously-scored pick of the
+/// targeted sport; corrects mismatches in place and resets picks scored
+/// against contests that aren't actually finalized.
+///
+/// Why per-sport: each instance fans out to one sport's Producer pod via
+/// <see cref="IContestClientFactory.Resolve"/>. Sport-scoping gives
+/// operational isolation (a failing MLB audit doesn't block NCAAFB),
+/// trivial Seq segmentation, and aligns with the per-sport Producer
+/// boundary. See <c>docs/pick-scoring-audit-job.md</c>.
+///
+/// Doesn't implement <see cref="SportsData.Core.Common.Jobs.IAmARecurringJob"/>
+/// because that interface requires a parameterless <c>ExecuteAsync()</c> and
+/// here we need the sport. The interface has no other consumers in the
+/// codebase (marker only), so dropping it costs nothing.
+/// </summary>
+public class PickScoringAuditJob
+{
+    private readonly ILogger<PickScoringAuditJob> _logger;
+    private readonly AppDataContext _dataContext;
+    private readonly IProvideBackgroundJobs _backgroundJobProvider;
+
+    public PickScoringAuditJob(
+        ILogger<PickScoringAuditJob> logger,
+        AppDataContext dataContext,
+        IProvideBackgroundJobs backgroundJobProvider)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _backgroundJobProvider = backgroundJobProvider;
+    }
+
+    public async Task ExecuteAsync(Sport sport)
+    {
+        var correlationId = Guid.NewGuid();
+
+        using (_logger.BeginScope(new Dictionary<string, object>
+               {
+                   ["CorrelationId"] = correlationId,
+                   ["Sport"] = sport
+               }))
+        {
+            _logger.LogInformation("{JobName} began.", nameof(PickScoringAuditJob));
+
+            // Sport-scoped candidate selection: every distinct ContestId
+            // that has at least one scored pick whose PickemGroup is for
+            // this sport. SQL-level filter so we don't pull other sports'
+            // contests into memory just to discard them.
+            var contestIds = await _dataContext.UserPicks
+                .Where(p => p.ScoredAt != null)
+                .Join(_dataContext.PickemGroups,
+                    p => p.PickemGroupId,
+                    g => g.Id,
+                    (p, g) => new { p.ContestId, g.Sport })
+                .Where(x => x.Sport == sport)
+                .Select(x => x.ContestId)
+                .Distinct()
+                .ToListAsync();
+
+            _logger.LogInformation(
+                "Found {Count} distinct contests to audit for {Sport}.",
+                contestIds.Count, sport);
+
+            foreach (var contestId in contestIds)
+            {
+                try
+                {
+                    var cmd = new AuditContestCommand(contestId, sport, correlationId);
+                    _backgroundJobProvider.Enqueue<IPickScoringAudit>(p => p.Process(cmd));
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Failed to enqueue audit for contest {ContestId}. Tomorrow's run will retry.",
+                        contestId);
+                }
+            }
+
+            _logger.LogInformation(
+                "{JobName} ended. EnqueuedCount={Count}.",
+                nameof(PickScoringAuditJob), contestIds.Count);
+        }
+    }
+}

--- a/src/SportsData.Api/Application/Scoring/AuditContestCommand.cs
+++ b/src/SportsData.Api/Application/Scoring/AuditContestCommand.cs
@@ -1,0 +1,35 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Scoring;
+
+public class AuditContestCommand
+{
+    public Guid ContestId { get; set; }
+
+    // Captured up-front by PickScoringAuditJob so the processor doesn't
+    // repeat the PickemGroupMatchups → PickemGroup.Sport join per contest.
+    // The job already filtered to this sport at the candidate-selection
+    // SQL layer; the processor trusts that.
+    public Sport Sport { get; set; }
+
+    public Guid CorrelationId { get; set; }
+
+    public AuditContestCommand()
+    {
+        CorrelationId = Guid.NewGuid();
+    }
+
+    public AuditContestCommand(Guid contestId, Sport sport)
+        : this()
+    {
+        ContestId = contestId;
+        Sport = sport;
+    }
+
+    public AuditContestCommand(Guid contestId, Sport sport, Guid correlationId)
+    {
+        ContestId = contestId;
+        Sport = sport;
+        CorrelationId = correlationId;
+    }
+}

--- a/src/SportsData.Api/Application/Scoring/IPickScoringAudit.cs
+++ b/src/SportsData.Api/Application/Scoring/IPickScoringAudit.cs
@@ -1,0 +1,15 @@
+namespace SportsData.Api.Application.Scoring;
+
+/// <summary>
+/// Per-contest audit work. Enqueued by
+/// <see cref="SportsData.Api.Application.Jobs.PickScoringAuditJob"/> once per
+/// distinct contest with scored picks. Re-runs <see cref="IPickScoringService"/>
+/// on a working copy of each scored pick and compares to stored values;
+/// corrects mismatches in place and fans out league-week rescoring.
+///
+/// See <c>docs/pick-scoring-audit-job.md</c> for design rationale.
+/// </summary>
+public interface IPickScoringAudit
+{
+    Task Process(AuditContestCommand command);
+}

--- a/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
@@ -43,10 +43,17 @@ public class PickScoringAuditProcessor : IPickScoringAudit
                }))
         {
             // Load scored picks (audit only re-checks already-scored picks;
-            // unscored picks are PickScoringJob's territory).
+            // unscored picks are PickScoringJob's territory). Sport filter is
+            // defense-in-depth — the job already SQL-filters candidates by
+            // PickemGroup.Sport, but if a future caller (admin endpoint,
+            // direct enqueue) passes a mismatched command.Sport, the filter
+            // here prevents cross-sport corrections at the data layer.
             var scoredPicks = await _dataContext.UserPicks
                 .Include(p => p.Group)
-                .Where(p => p.ContestId == command.ContestId && p.ScoredAt != null)
+                .Where(p =>
+                    p.ContestId == command.ContestId
+                    && p.ScoredAt != null
+                    && p.Group.Sport == command.Sport)
                 .ToListAsync();
 
             if (scoredPicks.Count == 0)
@@ -103,9 +110,15 @@ public class PickScoringAuditProcessor : IPickScoringAudit
     {
         // Per-(GroupId) (SeasonYear, SeasonWeek) lookup for fan-out. The
         // matchup row carries season metadata; the pick alone doesn't.
+        // Sport-scoped — same defense-in-depth as the scoredPicks query.
         var matchupKeys = await _dataContext.PickemGroupMatchups
             .Where(m => m.ContestId == command.ContestId)
-            .Select(m => new { m.GroupId, m.SeasonYear, m.SeasonWeek })
+            .Join(_dataContext.PickemGroups,
+                m => m.GroupId,
+                g => g.Id,
+                (m, g) => new { m.GroupId, m.SeasonYear, m.SeasonWeek, g.Sport })
+            .Where(x => x.Sport == command.Sport)
+            .Select(x => new { x.GroupId, x.SeasonYear, x.SeasonWeek })
             .ToListAsync();
 
         var keyByGroup = matchupKeys.ToDictionary(
@@ -142,9 +155,15 @@ public class PickScoringAuditProcessor : IPickScoringAudit
     {
         // Per-(GroupId) matchup lookup. Audit needs SeasonYear/Week per
         // affected league-week for fan-out, just like PickScoringProcessor.
+        // Sport-scoped — same defense-in-depth as the scoredPicks query.
         var matchupKeys = await _dataContext.PickemGroupMatchups
             .Where(m => m.ContestId == command.ContestId)
-            .Select(m => new { m.GroupId, m.SeasonYear, m.SeasonWeek })
+            .Join(_dataContext.PickemGroups,
+                m => m.GroupId,
+                g => g.Id,
+                (m, g) => new { m.GroupId, m.SeasonYear, m.SeasonWeek, g.Sport })
+            .Where(x => x.Sport == command.Sport)
+            .Select(x => new { x.GroupId, x.SeasonYear, x.SeasonWeek })
             .ToListAsync();
 
         var keyByGroup = matchupKeys.ToDictionary(

--- a/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
@@ -1,0 +1,250 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Processing;
+
+namespace SportsData.Api.Application.Scoring;
+
+public class PickScoringAuditProcessor : IPickScoringAudit
+{
+    private readonly ILogger<PickScoringAuditProcessor> _logger;
+    private readonly AppDataContext _dataContext;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly IPickScoringService _pickScoringService;
+    private readonly IProvideBackgroundJobs _backgroundJobProvider;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public PickScoringAuditProcessor(
+        ILogger<PickScoringAuditProcessor> logger,
+        AppDataContext dataContext,
+        IContestClientFactory contestClientFactory,
+        IPickScoringService pickScoringService,
+        IProvideBackgroundJobs backgroundJobProvider,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _contestClientFactory = contestClientFactory;
+        _pickScoringService = pickScoringService;
+        _backgroundJobProvider = backgroundJobProvider;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task Process(AuditContestCommand command)
+    {
+        using (_logger.BeginScope(new Dictionary<string, object>
+               {
+                   ["CorrelationId"] = command.CorrelationId,
+                   ["ContestId"] = command.ContestId,
+                   ["Sport"] = command.Sport
+               }))
+        {
+            // Load scored picks (audit only re-checks already-scored picks;
+            // unscored picks are PickScoringJob's territory).
+            var scoredPicks = await _dataContext.UserPicks
+                .Include(p => p.Group)
+                .Where(p => p.ContestId == command.ContestId && p.ScoredAt != null)
+                .ToListAsync();
+
+            if (scoredPicks.Count == 0)
+            {
+                _logger.LogInformation(
+                    "PickScoringAudit: no scored picks for contest. Skipping.");
+                return;
+            }
+
+            var matchupResultResponse = await _contestClientFactory
+                .Resolve(command.Sport)
+                .GetMatchupResult(command.ContestId);
+
+            var affectedLeagueWeeks = new HashSet<(Guid LeagueId, int SeasonYear, int Week)>();
+
+            if (matchupResultResponse.Status == ResultStatus.NotFound)
+            {
+                await HandleUnfinalizedAsync(scoredPicks, affectedLeagueWeeks, command);
+            }
+            else if (!matchupResultResponse.IsSuccess)
+            {
+                _logger.LogError(
+                    "PickScoringAudit: GetMatchupResult failed. Status={Status}. Next nightly run will retry.",
+                    matchupResultResponse.Status);
+                return;
+            }
+            else if (matchupResultResponse.Value.FinalizedUtc is null)
+            {
+                // SQL filter should prevent this; defensive log so a reverted
+                // filter shows up in Seq instead of silently corrupting picks.
+                _logger.LogWarning(
+                    "PickScoringAudit: GetMatchupResult returned Success with null FinalizedUtc. SQL filter may be reverted. Skipping.");
+                return;
+            }
+            else
+            {
+                await HandleMismatchCheckAsync(
+                    scoredPicks,
+                    matchupResultResponse.Value,
+                    affectedLeagueWeeks,
+                    command);
+            }
+
+            await _dataContext.SaveChangesAsync();
+
+            FanOutLeagueWeekScoring(affectedLeagueWeeks, command.CorrelationId);
+        }
+    }
+
+    private async Task HandleUnfinalizedAsync(
+        List<PickemGroupUserPick> scoredPicks,
+        HashSet<(Guid LeagueId, int SeasonYear, int Week)> affectedLeagueWeeks,
+        AuditContestCommand command)
+    {
+        // Per-(GroupId) (SeasonYear, SeasonWeek) lookup for fan-out. The
+        // matchup row carries season metadata; the pick alone doesn't.
+        var matchupKeys = await _dataContext.PickemGroupMatchups
+            .Where(m => m.ContestId == command.ContestId)
+            .Select(m => new { m.GroupId, m.SeasonYear, m.SeasonWeek })
+            .ToListAsync();
+
+        var keyByGroup = matchupKeys.ToDictionary(
+            m => m.GroupId,
+            m => (m.SeasonYear, m.SeasonWeek));
+
+        var now = _dateTimeProvider.UtcNow();
+
+        foreach (var pick in scoredPicks)
+        {
+            _logger.LogError(
+                "PickScoringAudit correction: PickId={PickId} StoredIsCorrect={StoredIsCorrect} ComputedIsCorrect=null StoredPoints={StoredPoints} ComputedPoints=null LeagueId={LeagueId} Mode=Unfinalized",
+                pick.Id, pick.IsCorrect, pick.PointsAwarded, pick.PickemGroupId);
+
+            pick.IsCorrect = null;
+            pick.PointsAwarded = null;
+            pick.ScoredAt = null;
+            pick.WasAgainstSpread = null;
+            pick.ModifiedUtc = now;
+            pick.ModifiedBy = CausationId.Api.PickScoringAuditProcessor;
+
+            if (keyByGroup.TryGetValue(pick.PickemGroupId, out var key))
+            {
+                affectedLeagueWeeks.Add((pick.PickemGroupId, key.SeasonYear, key.SeasonWeek));
+            }
+        }
+    }
+
+    private async Task HandleMismatchCheckAsync(
+        List<PickemGroupUserPick> scoredPicks,
+        Core.Dtos.Canonical.MatchupResult result,
+        HashSet<(Guid LeagueId, int SeasonYear, int Week)> affectedLeagueWeeks,
+        AuditContestCommand command)
+    {
+        // Per-(GroupId) matchup lookup. Audit needs SeasonYear/Week per
+        // affected league-week for fan-out, just like PickScoringProcessor.
+        var matchupKeys = await _dataContext.PickemGroupMatchups
+            .Where(m => m.ContestId == command.ContestId)
+            .Select(m => new { m.GroupId, m.SeasonYear, m.SeasonWeek })
+            .ToListAsync();
+
+        var keyByGroup = matchupKeys.ToDictionary(
+            m => m.GroupId,
+            m => (m.SeasonYear, m.SeasonWeek));
+
+        var now = _dateTimeProvider.UtcNow();
+
+        foreach (var pick in scoredPicks)
+        {
+            if (pick.Group is null)
+            {
+                _logger.LogError(
+                    "PickScoringAudit: Group navigation was null. PickId={PickId} LeagueId={LeagueId}. Skipping correction.",
+                    pick.Id, pick.PickemGroupId);
+                continue;
+            }
+
+            // Working copy: clone the inputs ScorePick reads, leave the
+            // outputs ScorePick writes uninitialized so we can read them
+            // post-call as the "computed" snapshot.
+            var clone = new PickemGroupUserPick
+            {
+                Id = pick.Id,
+                FranchiseId = pick.FranchiseId,
+                ConfidencePoints = pick.ConfidencePoints
+            };
+
+            try
+            {
+                _pickScoringService.ScorePick(pick.Group, result.Spread, clone, result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "PickScoringAudit: re-score threw. PickId={PickId} LeagueId={LeagueId}. Skipping correction.",
+                    pick.Id, pick.PickemGroupId);
+                continue;
+            }
+
+            var matches =
+                pick.IsCorrect == clone.IsCorrect
+                && pick.PointsAwarded == clone.PointsAwarded
+                && pick.WasAgainstSpread == clone.WasAgainstSpread;
+
+            if (matches)
+            {
+                continue;
+            }
+
+            var leagueKey = keyByGroup.TryGetValue(pick.PickemGroupId, out var key)
+                ? key
+                : ((int?)null, (int?)null);
+
+            _logger.LogError(
+                "PickScoringAudit correction: PickId={PickId} StoredIsCorrect={StoredIsCorrect} ComputedIsCorrect={ComputedIsCorrect} StoredPoints={StoredPoints} ComputedPoints={ComputedPoints} StoredWasAts={StoredWasAts} ComputedWasAts={ComputedWasAts} LeagueId={LeagueId} SeasonYear={SeasonYear} Week={Week} Mode=Mismatch",
+                pick.Id,
+                pick.IsCorrect, clone.IsCorrect,
+                pick.PointsAwarded, clone.PointsAwarded,
+                pick.WasAgainstSpread, clone.WasAgainstSpread,
+                pick.PickemGroupId, leagueKey.Item1, leagueKey.Item2);
+
+            pick.IsCorrect = clone.IsCorrect;
+            pick.PointsAwarded = clone.PointsAwarded;
+            pick.WasAgainstSpread = clone.WasAgainstSpread;
+            // Preserve original ScoredAt — it's the audit trail of when
+            // scoring first ran. ModifiedUtc records the correction time.
+            pick.ModifiedUtc = now;
+            pick.ModifiedBy = CausationId.Api.PickScoringAuditProcessor;
+
+            if (leagueKey.Item1.HasValue && leagueKey.Item2.HasValue)
+            {
+                affectedLeagueWeeks.Add((pick.PickemGroupId, leagueKey.Item1.Value, leagueKey.Item2.Value));
+            }
+        }
+    }
+
+    private void FanOutLeagueWeekScoring(
+        HashSet<(Guid LeagueId, int SeasonYear, int Week)> affectedLeagueWeeks,
+        Guid correlationId)
+    {
+        foreach (var (leagueId, seasonYear, week) in affectedLeagueWeeks)
+        {
+            try
+            {
+                _backgroundJobProvider.Enqueue<IScoreLeagueWeeks>(
+                    p => p.Process(leagueId, seasonYear, week, correlationId));
+
+                _logger.LogInformation(
+                    "PickScoringAudit: enqueued league-week rescore. LeagueId={LeagueId} SeasonYear={SeasonYear} Week={Week}",
+                    leagueId, seasonYear, week);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "PickScoringAudit: failed to enqueue league-week rescore. LeagueId={LeagueId} SeasonYear={SeasonYear} Week={Week}. LeagueWeekScoringJob nightly backstop will catch this.",
+                    leagueId, seasonYear, week);
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -255,6 +255,8 @@ namespace SportsData.Api.DependencyInjection
 
             services.AddScoped<IPickScoringService, PickScoringService>();
             services.AddScoped<ILeagueWeekScoringService, LeagueWeekScoringService>();
+            services.AddScoped<IPickScoringAudit, PickScoringAuditProcessor>();
+            services.AddScoped<PickScoringAuditJob>();
 
             // Synthetic pick services (required by other services)
             services.AddSingleton<ISyntheticPickStyleProvider, SyntheticPickStyleProvider>();
@@ -317,6 +319,31 @@ namespace SportsData.Api.DependencyInjection
                 nameof(MatchupScheduler),
                 job => job.ExecuteAsync(),
                 Cron.Daily(6));
+
+            // Per-sport historical audit of previously-scored picks. Catches
+            // (a) picks scored against a contest that later finalized to a
+            // different result and (b) picks still scored against an
+            // unfinalized contest. Runs before PickScoringJob(9) so any
+            // ScoredAt resets land in time for the daily rescore.
+            //
+            // Stagger by 15 min per sport so a single sport's audit owns
+            // its window in Seq — pods are separate so the lack of stagger
+            // wouldn't actually collide, but staggering makes "which sport
+            // is misbehaving" trivial to identify.
+            recurringJobManager.AddOrUpdate<PickScoringAuditJob>(
+                "PickScoringAudit-FootballNcaa",
+                job => job.ExecuteAsync(Sport.FootballNcaa),
+                "0 2 * * *");
+
+            recurringJobManager.AddOrUpdate<PickScoringAuditJob>(
+                "PickScoringAudit-FootballNfl",
+                job => job.ExecuteAsync(Sport.FootballNfl),
+                "15 2 * * *");
+
+            recurringJobManager.AddOrUpdate<PickScoringAuditJob>(
+                "PickScoringAudit-BaseballMlb",
+                job => job.ExecuteAsync(Sport.BaseballMlb),
+                "30 2 * * *");
 
             return services;
         }

--- a/src/SportsData.Core/Common/CausationId.cs
+++ b/src/SportsData.Core/Common/CausationId.cs
@@ -7,6 +7,7 @@ namespace SportsData.Core.Common
         public static class Api
         {
             public static Guid PickScoringProcessor = new Guid("10000000-2000-0000-0000-000000000001");
+            public static Guid PickScoringAuditProcessor = new Guid("10000000-2000-0000-0000-000000000002");
             public static Guid MatchupPreviewProcessor = new Guid("10000000-3000-0000-0000-000000000001");
             public static readonly Guid SignalRDebugBroadcaster = new Guid("10000000-4000-0000-0000-000000000001");
         }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditJobTests.cs
@@ -1,0 +1,169 @@
+using AutoFixture;
+
+using Moq;
+
+using SportsData.Api.Application.Jobs;
+using SportsData.Api.Application.Scoring;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Scoring;
+
+public class PickScoringAuditJobTests : ApiTestBase<PickScoringAuditJob>
+{
+    [Fact]
+    public async Task Execute_EnqueuesAuditCommand_ForEachDistinctScoredContestOfThisSport()
+    {
+        // Arrange — five scored picks: two distinct NCAAFB contests
+        // (one with a duplicate to verify Distinct), one NFL contest, one MLB
+        // contest, and one NCAAFB pick that is UNSCORED. Audit should enqueue
+        // exactly the two distinct NCAAFB scored contests.
+        var ncaaContest1 = Guid.NewGuid();
+        var ncaaContest2 = Guid.NewGuid();
+        var nflContest = Guid.NewGuid();
+        var mlbContest = Guid.NewGuid();
+        var ncaaUnscoredContest = Guid.NewGuid();
+
+        var ncaaGroup = Fixture.Build<PickemGroup>()
+            .With(g => g.Sport, Sport.FootballNcaa).Create();
+        var nflGroup = Fixture.Build<PickemGroup>()
+            .With(g => g.Sport, Sport.FootballNfl).Create();
+        var mlbGroup = Fixture.Build<PickemGroup>()
+            .With(g => g.Sport, Sport.BaseballMlb).Create();
+
+        DataContext.PickemGroups.AddRange(ncaaGroup, nflGroup, mlbGroup);
+
+        var scoredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Explicitly set Group navigation to the seeded instance. Without
+        // this, AutoFixture creates a *new* PickemGroup for each pick's
+        // navigation property and EF cascade-inserts it, overriding the FK.
+        DataContext.UserPicks.AddRange(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, ncaaContest1)
+                .With(x => x.PickemGroupId, ncaaGroup.Id)
+                .With(x => x.Group, ncaaGroup)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, ncaaContest1) // duplicate contest, same sport
+                .With(x => x.PickemGroupId, ncaaGroup.Id)
+                .With(x => x.Group, ncaaGroup)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, ncaaContest2)
+                .With(x => x.PickemGroupId, ncaaGroup.Id)
+                .With(x => x.Group, ncaaGroup)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, nflContest)
+                .With(x => x.PickemGroupId, nflGroup.Id)
+                .With(x => x.Group, nflGroup)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, mlbContest)
+                .With(x => x.PickemGroupId, mlbGroup.Id)
+                .With(x => x.Group, mlbGroup)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, ncaaUnscoredContest)
+                .With(x => x.PickemGroupId, ncaaGroup.Id)
+                .With(x => x.Group, ncaaGroup)
+                .With(x => x.ScoredAt, (DateTime?)null).Create()
+        );
+
+        await DataContext.SaveChangesAsync();
+
+        var enqueuedCommands = new List<AuditContestCommand>();
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        background
+            .Setup(x => x.Enqueue<IPickScoringAudit>(It.IsAny<Expression<Func<IPickScoringAudit, Task>>>()))
+            .Callback<Expression<Func<IPickScoringAudit, Task>>>(expr =>
+            {
+                var cmd = AuditContestCommandFromExpression(expr);
+                if (cmd != null) enqueuedCommands.Add(cmd);
+            });
+
+        var sut = Mocker.CreateInstance<PickScoringAuditJob>();
+
+        // Act
+        await sut.ExecuteAsync(Sport.FootballNcaa);
+
+        // Assert — exactly two enqueues, only the NCAAFB scored contests.
+        Assert.Equal(2, enqueuedCommands.Count);
+        Assert.Equal(
+            new HashSet<Guid> { ncaaContest1, ncaaContest2 },
+            enqueuedCommands.Select(c => c.ContestId).ToHashSet());
+        Assert.All(enqueuedCommands, c => Assert.Equal(Sport.FootballNcaa, c.Sport));
+    }
+
+    [Fact]
+    public async Task Execute_EnqueuesNothing_WhenSportHasNoScoredPicks()
+    {
+        // Arrange — only MLB picks scored; audit fires for NCAAFB.
+        var mlbGroup = Fixture.Build<PickemGroup>()
+            .With(g => g.Sport, Sport.BaseballMlb).Create();
+        DataContext.PickemGroups.Add(mlbGroup);
+
+        DataContext.UserPicks.Add(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, Guid.NewGuid())
+                .With(x => x.PickemGroupId, mlbGroup.Id)
+                .With(x => x.Group, mlbGroup)
+                .With(x => x.ScoredAt, (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                .Create()
+        );
+
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<PickScoringAuditJob>();
+
+        await sut.ExecuteAsync(Sport.FootballNcaa);
+
+        background.Verify(x => x.Enqueue<IPickScoringAudit>(
+            It.IsAny<Expression<Func<IPickScoringAudit, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsUnscoredPicks_EvenForTargetSport()
+    {
+        // Arrange — NCAAFB pick exists but ScoredAt = null. PickScoringJob's
+        // territory, not the audit's.
+        var ncaaGroup = Fixture.Build<PickemGroup>()
+            .With(g => g.Sport, Sport.FootballNcaa).Create();
+        DataContext.PickemGroups.Add(ncaaGroup);
+
+        DataContext.UserPicks.Add(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, Guid.NewGuid())
+                .With(x => x.PickemGroupId, ncaaGroup.Id)
+                .With(x => x.Group, ncaaGroup)
+                .With(x => x.ScoredAt, (DateTime?)null).Create()
+        );
+
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<PickScoringAuditJob>();
+
+        await sut.ExecuteAsync(Sport.FootballNcaa);
+
+        background.Verify(x => x.Enqueue<IPickScoringAudit>(
+            It.IsAny<Expression<Func<IPickScoringAudit, Task>>>()), Times.Never);
+    }
+
+    private static AuditContestCommand? AuditContestCommandFromExpression(
+        Expression<Func<IPickScoringAudit, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        if (call.Method.Name != nameof(IPickScoringAudit.Process)) return null;
+        if (call.Arguments.Count != 1) return null;
+
+        return Expression.Lambda<Func<AuditContestCommand>>(call.Arguments[0]).Compile()();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditProcessorTests.cs
@@ -60,9 +60,11 @@ public class PickScoringAuditProcessorTests : ApiTestBase<PickScoringAuditProces
             .ReturnsAsync(new Success<MatchupResult>(result));
 
         // Real PickScoringService — easier than mocking the score logic.
+        // Reuse the Mocker's already-mocked IDateTimeProvider (FixedUtcNow)
+        // so the service sees the same fixed time as the SUT.
         Mocker.Use<IPickScoringService>(new PickScoringService(
             Microsoft.Extensions.Logging.Abstractions.NullLogger<PickScoringService>.Instance,
-            new DateTimeProvider()));
+            Mocker.Get<IDateTimeProvider>()));
 
         var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
 
@@ -108,20 +110,31 @@ public class PickScoringAuditProcessorTests : ApiTestBase<PickScoringAuditProces
 
         Mocker.Use<IPickScoringService>(new PickScoringService(
             Microsoft.Extensions.Logging.Abstractions.NullLogger<PickScoringService>.Instance,
-            new DateTimeProvider()));
+            Mocker.Get<IDateTimeProvider>()));
 
-        AuditContestCommand? enqueuedFanOut = null;
+        // Capture the *actual* expression the processor passes to Enqueue so
+        // we can assert the league-week payload, not just the call count.
+        // Without this the test would pass even if the processor enqueued
+        // a wrong leagueId / year / week — exactly the kind of regression
+        // that breaks leaderboard rescore fan-out.
+        (Guid LeagueId, int SeasonYear, int Week, Guid CorrelationId)? enqueuedCall = null;
         Mocker.GetMock<IProvideBackgroundJobs>()
             .Setup(x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()))
-            .Callback<Expression<Func<IScoreLeagueWeeks, Task>>>(_ => enqueuedFanOut = new AuditContestCommand(contestId, Sport.FootballNcaa));
+            .Callback<Expression<Func<IScoreLeagueWeeks, Task>>>(expr =>
+                enqueuedCall = LeagueWeekScoreCallFromExpression(expr));
 
         var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
 
+        // Capture CorrelationId from the command we'll invoke with so the
+        // assertion can verify the processor propagates it to the fan-out.
+        var command = new AuditContestCommand(contestId, Sport.FootballNcaa);
+
         // Act
-        await sut.Process(new AuditContestCommand(contestId, Sport.FootballNcaa));
+        await sut.Process(command);
 
         // Assert — pick corrected in place; ScoredAt preserved; ModifiedBy
-        // stamped with the audit causation ID; fan-out fired.
+        // stamped with the audit causation ID; fan-out fired with the right
+        // league-week payload.
         var refreshed = await DataContext.UserPicks.FindAsync(pick.Id);
         refreshed!.IsCorrect.Should().BeTrue("clone re-scored to a correct pick");
         refreshed.PointsAwarded.Should().Be(1);
@@ -132,7 +145,11 @@ public class PickScoringAuditProcessorTests : ApiTestBase<PickScoringAuditProces
         Mocker.GetMock<IProvideBackgroundJobs>().Verify(
             x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
             Times.Once);
-        enqueuedFanOut.Should().NotBeNull();
+        enqueuedCall.Should().NotBeNull();
+        enqueuedCall!.Value.LeagueId.Should().Be(groupId, "fan-out must target the pick's league");
+        enqueuedCall.Value.SeasonYear.Should().Be(2025, "seeded matchup is for the 2025 season");
+        enqueuedCall.Value.Week.Should().Be(10, "seeded matchup is for week 10");
+        enqueuedCall.Value.CorrelationId.Should().Be(command.CorrelationId, "audit must propagate the command's correlation id");
     }
 
     [Fact]
@@ -167,6 +184,7 @@ public class PickScoringAuditProcessorTests : ApiTestBase<PickScoringAuditProces
         refreshed.PointsAwarded.Should().BeNull();
         refreshed.WasAgainstSpread.Should().BeNull();
         refreshed.ModifiedBy.Should().Be(CausationId.Api.PickScoringAuditProcessor);
+        refreshed.ModifiedUtc.Should().Be(FixedUtcNow, "audit must stamp the reset with the deterministic time provider");
 
         Mocker.GetMock<IProvideBackgroundJobs>().Verify(
             x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
@@ -232,6 +250,112 @@ public class PickScoringAuditProcessorTests : ApiTestBase<PickScoringAuditProces
         Mocker.GetMock<IProvideBackgroundJobs>().Verify(
             x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_IgnoresPicksFromOtherSports_EvenWithSameContestId()
+    {
+        // Defense in depth: even if a caller passes the wrong Sport in the
+        // command, the processor's data queries are sport-scoped so an MLB
+        // audit can't accidentally rewrite NCAAFB picks (or vice versa).
+        // Astronomically unlikely with random Guids, but the user explicitly
+        // wanted hard sport isolation per CR review on PR #422.
+        var sharedContestId = Guid.NewGuid();
+        var ncaaGroupId = Guid.NewGuid();
+        var mlbGroupId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+
+        // Seed an NCAAFB pick (wrong-sport for our MLB audit run).
+        var (ncaaPick, _, _) = await SeedScoredPickAsync(
+            sharedContestId, ncaaGroupId, winnerId,
+            storedIsCorrect: false, storedPoints: 0, wasAts: false,
+            franchiseId: winnerId);
+
+        // Seed an MLB pick that SHOULD be in scope.
+        var mlbGroup = Fixture.Build<PickemGroup>()
+            .With(g => g.Id, mlbGroupId)
+            .With(g => g.Sport, Sport.BaseballMlb)
+            .With(g => g.PickType, PickType.StraightUp)
+            .With(g => g.UseConfidencePoints, false)
+            .Create();
+        var mlbMatchup = Fixture.Build<PickemGroupMatchup>()
+            .With(m => m.ContestId, sharedContestId)
+            .With(m => m.GroupId, mlbGroupId)
+            .With(m => m.SeasonYear, 2026)
+            .With(m => m.SeasonWeek, 5)
+            .Without(m => m.GroupWeek)
+            .Create();
+        var mlbPick = Fixture.Build<PickemGroupUserPick>()
+            .With(p => p.ContestId, sharedContestId)
+            .With(p => p.PickemGroupId, mlbGroupId)
+            .With(p => p.Group, mlbGroup)
+            .With(p => p.FranchiseId, (Guid?)winnerId)
+            .With(p => p.IsCorrect, (bool?)false)
+            .With(p => p.PointsAwarded, 0)
+            .With(p => p.WasAgainstSpread, (bool?)false)
+            .With(p => p.ScoredAt, (DateTime?)OriginalScoredAt)
+            .Create();
+        await DataContext.PickemGroups.AddAsync(mlbGroup);
+        await DataContext.PickemGroupMatchups.AddAsync(mlbMatchup);
+        await DataContext.UserPicks.AddAsync(mlbPick);
+        await DataContext.SaveChangesAsync();
+        DataContext.ChangeTracker.Clear();
+
+        var result = Fixture.Build<MatchupResult>()
+            .With(r => r.ContestId, sharedContestId)
+            .With(r => r.WinnerFranchiseSeasonId, (Guid?)winnerId)
+            .With(r => r.FinalizedUtc, (DateTime?)FixedUtcNow.AddHours(-2))
+            .Create();
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupResult(sharedContestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupResult>(result));
+
+        Mocker.Use<IPickScoringService>(new PickScoringService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<PickScoringService>.Instance,
+            Mocker.Get<IDateTimeProvider>()));
+
+        var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
+
+        // Act — run the MLB audit. NCAAFB pick is "wrong" relative to the
+        // MatchupResult winner, but should NOT be corrected because it
+        // belongs to a different sport.
+        await sut.Process(new AuditContestCommand(sharedContestId, Sport.BaseballMlb));
+
+        // Assert — NCAAFB pick untouched.
+        var refreshedNcaa = await DataContext.UserPicks.FindAsync(ncaaPick.Id);
+        refreshedNcaa!.IsCorrect.Should().BeFalse("NCAAFB pick must not be touched by MLB audit");
+        refreshedNcaa.PointsAwarded.Should().Be(0);
+        refreshedNcaa.ModifiedBy.Should().NotBe(CausationId.Api.PickScoringAuditProcessor);
+
+        // MLB pick gets corrected — proves the audit DID run for the
+        // right sport.
+        var refreshedMlb = await DataContext.UserPicks.FindAsync(mlbPick.Id);
+        refreshedMlb!.IsCorrect.Should().BeTrue();
+        refreshedMlb.PointsAwarded.Should().Be(1);
+        refreshedMlb.ModifiedBy.Should().Be(CausationId.Api.PickScoringAuditProcessor);
+    }
+
+    /// <summary>
+    /// Compiles the four argument expressions of a
+    /// <c>p =&gt; p.Process(leagueId, seasonYear, week, correlationId)</c>
+    /// lambda and returns the captured values. Returns null when the
+    /// expression isn't shaped as expected — caller asserts NotBeNull.
+    /// Mirrors the pattern in PickScoringJobTests.
+    /// </summary>
+    private static (Guid LeagueId, int SeasonYear, int Week, Guid CorrelationId)?
+        LeagueWeekScoreCallFromExpression(Expression<Func<IScoreLeagueWeeks, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        if (call.Method.Name != nameof(IScoreLeagueWeeks.Process)) return null;
+        if (call.Arguments.Count != 4) return null;
+
+        var leagueId = Expression.Lambda<Func<Guid>>(call.Arguments[0]).Compile()();
+        var seasonYear = Expression.Lambda<Func<int>>(call.Arguments[1]).Compile()();
+        var week = Expression.Lambda<Func<int>>(call.Arguments[2]).Compile()();
+        var correlationId = Expression.Lambda<Func<Guid>>(call.Arguments[3]).Compile()();
+
+        return (leagueId, seasonYear, week, correlationId);
     }
 
     private async Task<(PickemGroupUserPick pick, PickemGroup group, PickemGroupMatchup matchup)>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditProcessorTests.cs
@@ -1,0 +1,285 @@
+using AutoFixture;
+
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.Scoring;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Scoring;
+
+public class PickScoringAuditProcessorTests : ApiTestBase<PickScoringAuditProcessor>
+{
+    private readonly Mock<IProvideContests> _contestClientMock = new();
+    private static readonly DateTime FixedUtcNow = new(2026, 6, 16, 2, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime OriginalScoredAt = new(2025, 11, 1, 23, 30, 0, DateTimeKind.Utc);
+
+    public PickScoringAuditProcessorTests()
+    {
+        Mocker.GetMock<IContestClientFactory>()
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_contestClientMock.Object);
+
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedUtcNow);
+    }
+
+    [Fact]
+    public async Task Process_WhenStoredMatchesRecomputed_DoesNotWriteAndDoesNotFanOut()
+    {
+        // Arrange — healthy pick: stored IsCorrect / PointsAwarded match
+        // what PickScoringService produces against the current MatchupResult.
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+
+        var (pick, _, _) = await SeedScoredPickAsync(
+            contestId, groupId, winnerId,
+            storedIsCorrect: true, storedPoints: 1, wasAts: false,
+            franchiseId: winnerId);
+
+        var result = Fixture.Build<MatchupResult>()
+            .With(r => r.ContestId, contestId)
+            .With(r => r.WinnerFranchiseSeasonId, (Guid?)winnerId)
+            .With(r => r.FinalizedUtc, (DateTime?)FixedUtcNow.AddHours(-2))
+            .Create();
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupResult>(result));
+
+        // Real PickScoringService — easier than mocking the score logic.
+        Mocker.Use<IPickScoringService>(new PickScoringService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<PickScoringService>.Instance,
+            new DateTimeProvider()));
+
+        var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
+
+        // Act
+        await sut.Process(new AuditContestCommand(contestId, Sport.FootballNcaa));
+
+        // Assert — pick fields untouched, no fan-out enqueued.
+        var refreshed = await DataContext.UserPicks.FindAsync(pick.Id);
+        refreshed!.IsCorrect.Should().BeTrue();
+        refreshed.PointsAwarded.Should().Be(1);
+        refreshed.ScoredAt.Should().Be(OriginalScoredAt);
+        refreshed.ModifiedBy.Should().NotBe(CausationId.Api.PickScoringAuditProcessor);
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenStoredIsWrong_CorrectsInPlaceAndEnqueuesLeagueWeek()
+    {
+        // Arrange — exact corruption pattern: pick was previously scored as
+        // IsCorrect=false / PointsAwarded=0 against Guid.Empty winner. Contest
+        // has since finalized with the user's actual pick as the real winner.
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+
+        var (pick, _, matchup) = await SeedScoredPickAsync(
+            contestId, groupId, winnerId,
+            storedIsCorrect: false, storedPoints: 0, wasAts: false,
+            franchiseId: winnerId);
+
+        var result = Fixture.Build<MatchupResult>()
+            .With(r => r.ContestId, contestId)
+            .With(r => r.WinnerFranchiseSeasonId, (Guid?)winnerId)
+            .With(r => r.FinalizedUtc, (DateTime?)FixedUtcNow.AddHours(-2))
+            .Create();
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupResult>(result));
+
+        Mocker.Use<IPickScoringService>(new PickScoringService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<PickScoringService>.Instance,
+            new DateTimeProvider()));
+
+        AuditContestCommand? enqueuedFanOut = null;
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()))
+            .Callback<Expression<Func<IScoreLeagueWeeks, Task>>>(_ => enqueuedFanOut = new AuditContestCommand(contestId, Sport.FootballNcaa));
+
+        var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
+
+        // Act
+        await sut.Process(new AuditContestCommand(contestId, Sport.FootballNcaa));
+
+        // Assert — pick corrected in place; ScoredAt preserved; ModifiedBy
+        // stamped with the audit causation ID; fan-out fired.
+        var refreshed = await DataContext.UserPicks.FindAsync(pick.Id);
+        refreshed!.IsCorrect.Should().BeTrue("clone re-scored to a correct pick");
+        refreshed.PointsAwarded.Should().Be(1);
+        refreshed.ScoredAt.Should().Be(OriginalScoredAt, "audit preserves the original scoring timestamp");
+        refreshed.ModifiedBy.Should().Be(CausationId.Api.PickScoringAuditProcessor);
+        refreshed.ModifiedUtc.Should().Be(FixedUtcNow);
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
+            Times.Once);
+        enqueuedFanOut.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Process_WhenMatchupResultNotFound_ResetsStuckPicksAndEnqueuesLeagueWeek()
+    {
+        // Arrange — pick is scored, but Producer says NotFound (the
+        // FinalizedUtc IS NOT NULL SQL filter is rejecting an unfinalized
+        // contest). The exact stuck-pick pattern audit is built for.
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        var (pick, _, _) = await SeedScoredPickAsync(
+            contestId, groupId, winnerId: Guid.NewGuid(),
+            storedIsCorrect: false, storedPoints: 0, wasAts: false,
+            franchiseId: Guid.NewGuid());
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<MatchupResult>(default!, ResultStatus.NotFound, []));
+
+        var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
+
+        // Act
+        await sut.Process(new AuditContestCommand(contestId, Sport.FootballNcaa));
+
+        // Assert — pick reset to "unscored" so PickScoringJob can re-do it once
+        // the contest enriches; fan-out enqueued so stale league-week
+        // aggregates rebuild.
+        var refreshed = await DataContext.UserPicks.FindAsync(pick.Id);
+        refreshed!.ScoredAt.Should().BeNull();
+        refreshed.IsCorrect.Should().BeNull();
+        refreshed.PointsAwarded.Should().BeNull();
+        refreshed.WasAgainstSpread.Should().BeNull();
+        refreshed.ModifiedBy.Should().Be(CausationId.Api.PickScoringAuditProcessor);
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Process_WhenNoScoredPicksForContest_ShortCircuits()
+    {
+        // Arrange — no scored picks at all. Cron may have enqueued this
+        // contest before all picks were deleted; processor should bail
+        // before any Producer round-trip.
+        var contestId = Guid.NewGuid();
+
+        var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
+
+        // Act
+        await sut.Process(new AuditContestCommand(contestId, Sport.FootballNcaa));
+
+        // Assert — no Producer call, no fan-out.
+        _contestClientMock.Verify(
+            x => x.GetMatchupResult(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenMatchupResultIsSuccessButFinalizedUtcIsNull_SkipsWithoutWriting()
+    {
+        // Arrange — defensive: the new SQL filter should prevent this, but
+        // if anyone reverts it, audit refuses to overwrite valid picks based
+        // on pre-enrichment data.
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+
+        var (pick, _, _) = await SeedScoredPickAsync(
+            contestId, groupId, winnerId,
+            storedIsCorrect: true, storedPoints: 1, wasAts: false,
+            franchiseId: winnerId);
+
+        var result = Fixture.Build<MatchupResult>()
+            .With(r => r.ContestId, contestId)
+            .With(r => r.FinalizedUtc, (DateTime?)null)
+            .Create();
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupResult>(result));
+
+        var sut = Mocker.CreateInstance<PickScoringAuditProcessor>();
+
+        await sut.Process(new AuditContestCommand(contestId, Sport.FootballNcaa));
+
+        var refreshed = await DataContext.UserPicks.FindAsync(pick.Id);
+        refreshed!.IsCorrect.Should().BeTrue("audit must not mutate when source data is suspect");
+        refreshed.PointsAwarded.Should().Be(1);
+        refreshed.ScoredAt.Should().Be(OriginalScoredAt);
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IScoreLeagueWeeks>(It.IsAny<Expression<Func<IScoreLeagueWeeks, Task>>>()),
+            Times.Never);
+    }
+
+    private async Task<(PickemGroupUserPick pick, PickemGroup group, PickemGroupMatchup matchup)>
+        SeedScoredPickAsync(
+            Guid contestId,
+            Guid groupId,
+            Guid winnerId,
+            bool storedIsCorrect,
+            int? storedPoints,
+            bool wasAts,
+            Guid franchiseId)
+    {
+        var group = Fixture.Build<PickemGroup>()
+            .With(g => g.Id, groupId)
+            .With(g => g.Sport, Sport.FootballNcaa)
+            .With(g => g.PickType, PickType.StraightUp)
+            .With(g => g.UseConfidencePoints, false)
+            .Create();
+
+        // Without(GroupWeek): AutoFixture's auto-populated GroupWeek
+        // navigation would cascade-insert a stray PickemGroupWeek and confuse
+        // the FK relationship the processor's query relies on.
+        var matchup = Fixture.Build<PickemGroupMatchup>()
+            .With(m => m.ContestId, contestId)
+            .With(m => m.GroupId, groupId)
+            .With(m => m.SeasonYear, 2025)
+            .With(m => m.SeasonWeek, 10)
+            .Without(m => m.GroupWeek)
+            .Create();
+
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+
+        var pick = Fixture.Build<PickemGroupUserPick>()
+            .With(p => p.ContestId, contestId)
+            .With(p => p.PickemGroupId, groupId)
+            .With(p => p.Group, group)
+            .With(p => p.FranchiseId, (Guid?)franchiseId)
+            .With(p => p.IsCorrect, (bool?)storedIsCorrect)
+            .With(p => p.PointsAwarded, storedPoints)
+            .With(p => p.WasAgainstSpread, (bool?)wasAts)
+            .With(p => p.ScoredAt, (DateTime?)OriginalScoredAt)
+            .Create();
+
+        await DataContext.UserPicks.AddAsync(pick);
+        await DataContext.SaveChangesAsync();
+        DataContext.ChangeTracker.Clear();
+
+        return (pick, group, matchup);
+    }
+}


### PR DESCRIPTION
## Summary

Nightly per-sport audit that re-runs `PickScoringService` against current canonical data for every previously-scored pick, corrects mismatches in place, and fans out league-week rescoring. Targets historical corruption that PR #421's upstream fix can't reach: picks scored against an unfinalized contest that *later finalized to a different result* still carry the bad `IsCorrect`/`PointsAwarded` forever, because `PickScoringJob` filters on `ScoredAt IS NULL`.

Two detection modes:

- **Mismatch** — `GetMatchupResult` returns finalized data. Audit clones the pick, runs `PickScoringService.ScorePick` on the clone, compares stored `(IsCorrect, PointsAwarded, WasAgainstSpread)` to recomputed. On mismatch: overwrite stored fields in place, preserve original `ScoredAt` as audit trail, stamp `ModifiedBy` with the new `CausationId.Api.PickScoringAuditProcessor`. `LogError` per correction.
- **Unfinalized** — `GetMatchupResult` returns `NotFound` (new SQL filter rejected unfinalized contest). Pick should never have been scored; reset `ScoredAt`/`IsCorrect`/`PointsAwarded`/`WasAgainstSpread` so `PickScoringJob` re-does it once the contest enriches.

Both modes collect `(LeagueId, SeasonYear, Week)` and enqueue `IScoreLeagueWeeks` so leaderboard aggregates rebuild.

**Per-sport scoping.** `PickScoringAuditJob.ExecuteAsync(Sport sport)` filters candidate ContestIds at the SQL layer via the `PickemGroup.Sport` join. Registered three times in `ConfigureHangfireJobs` with staggered crons (NCAAFB 02:00, NFL 02:15, MLB 02:30 UTC). MLB audit traffic never touches NCAAFB/NFL Producer pods, and Seq queries naturally segment by sport. All three run before `PickScoringJob`'s 09:00 cron so any `ScoredAt` resets land in time for the daily rescore.

Doesn't implement `IAmARecurringJob` because the interface requires a parameterless `ExecuteAsync()`. The marker has no other consumers in the codebase (declared, never queried).

Design doc: `docs/pick-scoring-audit-job.md`.

## Test plan

- [x] `dotnet build` clean on SportsData.Api
- [x] `dotnet test` clean on SportsData.Api.Tests.Unit (402 pass; +8 new)
- [x] `Execute_EnqueuesAuditCommand_ForEachDistinctScoredContestOfThisSport` — proves sport-scoping at the SQL filter level; NFL/MLB picks are *not* enqueued when running the NCAAFB audit
- [x] `Execute_EnqueuesNothing_WhenSportHasNoScoredPicks` — clean no-op
- [x] `Execute_SkipsUnscoredPicks_EvenForTargetSport` — audit doesn't double up on `PickScoringJob`'s territory
- [x] `Process_WhenStoredMatchesRecomputed_DoesNotWriteAndDoesNotFanOut` — healthy picks untouched
- [x] `Process_WhenStoredIsWrong_CorrectsInPlaceAndEnqueuesLeagueWeek` — exact corruption-correction path
- [x] `Process_WhenMatchupResultNotFound_ResetsStuckPicksAndEnqueuesLeagueWeek` — unfinalized stuck-pick reset
- [x] `Process_WhenNoScoredPicksForContest_ShortCircuits` — race where picks were deleted between cron enqueue and processor fire
- [x] `Process_WhenMatchupResultIsSuccessButFinalizedUtcIsNull_SkipsWithoutWriting` — defensive: SQL filter reverted shouldn't corrupt valid picks
- [ ] Manual E2E (local with prod DB snapshot): seed one known-bad pick (NCAAFB 2025), run audit, verify `LogError` correction + leaderboard rebuild
- [ ] Prod monitoring after first nightly run: Seq query `"PickScoringAudit correction"` grouped by `Sport` + `Mode` + `LeagueId`. Initial sweep expected to be large; subsequent runs should taper.

## Operational rollout

Per design doc §"Operating procedure": watch the first 02:00 / 02:15 / 02:30 UTC runs. Expect large initial correction volume from MLB-testing-era and NCAAFB 2025 corruption. Reassess scope after steady state. Job stays in code forever; we just stop scheduling it once we trust the upstream path (see design doc §D4-D6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a scheduled pick scoring audit that scans previously scored picks and repairs inconsistent scoring results.
  * Runs separately per sport (NCAA Football, NFL, MLB) on staggered daily schedules.
  * Automatically triggers league-week rescoring for leagues affected by detected corrections.

* **Bug Fixes**
  * Prevents “stuck” or mismatched pick scoring by resetting or re-computing values when audit discrepancies are found.

* **Tests**
  * Added unit tests covering enqueuing, audit correctness, match “not found” handling, and sport isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->