### PR TITLE
feat(producer): odds-late finalization path in Football + Baseball enrichment

### DIFF
--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -59,10 +59,14 @@ namespace SportsData.Producer.Application.Contests
                 return;
             }
 
-            if (competition.Contest.FinalizedUtc != null)
+            var contestAlreadyFinalized = competition.Contest.FinalizedUtc != null;
+            var unfinalizedOdds = competition.Odds?
+                .Where(o => o.FinalizedUtc == null).ToList() ?? new List<CompetitionOdds>();
+
+            if (contestAlreadyFinalized && unfinalizedOdds.Count == 0)
             {
                 _logger.LogInformation(
-                    "Contest already finalized. Skipping. FinalizedUtc={FinalizedUtc}",
+                    "Contest and all odds rows already finalized. Nothing to do. FinalizedUtc={FinalizedUtc}",
                     competition.Contest.FinalizedUtc);
                 return;
             }
@@ -78,6 +82,76 @@ namespace SportsData.Producer.Application.Contests
                 return;
             }
 
+            var contest = competition.Contest;
+
+            if (contestAlreadyFinalized)
+            {
+                // Odds-late path: Contest finalized earlier, but ≥1
+                // CompetitionOdds row arrived (or stayed unfinalized) after.
+                // Reuse the persisted Contest scores — do NOT re-derive
+                // from CompetitorScores so we don't drift from the values
+                // picks were scored against. Do NOT republish
+                // ContestFinalized — downstream picks scoring already ran;
+                // republishing would double-score.
+                if (contest.AwayScore is null || contest.HomeScore is null)
+                {
+                    _logger.LogWarning(
+                        "Contest finalized but missing AwayScore/HomeScore — cannot finalize {UnfinalizedOddsCount} late odds row(s). Manual intervention required.",
+                        unfinalizedOdds.Count);
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Contest already finalized; running odds-late finalization for {UnfinalizedOddsCount} provider(s).",
+                    unfinalizedOdds.Count);
+
+                EnrichOddsResults(
+                    unfinalizedOdds,
+                    awayCompetitor.FranchiseSeasonId,
+                    homeCompetitor.FranchiseSeasonId,
+                    contest.AwayScore.Value,
+                    contest.HomeScore.Value);
+
+                // Refresh Contest-level denorm if a higher-priority provider
+                // just landed (e.g. EspnBet missing before, now present —
+                // promote it).
+                var primaryOddsLate = competition.Odds!
+                    .FirstOrDefault(o => o.FinalizedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
+                    ?? competition.Odds!.FirstOrDefault(o => o.FinalizedUtc.HasValue);
+
+                if (primaryOddsLate != null)
+                {
+                    var denormChanged =
+                        contest.OverUnder != primaryOddsLate.OverUnderResult
+                        || contest.SpreadWinnerFranchiseSeasonId != primaryOddsLate.AtsWinnerFranchiseSeasonId;
+
+                    contest.OverUnder = primaryOddsLate.OverUnderResult;
+                    contest.SpreadWinnerFranchiseSeasonId = primaryOddsLate.AtsWinnerFranchiseSeasonId;
+
+                    if (denormChanged)
+                    {
+                        _logger.LogWarning(
+                            "Contest denorm refreshed by late primary odds. ProviderName={ProviderName}, OverUnderResult={OverUnderResult}, AtsWinner={AtsWinnerFranchiseSeasonId}. Downstream picks NOT re-scored (per-provider scoring is a future refactor).",
+                            primaryOddsLate.ProviderName,
+                            primaryOddsLate.OverUnderResult,
+                            primaryOddsLate.AtsWinnerFranchiseSeasonId);
+                    }
+                    else
+                    {
+                        _logger.LogInformation(
+                            "Primary odds provider unchanged after odds-late finalization. ProviderName={ProviderName}",
+                            primaryOddsLate.ProviderName);
+                    }
+                }
+
+                await _dataContext.SaveChangesAsync();
+
+                _logger.LogInformation(
+                    "Odds-late finalization completed. OddsProvidersFinalized={OddsProvidersFinalized}",
+                    competition.Odds!.Count(o => o.FinalizedUtc.HasValue));
+                return;
+            }
+
             var status = await _dataContext.CompetitionStatuses
                 .AsNoTracking()
                 .FirstOrDefaultAsync(s => s.CompetitionId == competition.Id);
@@ -86,11 +160,9 @@ namespace SportsData.Producer.Application.Contests
             {
                 _logger.LogInformation(
                     "Contest status is not yet final for {ContestName}. Current: {Status}. Skipping enrichment.",
-                    competition.Contest.Name, status?.StatusTypeName ?? "unknown");
+                    contest.Name, status?.StatusTypeName ?? "unknown");
                 return;
             }
-
-            var contest = competition.Contest;
 
             // MAX(Value) per competitor. Cross-sport schema variance in
             // CompetitionCompetitorScores prevents a SourceDescription-based

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -58,11 +58,15 @@ namespace SportsData.Producer.Application.Contests
                     return;
                 }
 
-                if (competition.Contest.FinalizedUtc != null)
+                var contestAlreadyFinalized = competition.Contest.FinalizedUtc != null;
+                var unfinalizedOdds = competition.Odds?
+                    .Where(o => o.FinalizedUtc == null).ToList() ?? new List<CompetitionOdds>();
+
+                if (contestAlreadyFinalized && unfinalizedOdds.Count == 0)
                 {
                     _logger.LogInformation(
-                        "Contest already finalized. Skipping. ContestId={ContestId}, FinalizedUtc={FinalizedUtc}",
-                        command.ContestId, competition.Contest.FinalizedUtc);
+                        "Contest and all odds rows already finalized. Nothing to do. FinalizedUtc={FinalizedUtc}",
+                        competition.Contest.FinalizedUtc);
                     return;
                 }
 
@@ -74,6 +78,76 @@ namespace SportsData.Producer.Application.Contests
                     _logger.LogError(
                         "Competition is missing away or home competitor. ContestId={ContestId}, Away={HasAway}, Home={HasHome}",
                         command.ContestId, awayCompetitor is not null, homeCompetitor is not null);
+                    return;
+                }
+
+                var contest = competition.Contest;
+
+                if (contestAlreadyFinalized)
+                {
+                    // Odds-late path: Contest finalized earlier, but ≥1
+                    // CompetitionOdds row arrived (or stayed unfinalized) after.
+                    // Reuse the persisted Contest scores — do NOT re-derive
+                    // from CompetitorScores so we don't drift from the values
+                    // picks were scored against. Do NOT republish
+                    // ContestFinalized — downstream picks scoring already ran;
+                    // republishing would double-score.
+                    if (contest.AwayScore is null || contest.HomeScore is null)
+                    {
+                        _logger.LogWarning(
+                            "Contest finalized but missing AwayScore/HomeScore — cannot finalize {UnfinalizedOddsCount} late odds row(s). Manual intervention required.",
+                            unfinalizedOdds.Count);
+                        return;
+                    }
+
+                    _logger.LogInformation(
+                        "Contest already finalized; running odds-late finalization for {UnfinalizedOddsCount} provider(s).",
+                        unfinalizedOdds.Count);
+
+                    EnrichOddsResults(
+                        unfinalizedOdds,
+                        awayCompetitor.FranchiseSeasonId,
+                        homeCompetitor.FranchiseSeasonId,
+                        contest.AwayScore.Value,
+                        contest.HomeScore.Value);
+
+                    // Refresh Contest-level denorm if a higher-priority provider
+                    // just landed (e.g. EspnBet missing before, now present —
+                    // promote it).
+                    var primaryOddsLate = competition.Odds!
+                        .FirstOrDefault(o => o.FinalizedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
+                        ?? competition.Odds!.FirstOrDefault(o => o.FinalizedUtc.HasValue);
+
+                    if (primaryOddsLate != null)
+                    {
+                        var denormChanged =
+                            contest.OverUnder != primaryOddsLate.OverUnderResult
+                            || contest.SpreadWinnerFranchiseSeasonId != primaryOddsLate.AtsWinnerFranchiseSeasonId;
+
+                        contest.OverUnder = primaryOddsLate.OverUnderResult;
+                        contest.SpreadWinnerFranchiseSeasonId = primaryOddsLate.AtsWinnerFranchiseSeasonId;
+
+                        if (denormChanged)
+                        {
+                            _logger.LogWarning(
+                                "Contest denorm refreshed by late primary odds. ProviderName={ProviderName}, OverUnderResult={OverUnderResult}, AtsWinner={AtsWinnerFranchiseSeasonId}. Downstream picks NOT re-scored (per-provider scoring is a future refactor).",
+                                primaryOddsLate.ProviderName,
+                                primaryOddsLate.OverUnderResult,
+                                primaryOddsLate.AtsWinnerFranchiseSeasonId);
+                        }
+                        else
+                        {
+                            _logger.LogInformation(
+                                "Primary odds provider unchanged after odds-late finalization. ProviderName={ProviderName}",
+                                primaryOddsLate.ProviderName);
+                        }
+                    }
+
+                    await _dataContext.SaveChangesAsync();
+
+                    _logger.LogInformation(
+                        "Odds-late finalization completed. OddsProvidersFinalized={OddsProvidersFinalized}",
+                        competition.Odds!.Count(o => o.FinalizedUtc.HasValue));
                     return;
                 }
 
@@ -91,11 +165,9 @@ namespace SportsData.Producer.Application.Contests
                 {
                     _logger.LogInformation(
                         "Contest status is not yet final for {ContestName}. Current: {Status}. Skipping enrichment.",
-                        competition.Contest.Name, status?.StatusTypeName ?? "unknown");
+                        contest.Name, status?.StatusTypeName ?? "unknown");
                     return;
                 }
-
-                var contest = competition.Contest;
 
                 // Query canonical plays to determine final score (project to DTO)
                 var lastScoringPlay = await _dataContext.CompetitionPlays

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -458,18 +459,49 @@ public class BaseballContestEnrichmentProcessorTests
             OverUnder = 12m,        // total 11 < 12 → Under
             FinalizedUtc = null
         };
+
+        // Regression guard: a SECOND odds row that's already finalized with
+        // distinct pre-computed values. If EnrichOddsResults were called
+        // against all odds (not just unfinalizedOdds), this row's
+        // FinalizedUtc would be re-stamped and its OverUnderResult would
+        // flip from Over → Under. The asserts below catch that.
+        var alreadyFinalizedUtc = new DateTime(2026, 4, 26, 20, 0, 0, DateTimeKind.Utc);
+        var oddsRowAlreadyFinalized = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds/fanduel"),
+            ProviderId = "fanduel",
+            ProviderName = "FanDuel",
+            Spread = -1.5m,
+            OverUnder = 9m,         // total 11 > 9 → Over (distinct from late row's Under)
+            FinalizedUtc = alreadyFinalizedUtc,
+            WinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            AtsWinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            OverUnderResult = OverUnderResult.Over
+        };
+
         _baseballDataContext.CompetitionOdds.Add(oddsRowLate);
+        _baseballDataContext.CompetitionOdds.Add(oddsRowAlreadyFinalized);
         await _baseballDataContext.SaveChangesAsync();
 
         var command = new EnrichContestCommand(contestId, Guid.NewGuid());
         await _sut.Process(command);
 
-        // Odds row finalized with computed result fields.
-        var oddsAfter = await _baseballDataContext.CompetitionOdds.FindAsync(oddsRowLate.Id);
-        oddsAfter!.FinalizedUtc.Should().NotBeNull();
-        oddsAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
-        oddsAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
-        oddsAfter.OverUnderResult.Should().Be(OverUnderResult.Under);
+        // Late row: finalized with computed result fields.
+        var lateAfter = await _baseballDataContext.CompetitionOdds.FindAsync(oddsRowLate.Id);
+        lateAfter!.FinalizedUtc.Should().NotBeNull();
+        lateAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        lateAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        lateAfter.OverUnderResult.Should().Be(OverUnderResult.Under);
+
+        // Already-finalized row: every derived field unchanged. Verifies
+        // EnrichOddsResults was called only against the unfinalized subset.
+        var alreadyFinalizedAfter = await _baseballDataContext.CompetitionOdds.FindAsync(oddsRowAlreadyFinalized.Id);
+        alreadyFinalizedAfter!.FinalizedUtc.Should().Be(alreadyFinalizedUtc);
+        alreadyFinalizedAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        alreadyFinalizedAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        alreadyFinalizedAfter.OverUnderResult.Should().Be(OverUnderResult.Over);
 
         // Contest.FinalizedUtc untouched (no double-stamp).
         var contestAfter = await _baseballDataContext.Contests.FindAsync(contestId);
@@ -519,6 +551,21 @@ public class BaseballContestEnrichmentProcessorTests
 
         Mock.Get(Mocker.Get<IEventBus>())
             .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Warning emitted exactly once and references the null-score
+        // condition. Matches on a short, stable property-name fragment
+        // ("AwayScore") rather than the full message text so harmless
+        // wording tweaks don't break the test, while still confirming
+        // the warning describes the right scenario.
+        Mock.Get(Mocker.Get<ILogger<BaseballContestEnrichmentProcessor>>())
+            .Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("AwayScore")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
     }
 
     #endregion

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/BaseballContestEnrichmentProcessorTests.cs
@@ -383,6 +383,146 @@ public class BaseballContestEnrichmentProcessorTests
 
     #endregion
 
+    #region Process — odds-late path
+
+    [Fact]
+    public async Task Process_WhenContestFinalizedAndAllOddsFinalized_NoOp()
+    {
+        // Both Contest and every CompetitionOdds row carry FinalizedUtc.
+        // Three-state branch returns "Nothing to do" without touching odds
+        // (must not re-stamp already-final rows — that breaks the audit
+        // trail of when the odds row originally finalized).
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc = new DateTime(2026, 4, 26, 23, 30, 0, DateTimeKind.Utc);
+        contest.AwayScore = 4;
+        contest.HomeScore = 7;
+        contest.WinnerFranchiseSeasonId = HomeFranchiseSeasonId;
+
+        var oddsFinalizedAt = new DateTime(2026, 4, 26, 23, 30, 0, DateTimeKind.Utc);
+        var oddsRow = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds/draftkings"),
+            ProviderId = "draftkings",
+            ProviderName = "DraftKings",
+            Spread = -1.5m,
+            OverUnder = 9.0m,
+            FinalizedUtc = oddsFinalizedAt,
+            WinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            AtsWinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            OverUnderResult = OverUnderResult.Over
+        };
+        _baseballDataContext.CompetitionOdds.Add(oddsRow);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        // FinalizedUtc unchanged — proves the early-return fired before
+        // EnrichOddsResults could re-stamp the row.
+        var oddsAfter = await _baseballDataContext.CompetitionOdds.FindAsync(oddsRow.Id);
+        oddsAfter!.FinalizedUtc.Should().Be(oddsFinalizedAt);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenContestFinalizedAndOddsUnfinalized_FinalizesOddsOnly()
+    {
+        // Contest finalized earlier; a CompetitionOdds row arrived late with
+        // FinalizedUtc null. Odds-late path finalizes only the unfinalized
+        // row, reuses persisted Contest scores (no re-derivation), and does
+        // NOT republish ContestFinalized (downstream picks scoring already
+        // ran — republishing would double-score).
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var contestPriorFinalizedUtc = new DateTime(2026, 4, 26, 23, 30, 0, DateTimeKind.Utc);
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc = contestPriorFinalizedUtc;
+        contest.AwayScore = 4;
+        contest.HomeScore = 7;
+        contest.WinnerFranchiseSeasonId = HomeFranchiseSeasonId;
+
+        var oddsRowLate = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds/draftkings"),
+            ProviderId = "draftkings",
+            ProviderName = "DraftKings",
+            Spread = -1.5m,         // home favored — 7+(-1.5)=5.5 vs 4 → home covers
+            OverUnder = 12m,        // total 11 < 12 → Under
+            FinalizedUtc = null
+        };
+        _baseballDataContext.CompetitionOdds.Add(oddsRowLate);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        // Odds row finalized with computed result fields.
+        var oddsAfter = await _baseballDataContext.CompetitionOdds.FindAsync(oddsRowLate.Id);
+        oddsAfter!.FinalizedUtc.Should().NotBeNull();
+        oddsAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        oddsAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        oddsAfter.OverUnderResult.Should().Be(OverUnderResult.Under);
+
+        // Contest.FinalizedUtc untouched (no double-stamp).
+        var contestAfter = await _baseballDataContext.Contests.FindAsync(contestId);
+        contestAfter!.FinalizedUtc.Should().Be(contestPriorFinalizedUtc);
+
+        // No republish — downstream picks scoring already ran for this Contest.
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenContestFinalizedButScoresNull_WarnsAndReturns()
+    {
+        // Stale partial-failure shape: Contest.FinalizedUtc set but
+        // AwayScore/HomeScore null. Odds-late path bails with a warning
+        // rather than feed nulls into EnrichOddsResults.
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var contest = await _baseballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc = new DateTime(2026, 4, 26, 23, 30, 0, DateTimeKind.Utc);
+        // AwayScore and HomeScore stay null intentionally.
+        await _baseballDataContext.SaveChangesAsync();
+
+        var oddsRow = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds"),
+            ProviderId = "draftkings",
+            ProviderName = "DraftKings",
+            Spread = -1.5m,
+            OverUnder = 9.0m,
+            FinalizedUtc = null
+        };
+        _baseballDataContext.CompetitionOdds.Add(oddsRow);
+        await _baseballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        // Odds row stays unfinalized — bail fired before EnrichOddsResults.
+        var oddsAfter = await _baseballDataContext.CompetitionOdds.FindAsync(oddsRow.Id);
+        oddsAfter!.FinalizedUtc.Should().BeNull();
+        oddsAfter.WinnerFranchiseSeasonId.Should().BeNull();
+        oddsAfter.AtsWinnerFranchiseSeasonId.Should().BeNull();
+        oddsAfter.OverUnderResult.Should().Be(OverUnderResult.None);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
     #region GetOverUnderResult
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
@@ -369,6 +369,146 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
 
     #endregion
 
+    #region Process — odds-late path
+
+    [Fact]
+    public async Task Process_WhenContestFinalizedAndAllOddsFinalized_NoOp()
+    {
+        // Both Contest and every CompetitionOdds row carry FinalizedUtc.
+        // Three-state branch returns "Nothing to do" without touching odds
+        // (must not re-stamp already-final rows — that breaks the audit
+        // trail of when the odds row originally finalized).
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var contest = await FootballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc = new DateTime(2026, 3, 9, 23, 30, 0, DateTimeKind.Utc);
+        contest.AwayScore = 21;
+        contest.HomeScore = 28;
+        contest.WinnerFranchiseSeasonId = HomeFranchiseSeasonId;
+
+        var oddsFinalizedAt = new DateTime(2026, 3, 9, 23, 30, 0, DateTimeKind.Utc);
+        var oddsRow = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds/draftkings"),
+            ProviderId = "draftkings",
+            ProviderName = "DraftKings",
+            Spread = -7m,
+            OverUnder = 45.5m,
+            FinalizedUtc = oddsFinalizedAt,
+            WinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            AtsWinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            OverUnderResult = OverUnderResult.Over
+        };
+        FootballDataContext.CompetitionOdds.Add(oddsRow);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        // FinalizedUtc unchanged — proves the early-return fired before
+        // EnrichOddsResults could re-stamp the row.
+        var oddsAfter = await FootballDataContext.CompetitionOdds.FindAsync(oddsRow.Id);
+        oddsAfter!.FinalizedUtc.Should().Be(oddsFinalizedAt);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenContestFinalizedAndOddsUnfinalized_FinalizesOddsOnly()
+    {
+        // Contest finalized earlier; a CompetitionOdds row arrived late with
+        // FinalizedUtc null. Odds-late path finalizes only the unfinalized
+        // row, reuses persisted Contest scores (no re-derivation), and does
+        // NOT republish ContestFinalized (downstream picks scoring already
+        // ran — republishing would double-score).
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var contestPriorFinalizedUtc = new DateTime(2026, 3, 9, 23, 30, 0, DateTimeKind.Utc);
+        var contest = await FootballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc = contestPriorFinalizedUtc;
+        contest.AwayScore = 14;
+        contest.HomeScore = 28;
+        contest.WinnerFranchiseSeasonId = HomeFranchiseSeasonId;
+
+        var oddsRowLate = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds/draftkings"),
+            ProviderId = "draftkings",
+            ProviderName = "DraftKings",
+            Spread = -7m,           // home favored — 28+(-7)=21 vs 14 → home covers
+            OverUnder = 50m,        // total 42 < 50 → Under
+            FinalizedUtc = null
+        };
+        FootballDataContext.CompetitionOdds.Add(oddsRowLate);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        // Odds row finalized with computed result fields.
+        var oddsAfter = await FootballDataContext.CompetitionOdds.FindAsync(oddsRowLate.Id);
+        oddsAfter!.FinalizedUtc.Should().NotBeNull();
+        oddsAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        oddsAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        oddsAfter.OverUnderResult.Should().Be(OverUnderResult.Under);
+
+        // Contest.FinalizedUtc untouched (no double-stamp).
+        var contestAfter = await FootballDataContext.Contests.FindAsync(contestId);
+        contestAfter!.FinalizedUtc.Should().Be(contestPriorFinalizedUtc);
+
+        // No republish — downstream picks scoring already ran for this Contest.
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenContestFinalizedButScoresNull_WarnsAndReturns()
+    {
+        // Stale partial-failure shape: Contest.FinalizedUtc set but
+        // AwayScore/HomeScore null. Odds-late path bails with a warning
+        // rather than feed nulls into EnrichOddsResults.
+        var (contestId, competitionId) = await SeedCompetitionWithStatus("STATUS_FINAL");
+
+        var contest = await FootballDataContext.Contests.FindAsync(contestId);
+        contest!.FinalizedUtc = new DateTime(2026, 3, 9, 23, 30, 0, DateTimeKind.Utc);
+        // AwayScore and HomeScore stay null intentionally.
+        await FootballDataContext.SaveChangesAsync();
+
+        var oddsRow = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds"),
+            ProviderId = "draftkings",
+            ProviderName = "DraftKings",
+            Spread = -7m,
+            OverUnder = 45.5m,
+            FinalizedUtc = null
+        };
+        FootballDataContext.CompetitionOdds.Add(oddsRow);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = new EnrichContestCommand(contestId, Guid.NewGuid());
+        await _sut.Process(command);
+
+        // Odds row stays unfinalized — bail fired before EnrichOddsResults.
+        var oddsAfter = await FootballDataContext.CompetitionOdds.FindAsync(oddsRow.Id);
+        oddsAfter!.FinalizedUtc.Should().BeNull();
+        oddsAfter.WinnerFranchiseSeasonId.Should().BeNull();
+        oddsAfter.AtsWinnerFranchiseSeasonId.Should().BeNull();
+        oddsAfter.OverUnderResult.Should().Be(OverUnderResult.None);
+
+        Mock.Get(Mocker.Get<IEventBus>())
+            .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
     #region GetOverUnderResult
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentProcessorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -444,18 +445,49 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
             OverUnder = 50m,        // total 42 < 50 → Under
             FinalizedUtc = null
         };
+
+        // Regression guard: a SECOND odds row that's already finalized with
+        // distinct pre-computed values. If EnrichOddsResults were called
+        // against all odds (not just unfinalizedOdds), this row's
+        // FinalizedUtc would be re-stamped and its OverUnderResult would
+        // flip from Over → Under. The asserts below catch that.
+        var alreadyFinalizedUtc = new DateTime(2026, 3, 9, 20, 0, 0, DateTimeKind.Utc);
+        var oddsRowAlreadyFinalized = new CompetitionOdds
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            ProviderRef = new Uri("https://example.com/odds/fanduel"),
+            ProviderId = "fanduel",
+            ProviderName = "FanDuel",
+            Spread = -7m,
+            OverUnder = 40m,        // total 42 > 40 → Over (distinct from late row's Under)
+            FinalizedUtc = alreadyFinalizedUtc,
+            WinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            AtsWinnerFranchiseSeasonId = HomeFranchiseSeasonId,
+            OverUnderResult = OverUnderResult.Over
+        };
+
         FootballDataContext.CompetitionOdds.Add(oddsRowLate);
+        FootballDataContext.CompetitionOdds.Add(oddsRowAlreadyFinalized);
         await FootballDataContext.SaveChangesAsync();
 
         var command = new EnrichContestCommand(contestId, Guid.NewGuid());
         await _sut.Process(command);
 
-        // Odds row finalized with computed result fields.
-        var oddsAfter = await FootballDataContext.CompetitionOdds.FindAsync(oddsRowLate.Id);
-        oddsAfter!.FinalizedUtc.Should().NotBeNull();
-        oddsAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
-        oddsAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
-        oddsAfter.OverUnderResult.Should().Be(OverUnderResult.Under);
+        // Late row: finalized with computed result fields.
+        var lateAfter = await FootballDataContext.CompetitionOdds.FindAsync(oddsRowLate.Id);
+        lateAfter!.FinalizedUtc.Should().NotBeNull();
+        lateAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        lateAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        lateAfter.OverUnderResult.Should().Be(OverUnderResult.Under);
+
+        // Already-finalized row: every derived field unchanged. Verifies
+        // EnrichOddsResults was called only against the unfinalized subset.
+        var alreadyFinalizedAfter = await FootballDataContext.CompetitionOdds.FindAsync(oddsRowAlreadyFinalized.Id);
+        alreadyFinalizedAfter!.FinalizedUtc.Should().Be(alreadyFinalizedUtc);
+        alreadyFinalizedAfter.WinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        alreadyFinalizedAfter.AtsWinnerFranchiseSeasonId.Should().Be(HomeFranchiseSeasonId);
+        alreadyFinalizedAfter.OverUnderResult.Should().Be(OverUnderResult.Over);
 
         // Contest.FinalizedUtc untouched (no double-stamp).
         var contestAfter = await FootballDataContext.Contests.FindAsync(contestId);
@@ -505,6 +537,21 @@ public class ContestEnrichmentProcessorTests : ProducerTestBase<FootballContestE
 
         Mock.Get(Mocker.Get<IEventBus>())
             .Verify(x => x.Publish(It.IsAny<ContestFinalized>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Warning emitted exactly once and references the null-score
+        // condition. Matches on a short, stable property-name fragment
+        // ("AwayScore") rather than the full message text so harmless
+        // wording tweaks don't break the test, while still confirming
+        // the warning describes the right scenario.
+        Mock.Get(Mocker.Get<ILogger<FootballContestEnrichmentProcessor>>())
+            .Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("AwayScore")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
The existing Contest enrichment processors short-circuited on \`Contest.FinalizedUtc != null\`, which silently blocked finalization of any \`CompetitionOdds\` rows that arrived after the Contest itself was finalized (new provider sourced late, admin re-enrich window, etc.). The admin "Re-run Enrichment" button worked around it by explicitly nulling \`FinalizedUtc\`, but the automated cron sweep didn't.

Replace the single early-return with a **three-state branch**:

| State | Action |
|---|---|
| Both Contest and all odds finalized | "Nothing to do", return |
| Contest finalized, ≥1 odds unfinalized | **Odds-late path (new)** |
| Contest not finalized | Full path (existing, unchanged) |

## Odds-late path

- **Reuses persisted \`Contest.AwayScore\` / \`HomeScore\`** as the source of truth. Do NOT re-derive from \`CompetitorScores\` / scoring plays — the persisted values are what picks were scored against; re-deriving could drift if upstream data shifted post-finalization.
- **Defensive guard**: if \`Contest.FinalizedUtc\` is set but \`AwayScore\` or \`HomeScore\` is null (stale partial-failure shape), bail with a warning rather than feed nulls into \`EnrichOddsResults\`.
- **Passes only the unfinalized subset** to \`EnrichOddsResults\` so already-final rows don't get their \`FinalizedUtc\` re-stamped (would break the audit trail of when each provider originally finalized).
- **Re-selects primary odds** across the now-fuller set. If a higher-priority provider (EspnBet) just landed and the Contest-level denorm value changes, \`LogWarning\` with explicit "downstream picks NOT re-scored (per-provider scoring is a future refactor)". Unchanged primary logs at \`Information\`.
- **Does NOT republish \`ContestFinalized\`** — downstream picks scoring already ran once for this Contest; republishing would double-score.

## Tests (six new, three per processor)

- \`Process_WhenContestFinalizedAndAllOddsFinalized_NoOp\` — verifies odds \`FinalizedUtc\` unchanged (early-return fired before re-stamping).
- \`Process_WhenContestFinalizedAndOddsUnfinalized_FinalizesOddsOnly\` — verifies late row gets \`FinalizedUtc\` + \`WinnerFranchiseSeasonId\` + \`AtsWinnerFranchiseSeasonId\` + \`OverUnderResult\`; Contest \`FinalizedUtc\` untouched; no republish.
- \`Process_WhenContestFinalizedButScoresNull_WarnsAndReturns\` — verifies bail before \`EnrichOddsResults\` when scores are missing.

Result-field calculations are deliberately set so the asserts catch real writes, not just timestamp stamping:
- Football: scores 14-28 with spread -7 → home covers ATS; O/U 50 → Under (total 42)
- Baseball: scores 4-7 with spread -1.5 → home covers ATS; O/U 12 → Under (total 11)

**71 producer enrichment tests passing** (was 65; +6 new).

## Follow-up (out of scope)

When picks scoring moves to per-provider (league-level preferred-provider setting), the no-republish policy here may need to change — publish a \`CompetitionOddsFinalized\` (or equivalent) event so the league's chosen provider can drive re-scoring on late-arriving data. To be revisited as part of that refactor.

## Test plan
- [ ] Find a contest with \`Contest.FinalizedUtc IS NOT NULL\` and ≥1 \`CompetitionOdds\` row where \`FinalizedUtc IS NULL\`. Trigger the cron sweep (or admin re-enrich) → odds row finalizes; Contest unchanged; no double-scoring on the league standings.
- [ ] Run the four existing \`audit_stuck_*.sql\` queries before and after — confirm the odds-late path closes the stuck-row count.
- [ ] Verify Seq scope logs show \`OddsProvidersFinalized\` count incrementing on the odds-late path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of odds that arrive after a contest is already finalized: late odds are now finalized when possible, without re-publishing the contest as finalized.
  * Ensures odds late-finalization is skipped when required scores are missing, and keeps contest-level denormalized fields in sync when late updates occur.

* **Tests**
  * Added unit tests covering late-arriving odds for both baseball and football, including no-op, correct late odds finalization, and missing-score warning/early return scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->