### PR TITLE
fix(web): persist picks-page week across refresh + stuck-enrichment audit SQL

### DIFF
--- a/sql/pgsql/audit_stuck_overunder_ncaafb_fbs.sql
+++ b/sql/pgsql/audit_stuck_overunder_ncaafb_fbs.sql
@@ -1,0 +1,68 @@
+-- Find finalized NCAAFB FBS contests where Contest.OverUnder never
+-- propagated from the underlying CompetitionOdds row. Each row returned
+-- is a candidate for the admin "Re-run Enrichment" button.
+--
+-- Companion to audit_stuck_spread_winner_ncaafb_fbs.sql. Same enrichment
+-- processor wrote both fields in one pass —
+--
+--     contest.OverUnder = primaryOdds.OverUnderResult;
+--     contest.SpreadWinnerFranchiseSeasonId = primaryOdds.AtsWinnerFranchiseSeasonId;
+--
+-- so historically the two drift cases tend to come paired. Run both audits
+-- and reconcile the union into a single re-enrich pass per ContestId.
+--
+-- Detection rule: finalized contest + Contest.OverUnder = 0 (None) +
+-- at least one enriched CompetitionOdds row has a non-zero OverUnderResult.
+-- The OverUnderResult enum values are: 0=None, 1=Over, 2=Under, 3=Push.
+-- Push is a real result and SHOULD propagate; the Contest = 0 means it
+-- didn't.
+--
+-- Run against the Football Producer DB. Replace :seasonYear with the target
+-- year (e.g. 2024).
+
+WITH RECURSIVE gs_tree AS (
+    SELECT gs."Id", gs."ParentId", gs."Slug", gs."SeasonYear"
+    FROM public."GroupSeason" gs
+    WHERE gs."Slug" = 'fbs-i-a'
+      AND gs."SeasonYear" = :seasonYear
+
+    UNION ALL
+
+    SELECT child."Id", child."ParentId", child."Slug", child."SeasonYear"
+    FROM public."GroupSeason" child
+    JOIN gs_tree parent ON child."ParentId" = parent."Id"
+),
+fbs_fs AS (
+    SELECT fs."Id" AS "FranchiseSeasonId"
+    FROM public."FranchiseSeason" fs
+    JOIN gs_tree g ON fs."GroupSeasonId" = g."Id"
+    WHERE fs."SeasonYear" = :seasonYear
+),
+fbs_competitions AS (
+    SELECT DISTINCT cc."CompetitionId"
+    FROM public."CompetitionCompetitor" cc
+    JOIN fbs_fs fbs ON cc."FranchiseSeasonId" = fbs."FranchiseSeasonId"
+)
+SELECT
+    con."Id"                                AS "ContestId",
+    con."Name"                              AS "ContestName",
+    con."SeasonYear",
+    con."StartDateUtc",
+    con."FinalizedUtc",
+    con."AwayScore",
+    con."HomeScore",
+    con."OverUnder"                         AS "Contest_OverUnder",
+    o."ProviderId"                          AS "Odds_ProviderId",
+    o."OverUnder"                           AS "Odds_OverUnderLine",
+    o."OverUnderResult"                     AS "Odds_OverUnderResult",
+    o."EnrichedUtc"                         AS "Odds_EnrichedUtc"
+FROM public."Contest" con
+JOIN public."Competition" comp     ON comp."ContestId" = con."Id"
+JOIN fbs_competitions fc           ON fc."CompetitionId" = comp."Id"
+JOIN public."CompetitionOdds" o    ON o."CompetitionId" = comp."Id"
+WHERE con."SeasonYear" = :seasonYear
+  AND con."FinalizedUtc" IS NOT NULL
+  AND con."OverUnder" = 0                  -- OverUnderResult.None
+  AND o."EnrichedUtc" IS NOT NULL
+  AND o."OverUnderResult" <> 0             -- enrichment derived a real value
+ORDER BY con."StartDateUtc", o."ProviderId";

--- a/sql/pgsql/audit_stuck_overunder_nfl.sql
+++ b/sql/pgsql/audit_stuck_overunder_nfl.sql
@@ -1,0 +1,38 @@
+-- Find finalized NFL contests where Contest.OverUnder never propagated from
+-- the underlying CompetitionOdds row. Each row returned is a candidate for
+-- the admin "Re-run Enrichment" button.
+--
+-- NFL variant of audit_stuck_overunder_ncaafb_fbs.sql. NFL has no FBS
+-- concept; replaces the GroupSeason tree walk with Sport.FootballNfl = 3.
+--
+-- Detection rule: finalized contest + Contest.OverUnder = 0 (None) +
+-- at least one enriched CompetitionOdds row has a non-zero OverUnderResult.
+-- Enum: 0=None, 1=Over, 2=Under, 3=Push. Push IS a real result and should
+-- propagate.
+--
+-- Run against the Football Producer DB. Replace :seasonYear with the target
+-- year (e.g. 2025).
+
+SELECT
+    con."Id"                                AS "ContestId",
+    con."Name"                              AS "ContestName",
+    con."SeasonYear",
+    con."StartDateUtc",
+    con."FinalizedUtc",
+    con."AwayScore",
+    con."HomeScore",
+    con."OverUnder"                         AS "Contest_OverUnder",
+    o."ProviderId"                          AS "Odds_ProviderId",
+    o."OverUnder"                           AS "Odds_OverUnderLine",
+    o."OverUnderResult"                     AS "Odds_OverUnderResult",
+    o."EnrichedUtc"                         AS "Odds_EnrichedUtc"
+FROM public."Contest" con
+JOIN public."Competition" comp     ON comp."ContestId" = con."Id"
+JOIN public."CompetitionOdds" o    ON o."CompetitionId" = comp."Id"
+WHERE con."SeasonYear" = :seasonYear
+  AND con."Sport" = 3                      -- Sport.FootballNfl
+  AND con."FinalizedUtc" IS NOT NULL
+  AND con."OverUnder" = 0                  -- OverUnderResult.None
+  AND o."EnrichedUtc" IS NOT NULL
+  AND o."OverUnderResult" <> 0
+ORDER BY con."StartDateUtc", o."ProviderId";

--- a/sql/pgsql/audit_stuck_spread_winner_ncaafb_fbs.sql
+++ b/sql/pgsql/audit_stuck_spread_winner_ncaafb_fbs.sql
@@ -1,0 +1,61 @@
+-- Find finalized NCAAFB FBS contests where Contest.SpreadWinnerFranchiseSeasonId
+-- never propagated from the underlying CompetitionOdds row. Each row returned
+-- is a candidate for the admin "Re-run Enrichment" button — the same recovery
+-- path that flipped the first observed case on 2026-06-21.
+--
+-- Run against the Football Producer DB. Replace :seasonYear with the target
+-- year (e.g. 2024). For multiple seasons, sweep them individually.
+--
+-- Detection rule: contest is Final but SpreadWinnerFranchiseSeasonId IS NULL,
+-- AND there's at least one enriched CompetitionOdds row for the underlying
+-- Competition with a non-null AtsWinnerFranchiseSeasonId. That's the
+-- "enrichment derived an ATS winner but didn't write it back to Contest"
+-- signature. A Guid.Empty AtsWinner (push) is a real result and SHOULD
+-- propagate; the Contest NULL means it didn't.
+
+WITH RECURSIVE gs_tree AS (
+    -- FBS group tree for the season (mirrors errors_CompetitionsWithoutMetrics.sql)
+    SELECT gs."Id", gs."ParentId", gs."Slug", gs."SeasonYear"
+    FROM public."GroupSeason" gs
+    WHERE gs."Slug" = 'fbs-i-a'
+      AND gs."SeasonYear" = :seasonYear
+
+    UNION ALL
+
+    SELECT child."Id", child."ParentId", child."Slug", child."SeasonYear"
+    FROM public."GroupSeason" child
+    JOIN gs_tree parent ON child."ParentId" = parent."Id"
+),
+fbs_fs AS (
+    SELECT fs."Id" AS "FranchiseSeasonId"
+    FROM public."FranchiseSeason" fs
+    JOIN gs_tree g ON fs."GroupSeasonId" = g."Id"
+    WHERE fs."SeasonYear" = :seasonYear
+),
+fbs_competitions AS (
+    SELECT DISTINCT cc."CompetitionId"
+    FROM public."CompetitionCompetitor" cc
+    JOIN fbs_fs fbs ON cc."FranchiseSeasonId" = fbs."FranchiseSeasonId"
+)
+SELECT
+    con."Id"                                AS "ContestId",
+    con."Name"                              AS "ContestName",
+    con."SeasonYear",
+    con."StartDateUtc",
+    con."FinalizedUtc",
+    con."WinnerFranchiseSeasonId"           AS "Contest_StraightUpWinner",
+    con."SpreadWinnerFranchiseSeasonId"     AS "Contest_SpreadWinner",
+    o."ProviderId"                          AS "Odds_ProviderId",
+    o."AtsWinnerFranchiseSeasonId"          AS "Odds_AtsWinner",
+    o."OverUnderResult"                     AS "Odds_OverUnderResult",
+    o."EnrichedUtc"                         AS "Odds_EnrichedUtc"
+FROM public."Contest" con
+JOIN public."Competition" comp     ON comp."ContestId" = con."Id"
+JOIN fbs_competitions fc           ON fc."CompetitionId" = comp."Id"
+JOIN public."CompetitionOdds" o    ON o."CompetitionId" = comp."Id"
+WHERE con."SeasonYear" = :seasonYear
+  AND con."FinalizedUtc" IS NOT NULL
+  AND con."SpreadWinnerFranchiseSeasonId" IS NULL
+  AND o."EnrichedUtc" IS NOT NULL
+  AND o."AtsWinnerFranchiseSeasonId" IS NOT NULL
+ORDER BY con."StartDateUtc", o."ProviderId";

--- a/sql/pgsql/audit_stuck_spread_winner_nfl.sql
+++ b/sql/pgsql/audit_stuck_spread_winner_nfl.sql
@@ -1,0 +1,39 @@
+-- Find finalized NFL contests where Contest.SpreadWinnerFranchiseSeasonId
+-- never propagated from the underlying CompetitionOdds row. Each row returned
+-- is a candidate for the admin "Re-run Enrichment" button.
+--
+-- NFL variant of audit_stuck_spread_winner_ncaafb_fbs.sql. NFL has no FBS
+-- concept (all franchises are in scope), so the GroupSeason tree walk is
+-- replaced with a simple Sport filter (Sport.FootballNfl = 3).
+--
+-- Run against the Football Producer DB. Replace :seasonYear with the target
+-- year (e.g. 2025).
+--
+-- Detection rule: same as the NCAAFB FBS variant. Finalized contest +
+-- SpreadWinnerFranchiseSeasonId IS NULL + at least one enriched
+-- CompetitionOdds row has a non-null AtsWinnerFranchiseSeasonId. A push
+-- (AtsWinner = Guid.Empty) IS a real result and should propagate — the
+-- rule flags those correctly because Guid.Empty is non-null.
+
+SELECT
+    con."Id"                                AS "ContestId",
+    con."Name"                              AS "ContestName",
+    con."SeasonYear",
+    con."StartDateUtc",
+    con."FinalizedUtc",
+    con."WinnerFranchiseSeasonId"           AS "Contest_StraightUpWinner",
+    con."SpreadWinnerFranchiseSeasonId"     AS "Contest_SpreadWinner",
+    o."ProviderId"                          AS "Odds_ProviderId",
+    o."AtsWinnerFranchiseSeasonId"          AS "Odds_AtsWinner",
+    o."OverUnderResult"                     AS "Odds_OverUnderResult",
+    o."EnrichedUtc"                         AS "Odds_EnrichedUtc"
+FROM public."Contest" con
+JOIN public."Competition" comp     ON comp."ContestId" = con."Id"
+JOIN public."CompetitionOdds" o    ON o."CompetitionId" = comp."Id"
+WHERE con."SeasonYear" = :seasonYear
+  AND con."Sport" = 3                    -- Sport.FootballNfl
+  AND con."FinalizedUtc" IS NOT NULL
+  AND con."SpreadWinnerFranchiseSeasonId" IS NULL
+  AND o."EnrichedUtc" IS NOT NULL
+  AND o."AtsWinnerFranchiseSeasonId" IS NOT NULL
+ORDER BY con."StartDateUtc", o."ProviderId";

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -50,5 +50,14 @@ public class UserDto
         /// not a <c>1..N</c> upper bound. Populated by <c>GetMeQueryHandler</c>.
         /// </remarks>
         public IList<int> SeasonWeeks { get; set; } = [];
+
+        /// <summary>
+        /// The week the user should be picking right now. Smallest <see cref="SeasonWeeks"/>
+        /// entry whose matchups still have at least one unstarted game (StartDateUtc &gt; now).
+        /// Falls back to the maximum SeasonWeek when the season is fully past so the picks
+        /// page lands on the most recent week instead of an arbitrary default. Null only when
+        /// the league has no weeks at all.
+        /// </summary>
+        public int? CurrentSeasonWeek { get; set; }
     }
 }

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -21,15 +21,18 @@ public class GetMeQueryHandler : IGetMeQueryHandler
 {
     private readonly ApiConfig _config;
     private readonly AppDataContext _db;
+    private readonly IDateTimeProvider _dateTimeProvider;
     private readonly ILogger<GetMeQueryHandler> _logger;
 
     public GetMeQueryHandler(
         IOptions<ApiConfig> config,
         AppDataContext db,
+        IDateTimeProvider dateTimeProvider,
         ILogger<GetMeQueryHandler> logger)
     {
         _config = config.Value;
         _db = db;
+        _dateTimeProvider = dateTimeProvider;
         _logger = logger;
     }
 
@@ -38,6 +41,11 @@ public class GetMeQueryHandler : IGetMeQueryHandler
         CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Getting user details for UserId={UserId}", query.UserId);
+
+        // Captured once so the "current week" projection evaluates against a single
+        // point in time per request — and so IDateTimeProvider (not raw UtcNow) drives
+        // it, keeping the projection deterministic under unit-test mocks.
+        var nowUtc = _dateTimeProvider.UtcNow();
 
         var userDto = await _db.Users
             .AsNoTracking()
@@ -77,7 +85,22 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                             .Select(w => w.SeasonWeek)
                             .Distinct()
                             .OrderBy(w => w)
-                            .ToList()
+                            .ToList(),
+                        // "Current week" = smallest SeasonWeek that still has an unstarted
+                        // matchup. Picks-page UX intent: when the user opens the page mid-
+                        // season, drop them on the week they should be picking, not the
+                        // last week of the season. Coalesces to MAX(SeasonWeek) once every
+                        // matchup has kicked off so a season-over visit lands on the most
+                        // recent week instead of nothing.
+                        CurrentSeasonWeek = m.Group.Weeks
+                            .Where(w => w.Matchups.Any(mm => mm.StartDateUtc > nowUtc))
+                            .OrderBy(w => w.SeasonWeek)
+                            .Select(w => (int?)w.SeasonWeek)
+                            .FirstOrDefault()
+                            ?? m.Group.Weeks
+                                .OrderByDescending(w => w.SeasonWeek)
+                                .Select(w => (int?)w.SeasonWeek)
+                                .FirstOrDefault()
                     })
                     .ToList()
             })

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -158,6 +158,7 @@ function MainApp() {
           <Routes>
             <Route index element={<HomePage />} />
             <Route path="/picks/:leagueId?" element={<PicksPage />} />
+            <Route path="/picks/:leagueId/weeks/:week" element={<PicksPage />} />
             <Route path="/warroom" element={<WarRoomPage />} />
             <Route path="/leaderboard" element={<LeaderboardPage />} />
             <Route path="/map" element={<GameMap />} />

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -19,8 +19,17 @@ function PicksPage() {
     setSelectedLeagueId: setGlobalLeagueId,
     initializeLeagueSelection,
   } = useLeagueContext();
-  const { leagueId: routeLeagueId } = useParams(); // optional route param
+  const { leagueId: routeLeagueId, week: routeWeekParam } = useParams();
   const navigate = useNavigate();
+
+  // Route param arrives as a string; parse once. Invalid values (negative,
+  // non-numeric, NaN) become null so the week-snap effect redirects to a
+  // valid week instead of trusting garbage in the URL.
+  const routeWeek = useMemo(() => {
+    if (routeWeekParam == null) return null;
+    const n = Number(routeWeekParam);
+    return Number.isInteger(n) && n > 0 ? n : null;
+  }, [routeWeekParam]);
 
   const [userPicks, setUserPicks] = useState({});
   const [isSubscribed] = useState(false);
@@ -40,12 +49,13 @@ function PicksPage() {
   const [leagueAsOfDate, setLeagueAsOfDate] = useState(null);
   const [loadingMatchups, setLoadingMatchups] = useState(true);
 
-  // Source of truth for the selected league is the route param
-  // (/app/picks/:leagueId?). The dropdown navigates instead of holding
-  // local state — this kills the prior fight between `selectedLeagueId`
-  // state, the URL sync effect, and the week-snap effect that was
-  // emitting 5 matchups XHRs per league switch.
-  const [selectedWeek, setSelectedWeek] = useState(null);
+  // Source of truth for both league AND week is the URL — the dropdowns
+  // navigate instead of holding local state. This kills the prior fight
+  // between `selectedLeagueId` state, the URL sync effect, and the
+  // week-snap effect that was emitting 5 matchups XHRs per league switch,
+  // AND fixes refresh-loses-week (selectedWeek used to reset to
+  // latestSeasonWeek on every mount).
+  const selectedWeek = routeWeek;
   const viewMode = "card";
 
   const [hidePicked, setHidePicked] = useState(false);
@@ -80,10 +90,17 @@ function PicksPage() {
     () => selectedLeague?.seasonWeeks ?? [],
     [selectedLeague]
   );
-  // Default to the latest week the league has (last element of the
-  // ascending list). Custom-window leagues may only have a single entry.
+  // Default landing week — prefer the backend-computed current week (the
+  // earliest week with an unstarted matchup, falling back to the last
+  // week of the season). Custom-window leagues may only have a single
+  // entry.
   const latestSeasonWeek =
     seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
+  const currentSeasonWeek = selectedLeague?.currentSeasonWeek ?? null;
+  const defaultLandingWeek =
+    currentSeasonWeek && seasonWeeks.includes(currentSeasonWeek)
+      ? currentSeasonWeek
+      : latestSeasonWeek;
 
   // Recovery for newly-created leagues. League creation publishes
   // PickemGroupCreated via the outbox; the consumer that populates
@@ -449,11 +466,10 @@ function PicksPage() {
     }
   }
 
-  // Switch league → ensure the URL changes (route is the source of
-  // truth) and persist the choice for cross-page memory. The week-snap
-  // effect below adjusts selectedWeek on the next render; the matchups
-  // fetch is gated on the new league's seasonWeeks so the brief
-  // (newLeagueId, oldWeek) window doesn't emit an XHR.
+  // Switch league → drop the `/weeks/:week` segment so the week-snap
+  // effect below can redirect to the new league's default landing week
+  // (current week, falling back to latest). Cross-page memory still
+  // tracks the league choice.
   const handleLeagueChange = useCallback(
     (newLeagueId) => {
       if (!newLeagueId || newLeagueId === routeLeagueId) return;
@@ -463,22 +479,39 @@ function PicksPage() {
     [routeLeagueId, navigate, setGlobalLeagueId]
   );
 
-  // Snap selectedWeek when the URL-driven league changes, or when the
-  // current week falls outside the new league's week list. Respects a
-  // user's manual mid-week selection (deps don't change on week
-  // selection alone, and we only re-snap when the current week is no
-  // longer valid for this league).
+  // Switch week → navigate to the canonical URL. `replace: true` so the
+  // back button returns to wherever the user came from rather than
+  // cycling through every week they clicked through.
+  const handleWeekChange = useCallback(
+    (newWeek) => {
+      if (!routeLeagueId || newWeek == null) return;
+      if (newWeek === routeWeek) return;
+      navigate(`/app/picks/${routeLeagueId}/weeks/${newWeek}`, {
+        replace: true,
+      });
+    },
+    [routeLeagueId, routeWeek, navigate]
+  );
+
+  // Redirect to the canonical URL when the route is missing the week
+  // segment or carries one that's not in the league's week list.
+  // Replaces the prior `setSelectedWeek(latestSeasonWeek)` snap which
+  // only updated local state — that's the refresh-loses-selection bug:
+  // every remount re-defaulted to the latest week regardless of what
+  // the user had picked.
   useEffect(() => {
     if (!routeLeagueId) return;
-    if (!latestSeasonWeek) {
-      if (selectedWeek !== null) setSelectedWeek(null);
-      return;
-    }
-    if (selectedWeek === null || !seasonWeeks.includes(selectedWeek)) {
-      setSelectedWeek(latestSeasonWeek);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeLeagueId, latestSeasonWeek, selectedLeague]);
+    if (seasonWeeks.length === 0) return; // user-dto still hydrating
+
+    const weekIsValid =
+      routeWeek != null && seasonWeeks.includes(routeWeek);
+    if (weekIsValid) return;
+
+    if (defaultLandingWeek == null) return;
+    navigate(`/app/picks/${routeLeagueId}/weeks/${defaultLandingWeek}`, {
+      replace: true,
+    });
+  }, [routeLeagueId, routeWeek, seasonWeeks, defaultLandingWeek, navigate]);
 
   if (userLoading) return <div>Loading user info...</div>;
 
@@ -515,7 +548,7 @@ function PicksPage() {
             selectedLeagueId={routeLeagueId}
             setSelectedLeagueId={handleLeagueChange}
             selectedWeek={selectedWeek}
-            setSelectedWeek={setSelectedWeek}
+            setSelectedWeek={handleWeekChange}
             seasonWeeks={seasonWeeks}
           />
           <div className="pick-status-toggle-row">

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
@@ -23,6 +23,8 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
 {
     private static readonly Guid SystemUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
+    private static readonly DateTime FixedNow = new(2024, 10, 15, 12, 0, 0, DateTimeKind.Utc);
+
     public GetMeQueryHandlerTests()
     {
         var apiConfig = new ApiConfig
@@ -33,6 +35,12 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         Mocker.GetMock<IOptions<ApiConfig>>()
             .Setup(x => x.Value)
             .Returns(apiConfig);
+
+        // Fixed "now" for the CurrentSeasonWeek projection. Tests that care
+        // about the field seed matchups relative to FixedNow.
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
     }
     [Fact]
     public async Task ExecuteAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
@@ -266,6 +274,221 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         result.Value.Should().NotBeNull();
         result.Value.Leagues.Should().HaveCount(1);
         result.Value.Leagues.First().SeasonWeeks.Should().Equal(3, 5, 7);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnCurrentSeasonWeek_AsSmallestWeekWithUnstartedMatchup()
+    {
+        // Three weeks, each with one matchup. Week 3 is past, Week 5 is mid-window
+        // (already started), Week 7 is future. Expected CurrentSeasonWeek = 7 —
+        // the earliest week that still has an unstarted game from "now"'s vantage.
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        var user = new UserEntity
+        {
+            Id = userId,
+            FirebaseUid = "firebase-current-week",
+            Email = "currentweek@example.com",
+            DisplayName = "Current Week User",
+            SignInProvider = "password",
+            EmailVerified = false,
+            CreatedUtc = FixedNow.AddDays(-60),
+            LastLoginUtc = FixedNow
+        };
+
+        var group = new PickemGroup
+        {
+            Id = groupId,
+            Name = "Current Week League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF
+        };
+
+        var week3 = new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonYear = 2024,
+            SeasonWeek = 3,
+            SeasonWeekId = Guid.NewGuid(),
+            Group = group
+        };
+        var week5 = new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonYear = 2024,
+            SeasonWeek = 5,
+            SeasonWeekId = Guid.NewGuid(),
+            Group = group
+        };
+        var week7 = new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonYear = 2024,
+            SeasonWeek = 7,
+            SeasonWeekId = Guid.NewGuid(),
+            Group = group
+        };
+
+        var membership = new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = groupId,
+            User = user,
+            Group = group
+        };
+
+        group.Weeks.Add(week3);
+        group.Weeks.Add(week5);
+        group.Weeks.Add(week7);
+        user.GroupMemberships.Add(membership);
+
+        await DataContext.Users.AddAsync(user);
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupWeeks.AddRangeAsync([week3, week5, week7]);
+        await DataContext.PickemGroupMembers.AddAsync(membership);
+
+        // One matchup per week, dated relative to FixedNow.
+        await DataContext.PickemGroupMatchups.AddRangeAsync([
+            new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = week3.SeasonWeekId,
+                ContestId = Guid.NewGuid(),
+                StartDateUtc = FixedNow.AddDays(-21),
+                SeasonYear = 2024,
+                SeasonWeek = 3
+            },
+            new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = week5.SeasonWeekId,
+                ContestId = Guid.NewGuid(),
+                StartDateUtc = FixedNow.AddHours(-2),
+                SeasonYear = 2024,
+                SeasonWeek = 5
+            },
+            new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = week7.SeasonWeekId,
+                ContestId = Guid.NewGuid(),
+                StartDateUtc = FixedNow.AddDays(10),
+                SeasonYear = 2024,
+                SeasonWeek = 7
+            }
+        ]);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetMeQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetMeQuery { UserId = userId });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Leagues.First().CurrentSeasonWeek.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldFallBackToMaxSeasonWeek_WhenAllMatchupsArePast()
+    {
+        // Season-over case — every matchup is in the past. CurrentSeasonWeek
+        // should land on MAX(SeasonWeek) (= 7) instead of null so the picks
+        // page has somewhere meaningful to display.
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        var user = new UserEntity
+        {
+            Id = userId,
+            FirebaseUid = "firebase-season-over",
+            Email = "seasonover@example.com",
+            DisplayName = "Season Over User",
+            SignInProvider = "password",
+            EmailVerified = false,
+            CreatedUtc = FixedNow.AddDays(-120),
+            LastLoginUtc = FixedNow
+        };
+
+        var group = new PickemGroup
+        {
+            Id = groupId,
+            Name = "Season Over League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF
+        };
+
+        var week3 = new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonYear = 2024,
+            SeasonWeek = 3,
+            SeasonWeekId = Guid.NewGuid(),
+            Group = group
+        };
+        var week7 = new PickemGroupWeek
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonYear = 2024,
+            SeasonWeek = 7,
+            SeasonWeekId = Guid.NewGuid(),
+            Group = group
+        };
+
+        var membership = new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = groupId,
+            User = user,
+            Group = group
+        };
+
+        group.Weeks.Add(week3);
+        group.Weeks.Add(week7);
+        user.GroupMemberships.Add(membership);
+
+        await DataContext.Users.AddAsync(user);
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupWeeks.AddRangeAsync([week3, week7]);
+        await DataContext.PickemGroupMembers.AddAsync(membership);
+
+        await DataContext.PickemGroupMatchups.AddRangeAsync([
+            new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = week3.SeasonWeekId,
+                ContestId = Guid.NewGuid(),
+                StartDateUtc = FixedNow.AddDays(-30),
+                SeasonYear = 2024,
+                SeasonWeek = 3
+            },
+            new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                SeasonWeekId = week7.SeasonWeekId,
+                ContestId = Guid.NewGuid(),
+                StartDateUtc = FixedNow.AddDays(-3),
+                SeasonYear = 2024,
+                SeasonWeek = 7
+            }
+        ]);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetMeQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetMeQuery { UserId = userId });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Leagues.First().CurrentSeasonWeek.Should().Be(7);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Two related changes that came out of the same conversation:

### 1. Picks page — week selection persists across refresh
Refreshing \`/app/picks/{leagueId}\` was dropping the user's week selection and re-defaulting to the last week of the league. Root cause: \`PicksPage\` held \`selectedWeek\` in component state with no URL/storage backing, so every remount reset it via the week-snap effect that defaulted to \`seasonWeeks[seasonWeeks.length - 1]\`.

**Fix:**
- New canonical route \`/app/picks/{leagueId}/weeks/{N}\` alongside the existing bare route.
- URL is now the source of truth for the selected week (\`selectedWeek = routeWeek\`, no local state).
- Week-snap effect became a redirect — when the URL is missing the \`/weeks/{N}\` segment or carries an invalid value, navigate to the canonical URL using a new \`defaultLandingWeek\`.
- \`defaultLandingWeek\` prefers the backend-computed \`CurrentSeasonWeek\` over \`latestSeasonWeek\` so a user opening the page mid-season lands on the week they should be picking, not the final week of the season.
- Selector week change routes through \`handleWeekChange\` which navigates with \`replace: true\`, matching \`handleLeagueChange\` (back button returns to whatever page brought the user to picks, not through every week click).

### 2. Backend — \`CurrentSeasonWeek\` on \`UserDto.UserLeagueMembership\`
Needed by the picks-page default-landing logic.

- Computed in \`GetMeQueryHandler\` as the smallest \`SeasonWeek\` whose matchups still have an unstarted game (\`StartDateUtc > nowUtc\`), falling back to \`MAX(SeasonWeek)\` so a season-over visit still lands somewhere meaningful.
- \`IDateTimeProvider\` injected so the projection is deterministic under unit-test mocks (codebase rule: no direct \`DateTime.UtcNow\` in production handlers).
- 2 new tests: smallest-week-with-unstarted-matchup happy path, and season-over fallback to MAX \`SeasonWeek\`.

### 3. Audit SQL — stuck enrichment fields (bonus, related)
Came out of the same session — after the admin Re-run Enrichment button corrected a stuck \`SpreadWinnerFranchiseSeasonId\` last night, we agreed it was worth a pre-season sweep for the rest of the backlog.

Four new files under \`sql/pgsql/audit_stuck_*.sql\`:
- \`audit_stuck_spread_winner_ncaafb_fbs.sql\` — NCAAFB FBS variant for stuck SpreadWinner.
- \`audit_stuck_spread_winner_nfl.sql\` — NFL variant (no FBS tree).
- \`audit_stuck_overunder_ncaafb_fbs.sql\` — NCAAFB FBS variant for stuck OverUnder.
- \`audit_stuck_overunder_nfl.sql\` — NFL variant.

Detection rule: finalized contest with the Contest-level derived field NULL/None while the underlying enriched \`CompetitionOdds\` row has a populated value. The admin "Re-run Enrichment" button is the recovery path per row. The same enrichment processor writes both fields in one pass — drift cases tend to come paired, so sweep the union of \`ContestId\`s across all four queries and run one re-enrich per contest, not per finding.

## Tests
- \`dotnet test\` — all 406 \`SportsData.Api.Tests.Unit\` pass.
- Frontend manually verified locally.

## Test plan
- [ ] Open \`/app/picks/{leagueId}\` (bare) → redirects to \`/app/picks/{leagueId}/weeks/{currentSeasonWeek}\` on a live-season league, or \`/weeks/{latest}\` on a season-over league.
- [ ] Navigate to a different week via the selector → URL updates to \`/weeks/{N}\`, back button returns to the prior page (not the prior week).
- [ ] Hard-refresh \`/app/picks/{leagueId}/weeks/3\` → page comes back on week 3, no flash of week-N content.
- [ ] Single-week league (custom window) → selector renders as static text, URL is \`/weeks/1\`, behaves correctly.
- [ ] Run the four audit SQL queries against the Football Producer DB for a known good season → expect zero rows. For an old NCAAFB season where you know there are stuck rows, expect those rows to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added URL-driven week navigation for picks page (`/picks/:leagueId/weeks/:week`), allowing direct linking to specific weeks.
  * Picks page now intelligently selects the current active season week, showing users the most relevant week automatically.

* **Chores**
  * Added internal audit queries to detect and resolve data synchronization issues.
  * Enhanced test coverage for season week selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->