### PR TITLE
fix(producer): defer contest enrichment when scores indicate stale data

### DIFF
--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -92,57 +92,50 @@ namespace SportsData.Producer.Application.Contests
 
             var contest = competition.Contest;
 
-            // Exclude the bootstrap placeholder rows that get seeded for
-            // every competitor at season-start with Value=0 and
-            // SourceDescription="basic/manual" (SourceId="1"). The
-            // canonical ESPN feed records arrive later with
-            // SourceDescription="feed" (SourceId="2"). The original code's
-            // preference-then-fallback ordering would silently pick those
-            // bootstrap zeros when feed sourcing lagged STATUS_FINAL —
-            // producing a finalized 0-0 contest with null WinnerFranchiseId
-            // (the 0-0 != 0-0 branch is false). ContestEnrichmentJob cron
-            // sweep will retry once the feed rows land.
-            var awayFinalScore = await _dataContext.CompetitionCompetitorScores
+            // MAX(Value) per competitor. Cross-sport schema variance in
+            // CompetitionCompetitorScores prevents a SourceDescription-based
+            // filter (MLB inserts new "feed" rows alongside "basic/manual"
+            // bootstrap rows; NCAAFB updates the "Basic/Manual" bootstrap
+            // row in place — same SourceDescription before and after).
+            // MAX side-steps it: bootstrap rows have Value=0 and any real
+            // score exceeds them; in-game ticks only go up, so the highest
+            // recorded value per competitor is always the latest known
+            // cumulative score.
+            var awayMaxScore = await _dataContext.CompetitionCompetitorScores
                 .AsNoTracking()
-                .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id
-                            && s.SourceDescription != "basic/manual")
-                .OrderByDescending(s => s.CreatedUtc)
+                .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
                 .Select(s => (double?)s.Value)
-                .FirstOrDefaultAsync();
+                .MaxAsync();
 
-            var homeFinalScore = await _dataContext.CompetitionCompetitorScores
+            var homeMaxScore = await _dataContext.CompetitionCompetitorScores
                 .AsNoTracking()
-                .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id
-                            && s.SourceDescription != "basic/manual")
-                .OrderByDescending(s => s.CreatedUtc)
+                .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
                 .Select(s => (double?)s.Value)
-                .FirstOrDefaultAsync();
+                .MaxAsync();
 
-            if (awayFinalScore is null || homeFinalScore is null)
+            if (awayMaxScore is null || homeMaxScore is null)
             {
                 _logger.LogInformation(
-                    "Feed competitor scores not yet available for {ContestName} (only bootstrap rows). " +
-                    "AwayFeedPresent={AwayPresent}, HomeFeedPresent={HomePresent}. Deferring to cron sweep.",
-                    contest.Name,
-                    awayFinalScore.HasValue,
-                    homeFinalScore.HasValue);
-                return;
-            }
-
-            // MLB games cannot end 0-0 in regulation — would proceed to extras
-            // until a side leads. A 0-0 "Final" is corrupt ESPN data or a
-            // sourcing-window race; defer rather than lock in a finalized 0-0
-            // contest with null Winner.
-            if (awayFinalScore.Value == 0 && homeFinalScore.Value == 0)
-            {
-                _logger.LogWarning(
-                    "MLB Final scores read as 0-0 for {ContestName} — implausible. Deferring enrichment.",
+                    "No competitor score rows for {ContestName}. Deferring to cron sweep.",
                     contest.Name);
                 return;
             }
 
-            contest.AwayScore = (int)awayFinalScore.Value;
-            contest.HomeScore = (int)homeFinalScore.Value;
+            // MLB games cannot end 0-0 in regulation — would proceed to extras
+            // until a side leads. A 0-0 result here means only the bootstrap
+            // rows exist (feed hasn't sourced yet) or genuinely-corrupt data;
+            // defer rather than lock in a finalized 0-0 contest with null
+            // Winner.
+            if (awayMaxScore.Value == 0 && homeMaxScore.Value == 0)
+            {
+                _logger.LogWarning(
+                    "MLB MAX competitor scores read as 0-0 for {ContestName} — implausible. Deferring enrichment.",
+                    contest.Name);
+                return;
+            }
+
+            contest.AwayScore = (int)awayMaxScore.Value;
+            contest.HomeScore = (int)homeMaxScore.Value;
 
             var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
             var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;

--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -92,29 +92,51 @@ namespace SportsData.Producer.Application.Contests
 
             var contest = competition.Contest;
 
-            // Baseball plays don't carry a clock for tiebreak ordering. Use the
-            // canonical CompetitionCompetitorScore record as the source of final
-            // score: prefer SourceDescription = "Final", otherwise the most recent.
+            // Exclude the bootstrap placeholder rows that get seeded for
+            // every competitor at season-start with Value=0 and
+            // SourceDescription="basic/manual" (SourceId="1"). The
+            // canonical ESPN feed records arrive later with
+            // SourceDescription="feed" (SourceId="2"). The original code's
+            // preference-then-fallback ordering would silently pick those
+            // bootstrap zeros when feed sourcing lagged STATUS_FINAL —
+            // producing a finalized 0-0 contest with null WinnerFranchiseId
+            // (the 0-0 != 0-0 branch is false). ContestEnrichmentJob cron
+            // sweep will retry once the feed rows land.
             var awayFinalScore = await _dataContext.CompetitionCompetitorScores
                 .AsNoTracking()
-                .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
-                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                .ThenByDescending(s => s.CreatedUtc)
+                .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id
+                            && s.SourceDescription != "basic/manual")
+                .OrderByDescending(s => s.CreatedUtc)
                 .Select(s => (double?)s.Value)
                 .FirstOrDefaultAsync();
 
             var homeFinalScore = await _dataContext.CompetitionCompetitorScores
                 .AsNoTracking()
-                .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
-                .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                .ThenByDescending(s => s.CreatedUtc)
+                .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id
+                            && s.SourceDescription != "basic/manual")
+                .OrderByDescending(s => s.CreatedUtc)
                 .Select(s => (double?)s.Value)
                 .FirstOrDefaultAsync();
 
             if (awayFinalScore is null || homeFinalScore is null)
             {
                 _logger.LogInformation(
-                    "No competitor scores available for {ContestName}. Data not ready for enrichment.",
+                    "Feed competitor scores not yet available for {ContestName} (only bootstrap rows). " +
+                    "AwayFeedPresent={AwayPresent}, HomeFeedPresent={HomePresent}. Deferring to cron sweep.",
+                    contest.Name,
+                    awayFinalScore.HasValue,
+                    homeFinalScore.HasValue);
+                return;
+            }
+
+            // MLB games cannot end 0-0 in regulation — would proceed to extras
+            // until a side leads. A 0-0 "Final" is corrupt ESPN data or a
+            // sourcing-window race; defer rather than lock in a finalized 0-0
+            // contest with null Winner.
+            if (awayFinalScore.Value == 0 && homeFinalScore.Value == 0)
+            {
+                _logger.LogWarning(
+                    "MLB Final scores read as 0-0 for {ContestName} — implausible. Deferring enrichment.",
                     contest.Name);
                 return;
             }

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -112,40 +112,46 @@ namespace SportsData.Producer.Application.Contests
                 }
                 else
                 {
-                    // D2 fallback when no scoring plays exist. Exclude the
-                    // season-start bootstrap rows (SourceDescription="basic/manual")
-                    // that would otherwise be silently picked as the "latest"
-                    // when ESPN feed sourcing has not caught up to STATUS_FINAL.
-                    // See the matching guard in BaseballContestEnrichmentProcessor.
-                    var awayFinalScore = await _dataContext.CompetitionCompetitorScores
+                    // D2 fallback when no scoring plays exist. MAX(Value) per
+                    // competitor — see the matching note in
+                    // BaseballContestEnrichmentProcessor. Bootstrap-row schema
+                    // differs across sports (NCAAFB updates "Basic/Manual"
+                    // in place; MLB inserts a separate "feed" row), but in
+                    // both cases MAX equals the latest known cumulative score.
+                    var awayMaxScore = await _dataContext.CompetitionCompetitorScores
                         .AsNoTracking()
-                        .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id
-                                    && s.SourceDescription != "basic/manual")
-                        .OrderByDescending(s => s.CreatedUtc)
+                        .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
                         .Select(s => (double?)s.Value)
-                        .FirstOrDefaultAsync();
+                        .MaxAsync();
 
-                    var homeFinalScore = await _dataContext.CompetitionCompetitorScores
+                    var homeMaxScore = await _dataContext.CompetitionCompetitorScores
                         .AsNoTracking()
-                        .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id
-                                    && s.SourceDescription != "basic/manual")
-                        .OrderByDescending(s => s.CreatedUtc)
+                        .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
                         .Select(s => (double?)s.Value)
-                        .FirstOrDefaultAsync();
+                        .MaxAsync();
 
-                    if (awayFinalScore is null || homeFinalScore is null)
+                    if (awayMaxScore is null || homeMaxScore is null)
                     {
                         _logger.LogInformation(
-                            "Feed competitor scores not yet available for {ContestName} (only bootstrap rows). " +
-                            "AwayFeedPresent={AwayPresent}, HomeFeedPresent={HomePresent}. Deferring to cron sweep.",
-                            contest.Name,
-                            awayFinalScore.HasValue,
-                            homeFinalScore.HasValue);
+                            "No scoring plays and no competitor score rows for {ContestName}. Deferring to cron sweep.",
+                            contest.Name);
                         return;
                     }
 
-                    contest.AwayScore = (int)awayFinalScore.Value;
-                    contest.HomeScore = (int)homeFinalScore.Value;
+                    // D2 path + 0-0 MAX = no scoring plays AND only bootstrap
+                    // rows exist. NFL hasn't had a 0-0 final since 1943 and
+                    // NCAA OT rules guarantee a non-tie; this state is
+                    // always stale data, never a legitimate final.
+                    if (awayMaxScore.Value == 0 && homeMaxScore.Value == 0)
+                    {
+                        _logger.LogWarning(
+                            "D2 MAX competitor scores read as 0-0 for {ContestName} (no scoring plays either) — implausible. Deferring enrichment.",
+                            contest.Name);
+                        return;
+                    }
+
+                    contest.AwayScore = (int)awayMaxScore.Value;
+                    contest.HomeScore = (int)homeMaxScore.Value;
                 }
 
                 var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -112,28 +112,35 @@ namespace SportsData.Producer.Application.Contests
                 }
                 else
                 {
-                    // No scoring plays — check competitor scores (D2 fallback, project to score value only)
+                    // D2 fallback when no scoring plays exist. Exclude the
+                    // season-start bootstrap rows (SourceDescription="basic/manual")
+                    // that would otherwise be silently picked as the "latest"
+                    // when ESPN feed sourcing has not caught up to STATUS_FINAL.
+                    // See the matching guard in BaseballContestEnrichmentProcessor.
                     var awayFinalScore = await _dataContext.CompetitionCompetitorScores
                         .AsNoTracking()
-                        .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
-                        .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                        .ThenByDescending(s => s.CreatedUtc)
+                        .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id
+                                    && s.SourceDescription != "basic/manual")
+                        .OrderByDescending(s => s.CreatedUtc)
                         .Select(s => (double?)s.Value)
                         .FirstOrDefaultAsync();
 
                     var homeFinalScore = await _dataContext.CompetitionCompetitorScores
                         .AsNoTracking()
-                        .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
-                        .OrderByDescending(s => s.SourceDescription == "Final" ? 1 : 0)
-                        .ThenByDescending(s => s.CreatedUtc)
+                        .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id
+                                    && s.SourceDescription != "basic/manual")
+                        .OrderByDescending(s => s.CreatedUtc)
                         .Select(s => (double?)s.Value)
                         .FirstOrDefaultAsync();
 
                     if (awayFinalScore is null || homeFinalScore is null)
                     {
                         _logger.LogInformation(
-                            "No plays or competitor scores available for {ContestName}. Data not ready for enrichment.",
-                            contest.Name);
+                            "Feed competitor scores not yet available for {ContestName} (only bootstrap rows). " +
+                            "AwayFeedPresent={AwayPresent}, HomeFeedPresent={HomePresent}. Deferring to cron sweep.",
+                            contest.Name,
+                            awayFinalScore.HasValue,
+                            homeFinalScore.HasValue);
                         return;
                     }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -236,8 +236,15 @@ public class BaseballContestEnrichmentProcessorTests
     }
 
     [Fact]
-    public async Task Process_WhenNoFinalRecord_FallsBackToMostRecent()
+    public async Task Process_WhenOnlyBootstrapRecords_DefersForCronRetry()
     {
+        // Every competitor gets a SourceDescription="basic/manual" placeholder
+        // row at season-start (Value=0). The ESPN feed inserts the real
+        // SourceDescription="feed" rows when scores actually exist. Prior
+        // buggy behavior would happily pick the bootstrap zeros when feed
+        // sourcing lagged STATUS_FINAL — producing a finalized 0-0 contest
+        // with null Winner. Fix: skip bootstrap rows; defer if that leaves
+        // nothing. ContestEnrichmentJob cron sweep retries once feed lands.
         var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
 
         var competition = await _baseballDataContext.Competitions
@@ -247,23 +254,55 @@ public class BaseballContestEnrichmentProcessorTests
         var away = competition.Competitors.First(c => c.HomeAway == "away");
         var home = competition.Competitors.First(c => c.HomeAway == "home");
 
-        var earlier = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc);
-        var later = new DateTime(2026, 4, 27, 13, 0, 0, DateTimeKind.Utc);
-
         _baseballDataContext.CompetitionCompetitorScores.AddRange(
-            CreateScore(away.Id, value: 1, sourceDescription: "Live", createdUtc: earlier),
-            CreateScore(away.Id, value: 8, sourceDescription: "Live", createdUtc: later),
-            CreateScore(home.Id, value: 2, sourceDescription: "Live", createdUtc: earlier),
-            CreateScore(home.Id, value: 3, sourceDescription: "Live", createdUtc: later));
+            CreateScore(away.Id, value: 0, sourceDescription: "basic/manual"),
+            CreateScore(home.Id, value: 0, sourceDescription: "basic/manual"));
         await _baseballDataContext.SaveChangesAsync();
 
         var command = new EnrichContestCommand(contestId, Guid.NewGuid());
         await _sut.Process(command);
 
         var contest = await _baseballDataContext.Contests.FindAsync(contestId);
-        contest!.AwayScore.Should().Be(8);
-        contest.HomeScore.Should().Be(3);
-        contest.WinnerFranchiseId.Should().Be(AwayFranchiseSeasonId);
+        contest!.AwayScore.Should().BeNull();
+        contest.HomeScore.Should().BeNull();
+        contest.WinnerFranchiseId.Should().BeNull();
+        contest.FinalizedUtc.Should().BeNull();
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenMlbFinalScoresAreZeroZero_DefersForCronRetry()
+    {
+        // MLB games cannot end 0-0 in regulation — would proceed to extras.
+        // A 0-0 "Final" is corrupt ESPN data or a sourcing-window race;
+        // defer rather than lock in a finalized 0-0 contest with null Winner.
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var competition = await _baseballDataContext.Competitions
+            .Include(c => c.Competitors)
+            .FirstAsync(c => c.Id == competitionId);
+
+        var away = competition.Competitors.First(c => c.HomeAway == "away");
+        var home = competition.Competitors.First(c => c.HomeAway == "home");
+
+        _baseballDataContext.CompetitionCompetitorScores.AddRange(
+            CreateScore(away.Id, value: 0, sourceDescription: "feed"),
+            CreateScore(home.Id, value: 0, sourceDescription: "feed"));
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.AwayScore.Should().BeNull();
+        contest.HomeScore.Should().BeNull();
+        contest.WinnerFranchiseId.Should().BeNull();
+        contest.FinalizedUtc.Should().BeNull();
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -208,8 +208,11 @@ public class BaseballContestEnrichmentProcessorTests
     }
 
     [Fact]
-    public async Task Process_PrefersFinalScoreOverNonFinalRecords()
+    public async Task Process_PicksMaxValuePerCompetitor()
     {
+        // Earlier ticks (lower values) are ignored — MAX(Value) per
+        // competitor returns the highest recorded score, which is always
+        // the latest cumulative state because game scores only ever climb.
         var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
 
         var competition = await _baseballDataContext.Competitions
@@ -219,12 +222,11 @@ public class BaseballContestEnrichmentProcessorTests
         var away = competition.Competitors.First(c => c.HomeAway == "away");
         var home = competition.Competitors.First(c => c.HomeAway == "home");
 
-        // Mid-game ticks should be ignored in favor of the "Final" record.
         _baseballDataContext.CompetitionCompetitorScores.AddRange(
-            CreateScore(away.Id, value: 2, sourceDescription: "Live"),
-            CreateScore(away.Id, value: 5, sourceDescription: "Final"),
-            CreateScore(home.Id, value: 3, sourceDescription: "Live"),
-            CreateScore(home.Id, value: 6, sourceDescription: "Final"));
+            CreateScore(away.Id, value: 2, sourceDescription: "feed"),
+            CreateScore(away.Id, value: 5, sourceDescription: "feed"),
+            CreateScore(home.Id, value: 3, sourceDescription: "feed"),
+            CreateScore(home.Id, value: 6, sourceDescription: "feed"));
         await _baseballDataContext.SaveChangesAsync();
 
         var command = new EnrichContestCommand(contestId, Guid.NewGuid());
@@ -239,12 +241,11 @@ public class BaseballContestEnrichmentProcessorTests
     public async Task Process_WhenOnlyBootstrapRecords_DefersForCronRetry()
     {
         // Every competitor gets a SourceDescription="basic/manual" placeholder
-        // row at season-start (Value=0). The ESPN feed inserts the real
-        // SourceDescription="feed" rows when scores actually exist. Prior
-        // buggy behavior would happily pick the bootstrap zeros when feed
-        // sourcing lagged STATUS_FINAL — producing a finalized 0-0 contest
-        // with null Winner. Fix: skip bootstrap rows; defer if that leaves
-        // nothing. ContestEnrichmentJob cron sweep retries once feed lands.
+        // row at season-start with Value=0. The ESPN feed later inserts (MLB)
+        // or updates in place (NCAAFB) the real score. Before that lands,
+        // MAX(Value) per competitor returns 0/0 — the MLB 0-0 sanity guard
+        // catches this and defers (MLB cannot end 0-0 in regulation).
+        // ContestEnrichmentJob cron sweep retries once feed lands.
         var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
 
         var competition = await _baseballDataContext.Competitions

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -548,7 +548,13 @@ public class BaseballContestEnrichmentProcessorTests
         Value = value,
         DisplayValue = value.ToString(),
         Winner = false,
-        SourceId = "1",
+        // Derive SourceId from sourceDescription to match production semantics
+        // (SourceId="1" + "basic/manual" is the bootstrap; SourceId="2" + "feed"
+        // is the canonical ESPN feed value). Case-insensitive to cover the
+        // NCAAFB "Basic/Manual" variant.
+        SourceId = sourceDescription.Equals("basic/manual", StringComparison.OrdinalIgnoreCase)
+            ? "1"
+            : "2",
         SourceDescription = sourceDescription,
         CreatedUtc = createdUtc ?? DateTime.UtcNow
     };


### PR DESCRIPTION
## Summary

Both `BaseballContestEnrichmentProcessor` and `FootballContestEnrichmentProcessor` (D2 fallback) used to read `CompetitionCompetitorScores` with a hardcoded preference for `SourceDescription == \"Final\"`, then fall back to the latest record. That \"Final\" magic string doesn't exist anywhere in production data, so the fallback unconditionally picked the latest row — which collapsed to the bootstrap zeros whenever `STATUS_FINAL` flipped before the canonical score feed sourced.

This PR replaces the SourceDescription dance with `MAX(Value) per competitor`, plus a 0-0 sanity guard that defers stale-data states.

## Why MAX vs the original `!= \"basic/manual\"` filter

First pass on this PR filtered out `\"basic/manual\"` rows. A round-trip through the NCAAFB database with the debug script (`sql/pgsql/_debug_MLB.sql`) exposed two showstoppers:

1. **Casing differs across sports.** MLB seeds with lowercase `\"basic/manual\"`; NCAAFB seeds with Title Case `\"Basic/Manual\"`. A case-sensitive filter lets NCAAFB bootstrap rows through.
2. **NCAAFB updates the bootstrap row in place** rather than inserting a feed row. The real final scores (9/42 in the sample I checked) live on the `\"Basic/Manual\"` row itself (`ModifiedUtc=2025-12-22`, a month after `CreatedUtc=2025-11-19`). MLB leaves the bootstrap row untouched and inserts a separate `\"feed\"` row.

A single `SourceDescription` filter can't distinguish \"bootstrap-with-real-value\" from \"bootstrap-with-placeholder-zero\" cross-sport. MAX side-steps it:
- MLB: bootstrap `Value=0` vs feed `Value=8` → MAX returns the feed value.
- NCAAFB: only the updated bootstrap row exists → MAX trivially returns its value.
- In-progress ticks only climb → MAX = latest cumulative score.

## Concrete case (the bug that surfaced this): Rockies @ Cubs, 2026-06-17

Game ended 6-8. Enrichment ran at `03:33:21 UTC` when only the `basic/manual=0` rows existed on both sides:

```
ContestId=b9c70317-d6a6-182e-e9f3-1e6a7aba1ea1
AwayScore=0, HomeScore=0, WinnerFranchiseSeasonId=null
FinalizedUtc=2026-06-18T03:33:21.4683653Z, OddsProvidersEnriched=1
```

The 0-0 != 0-0 branch skipped, so `WinnerFranchiseId` stayed null. `SpreadWinnerFranchiseId` still got computed from odds (spread ≠ 0 pushes ATS off the tie even at 0-0), producing the corruption signature: **`FinalizedUtc` + `SpreadWinner` + null `Winner`**.

Five minutes later (03:38:44 / 03:38:46) the canonical feed rows landed via `EventCompetitionCompetitorScoreDocumentProcessor`. `CompetitorScoreUpdatedConsumerHandler` corrected `Contest.HomeScore/AwayScore` to the real 6-8 — but the derived fields stay wrong forever because that consumer doesn't touch them.

## Fix

1. Read MAX(Value) per competitor from `CompetitionCompetitorScores`. No SourceDescription filter.
2. If either side has zero rows, defer.
3. **0-0 sanity guard, cross-sport**: if both MAX values are 0, defer.
   - MLB: 0-0 impossible in regulation (extras until a side leads).
   - Football D2 path: no scoring plays AND MAX=0/0 = always stale data (NFL hasn't had a 0-0 final since 1943; NCAA OT rules guarantee a non-tie).
4. Football D1 (scoring plays) path untouched — play-by-play remains the gold standard for football when available.

## Deliberately NOT changing

`CompetitorScoreUpdatedConsumerHandler` was originally going to get a `FinalizedUtc` gate. That consumer is the canonical ESPN ingestion path — the only mechanism that can ever correct an already-corrupt finalized row. Gating it would lock in any wrong enrichment forever. Repair belongs in a separate `ContestEnrichmentAuditJob` (next PR) that clears `FinalizedUtc` and re-runs enrichment on the corrupted contests.

## Test plan

- [x] All 45 enrichment processor tests pass
- [x] `Process_PicksMaxValuePerCompetitor` (renamed from `Process_PrefersFinalScoreOverNonFinalRecords`) seeds 2/5 and 3/6 feed rows, asserts MAX picks 5/6
- [x] `Process_WhenOnlyBootstrapRecords_DefersForCronRetry` seeds two `basic/manual` rows with Value=0, asserts defer via the 0-0 guard
- [x] `Process_WhenMlbFinalScoresAreZeroZero_DefersForCronRetry` covers the 0-0 sanity guard for non-bootstrap rows too
- [x] `dotnet build` clean on Producer
- [ ] Verify in prod: subsequent MLB games defer rather than finalize 0-0 when feed lag occurs

## Follow-up

- `ContestEnrichmentAuditJob` — separate PR. Detects already-corrupted contests (`FinalizedUtc IS NOT NULL AND WinnerFranchiseId IS NULL`, plus suspect 0-0 MLB finals) and re-runs enrichment after clearing `FinalizedUtc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contest final score calculation by using the maximum available competitor score values rather than relying on source/recency ordering.
  * Added stronger deferral behavior when required competitor score data is missing to avoid publishing incomplete or incorrect contest results.
  * For MLB, added a safeguard to avoid finalizing implausible 0–0 outcomes.
* **Tests**
  * Updated and expanded unit coverage to validate max-based score selection and the new deferral scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->