### PR TITLE
fix(web): allow @react-google-maps/api inline loader via SHA-256 hash in CSP

### DIFF
--- a/src/UI/sd-ui/security-headers.conf
+++ b/src/UI/sd-ui/security-headers.conf
@@ -21,9 +21,17 @@
 # violation will surface in Sentry — fix is to externalize the script or add
 # a SHA-256 hash to script-src. report-uri POSTs are exempt from CSP itself,
 # so no connect-src entry is needed for the Sentry host.
+#
+# script-src hashes whitelisted:
+#   sha256-8eohedfRaQoWnH7igD20HvjedM7lPcYbqukJ7DEpMOk=
+#     — Inline bootstrap snippet from @react-google-maps/api's useLoadScript
+#     hook, used by /app/map. If the package version bumps and the snippet
+#     content changes by even one byte, this hash invalidates and the map
+#     page breaks (with a Sentry CSP-violation report). Regenerate by
+#     copying the new hash from the next browser console violation.
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://analytics.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri https://o4511399352729600.ingest.us.sentry.io/api/4511405062225920/security/?sentry_key=3ff92120e166bebbe395faa904795362;" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-8eohedfRaQoWnH7igD20HvjedM7lPcYbqukJ7DEpMOk=' https://maps.googleapis.com https://apis.google.com https://analytics.sportdeets.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.sportdeets.com https://api-int.sportdeets.com https://analytics.sportdeets.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://maps.googleapis.com https://*.service.signalr.net wss://*.service.signalr.net; frame-src 'self' https://www.youtube.com https://accounts.google.com https://sportdeets.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri https://o4511399352729600.ingest.us.sentry.io/api/4511405062225920/security/?sentry_key=3ff92120e166bebbe395faa904795362;" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;


### PR DESCRIPTION
## Summary
The \`/app/map\` page (\`GameMap.jsx\`) uses \`@react-google-maps/api\`'s \`useLoadScript\` hook, which injects a small inline \`<script>\` snippet to bootstrap the Maps API loader. The external \`maps.googleapis.com\` URLs were already whitelisted in \`script-src\`, but the inline bootstrap itself was being blocked by the strict CSP — page silently broke with a CSP-violation report to Sentry.

Fix: add the snippet's SHA-256 hash to \`script-src\` in \`security-headers.conf\`.

## What changed
- \`security-headers.conf\` — added \`'sha256-8eohedfRaQoWnH7igD20HvjedM7lPcYbqukJ7DEpMOk='\` to \`script-src\`.
- Added a comment block documenting which hash is whitelisted, what it's for, and the recovery procedure when it invalidates (one-byte change in the library's bootstrap snippet → swap in the next hash from the browser console violation).

## Trade-off acknowledged
Hashes are fragile by design — if \`@react-google-maps/api\` bumps to a version with a different inline bootstrap, the map page breaks again. This is the documented "fix is to externalize the script or add a SHA-256 hash to script-src" path called out in the existing CSP comment block. The library writes the inline snippet itself, so externalizing isn't reachable without forking the library.

## Context
Game map is being actively hardened for the upcoming season; this unblocks that work.

## Test plan
- [ ] Hit https://www.sportdeets.com/app/map after deploy — confirm map loads with no CSP violation in browser console.
- [ ] Confirm Sentry stops receiving the \`/app/map\` CSP violation events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated security headers configuration to enforce Content Security Policy requirements for third-party integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->