### PR TITLE
fix(ui): replace LIVE with delay status text for suspended/delayed games

### DIFF
--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -299,13 +299,17 @@ function FootballInProgress({
           <>
             <View style={styles.liveDot} />
             <Text style={styles.liveText}>LIVE</Text>
-            {matchup.period && matchup.clock ? (
-              <Text style={[styles.clockText, { color: theme.textMuted }]}>
-                {matchup.period} – {matchup.clock}
-              </Text>
-            ) : null}
           </>
         )}
+        {/* Period + clock renders in both branches: for a delayed game
+            it's the meaningful "we paused at Q2 5:32" context. Mirrors
+            web's FootballGameStatusInProgress where the .game-clock
+            span is rendered outside the LIVE/delay-indicator ternary. */}
+        {matchup.period && matchup.clock ? (
+          <Text style={[styles.clockText, { color: theme.textMuted }]}>
+            {matchup.period} – {matchup.clock}
+          </Text>
+        ) : null}
       </View>
 
       <View style={[styles.scoreRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -109,25 +109,23 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail, pickType }
           matchup={matchup}
           theme={theme}
           onPressGameDetail={onPressGameDetail}
+          isDelayed={isDelayed}
         />
       ) : (
         <FootballInProgress
           matchup={matchup}
           theme={theme}
           onPressGameDetail={onPressGameDetail}
+          isDelayed={isDelayed}
         />
       );
 
-    if (isDelayed) {
-      return (
-        <View>
-          <Text style={[styles.delayBanner, { color: theme.tint }]}>
-            {(matchup.statusDescription ?? matchup.status).toUpperCase()}
-          </Text>
-          {inProgressBlock}
-        </View>
-      );
-    }
+    // Delay status (SUSPENDED / DELAYED / RAIN_DELAY) is now displayed
+    // inside the in-progress block itself — the LIVE slot is replaced
+    // with the status description, styled as a muted static indicator.
+    // The earlier delayBanner above the block led to contradictory
+    // rendering (SUSPENDED above + pulsing LIVE below). Web mirrors
+    // this in GameStatus.jsx.
     return inProgressBlock;
   }
 
@@ -264,11 +262,20 @@ function FootballInProgress({
   matchup,
   theme,
   onPressGameDetail,
+  // When status is SUSPENDED / DELAYED / RAIN_DELAY, the LIVE slot is
+  // replaced with the delay status text and the red pulse dot is
+  // dropped — the game isn't actively in play, so the red-pulse cue
+  // would be misleading. Mirrors web's isDelayed prop.
+  isDelayed = false,
 }: {
   matchup: Matchup;
   theme: Theme;
   onPressGameDetail?: () => void;
+  isDelayed?: boolean;
 }) {
+  const delayLabel = (
+    matchup.statusDescription ?? matchup.status ?? 'PAUSED'
+  ).toUpperCase();
   const awayScore = matchup.awayScore ?? 0;
   const homeScore = matchup.homeScore ?? 0;
   const awayHasPossession =
@@ -284,13 +291,21 @@ function FootballInProgress({
   return (
     <View style={styles.statusSection}>
       <View style={styles.liveRow}>
-        <View style={styles.liveDot} />
-        <Text style={styles.liveText}>LIVE</Text>
-        {matchup.period && matchup.clock ? (
-          <Text style={[styles.clockText, { color: theme.textMuted }]}>
-            {matchup.period} – {matchup.clock}
+        {isDelayed ? (
+          <Text style={[styles.delayText, { color: theme.textMuted }]}>
+            {delayLabel}
           </Text>
-        ) : null}
+        ) : (
+          <>
+            <View style={styles.liveDot} />
+            <Text style={styles.liveText}>LIVE</Text>
+            {matchup.period && matchup.clock ? (
+              <Text style={[styles.clockText, { color: theme.textMuted }]}>
+                {matchup.period} – {matchup.clock}
+              </Text>
+            ) : null}
+          </>
+        )}
       </View>
 
       <View style={[styles.scoreRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
@@ -323,11 +338,18 @@ function BaseballInProgress({
   matchup,
   theme,
   onPressGameDetail,
+  // See FootballInProgress isDelayed comment — same semantics,
+  // mirrors the web isDelayed prop.
+  isDelayed = false,
 }: {
   matchup: Matchup;
   theme: Theme;
   onPressGameDetail?: () => void;
+  isDelayed?: boolean;
 }) {
+  const delayLabel = (
+    matchup.statusDescription ?? matchup.status ?? 'PAUSED'
+  ).toUpperCase();
   const awayScore = matchup.awayScore ?? 0;
   const homeScore = matchup.homeScore ?? 0;
   // halfInning "Top" → away batting (gets the ⚾); "Bottom" → home batting.
@@ -355,8 +377,16 @@ function BaseballInProgress({
   return (
     <View style={styles.statusSection}>
       <View style={styles.liveRow}>
-        <View style={styles.liveDot} />
-        <Text style={styles.liveText}>LIVE</Text>
+        {isDelayed ? (
+          <Text style={[styles.delayText, { color: theme.textMuted }]}>
+            {delayLabel}
+          </Text>
+        ) : (
+          <>
+            <View style={styles.liveDot} />
+            <Text style={styles.liveText}>LIVE</Text>
+          </>
+        )}
       </View>
 
       <View style={[styles.scoreRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
@@ -461,20 +491,6 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
-  // Mid-game paused banner — sits above the InProgress block when status is
-  // Delayed / RainDelay / Suspended. The InProgress block below still shows
-  // the meaningful state (score, period, runners) — the banner just names
-  // why no play is happening.
-  delayBanner: {
-    textAlign: 'center',
-    fontSize: 13,
-    fontWeight: '800',
-    letterSpacing: 1,
-    paddingVertical: 4,
-    paddingHorizontal: 10,
-    marginHorizontal: 12,
-    marginBottom: 2,
-  },
   struckThrough: {
     textDecorationLine: 'line-through',
     opacity: 0.7,
@@ -505,6 +521,15 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '800',
     color: '#DC2626',
+    letterSpacing: 1,
+  },
+  // Same slot as liveText — rendered when status is SUSPENDED /
+  // DELAYED / RAIN_DELAY. Color is applied at the call site from
+  // theme.textMuted; no animation. Distinguishes paused-but-not-final
+  // state from active live play.
+  delayText: {
+    fontSize: 12,
+    fontWeight: '800',
     letterSpacing: 1,
   },
   clockText: {

--- a/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
@@ -43,10 +43,20 @@ function BaseballGameStatusInProgress({
   pitchingPositionAbbreviation,
   pitchingHeadshotUrl,
   isScoringPlay,
+  // When the upstream status is SUSPENDED / DELAYED / RAIN_DELAY, the
+  // LIVE slot is replaced with the delay status text and styled as a
+  // static muted indicator rather than the red pulsing live indicator.
+  // The game isn't actively in play, so the red-pulse animation would
+  // be misleading. statusDescription is the ESPN-provided human label
+  // ("Suspended", "Rain Delay"); falls back to the raw status name.
+  isDelayed = false,
+  statusDescription,
+  status,
   contestId,
   sport,
   league,
 }) {
+  const delayLabel = (statusDescription || status || 'PAUSED').toUpperCase();
   // Top of the inning → away team is batting; Bottom → home batting.
   // Empty/unknown halfInning produces no indicator (graceful degrade).
   const half = (halfInning ?? '').toLowerCase();
@@ -79,7 +89,11 @@ function BaseballGameStatusInProgress({
 
   const liveContent = (
     <>
-      <span className="status-label live-indicator">LIVE</span>
+      {isDelayed ? (
+        <span className="status-label delay-indicator">{delayLabel}</span>
+      ) : (
+        <span className="status-label live-indicator">LIVE</span>
+      )}
       <span className={`score-display ${isScoringPlay ? 'score-flash' : ''}`}>
         {awayIsBatting && <span className="possession-indicator" aria-label="batting">⚾</span>}
         {awayShort} {awayScore} - {homeScore} {homeShort}

--- a/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
@@ -22,10 +22,16 @@ function FootballGameStatusInProgress({
   possessionFranchiseSeasonId,
   isScoringPlay,
   lastPlayDescription,
+  // See BaseballGameStatusInProgress isDelayed comment — same
+  // semantics, mirrors the LIVE → delay-status text swap.
+  isDelayed = false,
+  statusDescription,
+  status,
   contestId,
   sport,
   league,
 }) {
+  const delayLabel = (statusDescription || status || 'PAUSED').toUpperCase();
   // Guard against null/undefined possession — without the != null check,
   // a missing possessionFranchiseSeasonId could match a missing
   // awayFranchiseSeasonId / homeFranchiseSeasonId via `===` and falsely
@@ -42,7 +48,11 @@ function FootballGameStatusInProgress({
 
   const liveContent = (
     <>
-      <span className="result-label live-indicator">LIVE</span>
+      {isDelayed ? (
+        <span className="result-label delay-indicator">{delayLabel}</span>
+      ) : (
+        <span className="result-label live-indicator">LIVE</span>
+      )}
       {period && clock && (
         <span className="game-clock">{period} - {clock}</span>
       )}

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -181,6 +181,9 @@ function GameStatus({
         pitchingPositionAbbreviation={pitchingPositionAbbreviation}
         pitchingHeadshotUrl={pitchingHeadshotUrl}
         isScoringPlay={isScoringPlay}
+        isDelayed={isDelayed}
+        statusDescription={statusDescription}
+        status={status}
         contestId={contestId}
         sport={sport}
         league={league}
@@ -200,6 +203,9 @@ function GameStatus({
         homeFranchiseSeasonId={homeFranchiseSeasonId}
         possessionFranchiseSeasonId={possessionFranchiseSeasonId}
         isScoringPlay={isScoringPlay}
+        isDelayed={isDelayed}
+        statusDescription={statusDescription}
+        status={status}
         lastPlayDescription={lastPlayDescription}
         contestId={contestId}
         sport={sport}
@@ -207,16 +213,11 @@ function GameStatus({
       />
     );
 
-    if (isDelayed) {
-      return (
-        <>
-          <div className="game-delay-banner">
-            {(statusDescription || status || '').toUpperCase()}
-          </div>
-          {inProgressBlock}
-        </>
-      );
-    }
+    // Delay status (SUSPENDED / DELAYED / RAIN_DELAY) is now displayed
+    // inside the in-progress block itself — the LIVE slot is replaced
+    // with the status description, styled as a muted static indicator.
+    // The earlier separate .game-delay-banner above the block led to
+    // contradictory rendering (SUSPENDED above + pulsing LIVE below).
     return inProgressBlock;
   }
 

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -254,18 +254,6 @@
    game is Delayed / RainDelay / Suspended. The game IS still live (the
    InProgress block below shows score + period/inning), but no play is
    happening right now, so we name the reason prominently. */
-.game-delay-banner {
-  text-align: center;
-  font-size: 0.85rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  color: var(--accent);
-  background-color: var(--bg-elevated);
-  border-radius: 6px;
-  padding: 4px 10px;
-  margin: 6px 8px 0;
-}
-
 /* Game Result Section */
 .game-result {
   text-align: center;
@@ -315,6 +303,15 @@
 .live-indicator {
   color: var(--error);
   animation: pulse-live 2s ease-in-out infinite;
+}
+
+/* Same slot as .live-indicator — rendered when status is SUSPENDED /
+   DELAYED / RAIN_DELAY. Muted color + no animation distinguishes a
+   paused-but-not-final state from active live play. */
+.delay-indicator {
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  font-weight: 700;
 }
 
 @keyframes pulse-live {


### PR DESCRIPTION
## Summary

When ESPN reports `STATUS_SUSPENDED` / `STATUS_DELAYED` / `STATUS_RAIN_DELAY`, both web and mobile were rendering a separate delay banner *above* the in-progress block, while the in-progress block itself kept pulsing \"LIVE\" in red. The result was a card that simultaneously read \"SUSPENDED\" *and* \"LIVE\" — contradictory.

Replaces the separate banner with an in-slot swap: the LIVE position itself shows the delay status text in a muted static treatment when delayed, or LIVE (red pulse) when actually live. Score and all other in-progress rows render unchanged in either case — last known score is still informative for a paused game.

## Surfaced by

A real MLB STATUS_SUSPENDED game from 2026-06-16 that the streamer failed to finalize. Producer-side handling of stranded SUSPENDED streams is a separate follow-up.

## Web

- **`BaseballGameStatusInProgress.jsx`** / **`FootballGameStatusInProgress.jsx`**: accept `isDelayed` + `statusDescription` + `status`; render either `.live-indicator` (red pulse \"LIVE\") or `.delay-indicator` (muted text) in the same span.
- **`GameStatus.jsx`**: drop the outer `.game-delay-banner` div; thread the new props through both child invocations.
- **`MatchupCard.css`**: new `.delay-indicator` class (muted, no animation); orphan `.game-delay-banner` removed.

## Mobile

- **`GameStatus.tsx`** (`BaseballInProgress` + `FootballInProgress`): accept `isDelayed`; read `matchup.statusDescription` / `matchup.status` for the label; `liveRow` renders dot+LIVE or muted delay text.
- Outer `delayBanner` block removed from the `GameStatus` wrapper.
- New `delayText` style; orphan `delayBanner` style removed.

## Parity

Same prop name (`isDelayed`), same fallback chain (`statusDescription` → `status` → `\"PAUSED\"`), same visual semantic (muted static text replaces the red-pulse LIVE) on both platforms.

## Test plan

- [x] `npx tsc --noEmit` clean on sd-mobile
- [x] `npm run build` clean on sd-ui
- [x] `npx jest --testPathPattern MatchupCard|GameStatus` — 6/6 pass
- [ ] Visual verification against the live MLB STATUS_SUSPENDED game (pending — Claude couldn't run the dev server)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of delayed, paused, and rain-delayed game statuses by replacing the separate delay banner with an in-place muted indicator within the standard live status area (including both football and baseball in-progress views).

* **Style**
  * Updated the delayed indicator styling to match the existing live indicator position, using a static muted label instead of the pulsing “LIVE” presentation during delayed states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->