### PR TITLE
feat(producer): contest enrichment historical sweep + cancellation marker

### DIFF
--- a/docs/contest-enrichment-historical-sweep.md
+++ b/docs/contest-enrichment-historical-sweep.md
@@ -1,0 +1,113 @@
+# Contest Enrichment Historical Sweep
+
+**Status:** Implementing
+**Date:** 2026-06-16
+**Driver:** ContestEnrichmentJob's season-week filter has been silently excluding ~44K historical contests (NCAAFB 19,208 + NFL 1,048 + MLB 24,430) that have `STATUS_FINAL` ready for enrichment but never had `FinalizedUtc` stamped.
+
+## Problem
+
+`ContestEnrichmentJob` is registered as a daily cron. Its steady-state code path (`BackfillCurrentSeason = false`) only considers contests whose `SeasonWeekId` matches the current two season weeks. Its backfill path (`BackfillCurrentSeason = true`, currently always on) widens to "current season only." Neither catches historical contests.
+
+After the season-week filter dropped, the actual blocker on enrichment is just status availability — the sport-specific enrichment processors already short-circuit cleanly when `CompetitionStatus.StatusTypeName != "STATUS_FINAL"`. The job's filter has been turning away contests that the processor would have happily finalized.
+
+A subset of those 44K contests are *truly cancelled* (ESPN status = `STATUS_CANCELED`). Once the job stops excluding them, they would re-enqueue every nightly run because the enrichment processor never stamps `FinalizedUtc` on cancelled games — they're not final. We need a separate marker.
+
+## Decisions
+
+### D1. Add `CancelledUtc DateTime?` to `ContestBase`
+
+Sport-agnostic, single nullable column. Inherited by `FootballContest` and `BaseballContest`. Two EF migrations (one per sport DbContext) add the column. No index — the unbounded query runs at most daily and the column participates in a single `IS NULL` predicate.
+
+### D2. `EventCompetitionStatusDocumentProcessor` is the only `CancelledUtc` setter
+
+When the status processors (`EventCompetitionStatusDocumentProcessor<TDataContext>` for Football, `BaseballEventCompetitionStatusDocumentProcessor<TDataContext>` for Baseball) see `StatusTypeName == "STATUS_CANCELED"`:
+
+- Load the parent `Contest` via the projected `ContestId`.
+- If `Contest.CancelledUtc is null`, stamp it with `_dateTimeProvider.UtcNow()`.
+- If already non-null, leave it alone — preserves the "first observed" timestamp.
+
+If the status transitions *away from* `STATUS_CANCELED` (rare: a cancelled game gets uncancelled), log a `LogWarning` but do not clear `CancelledUtc`. Treat cancellation as irrevocable; require a manual override if a real bad case appears.
+
+The Football processor doesn't currently inject `IDateTimeProvider`; add it. Baseball already has it.
+
+### D3. Only `STATUS_CANCELED` qualifies as terminal for now
+
+`STATUS_FORFEIT` is deferred. Real forfeits are vanishingly rare in NFL/NCAAFB and effectively extinct in MLB. If a forfeit game appears and someone complains, revisit. `STATUS_POSTPONED`, `STATUS_SUSPENDED`, `STATUS_DELAYED` are all transient — game eventually resumes/plays. Status processor already publishes `ContestStatusChanged` on these; nothing else to do.
+
+### D4. ContestEnrichmentJob runs an unbounded query
+
+```csharp
+var contests = await _dataContext.Contests
+    .AsNoTracking()
+    .Where(c => c.FinalizedUtc == null
+             && c.CancelledUtc == null
+             && c.StartDateUtc < _dateTimeProvider.UtcNow())
+    .OrderBy(c => c.StartDateUtc)
+    .ToListAsync();
+```
+
+- `FinalizedUtc IS NULL` — not yet enriched.
+- `CancelledUtc IS NULL` — not terminal-cancelled. Once D2's setter fires, those are permanently excluded.
+- `StartDateUtc < now` — past games only. Future-scheduled games can't be enriched.
+
+Delete the `BackfillCurrentSeason` flag, the `SeasonWeeks` query, and the per-season-week loop. The 3h grace window (`< now + 3h`) goes away — including future games never made sense for enrichment.
+
+### D5. Daily cadence (`Cron.Daily(8)`) stays
+
+The 44K initial sweep is a one-shot, triggered manually via the Hangfire dashboard's "Trigger now" on the recurring job. After that, daily runs see only the small day's-worth of newly-finalized games (~hundreds during MLB regular season, ~dozens NCAAFB on game days, ~zero NFL most days). Event-driven path (`ContestCompleted` → `ContestCompletedHandler` schedules `EnrichContestCommand` with 30s delay) handles live churn; the daily cron is cheap insurance for events lost in transit.
+
+### D6. No backfill for existing cancelled contests
+
+After the column ships, only newly-observed cancellations get `CancelledUtc` stamped. Historical cancelled games already in the DB stay non-cancelled-from-our-perspective and re-enqueue every run. Cost: a fast no-op per re-enqueue (enrichment processor short-circuits on non-FINAL). We accept the noise and revisit once we see what surfaces from the sweep.
+
+### D7. No `ContestCancelled` event published
+
+The status processor already publishes `ContestStatusChanged` on transitions. Downstream subscribers can branch on `StatusTypeName == "STATUS_CANCELED"` if they need to react. No new event surface.
+
+### D8. No changes to enrichment processors
+
+`FootballContestEnrichmentProcessor` and `BaseballContestEnrichmentProcessor` stay as-is. They already short-circuit cleanly on `StatusTypeName != "STATUS_FINAL"`, log informationally, and return. A cancelled contest that survives to the processor (e.g., first nightly run after deploy, before its status doc re-fires) will hit this short-circuit. Wasted enqueue, fast no-op.
+
+### D9. Picks on cancelled games — deferred
+
+Audit job will see `GetMatchupResult → NotFound` for cancelled contests and reset pick `ScoredAt = null`. `PickScoringJob` will then re-enqueue, get NotFound, short-circuit. Cycle repeats nightly with small per-pick cost. Real fix is probably an `IsVoid` flag on `PickemGroupUserPick` plus a "skip cancelled" branch in `PickScoringJob`, but defer until volume warrants — see how big the cancelled-game pick pool actually is post-sweep.
+
+## File-by-file plan
+
+| File | Change |
+|---|---|
+| `src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs` | Add `public DateTime? CancelledUtc { get; set; }`. No EF config — nullable column with default mapping is sufficient. |
+| `src/SportsData.Producer/Migrations/Football/{timestamp}_AddContestCancelledUtc.cs` | **New** EF migration — adds `CancelledUtc` nullable timestamptz column. |
+| `src/SportsData.Producer/Migrations/Baseball/{timestamp}_AddContestCancelledUtc.cs` | **New** EF migration — mirror for Baseball context. |
+| `src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusDocumentProcessor.cs` | Inject `IDateTimeProvider`. After determining the new status, call a small inline helper that loads the parent Contest and stamps/logs `CancelledUtc`. |
+| `src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessor.cs` | Same `CancelledUtc` stamp logic. Uses existing `IDateTimeProvider`. |
+| `src/SportsData.Producer/Application/Contests/ContestEnrichmentJob.cs` | Delete `BackfillCurrentSeason` flag, `ExecuteBackfillCurrentSeason` method, and the season-week query path. Inject `IDateTimeProvider`. New `ExecuteAsync` is the unbounded query. |
+| `test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs` | Add tests for: STATUS_CANCELED stamps `CancelledUtc`; second observation with CancelledUtc already set is no-op; transition away from CANCELED logs warning, doesn't clear. |
+| `test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs` | Same set of tests for the Baseball processor (create file if it doesn't exist). |
+| `test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentJobTests.cs` | **New** test file. Coverage: unfinalized + uncancelled + past start → enqueued; cancelled → skipped; future-start → skipped; finalized → skipped. |
+
+## Operational rollout
+
+1. Test EF migrations locally (per CLAUDE.md migration rule).
+2. Local E2E: seed a few unfinalized contests of varying statuses in a copied prod DB snapshot, run the job, watch them finalize / skip appropriately.
+3. Open PR. Land via normal CR cycle.
+4. Deploy.
+5. Verify Hangfire dashboard shows three recurring jobs registered correctly.
+6. Hit "Trigger now" on `ContestEnrichmentJob` during a quiet window. Watch Seq for the new `JobRunId`-scoped logs.
+7. After sweep settles (~8-10 hours expected at current worker pool size), query Postgres for the residual unfinalized count per sport. Compare to the 44K baseline to gauge what surfaced.
+
+## Test plan
+
+- [ ] `dotnet build` clean.
+- [ ] `dotnet test` clean on `SportsData.Producer.Tests.Unit`.
+- [ ] Migration applies cleanly on a local Postgres copy.
+- [ ] Local E2E: cancelled contest stays out of the enrichment queue after status doc fires.
+- [ ] Local E2E: previously-stuck NCAAFB contest from 2018 with `STATUS_FINAL` finalizes on first run of the new job.
+
+## Out of scope
+
+- Backfill of `CancelledUtc` on already-cancelled-in-DB contests (D6).
+- Picks on cancelled games — `IsVoid` flag, audit-job branch (D9).
+- Forfeit handling (D3).
+- `ContestCancelled` event (D7).
+- Sourcing-incomplete contests (no `CompetitionStatus` row): these will repeatedly no-op through enrichment. A separate sourcing audit / Provider re-fetch tool is the right venue.

--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -32,146 +32,152 @@ namespace SportsData.Producer.Application.Contests
         {
             using (_logger.BeginScope(new Dictionary<string, object>
                    {
+                       ["ContestId"] = command.ContestId,
                        ["CorrelationId"] = command.CorrelationId
                    }))
             {
-                _logger.LogInformation("Contest enrichment job started for {@command}", command);
-
-                var competition = await _dataContext.Competitions
-                    .Include(c => c.Competitors)
-                    .Include(c => c.Odds)
-                    .ThenInclude(o => o.Teams)
-                    .Include(c => c.Contest)
-                    .Where(c => c.ContestId == command.ContestId)
-                    .AsSplitQuery()
-                    .FirstOrDefaultAsync();
-
-                if (competition is null)
-                {
-                    _logger.LogError("Competition could not be loaded for provided contest id. {@Command}", command);
-                    return;
-                }
-
-                if (competition.Contest.FinalizedUtc != null)
-                {
-                    _logger.LogInformation(
-                        "Contest already finalized. Skipping. ContestId={ContestId}, FinalizedUtc={FinalizedUtc}",
-                        command.ContestId, competition.Contest.FinalizedUtc);
-                    return;
-                }
-
-                var awayCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "away");
-                var homeCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "home");
-
-                if (awayCompetitor is null || homeCompetitor is null)
-                {
-                    _logger.LogError(
-                        "Competition is missing away or home competitor. ContestId={ContestId}, Away={HasAway}, Home={HasHome}",
-                        command.ContestId, awayCompetitor is not null, homeCompetitor is not null);
-                    return;
-                }
-
-                var status = await _dataContext.CompetitionStatuses
-                    .AsNoTracking()
-                    .FirstOrDefaultAsync(s => s.CompetitionId == competition.Id);
-
-                if (status?.StatusTypeName != "STATUS_FINAL")
-                {
-                    _logger.LogInformation(
-                        "Contest status is not yet final for {ContestName}. Current: {Status}. Skipping enrichment.",
-                        competition.Contest.Name, status?.StatusTypeName ?? "unknown");
-                    return;
-                }
-
-                var contest = competition.Contest;
-
-                // Baseball plays don't carry a clock for tiebreak ordering. Use the
-                // canonical CompetitionCompetitorScore record as the source of final
-                // score: prefer SourceDescription = "Final", otherwise the most recent.
-                var awayFinalScore = await _dataContext.CompetitionCompetitorScores
-                    .AsNoTracking()
-                    .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
-                    .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                    .ThenByDescending(s => s.CreatedUtc)
-                    .Select(s => (double?)s.Value)
-                    .FirstOrDefaultAsync();
-
-                var homeFinalScore = await _dataContext.CompetitionCompetitorScores
-                    .AsNoTracking()
-                    .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
-                    .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                    .ThenByDescending(s => s.CreatedUtc)
-                    .Select(s => (double?)s.Value)
-                    .FirstOrDefaultAsync();
-
-                if (awayFinalScore is null || homeFinalScore is null)
-                {
-                    _logger.LogInformation(
-                        "No competitor scores available for {ContestName}. Data not ready for enrichment.",
-                        contest.Name);
-                    return;
-                }
-
-                contest.AwayScore = (int)awayFinalScore.Value;
-                contest.HomeScore = (int)homeFinalScore.Value;
-
-                var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
-                var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;
-
-                if (contest.AwayScore != contest.HomeScore)
-                {
-                    var homeWasWinner = contest.AwayScore < contest.HomeScore;
-
-                    contest.WinnerFranchiseId =
-                        homeWasWinner ?
-                        homeFranchiseSeasonId :
-                        awayFranchiseSeasonId;
-                }
-
-                contest.FinalizedUtc = _dateTimeProvider.UtcNow();
-
-                if (competition.Odds?.Any() == true)
-                {
-                    EnrichOddsResults(
-                        competition.Odds,
-                        awayFranchiseSeasonId,
-                        homeFranchiseSeasonId,
-                        contest.AwayScore!.Value,
-                        contest.HomeScore!.Value);
-
-                    var primaryOdds = competition.Odds
-                        .FirstOrDefault(o => o.EnrichedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
-                        ?? competition.Odds.FirstOrDefault(o => o.EnrichedUtc.HasValue);
-
-                    if (primaryOdds != null)
-                    {
-                        contest.OverUnder = primaryOdds.OverUnderResult;
-                        contest.SpreadWinnerFranchiseId = primaryOdds.AtsWinnerFranchiseSeasonId;
-                    }
-                }
-
-                await _bus.Publish(
-                    new ContestFinalized(
-                        command.ContestId,
-                        null,
-                        contest.Sport,
-                        contest.SeasonYear,
-                        command.CorrelationId,
-                        Guid.NewGuid()));
-                await _dataContext.SaveChangesAsync();
-
-                _logger.LogInformation(
-                    "Contest enrichment completed. ContestId={ContestId}, ContestName={ContestName}, " +
-                    "AwayScore={AwayScore}, HomeScore={HomeScore}, WinnerFranchiseSeasonId={WinnerFranchiseSeasonId}, " +
-                    "FinalizedUtc={FinalizedUtc}, OddsProvidersEnriched={OddsProvidersEnriched}",
-                    command.ContestId,
-                    contest.Name,
-                    contest.AwayScore,
-                    contest.HomeScore,
-                    contest.WinnerFranchiseId,
-                    contest.FinalizedUtc,
-                    competition.Odds?.Count(o => o.EnrichedUtc.HasValue) ?? 0);
+                await ProcessInternal(command);
             }
+        }
+
+        private async Task ProcessInternal(EnrichContestCommand command)
+        {
+            _logger.LogInformation("Contest enrichment job started for {@command}", command);
+
+            var competition = await _dataContext.Competitions
+                .Include(c => c.Competitors)
+                .Include(c => c.Odds)
+                .ThenInclude(o => o.Teams)
+                .Include(c => c.Contest)
+                .Where(c => c.ContestId == command.ContestId)
+                .AsSplitQuery()
+                .FirstOrDefaultAsync();
+
+            if (competition is null)
+            {
+                _logger.LogError("Competition could not be loaded for provided contest id. {@Command}", command);
+                return;
+            }
+
+            if (competition.Contest.FinalizedUtc != null)
+            {
+                _logger.LogInformation(
+                    "Contest already finalized. Skipping. ContestId={ContestId}, FinalizedUtc={FinalizedUtc}",
+                    command.ContestId, competition.Contest.FinalizedUtc);
+                return;
+            }
+
+            var awayCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "away");
+            var homeCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "home");
+
+            if (awayCompetitor is null || homeCompetitor is null)
+            {
+                _logger.LogError(
+                    "Competition is missing away or home competitor. Away={HasAway}, Home={HasHome}",
+                    awayCompetitor is not null, homeCompetitor is not null);
+                return;
+            }
+
+            var status = await _dataContext.CompetitionStatuses
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.CompetitionId == competition.Id);
+
+            if (status?.StatusTypeName != "STATUS_FINAL")
+            {
+                _logger.LogInformation(
+                    "Contest status is not yet final for {ContestName}. Current: {Status}. Skipping enrichment.",
+                    competition.Contest.Name, status?.StatusTypeName ?? "unknown");
+                return;
+            }
+
+            var contest = competition.Contest;
+
+            // Baseball plays don't carry a clock for tiebreak ordering. Use the
+            // canonical CompetitionCompetitorScore record as the source of final
+            // score: prefer SourceDescription = "Final", otherwise the most recent.
+            var awayFinalScore = await _dataContext.CompetitionCompetitorScores
+                .AsNoTracking()
+                .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
+                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                .ThenByDescending(s => s.CreatedUtc)
+                .Select(s => (double?)s.Value)
+                .FirstOrDefaultAsync();
+
+            var homeFinalScore = await _dataContext.CompetitionCompetitorScores
+                .AsNoTracking()
+                .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
+                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
+                .ThenByDescending(s => s.CreatedUtc)
+                .Select(s => (double?)s.Value)
+                .FirstOrDefaultAsync();
+
+            if (awayFinalScore is null || homeFinalScore is null)
+            {
+                _logger.LogInformation(
+                    "No competitor scores available for {ContestName}. Data not ready for enrichment.",
+                    contest.Name);
+                return;
+            }
+
+            contest.AwayScore = (int)awayFinalScore.Value;
+            contest.HomeScore = (int)homeFinalScore.Value;
+
+            var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
+            var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;
+
+            if (contest.AwayScore != contest.HomeScore)
+            {
+                var homeWasWinner = contest.AwayScore < contest.HomeScore;
+
+                contest.WinnerFranchiseId =
+                    homeWasWinner ?
+                    homeFranchiseSeasonId :
+                    awayFranchiseSeasonId;
+            }
+
+            contest.FinalizedUtc = _dateTimeProvider.UtcNow();
+
+            if (competition.Odds?.Any() == true)
+            {
+                EnrichOddsResults(
+                    competition.Odds,
+                    awayFranchiseSeasonId,
+                    homeFranchiseSeasonId,
+                    contest.AwayScore!.Value,
+                    contest.HomeScore!.Value);
+
+                var primaryOdds = competition.Odds
+                    .FirstOrDefault(o => o.EnrichedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
+                    ?? competition.Odds.FirstOrDefault(o => o.EnrichedUtc.HasValue);
+
+                if (primaryOdds != null)
+                {
+                    contest.OverUnder = primaryOdds.OverUnderResult;
+                    contest.SpreadWinnerFranchiseId = primaryOdds.AtsWinnerFranchiseSeasonId;
+                }
+            }
+
+            await _bus.Publish(
+                new ContestFinalized(
+                    command.ContestId,
+                    null,
+                    contest.Sport,
+                    contest.SeasonYear,
+                    command.CorrelationId,
+                    Guid.NewGuid()));
+            await _dataContext.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "Contest enrichment completed. ContestId={ContestId}, ContestName={ContestName}, " +
+                "AwayScore={AwayScore}, HomeScore={HomeScore}, WinnerFranchiseSeasonId={WinnerFranchiseSeasonId}, " +
+                "FinalizedUtc={FinalizedUtc}, OddsProvidersEnriched={OddsProvidersEnriched}",
+                command.ContestId,
+                contest.Name,
+                contest.AwayScore,
+                contest.HomeScore,
+                contest.WinnerFranchiseId,
+                contest.FinalizedUtc,
+                competition.Odds?.Count(o => o.EnrichedUtc.HasValue) ?? 0);
         }
 
         internal void EnrichOddsResults(

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentJob.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 
+using SportsData.Core.Common;
 using SportsData.Core.Common.Jobs;
 using SportsData.Core.Processing;
 using SportsData.Producer.Infrastructure.Data.Common;
@@ -13,33 +14,49 @@ namespace SportsData.Producer.Application.Contests
         Task ExecuteAsync();
     }
 
+    /// <summary>
+    /// Sweep-style backstop for the live <see cref="EnrichContestCommand"/> path.
+    ///
+    /// Primary enrichment trigger is event-driven:
+    /// <c>ContestCompletedHandler</c> consumes <c>ContestCompleted</c> from the
+    /// streamer and schedules <see cref="IEnrichContests"/> after a 30s delay
+    /// (see docs/contest-finalization-event-restructure.md).
+    ///
+    /// This job is the sweep that picks up everything that didn't go through
+    /// the event-driven path: historical contests sourced from a backfill, games
+    /// where the event was lost in transit, pod restarts during the publish
+    /// window, etc. The filter is intentionally minimal — every contest that
+    /// has started, is not yet finalized, and is not terminally cancelled is
+    /// a candidate. The sport-specific enrichment processor short-circuits
+    /// cleanly on non-STATUS_FINAL, so non-ready candidates are cheap no-ops.
+    ///
+    /// See docs/contest-enrichment-historical-sweep.md.
+    /// </summary>
     public class ContestEnrichmentJob<TDataContext> : IContestEnrichmentJob, IAmARecurringJob
         where TDataContext : TeamSportDataContext
     {
-        // One-shot backfill: when true, ignore current-season-week scoping and enqueue
-        // enrichment for every non-finalized contest in the most recent season whose start
-        // time has passed. Mirrors ContestUpdateJob.BackfillCurrentSeason — used to catch
-        // MLB up after mid-season onboarding. Flip back to false before steady-state
-        // deploys.
-        private static readonly bool BackfillCurrentSeason = true;
-
         private readonly ILogger<ContestEnrichmentJob<TDataContext>> _logger;
         private readonly TDataContext _dataContext;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public ContestEnrichmentJob(
             ILogger<ContestEnrichmentJob<TDataContext>> logger,
             TDataContext dataContext,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
             _backgroundJobProvider = backgroundJobProvider;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task ExecuteAsync()
         {
             var jobRunId = Guid.NewGuid();
+            var nowUtc = _dateTimeProvider.UtcNow();
+
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
                 ["JobName"] = "ContestEnrichmentJob",
@@ -48,135 +65,25 @@ namespace SportsData.Producer.Application.Contests
 
             _logger.LogInformation(
                 "ContestEnrichmentJob starting. JobRunId={JobRunId}, NowUtc={NowUtc}",
-                jobRunId, DateTime.UtcNow);
+                jobRunId, nowUtc);
 
-            if (BackfillCurrentSeason)
-            {
-                await ExecuteBackfillCurrentSeason(jobRunId);
-                return;
-            }
-
-            // get the current and previous season week
-            var seasonWeeks = await _dataContext.SeasonWeeks
-                .AsNoTracking()
-                .Where(sw => sw.StartDate < DateTime.UtcNow &&
-                             sw.EndDate > DateTime.UtcNow)
-                .OrderByDescending(sw => sw.StartDate)
-                .Take(2)
-                .ToListAsync();
-
-            if (!seasonWeeks.Any())
-            {
-                _logger.LogError(
-                    "Could not determine current season week. NowUtc={NowUtc}",
-                    DateTime.UtcNow);
-                return;
-            }
-
-            _logger.LogInformation(
-                "Found {SeasonWeekCount} season week(s) to process. SeasonWeeks={@SeasonWeeks}",
-                seasonWeeks.Count,
-                seasonWeeks.Select(sw => new
-                {
-                    sw.Id,
-                    sw.Number,
-                    sw.StartDate,
-                    sw.EndDate
-                }));
-
-            var totalEnqueued = 0;
-            var totalSkipped = 0;
-
-            foreach (var seasonWeek in seasonWeeks)
-            {
-                // get contests that have not been finalized
-                var contests = await _dataContext.Contests
-                    .AsNoTracking()
-                    .Where(c => c.SeasonWeekId == seasonWeek.Id &&
-                                c.StartDateUtc < DateTime.UtcNow.AddHours(3) &&
-                                c.FinalizedUtc == null)
-                    .OrderBy(c => c.StartDateUtc)
-                    .ToListAsync();
-
-                _logger.LogInformation(
-                    "Season week {SeasonWeekId} (week {WeekNumber}): {ContestCount} non-finalized contest(s) to enrich.",
-                    seasonWeek.Id, seasonWeek.Number, contests.Count);
-
-                if (contests.Count == 0)
-                {
-                    continue;
-                }
-
-                // spawn a job to finalize each
-                foreach (var contest in contests)
-                {
-                    try
-                    {
-                        var cmd = new EnrichContestCommand(contest.Id, Guid.NewGuid());
-                        var hangfireJobId = _backgroundJobProvider.Enqueue<IEnrichContests>(p => p.Process(cmd));
-                        totalEnqueued++;
-
-                        _logger.LogInformation(
-                            "Enqueued enrichment for ContestId={ContestId}, ContestName={ContestName}, " +
-                            "StartDateUtc={StartDateUtc}, SeasonWeekId={SeasonWeekId}, HangfireJobId={HangfireJobId}, " +
-                            "EnrichCorrelationId={EnrichCorrelationId}",
-                            contest.Id, contest.Name, contest.StartDateUtc,
-                            seasonWeek.Id, hangfireJobId, cmd.CorrelationId);
-                    }
-                    catch (Exception ex)
-                    {
-                        totalSkipped++;
-                        _logger.LogError(
-                            ex,
-                            "Failed to enqueue enrichment. ContestId={ContestId}, ContestName={ContestName}, " +
-                            "SeasonWeekId={SeasonWeekId}",
-                            contest.Id, contest.Name, seasonWeek.Id);
-                    }
-                }
-            }
-
-            _logger.LogInformation(
-                "ContestEnrichmentJob completed. JobRunId={JobRunId}, SeasonWeeksProcessed={SeasonWeekCount}, " +
-                "TotalEnqueued={TotalEnqueued}, TotalSkipped={TotalSkipped}",
-                jobRunId, seasonWeeks.Count, totalEnqueued, totalSkipped);
-        }
-
-        private async Task ExecuteBackfillCurrentSeason(Guid jobRunId)
-        {
-            _logger.LogWarning(
-                "BACKFILL_MODE: BackfillCurrentSeason flag is ON. Bypassing current-season-week scope. " +
-                "NowUtc={NowUtc}, JobRunId={JobRunId}",
-                DateTime.UtcNow, jobRunId);
-
-            var currentSeasonYear = await _dataContext.Seasons
-                .AsNoTracking()
-                .OrderByDescending(s => s.Year)
-                .Select(s => (int?)s.Year)
-                .FirstOrDefaultAsync();
-
-            if (currentSeasonYear is null)
-            {
-                _logger.LogError(
-                    "No seasons found in database. Cannot run enrichment backfill. JobRunId={JobRunId}",
-                    jobRunId);
-                return;
-            }
-
-            _logger.LogInformation(
-                "Targeting season for enrichment backfill. SeasonYear={SeasonYear}, JobRunId={JobRunId}",
-                currentSeasonYear, jobRunId);
-
+            // Unbounded sweep — every contest past its start time that is
+            // neither finalized nor terminally cancelled. After the initial
+            // historical sweep (manually triggered post-deploy), the daily
+            // steady-state volume is small: only contests whose StartDateUtc
+            // crossed `now` since yesterday's run AND that the event-driven
+            // ContestCompletedHandler didn't already catch.
             var contests = await _dataContext.Contests
                 .AsNoTracking()
-                .Where(c => c.SeasonYear == currentSeasonYear &&
-                            c.StartDateUtc < DateTime.UtcNow &&
-                            c.FinalizedUtc == null)
+                .Where(c => c.FinalizedUtc == null
+                         && c.CancelledUtc == null
+                         && c.StartDateUtc < nowUtc)
                 .OrderBy(c => c.StartDateUtc)
                 .ToListAsync();
 
             _logger.LogInformation(
-                "Backfill: {ContestCount} non-finalized started contest(s) for season {SeasonYear}. JobRunId={JobRunId}",
-                contests.Count, currentSeasonYear, jobRunId);
+                "ContestEnrichmentJob: {ContestCount} non-finalized, non-cancelled contest(s) with past start time. JobRunId={JobRunId}",
+                contests.Count, jobRunId);
 
             if (contests.Count == 0)
             {
@@ -195,26 +102,26 @@ namespace SportsData.Producer.Application.Contests
                     totalEnqueued++;
 
                     _logger.LogInformation(
-                        "Backfill enqueued enrichment for ContestId={ContestId}, ContestName={ContestName}, " +
+                        "Enqueued enrichment for ContestId={ContestId}, ContestName={ContestName}, " +
                         "StartDateUtc={StartDateUtc}, HangfireJobId={HangfireJobId}, " +
-                        "EnrichCorrelationId={EnrichCorrelationId}, JobRunId={JobRunId}",
+                        "EnrichCorrelationId={EnrichCorrelationId}",
                         contest.Id, contest.Name, contest.StartDateUtc,
-                        hangfireJobId, cmd.CorrelationId, jobRunId);
+                        hangfireJobId, cmd.CorrelationId);
                 }
                 catch (Exception ex)
                 {
                     totalSkipped++;
                     _logger.LogError(
                         ex,
-                        "Backfill failed to enqueue enrichment. ContestId={ContestId}, ContestName={ContestName}, JobRunId={JobRunId}",
-                        contest.Id, contest.Name, jobRunId);
+                        "Failed to enqueue enrichment. ContestId={ContestId}, ContestName={ContestName}",
+                        contest.Id, contest.Name);
                 }
             }
 
             _logger.LogInformation(
-                "ContestEnrichmentJob backfill completed. JobRunId={JobRunId}, SeasonYear={SeasonYear}, " +
+                "ContestEnrichmentJob completed. JobRunId={JobRunId}, " +
                 "TotalEnqueued={TotalEnqueued}, TotalSkipped={TotalSkipped}",
-                jobRunId, currentSeasonYear, totalEnqueued, totalSkipped);
+                jobRunId, totalEnqueued, totalSkipped);
         }
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessor.cs
@@ -134,16 +134,28 @@ public class BaseballEventCompetitionStatusDocumentProcessor<TDataContext> : Doc
                 entity.FeaturedAthletes.Count);
         }
 
-        if (publishEvent)
+        // ContestId is needed for both the transition event and the
+        // cancellation lifecycle update. Fetch once. The publish/stamp
+        // branches each gate independently below. See matching block in
+        // EventCompetitionStatusDocumentProcessor (football variant).
+        var newStatusIsCanceled = entity.StatusTypeName == "STATUS_CANCELED";
+        var existedAsCanceled = existing?.StatusTypeName == "STATUS_CANCELED";
+        var contestIdNeeded = publishEvent || newStatusIsCanceled || existedAsCanceled;
+
+        Guid contestId = Guid.Empty;
+        if (contestIdNeeded)
         {
             // ContestId is what crosses the service boundary — Competition
             // is a Producer-internal sub-aggregate. Projected read so we
             // don't pull the full Competition row.
-            var contestId = await _dataContext.Competitions
+            contestId = await _dataContext.Competitions
                 .Where(c => c.Id == competitionIdValue)
                 .Select(c => c.ContestId)
                 .FirstAsync();
+        }
 
+        if (publishEvent)
+        {
             _logger.LogInformation(
                 "MLB Contest status changed, publishing event. ContestId={ContestId}, CompetitionId={CompId}, NewStatus={Status}",
                 contestId,
@@ -161,6 +173,30 @@ public class BaseballEventCompetitionStatusDocumentProcessor<TDataContext> : Doc
                 command.CorrelationId,
                 CausationId.Producer.EventCompetitionStatusDocumentProcessor
             ));
+        }
+
+        // CancelledUtc lifecycle: see matching comment in the football
+        // variant. Stamp on first STATUS_CANCELED observation; preserve
+        // on reversal. Treated as irrevocable.
+        if (newStatusIsCanceled || existedAsCanceled)
+        {
+            var contest = await _dataContext.Contests.FindAsync(contestId);
+            if (contest is not null)
+            {
+                if (newStatusIsCanceled && contest.CancelledUtc is null)
+                {
+                    contest.CancelledUtc = _dateTimeProvider.UtcNow();
+                    _logger.LogInformation(
+                        "MLB Contest cancelled — stamped CancelledUtc. ContestId={ContestId}, CancelledUtc={CancelledUtc}",
+                        contestId, contest.CancelledUtc);
+                }
+                else if (!newStatusIsCanceled && existedAsCanceled && contest.CancelledUtc is not null)
+                {
+                    _logger.LogWarning(
+                        "MLB Contest status moved away from STATUS_CANCELED but CancelledUtc is preserved (treated as irrevocable). ContestId={ContestId}, NewStatus={NewStatus}",
+                        contestId, entity.StatusTypeName);
+                }
+            }
         }
 
         await _dataContext.Set<BaseballCompetitionStatus>().AddAsync(entity);

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusDocumentProcessor.cs
@@ -25,14 +25,18 @@ namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Co
 public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {
+    private readonly IDateTimeProvider _dateTimeProvider;
+
     public EventCompetitionStatusDocumentProcessor(
         ILogger<EventCompetitionStatusDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,
-        IGenerateResourceRefs refGenerator)
+        IGenerateResourceRefs refGenerator,
+        IDateTimeProvider dateTimeProvider)
         : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refGenerator)
     {
+        _dateTimeProvider = dateTimeProvider;
     }
 
     protected override async Task ProcessInternal(ProcessDocumentCommand command)
@@ -100,16 +104,27 @@ public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentPro
                 dto.Type.Name);
         }
 
-        if (publishEvent)
+        // ContestId is needed for both the transition event and the
+        // cancellation lifecycle update. Fetch once. The publish/stamp
+        // branches each gate independently below.
+        var newStatusIsCanceled = entity.StatusTypeName == "STATUS_CANCELED";
+        var existedAsCanceled = existing?.StatusTypeName == "STATUS_CANCELED";
+        var contestIdNeeded = publishEvent || newStatusIsCanceled || existedAsCanceled;
+
+        Guid contestId = Guid.Empty;
+        if (contestIdNeeded)
         {
             // ContestId is what crosses the service boundary — Competition
             // is a Producer-internal sub-aggregate. Projected read so we
             // don't pull the full Competition row.
-            var contestId = await _dataContext.Competitions
+            contestId = await _dataContext.Competitions
                 .Where(c => c.Id == competitionIdValue)
                 .Select(c => c.ContestId)
                 .FirstAsync();
+        }
 
+        if (publishEvent)
+        {
             _logger.LogInformation(
                 "Contest status changed, publishing event. ContestId={ContestId}, CompetitionId={CompId}, NewStatus={Status}",
                 contestId,
@@ -130,6 +145,31 @@ public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentPro
                 command.CorrelationId,
                 CausationId.Producer.EventCompetitionStatusDocumentProcessor
             ));
+        }
+
+        // CancelledUtc lifecycle: stamp on first observation of
+        // STATUS_CANCELED (idempotent — preserves "first observed"
+        // timestamp). Log a warning if ESPN reverses a cancellation —
+        // treated as irrevocable. See docs/contest-enrichment-historical-sweep.md.
+        if (newStatusIsCanceled || existedAsCanceled)
+        {
+            var contest = await _dataContext.Contests.FindAsync(contestId);
+            if (contest is not null)
+            {
+                if (newStatusIsCanceled && contest.CancelledUtc is null)
+                {
+                    contest.CancelledUtc = _dateTimeProvider.UtcNow();
+                    _logger.LogInformation(
+                        "Contest cancelled — stamped CancelledUtc. ContestId={ContestId}, CancelledUtc={CancelledUtc}",
+                        contestId, contest.CancelledUtc);
+                }
+                else if (!newStatusIsCanceled && existedAsCanceled && contest.CancelledUtc is not null)
+                {
+                    _logger.LogWarning(
+                        "Contest status moved away from STATUS_CANCELED but CancelledUtc is preserved (treated as irrevocable). ContestId={ContestId}, NewStatus={NewStatus}",
+                        contestId, entity.StatusTypeName);
+                }
+            }
         }
 
         await _dataContext.Set<FootballCompetitionStatus>().AddAsync(entity);

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
@@ -63,9 +63,19 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
         public DateTime? FinalizedUtc { get; set; }
 
+        // === Cancellation ===
+        // Stamped (once) by EventCompetitionStatusDocumentProcessor when
+        // ESPN reports StatusTypeName == "STATUS_CANCELED". Treated as
+        // terminal/irrevocable — ContestEnrichmentJob excludes these from
+        // future runs. See docs/contest-enrichment-historical-sweep.md.
+        public DateTime? CancelledUtc { get; set; }
+
         // === Helpers (not mapped to DB) ===
         [NotMapped]
         public bool IsFinal => FinalizedUtc.HasValue;
+
+        [NotMapped]
+        public bool IsCancelled => CancelledUtc.HasValue;
 
         [NotMapped]
         public int? TotalScore =>

--- a/src/SportsData.Producer/Migrations/Baseball/20260616133753_AddContestCancelledUtc.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260616133753_AddContestCancelledUtc.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260616133753_AddContestCancelledUtc")]
+    partial class AddContestCancelledUtc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260616133753_AddContestCancelledUtc.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260616133753_AddContestCancelledUtc.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class AddContestCancelledUtc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CancelledUtc",
+                table: "Contest",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CancelledUtc",
+                table: "Contest");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/20260616133705_AddContestCancelledUtc.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260616133705_AddContestCancelledUtc.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Football;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Baseball
+namespace SportsData.Producer.Migrations.Football
 {
-    [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(FootballDataContext))]
+    [Migration("20260616133705_AddContestCancelledUtc")]
+    partial class AddContestCancelledUtc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,233 +415,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<bool>("Active")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("ConfigurationId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int>("Season")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SeasonType")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SplitTypeId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
-
-                    b.ToTable("AthleteSeasonHotZone", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("AtBats")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("AthleteSeasonHotZoneId")
-                        .HasColumnType("uuid");
-
-                    b.Property<double?>("BattingAvg")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("BattingAvgScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int?>("Hits")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<double?>("Slugging")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("SluggingScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("ZoneId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonHotZoneId");
-
-                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("AthleteRef")
-                        .HasColumnType("text");
-
-                    b.Property<Guid>("CompetitionStatusId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("PlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasColumnType("text");
-
-                    b.Property<string>("TeamRef")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionStatusId");
-
-                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionCompetitorId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("EspnPlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId");
-
-                    b.HasIndex("CompetitionCompetitorId", "Name")
-                        .IsUnique();
-
-                    b.ToTable("CompetitionCompetitorProbable", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3248,6 +3024,206 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("CompetitionCompetitorStatisticStats");
                 });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
+                    b.Property<string>("DisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("EndClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("EndClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("EndDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EndShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("EndText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("EndYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsScore")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("OffensivePlays")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Result")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SequenceNumber")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("ShortDisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SourceDescription")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SourceId")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("StartClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("StartClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("StartFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("StartPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("StartShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StartText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeElapsedDisplay")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("TimeElapsedValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("Yards")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionId");
+
+                    b.ToTable("CompetitionDrive", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DriveId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Provider")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SourceUrl")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("SourceUrlHash")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DriveId");
+
+                    b.ToTable("CompetitionDriveExternalId", (string)null);
+                });
+
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
                 {
                     b.Property<Guid>("Id")
@@ -4069,65 +4045,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("CompetitionPlayId");
 
                     b.ToTable("CompetitionPlayExternalId", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionPlayId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Discriminator")
-                        .IsRequired()
-                        .HasMaxLength(34)
-                        .HasColumnType("character varying(34)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Order")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("PositionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<string>("Type")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId");
-
-                    b.HasIndex("PositionId");
-
-                    b.HasIndex("CompetitionPlayId", "Type");
-
-                    b.ToTable("CompetitionPlayParticipant", (string)null);
-
-                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionPlayParticipantBase");
-
-                    b.UseTphMappingStrategy();
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPowerIndex", b =>
@@ -7986,17 +7903,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -8007,247 +7916,99 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("ThrowsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("ThrowsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("BaseballAthlete");
+                    b.HasDiscriminator().HasValue("FootballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
+                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.Property<int?>("CurrentSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("CurrentSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("CurrentSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("CurrentSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("CurrentSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EspnSeriesId")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("SeasonSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("SeasonSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SeasonSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.HasIndex("EspnSeriesId");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetition");
+                    b.HasDiscriminator().HasValue("FootballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
+                    b.Property<int?>("CuratedRankCurrent")
+                        .HasColumnType("integer");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<Guid?>("AtBatAthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("AtBatId")
+                    b.Property<string>("ClockDisplayValue")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<int?>("AtBatPitchNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayHits")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("BatOrder")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("HalfInning")
-                        .HasMaxLength(8)
-                        .HasColumnType("character varying(8)");
-
-                    b.Property<double?>("HitCoordinateX")
-                        .HasPrecision(7, 2)
+                    b.Property<double>("ClockValue")
                         .HasColumnType("double precision");
 
-                    b.Property<double?>("HitCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("HomeErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("HomeHits")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsDoublePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsTriplePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsValid")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("Outs")
-                        .HasColumnType("integer");
-
-                    b.Property<double?>("PitchCoordinateX")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("PitchCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("PitchCountBalls")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("PitchCountStrikes")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PitchTypeAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeId")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int?>("PitchVelocity")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PitchesAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("PitchesType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<Guid?>("PitchingAthleteSeasonId")
+                    b.Property<Guid?>("DriveId")
                         .HasColumnType("uuid");
 
-                    b.Property<int>("RbiCount")
+                    b.Property<int?>("EndDistance")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountBalls")
+                    b.Property<int?>("EndDown")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountStrikes")
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndYardLine")
                         .HasColumnType("integer");
 
-                    b.Property<string>("StrikeType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("SummaryType")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("Trajectory")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
 
-                    b.Property<DateTime?>("Wallclock")
-                        .HasColumnType("timestamp with time zone");
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("StatYardage")
+                        .HasColumnType("integer");
+
+                    b.HasIndex("DriveId");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
-                {
-                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlayParticipant");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
-
-                    b.Property<int?>("HalfInning")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PeriodPrefix")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("BaseballContest");
+                    b.HasDiscriminator().HasValue("FootballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8280,47 +8041,6 @@ namespace SportsData.Producer.Migrations.Baseball
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
-                        .WithMany("Entries")
-                        .HasForeignKey("AthleteSeasonHotZoneId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("HotZone");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
-                        .WithMany("FeaturedAthletes")
-                        .HasForeignKey("CompetitionStatusId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionStatus");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "AthleteSeason")
-                        .WithMany()
-                        .HasForeignKey("AthleteSeasonId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", "CompetitionCompetitor")
-                        .WithMany("Probables")
-                        .HasForeignKey("CompetitionCompetitorId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("AthleteSeason");
-
-                    b.Navigation("CompetitionCompetitor");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8905,6 +8625,34 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
+                        .WithMany()
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                        .WithMany("Drives")
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Competition");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("ExternalIds")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9817,7 +9565,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9826,40 +9574,36 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("Plays")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", "CompetitionPlay")
-                        .WithMany("Participants")
-                        .HasForeignKey("CompetitionPlayId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionPlay");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9871,11 +9615,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -10029,6 +9768,13 @@ namespace SportsData.Producer.Migrations.Baseball
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Navigation("ExternalIds");
+
+                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10221,29 +9967,16 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
+                    b.Navigation("Drives");
+
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
-                {
-                    b.Navigation("Probables");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
-                {
-                    b.Navigation("Participants");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.Navigation("FeaturedAthletes");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Football/20260616133705_AddContestCancelledUtc.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260616133705_AddContestCancelledUtc.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class AddContestCancelledUtc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CancelledUtc",
+                table: "Contest",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CancelledUtc",
+                table: "Contest");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
@@ -4556,6 +4556,9 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid>("AwayTeamFranchiseSeasonId")
                         .HasColumnType("uuid");
 
+                    b.Property<DateTime?>("CancelledUtc")
+                        .HasColumnType("timestamp with time zone");
+
                     b.Property<Guid>("CreatedBy")
                         .HasColumnType("uuid");
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentJobTests.cs
@@ -50,9 +50,10 @@ public class ContestEnrichmentJobTests : ProducerTestBase<ContestEnrichmentJob<F
         // Act
         await sut.ExecuteAsync();
 
-        // Assert
-        enqueued.Should().HaveCount(3);
-        enqueued.Should().BeEquivalentTo(ids);
+        // Assert — strict-equal so the OrderBy(StartDateUtc) contract is
+        // actually verified. Seed order matches ascending StartDateUtc
+        // (-30, -5, -1 days) so ids[] is already in the expected order.
+        enqueued.Should().Equal(ids);
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentJobTests.cs
@@ -1,0 +1,178 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Contests;
+using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests;
+
+[Collection("Sequential")]
+public class ContestEnrichmentJobTests : ProducerTestBase<ContestEnrichmentJob<FootballDataContext>>
+{
+    private static readonly DateTime FixedNow =
+        new(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+
+    public ContestEnrichmentJobTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    [Fact]
+    public async Task Execute_EnqueuesOnePerCandidate_WhenContestIsPastStartAndUnfinalizedAndUncancelled()
+    {
+        // Arrange — three legitimate candidates spanning different StartDateUtc
+        // values to exercise the ordering. None finalized, none cancelled.
+        var ids = new[]
+        {
+            await SeedContestAsync(startDaysFromNow: -30),
+            await SeedContestAsync(startDaysFromNow: -5),
+            await SeedContestAsync(startDaysFromNow: -1)
+        };
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()))
+            .Callback<Expression<Func<IEnrichContests, Task>>>(expr =>
+                enqueued.Add(EnrichContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentJob<FootballDataContext>>();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert
+        enqueued.Should().HaveCount(3);
+        enqueued.Should().BeEquivalentTo(ids);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsContestsThatAreAlreadyFinalized()
+    {
+        var ineligibleId = await SeedContestAsync(
+            startDaysFromNow: -10,
+            finalizedUtc: FixedNow.AddDays(-9));
+        var eligibleId = await SeedContestAsync(startDaysFromNow: -5);
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()))
+            .Callback<Expression<Func<IEnrichContests, Task>>>(expr =>
+                enqueued.Add(EnrichContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        enqueued.Should().ContainSingle().Which.Should().Be(eligibleId);
+        enqueued.Should().NotContain(ineligibleId);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsContestsThatHaveCancelledUtcStamped()
+    {
+        // Regression — the cancelled-game exclusion is the whole reason the
+        // CancelledUtc column exists. Without this filter, the unbounded query
+        // would re-enqueue cancelled contests on every run.
+        var cancelledId = await SeedContestAsync(
+            startDaysFromNow: -10,
+            cancelledUtc: FixedNow.AddDays(-9));
+        var eligibleId = await SeedContestAsync(startDaysFromNow: -5);
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()))
+            .Callback<Expression<Func<IEnrichContests, Task>>>(expr =>
+                enqueued.Add(EnrichContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        enqueued.Should().ContainSingle().Which.Should().Be(eligibleId);
+        enqueued.Should().NotContain(cancelledId);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsContestsWithFutureStartTime()
+    {
+        var futureId = await SeedContestAsync(startDaysFromNow: 2);
+        var pastId = await SeedContestAsync(startDaysFromNow: -2);
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()))
+            .Callback<Expression<Func<IEnrichContests, Task>>>(expr =>
+                enqueued.Add(EnrichContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        enqueued.Should().ContainSingle().Which.Should().Be(pastId);
+        enqueued.Should().NotContain(futureId);
+    }
+
+    [Fact]
+    public async Task Execute_NoCandidates_ReturnsCleanlyWithoutEnqueuing()
+    {
+        // Seed only ineligible contests so the candidate query returns empty.
+        await SeedContestAsync(startDaysFromNow: -10, finalizedUtc: FixedNow.AddDays(-9));
+        await SeedContestAsync(startDaysFromNow: -10, cancelledUtc: FixedNow.AddDays(-9));
+        await SeedContestAsync(startDaysFromNow: 5);
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    private async Task<Guid> SeedContestAsync(
+        int startDaysFromNow,
+        DateTime? finalizedUtc = null,
+        DateTime? cancelledUtc = null)
+    {
+        var contest = new FootballContest
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Contest {Guid.NewGuid():N}",
+            ShortName = "TC",
+            Sport = Sport.FootballNcaa,
+            SeasonYear = 2025,
+            StartDateUtc = FixedNow.AddDays(startDaysFromNow),
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            FinalizedUtc = finalizedUtc,
+            CancelledUtc = cancelledUtc,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.SaveChangesAsync();
+        return contest.Id;
+    }
+
+    private static Guid? EnrichContestIdFromExpression(
+        Expression<Func<IEnrichContests, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        if (call.Method.Name != nameof(IEnrichContests.Process)) return null;
+        if (call.Arguments.Count != 1) return null;
+
+        var cmd = Expression.Lambda<Func<EnrichContestCommand>>(call.Arguments[0]).Compile()();
+        return cmd.ContestId;
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
@@ -291,4 +291,118 @@ public class BaseballEventCompetitionStatusDocumentProcessorTests
         athletes[1].Ordinal.Should().Be(1);
         athletes[1].Name.Should().Be("losingPitcher");
     }
+
+    [Fact]
+    public async Task WhenStatusIsCanceled_StampsContestCancelledUtc()
+    {
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var compId = Guid.NewGuid();
+        var (contest, _) = await SeedContestAndCompetitionAsync(compId);
+
+        var cmd = await BuildCommandAsync(compId, statusTypeName: "STATUS_CANCELED");
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        var refreshed = await _baseballDataContext.Contests
+            .FirstAsync(c => c.Id == contest.Id);
+        refreshed.CancelledUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task WhenStatusIsCanceledButCancelledUtcAlreadySet_PreservesOriginal()
+    {
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var compId = Guid.NewGuid();
+        var originalCancelledUtc = FixedNow.AddDays(-5);
+        var (contest, _) = await SeedContestAndCompetitionAsync(compId);
+
+        // Stamp Contest.CancelledUtc as if a prior cancellation observation
+        // already fired. Also seed the existing CompetitionStatus as
+        // STATUS_CANCELED so the processor sees the "no transition" case.
+        contest.CancelledUtc = originalCancelledUtc;
+        await _baseballDataContext.SaveChangesAsync();
+
+        var existing = new BaseballCompetitionStatus
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = compId,
+            StatusTypeName = "STATUS_CANCELED",
+            CreatedUtc = FixedNow.AddDays(-5),
+            CreatedBy = Guid.NewGuid()
+        };
+        await _baseballDataContext.Set<BaseballCompetitionStatus>().AddAsync(existing);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var cmd = await BuildCommandAsync(compId, statusTypeName: "STATUS_CANCELED");
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        var refreshed = await _baseballDataContext.Contests
+            .FirstAsync(c => c.Id == contest.Id);
+        refreshed.CancelledUtc.Should().Be(originalCancelledUtc,
+            "first-observed cancellation timestamp is preserved across redundant doc refreshes");
+    }
+
+    [Fact]
+    public async Task WhenStatusTransitionsAwayFromCanceled_LeavesCancelledUtcInPlace()
+    {
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var compId = Guid.NewGuid();
+        var originalCancelledUtc = FixedNow.AddDays(-5);
+        var (contest, _) = await SeedContestAndCompetitionAsync(compId);
+
+        contest.CancelledUtc = originalCancelledUtc;
+        await _baseballDataContext.SaveChangesAsync();
+
+        var existing = new BaseballCompetitionStatus
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = compId,
+            StatusTypeName = "STATUS_CANCELED",
+            CreatedUtc = FixedNow.AddDays(-5),
+            CreatedBy = Guid.NewGuid()
+        };
+        await _baseballDataContext.Set<BaseballCompetitionStatus>().AddAsync(existing);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var cmd = await BuildCommandAsync(compId, statusTypeName: "STATUS_SCHEDULED");
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        var refreshed = await _baseballDataContext.Contests
+            .FirstAsync(c => c.Id == contest.Id);
+        refreshed.CancelledUtc.Should().Be(originalCancelledUtc,
+            "cancellation is treated as irrevocable; only an admin override should clear it");
+    }
+
+    private async Task<ProcessDocumentCommand> BuildCommandAsync(Guid compId, string statusTypeName)
+    {
+        var baseJson = await LoadJsonTestData("EspnBaseballMlb/EventCompetitionStatus.json");
+        // Swap the status name + description in the canonical MLB fixture so
+        // the processor sees the intended status without us authoring a
+        // separate fixture file per terminal state.
+        var json = baseJson
+            .Replace("\"STATUS_FINAL\"", $"\"{statusTypeName}\"")
+            .Replace("\"Final\"", $"\"{statusTypeName}\"");
+
+        return Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, compId.ToString())
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionStatus)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash,
+                "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401814844/competitions/401814844/status?lang=en&region=us"
+                    .UrlHash())
+            .With(x => x.CorrelationId, Guid.NewGuid())
+            .OmitAutoProperties()
+            .Create();
+    }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
@@ -5,6 +5,8 @@ using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Producer.Application.Documents.Processors.Commands;
@@ -76,6 +78,172 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             status.StatusTypeName.Should().Be("STATUS_FINAL");
             status.DisplayClock.Should().Be("0:00");
             status.IsCompleted.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task WhenStatusIsCanceled_StampsContestCancelledUtc()
+        {
+            // Arrange — seed a Contest + Competition, run the processor with a
+            // STATUS_CANCELED status doc, expect Contest.CancelledUtc populated.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
+            var (contest, competition, command) = await SeedAndBuildCommandAsync(
+                statusJsonName: "STATUS_CANCELED");
+
+            var sut = Mocker.CreateInstance<EventCompetitionStatusDocumentProcessor<FootballDataContext>>();
+
+            // Act
+            await sut.ProcessAsync(command);
+
+            // Assert — Contest.CancelledUtc stamped with the deterministic clock.
+            var refreshed = await FootballDataContext.Contests
+                .FirstAsync(c => c.Id == contest.Id);
+            refreshed.CancelledUtc.Should().Be(fixedNow);
+        }
+
+        [Fact]
+        public async Task WhenStatusIsCanceledButCancelledUtcAlreadySet_PreservesOriginal()
+        {
+            // Arrange — Contest already has CancelledUtc from a prior observation.
+            // A redundant STATUS_CANCELED doc must not refresh the timestamp.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            var originalCancelledUtc = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc);
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
+            var (contest, _, command) = await SeedAndBuildCommandAsync(
+                statusJsonName: "STATUS_CANCELED",
+                priorStatusTypeName: "STATUS_CANCELED",
+                contestCancelledUtc: originalCancelledUtc);
+
+            var sut = Mocker.CreateInstance<EventCompetitionStatusDocumentProcessor<FootballDataContext>>();
+
+            await sut.ProcessAsync(command);
+
+            var refreshed = await FootballDataContext.Contests
+                .FirstAsync(c => c.Id == contest.Id);
+            refreshed.CancelledUtc.Should().Be(originalCancelledUtc,
+                "first-observed cancellation timestamp is preserved across redundant doc refreshes");
+        }
+
+        [Fact]
+        public async Task WhenStatusTransitionsAwayFromCanceled_LeavesCancelledUtcInPlace()
+        {
+            // Arrange — ESPN reverses a cancellation (rare, but possible).
+            // Audit-as-irrevocable: CancelledUtc remains stamped and the
+            // processor logs a warning. ContestEnrichmentJob continues to
+            // skip the contest.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            var originalCancelledUtc = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc);
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
+            var (contest, _, command) = await SeedAndBuildCommandAsync(
+                statusJsonName: "STATUS_SCHEDULED",
+                priorStatusTypeName: "STATUS_CANCELED",
+                contestCancelledUtc: originalCancelledUtc);
+
+            var sut = Mocker.CreateInstance<EventCompetitionStatusDocumentProcessor<FootballDataContext>>();
+
+            await sut.ProcessAsync(command);
+
+            var refreshed = await FootballDataContext.Contests
+                .FirstAsync(c => c.Id == contest.Id);
+            refreshed.CancelledUtc.Should().Be(originalCancelledUtc,
+                "cancellation is treated as irrevocable; only an admin override should clear it");
+        }
+
+        /// <summary>
+        /// Builds a STATUS_FINAL-shaped JSON payload by string-replacing
+        /// the type.name and type.description on the canonical test fixture.
+        /// Sufficient for the cancellation-lifecycle tests; the rest of the
+        /// payload shape (refs, clock, period) isn't material to the
+        /// stamping logic under test.
+        /// </summary>
+        private async Task<string> BuildStatusJsonAsync(string statusTypeName)
+        {
+            var baseJson = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionStatus.json");
+            return baseJson
+                .Replace("\"STATUS_FINAL\"", $"\"{statusTypeName}\"")
+                .Replace("\"Final\"", "\"" + statusTypeName + "\"");
+        }
+
+        private async Task<(FootballContest contest, FootballCompetition competition, ProcessDocumentCommand command)>
+            SeedAndBuildCommandAsync(
+                string statusJsonName,
+                string? priorStatusTypeName = null,
+                DateTime? contestCancelledUtc = null)
+        {
+            Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+            var contest = new FootballContest
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Contest",
+                ShortName = "TC",
+                Sport = Sport.FootballNcaa,
+                SeasonYear = 2025,
+                StartDateUtc = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+                AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid(),
+                CancelledUtc = contestCancelledUtc
+            };
+
+            var competition = new FootballCompetition
+            {
+                Id = Guid.NewGuid(),
+                ContestId = contest.Id,
+                Date = DateTime.UtcNow,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            };
+
+            await FootballDataContext.Contests.AddAsync(contest);
+            await FootballDataContext.Competitions.AddAsync(competition);
+
+            if (!string.IsNullOrEmpty(priorStatusTypeName))
+            {
+                var priorStatus = new FootballCompetitionStatus
+                {
+                    Id = Guid.NewGuid(),
+                    CompetitionId = competition.Id,
+                    StatusTypeId = "0",
+                    StatusTypeName = priorStatusTypeName,
+                    StatusState = "post",
+                    StatusDescription = priorStatusTypeName,
+                    StatusDetail = priorStatusTypeName,
+                    StatusShortDetail = priorStatusTypeName,
+                    IsCompleted = priorStatusTypeName == "STATUS_FINAL" || priorStatusTypeName == "STATUS_CANCELED",
+                    CreatedBy = Guid.NewGuid(),
+                    CreatedUtc = DateTime.UtcNow
+                };
+                await FootballDataContext.CompetitionStatuses.AddAsync(priorStatus);
+            }
+
+            await FootballDataContext.SaveChangesAsync();
+            FootballDataContext.ChangeTracker.Clear();
+
+            var json = await BuildStatusJsonAsync(statusJsonName);
+            var command = Fixture.Build<ProcessDocumentCommand>()
+                .OmitAutoProperties()
+                .With(x => x.Document, json)
+                .With(x => x.UrlHash,
+                    "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334/competitions/401628334/status?lang=en".UrlHash())
+                .With(x => x.DocumentType, DocumentType.EventCompetitionStatus)
+                .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+                .With(x => x.Sport, Sport.FootballNcaa)
+                .With(x => x.CorrelationId, Guid.NewGuid())
+                .With(x => x.ParentId, competition.Id.ToString())
+                .Create();
+
+            return (contest, competition, command);
         }
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
@@ -181,6 +181,12 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
         {
             Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
 
+            // Each caller has already set up IDateTimeProvider.UtcNow() with
+            // a fixed value before invoking this helper. Capture it once
+            // and reuse for every seeded entity's timestamp so the test
+            // doesn't accidentally depend on real wall-clock time.
+            var seededUtc = Mocker.Get<IDateTimeProvider>().UtcNow();
+
             var contest = new FootballContest
             {
                 Id = Guid.NewGuid(),
@@ -191,7 +197,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 StartDateUtc = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
                 HomeTeamFranchiseSeasonId = Guid.NewGuid(),
                 AwayTeamFranchiseSeasonId = Guid.NewGuid(),
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = seededUtc,
                 CreatedBy = Guid.NewGuid(),
                 CancelledUtc = contestCancelledUtc
             };
@@ -200,8 +206,8 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             {
                 Id = Guid.NewGuid(),
                 ContestId = contest.Id,
-                Date = DateTime.UtcNow,
-                CreatedUtc = DateTime.UtcNow,
+                Date = seededUtc,
+                CreatedUtc = seededUtc,
                 CreatedBy = Guid.NewGuid()
             };
 
@@ -222,7 +228,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                     StatusShortDetail = priorStatusTypeName,
                     IsCompleted = priorStatusTypeName == "STATUS_FINAL" || priorStatusTypeName == "STATUS_CANCELED",
                     CreatedBy = Guid.NewGuid(),
-                    CreatedUtc = DateTime.UtcNow
+                    CreatedUtc = seededUtc
                 };
                 await FootballDataContext.CompetitionStatuses.AddAsync(priorStatus);
             }


### PR DESCRIPTION
## Summary

Removes the season-week scoping from `ContestEnrichmentJob` so historical contests get a chance to finalize, and introduces a `Contest.CancelledUtc` marker so cancelled games stop re-enqueueing on every run.

The season-week filter was load-bearing in an unintended way: it silently excluded ~44K contests (NCAAFB 19K, NFL 1K, MLB 24K) that had `STATUS_FINAL` waiting in their `CompetitionStatus` rows but never had `FinalizedUtc` stamped, because the historical contests' SeasonWeekIds didn't match the current week. Treating the job as a sweep tool rather than churn-protection, one manual trigger via the Hangfire dashboard clears the bulk on first run, after which the daily cadence just catches the small day's-worth of newly-finalized games (event-driven `ContestCompletedHandler` handles the live churn).

Once the season-week filter drops, the next problem is cancelled games — ESPN's `STATUS_CANCELED` never transitions to `STATUS_FINAL`, so without a marker those contests would re-enqueue forever under the unbounded query. New nullable `Contest.CancelledUtc` is stamped (once) by the status processors on first observation of `STATUS_CANCELED`.

## What changed

- **`ContestBase`** — new `CancelledUtc DateTime?` + `IsCancelled` helper.
- **EF migrations** — Football + Baseball contexts each get the nullable column.
- **Status processors** (`EventCompetitionStatusDocumentProcessor`, `BaseballEventCompetitionStatusDocumentProcessor`) — stamp `Contest.CancelledUtc` on first `STATUS_CANCELED` observation. Idempotent (preserves first-observed timestamp). Log warning on reversal — cancellation is treated as irrevocable. Football processor gains `IDateTimeProvider` injection; Baseball already had it.
- **`ContestEnrichmentJob`** — delete `BackfillCurrentSeason` flag, the per-season-week query path, and the 3h grace window. New query is unbounded: `FinalizedUtc IS NULL AND CancelledUtc IS NULL AND StartDateUtc < now`. Inject `IDateTimeProvider`. Keep `Cron.Daily(8)` — post-sweep daily volume is small.

## Design rationale

Full discussion in `docs/contest-enrichment-historical-sweep.md`. Notable deferred decisions:

- **`STATUS_FORFEIT`** — kept as terminal-but-not-marked for now. Forfeits in NFL/NCAAFB are vanishingly rare and effectively extinct in MLB. Revisit if one appears.
- **Backfill of `CancelledUtc` on historical cancelled games** — none. Accept the noise (a few hundred fast no-op enqueues per run). Revisit if Hangfire load justifies it.
- **Picks on cancelled games** — pick lifecycle defers to PR follow-up. Audit job will reset them on first run, `PickScoringJob` will short-circuit on the resulting NotFound, picks sit in limbo until we decide an `IsVoid` semantic.

## Operational status

Deployed to prod and the manual sweep ran cleanly prior to PR creation. Full audit pending — will surface in tomorrow's review.

## Test plan

- [x] `dotnet build` clean on `SportsData.Producer`.
- [x] `dotnet test` clean on `SportsData.Producer.Tests.Unit` — 436 pass (+11 new tests).
- [x] EF migrations applied cleanly on prod DB.
- [x] Manual sweep via Hangfire dashboard cleared the historical backlog.
- [ ] In-depth audit of post-sweep state (residual unfinalized counts, surface-area of what didn't finalize, cancelled-status candidates that didn't auto-stamp because their status doc hasn't re-fired since deploy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic contest cancellation tracking, including stamping and preservation of cancellation time as status updates change.
  * Updated contest enrichment to run an ongoing historical sweep for started, unfinalized, non-cancelled contests.
* **Documentation**
  * Added a new page describing the “Contest Enrichment Historical Sweep” initiative and rollout scope.
* **Bug Fixes**
  * Improved cancellation lifecycle handling, including warnings when cancellation is later reversed.
* **Tests**
  * Added unit test coverage for the sweep selection logic and cancellation stamping behavior.
* **Chores**
  * Added `CancelledUtc` to contest storage schema (including model snapshots).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->