### PR TITLE
feat(events): wire PickemGroup membership/matchup + introduce UserPickScored publishes

### DIFF
--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -100,6 +100,7 @@ namespace SportsData.Api.Application.Processors
             var matchupsResult = await _contestClientFactory
                 .Resolve(group.Sport)
                 .GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek);
+
             if (!matchupsResult.IsSuccess)
             {
                 _logger.LogWarning("Failed to retrieve matchups for season {Year} week {Week}. Skipping.", command.SeasonYear, command.SeasonWeek);
@@ -172,6 +173,7 @@ namespace SportsData.Api.Application.Processors
             var existingByContestId = groupWeek.Matchups
                 .ToDictionary(m => m.ContestId, m => m);
             var insertedCount = 0;
+            var insertedContestIds = new List<Guid>();
 
             foreach (var groupMatchup in groupMatchups)
             {
@@ -231,6 +233,7 @@ namespace SportsData.Api.Application.Processors
                         UnderOdds = groupMatchup.UnderOdds
                     });
                     insertedCount++;
+                    insertedContestIds.Add(groupMatchup.ContestId);
                 }
             }
 
@@ -282,6 +285,24 @@ namespace SportsData.Api.Application.Processors
             {
                 _logger.LogInformation("Skipping PickemGroupWeekMatchupsGenerated event for completed week. GroupId={GroupId}, SeasonYear={SeasonYear}, SeasonWeek={SeasonWeek}",
                     group.Id, command.SeasonYear, command.SeasonWeek);
+            }
+
+            // Per-matchup fan-out for the Notification service. Published BEFORE
+            // SaveChanges so the bus-outbox interceptor commits these together
+            // with the matchup inserts in the same transaction. One event per
+            // newly-inserted matchup (refresh-only updates are intentionally
+            // silent here — Notification cares about "this league now has this
+            // contest," not about line/rank churn on already-known matchups).
+            foreach (var contestId in insertedContestIds)
+            {
+                await _eventBus.Publish(new PickemGroupMatchupCreated(
+                        group.Id,
+                        contestId,
+                        group.Sport,
+                        command.SeasonYear,
+                        command.CorrelationId,
+                        Guid.NewGuid()),
+                    CancellationToken.None);
             }
 
             await _dataContext.SaveChangesAsync();

--- a/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
@@ -4,6 +4,7 @@ using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Picks;
 using SportsData.Core.Processing;
 
 namespace SportsData.Api.Application.Scoring
@@ -186,6 +187,34 @@ namespace SportsData.Api.Application.Scoring
 
                     pick.ModifiedUtc = _dateTimeProvider.UtcNow();
                     pick.ModifiedBy = CausationId.Api.PickScoringProcessor;
+
+                    // Fat-event for the Notification service (design doc §4 /
+                    // §5 v1). Publish BEFORE SaveChanges so the bus-outbox
+                    // interceptor commits this together with the pick update;
+                    // an at-least-once redelivery is fine — Notification's
+                    // NotificationLog dedupe on (CorrelationId, UserId, Channel)
+                    // absorbs it. Today's payload populates the cheap fields;
+                    // DisplayName, AwayName/HomeName, and PickValue require
+                    // additional joins (User + FranchiseSeason) and are
+                    // intentionally nullable in the contract until that
+                    // fattening pass lands.
+                    await _bus.Publish(new UserPickScored(
+                            pick.UserId,
+                            null,
+                            command.ContestId,
+                            null,
+                            null,
+                            result.AwayScore,
+                            result.HomeScore,
+                            null,
+                            pick.IsCorrect,
+                            group.Id,
+                            group.Name,
+                            group.Sport,
+                            matchup.SeasonYear,
+                            command.CorrelationId,
+                            CausationId.Api.PickScoringProcessor),
+                        CancellationToken.None);
 
                     await _dataContext.SaveChangesAsync();
                 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueCommandHandler.cs
@@ -5,6 +5,8 @@ using Microsoft.EntityFrameworkCore;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
 
 using SportsData.Api.Application.Common.Enums;
 
@@ -19,13 +21,16 @@ namespace SportsData.Api.Application.UI.Leagues.Commands.JoinLeague
     {
         private readonly ILogger<JoinLeagueCommandHandler> _logger;
         private readonly AppDataContext _dbContext;
+        private readonly IEventBus _eventBus;
 
         public JoinLeagueCommandHandler(
             ILogger<JoinLeagueCommandHandler> logger,
-            AppDataContext dbContext)
+            AppDataContext dbContext,
+            IEventBus eventBus)
         {
             _logger = logger;
             _dbContext = dbContext;
+            _eventBus = eventBus;
         }
 
         public async Task<Result<Guid?>> ExecuteAsync(
@@ -64,6 +69,19 @@ namespace SportsData.Api.Application.UI.Leagues.Commands.JoinLeague
             };
 
             await _dbContext.PickemGroupMembers.AddAsync(membership, cancellationToken);
+
+            // Publish BEFORE SaveChanges so the bus-outbox interceptor commits
+            // the event together with the membership row. SeasonYear is null —
+            // joining a league isn't season-scoped.
+            await _eventBus.Publish(new PickemGroupMemberAdded(
+                    league.Id,
+                    command.UserId,
+                    league.Sport,
+                    null,
+                    Guid.NewGuid(),
+                    Guid.NewGuid()),
+                cancellationToken);
+
             await _dbContext.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation(

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupCreated.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupCreated.cs
@@ -1,0 +1,15 @@
+﻿using SportsData.Core.Common;
+
+using System;
+
+namespace SportsData.Core.Eventing.Events.PickemGroups
+{
+    public record PickemGroupMatchupCreated(
+        Guid GroupId,
+        Guid ContestId,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMemberAdded.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMemberAdded.cs
@@ -1,0 +1,15 @@
+﻿using SportsData.Core.Common;
+
+using System;
+
+namespace SportsData.Core.Eventing.Events.PickemGroups
+{
+    public record PickemGroupMemberAdded(
+        Guid GroupId,
+        Guid UserId,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
+++ b/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
@@ -1,0 +1,40 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Picks
+{
+    /// <summary>
+    /// A user's pick was scored after the underlying contest finalized.
+    /// This is the headline event for the Notification service (design doc
+    /// <c>docs/architecture/notification-service-events-and-state.md</c> §4 / §5
+    /// v1) — every member who picked a finalized contest gets one of these
+    /// and it drives the "#1 pick result" notification.
+    ///
+    /// <para>
+    /// Fat-event by design: Notification doesn't project User, Contest, or
+    /// League, so the publisher carries the display facts that compose the
+    /// notification copy. Today's publisher (<c>PickScoringProcessor</c>)
+    /// populates the cheap fields; the team-name fields and
+    /// <see cref="DisplayName"/> are <c>null</c> pending fat-payload joins.
+    /// Consumers must degrade gracefully on the nullable fields.
+    /// </para>
+    /// </summary>
+    public record UserPickScored(
+        Guid UserId,
+        string? DisplayName,
+        Guid ContestId,
+        string? AwayName,
+        string? HomeName,
+        int AwayScore,
+        int HomeScore,
+        string? PickValue,
+        bool? IsCorrect,
+        Guid LeagueId,
+        string LeagueName,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}


### PR DESCRIPTION
## Summary
Foundation for the upcoming Notification service (PR 2 of 2, stacked). Adds three event publishes from the API and introduces the headline pick-result event in Core. Notification will consume these to drive pick-result, kickoff-reminder, and membership notifications per design doc \`docs/architecture/notification-service-events-and-state.md\` §4–§5.

## Core — new event records
- **\`UserPickScored\`** — fat-event for the design-doc v1 ""pick result"" notification. \`DisplayName\`/\`AwayName\`/\`HomeName\`/\`PickValue\` are nullable until the publisher-side fattening pass lands (joins against \`Users\` + \`FranchiseSeason\`). Consumers degrade gracefully.
- **\`PickemGroupMatchupCreated\`**, **\`PickemGroupMemberAdded\`** — promoted to Core from local scratch files.

## API — publish sites
- **\`MatchupScheduleProcessor\`**: per-new-matchup \`PickemGroupMatchupCreated\` fan-out inside the insert loop. Refresh-only updates stay silent (line/rank churn on already-known matchups is not a notification trigger).
- **\`JoinLeagueCommandHandler\`**: \`PickemGroupMemberAdded\` via outbox (\`IEventBus\` injected). \`SeasonYear\` is null — joining a league isn't season-scoped.
- **\`PickScoringProcessor\`**: \`UserPickScored\` inside the per-pick loop, before \`SaveChangesAsync\`, so the bus-outbox interceptor commits the publish with the pick update atomically.

## Outbox pattern
All three follow the established ""publish BEFORE \`SaveChanges\`"" pattern (see \`CreateLeagueCommandHandlerBase:200\` for the canonical reference). At-least-once redelivery is safe — Notification's \`NotificationLog\` dedupe on \`(CorrelationId, UserId, Channel)\` will absorb duplicates.

## What this PR does NOT do
- No consumer code. Existing API consumer (\`PickemGroupCreatedHandler\`) is unchanged.
- No shovels. Per the design doc §5 phased rollout, shovels are out-of-band once the Notification broker exists.
- No tests for the publishes themselves — pure outbox plumbing, consistent with the existing \`PickemGroupCreated\` publish site at \`CreateLeagueCommandHandlerBase:200\` which is also test-free.

## Test plan
- [x] \`dotnet build src/SportsData.Api/SportsData.Api.csproj\` — 0 warn / 0 err
- [ ] After merge: PR 2 (Notification skeleton) consumes these events end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications when a user joins a league, a new matchup is created, or a pick is scored.
  * Improved contest and league activity tracking so key updates are now available as events right away.
  * Scoring updates now include richer context for downstream displays and summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->