### PR TITLE
chore(producer): add visibility logs to Football + Baseball ContestEnrichmentProcessor

### DIFF
--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -143,6 +143,12 @@ namespace SportsData.Producer.Application.Contests
             contest.AwayScore = (int)awayMaxScore.Value;
             contest.HomeScore = (int)homeMaxScore.Value;
 
+            _logger.LogInformation(
+                "Final score derived. Source={Source}, Away={AwayScore}, Home={HomeScore}",
+                "CompetitorMaxScore",
+                contest.AwayScore,
+                contest.HomeScore);
+
             var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
             var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;
 
@@ -155,6 +161,11 @@ namespace SportsData.Producer.Application.Contests
                     homeFranchiseSeasonId :
                     awayFranchiseSeasonId;
             }
+
+            _logger.LogInformation(
+                "Straight-up winner derived. WinnerFranchiseSeasonId={WinnerFranchiseSeasonId}, IsTie={IsTie}",
+                contest.WinnerFranchiseSeasonId,
+                contest.AwayScore == contest.HomeScore);
 
             contest.FinalizedUtc = _dateTimeProvider.UtcNow();
 
@@ -175,7 +186,23 @@ namespace SportsData.Producer.Application.Contests
                 {
                     contest.OverUnder = primaryOdds.OverUnderResult;
                     contest.SpreadWinnerFranchiseSeasonId = primaryOdds.AtsWinnerFranchiseSeasonId;
+
+                    _logger.LogInformation(
+                        "Primary odds provider selected. ProviderName={ProviderName}, OverUnderResult={OverUnderResult}, AtsWinner={AtsWinnerFranchiseSeasonId}",
+                        primaryOdds.ProviderName,
+                        primaryOdds.OverUnderResult,
+                        primaryOdds.AtsWinnerFranchiseSeasonId);
                 }
+                else
+                {
+                    _logger.LogInformation(
+                        "No finalized odds row available; Contest-level ATS / OverUnder not denormalized.");
+                }
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "No CompetitionOdds rows present; skipping per-provider enrichment.");
             }
 
             await _bus.Publish(
@@ -195,14 +222,16 @@ namespace SportsData.Producer.Application.Contests
             await _dataContext.SaveChangesAsync();
 
             _logger.LogInformation(
-                "Contest enrichment completed. ContestId={ContestId}, ContestName={ContestName}, " +
+                "Contest enrichment completed. ContestName={ContestName}, " +
                 "AwayScore={AwayScore}, HomeScore={HomeScore}, WinnerFranchiseSeasonId={WinnerFranchiseSeasonId}, " +
-                "FinalizedUtc={FinalizedUtc}, OddsProvidersEnriched={OddsProvidersEnriched}",
-                command.ContestId,
+                "SpreadWinnerFranchiseSeasonId={SpreadWinnerFranchiseSeasonId}, OverUnder={OverUnder}, " +
+                "FinalizedUtc={FinalizedUtc}, OddsProvidersFinalized={OddsProvidersFinalized}",
                 contest.Name,
                 contest.AwayScore,
                 contest.HomeScore,
                 contest.WinnerFranchiseSeasonId,
+                contest.SpreadWinnerFranchiseSeasonId,
+                contest.OverUnder,
                 contest.FinalizedUtc,
                 competition.Odds?.Count(o => o.FinalizedUtc.HasValue) ?? 0);
         }

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -37,6 +37,7 @@ namespace SportsData.Producer.Application.Contests
         {
             using (_logger.BeginScope(new Dictionary<string, object>
                    {
+                       ["ContestId"] = command.ContestId,
                        ["CorrelationId"] = command.CorrelationId
                    }))
             {
@@ -154,6 +155,12 @@ namespace SportsData.Producer.Application.Contests
                     contest.HomeScore = (int)homeMaxScore.Value;
                 }
 
+                _logger.LogInformation(
+                    "Final score derived. Source={Source}, Away={AwayScore}, Home={HomeScore}",
+                    lastScoringPlay != null ? "ScoringPlay" : "CompetitorMaxScore",
+                    contest.AwayScore,
+                    contest.HomeScore);
+
                 var awayFranchiseSeasonId = awayCompetitor.FranchiseSeasonId;
                 var homeFranchiseSeasonId = homeCompetitor.FranchiseSeasonId;
 
@@ -166,6 +173,11 @@ namespace SportsData.Producer.Application.Contests
                         homeFranchiseSeasonId :
                         awayFranchiseSeasonId;
                 }
+
+                _logger.LogInformation(
+                    "Straight-up winner derived. WinnerFranchiseSeasonId={WinnerFranchiseSeasonId}, IsTie={IsTie}",
+                    contest.WinnerFranchiseSeasonId,
+                    contest.AwayScore == contest.HomeScore);
 
                 contest.FinalizedUtc = _dateTimeProvider.UtcNow();
 
@@ -188,7 +200,23 @@ namespace SportsData.Producer.Application.Contests
                     {
                         contest.OverUnder = primaryOdds.OverUnderResult;
                         contest.SpreadWinnerFranchiseSeasonId = primaryOdds.AtsWinnerFranchiseSeasonId;
+
+                        _logger.LogInformation(
+                            "Primary odds provider selected. ProviderName={ProviderName}, OverUnderResult={OverUnderResult}, AtsWinner={AtsWinnerFranchiseSeasonId}",
+                            primaryOdds.ProviderName,
+                            primaryOdds.OverUnderResult,
+                            primaryOdds.AtsWinnerFranchiseSeasonId);
                     }
+                    else
+                    {
+                        _logger.LogInformation(
+                            "No finalized odds row available; Contest-level ATS / OverUnder not denormalized.");
+                    }
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "No CompetitionOdds rows present; skipping per-provider enrichment.");
                 }
 
                 await _bus.Publish(
@@ -206,6 +234,20 @@ namespace SportsData.Producer.Application.Contests
                         OverUnderResultRaw: (int)contest.OverUnder,
                         CompletedUtc: contest.FinalizedUtc));
                 await _dataContext.SaveChangesAsync();
+
+                _logger.LogInformation(
+                    "Contest enrichment completed. ContestName={ContestName}, " +
+                    "AwayScore={AwayScore}, HomeScore={HomeScore}, WinnerFranchiseSeasonId={WinnerFranchiseSeasonId}, " +
+                    "SpreadWinnerFranchiseSeasonId={SpreadWinnerFranchiseSeasonId}, OverUnder={OverUnder}, " +
+                    "FinalizedUtc={FinalizedUtc}, OddsProvidersFinalized={OddsProvidersFinalized}",
+                    contest.Name,
+                    contest.AwayScore,
+                    contest.HomeScore,
+                    contest.WinnerFranchiseSeasonId,
+                    contest.SpreadWinnerFranchiseSeasonId,
+                    contest.OverUnder,
+                    contest.FinalizedUtc,
+                    competition.Odds?.Count(o => o.FinalizedUtc.HasValue) ?? 0);
             }
         }
 


### PR DESCRIPTION
## Summary
Six new structured logs each in \`FootballContestEnrichmentProcessor\` and \`BaseballContestEnrichmentProcessor\`, covering the happy-path milestones that were previously silent. Aimed at the questions an operator actually asks Seq during a debugging session — score-source path, who won SU, which odds provider became the Contest-level denorm, completion state.

**No behavior change.** All 65 enrichment unit tests pass, 0 regressions.

## Football
- \`BeginScope\` now carries \`ContestId\` (parity with Baseball — every line in the request becomes filterable in Seq by ContestId, not just CorrelationId).
- **Final score path**: \`"Final score derived. Source={ScoringPlay|CompetitorMaxScore}, Away=X, Home=Y"\`. Disambiguates which lookup won when debugging a wrong final score.
- **Straight-up winner**: \`"Straight-up winner derived. WinnerFranchiseSeasonId=..., IsTie=..."\`. Tie cases were previously silent.
- **Primary odds selection**: \`"Primary odds provider selected. ProviderName=..., OverUnderResult=..., AtsWinner=..."\`. Direct visibility into which provider's row became \`Contest.SpreadWinnerFranchiseSeasonId\` / \`Contest.OverUnder\`. This is the exact bug class behind the recent admin Re-run Enrichment recovery.
- **No-finalized-odds fallback**: \`"No finalized odds row available; Contest-level ATS / OverUnder not denormalized."\`. Surfaces the inverse instead of leaving the denorm silently untouched.
- **No-odds case**: \`"No CompetitionOdds rows present; skipping per-provider enrichment."\`. Previously invisible.
- **Completion log**: \`"Contest enrichment completed. ContestName=..., AwayScore=..., HomeScore=..., WinnerFranchiseSeasonId=..., SpreadWinnerFranchiseSeasonId=..., OverUnder=..., FinalizedUtc=..., OddsProvidersFinalized=N"\`. Football had no completion log at all before.

## Baseball
Same five new log lines (single score-source path — \`CompetitorMaxScore\` — since Baseball doesn't have the ScoringPlay primary path).

The existing completion log is enhanced to include \`SpreadWinnerFranchiseSeasonId\` and \`OverUnder\`, and the parameter is renamed \`OddsProvidersEnriched\` → \`OddsProvidersFinalized\` (parity with the \`EnrichedUtc\` → \`FinalizedUtc\` column rename in #445). The redundant \`ContestId={ContestId}\` parameter is dropped from the message text since \`BeginScope\` already carries it.

## Verified
- \`dotnet build src/SportsData.Producer/SportsData.Producer.csproj\` — clean, 0 warnings
- \`dotnet test\` enrichment tests — 65 passing, 0 failing
- Logging-only change; no production behavior impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging throughout the contest enrichment pipeline for improved operational visibility and troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->