### PR TITLE
Batch: Producer log cleanups + MLB tie guard + on-final score re-source + Provider visibility + migration runner proposal

### DIFF
--- a/docs/migration-runner-separation.md
+++ b/docs/migration-runner-separation.md
@@ -1,0 +1,226 @@
+# Migration Runner Separation
+
+**Status**: proposal, not started
+**Author**: drafted 2026-06-20 after the MLB Worker `LOCK TABLE __EFMigrationsHistory` 30s-timeout incident
+**Driver memory**: `project_migration_runner` (this doc is the codebase-side artifact for review)
+
+## Problem
+
+EF Core migrations run inside every pod's startup, with EF taking an
+`ACCESS EXCLUSIVE` lock on `__EFMigrationsHistory` before checking what's
+pending. With many pods coming up in parallel — KEDA-scaled Workers,
+plus the Api / Ingest / Daemon roles, plus the per-sport multiplication
+(NCAA + NFL + MLB Producers all hitting the same per-sport DB) — pods
+race for that lock. On 2026-06-20 the symptom surfaced clearly: two
+newly-scaled MLB Worker pods sat for 30s each on the LOCK statement and
+emitted command timeouts to Seq, even though zero migrations were
+pending. The losing pod gets stuck behind whichever pod EF Core happens
+to schedule first, and if a stale `idle in transaction` session is
+sitting on the table the loser waits up to PG's lock timeout.
+
+Beyond the failure mode, the pattern taxes every startup:
+
+- Each pod opens a DB connection just to verify "no migrations pending."
+- Each pod takes + releases an exclusive lock against a hot table.
+- Worker pods are on the critical path for queue draining, so their
+  startup time is user-visible (queue depth grows while they boot).
+
+The right boundary is: **migrations are a deploy-time concern, not a
+runtime concern**. Pods should trust that the schema is current by the
+time they boot.
+
+## Current behavior
+
+`src/SportsData.Producer/Program.cs:236-260`:
+
+```csharp
+using (var scope = app.Services.CreateScope())
+{
+    var appServices = scope.ServiceProvider;
+    switch (mode)
+    {
+        case Sport.GolfPga:
+            await appServices.GetRequiredService<GolfDataContext>().Database.MigrateAsync();
+            break;
+        case Sport.FootballNcaa:
+        case Sport.FootballNfl:
+            await appServices.GetRequiredService<FootballDataContext>().Database.MigrateAsync();
+            break;
+        case Sport.BaseballMlb:
+            await appServices.GetRequiredService<BaseballDataContext>().Database.MigrateAsync();
+            break;
+    }
+}
+```
+
+Producer has multiple roles per sport: `ProducerRole.Api`,
+`ProducerRole.Ingest`, `ProducerRole.Worker` (replicated, KEDA-scaled),
+`ProducerRole.Daemon`. Every one of them runs `MigrateAsync` against
+the same per-sport DB. Per-sport pod count varies but a typical state is:
+
+| Sport | Api | Ingest | Worker (KEDA min/max) | Daemon | Total racers |
+|---|---|---|---|---|---|
+| NCAA | 1 | 1 | 2-5 | 1 | 5-8 |
+| NFL  | 1 | 1 | 2-5 | 1 | 5-8 |
+| MLB  | 1 | 1 | 2-5 | 1 | 5-8 |
+
+API and Provider services have the same pattern against their own DBs.
+
+## Proposed design
+
+**Separate console application per service that performs migrations,
+nothing else.** Pods stop calling `MigrateAsync` entirely and instead
+verify (cheaply) that the schema is at the expected revision.
+
+### `SportsData.Producer.Migrator` (new project)
+
+- Type: `Microsoft.NET.Sdk` console app (not `Microsoft.NET.Sdk.Web`)
+- References: `SportsData.Producer` (to reach the `DbContext` types) and
+  `SportsData.Core` (for config + DateTimeProvider, which migrations
+  occasionally touch via seed data).
+- CLI: `dotnet SportsData.Producer.Migrator.dll -context BaseballDataContext`
+  (or `-context FootballDataContext`, etc.).
+- Reads its connection string the same way `SportsData.Producer` does
+  (Azure App Config → `CommonConfig:SqlBaseConnectionString`).
+- Runs `MigrateAsync` exactly once, logs the applied migrations, exits
+  0 on success, non-zero on failure.
+- No Hangfire, no MassTransit, no HTTP, no SignalR — just enough DI to
+  spin up the DbContext.
+
+Same shape for `SportsData.Api.Migrator` and `SportsData.Provider.Migrator`.
+Each is small (probably <100 lines of `Main`).
+
+### Pod startup change
+
+Replace `MigrateAsync` with a one-row read that asserts the schema is
+at the expected revision:
+
+```csharp
+var latestApplied = await context.Database
+    .GetAppliedMigrationsAsync();
+var expected = context.Database
+    .GetMigrations()
+    .Last();
+
+if (!latestApplied.Contains(expected))
+{
+    throw new InvalidOperationException(
+        $"Schema is behind expected revision {expected}. Migrations Job must run before pods.");
+}
+```
+
+This is a single `SELECT MigrationId FROM __EFMigrationsHistory ORDER BY
+MigrationId DESC LIMIT 1` (EF's `GetAppliedMigrationsAsync` is a bit
+chattier, but still cheap and uses no locks). No `ACCESS EXCLUSIVE`,
+no race window.
+
+If the assert fails the pod crashes loud — which is what we want, since
+it means the deploy ran out of order and pods would otherwise serve
+traffic against a stale schema.
+
+### Deploy choreography
+
+Kubernetes Job per service, gated *before* the Deployment image rollout:
+
+```yaml
+# producer-mlb-migrator-job.yaml — generated per-deploy
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: producer-baseball-mlb-migrator-{{ revision }}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: migrator
+        image: sportsdata/producer-migrator:{{ tag }}
+        args: ["-context", "BaseballDataContext"]
+```
+
+CI sequence:
+
+1. Build + push migrator image alongside the service image.
+2. `kubectl apply` the Job manifest.
+3. `kubectl wait --for=condition=complete --timeout=300s job/<name>`.
+4. On success: `kubectl apply` the Deployment manifest (image swap).
+5. On failure: abort deploy, alert, surface logs.
+
+For the existing self-hosted Azure Pipelines path (`Bender`), this is
+two extra steps in the Producer / Api / Provider templates. For the
+GitHub Actions mobile path, n/a (no DB).
+
+The Job runs as a single pod, so there is exactly one migrator at a
+time per service+context. The lock contention disappears at the source.
+
+## Failure modes
+
+| Failure | Behavior | Recovery |
+|---|---|---|
+| Migration throws (FK violation, etc.) | Job exits non-zero, `backoffLimit: 2` retries twice, then deploy stage fails | Fix the migration, redeploy. Pods never roll, no half-migrated state. |
+| Migration takes longer than the Job timeout (300s) | Job is killed, deploy fails | Bump timeout for known-large migrations; default fine for column renames + indexes. |
+| Pod schema-assert fails post-deploy | Pod crashes at startup, K8s restarts it; eventually CrashLoopBackOff | Indicates Job didn't actually run / deploy sequence broken. Page on this — it's an out-of-order deploy bug. |
+| Multiple deploys queued simultaneously | Second deploy's Job waits for first to complete (Kubernetes serializes by name) | Standard CI queueing. |
+| Need to roll back code without rolling back schema | Deploy old image; old code's schema-assert sees a *newer* migration than it expects | Decide: relax the assert to "at least my expected revision" so old code can run against new schema, OR require explicit down-migration. Default: allow newer (forward-compatible schema is the project standard). |
+
+## Rollout plan
+
+Three phases, each safe to ship independently:
+
+### Phase 1 — Build the migrator, keep startup migrations
+
+- New project `SportsData.Producer.Migrator` (+ Api + Provider variants).
+- New Dockerfile / image build in CI.
+- Add the Job manifest to `sports-data-config` under
+  `app/base/jobs/<service>/migrator-job.yaml.template` (rendered per-deploy).
+- **Do not** remove `MigrateAsync` from pod startup yet — run both.
+- The Job becomes a no-op if it runs first (no pending migrations by the
+  time pods start), or it correctly applies migrations and pods then
+  see "no work to do."
+
+This is risk-free: the worst case is the Job runs successfully and pods
+*also* run `MigrateAsync` finding nothing to do.
+
+### Phase 2 — Cut over via flag
+
+- Add `-skip-startup-migrations` arg to each service.
+- CI deploys flip it to true once the Job step is wired in and proven.
+- Pods now boot with the schema-assert path instead of `MigrateAsync`.
+- The lock-contention symptom disappears here.
+
+Can be done per-service (Api first, then Provider, then Producer) so
+the riskiest one (Producer, the most pods) is last.
+
+### Phase 3 — Remove the dead code
+
+- Once all services run on the migrator + assert path in prod, delete
+  the `MigrateAsync` call sites and the `-skip-startup-migrations` flag.
+- Single follow-up PR; pure deletion.
+
+## Out of scope
+
+- **Expand/contract migration patterns** (the textbook zero-downtime
+  column rename CodeRabbit asked about on PR #434). Orthogonal — this
+  proposal addresses *when* migrations run, not *how* they're structured.
+- **Cross-service migration ordering** (Api migrating before Producer
+  on a coordinated change). Each service's migrator is independent; if
+  cross-service ordering becomes a concern, it's solved at the
+  deploy-pipeline level, not in the migrator.
+- **Schema drift detection** (catching cases where someone changes a
+  model without adding a migration). Out of scope here, but the
+  schema-assert in Phase 2 actually catches a subset of it for free —
+  the pod won't start if its expected revision is missing.
+
+## Why this is worth doing soon
+
+- Eliminates the 30s `LOCK TABLE` timeout class of incident outright.
+- Removes the racing-pods debugging story from oncall.
+- Trims a measurable chunk off Worker pod startup latency (no migration
+  check on the critical path for queue draining).
+- Makes the next migration-touching feature PR safer — no deploy-day
+  anxiety about lock windows.
+
+Best slotted in *before* the next migration-touching feature lands, so
+that feature ships on the cleaner path.

--- a/docs/migration-runner-separation.md
+++ b/docs/migration-runner-separation.md
@@ -37,17 +37,21 @@ time they boot.
 using (var scope = app.Services.CreateScope())
 {
     var appServices = scope.ServiceProvider;
+
     switch (mode)
     {
         case Sport.GolfPga:
-            await appServices.GetRequiredService<GolfDataContext>().Database.MigrateAsync();
+            var golfContext = appServices.GetRequiredService<GolfDataContext>();
+            await golfContext.Database.MigrateAsync();
             break;
         case Sport.FootballNcaa:
         case Sport.FootballNfl:
-            await appServices.GetRequiredService<FootballDataContext>().Database.MigrateAsync();
+            var context = appServices.GetRequiredService<FootballDataContext>();
+            await context.Database.MigrateAsync();
             break;
         case Sport.BaseballMlb:
-            await appServices.GetRequiredService<BaseballDataContext>().Database.MigrateAsync();
+            var baseballContext = appServices.GetRequiredService<BaseballDataContext>();
+            await baseballContext.Database.MigrateAsync();
             break;
     }
 }
@@ -190,8 +194,8 @@ This is risk-free: the worst case is the Job runs successfully and pods
 - Pods now boot with the schema-assert path instead of `MigrateAsync`.
 - The lock-contention symptom disappears here.
 
-Can be done per-service (Api first, then Provider, then Producer) so
-the riskiest one (Producer, the most pods) is last.
+The cut-over can be done per-service (Api first, then Provider, then
+Producer) so the riskiest one (Producer, the most pods) is last.
 
 ### Phase 3 — Remove the dead code
 

--- a/sql/pgsql/_admin_config.sql
+++ b/sql/pgsql/_admin_config.sql
@@ -15,3 +15,26 @@ SELECT usename, count(*) AS conns
 FROM pg_stat_activity GROUP BY usename ORDER BY conns DESC;
 
 SELECT pg_size_pretty(pg_database_size(datname)) AS size, datname FROM pg_database ORDER BY pg_database_size(datname) DESC;
+
+-- ─── Lock contention diagnostics ──────────────────────────────────────────────
+-- Find sessions blocked on a lock + who's blocking them. Sort by oldest
+-- blocker transaction first — a zombie "idle in transaction" left over from
+-- a failed pod startup or an abandoned psql session shows up at the top.
+-- Use case: EF "LOCK TABLE __EFMigrationsHistory IN ACCESS EXCLUSIVE MODE"
+-- timing out at 30s on new pod startup means another session is sitting on
+-- the table; this query identifies who.
+-- Once identified: SELECT pg_terminate_backend(<blocker_pid>);
+SELECT
+  blocked.pid              AS blocked_pid,
+  blocked.application_name AS blocked_app,
+  blocked.wait_event,
+  blocker.pid              AS blocker_pid,
+  blocker.application_name AS blocker_app,
+  blocker.state            AS blocker_state,
+  blocker.xact_start       AS blocker_xact_start,
+  now() - blocker.xact_start AS blocker_xact_age,
+  blocker.query            AS blocker_query
+FROM pg_stat_activity blocked
+JOIN pg_stat_activity blocker ON blocker.pid = ANY(pg_blocking_pids(blocked.pid))
+WHERE blocked.wait_event_type = 'Lock'
+ORDER BY blocker_xact_age DESC;

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
@@ -93,6 +93,28 @@ public static class EspnUriMapper
         return BuildCompetitionCompetitorRefFrom(competitionCompetitorStatisticsRef, nameof(competitionCompetitorStatisticsRef));
     }
 
+    /// <summary>
+    /// Inverse of <see cref="CompetitionCompetitorScoreRefToCompetitionCompetitorRef"/>.
+    /// Used by the on-final score doc re-source path in
+    /// <c>EventCompetitionStatusProcessorBase.HandleStatusLifecycleAsync</c>:
+    /// the processor has the competitor ref loaded from
+    /// <c>CompetitionCompetitorExternalId.SourceUrl</c> and needs the per-
+    /// competitor score URI to publish a targeted <c>DocumentRequested</c>
+    /// that forces ESPN to expose the deciding-inning scores before the
+    /// 30s-deferred enrichment runs.
+    /// </summary>
+    public static Uri CompetitionCompetitorRefToCompetitionCompetitorScoreRef(Uri competitionCompetitorRef)
+    {
+        if (competitionCompetitorRef is null)
+            throw new ArgumentNullException(nameof(competitionCompetitorRef));
+
+        // Strip any existing query string and tail segments past the
+        // competitor id, then append /score. ESPN's URL structure for
+        // competitor scores is consistent across sports.
+        var path = competitionCompetitorRef.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        return new Uri($"{path}/score");
+    }
+
     public static Uri CompetitionLeadersRefToCompetitionRef(Uri competitionLeadersRef)
     {
         if (competitionLeadersRef == null)

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
@@ -108,11 +108,14 @@ public static class EspnUriMapper
         if (competitionCompetitorRef is null)
             throw new ArgumentNullException(nameof(competitionCompetitorRef));
 
-        // Strip any existing query string and tail segments past the
-        // competitor id, then append /score. ESPN's URL structure for
-        // competitor scores is consistent across sports.
-        var path = competitionCompetitorRef.GetLeftPart(UriPartial.Path).TrimEnd('/');
-        return new Uri($"{path}/score");
+        // Normalize to the competitor root first — strips query string AND
+        // any tail segments past /competitors/{id} (e.g. /statistics, /score
+        // itself, /linescores). Without this, calling with a deeper URL
+        // would produce nonsense like .../competitors/29/statistics/score.
+        // Then append /score. ESPN's URL structure for competitor scores
+        // is consistent across sports.
+        var competitorRoot = BuildCompetitionCompetitorRefFrom(competitionCompetitorRef, nameof(competitionCompetitorRef));
+        return new Uri($"{competitorRoot.AbsoluteUri.TrimEnd('/')}/score");
     }
 
     public static Uri CompetitionLeadersRefToCompetitionRef(Uri competitionLeadersRef)

--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -121,16 +121,22 @@ namespace SportsData.Producer.Application.Contests
                 return;
             }
 
-            // MLB games cannot end 0-0 in regulation — would proceed to extras
-            // until a side leads. A 0-0 result here means only the bootstrap
-            // rows exist (feed hasn't sourced yet) or genuinely-corrupt data;
-            // defer rather than lock in a finalized 0-0 contest with null
-            // Winner.
-            if (awayMaxScore.Value == 0 && homeMaxScore.Value == 0)
+            // MLB games cannot end tied in regulation — extras run until a
+            // side leads at the end of an inning. A tied result here means
+            // ESPN feed sourcing hasn't caught the deciding inning yet, or
+            // the row is genuinely corrupt. Defer rather than lock in a
+            // finalized tied contest with null Winner (the
+            // contest.AwayScore != contest.HomeScore branch below would be
+            // skipped, leaving WinnerFranchiseSeasonId unset). The
+            // statistically-negligible "officially-tied" cases (rain-
+            // shortened tie game, the historical 2002 All-Star Game) get
+            // deferred forever and surface via warning logs — acceptable
+            // cost vs. corrupting picks scoring for an entire league.
+            if (awayMaxScore.Value == homeMaxScore.Value)
             {
                 _logger.LogWarning(
-                    "MLB MAX competitor scores read as 0-0 for {ContestName} — implausible. Deferring enrichment.",
-                    contest.Name);
+                    "MLB MAX competitor scores are tied ({Score}-{Score}) for {ContestName} — implausible final. Deferring enrichment.",
+                    awayMaxScore.Value, homeMaxScore.Value, contest.Name);
                 return;
             }
 

--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditProcessor.cs
@@ -120,20 +120,21 @@ public class ContestEnrichmentAuditProcessor<TDataContext> : IAuditContestEnrich
             return;
         }
 
-        // MLB-specific 0-0 guard: extra innings until a side leads, so a
-        // 0-0 "final" can only mean bootstrap-only data hasn't been replaced
-        // by the canonical feed yet. Football is exempt: NFL hasn't had a
-        // 0-0 final since 1943 and NCAA OT rules guarantee a non-tie, so a
-        // football 0-0 audit candidate is effectively impossible to begin
-        // with (enrichment's D1 + D2 guards reject 0-0 too). Scoping this
-        // to MLB matches the underlying reasoning instead of relying on
-        // "essentially impossible" upstream.
+        // MLB-specific tie guard: extras run until a side leads at the end
+        // of an inning, so a tied "final" — whether 0-0 (bootstrap-only,
+        // feed hasn't sourced yet) or non-zero (feed cut off mid-game) —
+        // can only mean stale data. Football is exempt: NFL hasn't had a
+        // 0-0 final since 1943 and ties are otherwise legitimate; NCAA OT
+        // rules guarantee a non-tie. Scoping this to MLB matches the
+        // underlying reasoning. Originally just the 0-0 case; broadened to
+        // all ties after 2026-06-20 Chicago White Sox @ Detroit Tigers
+        // finalized 2-2 with null Winner.
         if (contest.Sport == Sport.BaseballMlb
-            && awayMaxScore.Value == 0 && homeMaxScore.Value == 0)
+            && awayMaxScore.Value == homeMaxScore.Value)
         {
             _logger.LogWarning(
-                "Audit deferred — MLB MAX competitor scores are 0-0 (canonical source still stale). ContestName={ContestName}",
-                contest.Name);
+                "Audit deferred — MLB MAX competitor scores are tied ({Score}-{Score}) (canonical source still stale). ContestName={ContestName}",
+                awayMaxScore.Value, homeMaxScore.Value, contest.Name);
             return;
         }
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
@@ -4,6 +4,8 @@ using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Infrastructure.Data.Common;
@@ -122,18 +124,31 @@ public abstract class EventCompetitionStatusProcessorBase<TDataContext> : Docume
             ));
         }
 
-        // Defensive ContestCompleted fan-out. The streamer publishes
-        // this event at its STATUS_FINAL detection sites, but the
-        // streamer's publish can race ahead of the status row write —
-        // if the 30s-deferred enrichment runs before this processor
-        // persists STATUS_FINAL, enrichment short-circuits on the
-        // non-FINAL row and never re-fires. Publishing here, AFTER
-        // the row is definitely written, closes that gap. Consumer is
-        // idempotent (enrichment processor short-circuits on
-        // Contest.FinalizedUtc != null), so a duplicate fire alongside
-        // the streamer is harmless. No paired Event-document
-        // re-source — Provider has dedupe but a defensive cascade
-        // shouldn't risk a sourcing cycle.
+        // Defensive ContestCompleted fan-out + targeted per-competitor
+        // score-doc re-source. The streamer publishes ContestCompleted at
+        // its STATUS_FINAL detection sites, but the streamer's publish can
+        // race ahead of the status row write — if the 30s-deferred
+        // enrichment runs before this processor persists STATUS_FINAL,
+        // enrichment short-circuits on the non-FINAL row and never re-fires.
+        // Publishing here, AFTER the row is definitely written, closes that
+        // gap. Consumer is idempotent (enrichment processor short-circuits
+        // on Contest.FinalizedUtc != null), so a duplicate fire alongside
+        // the streamer is harmless.
+        //
+        // Score-doc re-source: enrichment reads MAX(CompetitionCompetitor-
+        // Scores.Value), so if ESPN's feed hasn't propagated the deciding
+        // inning into CCS by the time enrichment runs, we finalize with
+        // stale scores (the 2026-06-20 White Sox @ Tigers 2-2 corruption
+        // shape, repaired by the audit job but better prevented). Publish a
+        // targeted DocumentRequested per competitor score URI here so
+        // Provider re-fetches from ESPN immediately. Provider's
+        // ShouldBypassCache returns true for current-season requests, and
+        // the content-hash dedupe in ResourceIndexItemProcessor naturally
+        // suppresses the downstream publish if the score actually hasn't
+        // changed — so the worst case is two ESPN fetches per game-end
+        // (negligible against the rate-limit envelope). Restricted to the
+        // score docs only — NOT a re-source of the Event doc — to avoid a
+        // status → event → status sourcing cycle.
         if (newStatusIsFinal && !existedAsFinal)
         {
             _logger.LogInformation(
@@ -150,6 +165,8 @@ public abstract class EventCompetitionStatusProcessorBase<TDataContext> : Docume
                 CorrelationId: command.CorrelationId,
                 CausationId: CausationId.Producer.EventCompetitionStatusDocumentProcessor
             ));
+
+            await RequestCompetitorScoreResourceAsync(competitionId, command);
         }
 
         // CancelledUtc lifecycle: stamp on first observation of
@@ -176,6 +193,68 @@ public abstract class EventCompetitionStatusProcessorBase<TDataContext> : Docume
                         contestId, newStatusTypeName);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// On STATUS_FINAL transition, publish a DocumentRequested for each
+    /// per-competitor score URI so Provider re-fetches from ESPN before the
+    /// 30s-deferred enrichment runs. Without this, enrichment frequently
+    /// reads stale CCS values (the corruption shape PR #431 + the broader
+    /// MLB-tie guard ship after-the-fact, but better prevented).
+    ///
+    /// Loads CompetitionCompetitor.ExternalIds filtered to the Espn
+    /// provider — one round-trip — and derives the score URI from each
+    /// competitor's ref via EspnUriMapper. If a competitor has no Espn
+    /// external id (shouldn't happen for ESPN-sourced games but worth
+    /// guarding), it's skipped with a warning.
+    /// </summary>
+    private async Task RequestCompetitorScoreResourceAsync(
+        Guid competitionId,
+        ProcessDocumentCommand command)
+    {
+        var competitorRefs = await _dataContext.CompetitionCompetitors
+            .AsNoTracking()
+            .Where(cc => cc.CompetitionId == competitionId)
+            .Select(cc => new
+            {
+                cc.Id,
+                EspnRef = cc.ExternalIds
+                    .Where(x => x.Provider == SourceDataProvider.Espn)
+                    .Select(x => x.SourceUrl)
+                    .FirstOrDefault()
+            })
+            .ToListAsync();
+
+        foreach (var competitor in competitorRefs)
+        {
+            if (string.IsNullOrWhiteSpace(competitor.EspnRef))
+            {
+                _logger.LogWarning(
+                    "On-final score-doc re-source skipped — no Espn external id. CompetitionId={CompId}, CompetitorId={CompetitorId}",
+                    competitionId, competitor.Id);
+                continue;
+            }
+
+            var competitorRef = new Uri(competitor.EspnRef);
+            var scoreRef = EspnUriMapper.CompetitionCompetitorRefToCompetitionCompetitorScoreRef(competitorRef);
+
+            _logger.LogInformation(
+                "Publishing on-final score-doc re-source. CompetitionId={CompId}, CompetitorId={CompetitorId}, ScoreUri={ScoreUri}",
+                competitionId, competitor.Id, scoreRef);
+
+            await _publishEndpoint.Publish(new DocumentRequested(
+                Id: Guid.NewGuid().ToString(),
+                ParentId: competitor.Id.ToString(),
+                Uri: scoreRef,
+                Ref: null,
+                Sport: command.Sport,
+                SeasonYear: command.SeasonYear,
+                DocumentType: DocumentType.EventCompetitionCompetitorScore,
+                SourceDataProvider: SourceDataProvider.Espn,
+                CorrelationId: command.CorrelationId,
+                CausationId: CausationId.Producer.EventCompetitionStatusDocumentProcessor
+            ));
         }
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
@@ -236,7 +236,21 @@ public abstract class EventCompetitionStatusProcessorBase<TDataContext> : Docume
                 continue;
             }
 
-            var competitorRef = new Uri(competitor.EspnRef);
+            // TryCreate over `new Uri(...)` so a malformed stored ref
+            // doesn't tank the fan-out for the OTHER competitor in this
+            // loop (or bubble up and kill the surrounding document
+            // processor pass). Malformed URIs in the external-id store
+            // are non-retryable contract violations — log loudly so the
+            // bad row is fixable, skip individually, and let the other
+            // competitor's request go through.
+            if (!Uri.TryCreate(competitor.EspnRef, UriKind.Absolute, out var competitorRef))
+            {
+                _logger.LogError(
+                    "On-final score-doc re-source skipped — competitor external ref is not a valid absolute URI. CompetitionId={CompId}, CompetitorId={CompetitorId}, EspnRef={EspnRef}",
+                    competitionId, competitor.Id, competitor.EspnRef);
+                continue;
+            }
+
             var scoreRef = EspnUriMapper.CompetitionCompetitorRefToCompetitionCompetitorScoreRef(competitorRef);
 
             _logger.LogInformation(

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
@@ -251,7 +251,26 @@ public abstract class EventCompetitionStatusProcessorBase<TDataContext> : Docume
                 continue;
             }
 
-            var scoreRef = EspnUriMapper.CompetitionCompetitorRefToCompetitionCompetitorScoreRef(competitorRef);
+            // Same per-competitor fault-isolation reasoning as the
+            // TryCreate guard above. The URI parses, but ESPN's expected
+            // /events/{id}/competitions/{id}/competitors/{id} shape might
+            // not hold if the stored ref was corrupted or pointed at the
+            // wrong resource — BuildCompetitionCompetitorRefFrom throws
+            // ArgumentException in that case. Log + skip so the other
+            // competitor's publish still goes out.
+            Uri scoreRef;
+            try
+            {
+                scoreRef = EspnUriMapper.CompetitionCompetitorRefToCompetitionCompetitorScoreRef(competitorRef);
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "On-final score-doc re-source skipped — competitor external ref did not match the expected ESPN shape. CompetitionId={CompId}, CompetitorId={CompetitorId}, EspnRef={EspnRef}",
+                    competitionId, competitor.Id, competitor.EspnRef);
+                continue;
+            }
 
             _logger.LogInformation(
                 "Publishing on-final score-doc re-source. CompetitionId={CompId}, CompetitorId={CompetitorId}, ScoreUri={ScoreUri}",

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionStatusProcessorBase.cs
@@ -103,8 +103,8 @@ public abstract class EventCompetitionStatusProcessorBase<TDataContext> : Docume
         if (publishStatusChanged)
         {
             _logger.LogInformation(
-                "Contest status changed, publishing event. ContestId={ContestId}, CompetitionId={CompId}, NewStatus={Status}",
-                contestId, competitionId, newStatusTypeName);
+                "Contest status changed, publishing event. ContestId={ContestId}, CompetitionId={CompId}, OldStatus={OldStatus}, NewStatus={NewStatus}",
+                contestId, competitionId, existingStatusTypeName, newStatusTypeName);
 
             await _publishEndpoint.Publish(new ContestStatusChanged(
                 contestId,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
@@ -417,14 +417,24 @@ public abstract class EventDocumentProcessorBase<TDataContext> : DocumentProcess
 
         if (DateTime.TryParse(dto.Date, out var startDateTime))
         {
-            _logger.LogInformation(
-                "Updating Contest StartDateUtc. ContestId={ContestId}, OldDate={OldDate}, NewDate={NewDate}",
-                contest.Id,
-                contest.StartDateUtc,
-                startDateTime.ToUniversalTime());
-
-            contest.StartDateUtc = DateTime.Parse(dto.Date).ToUniversalTime();
-            await _dataContext.SaveChangesAsync();
+            // Gate the log + write on an actual change. ESPN re-publishes
+            // the Event document frequently with the same date; without
+            // this guard every republish emitted a misleading "Updating
+            // StartDateUtc" line where OldDate == NewDate, and EF rode the
+            // no-op write through to a SaveChangesAsync round-trip. The
+            // outer SaveChangesAsync at the end of ProcessUpdate already
+            // commits any genuine change alongside the child-document
+            // publishes — no need for the inner save here.
+            var newStartUtc = startDateTime.ToUniversalTime();
+            if (contest.StartDateUtc != newStartUtc)
+            {
+                _logger.LogInformation(
+                    "Updating Contest StartDateUtc. ContestId={ContestId}, OldDate={OldDate}, NewDate={NewDate}",
+                    contest.Id,
+                    contest.StartDateUtc,
+                    newStartUtc);
+                contest.StartDateUtc = newStartUtc;
+            }
         }
 
         _logger.LogInformation(

--- a/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
+++ b/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
@@ -216,9 +216,25 @@ namespace SportsData.Provider.Application.Processors
                             if (contentHash == dbItem.LastPublishedContentHash &&
                                 IsWithinPublishCooldown(dbItem.LastPublishedUtc))
                             {
+                                // Surface enough timing context that "why
+                                // didn't Producer get this re-source?"
+                                // questions are answerable from Seq alone:
+                                // age of the prior publish + remaining
+                                // cooldown window. Both stored as numbers
+                                // (not durations) so Seq filter expressions
+                                // like CooldownRemainingMinutes > 30 work.
+                                var lastPublishedAgeMinutes = dbItem.LastPublishedUtc.HasValue
+                                    ? (_dateTimeProvider.UtcNow() - dbItem.LastPublishedUtc.Value).TotalMinutes
+                                    : (double?)null;
+                                var cooldownRemainingMinutes = GetCooldownRemainingMinutes(dbItem.LastPublishedUtc);
+
                                 _logger.LogInformation(
-                                    "ESPN {CacheResult}. Content unchanged and within cooldown, skipping. Url={Url}",
-                                    "HIT-SUPPRESSED", dbItem.Uri.OriginalString);
+                                    "ESPN {CacheResult}. Content unchanged and within cooldown, skipping. " +
+                                    "Url={Url}, LastPublishedAgeMinutes={LastPublishedAgeMinutes:F1}, CooldownRemainingMinutes={CooldownRemainingMinutes:F1}",
+                                    "HIT-SUPPRESSED",
+                                    dbItem.Uri.OriginalString,
+                                    lastPublishedAgeMinutes,
+                                    cooldownRemainingMinutes);
                                 return;
                             }
                         }
@@ -500,6 +516,34 @@ namespace SportsData.Provider.Application.Processors
                 return false; // cooldown disabled — always allow re-publish
 
             return (_dateTimeProvider.UtcNow() - lastPublishedUtc.Value).TotalMinutes < cooldownMinutes;
+        }
+
+        /// <summary>
+        /// Minutes remaining in the publish-suppression window for a
+        /// document with the given LastPublishedUtc. Caller has already
+        /// verified <see cref="IsWithinPublishCooldown"/> returned true.
+        /// Returns null when the cooldown is disabled, misconfigured, or
+        /// the document has never been published — the suppression
+        /// log site uses null to mean "not applicable" rather than zero,
+        /// so Seq filter expressions like
+        /// <c>CooldownRemainingMinutes &gt; 30</c> don't false-match
+        /// disabled-cooldown rows.
+        /// </summary>
+        private double? GetCooldownRemainingMinutes(DateTime? lastPublishedUtc)
+        {
+            if (!lastPublishedUtc.HasValue)
+                return null;
+
+            var cooldownStr = _commonConfig["SportsData.Provider:DocumentPublishCooldownMinutes"];
+            if (string.IsNullOrWhiteSpace(cooldownStr) || !int.TryParse(cooldownStr, out var cooldownMinutes))
+                return null;
+
+            if (cooldownMinutes <= 0)
+                return null;
+
+            var ageMinutes = (_dateTimeProvider.UtcNow() - lastPublishedUtc.Value).TotalMinutes;
+            var remaining = cooldownMinutes - ageMinutes;
+            return remaining > 0 ? remaining : 0;
         }
 
         private async Task UpdateLastPublishedStateAsync(string collectionName, string urlHash, string json)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -347,8 +347,16 @@ public class BaseballContestEnrichmentProcessorTests
     }
 
     [Fact]
-    public async Task Process_WhenTie_DoesNotSetWinner()
+    public async Task Process_WhenMlbScoresAreNonZeroTie_DefersForCronRetry()
     {
+        // MLB cannot end tied — extras run until a side leads at the end of
+        // an inning. A non-zero tied "Final" (e.g. the 2026-06-20 White Sox
+        // @ Tigers incident: enrichment ran with MAX(CCS)=2-2 because the
+        // feed had only sourced through the early innings) means stale data,
+        // same root cause as the 0-0 case but with a non-bootstrap value.
+        // Defer rather than lock in a finalized tied contest with null
+        // Winner. Prior behavior here was "finalize tied with null winner",
+        // which was the corruption shape we're explicitly preventing.
         var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
 
         var competition = await _baseballDataContext.Competitions
@@ -359,18 +367,18 @@ public class BaseballContestEnrichmentProcessorTests
         var home = competition.Competitors.First(c => c.HomeAway == "home");
 
         _baseballDataContext.CompetitionCompetitorScores.AddRange(
-            CreateScore(away.Id, value: 5, sourceDescription: "Final"),
-            CreateScore(home.Id, value: 5, sourceDescription: "Final"));
+            CreateScore(away.Id, value: 2, sourceDescription: "feed"),
+            CreateScore(home.Id, value: 2, sourceDescription: "feed"));
         await _baseballDataContext.SaveChangesAsync();
 
         var command = new EnrichContestCommand(contestId, Guid.NewGuid());
         await _sut.Process(command);
 
         var contest = await _baseballDataContext.Contests.FindAsync(contestId);
-        contest!.AwayScore.Should().Be(5);
-        contest.HomeScore.Should().Be(5);
+        contest!.AwayScore.Should().BeNull();
+        contest.HomeScore.Should().BeNull();
         contest.WinnerFranchiseSeasonId.Should().BeNull();
-        contest.FinalizedUtc.Should().NotBeNull();
+        contest.FinalizedUtc.Should().BeNull();
     }
 
     #endregion

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
@@ -152,6 +152,34 @@ public class ContestEnrichmentAuditProcessorTests
     }
 
     [Fact]
+    public async Task Process_WhenMlbMaxScoresAreNonZeroTie_DefersAndLeavesContestUntouched()
+    {
+        // Mid-game feed cut-off race — the canonical feed sourced through
+        // a few innings and stopped, so MAX(CCS) reads as a non-zero tie
+        // (e.g. the 2026-06-20 White Sox @ Tigers incident: MAX returned
+        // 2-2 because the feed only had the first two innings sourced).
+        // MLB cannot end tied in regulation, so the audit cannot verify a
+        // tied state and defers; next sweep retries once the feed lands
+        // the deciding inning.
+        var (contestId, _, away, home) = await SeedFinalizedContestAsync(
+            currentAway: 2, currentHome: 2,
+            currentWinner: null,
+            sport: Sport.BaseballMlb);
+        await SeedScoreAsync(away.Id, value: 2);
+        await SeedScoreAsync(home.Id, value: 2);
+
+        await _sut.Process(new AuditContestEnrichmentCommand(contestId, Guid.NewGuid()));
+
+        var contest = await FootballDataContext.Contests.AsNoTracking().FirstAsync(c => c.Id == contestId);
+        contest.FinalizedUtc.Should().NotBeNull();
+        contest.AuditedUtc.Should().BeNull();
+
+        Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+            x => x.Enqueue<IEnrichContests>(It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task Process_WhenNonMlbMaxScoresAreZeroZero_StampsAuditedUtc()
     {
         // Football is exempt from the MLB-specific 0-0 guard. A theoretical


### PR DESCRIPTION
## Batch PR — not cohesive on purpose

Seven commits gathered from a single Seq-spelunking session this morning. Each commit is self-contained and reviewable independently; bundled together to avoid PR sprawl.

## Commits

| # | Commit | What |
|---|---|---|
| 1 | `fix(producer): gate Contest StartDateUtc update on actual change` | `EventDocumentProcessorBase.ProcessUpdate` was logging "Updating StartDateUtc OldDate=X NewDate=X" on every ESPN re-publish where the date hadn't actually changed. Guard now compares to persisted value. Also drops an inner `SaveChangesAsync` (outer one at end of method already covers it) and an unnecessary second `DateTime.Parse`. |
| 2 | `chore(producer): include OldStatus in "Contest status changed" log` | Status-transition publish log line carried only `NewStatus`. Reading Seq required pulling the prior log line on the same ContestId. Both `OldStatus` and `NewStatus` are non-null + meaningful at the publish site already. |
| 3 | `fix(producer): broaden MLB tie guard from 0-0 to any tied score` | PR #431 added a 0-0 sanity guard. Same reasoning applies to any tied MLB score (extras run until a side leads). The 2026-06-20 White Sox @ Tigers incident finalized 2-2 with null Winner — same corruption shape as Rockies-Cubs, non-zero variant. Broadens the guard in both the enrichment processor and the audit processor. |
| 4 | `feat(producer): on-final per-competitor score-doc re-source` | Prevention layer for the eventual-consistency window that lets the 2-2 shape happen. `EventCompetitionStatusProcessorBase.HandleStatusLifecycleAsync` now publishes targeted `DocumentRequested` for the per-competitor score URIs on `STATUS_FINAL` transition. Provider's `ShouldBypassCache` returns true for current-season → fresh ESPN fetch; content-hash dedupe suppresses noise. **Sketch — no test coverage yet for the new behavior; reviewing the shape first.** |
| 5 | `chore(provider): expand HIT-SUPPRESSED log with cooldown timing context` | When Provider suppresses a publish (content-hash unchanged + within cooldown), the log now carries `LastPublishedAgeMinutes` + `CooldownRemainingMinutes` so "why didn't Producer get this re-source?" investigations are answerable from Seq alone. |
| 6 | `docs: add migration runner separation proposal` | Doc-only proposal drafted after the 2026-06-20 MLB Worker `LOCK TABLE __EFMigrationsHistory` 30s-timeout incident. Captures the racing-pods problem at the codebase level so the existing `project_migration_runner` memory note has a public review surface. Not committing to action — review first. |
| 7 | `chore(sql): add lock-contention diagnostic to _admin_config.sql` | `pg_blocking_pids` join stashed in the admin script with rationale + "once identified, terminate the blocker pid" follow-through so the next 4 AM page is one copy-paste. |

## Test plan

- [x] `dotnet build` clean on Producer + Provider
- [x] Producer unit suite: 30 enrichment + audit tests pass with the broadened tie guard
- [x] Producer status-processor suite: 19 tests pass with the new on-final score-doc publish wired in (existing tests don't exercise the new branch — gap to close with explicit tests after sketch review)
- [x] Provider unit suite: 56 pass, 0 fail
- [ ] Post-deploy verification:
  - Seq: no more `OldDate == NewDate` "Updating StartDateUtc" lines from `BaseballEventDocumentProcessor` / `FootballEventDocumentProcessor`
  - Seq: status-change log lines show `OldStatus=X, NewStatus=Y`
  - Seq: `Publishing on-final score-doc re-source` appears on every MLB / NFL / NCAA game-end
  - Seq: 2-2-shape audit-job mismatches drop to near zero (audit continues to repair any that slip through)
  - Seq: `HIT-SUPPRESSED` lines carry `LastPublishedAgeMinutes` + `CooldownRemainingMinutes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MLB contest enrichment/auditing to defer when MAX competitor scores are tied (including non-zero ties)
  * Improved final competition status handling to re-request per-competitor ESPN score documents before deferred enrichment
  * Reduced unnecessary `StartDateUtc` updates/republish churn by only persisting when the value actually changes

* **Documentation**
  * Added a migration-runner separation proposal to run EF Core migrations once per deploy via dedicated Job(s)

* **Chores**
  * Added lock contention diagnostics to admin SQL and expanded cooldown/timing context in cache suppression logging

* **Tests**
  * Updated/added unit tests for MLB tie deferral scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->