### PR TITLE
feat(matchups): surface CompetitionOdds.ProviderName on league-week matchups

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekMatchupsDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekMatchupsDto.cs
@@ -95,6 +95,17 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
             public decimal? OverUnderCurrent { get; set; }
             public decimal? OverUnderOpen { get; set; }
 
+            /// <summary>
+            /// Sportsbook display name (e.g. "ESPN BET", "DraftKings") whose
+            /// spread / O/U values populated the odds fields above. Sourced
+            /// per-competition by Producer's preferred-then-fallback provider
+            /// selection. Null when no qualifying odds row exists. Future
+            /// "view all odds" expansion will surface a per-provider list;
+            /// this single field is the single-provider header in the
+            /// interim.
+            /// </summary>
+            public string? ProviderName { get; set; }
+
             // Venue
             public string Venue { get; set; } = default!;
             public string VenueCity { get; set; } = default!;

--- a/src/SportsData.Api/Application/UI/Leagues/Mapping/MatchupForPickDtoMapper.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Mapping/MatchupForPickDtoMapper.cs
@@ -78,6 +78,8 @@ public static class MatchupForPickDtoMapper
             ? (decimal)Math.Round(canonical.OverUnderOpen.Value, 1, MidpointRounding.AwayFromZero)
             : null;
 
+        matchup.ProviderName = canonical.ProviderName;
+
         // Venue
         matchup.Venue = canonical.Venue ?? matchup.Venue;
         matchup.VenueCity = canonical.VenueCity ?? matchup.VenueCity;

--- a/src/SportsData.Core/Dtos/Canonical/LeagueMatchupDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/LeagueMatchupDto.cs
@@ -89,6 +89,16 @@ public class LeagueMatchupDto
     public double? OverOdds { get; set; }
     public double? UnderOdds { get; set; }
 
+    /// <summary>
+    /// Display name of the sportsbook whose spread / O/U values populated
+    /// the odds fields above. Selected by Producer's SQL via the
+    /// preferred-then-fallback provider ordering on <c>CompetitionOdds</c>.
+    /// Null when no qualifying odds row exists for this competition.
+    /// Future per-league preferred-provider work will replace the global
+    /// preference baked into the SQL today.
+    /// </summary>
+    public string? ProviderName { get; set; }
+
     public int? AwayScore { get; set; }
     public int? HomeScore { get; set; }
     public Guid? WinnerFranchiseSeasonId { get; set; }

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -28,6 +28,7 @@ SELECT
   cto."SpreadPointsOpen" AS "SpreadOpen",
   co."OverUnder" AS "OverUnderCurrent", co."TotalPointsOpen" AS "OverUnderOpen",
   co."OverOdds", co."UnderOdds",
+  co."ProviderName" AS "ProviderName",
   c."AwayScore", c."HomeScore",
   c."WinnerFranchiseSeasonId",
   c."SpreadWinnerFranchiseSeasonId",
@@ -215,6 +216,7 @@ GROUP BY
   fsrdHome."Current", gsHome."Slug",
   fsHome."Wins", fsHome."Losses", fsHome."ConferenceWins", fsHome."ConferenceLosses",
   co."Details", co."Spread", co."OverUnder", co."OverOdds", co."UnderOdds",
+  co."ProviderName",
   cto."SpreadPointsOpen", co."TotalPointsOpen",
   c."AwayScore", c."HomeScore", c."WinnerFranchiseSeasonId", c."SpreadWinnerFranchiseSeasonId",
   c."OverUnder", c."EndDateUtc"

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -258,42 +258,52 @@ function OddsRow({ matchup }: { matchup: Matchup }) {
   const showOuOpen = hasOu && ouOpen != null && ouOpen !== ou;
 
   return (
-    <View style={[styles.oddsRow, { borderColor: theme.separator }]}>
-      {/* Spread */}
-      {hasSpread && (
-        <View style={styles.oddsInline}>
-          <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>Spread </Text>
-          {sArrow && (
-            <Text style={[styles.oddsArrow, { color: sArrow.color }]}>{sArrow.symbol}</Text>
-          )}
-          <Text style={[styles.oddsValue, { color: theme.tint }]}>{spreadVal}</Text>
-          {showSpreadOpen && (
-            <Text style={[styles.oddsOpen, { color: theme.textMuted }]}>
-              {' '}({spreadOpen! > 0 ? `+${spreadOpen}` : spreadOpen})
-            </Text>
-          )}
-        </View>
-      )}
+    <View style={styles.oddsBlock}>
+      <View style={[styles.oddsRow, { borderColor: theme.separator }]}>
+        {/* Spread */}
+        {hasSpread && (
+          <View style={styles.oddsInline}>
+            <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>Spread </Text>
+            {sArrow && (
+              <Text style={[styles.oddsArrow, { color: sArrow.color }]}>{sArrow.symbol}</Text>
+            )}
+            <Text style={[styles.oddsValue, { color: theme.tint }]}>{spreadVal}</Text>
+            {showSpreadOpen && (
+              <Text style={[styles.oddsOpen, { color: theme.textMuted }]}>
+                {' '}({spreadOpen! > 0 ? `+${spreadOpen}` : spreadOpen})
+              </Text>
+            )}
+          </View>
+        )}
 
-      {/* Separator */}
-      {hasSpread && hasOu && (
-        <Text style={[styles.oddsSep, { color: theme.textMuted }]}> | </Text>
-      )}
+        {/* Separator */}
+        {hasSpread && hasOu && (
+          <Text style={[styles.oddsSep, { color: theme.textMuted }]}> | </Text>
+        )}
 
-      {/* O/U */}
-      {hasOu && (
-        <View style={styles.oddsInline}>
-          <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>O/U </Text>
-          {oArrow && (
-            <Text style={[styles.oddsArrow, { color: oArrow.color }]}>{oArrow.symbol}</Text>
-          )}
-          <Text style={[styles.oddsValue, { color: theme.tint }]}>{ouVal}</Text>
-          {showOuOpen && (
-            <Text style={[styles.oddsOpen, { color: theme.textMuted }]}>
-              {' '}({ouOpen})
-            </Text>
-          )}
-        </View>
+        {/* O/U */}
+        {hasOu && (
+          <View style={styles.oddsInline}>
+            <Text style={[styles.oddsLabel, { color: theme.textMuted }]}>O/U </Text>
+            {oArrow && (
+              <Text style={[styles.oddsArrow, { color: oArrow.color }]}>{oArrow.symbol}</Text>
+            )}
+            <Text style={[styles.oddsValue, { color: theme.tint }]}>{ouVal}</Text>
+            {showOuOpen && (
+              <Text style={[styles.oddsOpen, { color: theme.textMuted }]}>
+                {' '}({ouOpen})
+              </Text>
+            )}
+          </View>
+        )}
+      </View>
+
+      {/* Provider attribution — centered below the odds line. Suppressed when
+          both spread and O/U are off (no values means no source to credit). */}
+      {matchup.providerName && (hasSpread || hasOu) && (
+        <Text style={[styles.oddsProvider, { color: theme.textMuted }]}>
+          {matchup.providerName}
+        </Text>
       )}
     </View>
   );
@@ -997,6 +1007,14 @@ const styles = StyleSheet.create({
   // Status styles live in GameStatus.tsx
 
   // Odds row
+  oddsBlock: {
+    alignItems: 'center',
+  },
+  oddsProvider: {
+    fontSize: 9,
+    marginTop: 2,
+    textAlign: 'center',
+  },
   oddsRow: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -138,6 +138,13 @@ export interface Matchup {
   spreadCurrentDetails?: string | null;
   overUnderCurrent?: number | null;
   overUnderOpen?: number | null;
+  /**
+   * Sportsbook display name whose spread / O/U populated the values
+   * above (e.g. "ESPN BET", "DraftKings"). Selected per-competition by
+   * Producer's preferred-then-fallback provider ordering. Null when no
+   * qualifying odds row exists for this contest.
+   */
+  providerName?: string | null;
 
   // Venue (flat strings, not nested object)
   venue?: string | null;

--- a/src/UI/sd-ui/src/components/matchups/BettingDisplays.jsx
+++ b/src/UI/sd-ui/src/components/matchups/BettingDisplays.jsx
@@ -55,8 +55,11 @@ export function OverUnderDisplay({ overUnder, overUnderOpen }) {
  * @param {number} props.spreadOpen - Opening spread value
  * @param {number|string} props.overUnder - Current O/U value
  * @param {number} props.overUnderOpen - Opening O/U value
+ * @param {string} [props.providerName] - Sportsbook name (e.g. "ESPN BET");
+ *   rendered as a small muted suffix when present. Hidden when both spread
+ *   and O/U are "Off" — no values means no source to attribute.
  */
-export function SpreadAndOverUnderDisplay({ spread, spreadOpen, overUnder, overUnderOpen }) {
+export function SpreadAndOverUnderDisplay({ spread, spreadOpen, overUnder, overUnderOpen, providerName }) {
   const spreadArrow = calculateSpreadArrow(spread, spreadOpen);
   const overUnderValue = (overUnder === null || overUnder === 0 || overUnder === 'TBD') ? 'Off' : overUnder;
   const ouArrow = calculateOverUnderArrow(overUnderValue, overUnderOpen);
@@ -87,6 +90,23 @@ export function SpreadAndOverUnderDisplay({ spread, spreadOpen, overUnder, overU
           </span>
         )}
       </span>
+      {providerName && (spreadValue !== 'Off' || overUnderValue !== 'Off') && (
+        <span
+          className="odds-provider"
+          style={{
+            color: '#adb5bd',
+            fontSize: '0.7em',
+            // .spread-ou is a CSS grid (1fr auto 1fr) — span all columns so
+            // textAlign: center is relative to the full row width, not the
+            // first 1fr track only.
+            gridColumn: '1 / -1',
+            textAlign: 'center',
+            marginTop: 2,
+          }}
+        >
+          {providerName}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -215,6 +215,7 @@ function MatchupCard({
           spreadOpen={matchup.spreadOpen}
           overUnder={matchup.overUnderCurrent}
           overUnderOpen={matchup.overUnderOpen}
+          providerName={matchup.providerName}
         />
 
         {/* Game Status */}


### PR DESCRIPTION
## Summary
Adds a single-provider attribution string (\`ProviderName\`) to the canonical league-week matchups payload, and renders it as muted text centered beneath the spread / O/U line on both web and mobile \`MatchupCard\`. Producer already selects ONE \`CompetitionOdds\` row per competition via preferred-then-fallback ordering — this PR just propagates the picked row's display name through the stack to the UI.

Future "view all odds from all providers" work (per-league preferred-provider setting, multi-provider list/dropdown) will swap the static label for a richer surface; the wire shape established here is the single-provider header that fits naturally next to it.

## Wire path (additive, no migration, no breakage)
| Layer | Change |
|---|---|
| Producer SQL | \`GetMatchupsByContestIds.sql\` — \`co.\"ProviderName\"\` added to SELECT + GROUP BY. Selection logic untouched. |
| Core canonical DTO | \`LeagueMatchupDto.ProviderName\` (string?) |
| API DTO | \`LeagueWeekMatchupsDto.MatchupForPickDto.ProviderName\` (string?) |
| API mapper | \`MatchupForPickDtoMapper.ApplyCanonical\` copies the field |
| Mobile types | \`Matchup.providerName?: string \| null\` |

Old clients ignore the new field; no contract break.

## UI (Option A — small muted label)
**Web** (\`BettingDisplays.SpreadAndOverUnderDisplay\` + \`MatchupCard.jsx\`):
- Block-level span spanning all CSS grid columns (\`gridColumn: '1 / -1'\`) so \`textAlign: center\` is relative to the full row width. The parent \`.spread-ou\` is \`grid-template-columns: 1fr auto 1fr\` — a naive block child centers within only the first 1fr track.
- \`fontSize: 0.7em\`, muted color.
- Suppressed when both spread and O/U are "Off".

**Mobile** (\`MatchupCard.tsx\` \`OddsRow\`):
- Outer \`oddsBlock\` View (\`alignItems: center\`) wraps the existing odds row plus a new \`oddsProvider\` Text below.
- \`fontSize: 9\` (vs the existing 11-pt \`oddsOpen\`) for visual hierarchy.
- Same suppression rule.

Result on both: \`Spread -6.5 | O/U 48.5\` line, then a small centered \`ESPN BET\` (or whichever provider) directly below.

## Verified
- \`dotnet build\` clean on Api + Producer
- 100 API matchup/mapper tests pass, 6 Producer matchup tests pass
- Mobile \`tsc --noEmit\` clean
- Manual: provider name renders centered, muted, smaller font on web — confirmed in browser

## Test plan
- [ ] Open the picks page on web — confirm provider name appears centered under the spread/O/U line on a matchup with odds, hides on a matchup without odds.
- [ ] Open the matchups list in Expo — same expectation.
- [ ] \`curl /ui/leagues/{id}/matchups/{week}\` — confirm \`providerName\` field in the response JSON.

## Future / out of scope
- Per-league preferred-provider setting (referenced in earlier conversation — the natural home for replacing the global \`MatchupSqlBuilder.PreferredOddsProviderId\` / \`FallbackOddsProviderId\` token replacement).
- Multi-provider list / dropdown UI.
- Contest Overview page also surfaces odds; same treatment can extend there in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Odds displays now show the sportsbook provider name attribution, allowing users to see which provider is supplying the displayed spread and over/under odds for each matchup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->