### PR TITLE
fix(web): render Week as static text when league has a single week

### DIFF
--- a/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.css
+++ b/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.css
@@ -156,3 +156,15 @@
   background-color: var(--bg-card);
   color: var(--text-primary);
 }
+
+/* Single-week leagues render the week as static text rather than a
+   one-option dropdown. Match the select's vertical rhythm so the
+   League selector and the week value line up on the same baseline. */
+.league-week-selector .week-static {
+  font-size: 1rem;
+  color: var(--text-primary);
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.2;
+}

--- a/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.css
+++ b/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.css
@@ -58,7 +58,8 @@
 
   /* Desktop-specific label alignment */
   .league-week-selector label,
-  .league-week-selector .league-selector label {
+  .league-week-selector .league-selector label,
+  .league-week-selector .week-label {
     text-align: right; /* Right-align labels on desktop for consistency */
     margin-right: 8px;
   }
@@ -86,7 +87,8 @@
   }
 
   .league-week-selector label,
-  .league-week-selector .league-selector label {
+  .league-week-selector .league-selector label,
+  .league-week-selector .week-label {
     min-width: 50px;
     text-align: left; /* Changed from right to left for mobile */
     margin-bottom: 0; /* Remove bottom margin to keep inline */
@@ -107,7 +109,8 @@
   }
 }
 
-.league-week-selector label {
+.league-week-selector label,
+.league-week-selector .week-label {
   font-size: 1rem;
   color: var(--text-secondary);
   white-space: nowrap;
@@ -115,7 +118,8 @@
   min-width: 60px;  /* forces both labels to same width on desktop */
 }
 
-.league-week-selector .selector-block label {
+.league-week-selector .selector-block label,
+.league-week-selector .selector-block .week-label {
   min-width: 60px;
 }
 

--- a/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
+++ b/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
@@ -12,6 +12,13 @@ function LeagueWeekSelector({
 }) {
   const hasWeeks = Array.isArray(seasonWeeks) && seasonWeeks.length > 0;
 
+  // Custom-window leagues (e.g. a one-week pool) only ever have a single
+  // entry — a dropdown there implies a selection to make when there isn't
+  // one. Render the value as static text instead so it stays informational.
+  // allowAll is the exception (admin view): even with one week, "All
+  // Weeks" is a meaningful alternative, so keep the dropdown.
+  const isSingleWeek = !allowAll && hasWeeks && seasonWeeks.length === 1;
+
   return (
     <div className="league-week-selector">
       {/* League Select */}
@@ -27,19 +34,25 @@ function LeagueWeekSelector({
       {/* Week Select */}
       <div className="selector-block">
         <label htmlFor="weekSelect">Week:</label>
-        <select
-          id="weekSelect"
-          value={selectedWeek ?? ""}
-          onChange={(e) => setSelectedWeek(e.target.value ? Number(e.target.value) : null)}
-          disabled={!hasWeeks}
-        >
-          {allowAll && <option value="">All Weeks</option>}
-          {hasWeeks && seasonWeeks.map((week) => (
-            <option key={week} value={week}>
-              Week {week}
-            </option>
-          ))}
-        </select>
+        {isSingleWeek ? (
+          <span id="weekSelect" className="week-static">
+            {seasonWeeks[0]}
+          </span>
+        ) : (
+          <select
+            id="weekSelect"
+            value={selectedWeek ?? ""}
+            onChange={(e) => setSelectedWeek(e.target.value ? Number(e.target.value) : null)}
+            disabled={!hasWeeks}
+          >
+            {allowAll && <option value="">All Weeks</option>}
+            {hasWeeks && seasonWeeks.map((week) => (
+              <option key={week} value={week}>
+                Week {week}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
     </div>
   );

--- a/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
+++ b/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
@@ -33,25 +33,31 @@ function LeagueWeekSelector({
 
       {/* Week Select */}
       <div className="selector-block">
-        <label htmlFor="weekSelect">Week:</label>
         {isSingleWeek ? (
-          <span id="weekSelect" className="week-static">
-            {seasonWeeks[0]}
-          </span>
+          <>
+            {/* No <label htmlFor> here — <label> must point at a labelable
+                form control (input/select/textarea/etc.), not at a <span>.
+                Use a styled span for the visual "Week:" prefix instead. */}
+            <span className="week-label">Week:</span>
+            <span className="week-static">{seasonWeeks[0]}</span>
+          </>
         ) : (
-          <select
-            id="weekSelect"
-            value={selectedWeek ?? ""}
-            onChange={(e) => setSelectedWeek(e.target.value ? Number(e.target.value) : null)}
-            disabled={!hasWeeks}
-          >
-            {allowAll && <option value="">All Weeks</option>}
-            {hasWeeks && seasonWeeks.map((week) => (
-              <option key={week} value={week}>
-                Week {week}
-              </option>
-            ))}
-          </select>
+          <>
+            <label htmlFor="weekSelect">Week:</label>
+            <select
+              id="weekSelect"
+              value={selectedWeek ?? ""}
+              onChange={(e) => setSelectedWeek(e.target.value ? Number(e.target.value) : null)}
+              disabled={!hasWeeks}
+            >
+              {allowAll && <option value="">All Weeks</option>}
+              {hasWeeks && seasonWeeks.map((week) => (
+                <option key={week} value={week}>
+                  Week {week}
+                </option>
+              ))}
+            </select>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

On the picks page, leagues with only one week (e.g. custom-window pools like `/app/picks/70c88eb5-acac-4825-b0b8-06ac98dd0277`) were showing a one-option dropdown — implying a selection to make when there isn't one. `PicksPage` already auto-snaps `selectedWeek` to the only available week, so the dropdown's affordance was purely decorative.

Replace the `<select>` with a static `<span>` in the single-week case:

```jsx
const isSingleWeek = !allowAll && hasWeeks && seasonWeeks.length === 1;

isSingleWeek
  ? <span className="week-static">{seasonWeeks[0]}</span>
  : <select ...>{/* normal dropdown */}</select>
```

The Week label stays (still informational). A new `.week-static` class matches the 32px height of the surrounding selects so the baseline lines up cleanly with the League selector.

## Why `allowAll` is excluded

In admin views with `allowAll`, the "All Weeks" option is meaningfully different from "Week N" — selection still makes sense even with one week in scope. So the dropdown stays for that path.

Multi-week leagues are unaffected.

## Test plan

- [x] Verified locally by the user
- [ ] Spot-check post-deploy that `/app/picks/70c88eb5-...` shows the week as static text
- [ ] Spot-check a multi-week league still gets the dropdown
- [ ] Spot-check that admin paths using `allowAll` are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-week leagues now show the “Week” value as static, read-only text instead of a dropdown selector.

* **Style**
  * Improved label and week-value alignment/typography across desktop and mobile layouts for the week selector.
  * Added styling to render single-week week values with consistent spacing and vertical rhythm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->