### PR TITLE
feat(producer): add ContestEnrichmentAuditJob

### DIFF
--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditJob.cs
@@ -1,0 +1,122 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Jobs;
+using SportsData.Core.Processing;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Contests;
+
+// Same Hangfire reflection-resolve issue that bit ContestUpdateJob and
+// ContestEnrichmentJob — register against this non-generic interface so the
+// recurring-job entry stores a stable type name across deployments.
+public interface IContestEnrichmentAuditJob
+{
+    Task ExecuteAsync();
+}
+
+/// <summary>
+/// Nightly sweep that re-verifies finalized contests against the canonical
+/// score source. Catches the
+/// "FinalizedUtc + SpreadWinner + null Winner" corruption signature
+/// (2026-06-18 Rockies @ Cubs) and anything else that drifts after the
+/// initial enrichment run.
+///
+/// Candidate set: <c>FinalizedUtc IS NOT NULL AND AuditedUtc IS NULL</c>.
+/// Steady-state, that is yesterday's newly-finalized contests; first-run
+/// after deploy is the entire backlog of historical finalized contests,
+/// which is why the batch is capped — additional candidates roll over to
+/// the next firing.
+///
+/// Fan-out: enqueues one <see cref="IAuditContestEnrichment"/> per contest
+/// so audits parallelize across Hangfire workers. The per-contest
+/// processor handles match/mismatch/stale-source logic; this sweep is just
+/// the candidate scanner.
+///
+/// Also exposed via the Hangfire dashboard for manual triggering when
+/// chasing a specific corruption.
+/// </summary>
+public class ContestEnrichmentAuditJob<TDataContext> : IContestEnrichmentAuditJob, IAmARecurringJob
+    where TDataContext : TeamSportDataContext
+{
+    // Cap the per-firing fan-out so the first-run backlog doesn't enqueue
+    // tens of thousands of Hangfire jobs at once. Tomorrow's firing picks
+    // up where today's left off. Tuned against the ContestEnrichmentJob
+    // sweep cadence so the two don't compete for the same worker pool.
+    private const int BatchSize = 500;
+
+    private readonly ILogger<ContestEnrichmentAuditJob<TDataContext>> _logger;
+    private readonly TDataContext _dataContext;
+    private readonly IProvideBackgroundJobs _backgroundJobProvider;
+
+    public ContestEnrichmentAuditJob(
+        ILogger<ContestEnrichmentAuditJob<TDataContext>> logger,
+        TDataContext dataContext,
+        IProvideBackgroundJobs backgroundJobProvider)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _backgroundJobProvider = backgroundJobProvider;
+    }
+
+    public async Task ExecuteAsync()
+    {
+        var jobRunId = Guid.NewGuid();
+
+        using var _ = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["JobName"] = "ContestEnrichmentAuditJob",
+            ["JobRunId"] = jobRunId
+        });
+
+        _logger.LogInformation(
+            "ContestEnrichmentAuditJob starting. JobRunId={JobRunId}, BatchSize={BatchSize}",
+            jobRunId, BatchSize);
+
+        // Order by FinalizedUtc so the oldest unverified finalizations are
+        // audited first — keeps the backlog draining predictably during
+        // the post-deploy ramp.
+        var contestIds = await _dataContext.Contests
+            .AsNoTracking()
+            .Where(c => c.FinalizedUtc != null && c.AuditedUtc == null)
+            .OrderBy(c => c.FinalizedUtc)
+            .Take(BatchSize)
+            .Select(c => c.Id)
+            .ToListAsync();
+
+        _logger.LogInformation(
+            "ContestEnrichmentAuditJob: {ContestCount} pending audit candidate(s) in this batch. JobRunId={JobRunId}",
+            contestIds.Count, jobRunId);
+
+        if (contestIds.Count == 0)
+        {
+            return;
+        }
+
+        var totalEnqueued = 0;
+        var totalSkipped = 0;
+
+        foreach (var contestId in contestIds)
+        {
+            try
+            {
+                var cmd = new AuditContestEnrichmentCommand(contestId, Guid.NewGuid());
+                _backgroundJobProvider.Enqueue<IAuditContestEnrichment>(p => p.Process(cmd));
+                totalEnqueued++;
+            }
+            catch (Exception ex)
+            {
+                totalSkipped++;
+                _logger.LogError(
+                    ex,
+                    "Failed to enqueue audit. ContestId={ContestId}",
+                    contestId);
+            }
+        }
+
+        _logger.LogInformation(
+            "ContestEnrichmentAuditJob completed. JobRunId={JobRunId}, " +
+            "TotalEnqueued={TotalEnqueued}, TotalSkipped={TotalSkipped}",
+            jobRunId, totalEnqueued, totalSkipped);
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
@@ -114,11 +114,10 @@ public class ContestEnrichmentAuditProcessor<TDataContext> : IAuditContestEnrich
             .Select(s => (double?)s.Value)
             .MaxAsync();
 
-        // Stale-source guard. If either side has no score rows at all, OR
-        // both MAX values are 0 (bootstrap-only race, MLB cannot end 0-0,
-        // NFL has not had a 0-0 final since 1943), the canonical source
-        // cannot validate this contest. Don't stamp AuditedUtc — next
-        // sweep retries. Warning is the human-eyes signal if it persists.
+        // No-rows guard. If either side has no score rows at all, the
+        // canonical source cannot validate this contest. Don't stamp
+        // AuditedUtc — next sweep retries. Warning is the human-eyes signal
+        // if it persists.
         if (awayMaxScore is null || homeMaxScore is null)
         {
             _logger.LogWarning(
@@ -127,10 +126,19 @@ public class ContestEnrichmentAuditProcessor<TDataContext> : IAuditContestEnrich
             return;
         }
 
-        if (awayMaxScore.Value == 0 && homeMaxScore.Value == 0)
+        // MLB-specific 0-0 guard: extra innings until a side leads, so a
+        // 0-0 "final" can only mean bootstrap-only data hasn't been replaced
+        // by the canonical feed yet. Football is exempt: NFL hasn't had a
+        // 0-0 final since 1943 and NCAA OT rules guarantee a non-tie, so a
+        // football 0-0 audit candidate is effectively impossible to begin
+        // with (enrichment's D1 + D2 guards reject 0-0 too). Scoping this
+        // to MLB matches the underlying reasoning instead of relying on
+        // "essentially impossible" upstream.
+        if (contest.Sport == Sport.BaseballMlb
+            && awayMaxScore.Value == 0 && homeMaxScore.Value == 0)
         {
             _logger.LogWarning(
-                "Audit deferred — MAX competitor scores are 0-0 (canonical source still stale). ContestId={ContestId}, ContestName={ContestName}",
+                "Audit deferred — MLB MAX competitor scores are 0-0 (canonical source still stale). ContestId={ContestId}, ContestName={ContestName}",
                 command.ContestId, contest.Name);
             return;
         }

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
@@ -175,10 +175,20 @@ public class ContestEnrichmentAuditProcessor<TDataContext> : IAuditContestEnrich
             contest.AwayScore, contest.HomeScore, contest.WinnerFranchiseId,
             expectedAway, expectedHome, expectedWinner);
 
+        // Enqueue BEFORE SaveChangesAsync. If Enqueue throws, FinalizedUtc
+        // stays in its prior state and the next audit sweep retries cleanly.
+        // If Enqueue succeeds but SaveChangesAsync throws, the queued
+        // enrichment fires harmlessly — the processor's FinalizedUtc != null
+        // early-exit short-circuits it — and the next audit sweep re-attempts
+        // the pair. The reverse order would orphan the row in an unfinalized
+        // state with no re-enrichment queued; ContestEnrichmentJob would
+        // eventually catch it, but that's a weekly cadence — long lag for
+        // no benefit.
         contest.FinalizedUtc = null;
-        await _dataContext.SaveChangesAsync();
 
         var enrichCmd = new EnrichContestCommand(command.ContestId, command.CorrelationId);
         _backgroundJobProvider.Enqueue<IEnrichContests>(p => p.Process(enrichCmd));
+
+        await _dataContext.SaveChangesAsync();
     }
 }

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
@@ -1,0 +1,184 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Contests;
+
+public interface IAuditContestEnrichment
+{
+    Task Process(AuditContestEnrichmentCommand command);
+}
+
+public record AuditContestEnrichmentCommand(Guid ContestId, Guid CorrelationId);
+
+/// <summary>
+/// Per-contest auditor. Verifies that the current Contest row's scores +
+/// derived winner match what re-running the enrichment processor would
+/// produce now (MAX(Value) per competitor against
+/// <c>CompetitionCompetitorScores</c>). Three outcomes:
+///   - Match: stamp <c>AuditedUtc</c>, done.
+///   - Mismatch: clear <c>FinalizedUtc</c>, enqueue
+///     <see cref="IEnrichContests"/> so the hardened enrichment processor
+///     re-derives everything (scores, winner, spread winner, over/under,
+///     per-provider odds enrichment) and publishes <c>ContestFinalized</c>
+///     itself on success. Do NOT stamp <c>AuditedUtc</c> on this path —
+///     the next sweep validates after re-enrichment lands.
+///   - Stale source (MAX=null on either side or 0-0 sanity): log warning,
+///     leave both <c>FinalizedUtc</c> and <c>AuditedUtc</c> intact. Next
+///     sweep retries; if the source stays bad, that is the human-eyes
+///     signal flagged by the warning.
+///
+/// Spawned per-contest by <see cref="IContestEnrichmentAuditJob"/> so
+/// audits fan out across Hangfire workers instead of one long-running
+/// sweep.
+/// </summary>
+public class ContestEnrichmentAuditProcessor<TDataContext> : IAuditContestEnrichment
+    where TDataContext : TeamSportDataContext
+{
+    private readonly ILogger<ContestEnrichmentAuditProcessor<TDataContext>> _logger;
+    private readonly TDataContext _dataContext;
+    private readonly IProvideBackgroundJobs _backgroundJobProvider;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public ContestEnrichmentAuditProcessor(
+        ILogger<ContestEnrichmentAuditProcessor<TDataContext>> logger,
+        TDataContext dataContext,
+        IProvideBackgroundJobs backgroundJobProvider,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _backgroundJobProvider = backgroundJobProvider;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task Process(AuditContestEnrichmentCommand command)
+    {
+        using var _ = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["ContestId"] = command.ContestId,
+            ["CorrelationId"] = command.CorrelationId
+        });
+
+        var competition = await _dataContext.Competitions
+            .Include(c => c.Competitors)
+            .Include(c => c.Contest)
+            .Where(c => c.ContestId == command.ContestId)
+            .FirstOrDefaultAsync();
+
+        if (competition is null)
+        {
+            _logger.LogWarning(
+                "Audit skipped — competition not found. ContestId={ContestId}",
+                command.ContestId);
+            return;
+        }
+
+        var contest = competition.Contest;
+
+        // Race-protect against the same contest being un-finalized between
+        // the sweep's candidate scan and this per-contest run.
+        if (contest.FinalizedUtc is null)
+        {
+            _logger.LogInformation(
+                "Audit skipped — Contest no longer finalized. ContestId={ContestId}",
+                command.ContestId);
+            return;
+        }
+
+        var awayCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "away");
+        var homeCompetitor = competition.Competitors.FirstOrDefault(c => c.HomeAway == "home");
+
+        if (awayCompetitor is null || homeCompetitor is null)
+        {
+            _logger.LogWarning(
+                "Audit skipped — Competition missing away or home competitor. ContestId={ContestId}",
+                command.ContestId);
+            return;
+        }
+
+        // Same MAX(Value) read pattern the enrichment processor now uses
+        // (PR #431). Keeps detection and re-enrichment using identical
+        // source semantics so they cannot diverge.
+        var awayMaxScore = await _dataContext.CompetitionCompetitorScores
+            .AsNoTracking()
+            .Where(s => s.CompetitionCompetitorId == awayCompetitor.Id)
+            .Select(s => (double?)s.Value)
+            .MaxAsync();
+
+        var homeMaxScore = await _dataContext.CompetitionCompetitorScores
+            .AsNoTracking()
+            .Where(s => s.CompetitionCompetitorId == homeCompetitor.Id)
+            .Select(s => (double?)s.Value)
+            .MaxAsync();
+
+        // Stale-source guard. If either side has no score rows at all, OR
+        // both MAX values are 0 (bootstrap-only race, MLB cannot end 0-0,
+        // NFL has not had a 0-0 final since 1943), the canonical source
+        // cannot validate this contest. Don't stamp AuditedUtc — next
+        // sweep retries. Warning is the human-eyes signal if it persists.
+        if (awayMaxScore is null || homeMaxScore is null)
+        {
+            _logger.LogWarning(
+                "Audit deferred — no competitor score rows. ContestId={ContestId}, ContestName={ContestName}",
+                command.ContestId, contest.Name);
+            return;
+        }
+
+        if (awayMaxScore.Value == 0 && homeMaxScore.Value == 0)
+        {
+            _logger.LogWarning(
+                "Audit deferred — MAX competitor scores are 0-0 (canonical source still stale). ContestId={ContestId}, ContestName={ContestName}",
+                command.ContestId, contest.Name);
+            return;
+        }
+
+        var expectedAway = (int)awayMaxScore.Value;
+        var expectedHome = (int)homeMaxScore.Value;
+
+        // Winner derivation mirrors the enrichment processor's branch:
+        // null on a tie, otherwise the franchise season of the higher score.
+        Guid? expectedWinner = null;
+        if (expectedAway != expectedHome)
+        {
+            expectedWinner = expectedAway < expectedHome
+                ? homeCompetitor.FranchiseSeasonId
+                : awayCompetitor.FranchiseSeasonId;
+        }
+
+        var scoresMatch = contest.AwayScore == expectedAway && contest.HomeScore == expectedHome;
+        var winnerMatches = contest.WinnerFranchiseId == expectedWinner;
+
+        if (scoresMatch && winnerMatches)
+        {
+            contest.AuditedUtc = _dateTimeProvider.UtcNow();
+            await _dataContext.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "Audit passed — stamped AuditedUtc. ContestId={ContestId}, ContestName={ContestName}, AwayScore={Away}, HomeScore={Home}",
+                command.ContestId, contest.Name, expectedAway, expectedHome);
+            return;
+        }
+
+        // Mismatch — clear FinalizedUtc and enqueue re-enrichment. The
+        // enrichment processor's early-exit on FinalizedUtc != null is
+        // the same guard that would otherwise no-op a re-run. AuditedUtc
+        // stays null; next sweep validates after enrichment lands.
+        _logger.LogWarning(
+            "Audit mismatch — clearing FinalizedUtc and enqueuing re-enrichment. " +
+            "ContestId={ContestId}, ContestName={ContestName}, " +
+            "Current: Away={CurrentAway}, Home={CurrentHome}, Winner={CurrentWinner}; " +
+            "Expected: Away={ExpectedAway}, Home={ExpectedHome}, Winner={ExpectedWinner}",
+            command.ContestId, contest.Name,
+            contest.AwayScore, contest.HomeScore, contest.WinnerFranchiseId,
+            expectedAway, expectedHome, expectedWinner);
+
+        contest.FinalizedUtc = null;
+        await _dataContext.SaveChangesAsync();
+
+        var enrichCmd = new EnrichContestCommand(command.ContestId, command.CorrelationId);
+        _backgroundJobProvider.Enqueue<IEnrichContests>(p => p.Process(enrichCmd));
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -210,10 +210,14 @@ namespace SportsData.Producer.DependencyInjection
                 case Sport.FootballNfl:
                     services.AddScoped<IEnrichContests, FootballContestEnrichmentProcessor>();
                     services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<FootballDataContext>>();
+                    services.AddScoped<IAuditContestEnrichment, ContestEnrichmentAuditProcessor<FootballDataContext>>();
+                    services.AddScoped<IContestEnrichmentAuditJob, ContestEnrichmentAuditJob<FootballDataContext>>();
                     break;
                 case Sport.BaseballMlb:
                     services.AddScoped<IEnrichContests, BaseballContestEnrichmentProcessor>();
                     services.AddScoped<IContestEnrichmentJob, ContestEnrichmentJob<BaseballDataContext>>();
+                    services.AddScoped<IAuditContestEnrichment, ContestEnrichmentAuditProcessor<BaseballDataContext>>();
+                    services.AddScoped<IContestEnrichmentAuditJob, ContestEnrichmentAuditJob<BaseballDataContext>>();
                     break;
             }
 
@@ -390,6 +394,15 @@ namespace SportsData.Producer.DependencyInjection
                     "ContestEnrichmentJob",
                     job => job.ExecuteAsync(),
                     Cron.Weekly);
+
+                // Nightly at 06:00 UTC — after all US prime-time games have
+                // ended and any post-game enrichment lag has resolved. Picks
+                // up corruption like the 2026-06-18 Rockies @ Cubs case
+                // (FinalizedUtc + null Winner from a stale-source race).
+                recurringJobManager.AddOrUpdate<IContestEnrichmentAuditJob>(
+                    "ContestEnrichmentAuditJob",
+                    job => job.ExecuteAsync(),
+                    "0 6 * * *");
             }
 
             if (mode is Sport.FootballNcaa or Sport.FootballNfl or Sport.BaseballMlb)

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
@@ -71,6 +71,16 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
         // these from future runs. See docs/contest-enrichment-historical-sweep.md.
         public DateTime? CancelledUtc { get; set; }
 
+        // === Audit ===
+        // Stamped by ContestEnrichmentAuditJob after it verifies that the
+        // current Contest state (scores, winner) matches what re-running the
+        // enrichment processor would produce now. Acts as an idempotency
+        // flag so the nightly audit sweep does not re-check the same
+        // finalized contest forever once it has been validated.
+        // Cleared (null) means "needs audit" — either never audited, or
+        // a prior audit found a mismatch that triggered re-enrichment.
+        public DateTime? AuditedUtc { get; set; }
+
         // === Helpers (not mapped to DB) ===
         [NotMapped]
         public bool IsFinal => FinalizedUtc.HasValue;
@@ -120,6 +130,14 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
                 // Backfill paths in ContestUpdateJob/ContestEnrichmentJob filter
                 // by SeasonYear; index avoids a full Contest scan during runs.
                 builder.HasIndex(x => x.SeasonYear);
+
+                // Filtered index for ContestEnrichmentAuditJob's batch scan.
+                // Steady-state, the audit candidate set is tiny (yesterday's
+                // newly-finalized contests); the index keeps the nightly scan
+                // O(candidates) instead of scanning the whole Contest table.
+                builder.HasIndex(x => x.FinalizedUtc)
+                    .HasFilter("\"FinalizedUtc\" IS NOT NULL AND \"AuditedUtc\" IS NULL")
+                    .HasDatabaseName("IX_Contest_AuditedUtc_Pending");
 
                 builder.Property(x => x.SeasonPhaseId);
 

--- a/src/SportsData.Producer/Migrations/Baseball/20260618125805_AddContestAuditedUtc.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260618125805_AddContestAuditedUtc.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Football
+namespace SportsData.Producer.Migrations.Baseball
 {
-    [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(BaseballDataContext))]
+    [Migration("20260618125805_AddContestAuditedUtc")]
+    partial class AddContestAuditedUtc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,6 +415,233 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("ConfigurationId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("Season")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SeasonType")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SplitTypeId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
+
+                    b.ToTable("AthleteSeasonHotZone", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("AtBats")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("AthleteSeasonHotZoneId")
+                        .HasColumnType("uuid");
+
+                    b.Property<double?>("BattingAvg")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("BattingAvgScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("Hits")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<double?>("Slugging")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("SluggingScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("ZoneId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonHotZoneId");
+
+                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("AthleteRef")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("CompetitionStatusId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasColumnType("text");
+
+                    b.Property<string>("TeamRef")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionStatusId");
+
+                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionCompetitorId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("EspnPlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId");
+
+                    b.HasIndex("CompetitionCompetitorId", "Name")
+                        .IsUnique();
+
+                    b.ToTable("CompetitionCompetitorProbable", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3021,206 +3251,6 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("CompetitionCompetitorStatisticStats");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Description")
-                        .IsRequired()
-                        .HasMaxLength(250)
-                        .HasColumnType("character varying(250)");
-
-                    b.Property<string>("DisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("EndClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("EndClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("EndDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("EndPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("EndShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("EndText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("EndYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsScore")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("OffensivePlays")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Result")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SequenceNumber")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("ShortDisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SourceDescription")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("SourceId")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("StartClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("StartClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("StartDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("StartFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("StartPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("StartShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StartText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("StartYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("TimeElapsedDisplay")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("TimeElapsedValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("Yards")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionId");
-
-                    b.ToTable("CompetitionDrive", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("DriveId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Provider")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SourceUrl")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("SourceUrlHash")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Value")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DriveId");
-
-                    b.ToTable("CompetitionDriveExternalId", (string)null);
-                });
-
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
                 {
                     b.Property<Guid>("Id")
@@ -4042,6 +4072,65 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("CompetitionPlayId");
 
                     b.ToTable("CompetitionPlayExternalId", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionPlayId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Discriminator")
+                        .IsRequired()
+                        .HasMaxLength(34)
+                        .HasColumnType("character varying(34)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Order")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("PositionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasMaxLength(32)
+                        .HasColumnType("character varying(32)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId");
+
+                    b.HasIndex("PositionId");
+
+                    b.HasIndex("CompetitionPlayId", "Type");
+
+                    b.ToTable("CompetitionPlayParticipant", (string)null);
+
+                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionPlayParticipantBase");
+
+                    b.UseTphMappingStrategy();
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPowerIndex", b =>
@@ -7907,9 +7996,17 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -7920,99 +8017,247 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("ThrowsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("ThrowsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("FootballAthlete");
+                    b.HasDiscriminator().HasValue("BaseballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
+                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetition");
+                    b.Property<int?>("CurrentSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("CurrentSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("CurrentSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CurrentSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("CurrentSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EspnSeriesId")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("SeasonSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("SeasonSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("SeasonSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SeasonSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("SeasonSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.HasIndex("EspnSeriesId");
+
+                    b.HasDiscriminator().HasValue("BaseballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.Property<int?>("CuratedRankCurrent")
-                        .HasColumnType("integer");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<string>("ClockDisplayValue")
+                    b.Property<Guid?>("AtBatAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("AtBatId")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<double>("ClockValue")
+                    b.Property<int?>("AtBatPitchNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayHits")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("BatOrder")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("HalfInning")
+                        .HasMaxLength(8)
+                        .HasColumnType("character varying(8)");
+
+                    b.Property<double?>("HitCoordinateX")
+                        .HasPrecision(7, 2)
                         .HasColumnType("double precision");
 
-                    b.Property<Guid?>("DriveId")
+                    b.Property<double?>("HitCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("HomeErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("HomeHits")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsDoublePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsTriplePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsValid")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("Outs")
+                        .HasColumnType("integer");
+
+                    b.Property<double?>("PitchCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("PitchCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("PitchCountBalls")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("PitchCountStrikes")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PitchTypeAbbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<string>("PitchTypeId")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<string>("PitchTypeText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int?>("PitchVelocity")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PitchesAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("PitchesType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<Guid?>("PitchingAthleteSeasonId")
                         .HasColumnType("uuid");
 
-                    b.Property<int?>("EndDistance")
+                    b.Property<int>("RbiCount")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndDown")
+                    b.Property<int?>("ResultCountBalls")
                         .HasColumnType("integer");
 
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("EndYardLine")
+                    b.Property<int?>("ResultCountStrikes")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndYardsToEndzone")
-                        .HasColumnType("integer");
+                    b.Property<string>("StrikeType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
-                    b.Property<int?>("StartDistance")
-                        .HasColumnType("integer");
+                    b.Property<string>("SummaryType")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
 
-                    b.Property<int?>("StartDown")
-                        .HasColumnType("integer");
+                    b.Property<string>("Trajectory")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
 
-                    b.Property<int?>("StartYardLine")
-                        .HasColumnType("integer");
+                    b.Property<DateTime?>("Wallclock")
+                        .HasColumnType("timestamp with time zone");
 
-                    b.Property<int?>("StartYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("StatYardage")
-                        .HasColumnType("integer");
-
-                    b.HasIndex("DriveId");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
+                {
+                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase");
+
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlayParticipant");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+
+                    b.Property<int?>("HalfInning")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PeriodPrefix")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("FootballContest");
+                    b.HasDiscriminator().HasValue("BaseballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8045,6 +8290,47 @@ namespace SportsData.Producer.Migrations.Football
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
+                        .WithMany("Entries")
+                        .HasForeignKey("AthleteSeasonHotZoneId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("HotZone");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
+                        .WithMany("FeaturedAthletes")
+                        .HasForeignKey("CompetitionStatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionStatus");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "AthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("AthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", "CompetitionCompetitor")
+                        .WithMany("Probables")
+                        .HasForeignKey("CompetitionCompetitorId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("AthleteSeason");
+
+                    b.Navigation("CompetitionCompetitor");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8629,34 +8915,6 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
-                        .WithMany()
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
-                        .WithMany("Drives")
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Competition");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("ExternalIds")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9569,7 +9827,7 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9578,36 +9836,40 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("Plays")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade);
-
-                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", "CompetitionPlay")
+                        .WithMany("Participants")
+                        .HasForeignKey("CompetitionPlayId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionPlay");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9619,6 +9881,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -9772,13 +10039,6 @@ namespace SportsData.Producer.Migrations.Football
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Navigation("ExternalIds");
-
-                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -9971,16 +10231,29 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.Navigation("Drives");
-
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+                {
+                    b.Navigation("Probables");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+                {
+                    b.Navigation("Participants");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.Navigation("FeaturedAthletes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Baseball/20260618125805_AddContestAuditedUtc.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260618125805_AddContestAuditedUtc.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class AddContestAuditedUtc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AuditedUtc",
+                table: "Contest",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Contest_AuditedUtc_Pending",
+                table: "Contest",
+                column: "FinalizedUtc",
+                filter: "\"FinalizedUtc\" IS NOT NULL AND \"AuditedUtc\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Contest_AuditedUtc_Pending",
+                table: "Contest");
+
+            migrationBuilder.DropColumn(
+                name: "AuditedUtc",
+                table: "Contest");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
@@ -4636,6 +4636,9 @@ namespace SportsData.Producer.Migrations.Baseball
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
+                    b.Property<DateTime?>("AuditedUtc")
+                        .HasColumnType("timestamp with time zone");
+
                     b.Property<int?>("AwayScore")
                         .HasColumnType("integer");
 
@@ -4724,6 +4727,10 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("AwayTeamFranchiseSeasonId");
+
+                    b.HasIndex("FinalizedUtc")
+                        .HasDatabaseName("IX_Contest_AuditedUtc_Pending")
+                        .HasFilter("\"FinalizedUtc\" IS NOT NULL AND \"AuditedUtc\" IS NULL");
 
                     b.HasIndex("HomeTeamFranchiseSeasonId");
 

--- a/src/SportsData.Producer/Migrations/Football/20260618125904_AddContestAuditedUtc.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260618125904_AddContestAuditedUtc.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260618125904_AddContestAuditedUtc")]
+    partial class AddContestAuditedUtc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260618125904_AddContestAuditedUtc.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260618125904_AddContestAuditedUtc.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class AddContestAuditedUtc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AuditedUtc",
+                table: "Contest",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Contest_AuditedUtc_Pending",
+                table: "Contest",
+                column: "FinalizedUtc",
+                filter: "\"FinalizedUtc\" IS NOT NULL AND \"AuditedUtc\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Contest_AuditedUtc_Pending",
+                table: "Contest");
+
+            migrationBuilder.DropColumn(
+                name: "AuditedUtc",
+                table: "Contest");
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
@@ -85,6 +85,39 @@ public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichment
     }
 
     [Fact]
+    public async Task Execute_RespectsBatchSizeCap_EnqueuesOldestFiveHundredOnly()
+    {
+        // Regression lock on the BatchSize cap (500) — prevents the first-run
+        // historical backlog from enqueuing tens of thousands of Hangfire jobs
+        // at once. Seed 600 candidates with monotonically-increasing
+        // FinalizedUtc so the expected enqueue set is the oldest 500, and the
+        // 100 newest get deferred to the next firing.
+        const int totalCandidates = 600;
+        const int expectedBatchSize = 500;
+
+        var seededIds = new List<Guid>();
+        for (var i = 0; i < totalCandidates; i++)
+        {
+            var id = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-totalCandidates + i));
+            seededIds.Add(id);
+        }
+        var expectedOldest = seededIds.Take(expectedBatchSize).ToList();
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IAuditContestEnrichment>(It.IsAny<Expression<Func<IAuditContestEnrichment, Task>>>()))
+            .Callback<Expression<Func<IAuditContestEnrichment, Task>>>(expr =>
+                enqueued.Add(AuditContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentAuditJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        enqueued.Should().HaveCount(expectedBatchSize);
+        enqueued.Should().Equal(expectedOldest);
+    }
+
+    [Fact]
     public async Task Execute_NoCandidates_ReturnsCleanlyWithoutEnqueuing()
     {
         await SeedContestAsync(finalizedUtc: null);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Contests;
+using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests;
+
+[Collection("Sequential")]
+public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichmentAuditJob<FootballDataContext>>
+{
+    private static readonly DateTime FixedNow =
+        new(2026, 6, 19, 6, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Execute_EnqueuesOnePerCandidate_OldestFinalizedFirst()
+    {
+        // Three legitimate candidates: FinalizedUtc set, AuditedUtc null.
+        // Seed in non-chronological order to verify ordering is by FinalizedUtc asc.
+        var middleId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-5));
+        var oldestId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-30));
+        var newestId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-1));
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IAuditContestEnrichment>(It.IsAny<Expression<Func<IAuditContestEnrichment, Task>>>()))
+            .Callback<Expression<Func<IAuditContestEnrichment, Task>>>(expr =>
+                enqueued.Add(AuditContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentAuditJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        enqueued.Should().Equal(oldestId, middleId, newestId);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsContestsAlreadyAudited()
+    {
+        var alreadyAuditedId = await SeedContestAsync(
+            finalizedUtc: FixedNow.AddDays(-10),
+            auditedUtc: FixedNow.AddDays(-1));
+        var pendingId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-5));
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IAuditContestEnrichment>(It.IsAny<Expression<Func<IAuditContestEnrichment, Task>>>()))
+            .Callback<Expression<Func<IAuditContestEnrichment, Task>>>(expr =>
+                enqueued.Add(AuditContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentAuditJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        enqueued.Should().ContainSingle().Which.Should().Be(pendingId);
+        enqueued.Should().NotContain(alreadyAuditedId);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsContestsNotYetFinalized()
+    {
+        var unfinalizedId = await SeedContestAsync(finalizedUtc: null);
+        var finalizedId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-1));
+
+        var enqueued = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IAuditContestEnrichment>(It.IsAny<Expression<Func<IAuditContestEnrichment, Task>>>()))
+            .Callback<Expression<Func<IAuditContestEnrichment, Task>>>(expr =>
+                enqueued.Add(AuditContestIdFromExpression(expr) ?? Guid.Empty));
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentAuditJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        enqueued.Should().ContainSingle().Which.Should().Be(finalizedId);
+        enqueued.Should().NotContain(unfinalizedId);
+    }
+
+    [Fact]
+    public async Task Execute_NoCandidates_ReturnsCleanlyWithoutEnqueuing()
+    {
+        await SeedContestAsync(finalizedUtc: null);
+        await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-1), auditedUtc: FixedNow);
+
+        var sut = Mocker.CreateInstance<ContestEnrichmentAuditJob<FootballDataContext>>();
+
+        await sut.ExecuteAsync();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IAuditContestEnrichment>(It.IsAny<Expression<Func<IAuditContestEnrichment, Task>>>()),
+            Times.Never);
+    }
+
+    private async Task<Guid> SeedContestAsync(
+        DateTime? finalizedUtc = null,
+        DateTime? auditedUtc = null)
+    {
+        var contest = new FootballContest
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Contest {Guid.NewGuid():N}",
+            ShortName = "TC",
+            Sport = Sport.FootballNcaa,
+            SeasonYear = 2025,
+            StartDateUtc = FixedNow.AddDays(-30),
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            FinalizedUtc = finalizedUtc,
+            AuditedUtc = auditedUtc,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.SaveChangesAsync();
+        return contest.Id;
+    }
+
+    private static Guid? AuditContestIdFromExpression(
+        Expression<Func<IAuditContestEnrichment, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        if (call.Method.Name != nameof(IAuditContestEnrichment.Process)) return null;
+        if (call.Arguments.Count != 1) return null;
+
+        var cmd = Expression.Lambda<Func<AuditContestEnrichmentCommand>>(call.Arguments[0]).Compile()();
+        return cmd.ContestId;
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
@@ -127,14 +127,16 @@ public class ContestEnrichmentAuditProcessorTests
     }
 
     [Fact]
-    public async Task Process_WhenMaxScoresAreZeroZero_DefersAndLeavesContestUntouched()
+    public async Task Process_WhenMlbMaxScoresAreZeroZero_DefersAndLeavesContestUntouched()
     {
         // Bootstrap-only race — only the basic/manual placeholder rows exist
-        // (Value=0). Audit cannot verify a 0-0 state, so it defers; next
-        // sweep retries once the canonical feed lands.
+        // (Value=0). MLB cannot end 0-0 in regulation, so the audit cannot
+        // verify a 0-0 state and defers; next sweep retries once the
+        // canonical feed lands.
         var (contestId, _, away, home) = await SeedFinalizedContestAsync(
             currentAway: 0, currentHome: 0,
-            currentWinner: null);
+            currentWinner: null,
+            sport: Sport.BaseballMlb);
         await SeedScoreAsync(away.Id, value: 0);
         await SeedScoreAsync(home.Id, value: 0);
 
@@ -143,6 +145,32 @@ public class ContestEnrichmentAuditProcessorTests
         var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
         contest.FinalizedUtc.Should().NotBeNull();
         contest.AuditedUtc.Should().BeNull();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenNonMlbMaxScoresAreZeroZero_StampsAuditedUtc()
+    {
+        // Football is exempt from the MLB-specific 0-0 guard. A theoretical
+        // 0-0 football final passes through and gets audited normally — if
+        // current scores and (null) winner match expected, stamp AuditedUtc.
+        // Codifies the sport-scoped guard intent so a future change to
+        // tighten the universal check would be caught here.
+        var (contestId, _, away, home) = await SeedFinalizedContestAsync(
+            currentAway: 0, currentHome: 0,
+            currentWinner: null,
+            sport: Sport.FootballNcaa);
+        await SeedScoreAsync(away.Id, value: 0);
+        await SeedScoreAsync(home.Id, value: 0);
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.FinalizedUtc.Should().NotBeNull();
+        contest.AuditedUtc.Should().Be(FixedNow);
 
         Mocker.GetMock<IProvideBackgroundJobs>().Verify(
             x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
@@ -191,7 +219,8 @@ public class ContestEnrichmentAuditProcessorTests
         SeedFinalizedContestAsync(
             int? currentAway,
             int? currentHome,
-            Guid? currentWinner)
+            Guid? currentWinner,
+            Sport sport = Sport.FootballNcaa)
     {
         var contestId = Guid.NewGuid();
         var competitionId = Guid.NewGuid();
@@ -201,7 +230,7 @@ public class ContestEnrichmentAuditProcessorTests
             Id = contestId,
             Name = $"Contest {Guid.NewGuid():N}",
             ShortName = "TC",
-            Sport = Sport.FootballNcaa,
+            Sport = sport,
             SeasonYear = 2025,
             StartDateUtc = FixedNow.AddDays(-1),
             HomeTeamFranchiseSeasonId = HomeFranchiseSeasonId,

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
@@ -1,0 +1,274 @@
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Contests;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests;
+
+[Collection("Sequential")]
+public class ContestEnrichmentAuditProcessorTests
+    : ProducerTestBase<ContestEnrichmentAuditProcessor<FootballDataContext>>
+{
+    private static readonly DateTime FixedNow =
+        new(2026, 6, 19, 6, 0, 0, DateTimeKind.Utc);
+
+    private static readonly Guid AwayFranchiseSeasonId = Guid.NewGuid();
+    private static readonly Guid HomeFranchiseSeasonId = Guid.NewGuid();
+
+    private readonly ContestEnrichmentAuditProcessor<FootballDataContext> _sut;
+
+    public ContestEnrichmentAuditProcessorTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+
+        _sut = Mocker.CreateInstance<ContestEnrichmentAuditProcessor<FootballDataContext>>();
+    }
+
+    [Fact]
+    public async Task Process_WhenScoresAndWinnerMatch_StampsAuditedUtc()
+    {
+        var (contestId, _, away, home) = await SeedFinalizedContestAsync(
+            currentAway: 14, currentHome: 21,
+            currentWinner: HomeFranchiseSeasonId);
+        await SeedScoreAsync(away.Id, value: 14);
+        await SeedScoreAsync(home.Id, value: 21);
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.AuditedUtc.Should().Be(FixedNow);
+        contest.FinalizedUtc.Should().NotBeNull();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenScoresMismatch_ClearsFinalizedUtcAndEnqueuesReenrichment()
+    {
+        // The 2026-06-18 Rockies @ Cubs corruption signature: Contest carries
+        // stale 0-0 scores + null Winner, but MAX(CCS) shows the real 6-8.
+        var (contestId, _, away, home) = await SeedFinalizedContestAsync(
+            currentAway: 0, currentHome: 0,
+            currentWinner: null);
+        await SeedScoreAsync(away.Id, value: 6);
+        await SeedScoreAsync(home.Id, value: 8);
+
+        var enqueuedContestIds = new List<Guid>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()))
+            .Callback<Expression<Func<IEnrichContests, Task>>>(expr =>
+                enqueuedContestIds.Add(EnrichContestIdFromExpression(expr) ?? Guid.Empty));
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.FinalizedUtc.Should().BeNull();
+        contest.AuditedUtc.Should().BeNull();
+
+        enqueuedContestIds.Should().ContainSingle().Which.Should().Be(contestId);
+    }
+
+    [Fact]
+    public async Task Process_WhenScoresMatchButWinnerWrong_ClearsFinalizedUtcAndEnqueuesReenrichment()
+    {
+        // Catches the specific 6-8/null-Winner shape: Contest scores are
+        // already correct (consumer chain caught up), but WinnerFranchiseId
+        // wasn't set because the original enrichment skipped the branch.
+        var (contestId, _, away, home) = await SeedFinalizedContestAsync(
+            currentAway: 6, currentHome: 8,
+            currentWinner: null);
+        await SeedScoreAsync(away.Id, value: 6);
+        await SeedScoreAsync(home.Id, value: 8);
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.FinalizedUtc.Should().BeNull();
+        contest.AuditedUtc.Should().BeNull();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Process_WhenNoCompetitorScoreRows_DefersAndLeavesContestUntouched()
+    {
+        var (contestId, _, _, _) = await SeedFinalizedContestAsync(
+            currentAway: 14, currentHome: 21,
+            currentWinner: HomeFranchiseSeasonId);
+        // Intentionally no score rows seeded.
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.FinalizedUtc.Should().NotBeNull();
+        contest.AuditedUtc.Should().BeNull();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenMaxScoresAreZeroZero_DefersAndLeavesContestUntouched()
+    {
+        // Bootstrap-only race — only the basic/manual placeholder rows exist
+        // (Value=0). Audit cannot verify a 0-0 state, so it defers; next
+        // sweep retries once the canonical feed lands.
+        var (contestId, _, away, home) = await SeedFinalizedContestAsync(
+            currentAway: 0, currentHome: 0,
+            currentWinner: null);
+        await SeedScoreAsync(away.Id, value: 0);
+        await SeedScoreAsync(home.Id, value: 0);
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.FinalizedUtc.Should().NotBeNull();
+        contest.AuditedUtc.Should().BeNull();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenContestNoLongerFinalized_SkipsCleanly()
+    {
+        // Race protection: the sweep saw FinalizedUtc != null when it built
+        // the batch, but by the time this audit ran something cleared it
+        // (the live event-driven path being most likely). Skip — let the
+        // ContestEnrichmentJob handle the unfinalized state.
+        var (contestId, _, away, home) = await SeedFinalizedContestAsync(
+            currentAway: 14, currentHome: 21,
+            currentWinner: HomeFranchiseSeasonId);
+
+        var contestToUnfinalize = await FootballDataContext.Contests.FirstAsync(c => c.Id == contestId);
+        contestToUnfinalize.FinalizedUtc = null;
+        await FootballDataContext.SaveChangesAsync();
+
+        await SeedScoreAsync(away.Id, value: 14);
+        await SeedScoreAsync(home.Id, value: 21);
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.AuditedUtc.Should().BeNull();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenCompetitionNotFound_SkipsCleanly()
+    {
+        await _sut.Process(new AuditContestEnrichmentCommand(Guid.NewGuid(), Guid.NewGuid()));
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    private async Task<(Guid ContestId, Guid CompetitionId, FootballCompetitionCompetitor Away, FootballCompetitionCompetitor Home)>
+        SeedFinalizedContestAsync(
+            int? currentAway,
+            int? currentHome,
+            Guid? currentWinner)
+    {
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+
+        var contest = new FootballContest
+        {
+            Id = contestId,
+            Name = $"Contest {Guid.NewGuid():N}",
+            ShortName = "TC",
+            Sport = Sport.FootballNcaa,
+            SeasonYear = 2025,
+            StartDateUtc = FixedNow.AddDays(-1),
+            HomeTeamFranchiseSeasonId = HomeFranchiseSeasonId,
+            AwayTeamFranchiseSeasonId = AwayFranchiseSeasonId,
+            FinalizedUtc = FixedNow.AddHours(-12),
+            AwayScore = currentAway,
+            HomeScore = currentHome,
+            WinnerFranchiseId = currentWinner,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        var away = new FootballCompetitionCompetitor
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            FranchiseSeasonId = AwayFranchiseSeasonId,
+            HomeAway = "away",
+            Order = 0
+        };
+        var home = new FootballCompetitionCompetitor
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            FranchiseSeasonId = HomeFranchiseSeasonId,
+            HomeAway = "home",
+            Order = 1
+        };
+
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Contest = contest,
+            Competitors = new List<CompetitionCompetitorBase> { away, home }
+        };
+
+        FootballDataContext.Contests.Add(contest);
+        FootballDataContext.Competitions.Add(competition);
+        await FootballDataContext.SaveChangesAsync();
+
+        return (contestId, competitionId, away, home);
+    }
+
+    private async Task SeedScoreAsync(Guid competitionCompetitorId, double value)
+    {
+        FootballDataContext.CompetitionCompetitorScores.Add(new CompetitionCompetitorScore
+        {
+            Id = Guid.NewGuid(),
+            CompetitionCompetitorId = competitionCompetitorId,
+            Value = value,
+            DisplayValue = value.ToString(),
+            Winner = false,
+            SourceId = "2",
+            SourceDescription = "feed"
+        });
+        await FootballDataContext.SaveChangesAsync();
+    }
+
+    private static Guid? EnrichContestIdFromExpression(
+        Expression<Func<IEnrichContests, Task>> expr)
+    {
+        if (expr.Body is not MethodCallExpression call) return null;
+        if (call.Method.Name != nameof(IEnrichContests.Process)) return null;
+        if (call.Arguments.Count != 1) return null;
+
+        var cmd = Expression.Lambda<Func<EnrichContestCommand>>(call.Arguments[0]).Compile()();
+        return cmd.ContestId;
+    }
+}


### PR DESCRIPTION
## Summary

Nightly sweep that re-verifies finalized contests against the canonical `MAX(CompetitionCompetitorScores.Value)` source. Catches the **`FinalizedUtc` + `SpreadWinner` + null `Winner`** corruption signature seen on the 2026-06-18 Rockies @ Cubs case.

PR #431 (merged) prevents new occurrences. This PR adds the repair mechanism for historical contests already carrying the corruption — plus an ongoing nightly safety net for any future drift the live path doesn't catch.

## Components

### `Contest.AuditedUtc` + filtered index
New nullable column. Stamped only when audit verifies current state matches what re-running enrichment would produce now. Filtered index:
```sql
CREATE INDEX "IX_Contest_AuditedUtc_Pending" ON "Contest" ("FinalizedUtc")
  WHERE "FinalizedUtc" IS NOT NULL AND "AuditedUtc" IS NULL;
```
keeps the steady-state nightly scan O(yesterday's finalizations) instead of scanning the whole `Contest` table.

### `IAuditContestEnrichment` / `ContestEnrichmentAuditProcessor<TDataContext>`
Per-contest auditor. Reuses the exact MAX(CCS) read pattern PR #431 settled on so detection cannot drift from the live enrichment path. Three outcomes:

| Result | Action |
|---|---|
| Scores + winner match | Stamp `AuditedUtc`. Done. |
| Mismatch | Clear `FinalizedUtc`, enqueue `IEnrichContests`. `AuditedUtc` stays null; next sweep validates after re-enrichment lands. |
| Stale source (no rows OR MAX=0-0 bootstrap-only) | Warn + defer. No state change. Next sweep retries. Persistent warnings = human-eyes signal that the canonical source is genuinely wrong. |

The enrichment processor publishes `ContestFinalized` itself on success, so the existing `ContestFinalizedHandler` → `ScorePicksCommand` chain fires automatically. Audit doesn't republish.

### `IContestEnrichmentAuditJob` / `ContestEnrichmentAuditJob<TDataContext>`
Cron sweeper. Selects `FinalizedUtc IS NOT NULL AND AuditedUtc IS NULL`, ordered by `FinalizedUtc` ascending, batched at 500 per firing so the first-run historical backlog drains over multiple nights instead of one fire-hose enqueue.

Fans out via `IProvideBackgroundJobs.Enqueue<IAuditContestEnrichment>` so per-contest audits parallelize across Hangfire workers.

## Wiring

Per-sport DI registration alongside `IContestEnrichmentJob` in `ServiceRegistration.cs`. Hangfire recurring registered for cron `0 6 * * *` (06:00 UTC = 1 AM ET / 2 AM EST) — after all US prime-time games have ended and any post-game enrichment lag has resolved. Also visible in the Hangfire dashboard for manual triggering when chasing a specific corruption.

## Test plan

- [x] 11 new tests, all green: 4 job-level (ordering by `FinalizedUtc`, skip already-audited, skip unfinalized, no-op on empty) + 7 processor-level (match path stamps; score mismatch + winner-only mismatch each trigger re-enrichment; no-rows defers; 0-0 MAX defers; unfinalized race skips; missing competition skips)
- [x] Full Producer suite: 452 pass, 0 fail, 19 skipped (unchanged from main)
- [x] `dotnet build` clean
- [ ] EF migrations generated locally (see Follow-up below)
- [ ] Manual trigger via Hangfire dashboard against a known-corrupt contest to verify the full chain end-to-end before relying on the cron

## Follow-up

EF migrations need to be generated locally (per the project's `feedback_test_migrations_locally.md` rule — not hand-rolled here):

```bash
dotnet ef migrations add AddContestAuditedUtc \
  -c BaseballDataContext \
  -o Migrations/Baseball \
  -p src/SportsData.Producer/SportsData.Producer.csproj

dotnet ef migrations add AddContestAuditedUtc \
  -c FootballDataContext \
  -o Migrations/Football \
  -p src/SportsData.Producer/SportsData.Producer.csproj
```

Expected: `AddColumn AuditedUtc` (timestamp with time zone, nullable) + `CreateIndex IX_Contest_AuditedUtc_Pending` with the filter clause above. Inspect and commit alongside this PR before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily recurring contest enrichment audit (runs at 06:00 UTC) that finds pending finalized contests (up to 500, oldest finalized first) and schedules per-contest audits.
  * Introduced `AuditedUtc` to track when a contest has been verified.
* **Bug Fixes**
  * Audits now detect canonical score/winner mismatches and clear the finalized state (including `AuditedUtc`) to trigger reenrichment.
  * Added sport-specific handling for MLB “0–0” to defer auditing until data is available.
* **Tests**
  * Added unit tests covering job batching/ordering and processor outcomes across match, mismatch, missing data, deferral, and skip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->