### PR TITLE
chore(producer): drop misleading scoreboard from CompetitorScoreUpdated completion log

### DIFF
--- a/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
+++ b/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
@@ -117,8 +117,12 @@ public class CompetitorScoreUpdatedConsumerHandler : ICompetitorScoreUpdatedCons
 
         await _dataContext.SaveChangesAsync();
 
-        _logger.LogInformation(
-            "CompetitorScoreUpdatedConsumerHandler completed. HomeScore={HomeScore}, AwayScore={AwayScore}",
-            contest.HomeScore, contest.AwayScore);
+        // Completion marker only. The event carries one team's score; the
+        // mid-flow "Updated HomeScore. HomeScore=X" / "Updated AwayScore.
+        // AwayScore=X" log line above already records which side changed
+        // and to what value. Including contest.HomeScore + contest.AwayScore
+        // here implied both sides were updated — leave the contest-wide
+        // scoreboard out of this log to avoid the misread.
+        _logger.LogInformation("CompetitorScoreUpdatedConsumerHandler completed.");
     }
 }


### PR DESCRIPTION
## Summary

`CompetitorScoreUpdated` carries one team's score. The completion log at the bottom of `CompetitorScoreUpdatedConsumerHandler.Process` was emitting `HomeScore=X, AwayScore=Y` — making it look like both sides were updated by this single event when only one was.

The mid-flow log already records which side changed and to what value:

```
Updated HomeScore. HomeScore=14
```

So the completion log can shrink to a "I finished" marker without losing diagnostic info. Everything in scope (`ContestId`, `FranchiseSeasonId`, `Score`, `Sport`, `CorrelationId`, `CausationId`) is already picked up by `BeginScope` for the entire handler.

## Wider review

User asked for a full review of logging + logic on this file. Documented findings in commit message but the short version:

- **Logging**: only the completion-log issue was misleading; mid-flow logs (`Updated HomeScore...`) are fine. The redundancy between the `BeginScope`'s `Score` field and the `HomeScore={HomeScore}` placeholder is acceptable — the latter adds the side semantic.
- **Logic**: no bugs found.
  - `contest.HomeScore == evt.Score` correctly treats null-vs-0 as a real change (so first-ever 0 score is persisted).
  - Redelivery no-op fires before any state mutation or publish — at-least-once safe.
  - Publish via outbox + `SaveChangesAsync` is correct per the interceptor pattern.
  - `contest.ModifiedBy = evt.CorrelationId` is unusual but consistent with the project's event-driven audit-chain convention.

## Test plan

- [x] `dotnet build` clean on Producer
- [x] `CompetitorScoreUpdatedConsumerHandlerTests`: 7 pass, 0 fail (tests don't assert log content)
- [ ] Post-deploy verification in Seq: completion log line shows just "CompetitorScoreUpdatedConsumerHandler completed." with the per-side update visible in the prior log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging accuracy in competitor score update processing to clearly reflect that individual team scores are updated one at a time, preventing potential misinterpretation in system logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->