### PR TITLE
feat(admin): re-run enrichment from Contest Overview admin panel

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -16,6 +16,7 @@ using SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests;
 using SportsData.Api.Application.Admin.Queries.GetMatchupForContest;
 using SportsData.Api.Application.Admin.Queries.GetMatchupPreview;
 using SportsData.Api.Application.Admin.SignalRDebug;
+using SportsData.Api.Application.Admin.Commands.ReenrichContest;
 using SportsData.Api.Application.Previews;
 using SportsData.Api.Application.Scoring;
 using SportsData.Api.Application.UI.Contest.Commands.SubmitContestPredictions;
@@ -153,6 +154,39 @@ namespace SportsData.Api.Application.Admin
             var cmd = new ScorePicksCommand(contestId);
             _backgroundJobProvider.Enqueue<IScorePicks>(p => p.Process(cmd));
             return Accepted(new { cmd.CorrelationId });
+        }
+
+        /// <summary>
+        /// Admin re-enrichment path. Clears UserPick scoring fields for this
+        /// contest, then asks Producer to clear the derived/enriched fields on
+        /// its Contest row and re-invoke the enrichment processor synchronously.
+        /// Returns the CorrelationId Producer logged the work under so the
+        /// admin UI can surface it for Seq tracing.
+        ///
+        /// Manual recovery path for stuck WinnerFranchiseSeasonId /
+        /// SpreadWinnerFranchiseSeasonId — the case where the canonical
+        /// CompetitionCompetitorScores are correct but the derived fields are
+        /// wrong and the nightly audit hasn't reset them yet.
+        ///
+        /// Lives on the admin controller (AdminApiToken-gated) deliberately:
+        /// the operation rolls back UserPicks, so exposing it under the
+        /// general /ui/contest surface would let a logged-in non-admin
+        /// fire it (the UI's isAdmin check is presentational only — not a
+        /// trust boundary).
+        /// </summary>
+        [HttpPost]
+        [Route("contest/{contestId}/reenrich")]
+        public async Task<ActionResult<Guid>> ReenrichContest(
+            [FromRoute] Guid contestId,
+            [FromQuery] string sport = "football",
+            [FromQuery] string league = "ncaa",
+            [FromServices] IReenrichContestCommandHandler handler = default!,
+            CancellationToken cancellationToken = default)
+        {
+            var mode = ModeMapper.ResolveMode(sport, league);
+            var command = new ReenrichContestCommand { ContestId = contestId, Sport = mode };
+            var result = await handler.ExecuteAsync(command, cancellationToken);
+            return result.ToActionResult();
         }
 
         [HttpPost]

--- a/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommand.cs
@@ -1,0 +1,9 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Commands.ReenrichContest;
+
+public class ReenrichContestCommand
+{
+    public required Guid ContestId { get; init; }
+    public required Sport Sport { get; init; }
+}

--- a/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommandHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommandHandler.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Infrastructure.Data;
@@ -41,21 +43,33 @@ public class ReenrichContestCommandHandler : IReenrichContestCommandHandler
     private readonly ILogger<ReenrichContestCommandHandler> _logger;
     private readonly IContestClientFactory _contestClientFactory;
     private readonly AppDataContext _dataContext;
+    private readonly IValidator<ReenrichContestCommand> _validator;
 
     public ReenrichContestCommandHandler(
         ILogger<ReenrichContestCommandHandler> logger,
         IContestClientFactory contestClientFactory,
-        AppDataContext dataContext)
+        AppDataContext dataContext,
+        IValidator<ReenrichContestCommand> validator)
     {
         _logger = logger;
         _contestClientFactory = contestClientFactory;
         _dataContext = dataContext;
+        _validator = validator;
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
         ReenrichContestCommand command,
         CancellationToken cancellationToken = default)
     {
+        var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return new Failure<Guid>(
+                Guid.Empty,
+                ResultStatus.Validation,
+                validationResult.Errors);
+        }
+
         var correlationId = ActivityExtensions.GetCorrelationId();
 
         _logger.LogInformation(

--- a/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommandHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommandHandler.cs
@@ -1,0 +1,107 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.Admin.Commands.ReenrichContest;
+
+public interface IReenrichContestCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        ReenrichContestCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Admin "re-run enrichment" path for a single contest. Two side effects
+/// in sequence:
+///   1. API nulls UserPick.ScoredAt / IsCorrect / PointsAwarded for every
+///      pick on this contest. This is the picks-side rollback — without
+///      it, the existing PickScoringProcessor's "already scored" short-
+///      circuit would no-op the re-score.
+///   2. API calls Producer's synchronous re-enrich endpoint. Producer
+///      clears the derived/enriched fields on its Contest row and re-
+///      invokes the enrichment processor inline. When that returns,
+///      ContestFinalized has fired and the API's ContestFinalizedHandler
+///      has already enqueued ScorePicksCommand for the cleared picks.
+///
+/// Picks-first ordering is deliberate: if Producer's call fails, picks
+/// stay nulled and the next click retries with picks-already-null
+/// (idempotent). The reverse — Producer clears its fields but API's
+/// picks reset fails — leaves picks scored against an unfinalized
+/// contest, which is the actively wrong state we're trying to fix.
+///
+/// Returns the CorrelationId Producer logged the work under so the UI
+/// can surface it for Seq tracing.
+/// </summary>
+public class ReenrichContestCommandHandler : IReenrichContestCommandHandler
+{
+    private readonly ILogger<ReenrichContestCommandHandler> _logger;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly AppDataContext _dataContext;
+
+    public ReenrichContestCommandHandler(
+        ILogger<ReenrichContestCommandHandler> logger,
+        IContestClientFactory contestClientFactory,
+        AppDataContext dataContext)
+    {
+        _logger = logger;
+        _contestClientFactory = contestClientFactory;
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        ReenrichContestCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var correlationId = ActivityExtensions.GetCorrelationId();
+
+        _logger.LogInformation(
+            "ReenrichContest initiated. ContestId={ContestId}, Sport={Sport}, CorrelationId={CorrelationId}",
+            command.ContestId, command.Sport, correlationId);
+
+        // Step 1: null the scored fields on every UserPick for this
+        // contest. ExecuteUpdateAsync to avoid pulling rows into memory —
+        // picks-per-contest can be in the hundreds across leagues.
+        var picksUpdated = await _dataContext.UserPicks
+            .Where(p => p.ContestId == command.ContestId)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(p => p.ScoredAt, (DateTime?)null)
+                .SetProperty(p => p.IsCorrect, (bool?)null)
+                .SetProperty(p => p.PointsAwarded, (int?)null),
+                cancellationToken);
+
+        _logger.LogInformation(
+            "ReenrichContest: cleared scored fields on {PickCount} UserPick row(s). ContestId={ContestId}, CorrelationId={CorrelationId}",
+            picksUpdated, command.ContestId, correlationId);
+
+        // Step 2: invoke Producer's synchronous re-enrich endpoint.
+        var contestClient = _contestClientFactory.Resolve(command.Sport);
+        var result = await contestClient.ReenrichContest(command.ContestId, cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            _logger.LogError(
+                "ReenrichContest: Producer call failed. ContestId={ContestId}, Sport={Sport}, Status={Status}, CorrelationId={CorrelationId}",
+                command.ContestId, command.Sport, result.Status, correlationId);
+
+            var failure = (Failure<Core.Infrastructure.Clients.Contest.Queries.ReenrichContestResponse>)result;
+            return new Failure<Guid>(correlationId, result.Status, failure.Errors);
+        }
+
+        // Producer returns the CorrelationId it ran under in the body.
+        // ActivityExtensions.GetCorrelationId() should yield the same
+        // value if traceparent / X-Correlation-Id propagation is healthy,
+        // but trust Producer's response when they disagree so the UI shows
+        // the id Seq actually has.
+        var producerCorrelationId = result.Value.CorrelationId;
+
+        _logger.LogInformation(
+            "ReenrichContest completed. ContestId={ContestId}, Sport={Sport}, ProducerCorrelationId={ProducerCorrelationId}, ApiCorrelationId={ApiCorrelationId}",
+            command.ContestId, command.Sport, producerCorrelationId, correlationId);
+
+        return new Success<Guid>(producerCorrelationId);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommandValidator.cs
+++ b/src/SportsData.Api/Application/Admin/Commands/ReenrichContest/ReenrichContestCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.Admin.Commands.ReenrichContest;
+
+public class ReenrichContestCommandValidator : AbstractValidator<ReenrichContestCommand>
+{
+    public ReenrichContestCommandValidator()
+    {
+        RuleFor(x => x.ContestId)
+            .NotEmpty()
+            .WithMessage("ContestId is required");
+
+        RuleFor(x => x.Sport)
+            .IsInEnum()
+            .WithMessage("Sport must be a valid value");
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -31,6 +31,7 @@ using SportsData.Api.Application.Venues.Queries.GetVenues;
 using SportsData.Api.Application.Venues.Queries.GetVenueById;
 using SportsData.Api.Application.UI.Conferences.Queries.GetConferenceNamesAndSlugs;
 using SportsData.Api.Infrastructure.Refs;
+using SportsData.Api.Application.Admin.Commands.ReenrichContest;
 using SportsData.Api.Application.UI.Contest.Commands.FinalizeContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContest;
 using SportsData.Api.Application.UI.Contest.Commands.RefreshContestMedia;
@@ -125,6 +126,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IBackfillLeagueScoresCommandHandler, BackfillLeagueScoresCommandHandler>();
             services.AddScoped<IGenerateGameRecapCommandHandler, GenerateGameRecapCommandHandler>();
             services.AddScoped<IGenerateLoadTestCommandHandler, GenerateLoadTestCommandHandler>();
+            services.AddScoped<IReenrichContestCommandHandler, ReenrichContestCommandHandler>();
             services.AddScoped<IRefreshAiExistenceCommandHandler, RefreshAiExistenceCommandHandler>();
             services.AddScoped<ISendTestPushNotificationCommandHandler, SendTestPushNotificationCommandHandler>();
             services.AddScoped<IUpsertMatchupPreviewCommandHandler, UpsertMatchupPreviewCommandHandler>();

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.Clients.Contest.Queries;
 using SportsData.Core.Middleware.Health;
 
@@ -44,6 +45,19 @@ public interface IProvideContests : IProvideHealthChecks
     Task<Result<bool>> RefreshContestMediaByContestId(Guid contestId, CancellationToken cancellationToken = default);
 
     Task<Result<bool>> FinalizeContestByContestId(Guid contestId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Synchronous admin "re-run enrichment" call. Producer clears the
+    /// derived/enriched fields on the Contest row and re-invokes the
+    /// sport-specific enrichment processor inline before returning, so the
+    /// caller doesn't need a separate "is it done?" poll. Returns the
+    /// CorrelationId Producer logged the work under for tracing in Seq.
+    ///
+    /// NOT a re-source — CompetitionCompetitorScores are not touched.
+    /// Manual recovery path for stuck WinnerFranchiseSeasonId /
+    /// SpreadWinnerFranchiseSeasonId that the nightly audit hasn't caught.
+    /// </summary>
+    Task<Result<ReenrichContestResponse>> ReenrichContest(Guid contestId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Triggers a replay of a stored contest's plays through the bus →
@@ -229,6 +243,76 @@ public class ContestClient : ClientBase, IProvideContests
             $"contests/{contestId}/enrich",
             "FinalizeContest",
             cancellationToken);
+    }
+
+    public async Task<Result<ReenrichContestResponse>> ReenrichContest(Guid contestId, CancellationToken cancellationToken = default)
+    {
+        if (contestId == Guid.Empty)
+        {
+            return new Failure<ReenrichContestResponse>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure("contestId", "Contest ID cannot be empty")]);
+        }
+
+        // Bodyless POST that returns a typed JSON response. No shared helper
+        // exists for this shape (Result<T> + bodyless), so inline the
+        // pattern. Mirrors the bodyless PostWithResultAsync's correlation-
+        // header stamping so Producer logs the same id we trace from in
+        // Seq.
+        const string operationName = "ReenrichContest";
+        var url = $"contests/{contestId}/admin/reenrich";
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Headers.TryAddWithoutValidation(
+                "X-Correlation-Id",
+                ActivityExtensions.GetCorrelationId().ToString());
+
+            using var response = await HttpClient.SendAsync(request, cancellationToken);
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var body = responseContent.FromJson<ReenrichContestResponse>();
+                if (body is null)
+                {
+                    return new Failure<ReenrichContestResponse>(
+                        default!,
+                        ResultStatus.Error,
+                        [new ValidationFailure(operationName, $"{operationName} succeeded but response body did not deserialize")]);
+                }
+                return new Success<ReenrichContestResponse>(body);
+            }
+
+            // MapHttpStatusCode is private on ClientBase, so map the common
+            // shapes inline here. NotFound is the only response code that
+            // needs a distinct ResultStatus today (Producer 404s when the
+            // contest doesn't exist); everything else falls through to
+            // generic Error so the API surface stays consistent.
+            var status = response.StatusCode == System.Net.HttpStatusCode.NotFound
+                ? ResultStatus.NotFound
+                : ResultStatus.Error;
+            return new Failure<ReenrichContestResponse>(
+                default!,
+                status,
+                [new ValidationFailure(operationName, $"{operationName} failed with status {response.StatusCode}")]);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new Failure<ReenrichContestResponse>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure(operationName, $"{operationName} failed: {ex.Message}")]);
+        }
+        catch (TaskCanceledException ex)
+        {
+            return new Failure<ReenrichContestResponse>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure(operationName, $"{operationName} timed out: {ex.Message}")]);
+        }
     }
 
     // ========== Matchup query methods (Phase 2) ==========

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/Queries/ReenrichContestResponse.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/Queries/ReenrichContestResponse.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace SportsData.Core.Infrastructure.Clients.Contest.Queries;
+
+/// <summary>
+/// Producer's response to the admin re-enrich endpoint. The CorrelationId
+/// is the value Producer logged the work under (and the value the
+/// downstream ContestFinalized broadcast carries) — surfaced to the admin
+/// UI so an operator can paste it into Seq for tracing.
+/// </summary>
+public record ReenrichContestResponse(Guid CorrelationId, Guid ContestId);

--- a/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestCommand.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestCommand.cs
@@ -1,0 +1,8 @@
+namespace SportsData.Producer.Application.Contests.Commands;
+
+public record ReenrichContestCommand
+{
+    public Guid ContestId { get; init; }
+
+    public Guid CorrelationId { get; init; } = Guid.Empty;
+}

--- a/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestCommandValidator.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace SportsData.Producer.Application.Contests.Commands;
+
+public class ReenrichContestCommandValidator : AbstractValidator<ReenrichContestCommand>
+{
+    public ReenrichContestCommandValidator()
+    {
+        RuleFor(x => x.ContestId)
+            .NotEmpty()
+            .WithMessage("ContestId is required");
+
+        RuleFor(x => x.CorrelationId)
+            .NotEmpty()
+            .WithMessage("CorrelationId is required");
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestHandler.cs
@@ -1,0 +1,135 @@
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Producer.Enums;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Contests.Commands
+{
+    public interface IReenrichContestHandler
+    {
+        Task<Result<Guid>> ExecuteAsync(
+            ReenrichContestCommand command,
+            CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Admin "re-run enrichment" path. Clears the derived/enriched fields
+    /// on the Contest row (FinalizedUtc, WinnerFranchiseSeasonId,
+    /// SpreadWinnerFranchiseSeasonId, OverUnder, AwayScore, HomeScore,
+    /// AuditedUtc) and re-invokes the sport-specific enrichment processor
+    /// SYNCHRONOUSLY in this request. Caller (the API admin endpoint) does
+    /// not need to poll Hangfire or follow a separate cron — once this
+    /// returns, enrichment has rerun, ContestFinalized has fired, and the
+    /// API's ContestFinalizedHandler has enqueued ScorePicksCommand.
+    ///
+    /// This is NOT a re-source. CompetitionCompetitorScores are not
+    /// touched. Enrichment reads MAX(CCS) and derives the result fields;
+    /// the bug class this handler is for is "derived fields are wrong
+    /// but the canonical scores are correct" — primarily a manual
+    /// recovery path for stuck WinnerFranchiseSeasonId /
+    /// SpreadWinnerFranchiseSeasonId values that the audit job hasn't
+    /// caught yet.
+    ///
+    /// Returns the CorrelationId on success so the caller can log /
+    /// surface the same id Producer ran under.
+    /// </summary>
+    public class ReenrichContestHandler : IReenrichContestHandler
+    {
+        private readonly ILogger<ReenrichContestHandler> _logger;
+        private readonly TeamSportDataContext _dataContext;
+        private readonly IEnrichContests _enrichContests;
+        private readonly IValidator<ReenrichContestCommand> _validator;
+
+        public ReenrichContestHandler(
+            ILogger<ReenrichContestHandler> logger,
+            TeamSportDataContext dataContext,
+            IEnrichContests enrichContests,
+            IValidator<ReenrichContestCommand> validator)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _enrichContests = enrichContests;
+            _validator = validator;
+        }
+
+        public async Task<Result<Guid>> ExecuteAsync(
+            ReenrichContestCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                return new Failure<Guid>(
+                    default!,
+                    ResultStatus.Validation,
+                    validationResult.Errors);
+            }
+
+            using (_logger.BeginScope(new Dictionary<string, object>
+                   {
+                       ["ContestId"] = command.ContestId,
+                       ["CorrelationId"] = command.CorrelationId
+                   }))
+            {
+                return await ExecuteInternalAsync(command, cancellationToken);
+            }
+        }
+
+        private async Task<Result<Guid>> ExecuteInternalAsync(
+            ReenrichContestCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                _logger.LogInformation("ReenrichContest requested.");
+
+                var contest = await _dataContext.Contests
+                    .FirstOrDefaultAsync(c => c.Id == command.ContestId, cancellationToken);
+
+                if (contest is null)
+                {
+                    _logger.LogWarning("ReenrichContest: contest not found.");
+                    return new Failure<Guid>(
+                        default!,
+                        ResultStatus.NotFound,
+                        []);
+                }
+
+                // Null the derived fields so the enrichment processor's
+                // FinalizedUtc != null short-circuit doesn't no-op. AwayScore
+                // / HomeScore get nulled too so they get re-written from
+                // MAX(CCS). AuditedUtc gets cleared so the next audit sweep
+                // verifies the newly-derived values.
+                contest.FinalizedUtc = null;
+                contest.WinnerFranchiseSeasonId = null;
+                contest.SpreadWinnerFranchiseSeasonId = null;
+                contest.OverUnder = OverUnderResult.None;
+                contest.AwayScore = null;
+                contest.HomeScore = null;
+                contest.AuditedUtc = null;
+
+                await _dataContext.SaveChangesAsync(cancellationToken);
+
+                _logger.LogInformation("ReenrichContest: cleared derived fields.");
+
+                await _enrichContests.Process(
+                    new EnrichContestCommand(command.ContestId, command.CorrelationId));
+
+                _logger.LogInformation("ReenrichContest completed.");
+
+                return new Success<Guid>(command.CorrelationId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ReenrichContest failed.");
+                return new Failure<Guid>(
+                    default!,
+                    ResultStatus.Error,
+                    []);
+            }
+        }
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/ReenrichContestHandler.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest.Queries;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Infrastructure.Data.Common;
 
@@ -10,7 +11,7 @@ namespace SportsData.Producer.Application.Contests.Commands
 {
     public interface IReenrichContestHandler
     {
-        Task<Result<Guid>> ExecuteAsync(
+        Task<Result<ReenrichContestResponse>> ExecuteAsync(
             ReenrichContestCommand command,
             CancellationToken cancellationToken = default);
     }
@@ -55,14 +56,14 @@ namespace SportsData.Producer.Application.Contests.Commands
             _validator = validator;
         }
 
-        public async Task<Result<Guid>> ExecuteAsync(
+        public async Task<Result<ReenrichContestResponse>> ExecuteAsync(
             ReenrichContestCommand command,
             CancellationToken cancellationToken = default)
         {
             var validationResult = await _validator.ValidateAsync(command, cancellationToken);
             if (!validationResult.IsValid)
             {
-                return new Failure<Guid>(
+                return new Failure<ReenrichContestResponse>(
                     default!,
                     ResultStatus.Validation,
                     validationResult.Errors);
@@ -78,7 +79,7 @@ namespace SportsData.Producer.Application.Contests.Commands
             }
         }
 
-        private async Task<Result<Guid>> ExecuteInternalAsync(
+        private async Task<Result<ReenrichContestResponse>> ExecuteInternalAsync(
             ReenrichContestCommand command,
             CancellationToken cancellationToken = default)
         {
@@ -92,7 +93,7 @@ namespace SportsData.Producer.Application.Contests.Commands
                 if (contest is null)
                 {
                     _logger.LogWarning("ReenrichContest: contest not found.");
-                    return new Failure<Guid>(
+                    return new Failure<ReenrichContestResponse>(
                         default!,
                         ResultStatus.NotFound,
                         []);
@@ -103,6 +104,13 @@ namespace SportsData.Producer.Application.Contests.Commands
                 // / HomeScore get nulled too so they get re-written from
                 // MAX(CCS). AuditedUtc gets cleared so the next audit sweep
                 // verifies the newly-derived values.
+                //
+                // Persisted explicitly here BEFORE invoking enrichment.
+                // If enrichment subsequently fails, the contest is left
+                // in the reset state and the admin gets an error in the
+                // UI; re-clicking the button is idempotent and safe.
+                // Preferred over relying on EF's identity-map behavior
+                // to defer the flush — explicit > clever.
                 contest.FinalizedUtc = null;
                 contest.WinnerFranchiseSeasonId = null;
                 contest.SpreadWinnerFranchiseSeasonId = null;
@@ -120,12 +128,13 @@ namespace SportsData.Producer.Application.Contests.Commands
 
                 _logger.LogInformation("ReenrichContest completed.");
 
-                return new Success<Guid>(command.CorrelationId);
+                return new Success<ReenrichContestResponse>(
+                    new ReenrichContestResponse(command.CorrelationId, command.ContestId));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "ReenrichContest failed.");
-                return new Failure<Guid>(
+                return new Failure<ReenrichContestResponse>(
                     default!,
                     ResultStatus.Error,
                     []);

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -132,34 +132,20 @@ namespace SportsData.Producer.Application.Contests
         /// </summary>
         [HttpPost]
         [Route("{contestId}/admin/reenrich")]
-        public async Task<IActionResult> ReenrichContest(
+        public async Task<ActionResult<ReenrichContestResponse>> ReenrichContest(
             [FromRoute] Guid contestId,
             [FromServices] IReenrichContestHandler handler,
             CancellationToken cancellationToken)
         {
-            var correlationId = GetCorrelationIdFromRequest();
-
             var result = await handler.ExecuteAsync(
                 new ReenrichContestCommand
                 {
                     ContestId = contestId,
-                    CorrelationId = correlationId
+                    CorrelationId = GetCorrelationIdFromRequest()
                 },
                 cancellationToken);
 
-            return result switch
-            {
-                Success<Guid> success => Ok(new
-                {
-                    CorrelationId = success.Value,
-                    ContestId = contestId
-                }),
-                Failure<Guid> failure when failure.Status == ResultStatus.NotFound =>
-                    NotFound(new { ContestId = contestId, CorrelationId = correlationId }),
-                Failure<Guid> failure when failure.Status == ResultStatus.Validation =>
-                    BadRequest(new { CorrelationId = correlationId, Errors = failure.Errors }),
-                _ => StatusCode(500, new { CorrelationId = correlationId, ContestId = contestId })
-            };
+            return result.ToActionResult();
         }
 
         [HttpPost]

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -113,6 +113,55 @@ namespace SportsData.Producer.Application.Contests
             return Accepted(new { CorrelationId = correlationId, ContestId = contestId });
         }
 
+        /// <summary>
+        /// Admin "re-run enrichment" path. Clears the derived/enriched fields
+        /// on the Contest row (FinalizedUtc, WinnerFranchiseSeasonId,
+        /// SpreadWinnerFranchiseSeasonId, OverUnder, AwayScore, HomeScore,
+        /// AuditedUtc) and re-invokes the sport-specific enrichment processor
+        /// SYNCHRONOUSLY in this request. Caller (the API admin endpoint) does
+        /// not need to poll Hangfire or follow a separate cron — once this
+        /// returns 200, enrichment has rerun, ContestFinalized has fired, and
+        /// the API's ContestFinalizedHandler has enqueued ScorePicksCommand.
+        ///
+        /// This is NOT a re-source. CompetitionCompetitorScores are not
+        /// touched. Enrichment reads MAX(CCS) and derives the result fields;
+        /// the bug class this endpoint is for is "derived fields are wrong
+        /// but the canonical scores are correct" — primarily a manual recovery
+        /// path for stuck WinnerFranchiseSeasonId / SpreadWinnerFranchiseSeasonId
+        /// values that the audit job hasn't caught yet.
+        /// </summary>
+        [HttpPost]
+        [Route("{contestId}/admin/reenrich")]
+        public async Task<IActionResult> ReenrichContest(
+            [FromRoute] Guid contestId,
+            [FromServices] IReenrichContestHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var correlationId = GetCorrelationIdFromRequest();
+
+            var result = await handler.ExecuteAsync(
+                new ReenrichContestCommand
+                {
+                    ContestId = contestId,
+                    CorrelationId = correlationId
+                },
+                cancellationToken);
+
+            return result switch
+            {
+                Success<Guid> success => Ok(new
+                {
+                    CorrelationId = success.Value,
+                    ContestId = contestId
+                }),
+                Failure<Guid> failure when failure.Status == ResultStatus.NotFound =>
+                    NotFound(new { ContestId = contestId, CorrelationId = correlationId }),
+                Failure<Guid> failure when failure.Status == ResultStatus.Validation =>
+                    BadRequest(new { CorrelationId = correlationId, Errors = failure.Errors }),
+                _ => StatusCode(500, new { CorrelationId = correlationId, ContestId = contestId })
+            };
+        }
+
         [HttpPost]
         [Route("finalize")]
         public IActionResult FinalizeContestsBySeasonYear(

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -305,9 +305,11 @@ namespace SportsData.Producer.DependencyInjection
 
             // Contest Commands
             services.AddScoped<IFinalizeContestsBySeasonYearHandler, FinalizeContestsBySeasonYearHandler>();
+            services.AddScoped<IReenrichContestHandler, ReenrichContestHandler>();
 
             // Contest Command Validators
             services.AddScoped<FluentValidation.IValidator<FinalizeContestsBySeasonYearCommand>, FinalizeContestsBySeasonYearCommandValidator>();
+            services.AddScoped<FluentValidation.IValidator<ReenrichContestCommand>, ReenrichContestCommandValidator>();
 
             // Contest Queries
             services.AddScoped<IGetContestByIdQueryHandler, GetContestByIdQueryHandler>();

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -36,6 +36,23 @@ const AdminApi = {
       params: league ? { league } : undefined,
     }),
 
+  // Re-run enrichment for a single contest. Clears UserPick scoring
+  // fields and asks Producer to clear the Contest derived fields and
+  // re-run enrichment inline. Response.data is the CorrelationId
+  // Producer logged the work under — surfaced in ContestOverviewAdmin
+  // so an operator can paste it into Seq for tracing.
+  //
+  // Lives here (AdminApi → /admin/...) deliberately. The earlier
+  // sibling actions on contestApi (Refresh / Refresh Media / Finalize)
+  // are exposed under the general /ui/contest surface gated only by
+  // [Authorize]. Re-enrich rolls back UserPicks, so it MUST be on the
+  // admin-token-gated controller — the UI's isAdmin check is
+  // presentational only, not a trust boundary.
+  reenrichContest: (contestId, sport, league) =>
+    apiClient.post(`/admin/contest/${contestId}/reenrich`, null, {
+      params: { sport, league }
+    }),
+
   // SignalR debug harness — see docs/signalr-debug-harness-plan.md.
   // Each call publishes a synthetic integration event through API's
   // MassTransit + own consumer + SignalR fan-out, exercising the same

--- a/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { useUserDto } from "../../contexts/UserContext";
-import toast from "react-hot-toast";
 import { useParams } from "react-router-dom";
 import apiWrapper from "../../api/apiWrapper";
 import "./ContestOverview.css";
@@ -12,6 +11,7 @@ import ContestOverviewWinProb from "./ContestOverviewWinProb";
 import ContestOverviewVideo from "./ContestOverviewVideo";
 import ContestOverviewInfo from "./ContestOverviewInfo";
 import ContestOverviewMetrics from "./ContestOverviewMetrics";
+import ContestOverviewAdmin from "./ContestOverviewAdmin";
 
 export default function ContestOverview() {
   const { sport, league, contestId } = useParams();
@@ -20,12 +20,6 @@ export default function ContestOverview() {
   const [error, setError] = useState(null);
   const { userDto } = useUserDto();
   const isAdmin = userDto?.isAdmin;
-  const [refreshing, setRefreshing] = useState(false);
-  const [refreshError, setRefreshError] = useState(null);
-  const [refreshingMedia, setRefreshingMedia] = useState(false);
-  const [refreshMediaError, setRefreshMediaError] = useState(null);
-  const [finalizing, setFinalizing] = useState(false);
-  const [finalizeError, setFinalizeError] = useState(null);
 
   useEffect(() => {
     setLoading(true);
@@ -50,45 +44,6 @@ export default function ContestOverview() {
   const { header, info, leaders, playLog, winProbability, homeMetrics, awayMetrics, mediaItems } = dto;
   const { homeTeam, awayTeam, quarterScores } = header;
 
-  const handleRefresh = async () => {
-    setRefreshing(true);
-    setRefreshError(null);
-    try {
-      await apiWrapper.Contest.refresh(contestId, sport, league);
-      toast.success("Contest refresh request submitted.");
-    } catch (err) {
-      setRefreshError("Failed to refresh contest.");
-      toast.error("Failed to submit refresh request.");
-    }
-    setRefreshing(false);
-  };
-
-  const handleRefreshMedia = async () => {
-    setRefreshingMedia(true);
-    setRefreshMediaError(null);
-    try {
-      await apiWrapper.Contest.refreshMedia(contestId, sport, league);
-      toast.success("Media refresh request submitted.");
-    } catch (err) {
-      setRefreshMediaError("Failed to refresh media.");
-      toast.error("Failed to submit media refresh request.");
-    }
-    setRefreshingMedia(false);
-  };
-
-  const handleFinalize = async () => {
-    setFinalizing(true);
-    setFinalizeError(null);
-    try {
-      await apiWrapper.Contest.finalize(contestId, sport, league);
-      toast.success("Finalize contest request submitted.");
-    } catch (err) {
-      setFinalizeError("Failed to finalize contest.");
-      toast.error("Failed to submit finalize request.");
-    }
-    setFinalizing(false);
-  };
-
   return (
     <div className="contest-overview-container">
       <ContestOverviewHeader homeTeam={homeTeam} awayTeam={awayTeam} quarterScores={quarterScores} seasonYear={header.seasonYear} sport={sport} league={league} status={header.statusDescription ?? header.status} />
@@ -102,42 +57,17 @@ export default function ContestOverview() {
           {/* Win probability moved up until TeamStats is available */}
           <ContestOverviewWinProb winProbability={winProbability} homeTeam={homeTeam} awayTeam={awayTeam} sport={sport} />
           <ContestOverviewMetrics homeMetrics={homeMetrics} awayMetrics={awayMetrics} homeName={homeTeam?.displayName} awayName={awayTeam?.displayName} />
+          {/* Admin section slots into the second column immediately after
+              Metrics. Hidden from non-admins via the isAdmin gate. */}
+          {isAdmin && (
+            <ContestOverviewAdmin contestId={contestId} sport={sport} league={league} />
+          )}
           <ContestOverviewInfo info={info} />
         </div>
         <div className="contest-overview-col">
           <ContestOverviewPlaylog playLog={playLog} sport={sport} contestId={contestId} league={league} />
         </div>
       </div>
-      {isAdmin && (
-        <div style={{ marginTop: 32, textAlign: "center" }}>
-          <button
-            onClick={handleRefresh}
-            disabled={refreshing}
-            style={{ padding: "10px 24px", fontSize: 16, fontWeight: 600, borderRadius: 6, background: "#23272f", color: "#fff", border: "none", cursor: "pointer" }}
-          >
-            {refreshing ? "Refreshing..." : "Refresh Contest"}
-          </button>
-          {refreshError && <div style={{ color: "#d32f2f", marginTop: 8 }}>{refreshError}</div>}
-          
-          <button
-            onClick={handleRefreshMedia}
-            disabled={refreshingMedia}
-            style={{ padding: "10px 24px", fontSize: 16, fontWeight: 600, borderRadius: 6, background: "#23272f", color: "#fff", border: "none", cursor: "pointer", marginTop: 16 }}
-          >
-            {refreshingMedia ? "Refreshing..." : "Refresh Media"}
-          </button>
-          {refreshMediaError && <div style={{ color: "#d32f2f", marginTop: 8 }}>{refreshMediaError}</div>}
-
-          <button
-            onClick={handleFinalize}
-            disabled={finalizing}
-            style={{ padding: "10px 24px", fontSize: 16, fontWeight: 600, borderRadius: 6, background: "#23272f", color: "#fff", border: "none", cursor: "pointer", marginTop: 16 }}
-          >
-            {finalizing ? "Finalizing..." : "Finalize Contest"}
-          </button>
-          {finalizeError && <div style={{ color: "#d32f2f", marginTop: 8 }}>{finalizeError}</div>}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewAdmin.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewAdmin.jsx
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import toast from "react-hot-toast";
+import apiWrapper from "../../api/apiWrapper";
+
+/**
+ * Admin-only operations on a single contest. Visibility is the parent's
+ * responsibility — ContestOverview already gates on userDto.isAdmin and
+ * skips rendering this component when the user isn't admin.
+ *
+ * The buttons here are deliberately low-style: each one fires a request
+ * that Producer turns into background work (refresh sourcing, refresh
+ * media, force finalize). None of them block the user, so the UX is
+ * "click and watch the toast / Seq."
+ *
+ * Lives in the .contest-section visual family so it slots cleanly into
+ * the second column of the overview grid right after Metrics.
+ */
+export default function ContestOverviewAdmin({ contestId, sport, league }) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState(null);
+  const [refreshingMedia, setRefreshingMedia] = useState(false);
+  const [refreshMediaError, setRefreshMediaError] = useState(null);
+  const [finalizing, setFinalizing] = useState(false);
+  const [finalizeError, setFinalizeError] = useState(null);
+  // Re-enrichment state. correlationId is what Producer logged the work
+  // under and is what we surface in the UI so the operator can paste it
+  // into Seq for tracing.
+  const [reenriching, setReenriching] = useState(false);
+  const [reenrichError, setReenrichError] = useState(null);
+  const [reenrichCorrelationId, setReenrichCorrelationId] = useState(null);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      await apiWrapper.Contest.refresh(contestId, sport, league);
+      toast.success("Contest refresh request submitted.");
+    } catch (err) {
+      setRefreshError("Failed to refresh contest.");
+      toast.error("Failed to submit refresh request.");
+    }
+    setRefreshing(false);
+  };
+
+  const handleRefreshMedia = async () => {
+    setRefreshingMedia(true);
+    setRefreshMediaError(null);
+    try {
+      await apiWrapper.Contest.refreshMedia(contestId, sport, league);
+      toast.success("Media refresh request submitted.");
+    } catch (err) {
+      setRefreshMediaError("Failed to refresh media.");
+      toast.error("Failed to submit media refresh request.");
+    }
+    setRefreshingMedia(false);
+  };
+
+  const handleFinalize = async () => {
+    setFinalizing(true);
+    setFinalizeError(null);
+    try {
+      await apiWrapper.Contest.finalize(contestId, sport, league);
+      toast.success("Finalize contest request submitted.");
+    } catch (err) {
+      setFinalizeError("Failed to finalize contest.");
+      toast.error("Failed to submit finalize request.");
+    }
+    setFinalizing(false);
+  };
+
+  const handleReenrich = async () => {
+    setReenriching(true);
+    setReenrichError(null);
+    // Clear the prior correlationId display so a failure doesn't leave
+    // the stale-from-a-previous-success id sitting on screen looking
+    // like it belongs to the new attempt.
+    setReenrichCorrelationId(null);
+    try {
+      const response = await apiWrapper.Admin.reenrichContest(contestId, sport, league);
+      // API handler returns Result<Guid> where the Guid IS the
+      // CorrelationId Producer logged the work under (see
+      // ReenrichContestCommandHandler: Success<Guid>(producerCorrelationId)).
+      const correlationId = response?.data ?? null;
+      setReenrichCorrelationId(correlationId);
+      toast.success("Re-enrichment complete.");
+    } catch (err) {
+      setReenrichError("Failed to re-run enrichment.");
+      toast.error("Failed to re-run enrichment.");
+    }
+    setReenriching(false);
+  };
+
+  // Shared button style — keeps each action visually equivalent and
+  // makes adding the next admin action a one-line copy. Inline because
+  // there's no Admin-specific class set in ContestOverview.css yet;
+  // promote to a class if this list grows.
+  //
+  // Color note: prior version used a hardcoded #23272f background, but
+  // that matches --bg-input exactly in the dark theme — buttons rendered
+  // invisible against the .contest-section background. Use --accent for
+  // a high-contrast call-to-action treatment that works in both themes.
+  const buttonStyle = {
+    padding: "10px 24px",
+    fontSize: 16,
+    fontWeight: 600,
+    borderRadius: 6,
+    background: "var(--accent)",
+    color: "var(--text-on-accent)",
+    border: "none",
+    cursor: "pointer",
+  };
+
+  return (
+    <div className="contest-section">
+      <div className="contest-section-title">Admin</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "stretch" }}>
+        <div>
+          <button onClick={handleRefresh} disabled={refreshing} style={buttonStyle}>
+            {refreshing ? "Refreshing..." : "Refresh Contest"}
+          </button>
+          {refreshError && (
+            <div style={{ color: "#d32f2f", marginTop: 6 }}>{refreshError}</div>
+          )}
+        </div>
+
+        <div>
+          <button onClick={handleRefreshMedia} disabled={refreshingMedia} style={buttonStyle}>
+            {refreshingMedia ? "Refreshing..." : "Refresh Media"}
+          </button>
+          {refreshMediaError && (
+            <div style={{ color: "#d32f2f", marginTop: 6 }}>{refreshMediaError}</div>
+          )}
+        </div>
+
+        <div>
+          <button onClick={handleFinalize} disabled={finalizing} style={buttonStyle}>
+            {finalizing ? "Finalizing..." : "Finalize Contest"}
+          </button>
+          {finalizeError && (
+            <div style={{ color: "#d32f2f", marginTop: 6 }}>{finalizeError}</div>
+          )}
+        </div>
+
+        <div>
+          <button onClick={handleReenrich} disabled={reenriching} style={buttonStyle}>
+            {reenriching ? "Re-running enrichment..." : "Re-run Enrichment"}
+          </button>
+          {reenrichError && (
+            <div style={{ color: "#d32f2f", marginTop: 6 }}>{reenrichError}</div>
+          )}
+          {reenrichCorrelationId && (
+            // monospace + userSelect:'all' so a click highlights the
+            // whole id for paste into Seq without selection drag.
+            <div style={{ marginTop: 6, fontSize: 14, color: "var(--text-secondary)" }}>
+              CorrelationId:{" "}
+              <code
+                style={{
+                  fontFamily: "monospace",
+                  userSelect: "all",
+                  background: "var(--bg-card, rgba(255,255,255,0.04))",
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  color: "var(--text-primary)",
+                }}
+              >
+                {reenrichCorrelationId}
+              </code>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New admin-only "Re-run Enrichment" path for a single contest, surfaced as a button on the Contest Overview admin panel. Aimed at the case where the audit job hasn't caught a stuck `WinnerFranchiseSeasonId` / `SpreadWinnerFranchiseSeasonId` on an already-finalized contest.
- **Not a re-source.** Canonical `CompetitionCompetitorScores` are left alone; only the derived/enriched contest fields are cleared (`FinalizedUtc`, `WinnerFranchiseSeasonId`, `SpreadWinnerFranchiseSeasonId`, `OverUnder`, `AwayScore`, `HomeScore`, `AuditedUtc`) and enrichment is rerun against MAX(CCS).
- API picks-reset runs FIRST, Producer reenrich runs SECOND. Failure-isolation rationale: "picks nulled + contest still finalized" is harmless; "picks scored + contest unfinalized" is the wrong state this endpoint exists to repair.

## Surface
- **API** — `POST /admin/contest/{contestId}/reenrich?sport=&league=` behind `[AdminApiToken]` (Firebase JWT Admin role OR `X-Admin-Token` header). Lives under `AdminController`, never exposed as a normal route. Vertical slice at `Application/Admin/Commands/ReenrichContest/`.
- **Core** — `IProvideContests.ReenrichContest(...)` typed-client method stamping `X-Correlation-Id` so API/Producer logs share the same id end-to-end. New `ReenrichContestResponse { CorrelationId, ContestId }` DTO.
- **Producer** — `POST /api/contests/{contestId}/admin/reenrich`. The endpoint's previous inline implementation has been refactored into a command/handler vertical slice (`ReenrichContestCommand` + `Validator` + `IReenrichContestHandler` / `ReenrichContestHandler`) following the existing `FinalizeContestsBySeasonYearHandler` pattern. Controller is now a thin dispatch + `Result<T>` switch. Handler awaits `IEnrichContests.Process` synchronously so the admin gets one-shot completion (no Hangfire poll).
- **UI** — Extracted admin section out of `ContestOverview` into a new `ContestOverviewAdmin` component. "Re-run Enrichment" button uses theme variables (no `#23272f` collision with `--bg-input`). Returned `correlationId` is rendered in a monospace `<code>` block with `userSelect: 'all'` for one-click copy.

## Why the explicit correlationId display
Audit logs / Seq queries pivot on `CorrelationId`. Showing it in the UI means the admin can drop straight into Seq without opening DevTools to fish it out of the response.

## Test plan
- [ ] Click "Re-run Enrichment" on a known-broken NCAAFB contest from last season; verify the returned correlationId appears in the UI.
- [ ] Search Seq for that correlationId — confirm API picks-reset, Producer `ReenrichContest requested`, `cleared derived fields`, enrichment processor, and `ContestFinalized` all share it.
- [ ] Verify `WinnerFranchiseSeasonId` / `SpreadWinnerFranchiseSeasonId` are now correct on the contest row.
- [ ] Verify `UserPicks` for that contest had `ScoredAt` / `IsCorrect` / `PointsAwarded` nulled, then re-scored after API's `ContestFinalizedHandler` runs.
- [ ] Confirm `CompetitionCompetitorScores` rows are untouched.
- [ ] Hit the endpoint without admin credentials → 401/403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an admin action to re-run enrichment for a single contest via a new endpoint (`sport` and `league` supported).
  * Updated the contest overview UI by replacing the old admin controls with a dedicated admin panel that includes re-run enrichment (along with refresh, refresh media, and finalize).
  * Re-enrichment now returns and displays a correlation ID to improve tracing and auditing for the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->