### PR TITLE
feat: broadcast ContestFinalized over SignalR so picks page updates without refresh

### DIFF
--- a/src/SportsData.Api/Application/Events/ContestFinalizedHandler.cs
+++ b/src/SportsData.Api/Application/Events/ContestFinalizedHandler.cs
@@ -1,19 +1,31 @@
 using MassTransit;
 
+using Microsoft.AspNetCore.SignalR;
+
 using SportsData.Api.Application.Scoring;
+using SportsData.Api.Infrastructure.Notifications;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Processing;
 
 namespace SportsData.Api.Application.Events
 {
     /// <summary>
-    /// Closes the live-scoring loop. Producer's sport-specific
+    /// Closes the live-scoring loop AND fans out the enriched final-state
+    /// update to connected SignalR clients. Producer's sport-specific
     /// ContestEnrichmentProcessor publishes <see cref="ContestFinalized"/>
     /// once the canonical Contest row has been enriched with final scores,
-    /// winner, odds results, and FinalizedUtc. This shim enqueues a
-    /// <see cref="ScorePicksCommand"/> via Hangfire so the existing
-    /// <see cref="PickScoringProcessor"/> path runs as soon as the
-    /// scoreable data is in place.
+    /// winner, odds results, and FinalizedUtc.
+    ///
+    /// Two responsibilities:
+    ///   1. Enqueue a <see cref="ScorePicksCommand"/> via Hangfire so the
+    ///      existing <see cref="PickScoringProcessor"/> path runs as soon
+    ///      as the scoreable data is in place.
+    ///   2. Broadcast over SignalR so the picks page can flip the matchup
+    ///      card from "raw STATUS_FINAL" (no cover line, no SU checkmark)
+    ///      to fully enriched without a page refresh. The 30s window
+    ///      between STATUS_FINAL and ContestFinalized is exactly the
+    ///      window where the card sits half-rendered; this broadcast
+    ///      closes it.
     ///
     /// Replaces the prior ContestCompletedHandler which fired off
     /// <see cref="ContestCompleted"/> the moment STATUS_FINAL was detected —
@@ -21,25 +33,30 @@ namespace SportsData.Api.Application.Events
     /// on. See docs/contest-finalization-event-restructure.md.
     ///
     /// Per the "ingest consumers must be thin Hangfire-spawn shims"
-    /// convention, this consumer does no inline DB work. The processor
-    /// handles all actual scoring work, including idempotency via its
-    /// already-scored short-circuit — safe against at-least-once redelivery
-    /// (broker redelivery, admin replay, pod restart, etc.).
+    /// convention, the SCORING path does no inline DB work — the
+    /// processor handles all actual scoring work, including idempotency
+    /// via its already-scored short-circuit (safe against at-least-once
+    /// redelivery). The SignalR fan-out is a pure broadcast of the
+    /// already-canonical message body, so it's still consistent with the
+    /// thin-shim rule.
     /// </summary>
     public class ContestFinalizedHandler : IConsumer<ContestFinalized>
     {
         private readonly ILogger<ContestFinalizedHandler> _logger;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IHubContext<NotificationHub> _hubContext;
 
         public ContestFinalizedHandler(
             ILogger<ContestFinalizedHandler> logger,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IHubContext<NotificationHub> hubContext)
         {
             _logger = logger;
             _backgroundJobProvider = backgroundJobProvider;
+            _hubContext = hubContext;
         }
 
-        public Task Consume(ConsumeContext<ContestFinalized> context)
+        public async Task Consume(ConsumeContext<ContestFinalized> context)
         {
             var msg = context.Message;
 
@@ -54,7 +71,18 @@ namespace SportsData.Api.Application.Events
                 "ContestFinalized consume: ScorePicksCommand enqueued. ContestId={ContestId}, CorrelationId={CorrelationId}",
                 msg.ContestId, msg.CorrelationId);
 
-            return Task.CompletedTask;
+            // SignalR broadcast — same Clients.All pattern as the existing
+            // ContestStatusChanged / ContestScoreChanged handlers. Web
+            // merges the enriched fields into ContestUpdatesContext so
+            // GameStatus + FinalScoreResult re-render with the cover line
+            // and the SU checkmark.
+            await _hubContext.Clients
+                .All
+                .SendAsync("ContestFinalized", msg, context.CancellationToken);
+
+            _logger.LogInformation(
+                "ContestFinalized consume: SignalR Clients.All.SendAsync completed. ContestId={ContestId}, CorrelationId={CorrelationId}, MessageId={MessageId}",
+                msg.ContestId, msg.CorrelationId, context.MessageId);
         }
     }
 }

--- a/src/SportsData.Core/Eventing/Events/Contests/ContestFinalized.cs
+++ b/src/SportsData.Core/Eventing/Events/Contests/ContestFinalized.cs
@@ -10,6 +10,28 @@ namespace SportsData.Core.Eventing.Events.Contests
     /// kick off picks scoring — distinct from <see cref="ContestCompleted"/>,
     /// which fires the moment STATUS_FINAL is detected and predates the
     /// enrichment write.
+    ///
+    /// Carries the enriched result fields so API can broadcast them over
+    /// SignalR without round-tripping back to Producer. Web clients then
+    /// merge these into their live-update cache to flip the matchup card
+    /// from "raw STATUS_FINAL" (no cover line, no SU checkmark) to fully
+    /// enriched without a page refresh.
+    ///
+    /// All result fields are nullable because:
+    ///   - <see cref="WinnerFranchiseSeasonId"/> is null on a tie (rare in
+    ///     football, impossible in MLB per the tie guards).
+    ///   - <see cref="SpreadWinnerFranchiseSeasonId"/> is null on a true
+    ///     spread push (game landed exactly on the line).
+    ///   - <see cref="OverUnderResultRaw"/> is null when no odds were
+    ///     enriched. Carrier wire type is int? mapping to the Producer-side
+    ///     OverUnderResult enum (None=0, Over=1, Under=2, Push=3). Sent as
+    ///     int? so Core stays free of the Producer-side enum; consumers
+    ///     translate to the appropriate display type.
+    ///   - <see cref="AwayScore"/> / <see cref="HomeScore"/> /
+    ///     <see cref="CompletedUtc"/> are always populated by enrichment
+    ///     before publish, but kept nullable so older Producer pods
+    ///     publishing the prior shape don't fail deserialization during a
+    ///     rolling deploy.
     /// </summary>
     public record ContestFinalized(
         Guid ContestId,
@@ -17,6 +39,12 @@ namespace SportsData.Core.Eventing.Events.Contests
         Sport Sport,
         int? SeasonYear,
         Guid CorrelationId,
-        Guid CausationId
+        Guid CausationId,
+        int? AwayScore = null,
+        int? HomeScore = null,
+        Guid? WinnerFranchiseSeasonId = null,
+        Guid? SpreadWinnerFranchiseSeasonId = null,
+        int? OverUnderResultRaw = null,
+        DateTime? CompletedUtc = null
         ) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId);
 }

--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -180,12 +180,18 @@ namespace SportsData.Producer.Application.Contests
 
             await _bus.Publish(
                 new ContestFinalized(
-                    command.ContestId,
-                    null,
-                    contest.Sport,
-                    contest.SeasonYear,
-                    command.CorrelationId,
-                    Guid.NewGuid()));
+                    ContestId: command.ContestId,
+                    Ref: null,
+                    Sport: contest.Sport,
+                    SeasonYear: contest.SeasonYear,
+                    CorrelationId: command.CorrelationId,
+                    CausationId: Guid.NewGuid(),
+                    AwayScore: contest.AwayScore,
+                    HomeScore: contest.HomeScore,
+                    WinnerFranchiseSeasonId: contest.WinnerFranchiseSeasonId,
+                    SpreadWinnerFranchiseSeasonId: contest.SpreadWinnerFranchiseSeasonId,
+                    OverUnderResultRaw: (int)contest.OverUnder,
+                    CompletedUtc: contest.FinalizedUtc));
             await _dataContext.SaveChangesAsync();
 
             _logger.LogInformation(

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -193,12 +193,18 @@ namespace SportsData.Producer.Application.Contests
 
                 await _bus.Publish(
                     new ContestFinalized(
-                        command.ContestId,
-                        null,
-                        contest.Sport,
-                        contest.SeasonYear,
-                        command.CorrelationId,
-                        Guid.NewGuid()));
+                        ContestId: command.ContestId,
+                        Ref: null,
+                        Sport: contest.Sport,
+                        SeasonYear: contest.SeasonYear,
+                        CorrelationId: command.CorrelationId,
+                        CausationId: Guid.NewGuid(),
+                        AwayScore: contest.AwayScore,
+                        HomeScore: contest.HomeScore,
+                        WinnerFranchiseSeasonId: contest.WinnerFranchiseSeasonId,
+                        SpreadWinnerFranchiseSeasonId: contest.SpreadWinnerFranchiseSeasonId,
+                        OverUnderResultRaw: (int)contest.OverUnder,
+                        CompletedUtc: contest.FinalizedUtc));
                 await _dataContext.SaveChangesAsync();
             }
         }

--- a/src/UI/sd-mobile/__tests__/hooks/useSignalRClient.test.tsx
+++ b/src/UI/sd-mobile/__tests__/hooks/useSignalRClient.test.tsx
@@ -110,12 +110,13 @@ describe('useSignalRClient', () => {
     jest.restoreAllMocks();
   });
 
-  it('registers handlers for the three SignalR events', async () => {
+  it('registers handlers for the four SignalR events', async () => {
     render(<HookHarness />);
     // Allow the start() promise to resolve.
     await act(async () => { await Promise.resolve(); });
 
     expect(mockConnection.on).toHaveBeenCalledWith('ContestStatusChanged', expect.any(Function));
+    expect(mockConnection.on).toHaveBeenCalledWith('ContestFinalized', expect.any(Function));
     expect(mockConnection.on).toHaveBeenCalledWith('FootballPlayCompleted', expect.any(Function));
     expect(mockConnection.on).toHaveBeenCalledWith('BaseballPlayCompleted', expect.any(Function));
     expect(mockConnection.start).toHaveBeenCalledTimes(1);
@@ -131,6 +132,38 @@ describe('useSignalRClient', () => {
     });
 
     expect(useContestUpdatesStore.getState().contests[cid]?.status).toBe('STATUS_IN_PROGRESS');
+  });
+
+  it('dispatches incoming ContestFinalized into the store with enriched fields', async () => {
+    render(<HookHarness />);
+    await act(async () => { await Promise.resolve(); });
+
+    const cid = '00000000-0000-0000-0000-000000000def';
+    const winnerId = '11111111-1111-1111-1111-111111111111';
+    const spreadWinnerId = '22222222-2222-2222-2222-222222222222';
+
+    act(() => {
+      mockConnection.__invoke('ContestFinalized', {
+        contestId: cid,
+        awayScore: 1,
+        homeScore: 4,
+        winnerFranchiseSeasonId: winnerId,
+        spreadWinnerFranchiseSeasonId: spreadWinnerId,
+        overUnderResultRaw: 1, // Over
+        completedUtc: '2026-06-20T22:30:00Z',
+      });
+    });
+
+    const record = useContestUpdatesStore.getState().contests[cid];
+    expect(record?.status).toBe('STATUS_FINAL');
+    expect(record?.statusDescription).toBe('Final');
+    expect(record?.awayScore).toBe(1);
+    expect(record?.homeScore).toBe(4);
+    expect(record?.winnerFranchiseSeasonId).toBe(winnerId);
+    expect(record?.spreadWinnerFranchiseSeasonId).toBe(spreadWinnerId);
+    // Wire-format translation: int 1 → "Over" string for FinalScoreResult.
+    expect(record?.overUnderResult).toBe('Over');
+    expect(record?.completedUtc).toBe('2026-06-20T22:30:00Z');
   });
 
   it('stops the connection when AppState transitions to background', async () => {

--- a/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
+++ b/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
@@ -205,6 +205,86 @@ describe('contestUpdatesStore', () => {
     });
   });
 
+  describe('handleContestFinalized', () => {
+    const finalizedPayload = (overrides?: Partial<{
+      contestId: string;
+      awayScore: number | null;
+      homeScore: number | null;
+      winnerFranchiseSeasonId: string | null;
+      spreadWinnerFranchiseSeasonId: string | null;
+      overUnderResultRaw: number | null;
+      completedUtc: string | null;
+    }>) => ({
+      contestId: CID,
+      awayScore: 1,
+      homeScore: 4,
+      winnerFranchiseSeasonId: '11111111-1111-1111-1111-111111111111',
+      spreadWinnerFranchiseSeasonId: '22222222-2222-2222-2222-222222222222',
+      overUnderResultRaw: 1, // Over
+      completedUtc: '2026-06-20T22:30:00Z',
+      ...overrides,
+    });
+
+    it('promotes status to STATUS_FINAL even if no prior status event arrived (self-heal)', () => {
+      useContestUpdatesStore.getState().handleContestFinalized(finalizedPayload());
+
+      const record = useContestUpdatesStore.getState().contests[CID];
+      expect(record.status).toBe('STATUS_FINAL');
+      expect(record.statusDescription).toBe('Final');
+    });
+
+    it('writes enrichment-result fields', () => {
+      useContestUpdatesStore.getState().handleContestFinalized(finalizedPayload());
+
+      const record = useContestUpdatesStore.getState().contests[CID];
+      expect(record.awayScore).toBe(1);
+      expect(record.homeScore).toBe(4);
+      expect(record.winnerFranchiseSeasonId).toBe('11111111-1111-1111-1111-111111111111');
+      expect(record.spreadWinnerFranchiseSeasonId).toBe('22222222-2222-2222-2222-222222222222');
+      expect(record.completedUtc).toBe('2026-06-20T22:30:00Z');
+    });
+
+    it.each([
+      [1, 'Over'],
+      [2, 'Under'],
+      [3, 'Push'],
+    ])('translates overUnderResultRaw %s to %s', (raw, expected) => {
+      useContestUpdatesStore.getState().handleContestFinalized(finalizedPayload({ overUnderResultRaw: raw }));
+
+      expect(useContestUpdatesStore.getState().contests[CID].overUnderResult).toBe(expected);
+    });
+
+    it.each([0, null, undefined])('leaves overUnderResult null when raw is %s (None / not enriched)', (raw) => {
+      useContestUpdatesStore.getState().handleContestFinalized(
+        finalizedPayload({ overUnderResultRaw: raw as number | null }),
+      );
+
+      expect(useContestUpdatesStore.getState().contests[CID].overUnderResult).toBeNull();
+    });
+
+    it('ignores payloads missing contestId', () => {
+      useContestUpdatesStore.getState().handleContestFinalized(finalizedPayload({ contestId: '' }));
+      expect(Object.keys(useContestUpdatesStore.getState().contests)).toHaveLength(0);
+    });
+
+    it('preserves prior live fields when finalizing (merges into existing record)', () => {
+      // Arrange: a live football play arrived earlier with possession +
+      // ball position; ContestFinalized should not clobber them.
+      useContestUpdatesStore.getState().handleFootballPlayCompleted(footballPayload({
+        possessionFranchiseSeasonId: '33333333-3333-3333-3333-333333333333',
+        ballOnYardLine: 42,
+      }));
+
+      useContestUpdatesStore.getState().handleContestFinalized(finalizedPayload());
+
+      const record = useContestUpdatesStore.getState().contests[CID];
+      expect(record.possessionFranchiseSeasonId).toBe('33333333-3333-3333-3333-333333333333');
+      expect(record.ballOnYardLine).toBe(42);
+      // And the new fields are present.
+      expect(record.winnerFranchiseSeasonId).toBe('11111111-1111-1111-1111-111111111111');
+    });
+  });
+
   describe('clearContestUpdate / clearAllUpdates', () => {
     it('clearContestUpdate removes a single record', () => {
       useContestUpdatesStore.getState().handleStatusUpdate(statusPayload());

--- a/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
+++ b/src/UI/sd-mobile/__tests__/stores/contestUpdatesStore.test.ts
@@ -1,6 +1,7 @@
 import { useContestUpdatesStore } from '@/src/stores/contestUpdatesStore';
 import type {
   BaseballPlayCompletedPayload,
+  ContestFinalizedPayload,
   ContestStatusChangedPayload,
   FootballPlayCompletedPayload,
 } from '@/src/types/signalR';
@@ -206,15 +207,7 @@ describe('contestUpdatesStore', () => {
   });
 
   describe('handleContestFinalized', () => {
-    const finalizedPayload = (overrides?: Partial<{
-      contestId: string;
-      awayScore: number | null;
-      homeScore: number | null;
-      winnerFranchiseSeasonId: string | null;
-      spreadWinnerFranchiseSeasonId: string | null;
-      overUnderResultRaw: number | null;
-      completedUtc: string | null;
-    }>) => ({
+    const finalizedPayload = (overrides?: Partial<ContestFinalizedPayload>): ContestFinalizedPayload => ({
       contestId: CID,
       awayScore: 1,
       homeScore: 4,
@@ -256,7 +249,7 @@ describe('contestUpdatesStore', () => {
 
     it.each([0, null, undefined])('leaves overUnderResult null when raw is %s (None / not enriched)', (raw) => {
       useContestUpdatesStore.getState().handleContestFinalized(
-        finalizedPayload({ overUnderResultRaw: raw as number | null }),
+        finalizedPayload({ overUnderResultRaw: raw }),
       );
 
       expect(useContestUpdatesStore.getState().contests[CID].overUnderResult).toBeNull();

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -540,6 +540,18 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
       pitchingHeadshotUrl: live.pitchingHeadshotUrl ?? matchup.pitchingHeadshotUrl,
       lastPlayId: live.lastPlayId ?? matchup.lastPlayId,
       lastPlayDescription: live.lastPlayDescription ?? matchup.lastPlayDescription,
+      // Enrichment-result fields, populated by handleContestFinalized.
+      // Pre-enrichment these are null on the wire from the matchups GET
+      // (the readiness contract documented in FinalScoreResult); the
+      // ContestFinalized SignalR broadcast fills them in without a
+      // refresh. Same nullish-fallback pattern as scores so a partial
+      // context state can't clobber a populated canonical field.
+      winnerFranchiseSeasonId:
+        live.winnerFranchiseSeasonId ?? matchup.winnerFranchiseSeasonId,
+      spreadWinnerFranchiseSeasonId:
+        live.spreadWinnerFranchiseSeasonId ?? matchup.spreadWinnerFranchiseSeasonId,
+      overUnderResult: live.overUnderResult ?? matchup.overUnderResult,
+      completedUtc: live.completedUtc ?? matchup.completedUtc,
     };
   }, [matchup, live]);
 

--- a/src/UI/sd-mobile/src/hooks/useSignalRClient.ts
+++ b/src/UI/sd-mobile/src/hooks/useSignalRClient.ts
@@ -33,6 +33,9 @@ export function useSignalRClient(): void {
   // store, so these selector subscriptions don't cause the effect below
   // to tear down + reconnect on every render.
   const handleStatusUpdate = useContestUpdatesStore((s) => s.handleStatusUpdate);
+  const handleContestFinalized = useContestUpdatesStore(
+    (s) => s.handleContestFinalized,
+  );
   const handleFootballPlayCompleted = useContestUpdatesStore(
     (s) => s.handleFootballPlayCompleted,
   );
@@ -59,6 +62,12 @@ export function useSignalRClient(): void {
     });
 
     connection.on('ContestStatusChanged', handleStatusUpdate);
+    // ContestFinalized fires AFTER ContestStatusChanged(STATUS_FINAL) and
+    // carries the enriched result fields (winner, spread winner, over/
+    // under, final scores) that the status event can't. Without this
+    // handler the matchup card would sit on raw STATUS_FINAL (no cover
+    // line, no SU checkmark) until the user pulls to refresh.
+    connection.on('ContestFinalized', handleContestFinalized);
     connection.on('FootballPlayCompleted', handleFootballPlayCompleted);
     connection.on('BaseballPlayCompleted', handleBaseballPlayCompleted);
 
@@ -101,6 +110,7 @@ export function useSignalRClient(): void {
     };
   }, [
     handleStatusUpdate,
+    handleContestFinalized,
     handleFootballPlayCompleted,
     handleBaseballPlayCompleted,
   ]);

--- a/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
+++ b/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type {
   BaseballPlayCompletedPayload,
+  ContestFinalizedPayload,
   ContestStatusChangedPayload,
   FootballPlayCompletedPayload,
 } from '@/src/types/signalR';
@@ -49,12 +50,25 @@ export interface ContestLiveRecord {
   lastPlayDescription?: string;
   lastPlayAt?: number;
   lastUpdated?: number;
+
+  // Enrichment-result fields, populated by handleContestFinalized when
+  // ContestFinalized fires. MatchupCard's enrichedMatchup merge picks
+  // these up so FinalScoreResult / GameStatus can render the cover line
+  // + SU checkmark without a refresh. overUnderResult is stored in the
+  // string form FinalScoreResult expects ("Over" / "Under" / "Push")
+  // even though the wire carries it as int? (overUnderResultRaw) — the
+  // handler translates.
+  winnerFranchiseSeasonId?: string | null;
+  spreadWinnerFranchiseSeasonId?: string | null;
+  overUnderResult?: 'Over' | 'Under' | 'Push' | null;
+  completedUtc?: string | null;
 }
 
 interface ContestUpdatesState {
   contests: Record<string, ContestLiveRecord>;
 
   handleStatusUpdate: (data: ContestStatusChangedPayload) => void;
+  handleContestFinalized: (data: ContestFinalizedPayload) => void;
   handleFootballPlayCompleted: (data: FootballPlayCompletedPayload) => void;
   handleBaseballPlayCompleted: (data: BaseballPlayCompletedPayload) => void;
   clearContestUpdate: (contestId: string) => void;
@@ -88,6 +102,40 @@ export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
           contestId: data.contestId,
           status: data.status,
           statusDescription: data.statusDescription,
+          lastUpdated: now,
+        },
+      },
+    }));
+  },
+
+  handleContestFinalized: (data) => {
+    if (!data?.contestId) return;
+    const now = Date.now();
+    // Translate the int? raw value to the display string FinalScoreResult
+    // expects. Producer-side enum: None=0, Over=1, Under=2, Push=3.
+    const overUnderResult: 'Over' | 'Under' | 'Push' | null =
+      data.overUnderResultRaw === 1 ? 'Over' :
+      data.overUnderResultRaw === 2 ? 'Under' :
+      data.overUnderResultRaw === 3 ? 'Push' :
+      null;
+    set((state) => ({
+      contests: {
+        ...state.contests,
+        [data.contestId]: {
+          ...state.contests[data.contestId],
+          contestId: data.contestId,
+          // Flip lifecycle to Final in case ContestStatusChanged was
+          // missed (post-connect handshake gap, etc.) — matches the
+          // play-handler pattern of promoting to InProgress on first
+          // play. (Web counterpart wires the same self-heal.)
+          status: 'STATUS_FINAL',
+          statusDescription: 'Final',
+          awayScore: data.awayScore ?? state.contests[data.contestId]?.awayScore,
+          homeScore: data.homeScore ?? state.contests[data.contestId]?.homeScore,
+          winnerFranchiseSeasonId: data.winnerFranchiseSeasonId,
+          spreadWinnerFranchiseSeasonId: data.spreadWinnerFranchiseSeasonId,
+          overUnderResult,
+          completedUtc: data.completedUtc,
           lastUpdated: now,
         },
       },

--- a/src/UI/sd-mobile/src/types/signalR.ts
+++ b/src/UI/sd-mobile/src/types/signalR.ts
@@ -39,6 +39,39 @@ export interface FootballPlayCompletedPayload {
   ballOnYardLine: number | null;
 }
 
+/**
+ * Fires AFTER ContestStatusChanged(STATUS_FINAL), once Producer's
+ * ContestEnrichmentProcessor has written the canonical Contest row with
+ * winner, spread winner, over/under result, and final scores. The status
+ * event can't carry these because it fires the moment STATUS_FINAL is
+ * detected (~30s before enrichment runs).
+ *
+ * Result fields are nullable mirroring the wire contract:
+ *   - winnerFranchiseSeasonId is null on a tie (rare in football,
+ *     impossible in MLB per the tie guards).
+ *   - spreadWinnerFranchiseSeasonId is null on a true spread push
+ *     (game landed exactly on the line).
+ *   - overUnderResultRaw is null when no odds were enriched. Wire type
+ *     is int? mapping to the Producer-side OverUnderResult enum
+ *     (None=0, Over=1, Under=2, Push=3). FinalScoreResult / GameStatus
+ *     consume the string form ("Over"/"Under"/"Push"), so the store
+ *     handler translates before writing.
+ *   - awayScore / homeScore / completedUtc are always populated when
+ *     this event is published, but kept nullable so older Producer pods
+ *     publishing the prior shape during a rolling deploy don't fail
+ *     deserialization.
+ */
+export interface ContestFinalizedPayload {
+  contestId: string;
+  awayScore?: number | null;
+  homeScore?: number | null;
+  winnerFranchiseSeasonId?: string | null;
+  spreadWinnerFranchiseSeasonId?: string | null;
+  /** Producer-side OverUnderResult enum value: 0 None, 1 Over, 2 Under, 3 Push. */
+  overUnderResultRaw?: number | null;
+  completedUtc?: string | null;
+}
+
 export interface BaseballPlayCompletedPayload {
   contestId: string;
   competitionId: string;

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -90,6 +90,7 @@ function MainApp() {
   // in one message).
   const {
     handleStatusUpdate,
+    handleContestFinalized,
     handleFootballPlayCompleted,
     handleBaseballPlayCompleted,
   } = useContestUpdates();
@@ -109,6 +110,11 @@ function MainApp() {
     handleStatusUpdate(data);
   }, [handleStatusUpdate]);
 
+  const onContestFinalized = useCallback((data) => {
+    console.log('🏁 Contest finalized received:', data);
+    handleContestFinalized(data);
+  }, [handleContestFinalized]);
+
   const onFootballPlayCompleted = useCallback((data) => {
     console.log('🏈 Football play completed received:', data);
     handleFootballPlayCompleted(data);
@@ -122,6 +128,7 @@ function MainApp() {
   useSignalRClient({
     onPreviewCompleted,
     onContestStatusChanged,
+    onContestFinalized,
     onFootballPlayCompleted,
     onBaseballPlayCompleted,
   });

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -143,6 +143,17 @@ function PicksPage() {
           statusDescription: liveUpdate.statusDescription ?? matchup.statusDescription,
           awayScore: liveUpdate.awayScore ?? matchup.awayScore,
           homeScore: liveUpdate.homeScore ?? matchup.homeScore,
+          // Enrichment-result fields land via handleContestFinalized.
+          // Pre-enrichment these are null on the matchups GET (the
+          // readiness contract documented in FinalScoreResult.jsx);
+          // the ContestFinalized SignalR broadcast fills them in
+          // without a refresh. Same nullish-fallback pattern as scores
+          // so a partial context state can't clobber a populated
+          // canonical field.
+          winnerFranchiseSeasonId: liveUpdate.winnerFranchiseSeasonId ?? matchup.winnerFranchiseSeasonId,
+          spreadWinnerFranchiseSeasonId: liveUpdate.spreadWinnerFranchiseSeasonId ?? matchup.spreadWinnerFranchiseSeasonId,
+          overUnderResult: liveUpdate.overUnderResult ?? matchup.overUnderResult,
+          completedUtc: liveUpdate.completedUtc ?? matchup.completedUtc,
           // Football-shaped
           period: liveUpdate.period ?? matchup.period,
           clock: liveUpdate.clock ?? matchup.clock,

--- a/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
+++ b/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
@@ -163,6 +163,60 @@ export const ContestUpdatesProvider = ({ children }) => {
   }, [instanceId]);
 
   /**
+   * Handle ContestFinalized — fires AFTER ContestStatusChanged(STATUS_FINAL)
+   * once Producer's ContestEnrichmentProcessor has written the canonical
+   * Contest row with winner, spread winner, over/under result, and final
+   * scores. The status event can't carry these because it fires the moment
+   * STATUS_FINAL is detected (~30s before enrichment runs).
+   *
+   * Wire shape: int? OverUnderResultRaw maps to the Producer-side enum
+   * (None=0, Over=1, Under=2, Push=3). Translate to the string form
+   * FinalScoreResult expects ("Over"/"Under"/"Push") so the merge in
+   * PicksPage.enrichedMatchups can substitute it directly into the
+   * matchup record (which carries the same string shape from
+   * GetLeagueWeekMatchups).
+   */
+  const handleContestFinalized = useCallback((data) => {
+    if (!data?.contestId) {
+      console.warn('ContestFinalized event missing contestId', data);
+      return;
+    }
+
+    const overUnderResult =
+      data.overUnderResultRaw === 1 ? 'Over' :
+      data.overUnderResultRaw === 2 ? 'Under' :
+      data.overUnderResultRaw === 3 ? 'Push' :
+      null;
+
+    console.log(`[ContestCtx#${instanceId}] setContests (finalized)`, {
+      contestId: data.contestId,
+      awayScore: data.awayScore,
+      homeScore: data.homeScore,
+      winnerFranchiseSeasonId: data.winnerFranchiseSeasonId,
+    });
+    setContests(prev => ({
+      ...prev,
+      [data.contestId]: {
+        ...prev[data.contestId],
+        contestId: data.contestId,
+        // Flip lifecycle to Final in case ContestStatusChanged was
+        // missed (post-connect handshake gap, etc.) — matches the
+        // play-handler pattern of promoting to InProgress on first
+        // play.
+        status: 'STATUS_FINAL',
+        statusDescription: 'Final',
+        awayScore: data.awayScore,
+        homeScore: data.homeScore,
+        winnerFranchiseSeasonId: data.winnerFranchiseSeasonId,
+        spreadWinnerFranchiseSeasonId: data.spreadWinnerFranchiseSeasonId,
+        overUnderResult,
+        completedUtc: data.completedUtc,
+        lastUpdated: Date.now()
+      }
+    }));
+  }, [instanceId]);
+
+  /**
    * Get live update data for a specific contest
    * @param {string} contestId
    * @returns {object|null} Live update data or null if no updates available
@@ -202,6 +256,7 @@ export const ContestUpdatesProvider = ({ children }) => {
     _instanceId: instanceId, // DIAG: lets consumers log which Provider they're reading from
     contests,
     handleStatusUpdate,
+    handleContestFinalized,
     handleFootballPlayCompleted,
     handleBaseballPlayCompleted,
     getContestUpdate,

--- a/src/UI/sd-ui/src/hooks/useSignalRClient.js
+++ b/src/UI/sd-ui/src/hooks/useSignalRClient.js
@@ -8,6 +8,7 @@ export default function useSignalRClient({
   leagueId,
   onPreviewCompleted,
   onContestStatusChanged,
+  onContestFinalized,
   onFootballPlayCompleted,
   onBaseballPlayCompleted,
 }) {
@@ -45,6 +46,15 @@ export default function useSignalRClient({
       connection.on("ContestStatusChanged", onContestStatusChanged);
     }
 
+    // ContestFinalized fires AFTER ContestStatusChanged(STATUS_FINAL) and
+    // carries the enriched result fields (winner, spread winner, over/under,
+    // final scores) that the status event can't. Without this handler the
+    // matchup card would sit on raw STATUS_FINAL (no cover line, no SU
+    // checkmark) until a page refresh re-fetched /ui/leagues/.../matchups.
+    if (onContestFinalized) {
+      connection.on("ContestFinalized", onContestFinalized);
+    }
+
     // Per-play merged events — sport-specific shapes carrying both the
     // play description and the scoreboard tick (period/clock/possession
     // for FB; inning/count/runners for MLB) in one message.
@@ -77,6 +87,7 @@ export default function useSignalRClient({
     leagueId,
     onPreviewCompleted,
     onContestStatusChanged,
+    onContestFinalized,
     onFootballPlayCompleted,
     onBaseballPlayCompleted,
   ]);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestFinalizedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Events/ContestFinalizedHandlerTests.cs
@@ -1,9 +1,12 @@
 using MassTransit;
 
+using Microsoft.AspNetCore.SignalR;
+
 using Moq;
 
 using SportsData.Api.Application.Events;
 using SportsData.Api.Application.Scoring;
+using SportsData.Api.Infrastructure.Notifications;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Processing;
@@ -32,6 +35,7 @@ namespace SportsData.Api.Tests.Unit.Application.Events
                 CausationId: correlationId);
 
             var background = Mocker.GetMock<IProvideBackgroundJobs>();
+            WireHubContext(out _);
 
             var context = Mock.Of<ConsumeContext<ContestFinalized>>(ctx =>
                 ctx.Message == message);
@@ -49,6 +53,60 @@ namespace SportsData.Api.Tests.Unit.Application.Events
                 It.Is<Expression<Func<IScorePicks, Task>>>(expr =>
                     EnqueueInvokesProcessWith(expr, contestId, correlationId))),
                 Times.Once);
+        }
+
+        [Fact]
+        public async Task Consume_BroadcastsContestFinalizedOverSignalR()
+        {
+            // Arrange — full enriched message, mirroring the post-PR shape.
+            var message = new ContestFinalized(
+                ContestId: Guid.NewGuid(),
+                Ref: null,
+                Sport: Sport.BaseballMlb,
+                SeasonYear: 2026,
+                CorrelationId: Guid.NewGuid(),
+                CausationId: Guid.NewGuid(),
+                AwayScore: 1,
+                HomeScore: 4,
+                WinnerFranchiseSeasonId: Guid.NewGuid(),
+                SpreadWinnerFranchiseSeasonId: Guid.NewGuid(),
+                OverUnderResultRaw: 1, // Over
+                CompletedUtc: new DateTime(2026, 6, 20, 22, 30, 0, DateTimeKind.Utc));
+
+            WireHubContext(out var clients);
+            var context = Mock.Of<ConsumeContext<ContestFinalized>>(ctx =>
+                ctx.Message == message);
+
+            var sut = Mocker.CreateInstance<ContestFinalizedHandler>();
+
+            // Act
+            await sut.Consume(context);
+
+            // Assert — the entire message body is fanned out as arg[0] of
+            // the SendCoreAsync extension target. Verifying the method name
+            // + first arg value is enough to lock the contract; SignalR's
+            // own extension translates SendAsync(name, msg) into
+            // SendCoreAsync(name, object?[]{ msg }).
+            clients.Verify(c => c.SendCoreAsync(
+                "ContestFinalized",
+                It.Is<object?[]>(args => args.Length == 1 && ReferenceEquals(args[0], message)),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Mocks IHubContext.Clients.All so the handler's SignalR fan-out
+        /// doesn't NRE on a null Clients property. Returns the mocked
+        /// <see cref="IClientProxy"/> so the caller can verify SendCoreAsync
+        /// was invoked with the expected event name + payload.
+        /// </summary>
+        private void WireHubContext(out Mock<IClientProxy> clients)
+        {
+            var hubContext = Mocker.GetMock<IHubContext<NotificationHub>>();
+            var hubClients = new Mock<IHubClients>();
+            clients = new Mock<IClientProxy>();
+            hubClients.Setup(c => c.All).Returns(clients.Object);
+            hubContext.Setup(h => h.Clients).Returns(hubClients.Object);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Closes the visual gap on the picks page where a contest sat half-rendered after `STATUS_FINAL` fired. The score line updated correctly, but the "X covered" line and the SU checkmark beside the winning team's short stayed missing until a full page refresh.

| Before refresh | After refresh |
|---|---|
| ![right card in screenshot](https://github.com/jrandallsexton/sports-data-core/raw/main/src/about/public/gallery/Screenshot%202026-06-20%20182331.png) — `FINAL: CIN 10 - 2 NYY`, no cover line | `FINAL: CHW 1 - 4 DET ✓ DET covered` |

User reference screenshot: `src/about/public/gallery/Screenshot 2026-06-20 182331.png`

## Why this happens

- `GET /ui/leagues/{id}/matchups/{week}` returns `winnerFranchiseSeasonId`, `spreadWinnerFranchiseSeasonId`, `overUnderResult` — but the picks page caches the response on mount; subsequent SignalR events have no way to refresh those fields.
- `FinalScoreResult.jsx` + `GameStatus.jsx` both gate the cover-line + SU checkmark on `winnerFranchiseSeasonId` being non-null (the "enrichment ran" signal — documented at `FinalScoreResult.jsx:14`).
- Producer's `ContestStatusChanged` event carries lifecycle only.
- Producer's `ContestFinalized` event existed but was API-only (kicked off `ScorePicksCommand`), never broadcast to clients.

## Changes

### Backend
- **`Core/Eventing/Events/Contests/ContestFinalized.cs`** — record gains six nullable fields: `AwayScore`, `HomeScore`, `WinnerFranchiseSeasonId`, `SpreadWinnerFranchiseSeasonId`, `OverUnderResultRaw` (int? mapping to Producer's `OverUnderResult` enum to keep Core enum-free), `CompletedUtc`. All defaulted to null so older Producer pods publishing the prior shape don't break deserialization during a rolling deploy.
- **`Producer/Application/Contests/Baseball|FootballContestEnrichmentProcessor.cs`** — publish sites populate the new fields off the canonical Contest row. Switched to named-parameter syntax so future record additions don't break silently on positional arg drift.
- **`Api/Application/Events/ContestFinalizedHandler.cs`** — broadcasts the full message body over SignalR (`"ContestFinalized"` event name) alongside the existing `ScorePicksCommand` enqueue. Same `Clients.All` pattern as the existing `ContestStatusChanged` / `ContestScoreChanged` handlers.

### Web
- **`hooks/useSignalRClient.js`** — registers a `"ContestFinalized"` handler.
- **`MainApp.jsx`** — wires `onContestFinalized` → context's `handleContestFinalized`.
- **`contexts/ContestUpdatesContext.jsx`** — new `handleContestFinalized` translates `overUnderResultRaw` (int) to the string form `FinalScoreResult` expects (`"Over"`/`"Under"`/`"Push"`), writes the enriched fields onto the contest record, defensively flips `status` to `STATUS_FINAL` in case `ContestStatusChanged` was missed (post-connect handshake gap pattern, mirrors the play-handler promote-to-`STATUS_IN_PROGRESS` behavior).
- **`components/picks/PicksPage.jsx`** — `enrichedMatchups` merge picks up the new fields via the same nullish-fallback pattern as scores so a partial context state can't clobber a populated canonical field.

## Test plan

- [x] Producer enrichment suite: 65 pass, 0 fail
- [x] API `ContestFinalizedHandlerTests`: 2 pass (existing + new SignalR broadcast assertion via mocked `IHubContext<NotificationHub>.Clients`)
- [x] Web build clean, +408 bytes gzipped
- [ ] Post-deploy verification:
  - Watch an MLB game complete on the picks page without refreshing. Card should flip from `FINAL: X-Y` to `FINAL: X-Y ✓ winnerShort covered` (ATS) or `FINAL: ✓ winnerShort X-Y winnerShort` (SU) when ContestFinalized arrives.
  - Verify Seq shows the `ContestFinalized consume: SignalR Clients.All.SendAsync completed` log line.

## Out of scope (deferred)

- Mobile equivalents.
- Pick-scoring SignalR update (the "next phase" — surfacing per-pick `IsCorrect` / `PointsAwarded` would require a new `PickScored` event from `PickScoringProcessor`).
- Pick-button disable behavior on finalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time “contest finalized” updates are now broadcast to all connected clients with enriched final results (final scores, winner/spread-winner identifiers, over/under outcome, and completed time).
  * The web and mobile experiences now listen for these updates to immediately reflect final status and show finalized over/under outcomes on picks and matchup views.

* **Tests**
  * Added/updated tests to verify SignalR broadcasting and end-to-end client handling/enrichment of finalized contest events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->