### PR TITLE
fix(web): refresh userDto on picks page when league has empty seasonWeeks

### DIFF
--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -1,6 +1,6 @@
 import "./PicksPage.css";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useUserDto } from "../../contexts/UserContext";
 import { useLeagueContext } from "../../contexts/LeagueContext";
@@ -13,7 +13,7 @@ import MatchupList from "../matchups/MatchupList.jsx";
 import MatchupGrid from "../matchups/MatchupGrid.jsx";
 
 function PicksPage() {
-  const { userDto, loading: userLoading } = useUserDto();
+  const { userDto, loading: userLoading, refreshUserDto } = useUserDto();
   const {
     selectedLeagueId: globalLeagueId,
     setSelectedLeagueId: setGlobalLeagueId,
@@ -84,6 +84,28 @@ function PicksPage() {
   // ascending list). Custom-window leagues may only have a single entry.
   const latestSeasonWeek =
     seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
+
+  // Recovery for newly-created leagues. League creation publishes
+  // PickemGroupCreated via the outbox; the consumer that populates
+  // seasonWeeks runs asynchronously. LeagueCreatePage's refreshUserDto
+  // can fire before the consumer finishes, so the new league lands in
+  // userDto.leagues with an empty seasonWeeks array. By the time the
+  // user clicks "Make Your Picks" the consumer has typically finished
+  // — but the stale userDto blocks the fetch effects below. Re-fetch
+  // userDto once per leagueId when we see the gap. Guarded with a ref
+  // so a genuinely-still-in-flight consumer doesn't trigger a refresh
+  // loop; the next league navigation resets and tries again.
+  const weeksRefreshAttemptedFor = useRef(null);
+  useEffect(() => {
+    if (!selectedLeague) return;
+    if (seasonWeeks.length > 0) {
+      weeksRefreshAttemptedFor.current = null;
+      return;
+    }
+    if (weeksRefreshAttemptedFor.current === selectedLeague.id) return;
+    weeksRefreshAttemptedFor.current = selectedLeague.id;
+    refreshUserDto();
+  }, [selectedLeague, seasonWeeks.length, refreshUserDto]);
 
   // Get contest updates for live game data
   const { getContestUpdate, _instanceId: contestCtxInstanceId } = useContestUpdates();


### PR DESCRIPTION
## Summary

After creating a new league, clicking **Make Your Picks** routed to the correct picks URL but the page sat empty until the user manually hit F5.

## Root cause: timing gap in the create flow

1. `LeagueCreatePage` POSTs to `/leagues`. The handler (`CreateLeagueCommandHandlerBase`) creates the `PickemGroup` and publishes `PickemGroupCreated` via the EF outbox.
2. `SaveChangesAsync` commits the group + outbox row atomically and returns. The MassTransit consumer that populates `seasonWeeks` runs **asynchronously** after the publish lands on the bus.
3. `LeagueCreatePage` awaits `refreshUserDto()` immediately, then navigates. The refresh races the consumer — the new league is in `userDto.leagues` but its `seasonWeeks` is still empty.
4. The user clicks **Make Your Picks** a few seconds later. By then the consumer has finished, but the stale `userDto` keeps `selectedLeague.seasonWeeks` empty in `PicksPage`. That makes `latestSeasonWeek` / `selectedWeek` null, and the matchups + picks fetch effects bail out at the `seasonWeeks.includes(selectedWeek)` guard.
5. F5 forces a full reload → `UserContext` re-mounts → `loadUserDto` re-fetches → `seasonWeeks` now populated → fetches succeed.

## Fix

In `PicksPage`, watch for the "league exists but has zero weeks" state and re-fetch `userDto` once per `leagueId`:

```jsx
const weeksRefreshAttemptedFor = useRef(null);
useEffect(() => {
  if (!selectedLeague) return;
  if (seasonWeeks.length > 0) {
    weeksRefreshAttemptedFor.current = null;
    return;
  }
  if (weeksRefreshAttemptedFor.current === selectedLeague.id) return;
  weeksRefreshAttemptedFor.current = selectedLeague.id;
  refreshUserDto();
}, [selectedLeague, seasonWeeks.length, refreshUserDto]);
```

The `useRef` guard makes it a one-shot — if the consumer is genuinely still in flight after the refresh, we don't loop; the next league navigation resets the ref and tries again. When `seasonWeeks` does populate, the ref clears so a later re-create of the same league would still recover.

## Considered and rejected

- **Block the create flow until the consumer finishes.** Re-entangles the API path with bus processing and undermines the whole point of the outbox + async consumer pattern. Latency under load (busy bus, retry) would punish the user.
- **Poll in `LeagueCreatePage` before navigating.** Same problem one layer up; user sits on a spinner while we wait for an event whose timing isn't bounded.
- **Always refresh `userDto` on `PicksPage` mount.** Burns a network call on every navigation between leagues. The current fix only fires when there's a real signal of stale data.

## Test plan

- [x] Create a new league via `/app/league/create`. After confirmation, click \"Make Your Picks\". Picks render without an F5.
- [ ] Repeat with a multi-week league (NCAA full season) and a single-week league.
- [ ] Navigate between existing leagues — no extra `getCurrentUser` calls in network tab (effect doesn't fire because `seasonWeeks.length > 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)