### PR TITLE
refactor(producer): rename Winner/SpreadWinner columns to *FranchiseSeasonId

### DIFF
--- a/sql/pgsql/_debug.sql
+++ b/sql/pgsql/_debug.sql
@@ -138,8 +138,8 @@ select
   c."SeasonWeekId",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."FinalizedUtc"
 from public."Contest" c
 where c."Id" = '8a64dddf-0094-9a3a-2618-55c276296ef8'
@@ -196,10 +196,10 @@ select count(*) from public."CompetitionDrive"
 -- delete from public."CompetitionPlay"
 -- delete from public."CompetitionDrive"
 
---update public."Contest" set "FinalizedUtc" = null, "SpreadWinnerFranchiseId" = null, "WinnerFranchiseId" = null, "OverUnder" = 0 where "Id" = '24477be2-e202-7ce2-ef3b-4b71a9bc3b58'
+--update public."Contest" set "FinalizedUtc" = null, "SpreadWinnerFranchiseSeasonId" = null, "WinnerFranchiseSeasonId" = null, "OverUnder" = 0 where "Id" = '24477be2-e202-7ce2-ef3b-4b71a9bc3b58'
 
 -- FIX DEV - 07 OCT 2025
--- update public."Contest" set "FinalizedUtc" = null, "SpreadWinnerFranchiseId" = null, "WinnerFranchiseId" = null, "OverUnder" = 0 where "SeasonWeekId" = 'cda55a87-951b-0e56-f114-f0733280efda'
+-- update public."Contest" set "FinalizedUtc" = null, "SpreadWinnerFranchiseSeasonId" = null, "WinnerFranchiseSeasonId" = null, "OverUnder" = 0 where "SeasonWeekId" = 'cda55a87-951b-0e56-f114-f0733280efda'
 
 select * from public."Contest" where "Id" = 'aa00bd58-a986-d3a3-d1e5-f166c92dbcd0'
 select * from public."Contest" where "SeasonWeekId" = '25fee87e-e0ee-ec63-4dfa-7bd98b787c7e'

--- a/sql/pgsql/_debug_MLB.sql
+++ b/sql/pgsql/_debug_MLB.sql
@@ -1,19 +1,70 @@
-select * from public."Contest" Where "Id" = 'b458cf5b-ef56-9e93-48a7-3a7f169a9681'
-select * from public."ContestExternalId" Where "ContestId" = 'b458cf5b-ef56-9e93-48a7-3a7f169a9681'
+-- ─── Variables ────────────────────────────────────────────────────────────────
+-- Postgres has no T-SQL-style DECLARE at the top level. Two patterns:
+--   SET          → literal value
+--   set_config() → value from a subquery (T-SQL "SELECT @var = col FROM ...")
+-- Strings only; cast at the call site against typed columns.
+SET my.contest_id  = '73399ac2-fb71-8ff5-7d43-cd9c1d0d0a05';
+SET my.season_id   = '4810b35f-8e31-2631-eba4-ac268341fc43';
+SET my.season_year = '2026';
 
-select * from public."Competition" where "ContestId" = 'b458cf5b-ef56-9e93-48a7-3a7f169a9681'
-select * from public."CompetitionStatus" where "CompetitionId" = 'a2d36bbb-d8cc-4468-838d-10ed9287c4e8'
+-- Derive competition_id from contest_id. set_config returns the value so the
+-- result row also confirms what got stashed. Empty subquery → variable keeps
+-- its prior value (silent no-op), so eyeball the output before running
+-- downstream queries when retargeting.
+SELECT set_config('my.competition_id', "Id"::text, false) AS competition_id
+FROM public."Competition"
+WHERE "ContestId" = current_setting('my.contest_id')::uuid
+LIMIT 1;
 
-select distinct "StatusTypeName" from public."CompetitionStatus"
+-- ─── Health snapshot ──────────────────────────────────────────────────────────
+--SELECT 'NonFinalizedContests', COUNT(*) FROM public."Contest" WHERE "FinalizedUtc" IS NULL; -- 24,337
 
-select * from public."CompetitionStream" where "CompetitionId" = 'fcdc3d62-9947-e9af-1525-d9dd9ccd8a14'
+-- ─── Contest by id ────────────────────────────────────────────────────────────
+SELECT 'Contest', * FROM public."Contest" WHERE "Id" = current_setting('my.contest_id')::uuid;
 
-select * from public."AthletePosition"
-select * from public."AthletePositionExternalId"
+SELECT 'ContestExternalId', * FROM public."ContestExternalId" WHERE "ContestId" = current_setting('my.contest_id')::uuid;
 
-select * from public."Season" where "Year" = 2026
-select * from public."SeasonWeek" where "SeasonId" = '4810b35f-8e31-2631-eba4-ac268341fc43' order by "Number"
+SELECT 'Competition', * FROM public."Competition" WHERE "ContestId" = current_setting('my.contest_id')::uuid;
 
+-- ─── Competition fan-out (uses derived competition_id) ────────────────────────
+SELECT 'CompetitionCompetitor', * FROM public."CompetitionCompetitor" WHERE "CompetitionId" = current_setting('my.competition_id')::uuid;
+
+SELECT 'CompetitionCompetitorScores', * FROM public."CompetitionCompetitorScores"
+WHERE "CompetitionCompetitorId" IN (
+    SELECT "Id" FROM public."CompetitionCompetitor"
+    WHERE "CompetitionId" = current_setting('my.competition_id')::uuid
+);
+
+-- Column1	Id	CompetitionCompetitorId	Value	DisplayValue	Winner	SourceId	SourceDescription	CreatedUtc	ModifiedUtc	CreatedBy	ModifiedBy
+-- CompetitionCompetitorScores	72cec001-e65e-6388-efaf-6cd72000a61b	25c4ef94-1118-3372-a127-c723c628a73e	0	0	False	1	basic/manual	2026-04-20 18:49:58.873879+00	NULL	3f2e28d8-471f-429c-8cc2-8f36ddf16b08	NULL
+-- CompetitionCompetitorScores	a10640ef-69a9-36f6-99b1-591473b5399e	25c4ef94-1118-3372-a127-c723c628a73e	8	8	True	2	feed	2026-06-18 03:38:46.413419+00	NULL	e083e222-ef4c-4cdf-84b6-95c0f31a5fd5	NULL
+-- CompetitionCompetitorScores	c1271982-00be-048f-f6b8-20723955a08c	31540111-c671-e130-f893-c5a35468c038	0	0	False	1	basic/manual	2026-04-20 18:49:58.895503+00	NULL	3f2e28d8-471f-429c-8cc2-8f36ddf16b08	NULL
+-- CompetitionCompetitorScores	c072fad1-d31a-37bc-a48e-46dfdc8576f9	31540111-c671-e130-f893-c5a35468c038	6	6	False	2	feed	2026-06-18 03:38:44.231185+00	NULL	e083e222-ef4c-4cdf-84b6-95c0f31a5fd5	NULL
+
+-- NCAAFB Example
+-- Column1	Id	CompetitionCompetitorId	Value	DisplayValue	Winner	SourceId	SourceDescription	CreatedUtc	ModifiedUtc	CreatedBy	ModifiedBy
+-- CompetitionCompetitorScores	dc48c9ca-1a61-8203-1b36-2e9b73cc4d49	052ed826-1de5-fe89-6a87-cb20b6cdb487	9	9	False	1	Basic/Manual	2025-11-19 18:34:46.836883+00	2025-12-22 14:03:57.745321+00	e5a246de-3622-4a04-8f70-98fe1973508c	da3c4d9d-9169-44f6-82a1-d0f1b9a5a840
+-- CompetitionCompetitorScores	901e12fb-bbf2-c972-f9f7-b08ca1cea6c4	e3f8d89f-1284-69aa-9858-5a6b3774f4bb	42	42	False	1	Basic/Manual	2025-11-19 18:34:45.092117+00	2025-12-22 14:03:48.272355+00	fac2799d-3cfe-400c-849b-d64c0691eda7	da3c4d9d-9169-44f6-82a1-d0f1b9a5a840
+
+SELECT 'CompetitionStatus', * FROM public."CompetitionStatus" WHERE "CompetitionId" = current_setting('my.competition_id')::uuid;
+
+SELECT 'CompetitionStream', * FROM public."CompetitionStream" WHERE "CompetitionId" = current_setting('my.competition_id')::uuid;
+
+SELECT 'CompetitionOdds', * FROM public."CompetitionOdds" WHERE "CompetitionId" = current_setting('my.competition_id')::uuid;
+
+-- ─── Lookup tables ────────────────────────────────────────────────────────────
+--SELECT DISTINCT "StatusTypeName" FROM public."CompetitionStatus";
+
+--SELECT * FROM public."AthletePosition";
+--SELECT * FROM public."AthletePositionExternalId";
+
+--SELECT * FROM public."Season" WHERE "Year" = current_setting('my.season_year')::int;
+
+-- SELECT * FROM public."SeasonWeek"
+-- WHERE "SeasonId" = current_setting('my.season_id')::uuid
+-- ORDER BY "Number";
+
+-- ─── MatchupResult-style join (mirrors GetMatchupResultByContestId.sql) ───────
 SELECT
   c."Id" AS "ContestId",
   c."AwayTeamFranchiseSeasonId" AS "AwayFranchiseSeasonId",
@@ -24,8 +75,8 @@ SELECT
   coo."ProviderName",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" AS "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" AS "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."FinalizedUtc"
 FROM public."Contest" c
 INNER JOIN public."Competition" co ON co."ContestId" = c."Id"
@@ -34,9 +85,7 @@ LEFT JOIN LATERAL (
   FROM public."CompetitionOdds"
   WHERE "CompetitionId" = co."Id"
     AND "ProviderId" IN ('58', '100')
-  ORDER BY CASE WHEN "ProviderId" = '{PreferredOddsProviderId}' THEN 1 ELSE 2 END
+  ORDER BY CASE WHEN "ProviderId" = '58' THEN 1 ELSE 2 END
   LIMIT 1
 ) coo ON TRUE
-WHERE c."Id" = 'b458cf5b-ef56-9e93-48a7-3a7f169a9681'
-
-  SELECT * FROM public."CompetitionOdds" WHERE "CompetitionId" = 'f19b6d72-92de-18f7-3db4-4e1eb8c4f74c'
+WHERE c."Id" = current_setting('my.contest_id')::uuid;

--- a/sql/pgsql/canonical_GetContestResultsByContestIds.sql
+++ b/sql/pgsql/canonical_GetContestResultsByContestIds.sql
@@ -20,8 +20,8 @@ SELECT
   c."FinalizedUtc",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 

--- a/sql/pgsql/canonical_GetFranchiseSeasonCompetitionResultsByFranchiseSeasonId.sql
+++ b/sql/pgsql/canonical_GetFranchiseSeasonCompetitionResultsByFranchiseSeasonId.sql
@@ -20,8 +20,8 @@ SELECT
   c."FinalizedUtc",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 

--- a/sql/pgsql/canonical_GetLeagueMatchupsByContestIds.sql
+++ b/sql/pgsql/canonical_GetLeagueMatchupsByContestIds.sql
@@ -46,8 +46,8 @@ SELECT
 
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 
@@ -149,7 +149,7 @@ GROUP BY
 
   co."Details", co."Spread", co."OverUnder", co."OverOdds", co."UnderOdds",
   cto."SpreadPointsOpen", co."TotalPointsOpen",
-  c."AwayScore", c."HomeScore", c."WinnerFranchiseId", c."SpreadWinnerFranchiseId",
+  c."AwayScore", c."HomeScore", c."WinnerFranchiseSeasonId", c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder", c."EndDateUtc"
 
 

--- a/sql/pgsql/canonical_GetLeagueResultsByContestIds.sql
+++ b/sql/pgsql/canonical_GetLeagueResultsByContestIds.sql
@@ -19,8 +19,8 @@ SELECT
   c."FinalizedUtc",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 

--- a/sql/pgsql/canonical_getTeamCardSchedule.sql
+++ b/sql/pgsql/canonical_getTeamCardSchedule.sql
@@ -24,8 +24,8 @@ select
 	c."AwayScore" as "AwayScore",
 	c."HomeScore" as "HomeScore",
 	CASE
-        WHEN fAway."Slug" = 'lsu-tigers' AND c."WinnerFranchiseId" = fsAway."Id" THEN true
-		WHEN fHome."Slug" = 'lsu-tigers' AND c."WinnerFranchiseId" = fsHome."Id" THEN true
+        WHEN fAway."Slug" = 'lsu-tigers' AND c."WinnerFranchiseSeasonId" = fsAway."Id" THEN true
+		WHEN fHome."Slug" = 'lsu-tigers' AND c."WinnerFranchiseSeasonId" = fsHome."Id" THEN true
         ELSE null
     END AS "WasWinner"
 

--- a/sql/pgsql/row_counts_by_table.sql
+++ b/sql/pgsql/row_counts_by_table.sql
@@ -112,8 +112,8 @@ select * from public."Contest" where "HomeTeamFranchiseSeasonId" = 'f3c03a13-780
 update public."Contest" set
 "EndDateUtc" = '2025-08-29 01:09:03+00',
 "HomeScore" = 34, "AwayScore" = 7, "FinalizedUtc" = '2025-08-29 01:09:03+00',
-"SpreadWinnerFranchiseId" = '48a3a492-be81-ce45-2481-a4698868c5ef',
-"WinnerFranchiseId" = '48a3a492-be81-ce45-2481-a4698868c5ef'
+"SpreadWinnerFranchiseSeasonId" = '48a3a492-be81-ce45-2481-a4698868c5ef',
+"WinnerFranchiseSeasonId" = '48a3a492-be81-ce45-2481-a4698868c5ef'
 where "Id" = 'a2aaa942-51ff-f2c0-8b57-e396ceb8404e'
 */
 

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetContestResultsByContestIds.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetContestResultsByContestIds.sql
@@ -20,8 +20,8 @@
   c."FinalizedUtc",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetFranchiseSeasonCompetitionResultsByFranchiseSeasonId.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetFranchiseSeasonCompetitionResultsByFranchiseSeasonId.sql
@@ -20,8 +20,8 @@
   c."FinalizedUtc",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetLeagueMatchupsByContestIds.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetLeagueMatchupsByContestIds.sql
@@ -46,8 +46,8 @@
 
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 
@@ -143,7 +143,7 @@ GROUP BY
 
   co."Details", co."Spread", co."OverUnder", co."OverOdds", co."UnderOdds",
   cto."SpreadPointsOpen", co."TotalPointsOpen",
-  c."AwayScore", c."HomeScore", c."WinnerFranchiseId", c."SpreadWinnerFranchiseId",
+  c."AwayScore", c."HomeScore", c."WinnerFranchiseSeasonId", c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder", c."EndDateUtc"
 
 

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupResultByContestId.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupResultByContestId.sql
@@ -6,8 +6,8 @@
   coo."Spread" as "Spread",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."FinalizedUtc"
 from public."Contest" c
 inner join public."Competition" co on co."ContestId" = c."Id"

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetTeamCardSchedule.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetTeamCardSchedule.sql
@@ -26,6 +26,7 @@
 	CASE
         WHEN fAway."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsAway."Id" THEN true
 		WHEN fHome."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsHome."Id" THEN true
+        WHEN c."WinnerFranchiseSeasonId" IS NOT NULL THEN false
         ELSE null
     END AS "WasWinner"
 

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetTeamCardSchedule.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetTeamCardSchedule.sql
@@ -24,8 +24,8 @@
 	c."AwayScore" as "AwayScore",
 	c."HomeScore" as "HomeScore",
 	CASE
-        WHEN fAway."Slug" = @Slug AND c."WinnerFranchiseId" = fsAway."Id" THEN true
-		WHEN fHome."Slug" = @Slug AND c."WinnerFranchiseId" = fsHome."Id" THEN true
+        WHEN fAway."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsAway."Id" THEN true
+		WHEN fHome."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsHome."Id" THEN true
         ELSE null
     END AS "WasWinner"
 

--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -144,7 +144,7 @@ namespace SportsData.Producer.Application.Contests
             {
                 var homeWasWinner = contest.AwayScore < contest.HomeScore;
 
-                contest.WinnerFranchiseId =
+                contest.WinnerFranchiseSeasonId =
                     homeWasWinner ?
                     homeFranchiseSeasonId :
                     awayFranchiseSeasonId;
@@ -168,7 +168,7 @@ namespace SportsData.Producer.Application.Contests
                 if (primaryOdds != null)
                 {
                     contest.OverUnder = primaryOdds.OverUnderResult;
-                    contest.SpreadWinnerFranchiseId = primaryOdds.AtsWinnerFranchiseSeasonId;
+                    contest.SpreadWinnerFranchiseSeasonId = primaryOdds.AtsWinnerFranchiseSeasonId;
                 }
             }
 
@@ -190,7 +190,7 @@ namespace SportsData.Producer.Application.Contests
                 contest.Name,
                 contest.AwayScore,
                 contest.HomeScore,
-                contest.WinnerFranchiseId,
+                contest.WinnerFranchiseSeasonId,
                 contest.FinalizedUtc,
                 competition.Odds?.Count(o => o.EnrichedUtc.HasValue) ?? 0);
         }

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
@@ -151,7 +151,7 @@ public class ContestEnrichmentAuditProcessor<TDataContext> : IAuditContestEnrich
         }
 
         var scoresMatch = contest.AwayScore == expectedAway && contest.HomeScore == expectedHome;
-        var winnerMatches = contest.WinnerFranchiseId == expectedWinner;
+        var winnerMatches = contest.WinnerFranchiseSeasonId == expectedWinner;
 
         if (scoresMatch && winnerMatches)
         {
@@ -174,7 +174,7 @@ public class ContestEnrichmentAuditProcessor<TDataContext> : IAuditContestEnrich
             "Current: Away={CurrentAway}, Home={CurrentHome}, Winner={CurrentWinner}; " +
             "Expected: Away={ExpectedAway}, Home={ExpectedHome}, Winner={ExpectedWinner}",
             contest.Name,
-            contest.AwayScore, contest.HomeScore, contest.WinnerFranchiseId,
+            contest.AwayScore, contest.HomeScore, contest.WinnerFranchiseSeasonId,
             expectedAway, expectedHome, expectedWinner);
 
         // Enqueue BEFORE SaveChangesAsync. If Enqueue throws, FinalizedUtc

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -161,7 +161,7 @@ namespace SportsData.Producer.Application.Contests
                 {
                     var homeWasWinner = contest.AwayScore < contest.HomeScore;
 
-                    contest.WinnerFranchiseId =
+                    contest.WinnerFranchiseSeasonId =
                         homeWasWinner ?
                         homeFranchiseSeasonId :
                         awayFranchiseSeasonId;
@@ -187,7 +187,7 @@ namespace SportsData.Producer.Application.Contests
                     if (primaryOdds != null)
                     {
                         contest.OverUnder = primaryOdds.OverUnderResult;
-                        contest.SpreadWinnerFranchiseId = primaryOdds.AtsWinnerFranchiseSeasonId;
+                        contest.SpreadWinnerFranchiseSeasonId = primaryOdds.AtsWinnerFranchiseSeasonId;
                     }
                 }
 

--- a/src/SportsData.Producer/Application/Franchises/Commands/EnrichFranchiseSeasonHandler.cs
+++ b/src/SportsData.Producer/Application/Franchises/Commands/EnrichFranchiseSeasonHandler.cs
@@ -124,8 +124,8 @@ namespace SportsData.Producer.Application.Franchises.Commands
 
             foreach (var contest in contests)
             {
-                var isTie = contest.WinnerFranchiseId == null;
-                var wasWinner = !isTie && contest.WinnerFranchiseId == franchiseSeason.Id;
+                var isTie = contest.WinnerFranchiseSeasonId == null;
+                var wasWinner = !isTie && contest.WinnerFranchiseSeasonId == franchiseSeason.Id;
 
                 if (isTie)
                     ties++;
@@ -176,8 +176,8 @@ namespace SportsData.Producer.Application.Franchises.Commands
             foreach (var contest in contests)
             {
                 var isHome = contest.HomeTeamFranchiseSeasonId == franchiseSeason.Id;
-                var isTie = contest.WinnerFranchiseId == null;
-                var isWinner = !isTie && contest.WinnerFranchiseId == franchiseSeason.Id;
+                var isTie = contest.WinnerFranchiseSeasonId == null;
+                var isWinner = !isTie && contest.WinnerFranchiseSeasonId == franchiseSeason.Id;
 
                 var teamScore = isHome ? contest.HomeScore!.Value : contest.AwayScore!.Value;
                 var opponentScore = isHome ? contest.AwayScore!.Value : contest.HomeScore!.Value;

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/ContestBase.cs
@@ -55,9 +55,9 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
         public int? AwayScore { get; set; }
 
-        public Guid? WinnerFranchiseId { get; set; }           // Straight-up
+        public Guid? WinnerFranchiseSeasonId { get; set; }           // Straight-up
 
-        public Guid? SpreadWinnerFranchiseId { get; set; }     // ATS winner
+        public Guid? SpreadWinnerFranchiseSeasonId { get; set; }     // ATS winner
 
         public OverUnderResult OverUnder { get; set; } = OverUnderResult.None;
 

--- a/src/SportsData.Producer/Infrastructure/Sql/GetContestResultsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetContestResultsByContestIds.sql
@@ -16,8 +16,8 @@ SELECT
   c."FinalizedUtc",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" AS "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" AS "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" AS "OverUnderResult",
   c."EndDateUtc" AS "CompletedUtc"
 FROM public."Contest" c

--- a/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseSeasonCompetitionResults.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseSeasonCompetitionResults.sql
@@ -16,8 +16,8 @@ SELECT
   c."FinalizedUtc",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" as "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" as "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" as "OverUnderResult",
   c."EndDateUtc" as "CompletedUtc"
 FROM public."Contest" c

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupResultByContestId.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupResultByContestId.sql
@@ -6,8 +6,8 @@ SELECT
   coo."Spread" AS "Spread",
   c."AwayScore",
   c."HomeScore",
-  c."WinnerFranchiseId" AS "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" AS "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."FinalizedUtc"
 FROM public."Contest" c
 INNER JOIN public."Competition" co ON co."ContestId" = c."Id"
@@ -20,8 +20,8 @@ LEFT JOIN LATERAL (
   LIMIT 1
 ) coo ON TRUE
 WHERE c."Id" = @ContestId
-  -- Scoring callers cannot tolerate pre-enrichment rows. WinnerFranchiseId,
-  -- SpreadWinnerFranchiseId, and the final HomeScore/AwayScore are all
+  -- Scoring callers cannot tolerate pre-enrichment rows. WinnerFranchiseSeasonId,
+  -- SpreadWinnerFranchiseSeasonId, and the final HomeScore/AwayScore are all
   -- populated atomically by ContestEnrichmentProcessor alongside
   -- FinalizedUtc. Returning a row before that point produced silent
   -- Guid.Empty/0-0 scoring (PickScoringProcessor / PickScoringService).

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -29,8 +29,8 @@ SELECT
   co."OverUnder" AS "OverUnderCurrent", co."TotalPointsOpen" AS "OverUnderOpen",
   co."OverOdds", co."UnderOdds",
   c."AwayScore", c."HomeScore",
-  c."WinnerFranchiseId" AS "WinnerFranchiseSeasonId",
-  c."SpreadWinnerFranchiseId" AS "SpreadWinnerFranchiseSeasonId",
+  c."WinnerFranchiseSeasonId",
+  c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder" AS "OverUnderResult",
   c."EndDateUtc" AS "CompletedUtc"
 FROM public."Contest" c
@@ -216,6 +216,6 @@ GROUP BY
   fsHome."Wins", fsHome."Losses", fsHome."ConferenceWins", fsHome."ConferenceLosses",
   co."Details", co."Spread", co."OverUnder", co."OverOdds", co."UnderOdds",
   cto."SpreadPointsOpen", co."TotalPointsOpen",
-  c."AwayScore", c."HomeScore", c."WinnerFranchiseId", c."SpreadWinnerFranchiseId",
+  c."AwayScore", c."HomeScore", c."WinnerFranchiseSeasonId", c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder", c."EndDateUtc"
 ORDER BY c."StartDateUtc", fHome."Slug"

--- a/src/SportsData.Producer/Infrastructure/Sql/GetTeamCardSchedule.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetTeamCardSchedule.sql
@@ -25,9 +25,9 @@ SELECT
     c."AwayScore" as "AwayScore",
     c."HomeScore" as "HomeScore",
     CASE
-        WHEN fAway."Slug" = @Slug AND c."WinnerFranchiseId" = fsAway."Id" THEN true
-        WHEN fHome."Slug" = @Slug AND c."WinnerFranchiseId" = fsHome."Id" THEN true
-        WHEN c."WinnerFranchiseId" IS NOT NULL THEN false
+        WHEN fAway."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsAway."Id" THEN true
+        WHEN fHome."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsHome."Id" THEN true
+        WHEN c."WinnerFranchiseSeasonId" IS NOT NULL THEN false
         ELSE null
     END AS "WasWinner"
 FROM public."Contest" C

--- a/src/SportsData.Producer/Infrastructure/Sql/GetTeamFinalizedGames.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetTeamFinalizedGames.sql
@@ -25,9 +25,9 @@ SELECT
     c."AwayScore" as "AwayScore",
     c."HomeScore" as "HomeScore",
     CASE
-        WHEN fAway."Slug" = @Slug AND c."WinnerFranchiseId" = fsAway."Id" THEN true
-        WHEN fHome."Slug" = @Slug AND c."WinnerFranchiseId" = fsHome."Id" THEN true
-        WHEN c."WinnerFranchiseId" IS NOT NULL THEN false
+        WHEN fAway."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsAway."Id" THEN true
+        WHEN fHome."Slug" = @Slug AND c."WinnerFranchiseSeasonId" = fsHome."Id" THEN true
+        WHEN c."WinnerFranchiseSeasonId" IS NOT NULL THEN false
         ELSE null
     END AS "WasWinner"
 FROM public."Contest" C

--- a/src/SportsData.Producer/Migrations/Baseball/20260619080603_RenameWinnerFranchiseSeasonIdColumns.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260619080603_RenameWinnerFranchiseSeasonIdColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260619080603_RenameWinnerFranchiseSeasonIdColumns")]
+    partial class RenameWinnerFranchiseSeasonIdColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260619080603_RenameWinnerFranchiseSeasonIdColumns.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260619080603_RenameWinnerFranchiseSeasonIdColumns.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class RenameWinnerFranchiseSeasonIdColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "WinnerFranchiseId",
+                table: "Contest",
+                newName: "WinnerFranchiseSeasonId");
+
+            migrationBuilder.RenameColumn(
+                name: "SpreadWinnerFranchiseId",
+                table: "Contest",
+                newName: "SpreadWinnerFranchiseSeasonId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "WinnerFranchiseSeasonId",
+                table: "Contest",
+                newName: "WinnerFranchiseId");
+
+            migrationBuilder.RenameColumn(
+                name: "SpreadWinnerFranchiseSeasonId",
+                table: "Contest",
+                newName: "SpreadWinnerFranchiseId");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/20260619080637_RenameWinnerFranchiseSeasonIdColumns.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260619080637_RenameWinnerFranchiseSeasonIdColumns.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Football;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Baseball
+namespace SportsData.Producer.Migrations.Football
 {
-    [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(FootballDataContext))]
+    [Migration("20260619080637_RenameWinnerFranchiseSeasonIdColumns")]
+    partial class RenameWinnerFranchiseSeasonIdColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,233 +415,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<bool>("Active")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("ConfigurationId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int>("Season")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SeasonType")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SplitTypeId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
-
-                    b.ToTable("AthleteSeasonHotZone", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("AtBats")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("AthleteSeasonHotZoneId")
-                        .HasColumnType("uuid");
-
-                    b.Property<double?>("BattingAvg")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("BattingAvgScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int?>("Hits")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<double?>("Slugging")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("SluggingScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("ZoneId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonHotZoneId");
-
-                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("AthleteRef")
-                        .HasColumnType("text");
-
-                    b.Property<Guid>("CompetitionStatusId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("PlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasColumnType("text");
-
-                    b.Property<string>("TeamRef")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionStatusId");
-
-                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionCompetitorId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("EspnPlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId");
-
-                    b.HasIndex("CompetitionCompetitorId", "Name")
-                        .IsUnique();
-
-                    b.ToTable("CompetitionCompetitorProbable", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3248,6 +3024,206 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("CompetitionCompetitorStatisticStats");
                 });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
+                    b.Property<string>("DisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("EndClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("EndClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("EndDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EndShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("EndText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("EndYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsScore")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("OffensivePlays")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Result")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SequenceNumber")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("ShortDisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SourceDescription")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SourceId")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("StartClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("StartClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("StartFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("StartPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("StartShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StartText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeElapsedDisplay")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("TimeElapsedValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("Yards")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionId");
+
+                    b.ToTable("CompetitionDrive", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DriveId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Provider")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SourceUrl")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("SourceUrlHash")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DriveId");
+
+                    b.ToTable("CompetitionDriveExternalId", (string)null);
+                });
+
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
                 {
                     b.Property<Guid>("Id")
@@ -4069,65 +4045,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("CompetitionPlayId");
 
                     b.ToTable("CompetitionPlayExternalId", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionPlayId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Discriminator")
-                        .IsRequired()
-                        .HasMaxLength(34)
-                        .HasColumnType("character varying(34)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Order")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("PositionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<string>("Type")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId");
-
-                    b.HasIndex("PositionId");
-
-                    b.HasIndex("CompetitionPlayId", "Type");
-
-                    b.ToTable("CompetitionPlayParticipant", (string)null);
-
-                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionPlayParticipantBase");
-
-                    b.UseTphMappingStrategy();
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPowerIndex", b =>
@@ -7993,17 +7910,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -8014,247 +7923,99 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("ThrowsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("ThrowsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("BaseballAthlete");
+                    b.HasDiscriminator().HasValue("FootballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
+                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.Property<int?>("CurrentSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("CurrentSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("CurrentSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("CurrentSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("CurrentSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EspnSeriesId")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("SeasonSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("SeasonSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SeasonSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.HasIndex("EspnSeriesId");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetition");
+                    b.HasDiscriminator().HasValue("FootballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
+                    b.Property<int?>("CuratedRankCurrent")
+                        .HasColumnType("integer");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<Guid?>("AtBatAthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("AtBatId")
+                    b.Property<string>("ClockDisplayValue")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<int?>("AtBatPitchNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayHits")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("BatOrder")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("HalfInning")
-                        .HasMaxLength(8)
-                        .HasColumnType("character varying(8)");
-
-                    b.Property<double?>("HitCoordinateX")
-                        .HasPrecision(7, 2)
+                    b.Property<double>("ClockValue")
                         .HasColumnType("double precision");
 
-                    b.Property<double?>("HitCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("HomeErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("HomeHits")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsDoublePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsTriplePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsValid")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("Outs")
-                        .HasColumnType("integer");
-
-                    b.Property<double?>("PitchCoordinateX")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("PitchCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("PitchCountBalls")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("PitchCountStrikes")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PitchTypeAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeId")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int?>("PitchVelocity")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PitchesAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("PitchesType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<Guid?>("PitchingAthleteSeasonId")
+                    b.Property<Guid?>("DriveId")
                         .HasColumnType("uuid");
 
-                    b.Property<int>("RbiCount")
+                    b.Property<int?>("EndDistance")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountBalls")
+                    b.Property<int?>("EndDown")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountStrikes")
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndYardLine")
                         .HasColumnType("integer");
 
-                    b.Property<string>("StrikeType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("SummaryType")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("Trajectory")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
 
-                    b.Property<DateTime?>("Wallclock")
-                        .HasColumnType("timestamp with time zone");
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("StatYardage")
+                        .HasColumnType("integer");
+
+                    b.HasIndex("DriveId");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
-                {
-                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlayParticipant");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
-
-                    b.Property<int?>("HalfInning")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PeriodPrefix")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("BaseballContest");
+                    b.HasDiscriminator().HasValue("FootballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8287,47 +8048,6 @@ namespace SportsData.Producer.Migrations.Baseball
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
-                        .WithMany("Entries")
-                        .HasForeignKey("AthleteSeasonHotZoneId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("HotZone");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
-                        .WithMany("FeaturedAthletes")
-                        .HasForeignKey("CompetitionStatusId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionStatus");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "AthleteSeason")
-                        .WithMany()
-                        .HasForeignKey("AthleteSeasonId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", "CompetitionCompetitor")
-                        .WithMany("Probables")
-                        .HasForeignKey("CompetitionCompetitorId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("AthleteSeason");
-
-                    b.Navigation("CompetitionCompetitor");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8912,6 +8632,34 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
+                        .WithMany()
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                        .WithMany("Drives")
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Competition");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("ExternalIds")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9824,7 +9572,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9833,40 +9581,36 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("Plays")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", "CompetitionPlay")
-                        .WithMany("Participants")
-                        .HasForeignKey("CompetitionPlayId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionPlay");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9878,11 +9622,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -10036,6 +9775,13 @@ namespace SportsData.Producer.Migrations.Baseball
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Navigation("ExternalIds");
+
+                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10228,29 +9974,16 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
+                    b.Navigation("Drives");
+
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
-                {
-                    b.Navigation("Probables");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
-                {
-                    b.Navigation("Participants");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.Navigation("FeaturedAthletes");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Football/20260619080637_RenameWinnerFranchiseSeasonIdColumns.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260619080637_RenameWinnerFranchiseSeasonIdColumns.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class RenameWinnerFranchiseSeasonIdColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "WinnerFranchiseId",
+                table: "Contest",
+                newName: "WinnerFranchiseSeasonId");
+
+            migrationBuilder.RenameColumn(
+                name: "SpreadWinnerFranchiseId",
+                table: "Contest",
+                newName: "SpreadWinnerFranchiseSeasonId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "WinnerFranchiseSeasonId",
+                table: "Contest",
+                newName: "WinnerFranchiseId");
+
+            migrationBuilder.RenameColumn(
+                name: "SpreadWinnerFranchiseSeasonId",
+                table: "Contest",
+                newName: "SpreadWinnerFranchiseId");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
@@ -4623,7 +4623,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<int>("Sport")
                         .HasColumnType("integer");
 
-                    b.Property<Guid?>("SpreadWinnerFranchiseId")
+                    b.Property<Guid?>("SpreadWinnerFranchiseSeasonId")
                         .HasColumnType("uuid");
 
                     b.Property<DateTime>("StartDateUtc")
@@ -4635,7 +4635,7 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<int?>("Week")
                         .HasColumnType("integer");
 
-                    b.Property<Guid?>("WinnerFranchiseId")
+                    b.Property<Guid?>("WinnerFranchiseSeasonId")
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -200,7 +200,7 @@ public class BaseballContestEnrichmentProcessorTests
         var contest = await _baseballDataContext.Contests.FindAsync(contestId);
         contest!.AwayScore.Should().Be(4);
         contest.HomeScore.Should().Be(7);
-        contest.WinnerFranchiseId.Should().Be(HomeFranchiseSeasonId);
+        contest.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
         contest.FinalizedUtc.Should().NotBeNull();
 
         Mock.Get(Mocker.Get<IEventBus>())
@@ -266,7 +266,7 @@ public class BaseballContestEnrichmentProcessorTests
         var contest = await _baseballDataContext.Contests.FindAsync(contestId);
         contest!.AwayScore.Should().BeNull();
         contest.HomeScore.Should().BeNull();
-        contest.WinnerFranchiseId.Should().BeNull();
+        contest.WinnerFranchiseSeasonId.Should().BeNull();
         contest.FinalizedUtc.Should().BeNull();
 
         Mock.Get(Mocker.Get<IEventBus>())
@@ -299,7 +299,7 @@ public class BaseballContestEnrichmentProcessorTests
         var contest = await _baseballDataContext.Contests.FindAsync(contestId);
         contest!.AwayScore.Should().BeNull();
         contest.HomeScore.Should().BeNull();
-        contest.WinnerFranchiseId.Should().BeNull();
+        contest.WinnerFranchiseSeasonId.Should().BeNull();
         contest.FinalizedUtc.Should().BeNull();
 
         Mock.Get(Mocker.Get<IEventBus>())
@@ -369,7 +369,7 @@ public class BaseballContestEnrichmentProcessorTests
         var contest = await _baseballDataContext.Contests.FindAsync(contestId);
         contest!.AwayScore.Should().Be(5);
         contest.HomeScore.Should().Be(5);
-        contest.WinnerFranchiseId.Should().BeNull();
+        contest.WinnerFranchiseSeasonId.Should().BeNull();
         contest.FinalizedUtc.Should().NotBeNull();
     }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
@@ -88,7 +88,7 @@ public class ContestEnrichmentAuditProcessorTests
     public async Task Process_WhenScoresMatchButWinnerWrong_ClearsFinalizedUtcAndEnqueuesReenrichment()
     {
         // Catches the specific 6-8/null-Winner shape: Contest scores are
-        // already correct (consumer chain caught up), but WinnerFranchiseId
+        // already correct (consumer chain caught up), but WinnerFranchiseSeasonId
         // wasn't set because the original enrichment skipped the branch.
         var (contestId, _, away, home) = await SeedFinalizedContestAsync(
             currentAway: 6, currentHome: 8,
@@ -238,7 +238,7 @@ public class ContestEnrichmentAuditProcessorTests
             FinalizedUtc = FixedNow.AddHours(-12),
             AwayScore = currentAway,
             HomeScore = currentHome,
-            WinnerFranchiseId = currentWinner,
+            WinnerFranchiseSeasonId = currentWinner,
             CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         };

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
@@ -260,7 +260,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
         await _sut.Process(command);
 
         var contest = await FootballDataContext.Contests.FindAsync(contestId);
-        contest!.WinnerFranchiseId.Should().Be(HomeFranchiseSeasonId);
+        contest!.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
     }
 
     #endregion
@@ -310,7 +310,7 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
         var contest = await FootballDataContext.Contests.FindAsync(contestId);
         contest!.AwayScore.Should().Be(17);
         contest.HomeScore.Should().Be(24);
-        contest.WinnerFranchiseId.Should().Be(HomeFranchiseSeasonId);
+        contest.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
         contest.FinalizedUtc.Should().NotBeNull();
 
         Mock.Get(Mocker.Get<IEventBus>())

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Franchises/Commands/EnrichFranchiseSeasonHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Franchises/Commands/EnrichFranchiseSeasonHandlerTests.cs
@@ -111,7 +111,7 @@ public class EnrichFranchiseSeasonHandlerTests :
             franchiseSeason.Id, opponentSeason.Id, seasonYear,
             homeScore: 28, awayScore: 14, winnerId: franchiseSeason.Id));
 
-        // Tie (WinnerFranchiseId = null)
+        // Tie (WinnerFranchiseSeasonId = null)
         await FootballDataContext.Contests.AddAsync(CreateContest(
             franchiseSeason.Id, opponentSeason.Id, seasonYear,
             homeScore: 21, awayScore: 21, winnerId: null));
@@ -232,7 +232,7 @@ public class EnrichFranchiseSeasonHandlerTests :
             franchiseSeason.Id, confOpponentSeason.Id, seasonYear,
             homeScore: 35, awayScore: 14, winnerId: franchiseSeason.Id));
 
-        // Conference Tie (WinnerFranchiseId = null)
+        // Conference Tie (WinnerFranchiseSeasonId = null)
         await FootballDataContext.Contests.AddAsync(CreateContest(
             franchiseSeason.Id, confOpponentSeason.Id, seasonYear,
             homeScore: 21, awayScore: 21, winnerId: null));
@@ -461,7 +461,7 @@ public class EnrichFranchiseSeasonHandlerTests :
             .With(x => x.SeasonYear, seasonYear)
             .With(x => x.HomeScore, homeScore)
             .With(x => x.AwayScore, awayScore)
-            .With(x => x.WinnerFranchiseId, winnerId)
+            .With(x => x.WinnerFranchiseSeasonId, winnerId)
             .With(x => x.FinalizedUtc, DateTime.UtcNow)
             .With(x => x.Name, "Test Contest")
             .With(x => x.ShortName, "Test")


### PR DESCRIPTION
## Summary

`Contest.WinnerFranchiseId` and `Contest.SpreadWinnerFranchiseId` have always stored **`FranchiseSeasonId`** values — set from `competitor.FranchiseSeasonId` (in the enrichment processors) and `CompetitionOdds.AtsWinnerFranchiseSeasonId` (for ATS) — but were named as if they were canonical `FranchiseId` values. The mismatch was bridged at the SQL layer via `AS` aliases: every query that joined `Contest` had to rename the column on output so `MatchupResult.WinnerFranchiseSeasonId` would line up.

Rename the property + column to match the actual value semantics:

| Before | After |
|---|---|
| `Contest.WinnerFranchiseId` | `Contest.WinnerFranchiseSeasonId` |
| `Contest.SpreadWinnerFranchiseId` | `Contest.SpreadWinnerFranchiseSeasonId` |

`MatchupResult` DTO already used the correct names — no change there. After the rename, the `AS` aliases disappear (column name matches DTO name).

## Surface area

| Layer | Files |
|---|---|
| Entity | `Producer.ContestBase` (1) |
| EF migrations | Baseball + Football, standard `RenameColumn` pair (metadata-only on PG) |
| Production C# | Enrichment processors (Baseball + Football + Audit), `EnrichFranchiseSeasonHandler` (5) |
| Tests | 4 |
| Producer SQL | 6 in `Infrastructure/Sql/` |
| API SQL | 5 in `Infrastructure/Data/Canonical/Sql/` |
| Debug SQL | 9 in `sql/pgsql/` |

Migration shape:
```sql
ALTER TABLE \"Contest\" RENAME COLUMN \"WinnerFranchiseId\" TO \"WinnerFranchiseSeasonId\";
ALTER TABLE \"Contest\" RENAME COLUMN \"SpreadWinnerFranchiseId\" TO \"SpreadWinnerFranchiseSeasonId\";
```

## Deploy coordination

The DB column rename is the only timing concern. Standard zero-downtime sequence:

1. Deploy new image to all Producer pods (per-sport: NCAA, NFL, MLB).
2. Deploy new image to all API pods.
3. Run the migration. Both contexts (Baseball + Football) need it.

Old pods running concurrently with the post-migration DB will 500 on every Contest query touching either column. Same playbook as any other column rename.

## Test plan

- [x] Producer unit suite: 455 pass, 0 fail, 19 pre-existing skips
- [x] API unit suite: 403 pass, 0 fail
- [x] Build clean on both services
- [ ] Verify post-deploy: pick a recently-finalized contest, hit `GetMatchupResult` endpoint, confirm `WinnerFranchiseSeasonId` populates correctly
- [ ] Verify in JobsDashboard that `ContestEnrichmentJob` / `ContestEnrichmentAuditJob` continue to fire cleanly

## Follow-up

Separate PR (already discussed): delete the orphaned `Api.Contest` entity (commented-out `EntityConfiguration`, no `DbSet`, still tracks legacy `WinningFranchiseId` in the model snapshot from Aug 2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated contest winner and spread-winner handling to use franchise-season identifiers end-to-end, including enrichment/auditing logic and schedule “WasWinner” determinations.
  * Updated canonical and API contest/league/matchup SQL queries to return the new season-specific winner identifiers.

* **Migrations**
  * Added database migrations (Baseball and Football) to rename contest winner/spread-winner columns from franchise-level to franchise-season-level.

* **Tests**
  * Updated unit tests to assert the season-specific winner identifier fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->