### PR TITLE
fix(mobile): drop redundant team mark from baseball live AB/P slots

### DIFF
--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -335,20 +335,6 @@ function BaseballInProgress({
   const awayIsBatting = half === 'top';
   const homeIsBatting = half === 'bottom';
 
-  // Per-slot team logo: batter wears the batting team's logo, pitcher
-  // wears the defensive team's. Either may be null when halfInning is
-  // missing or when the team has no logo URL — slot tolerates absence.
-  const batterLogoUri = awayIsBatting
-    ? matchup.awayLogoUri
-    : homeIsBatting
-      ? matchup.homeLogoUri
-      : null;
-  const pitcherLogoUri = awayIsBatting
-    ? matchup.homeLogoUri
-    : homeIsBatting
-      ? matchup.awayLogoUri
-      : null;
-
   const hasInningRow =
     (typeof matchup.inning === 'number' && matchup.inning > 0) ||
     (typeof matchup.halfInning === 'string' && matchup.halfInning.length > 0);
@@ -385,14 +371,6 @@ function BaseballInProgress({
         <View style={styles.baseballAtBatRow}>
           {matchup.atBatShortName ? (
             <View style={styles.baseballAtBatSlot}>
-              {batterLogoUri ? (
-                <Image
-                  source={{ uri: batterLogoUri }}
-                  style={styles.baseballAtBatLogo}
-                  resizeMode="contain"
-                  accessibilityIgnoresInvertColors
-                />
-              ) : null}
               {matchup.atBatHeadshotUrl ? (
                 <Image
                   source={{ uri: matchup.atBatHeadshotUrl }}
@@ -410,14 +388,6 @@ function BaseballInProgress({
           ) : null}
           {matchup.pitchingShortName ? (
             <View style={styles.baseballAtBatSlot}>
-              {pitcherLogoUri ? (
-                <Image
-                  source={{ uri: pitcherLogoUri }}
-                  style={styles.baseballAtBatLogo}
-                  resizeMode="contain"
-                  accessibilityIgnoresInvertColors
-                />
-              ) : null}
               {matchup.pitchingHeadshotUrl ? (
                 <Image
                   source={{ uri: matchup.pitchingHeadshotUrl }}
@@ -603,10 +573,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-  },
-  baseballAtBatLogo: {
-    width: 18,
-    height: 18,
   },
   baseballAtBatHeadshot: {
     width: 24,


### PR DESCRIPTION
## Summary

`BaseballInProgress` rendered both the team-colored team mark (`batterLogoUri` / `pitcherLogoUri`) *and* the player headshot side-by-side in each at-bat and pitcher slot. After the player-avatar engine landed in #410, the headshot itself is generated against a team-color background — so the two adjacent roundels in the same palette are visual noise rather than information.

Drops:
- The `batterLogoUri` / `pitcherLogoUri` precomputation in `BaseballInProgress` (`GameStatus.tsx`)
- The two team-mark `<Image>` blocks in the AB and P slots
- The now-orphan `baseballAtBatLogo` style

Keeps:
- Both player headshot `<Image>` blocks — they convey team identity through the avatar's color background and also identify the specific batter / pitcher
- `awayIsBatting` / `homeIsBatting` — still drives the possession ⚾ icon in the score row

\"AB:\" / \"P:\" prefix labels deferred per discussion (user reports they render correctly in-app and aren't part of this duplication issue).

## Before / After

Before: each slot showed a team mark roundel immediately followed by the player headshot — both team-colored, hard to distinguish at the tile size.

After: each slot shows only the player headshot.

## Test plan

- [x] `npx tsc --noEmit` clean on `sd-mobile`
- [x] `npx jest --testPathPattern MatchupCard|GameStatus` — 6/6 pass (existing `MatchupCard.live.test.tsx`)
- [ ] Visual verification in Expo against a live MLB game (pending — Claude couldn't run the dev server)