### PR TITLE
fix(producer): event-driven CompetitionStream reschedule on ContestStartTimeUpdated

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamScheduler.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamScheduler.cs
@@ -67,6 +67,65 @@ public class CompetitionStreamScheduler
     /// </summary>
     public Task Execute() => ExecuteAsync(CancellationToken.None);
 
+    /// <summary>
+    /// Event-driven single-contest reschedule path. Invoked from
+    /// <see cref="Consumers.ContestStartTimeUpdatedConsumerHandler"/> after
+    /// MassTransit delivers <c>ContestStartTimeUpdated</c>. Companion to the
+    /// recurring <see cref="ExecuteAsync"/> sweep — that one runs daily for
+    /// MLB and weekly for football, which is too sparse to catch mid-day ESPN
+    /// game-time changes (the failure mode this method exists to fix).
+    ///
+    /// Reuses <see cref="TryRescheduleAsync"/> for the actual reschedule logic
+    /// so the same drift threshold, about-to-fire guard, and crash-safe ordering
+    /// (schedule-new → save → delete-old) applies on both paths. Returns
+    /// <c>true</c> when a reschedule happened, <c>false</c> on any benign
+    /// no-op condition (contest finalized, no stream row yet, stream not in
+    /// Scheduled state, drift within threshold, etc.). Throws on hard failure
+    /// so Hangfire retries.
+    /// </summary>
+    public async Task<bool> RescheduleForContestAsync(Guid contestId, CancellationToken cancellationToken)
+    {
+        var now = _dateTimeProvider.UtcNow();
+
+        // Same filter as the recurring sweep: skip already-finalized contests.
+        // Also include the Contest navigation we'll need for the reschedule.
+        var competition = await _dataContext.Competitions
+            .Include(c => c.Contest)
+            .Where(c => c.ContestId == contestId && c.Contest.FinalizedUtc == null)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (competition == null)
+        {
+            _logger.LogInformation(
+                "No active competition found for ContestId {ContestId}; nothing to reschedule. " +
+                "(Contest may be finalized, deleted, or never sourced.)",
+                contestId);
+            return false;
+        }
+
+        // Single-row tracked load — TryRescheduleAsync mutates the row.
+        var existingStream = await _dataContext.CompetitionStreams
+            .FirstOrDefaultAsync(s => s.CompetitionId == competition.Id, cancellationToken);
+
+        if (existingStream == null)
+        {
+            // No stream scheduled yet — initial scheduling is the recurring
+            // sweep's responsibility, not the event path's. Returning false
+            // is correct: the next ExecuteAsync run will create the row using
+            // the current (updated) Competition.Date.
+            _logger.LogInformation(
+                "No CompetitionStream row for CompetitionId {CompetitionId} (ContestId {ContestId}); " +
+                "initial scheduling deferred to next recurring sweep.",
+                competition.Id, contestId);
+            return false;
+        }
+
+        var desiredScheduledTimeUtc = ComputeScheduledTimeUtc(competition.Date, now);
+
+        return await TryRescheduleAsync(
+            existingStream, competition, competition.Contest, desiredScheduledTimeUtc, now, cancellationToken);
+    }
+
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var now = _dateTimeProvider.UtcNow();

--- a/src/SportsData.Producer/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Producer/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -1,0 +1,53 @@
+using MassTransit;
+
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Processing;
+
+namespace SportsData.Producer.Application.Consumers;
+
+/// <summary>
+/// Thin Ingest-pod consumer for ContestStartTimeUpdated. Enqueues a Hangfire
+/// job (ContestStartTimeUpdatedConsumerHandler) so the actual DB + Hangfire
+/// reschedule work runs on a Worker pod. Keeps Ingest pods responsible only
+/// for translating bus messages into background work, in line with the
+/// Api/Ingest/Worker role split (see project_role_split memory).
+///
+/// Together with the per-sport CompetitionStreamScheduler recurring sweep,
+/// this gives the streamer two paths to a correct schedule: the recurring
+/// sweep (daily for MLB, weekly for football — the safety net) and the
+/// event-driven reschedule (this consumer chain — near-real-time when ESPN
+/// moves a game time).
+/// </summary>
+public class ContestStartTimeUpdatedConsumer : IConsumer<ContestStartTimeUpdated>
+{
+    private readonly ILogger<ContestStartTimeUpdatedConsumer> _logger;
+    private readonly IProvideBackgroundJobs _backgroundJobProvider;
+
+    public ContestStartTimeUpdatedConsumer(
+        ILogger<ContestStartTimeUpdatedConsumer> logger,
+        IProvideBackgroundJobs backgroundJobProvider)
+    {
+        _logger = logger;
+        _backgroundJobProvider = backgroundJobProvider;
+    }
+
+    public Task Consume(ConsumeContext<ContestStartTimeUpdated> context)
+    {
+        var message = context.Message;
+
+        var jobId = _backgroundJobProvider.Enqueue<IContestStartTimeUpdatedConsumerHandler>(
+            x => x.Process(message));
+
+        _logger.LogInformation(
+            "ContestStartTimeUpdated received; enqueued handler. " +
+            "ContestId={ContestId}, NewStartTime={NewStartTime}, Sport={Sport}, " +
+            "HangfireJobId={HangfireJobId}, CorrelationId={CorrelationId}",
+            message.ContestId,
+            message.NewStartTime,
+            message.Sport,
+            jobId,
+            message.CorrelationId);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/SportsData.Producer/Application/Consumers/ContestStartTimeUpdatedConsumerHandler.cs
+++ b/src/SportsData.Producer/Application/Consumers/ContestStartTimeUpdatedConsumerHandler.cs
@@ -1,0 +1,56 @@
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Producer.Application.Competitions;
+
+namespace SportsData.Producer.Application.Consumers;
+
+public interface IContestStartTimeUpdatedConsumerHandler
+{
+    Task Process(ContestStartTimeUpdated evt);
+}
+
+/// <summary>
+/// Hangfire job that does the actual work for a ContestStartTimeUpdated event:
+/// invokes <see cref="CompetitionStreamScheduler.RescheduleForContestAsync"/> to
+/// cancel-and-reschedule the existing CompetitionStream Hangfire job when ESPN
+/// moves a game's start time mid-day.
+///
+/// Spawned by <see cref="ContestStartTimeUpdatedConsumer"/> (Ingest) and executed
+/// on Worker pods so Ingest stays thin.
+/// </summary>
+public class ContestStartTimeUpdatedConsumerHandler : IContestStartTimeUpdatedConsumerHandler
+{
+    private readonly ILogger<ContestStartTimeUpdatedConsumerHandler> _logger;
+    private readonly CompetitionStreamScheduler _scheduler;
+
+    public ContestStartTimeUpdatedConsumerHandler(
+        ILogger<ContestStartTimeUpdatedConsumerHandler> logger,
+        CompetitionStreamScheduler scheduler)
+    {
+        _logger = logger;
+        _scheduler = scheduler;
+    }
+
+    public async Task Process(ContestStartTimeUpdated evt)
+    {
+        using var _ = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = evt.CorrelationId,
+            ["CausationId"] = evt.CausationId,
+            ["ContestId"] = evt.ContestId,
+            ["NewStartTime"] = evt.NewStartTime,
+            ["Sport"] = evt.Sport
+        });
+
+        _logger.LogInformation("ContestStartTimeUpdatedConsumerHandler started.");
+
+        // The scheduler reads Competition.Date directly from the DB rather
+        // than using NewStartTime off the event — keeps the reschedule
+        // idempotent under out-of-order delivery (the latest DB value wins,
+        // not whatever stale event was last delivered).
+        var rescheduled = await _scheduler.RescheduleForContestAsync(evt.ContestId, CancellationToken.None);
+
+        _logger.LogInformation(
+            "ContestStartTimeUpdatedConsumerHandler completed. Rescheduled={Rescheduled}",
+            rescheduled);
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -329,6 +329,7 @@ namespace SportsData.Producer.DependencyInjection
                 services.AddScoped<IFootballContestReplayService, FootballContestReplayService>();
                 services.AddScoped<ICompetitionBroadcastingJob, FootballCompetitionStreamer>();
                 services.AddScoped<CompetitionStreamScheduler>();
+                services.AddScoped<IContestStartTimeUpdatedConsumerHandler, ContestStartTimeUpdatedConsumerHandler>();
             }
 
             if (mode is Sport.BaseballMlb)
@@ -337,6 +338,7 @@ namespace SportsData.Producer.DependencyInjection
                 services.AddScoped<IBaseballContestReplayService, BaseballContestReplayService>();
                 services.AddScoped<ICompetitionBroadcastingJob, BaseballCompetitionStreamer>();
                 services.AddScoped<CompetitionStreamScheduler>();
+                services.AddScoped<IContestStartTimeUpdatedConsumerHandler, ContestStartTimeUpdatedConsumerHandler>();
             }
 
             // Season Queries

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -152,6 +152,7 @@ public class Program
             {
                 typeof(CompetitorScoreUpdatedConsumer),
                 typeof(ContestCompletedHandler),
+                typeof(ContestStartTimeUpdatedConsumer),
                 typeof(DocumentCreatedHandler),
                 // typeof(DocumentDeadLetterConsumer), // DISABLED: Allow messages to accumulate for later replay
                 typeof(LoadTestProducerEventConsumer),

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CompetitionStreamSchedulerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CompetitionStreamSchedulerTests.cs
@@ -264,6 +264,147 @@ public class CompetitionStreamSchedulerTests : ProducerTestBase<CompetitionStrea
             .Verify(x => x.Delete("hf-locked"), Times.Once);
     }
 
+    [Fact]
+    public async Task RescheduleForContest_WhenCompetitionNotFound_ReturnsFalseAndDoesNothing()
+    {
+        // Event arrives for a contest that doesn't exist locally (race between
+        // ESPN sourcing and event delivery, or contest already deleted).
+        // Handler logs and no-ops — the recurring sweep will catch it later.
+
+        var result = await _sut.RescheduleForContestAsync(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeFalse();
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()),
+                Times.Never);
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RescheduleForContest_WhenContestFinalized_ReturnsFalseAndDoesNothing()
+    {
+        // Filter mirrors the recurring sweep: finalized contests are excluded.
+        // No reschedule needed for a game that already ended.
+
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(5));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+
+        var contest = FootballDataContext.Contests.Single(c => c.Id == contestId);
+        contest.FinalizedUtc = FixedNow.AddHours(-1);
+        await FootballDataContext.SaveChangesAsync();
+
+        var result = await _sut.RescheduleForContestAsync(contestId, CancellationToken.None);
+
+        result.Should().BeFalse();
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RescheduleForContest_WhenNoCompetitionStreamRowExists_ReturnsFalse()
+    {
+        // The competition exists but has no stream row yet — initial scheduling
+        // is the recurring sweep's job, not the event path's. Event handler
+        // bails so we don't fight the sweep's insert logic.
+
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(5));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+
+        var result = await _sut.RescheduleForContestAsync(contestId, CancellationToken.None);
+
+        result.Should().BeFalse();
+        FootballDataContext.CompetitionStreams.Should().BeEmpty();
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task RescheduleForContest_WhenGameMovedBeyondThreshold_Reschedules()
+    {
+        // The bug this whole feature exists to fix: ESPN moves a game time
+        // mid-day, but the recurring sweep only runs daily (MLB) / weekly
+        // (football). Event-driven path catches it in near real time.
+
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+        var oldScheduledTime = FixedNow.AddHours(6) - TimeSpan.FromMinutes(10);
+        await SeedExistingStreamAsync(competitionId, oldScheduledTime, CompetitionStreamStatus.Scheduled, "hf-stale");
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Setup(x => x.Delete("hf-stale"))
+            .Returns(true);
+        SetupScheduleReturns("hf-rescheduled");
+
+        var result = await _sut.RescheduleForContestAsync(contestId, CancellationToken.None);
+
+        result.Should().BeTrue();
+
+        var stream = FootballDataContext.CompetitionStreams.Single();
+        stream.BackgroundJobId.Should().Be("hf-rescheduled");
+        stream.ScheduledTimeUtc.Should().Be(FixedNow.AddHours(3) - TimeSpan.FromMinutes(10));
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete("hf-stale"), Times.Once);
+    }
+
+    [Fact]
+    public async Task RescheduleForContest_WhenDriftWithinThreshold_ReturnsFalse()
+    {
+        // Small ESPN time noise — drift under the 5-minute threshold should
+        // not churn Hangfire. Same idempotency guarantee as the sweep path.
+
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+        var nearbyScheduledTime = (FixedNow.AddHours(3) - TimeSpan.FromMinutes(10)) + TimeSpan.FromMinutes(3);
+        await SeedExistingStreamAsync(competitionId, nearbyScheduledTime, CompetitionStreamStatus.Scheduled, "hf-near");
+
+        var result = await _sut.RescheduleForContestAsync(contestId, CancellationToken.None);
+
+        result.Should().BeFalse();
+        FootballDataContext.CompetitionStreams.Single().BackgroundJobId.Should().Be("hf-near");
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(CompetitionStreamStatus.AwaitingStart)]
+    [InlineData(CompetitionStreamStatus.Active)]
+    [InlineData(CompetitionStreamStatus.Completed)]
+    [InlineData(CompetitionStreamStatus.Failed)]
+    public async Task RescheduleForContest_WhenStreamNotInScheduledState_ReturnsFalse(CompetitionStreamStatus status)
+    {
+        // Same guard as the sweep: live or terminal streams are off-limits.
+        // Lifecycle from AwaitingStart onward belongs to the streamer.
+
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+        var staleScheduledTime = FixedNow.AddHours(6) - TimeSpan.FromMinutes(10);
+        await SeedExistingStreamAsync(competitionId, staleScheduledTime, status, "hf-untouchable");
+
+        var result = await _sut.RescheduleForContestAsync(contestId, CancellationToken.None);
+
+        result.Should().BeFalse();
+        FootballDataContext.CompetitionStreams.Single().BackgroundJobId.Should().Be("hf-untouchable");
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+    }
+
     private async Task SeedSeasonWeekAsync()
     {
         FootballDataContext.SeasonWeeks.Add(new SeasonWeek

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CompetitionStreamSchedulerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CompetitionStreamSchedulerTests.cs
@@ -304,6 +304,11 @@ public class CompetitionStreamSchedulerTests : ProducerTestBase<CompetitionStrea
 
         Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
             .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()),
+                Times.Never);
     }
 
     [Fact]
@@ -378,6 +383,11 @@ public class CompetitionStreamSchedulerTests : ProducerTestBase<CompetitionStrea
 
         Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
             .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()),
+                Times.Never);
     }
 
     [Theory]
@@ -403,6 +413,11 @@ public class CompetitionStreamSchedulerTests : ProducerTestBase<CompetitionStrea
 
         Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
             .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()),
+                Times.Never);
     }
 
     private async Task SeedSeasonWeekAsync()

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/ContestStartTimeUpdatedConsumerHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/ContestStartTimeUpdatedConsumerHandlerTests.cs
@@ -1,0 +1,203 @@
+using System.Linq.Expressions;
+
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Competitions;
+using SportsData.Producer.Application.Consumers;
+using SportsData.Producer.Enums;
+using SportsData.Producer.Infrastructure.Data;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Consumers;
+
+/// <summary>
+/// Worker-side handler is genuinely a thin wrapper around
+/// <see cref="CompetitionStreamScheduler.RescheduleForContestAsync"/>.
+/// We exercise it with a real scheduler so the test proves the wire-up
+/// (DI, parameter passing) and not just a Moq.Verify call against an
+/// interface that doesn't exist.
+/// </summary>
+public class ContestStartTimeUpdatedConsumerHandlerTests
+    : ProducerTestBase<ContestStartTimeUpdatedConsumerHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 5, 4, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly Guid SeasonWeekId = Guid.NewGuid();
+
+    private readonly ContestStartTimeUpdatedConsumerHandler _sut;
+
+    public ContestStartTimeUpdatedConsumerHandlerTests()
+    {
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use(dateTimeProvider.Object);
+
+        var appMode = new Mock<IAppMode>();
+        appMode.Setup(x => x.CurrentSport).Returns(Sport.FootballNcaa);
+        Mocker.Use(appMode.Object);
+
+        Mocker.Use(new Mock<IProvideBackgroundJobs>().Object);
+
+        // Real scheduler so the handler -> scheduler -> DB chain executes end-to-end.
+        var scheduler = Mocker.CreateInstance<CompetitionStreamScheduler>();
+        Mocker.Use(scheduler);
+
+        _sut = Mocker.CreateInstance<ContestStartTimeUpdatedConsumerHandler>();
+    }
+
+    [Fact]
+    public async Task Process_WhenStreamRowExistsWithStaleTime_ReschedulesHangfireJob()
+    {
+        // End-to-end happy path: ESPN moved the game earlier, the existing
+        // CompetitionStream points at a Hangfire job at the old time.
+        // Handler invokes the scheduler, which cancels the old job and
+        // schedules a new one at the new time.
+
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+        var oldScheduledTime = FixedNow.AddHours(6) - TimeSpan.FromMinutes(10);
+        await SeedExistingStreamAsync(competitionId, oldScheduledTime, "hf-old");
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Setup(x => x.Delete("hf-old"))
+            .Returns(true);
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Setup(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()))
+            .Returns("hf-new");
+
+        await _sut.Process(BuildEvent(contestId));
+
+        var stream = FootballDataContext.CompetitionStreams.Single();
+        stream.BackgroundJobId.Should().Be("hf-new");
+        stream.ScheduledTimeUtc.Should().Be(FixedNow.AddHours(3) - TimeSpan.FromMinutes(10));
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete("hf-old"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Process_WhenContestUnknown_DoesNotThrowAndDoesNotTouchHangfire()
+    {
+        // Event for a contest we don't have locally yet. The scheduler returns
+        // false; handler logs and completes. Critical: must not throw — Hangfire
+        // would retry forever on a permanent miss.
+
+        await _sut.Process(BuildEvent(Guid.NewGuid()));
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()),
+                Times.Never);
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_IgnoresNewStartTimeOnEvent_AndReadsCompetitionDateFromDb()
+    {
+        // Out-of-order delivery guard: scheduler reads Competition.Date from
+        // the DB, not the event payload. Stale event payloads (e.g., a re-delivery
+        // after a newer update already landed) must not roll the schedule back.
+        // Here the DB says the game is at +3h; we pass an event with NewStartTime
+        // at +9h. Result must match the DB, not the event.
+
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+        var oldScheduledTime = FixedNow.AddHours(6) - TimeSpan.FromMinutes(10);
+        await SeedExistingStreamAsync(competitionId, oldScheduledTime, "hf-old");
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Setup(x => x.Delete("hf-old"))
+            .Returns(true);
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Setup(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()))
+            .Returns("hf-new");
+
+        var staleEvent = BuildEvent(contestId, newStartTime: FixedNow.AddHours(9));
+
+        await _sut.Process(staleEvent);
+
+        FootballDataContext.CompetitionStreams.Single()
+            .ScheduledTimeUtc.Should().Be(FixedNow.AddHours(3) - TimeSpan.FromMinutes(10));
+    }
+
+    private async Task<Guid> SeedCompetitionAsync(DateTime competitionDate)
+    {
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+
+        var contest = new FootballContest
+        {
+            Id = contestId,
+            CreatedBy = Guid.Empty,
+            CreatedUtc = FixedNow.AddDays(-7),
+            Sport = Sport.FootballNcaa,
+            SeasonYear = 2026,
+            SeasonWeekId = SeasonWeekId,
+            Name = "Test Contest",
+            ShortName = "TST",
+            StartDateUtc = competitionDate,
+        };
+
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Contest = contest,
+            CreatedBy = Guid.Empty,
+            CreatedUtc = FixedNow.AddDays(-7),
+            Date = competitionDate,
+        };
+
+        FootballDataContext.Contests.Add(contest);
+        FootballDataContext.Competitions.Add(competition);
+        await FootballDataContext.SaveChangesAsync();
+
+        return competitionId;
+    }
+
+    private async Task SeedExistingStreamAsync(
+        Guid competitionId,
+        DateTime scheduledTimeUtc,
+        string backgroundJobId)
+    {
+        FootballDataContext.CompetitionStreams.Add(new CompetitionStream
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            SeasonWeekId = SeasonWeekId,
+            BackgroundJobId = backgroundJobId,
+            ScheduledBy = nameof(CompetitionStreamScheduler),
+            ScheduledTimeUtc = scheduledTimeUtc,
+            Status = CompetitionStreamStatus.Scheduled,
+            CreatedBy = Guid.Empty,
+            CreatedUtc = FixedNow.AddDays(-1),
+        });
+        await FootballDataContext.SaveChangesAsync();
+    }
+
+    private static ContestStartTimeUpdated BuildEvent(Guid contestId, DateTime? newStartTime = null)
+    {
+        return new ContestStartTimeUpdated(
+            ContestId: contestId,
+            NewStartTime: newStartTime ?? FixedNow.AddHours(3),
+            Ref: null,
+            Sport: Sport.FootballNcaa,
+            SeasonYear: 2026,
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid());
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/ContestStartTimeUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/ContestStartTimeUpdatedConsumerTests.cs
@@ -32,7 +32,7 @@ public class ContestStartTimeUpdatedConsumerTests
     }
 
     [Fact]
-    public async Task Consume_EnqueuesHandlerWithMessage()
+    public async Task Consume_EnqueuesHandlerWithOriginalMessage()
     {
         var evt = new ContestStartTimeUpdated(
             ContestId: Guid.NewGuid(),
@@ -46,17 +46,25 @@ public class ContestStartTimeUpdatedConsumerTests
         var context = new Mock<ConsumeContext<ContestStartTimeUpdated>>();
         context.Setup(x => x.Message).Returns(evt);
 
+        // Capture the expression so we can compile + invoke it against a stand-in
+        // handler. This proves the consumer forwards the bus message rather than
+        // (e.g.) the wrong field, default(T), or null.
+        Expression<Func<IContestStartTimeUpdatedConsumerHandler, Task>> captured = null;
         Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
             .Setup(x => x.Enqueue<IContestStartTimeUpdatedConsumerHandler>(
                 It.IsAny<Expression<Func<IContestStartTimeUpdatedConsumerHandler, Task>>>()))
+            .Callback<Expression<Func<IContestStartTimeUpdatedConsumerHandler, Task>>>(expr => captured = expr)
             .Returns("hf-enqueued-1");
 
         await _sut.Consume(context.Object);
 
-        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
-            .Verify(x => x.Enqueue<IContestStartTimeUpdatedConsumerHandler>(
-                It.IsAny<Expression<Func<IContestStartTimeUpdatedConsumerHandler, Task>>>()),
-                Times.Once);
+        captured.Should().NotBeNull("consumer must enqueue a handler invocation");
+
+        var handler = new Mock<IContestStartTimeUpdatedConsumerHandler>();
+        handler.Setup(x => x.Process(It.IsAny<ContestStartTimeUpdated>())).Returns(Task.CompletedTask);
+        await captured.Compile().Invoke(handler.Object);
+
+        handler.Verify(x => x.Process(evt), Times.Once);
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/ContestStartTimeUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/ContestStartTimeUpdatedConsumerTests.cs
@@ -1,0 +1,86 @@
+using System.Linq.Expressions;
+
+using FluentAssertions;
+
+using MassTransit;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Consumers;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Consumers;
+
+/// <summary>
+/// Ingest-side consumer is a thin shim: translate the bus message into a
+/// Hangfire job for the Worker pod. All real work happens in
+/// <see cref="ContestStartTimeUpdatedConsumerHandler"/>; this test only proves
+/// the enqueue happens with the message intact.
+/// </summary>
+public class ContestStartTimeUpdatedConsumerTests
+    : ProducerTestBase<ContestStartTimeUpdatedConsumer>
+{
+    private readonly ContestStartTimeUpdatedConsumer _sut;
+
+    public ContestStartTimeUpdatedConsumerTests()
+    {
+        _sut = Mocker.CreateInstance<ContestStartTimeUpdatedConsumer>();
+    }
+
+    [Fact]
+    public async Task Consume_EnqueuesHandlerWithMessage()
+    {
+        var evt = new ContestStartTimeUpdated(
+            ContestId: Guid.NewGuid(),
+            NewStartTime: new DateTime(2026, 6, 21, 23, 7, 0, DateTimeKind.Utc),
+            Ref: null,
+            Sport: Sport.BaseballMlb,
+            SeasonYear: 2026,
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid());
+
+        var context = new Mock<ConsumeContext<ContestStartTimeUpdated>>();
+        context.Setup(x => x.Message).Returns(evt);
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Setup(x => x.Enqueue<IContestStartTimeUpdatedConsumerHandler>(
+                It.IsAny<Expression<Func<IContestStartTimeUpdatedConsumerHandler, Task>>>()))
+            .Returns("hf-enqueued-1");
+
+        await _sut.Consume(context.Object);
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Enqueue<IContestStartTimeUpdatedConsumerHandler>(
+                It.IsAny<Expression<Func<IContestStartTimeUpdatedConsumerHandler, Task>>>()),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task Consume_DoesNotPerformAnyDbWork()
+    {
+        // Ingest consumers must be thin shims (per project convention).
+        // Anything that touches the DbContext belongs on the Worker side.
+
+        var evt = new ContestStartTimeUpdated(
+            ContestId: Guid.NewGuid(),
+            NewStartTime: new DateTime(2026, 6, 21, 23, 7, 0, DateTimeKind.Utc),
+            Ref: null,
+            Sport: Sport.FootballNcaa,
+            SeasonYear: 2026,
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid());
+
+        var context = new Mock<ConsumeContext<ContestStartTimeUpdated>>();
+        context.Setup(x => x.Message).Returns(evt);
+
+        await _sut.Consume(context.Object);
+
+        FootballDataContext.Contests.Should().BeEmpty();
+        FootballDataContext.Competitions.Should().BeEmpty();
+        FootballDataContext.CompetitionStreams.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
Bug: a baseball game started ~40 min before its originally-scheduled time. Seq shows Producer updated `Contest.StartDateUtc` from 23:07 UTC to 20:07 UTC at 11:21 UTC, but the user got no SignalR updates. Root cause: the `CompetitionStreamScheduler` recurring job only runs daily for MLB (`0 7 * * *`) and weekly for football (`0 7 * * 0`) — too sparse to catch mid-day ESPN game-time changes. The existing Hangfire job stayed pinned to the old fire time.

Fix: add an event-driven path so any `ContestStartTimeUpdated` event triggers a single-contest reschedule in near real time, complementing (not replacing) the recurring sweep.

- New `RescheduleForContestAsync(contestId, ct)` on `CompetitionStreamScheduler`, reusing the existing private `TryRescheduleAsync` core. Same drift threshold (5 min), same about-to-fire guard (1 min), same schedule-new → save → delete-old crash-safe ordering.
- New `ContestStartTimeUpdatedConsumer` (Ingest) — thin shim, enqueues a Hangfire job. Per the project convention that Ingest consumers must not do DB writes.
- New `ContestStartTimeUpdatedConsumerHandler` (Worker) — owns the DB + Hangfire reschedule work.
- Reads `Competition.Date` from the DB instead of `NewStartTime` off the event payload — keeps the reschedule idempotent under at-least-once redelivery (latest DB value wins).
- Registered for Football (NCAA/NFL) and BaseballMlb modes — the same two modes that have a `CompetitionStreamScheduler` and `ICompetitionBroadcastingJob`.

## Failure modes covered
- Event for a contest we don't have yet → no-op, no throw (Hangfire would retry forever otherwise).
- Contest finalized → no-op (matches recurring sweep filter).
- No `CompetitionStream` row yet → defer to recurring sweep (initial-schedule path).
- Drift within 5-min threshold → no churn.
- Stream not in `Scheduled` state → live/terminal streams left alone.

## Test plan
- [x] `dotnet build src/SportsData.Producer/SportsData.Producer.csproj` — 0 warn / 0 err
- [x] `dotnet test test/unit/SportsData.Producer.Tests.Unit` — 476 passed / 0 failed (added 11 new tests across scheduler/handler/consumer)
- [ ] Watch Seq next time ESPN moves a game time mid-day for `ContestStartTimeUpdatedConsumerHandler started` + `Rescheduled=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically reschedules competition stream scheduling when contest start times change, using the authoritative contest timing source to keep scheduled times up to date.
  * Hooks the start-time update event into the ingest pipeline so rescheduling is triggered reliably and safely.
* **Tests**
  * Added unit coverage for rescheduling outcomes (no action when not eligible, reschedule when drift exceeds threshold, and proper handling of stale or unknown events).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->