### PR TITLE
chore(producer): include PreviousScore + NewScore on score-update log

### DIFF
--- a/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
+++ b/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
@@ -76,8 +76,11 @@ public class CompetitorScoreUpdatedConsumerHandler : ICompetitorScoreUpdatedCons
                 return;
             }
 
+            var previousHomeScore = contest.HomeScore;
             contest.HomeScore = evt.Score;
-            _logger.LogInformation("Updated HomeScore. HomeScore={HomeScore}", evt.Score);
+            _logger.LogInformation(
+                "Updated HomeScore. PreviousScore={PreviousScore}, NewScore={NewScore}",
+                previousHomeScore, evt.Score);
         }
         else if (contest.AwayTeamFranchiseSeasonId == evt.FranchiseSeasonId)
         {
@@ -87,8 +90,11 @@ public class CompetitorScoreUpdatedConsumerHandler : ICompetitorScoreUpdatedCons
                 return;
             }
 
+            var previousAwayScore = contest.AwayScore;
             contest.AwayScore = evt.Score;
-            _logger.LogInformation("Updated AwayScore. AwayScore={AwayScore}", evt.Score);
+            _logger.LogInformation(
+                "Updated AwayScore. PreviousScore={PreviousScore}, NewScore={NewScore}",
+                previousAwayScore, evt.Score);
         }
         else
         {


### PR DESCRIPTION
## Summary

Follow-up to #439. The mid-flow "Updated HomeScore" / "Updated AwayScore" log line in `CompetitorScoreUpdatedConsumerHandler.Process` was correctly labeling which side updated, but only carried the new value. Reading Seq to answer "what was the score before this event?" required pulling the prior log entry on the same `ContestId`.

Capture the previous value before assigning the new one and log both:

```
before: "Updated HomeScore. HomeScore=14"
after:  "Updated HomeScore. PreviousScore=7, NewScore=14"
```

`PreviousScore` is nullable (`Contest.HomeScore` / `AwayScore` are `int?`). When this is the first observed score for that side (null → first value), `PreviousScore` renders as `null` in Seq — correct.

## Test plan

- [x] `dotnet build` clean on Producer
- [x] `CompetitorScoreUpdatedConsumerHandlerTests`: 7 pass, 0 fail (tests don't assert log content)
- [ ] Post-deploy verification in Seq: each score-update line carries both `PreviousScore` and `NewScore` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced score update audit logging to display both previous and new score values for all teams, providing clearer visibility into score change history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->