### PR TITLE
feat(producer): defensive ContestCompleted publish from status processor

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessor.cs
@@ -134,24 +134,31 @@ public class BaseballEventCompetitionStatusDocumentProcessor<TDataContext> : Doc
                 entity.FeaturedAthletes.Count);
         }
 
-        // ContestId is needed for both the transition event and the
-        // cancellation lifecycle update. Fetch once. The publish/stamp
-        // branches each gate independently below. See matching block in
+        // ContestId is needed for ContestStatusChanged, ContestCompleted,
+        // and the cancellation lifecycle update. Fetch once with
+        // SeasonWeekId so the ContestCompleted payload doesn't require a
+        // second roundtrip. See matching block in
         // EventCompetitionStatusDocumentProcessor (football variant).
         var newStatusIsCanceled = entity.StatusTypeName == "STATUS_CANCELED";
         var existedAsCanceled = existing?.StatusTypeName == "STATUS_CANCELED";
-        var contestIdNeeded = publishEvent || newStatusIsCanceled || existedAsCanceled;
+        var newStatusIsFinal = entity.StatusTypeName == "STATUS_FINAL";
+        var existedAsFinal = existing?.StatusTypeName == "STATUS_FINAL";
+        var contestIdNeeded =
+            publishEvent || newStatusIsCanceled || existedAsCanceled || newStatusIsFinal;
 
         Guid contestId = Guid.Empty;
+        Guid? seasonWeekId = null;
         if (contestIdNeeded)
         {
             // ContestId is what crosses the service boundary — Competition
-            // is a Producer-internal sub-aggregate. Projected read so we
-            // don't pull the full Competition row.
-            contestId = await _dataContext.Competitions
+            // is a Producer-internal sub-aggregate. SeasonWeekId comes off
+            // Contest via the Competition→Contest navigation.
+            var parent = await _dataContext.Competitions
                 .Where(c => c.Id == competitionIdValue)
-                .Select(c => c.ContestId)
+                .Select(c => new { c.ContestId, SeasonWeekId = c.Contest!.SeasonWeekId })
                 .FirstAsync();
+            contestId = parent.ContestId;
+            seasonWeekId = parent.SeasonWeekId;
         }
 
         if (publishEvent)
@@ -172,6 +179,30 @@ public class BaseballEventCompetitionStatusDocumentProcessor<TDataContext> : Doc
                 command.SeasonYear,
                 command.CorrelationId,
                 CausationId.Producer.EventCompetitionStatusDocumentProcessor
+            ));
+        }
+
+        // Defensive ContestCompleted fan-out. See matching block in
+        // EventCompetitionStatusDocumentProcessor (football variant) for
+        // rationale — closes the race where the streamer's
+        // ContestCompleted can fire before the status row write,
+        // causing the 30s-deferred enrichment to short-circuit. No
+        // Event-document re-source paired here to avoid a cascade.
+        if (newStatusIsFinal && !existedAsFinal)
+        {
+            _logger.LogInformation(
+                "Publishing ContestCompleted from MLB status processor (defensive). ContestId={ContestId}, CompetitionId={CompId}",
+                contestId, competitionIdValue);
+
+            await _publishEndpoint.Publish(new ContestCompleted(
+                ContestId: contestId,
+                CompetitionId: competitionIdValue,
+                SeasonWeekId: seasonWeekId,
+                Ref: null,
+                Sport: command.Sport,
+                SeasonYear: command.SeasonYear,
+                CorrelationId: command.CorrelationId,
+                CausationId: CausationId.Producer.EventCompetitionStatusDocumentProcessor
             ));
         }
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusDocumentProcessor.cs
@@ -104,23 +104,30 @@ public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentPro
                 dto.Type.Name);
         }
 
-        // ContestId is needed for both the transition event and the
-        // cancellation lifecycle update. Fetch once. The publish/stamp
-        // branches each gate independently below.
+        // ContestId is needed for ContestStatusChanged, ContestCompleted,
+        // and the cancellation lifecycle update. Fetch once with SeasonWeekId
+        // so the ContestCompleted payload doesn't require a second roundtrip.
         var newStatusIsCanceled = entity.StatusTypeName == "STATUS_CANCELED";
         var existedAsCanceled = existing?.StatusTypeName == "STATUS_CANCELED";
-        var contestIdNeeded = publishEvent || newStatusIsCanceled || existedAsCanceled;
+        var newStatusIsFinal = entity.StatusTypeName == "STATUS_FINAL";
+        var existedAsFinal = existing?.StatusTypeName == "STATUS_FINAL";
+        var contestIdNeeded =
+            publishEvent || newStatusIsCanceled || existedAsCanceled || newStatusIsFinal;
 
         Guid contestId = Guid.Empty;
+        Guid? seasonWeekId = null;
         if (contestIdNeeded)
         {
             // ContestId is what crosses the service boundary — Competition
-            // is a Producer-internal sub-aggregate. Projected read so we
-            // don't pull the full Competition row.
-            contestId = await _dataContext.Competitions
+            // is a Producer-internal sub-aggregate. SeasonWeekId comes off
+            // Contest via the Competition→Contest navigation; EF translates
+            // this to a join so we still avoid pulling full rows.
+            var parent = await _dataContext.Competitions
                 .Where(c => c.Id == competitionIdValue)
-                .Select(c => c.ContestId)
+                .Select(c => new { c.ContestId, SeasonWeekId = c.Contest!.SeasonWeekId })
                 .FirstAsync();
+            contestId = parent.ContestId;
+            seasonWeekId = parent.SeasonWeekId;
         }
 
         if (publishEvent)
@@ -144,6 +151,37 @@ public class EventCompetitionStatusDocumentProcessor<TDataContext> : DocumentPro
                 command.SeasonYear,
                 command.CorrelationId,
                 CausationId.Producer.EventCompetitionStatusDocumentProcessor
+            ));
+        }
+
+        // Defensive ContestCompleted fan-out. The streamer publishes this
+        // event at its STATUS_FINAL detection sites, but the streamer's
+        // ContestCompleted can race ahead of the status row write — if the
+        // 30s-deferred enrichment runs before this processor persists
+        // STATUS_FINAL, enrichment short-circuits on the non-FINAL status
+        // and never re-fires. Publishing here, AFTER the status row is
+        // definitely written, closes that gap. Consumer is idempotent
+        // (enrichment processor short-circuits on Contest.FinalizedUtc !=
+        // null), so a duplicate fire alongside the streamer is harmless.
+        //
+        // Skipping the paired Event-document re-source the streamer pairs
+        // with its publish — Provider has dedupe but a defensive cascade
+        // shouldn't risk a sourcing cycle.
+        if (newStatusIsFinal && !existedAsFinal)
+        {
+            _logger.LogInformation(
+                "Publishing ContestCompleted from status processor (defensive). ContestId={ContestId}, CompetitionId={CompId}",
+                contestId, competitionIdValue);
+
+            await _publishEndpoint.Publish(new ContestCompleted(
+                ContestId: contestId,
+                CompetitionId: competitionIdValue,
+                SeasonWeekId: seasonWeekId,
+                Ref: null,
+                Sport: command.Sport,
+                SeasonYear: command.SeasonYear,
+                CorrelationId: command.CorrelationId,
+                CausationId: CausationId.Producer.EventCompetitionStatusDocumentProcessor
             ));
         }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
@@ -66,7 +66,7 @@ public class BaseballEventCompetitionStatusDocumentProcessorTests
     }
 
     private async Task<(BaseballContest contest, BaseballCompetition competition)>
-        SeedContestAndCompetitionAsync(Guid competitionId)
+        SeedContestAndCompetitionAsync(Guid competitionId, Guid? seasonWeekId = null)
     {
         var contest = new BaseballContest
         {
@@ -78,6 +78,7 @@ public class BaseballEventCompetitionStatusDocumentProcessorTests
             StartDateUtc = FixedNow,
             HomeTeamFranchiseSeasonId = Guid.NewGuid(),
             AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            SeasonWeekId = seasonWeekId,
             CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         };
@@ -379,6 +380,124 @@ public class BaseballEventCompetitionStatusDocumentProcessorTests
             .FirstAsync(c => c.Id == contest.Id);
         refreshed.CancelledUtc.Should().Be(originalCancelledUtc,
             "cancellation is treated as irrevocable; only an admin override should clear it");
+    }
+
+    [Fact]
+    public async Task WhenStatusTransitionsToFinal_PublishesContestCompleted()
+    {
+        // Defensive fan-out (MLB variant). See matching test in the
+        // football processor for rationale.
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var compId = Guid.NewGuid();
+        var seasonWeekId = Guid.NewGuid();
+        var (contest, _) = await SeedContestAndCompetitionAsync(compId, seasonWeekId: seasonWeekId);
+
+        var existing = new BaseballCompetitionStatus
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = compId,
+            StatusTypeName = "STATUS_IN_PROGRESS",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        await _baseballDataContext.Set<BaseballCompetitionStatus>().AddAsync(existing);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var cmd = await BuildCommandAsync(compId, statusTypeName: "STATUS_FINAL");
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+            It.Is<ContestCompleted>(e =>
+                e.ContestId == contest.Id &&
+                e.CompetitionId == compId &&
+                e.SeasonWeekId == seasonWeekId &&
+                e.Sport == Sport.BaseballMlb),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task WhenStatusIsAlreadyFinal_DoesNotRepublishContestCompleted()
+    {
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var compId = Guid.NewGuid();
+        await SeedContestAndCompetitionAsync(compId);
+
+        var existing = new BaseballCompetitionStatus
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = compId,
+            StatusTypeName = "STATUS_FINAL",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        await _baseballDataContext.Set<BaseballCompetitionStatus>().AddAsync(existing);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var cmd = await BuildCommandAsync(compId, statusTypeName: "STATUS_FINAL");
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+            It.IsAny<ContestCompleted>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenStatusTransitionsToInProgress_DoesNotPublishContestCompleted()
+    {
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var compId = Guid.NewGuid();
+        await SeedContestAndCompetitionAsync(compId);
+
+        var existing = new BaseballCompetitionStatus
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = compId,
+            StatusTypeName = "STATUS_SCHEDULED",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        await _baseballDataContext.Set<BaseballCompetitionStatus>().AddAsync(existing);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var cmd = await BuildCommandAsync(compId, statusTypeName: "STATUS_IN_PROGRESS");
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+            It.IsAny<ContestCompleted>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenFirstObservationIsFinal_PublishesContestCompleted()
+    {
+        // Historical backfill: status doc arrives FINAL with no prior row.
+        // Defensive fan-out must still fire so enrichment gets triggered.
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+
+        var compId = Guid.NewGuid();
+        var (contest, _) = await SeedContestAndCompetitionAsync(compId);
+
+        var cmd = await BuildCommandAsync(compId, statusTypeName: "STATUS_FINAL");
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>();
+
+        await sut.ProcessAsync(cmd);
+
+        Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+            It.Is<ContestCompleted>(e => e.ContestId == contest.Id),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     private async Task<ProcessDocumentCommand> BuildCommandAsync(Guid compId, string statusTypeName)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
@@ -9,6 +9,8 @@ using Moq;
 
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -37,17 +39,36 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             var documentJson = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionStatus.json");
 
             var competitionId = Guid.NewGuid();
-            
+            var contestId = Guid.NewGuid();
+
+            // Contest seeded too: the processor now navigates Competition→Contest
+            // (for SeasonWeekId on the ContestCompleted payload), so a Competition
+            // without a parent Contest row would fail .FirstAsync() on the join.
+            var contest = new FootballContest
+            {
+                Id = contestId,
+                Name = "Test Contest",
+                ShortName = "TC",
+                Sport = Sport.FootballNcaa,
+                SeasonYear = 2025,
+                StartDateUtc = DateTime.UtcNow,
+                HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+                AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            };
+
             // OPTIMIZATION: Direct instantiation
             var competition = new FootballCompetition
             {
                 Id = competitionId,
-                ContestId = Guid.NewGuid(),
+                ContestId = contestId,
                 Date = DateTime.UtcNow,
                 CreatedUtc = DateTime.UtcNow,
                 CreatedBy = Guid.NewGuid()
             };
 
+            await FootballDataContext.Contests.AddAsync(contest);
             await FootballDataContext.Competitions.AddAsync(competition);
             await FootballDataContext.SaveChangesAsync();
 
@@ -158,6 +179,113 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 "cancellation is treated as irrevocable; only an admin override should clear it");
         }
 
+        [Fact]
+        public async Task WhenStatusTransitionsToFinal_PublishesContestCompleted()
+        {
+            // Arrange — Defensive fan-out: status processor publishes
+            // ContestCompleted on a FINAL transition so a 30s-deferred
+            // enrichment can't short-circuit on a not-yet-written status row.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            var seasonWeekId = Guid.NewGuid();
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
+            var (contest, competition, command) = await SeedAndBuildCommandAsync(
+                statusJsonName: "STATUS_FINAL",
+                priorStatusTypeName: "STATUS_IN_PROGRESS",
+                seasonWeekId: seasonWeekId);
+
+            var sut = Mocker.CreateInstance<EventCompetitionStatusDocumentProcessor<FootballDataContext>>();
+
+            // Act
+            await sut.ProcessAsync(command);
+
+            // Assert — exactly one ContestCompleted with the expected payload.
+            Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+                It.Is<ContestCompleted>(e =>
+                    e.ContestId == contest.Id &&
+                    e.CompetitionId == competition.Id &&
+                    e.SeasonWeekId == seasonWeekId &&
+                    e.Sport == command.Sport &&
+                    e.SeasonYear == command.SeasonYear),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task WhenStatusIsAlreadyFinal_DoesNotRepublishContestCompleted()
+        {
+            // Arrange — Idempotency: a redundant STATUS_FINAL refresh on an
+            // already-final game must not fire ContestCompleted again.
+            // Otherwise every status doc poll would re-enqueue enrichment.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
+            var (_, _, command) = await SeedAndBuildCommandAsync(
+                statusJsonName: "STATUS_FINAL",
+                priorStatusTypeName: "STATUS_FINAL");
+
+            var sut = Mocker.CreateInstance<EventCompetitionStatusDocumentProcessor<FootballDataContext>>();
+
+            await sut.ProcessAsync(command);
+
+            Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+                It.IsAny<ContestCompleted>(),
+                It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task WhenStatusTransitionsToInProgress_DoesNotPublishContestCompleted()
+        {
+            // Arrange — Non-FINAL transitions must not trigger
+            // ContestCompleted. Only STATUS_FINAL fires the defensive fan-out.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
+            var (_, _, command) = await SeedAndBuildCommandAsync(
+                statusJsonName: "STATUS_IN_PROGRESS",
+                priorStatusTypeName: "STATUS_SCHEDULED");
+
+            var sut = Mocker.CreateInstance<EventCompetitionStatusDocumentProcessor<FootballDataContext>>();
+
+            await sut.ProcessAsync(command);
+
+            Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+                It.IsAny<ContestCompleted>(),
+                It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task WhenFirstObservationIsFinal_PublishesContestCompleted()
+        {
+            // Arrange — Historical backfill scenario: status doc lands with
+            // STATUS_FINAL and no prior status row exists. The defensive
+            // fan-out must still fire so enrichment gets triggered.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
+            var (contest, _, command) = await SeedAndBuildCommandAsync(
+                statusJsonName: "STATUS_FINAL");
+
+            var sut = Mocker.CreateInstance<EventCompetitionStatusDocumentProcessor<FootballDataContext>>();
+
+            await sut.ProcessAsync(command);
+
+            Mocker.GetMock<IEventBus>().Verify(b => b.Publish(
+                It.Is<ContestCompleted>(e => e.ContestId == contest.Id),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
         /// <summary>
         /// Builds a STATUS_FINAL-shaped JSON payload by string-replacing
         /// the type.name and type.description on the canonical test fixture.
@@ -177,7 +305,8 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             SeedAndBuildCommandAsync(
                 string statusJsonName,
                 string? priorStatusTypeName = null,
-                DateTime? contestCancelledUtc = null)
+                DateTime? contestCancelledUtc = null,
+                Guid? seasonWeekId = null)
         {
             Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
 
@@ -197,6 +326,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 StartDateUtc = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
                 HomeTeamFranchiseSeasonId = Guid.NewGuid(),
                 AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+                SeasonWeekId = seasonWeekId,
                 CreatedUtc = seededUtc,
                 CreatedBy = Guid.NewGuid(),
                 CancelledUtc = contestCancelledUtc

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionStatusDocumentProcessorTests.cs
@@ -36,6 +36,13 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             var identityGenerator = new ExternalRefIdentityGenerator();
             Mocker.Use<IGenerateExternalRefIdentities>(identityGenerator);
 
+            // Deterministic clock for all seeded timestamps — matches the
+            // pattern the cancellation-lifecycle tests in this file use.
+            var fixedNow = new DateTime(2026, 6, 16, 14, 0, 0, DateTimeKind.Utc);
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(p => p.UtcNow())
+                .Returns(fixedNow);
+
             var documentJson = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionStatus.json");
 
             var competitionId = Guid.NewGuid();
@@ -51,10 +58,10 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 ShortName = "TC",
                 Sport = Sport.FootballNcaa,
                 SeasonYear = 2025,
-                StartDateUtc = DateTime.UtcNow,
+                StartDateUtc = fixedNow,
                 HomeTeamFranchiseSeasonId = Guid.NewGuid(),
                 AwayTeamFranchiseSeasonId = Guid.NewGuid(),
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = fixedNow,
                 CreatedBy = Guid.NewGuid()
             };
 
@@ -63,8 +70,8 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             {
                 Id = competitionId,
                 ContestId = contestId,
-                Date = DateTime.UtcNow,
-                CreatedUtc = DateTime.UtcNow,
+                Date = fixedNow,
+                CreatedUtc = fixedNow,
                 CreatedBy = Guid.NewGuid()
             };
 


### PR DESCRIPTION
## Summary

Closes a race where enrichment can be missed entirely on STATUS_FINAL transitions.

The streamer publishes `ContestCompleted` at its three STATUS_FINAL detection sites, and `ContestCompletedHandler` then schedules `EnrichContestCommand` with a 30s delay. But the streamer's publish can race ahead of the status row write — if the 30s-deferred enrichment runs before `EventCompetitionStatusDocumentProcessor` persists STATUS_FINAL, enrichment short-circuits on the non-FINAL `CompetitionStatus` row and never re-fires. The streamer's `ContestCompleted` has already been consumed, so no second trigger arrives.

Status processor now also publishes `ContestCompleted` on a FINAL transition, fired AFTER the status row is definitely written. Also covers the **first-observation-is-FINAL** case (historical sourcing of completed games), which the streamer never sees.

## What changed

- **`EventCompetitionStatusDocumentProcessor`** + **`BaseballEventCompetitionStatusDocumentProcessor`** — compute `newStatusIsFinal` / `existedAsFinal`. Extend the single-fetch contest lookup to also pull `SeasonWeekId` off Contest via the `Competition→Contest` nav (needed for the event payload). Publish `ContestCompleted` when `newStatusIsFinal && !existedAsFinal` — covers both the transition and the first-observation case. CausationId stamped as `EventCompetitionStatusDocumentProcessor` for Seq provenance.
- **No paired Event-document re-source** — the streamer pairs `ContestCompleted` with a `DocumentRequested(Event)` re-source, but a defensive cascade from the status processor shouldn't risk a sourcing cycle. Provider dedupe should absorb it, but \"should\" is doing work in that sentence.
- **Test fix:** the pre-existing `WhenCompetitionExists_StatusIsAdded` Football test seeded only a Competition; the new query joins through `c.Contest!.SeasonWeekId` and fails when the nav resolves to null. Updated to seed a parent Contest too.

## Idempotency

Enrichment processor already short-circuits on `Contest.FinalizedUtc != null`, so duplicate fires from streamer + status processor are harmless. The CausationId difference lets Seq distinguish defensive-cascade publishes from streamer publishes during operational triage.

## Test plan

- [x] `dotnet build` clean on `SportsData.Producer`
- [x] `dotnet test` on `SportsData.Producer.Tests.Unit` — 440 pass (+8 new)
- New tests (4 per processor):
  - `WhenStatusTransitionsToFinal_PublishesContestCompleted` — verifies payload (ContestId, CompetitionId, SeasonWeekId, Sport)
  - `WhenStatusIsAlreadyFinal_DoesNotRepublishContestCompleted` — idempotency
  - `WhenStatusTransitionsToInProgress_DoesNotPublishContestCompleted` — only FINAL transitions fire
  - `WhenFirstObservationIsFinal_PublishesContestCompleted` — historical sourcing path
- [ ] Manual E2E (local): replay a status doc transition through Provider → status processor, confirm both `ContestStatusChanged` and `ContestCompleted` land in the Seq tracer with distinct CausationIds
- [ ] Prod monitoring after deploy: Seq query `Publishing ContestCompleted from status processor (defensive)` count should be small relative to streamer publishes during normal operation; a spike indicates the streamer-publish-vs-status-write race is firing for real

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved contest completion handling by emitting a `ContestCompleted` signal when competitions transition into final status.
  * Added season-week context to the completion event payload to ensure correct downstream contest lifecycle correlation.
  * Prevented duplicate `ContestCompleted` emissions when a contest is already in final status, while still supporting historical/backfill scenarios.

* **Tests**
  * Expanded unit test coverage for MLB and football processors, including transition-to-final, already-final (no republish), non-final, and missing-initial-row backfill cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->