### PR TITLE
fix(web): drop redundant team mark from baseball live AB/P slots

### DIFF
--- a/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
@@ -13,8 +13,10 @@ import { contestLink } from '../../utils/sportLinks';
  *
  * Each optional row suppresses when its source fields are absent.
  * The at-bat header per-slot suppression handles the partial-resolution
- * case (e.g., only the pitcher has been sourced yet). Team logo for
- * each slot derives from halfInning + away/homeLogoUri.
+ * case (e.g., only the pitcher has been sourced yet). Each slot renders
+ * just the player headshot — the headshot already uses the player's
+ * team colors as its background (player-avatar engine, PR #410), so a
+ * separate team mark next to it was redundant.
  *
  * Uses status-neutral class names (`.game-status-block`, `.score-display`,
  * etc.) — the broader rename of football's `.game-result` / `.final-score`
@@ -40,8 +42,6 @@ function BaseballGameStatusInProgress({
   pitchingShortName,
   pitchingPositionAbbreviation,
   pitchingHeadshotUrl,
-  awayLogoUri,
-  homeLogoUri,
   isScoringPlay,
   contestId,
   sport,
@@ -71,8 +71,6 @@ function BaseballGameStatusInProgress({
   const hasAtBatRow =
     (typeof atBatShortName === 'string' && atBatShortName.length > 0) ||
     (typeof pitchingShortName === 'string' && pitchingShortName.length > 0);
-  const batterLogoUri = awayIsBatting ? awayLogoUri : homeIsBatting ? homeLogoUri : null;
-  const pitcherLogoUri = awayIsBatting ? homeLogoUri : homeIsBatting ? awayLogoUri : null;
 
   const outsLabel = outs === 1 ? 'out' : 'outs';
   const formattedHalfInning = halfInning && inning
@@ -92,14 +90,6 @@ function BaseballGameStatusInProgress({
         <span className="live-state-atbat">
           {atBatShortName && (
             <span className="live-state-atbat-slot">
-              {batterLogoUri && (
-                <img
-                  src={batterLogoUri}
-                  alt=""
-                  aria-hidden="true"
-                  className="live-state-atbat-logo"
-                />
-              )}
               {atBatHeadshotUrl && (
                 <img
                   src={atBatHeadshotUrl}
@@ -116,14 +106,6 @@ function BaseballGameStatusInProgress({
           )}
           {pitchingShortName && (
             <span className="live-state-atbat-slot">
-              {pitcherLogoUri && (
-                <img
-                  src={pitcherLogoUri}
-                  alt=""
-                  aria-hidden="true"
-                  className="live-state-atbat-logo"
-                />
-              )}
               {pitchingHeadshotUrl && (
                 <img
                   src={pitchingHeadshotUrl}

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -80,8 +80,6 @@ function GameStatus({
   pitchingShortName,
   pitchingPositionAbbreviation,
   pitchingHeadshotUrl,
-  awayLogoUri,
-  homeLogoUri,
   contestId,
   leagueSport,
   sport,
@@ -182,8 +180,6 @@ function GameStatus({
         pitchingShortName={pitchingShortName}
         pitchingPositionAbbreviation={pitchingPositionAbbreviation}
         pitchingHeadshotUrl={pitchingHeadshotUrl}
-        awayLogoUri={awayLogoUri}
-        homeLogoUri={homeLogoUri}
         isScoringPlay={isScoringPlay}
         contestId={contestId}
         sport={sport}

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -796,12 +796,6 @@
   gap: 4px;
 }
 
-.live-state-atbat-logo {
-  width: 16px;
-  height: 16px;
-  object-fit: contain;
-}
-
 .live-state-atbat-headshot {
   width: 22px;
   height: 22px;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -256,8 +256,6 @@ function MatchupCard({
           pitchingShortName={matchup.pitchingShortName}
           pitchingPositionAbbreviation={matchup.pitchingPositionAbbreviation}
           pitchingHeadshotUrl={matchup.pitchingHeadshotUrl}
-          awayLogoUri={awayLogoSrc}
-          homeLogoUri={homeLogoSrc}
           contestId={matchup.contestId}
           // leagueSport drives the in-progress sport dispatch inside
           // GameStatus (e.g. "BaseballMlb" → BaseballGameStatusInProgress).


### PR DESCRIPTION
## Summary

Web mirror of #424. `BaseballGameStatusInProgress` rendered both the team-colored team mark (`batterLogoUri` / `pitcherLogoUri`) *and* the player headshot side-by-side in each at-bat and pitcher slot. After the player-avatar engine landed in #410, the headshot is generated against a team-color background — so the adjacent team mark in the same palette is visual noise rather than information.

## Changes

- **`BaseballGameStatusInProgress.jsx`** — drop `batterLogoUri` / `pitcherLogoUri` derivation, drop the two team-mark `<img>` elements, drop `awayLogoUri` / `homeLogoUri` props (now unused), update the docblock to reflect the new rendering rationale.
- **`GameStatus.jsx`** — drop `awayLogoUri` / `homeLogoUri` from the prop destructure and from the `<BaseballGameStatusInProgress>` forwarding. Only consumer was the leaf component.
- **`MatchupCard.jsx`** — drop the `awayLogoUri={awayLogoSrc}` / `homeLogoUri={homeLogoSrc}` pass-through to GameStatus. Only consumer was GameStatus → BaseballGameStatusInProgress.
- **`MatchupCard.css`** — drop the now-orphan `.live-state-atbat-logo` class.

`awayLogoSrc` / `homeLogoSrc` derivation in `MatchupCard.jsx:56-61` stays — still used for the main team-row logos at lines 174 + 195.

## Test plan

- [x] No stray references to `live-state-atbat-logo`, `batterLogoUri`, or `pitcherLogoUri` in `sd-ui/src`
- [x] `npm run build` clean on `sd-ui`
- [ ] Visual verification in a running web app against a live MLB game (Claude couldn't run the dev server)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed team logos from the live at-bat header display. The interface now relies exclusively on player headshot images for visual identification in game status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->