### PR TITLE
fix(mobile): unblock iOS EAS build — modular headers for RecaptchaInterop + AppCheckCore

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -22,7 +22,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "33"
+      "buildNumber": "34"
     },
     "android": {
       "package": "com.sportdeets.mobile",
@@ -60,6 +60,14 @@
             "extraPods": [
               {
                 "name": "GoogleUtilities",
+                "modular_headers": true
+              },
+              {
+                "name": "RecaptchaInterop",
+                "modular_headers": true
+              },
+              {
+                "name": "AppCheckCore",
                 "modular_headers": true
               }
             ]


### PR DESCRIPTION
## Summary
EAS iOS build #33 failed at \`pod install\` with:

\`\`\`
The Swift pod \`AppCheckCore\` depends upon \`RecaptchaInterop\`,
which does not define modules.
pod install exited with non-zero code: 1
\`\`\`

\`@react-native-firebase/messaging\` v24 pulls Firebase iOS SDK 12.10, which transitively drags in \`AppCheckCore\` (Swift pod) → which depends on \`RecaptchaInterop\` (non-modular C pod). Swift can't import a non-modular pod when building as a static library, so CocoaPods bails before Xcode ever runs.

Fix mirrors the existing \`GoogleUtilities\` entry: add both pods to \`expo-build-properties.ios.extraPods\` with \`modular_headers: true\`. \`AppCheckCore\` itself is added defensively — same class of failure if Firebase bumps the transitive again.

Also bumps \`ios.buildNumber\` 33 → 34 so the next EAS submission is distinct from the failed build.

## Diff
\`\`\`json
"extraPods": [
  { "name": "GoogleUtilities",  "modular_headers": true },
  { "name": "RecaptchaInterop", "modular_headers": true },
  { "name": "AppCheckCore",     "modular_headers": true }
]
\`\`\`

## Test plan
- [ ] Kick a fresh EAS iOS build after merge.
- [ ] Confirm \`pod install\` completes (no \`exit 1\` on the AppCheckCore line).
- [ ] Confirm Xcode build proceeds past the dependency resolution phase.
- [ ] Push notification + Firebase auth smoke test on the resulting build (verifies AppCheck wiring is still healthy with modular headers).

## Out of scope (handled separately or intentional)
- \`expo-doctor\` patch-version drift (expo 55.0.26 etc.) — not the cause of the build failure; address in a separate housekeeping PR via \`npx expo install --check\`.
- \`expo-modules-core\` direct-dep warning from doctor — intentional, required by jest-expo on this SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build version from 33 to 34.
  * Enhanced iOS infrastructure with security and verification framework updates to support improved app integrity checks and user verification capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->