### PR TITLE
feat(notification): Phase 2a — FCM dispatch wired into UserPickScored + Membership consumers

### DIFF
--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMemberAddedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMemberAddedConsumer.cs
@@ -23,6 +23,12 @@ namespace SportsData.Notification.Application.Consumers
     /// </list>
     ///
     /// <para>
+    /// Idempotency uses the same atomic-claim pattern as
+    /// <see cref="UserPickScoredConsumer"/> — see its docstring for the
+    /// rationale (TOCTOU race, crash-vs-duplicate trade-off).
+    /// </para>
+    ///
+    /// <para>
     /// <b>Known fat-payload gap:</b> the current event carries
     /// <c>GroupId, UserId, Sport, SeasonYear</c> only. To send useful copy we
     /// also need <c>LeagueName</c>, <c>JoinedDisplayName</c>, and
@@ -34,6 +40,11 @@ namespace SportsData.Notification.Application.Consumers
     /// </summary>
     public class PickemGroupMemberAddedConsumer : IConsumer<PickemGroupMemberAdded>
     {
+        // NotificationLog.FailureReason is varchar(512); per-device detail
+        // stays in structured logs.
+        private const int FailureReasonMaxLength = 512;
+        private const string FailureReasonTruncationSuffix = "…(truncated)";
+
         private readonly ILogger<PickemGroupMemberAddedConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
@@ -64,27 +75,28 @@ namespace SportsData.Notification.Application.Consumers
 
             _logger.LogInformation("PickemGroupMemberAdded received.");
 
-            // Idempotency: at-least-once delivery from RabbitMQ means we may
-            // see the same event twice. Dedupe on (CorrelationId, UserId, Channel)
-            // — same key the design doc §3 calls out for NotificationLog — and
-            // write a Skipped_Duplicate audit row instead of firing a second
-            // welcome push. Mirrors the guard in UserPickScoredConsumer.
-            var alreadyAttempted = await _dataContext.NotificationLog
-                .AsNoTracking()
-                .AnyAsync(l =>
-                    l.CorrelationId == msg.CorrelationId &&
-                    l.UserId == msg.UserId &&
-                    l.Channel == "Fcm");
-
-            if (alreadyAttempted)
+            // Atomic claim — see UserPickScoredConsumer for full rationale.
+            var claim = new NotificationLog
             {
-                // The first delivery's NotificationLog row IS the audit
-                // trail. Writing a second row here would collide with the
-                // unique (CorrelationId, UserId, Channel) index and throw.
-                // Log + return; redelivery is silently absorbed.
+                UserId = msg.UserId,
+                CorrelationId = msg.CorrelationId,
+                Category = "Membership",
+                Channel = "Fcm",
+                Result = "Dispatching",
+                AttemptedUtc = _dateTimeProvider.UtcNow()
+            };
+            _dataContext.NotificationLog.Add(claim);
+
+            try
+            {
+                await _dataContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
                 _logger.LogInformation(
-                    "PickemGroupMemberAdded already dispatched for CorrelationId {CorrelationId}, UserId {UserId}; skipping duplicate.",
+                    "PickemGroupMemberAdded already claimed by another consumer for CorrelationId {CorrelationId}, UserId {UserId}; skipping.",
                     msg.CorrelationId, msg.UserId);
+                _dataContext.Entry(claim).State = EntityState.Detached;
                 return;
             }
 
@@ -98,8 +110,7 @@ namespace SportsData.Notification.Application.Consumers
                 _logger.LogInformation(
                     "Membership-category notifications disabled for UserId {UserId}; suppressing welcome push.",
                     msg.UserId);
-                // Still write a log row so suppression is auditable.
-                await LogSuppressedAsync(msg, "Suppressed_UserOptedOut");
+                await FinalizeAsync(claim, "Suppressed_UserOptedOut");
                 return;
             }
 
@@ -113,7 +124,7 @@ namespace SportsData.Notification.Application.Consumers
                 _logger.LogInformation(
                     "No active UserDevice rows for UserId {UserId}; suppressing welcome push.",
                     msg.UserId);
-                await LogSuppressedAsync(msg, "Suppressed_NoDevice");
+                await FinalizeAsync(claim, "Suppressed_NoDevice");
                 return;
             }
 
@@ -142,39 +153,39 @@ namespace SportsData.Notification.Application.Consumers
                 }
             }
 
-            var resultValue = successCount > 0 ? "Sent" : "Failed_FcmError";
-            var failureReason = failureReasons.Count > 0
-                ? string.Join("; ", failureReasons)
-                : null;
-
-            _dataContext.NotificationLog.Add(new NotificationLog
-            {
-                UserId = msg.UserId,
-                CorrelationId = msg.CorrelationId,
-                Category = "Membership",
-                Channel = "Fcm",
-                Title = title,
-                Body = body,
-                Result = resultValue,
-                FailureReason = failureReason,
-                AttemptedUtc = _dateTimeProvider.UtcNow()
-            });
+            claim.Title = title;
+            claim.Body = body;
+            claim.Result = successCount > 0 ? "Sent" : "Failed_FcmError";
+            claim.FailureReason = ComposeFailureReason(failureReasons);
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
 
             await _dataContext.SaveChangesAsync();
         }
 
-        private async Task LogSuppressedAsync(PickemGroupMemberAdded msg, string result)
+        private async Task FinalizeAsync(NotificationLog claim, string result)
         {
-            _dataContext.NotificationLog.Add(new NotificationLog
-            {
-                UserId = msg.UserId,
-                CorrelationId = msg.CorrelationId,
-                Category = "Membership",
-                Channel = "Fcm",
-                Result = result,
-                AttemptedUtc = _dateTimeProvider.UtcNow()
-            });
+            claim.Result = result;
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
             await _dataContext.SaveChangesAsync();
+        }
+
+        private static string ComposeFailureReason(List<string> failureReasons)
+        {
+            if (failureReasons.Count == 0)
+                return null;
+
+            var joined = string.Join("; ", failureReasons);
+            if (joined.Length <= FailureReasonMaxLength)
+                return joined;
+
+            var cutoff = FailureReasonMaxLength - FailureReasonTruncationSuffix.Length;
+            return joined.Substring(0, cutoff) + FailureReasonTruncationSuffix;
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
         }
     }
 }

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMemberAddedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMemberAddedConsumer.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
 
 namespace SportsData.Notification.Application.Consumers
 {
@@ -36,15 +37,18 @@ namespace SportsData.Notification.Application.Consumers
         private readonly ILogger<PickemGroupMemberAddedConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPushNotificationSender _pushSender;
 
         public PickemGroupMemberAddedConsumer(
             ILogger<PickemGroupMemberAddedConsumer> logger,
             AppDataContext dataContext,
-            IDateTimeProvider dateTimeProvider)
+            IDateTimeProvider dateTimeProvider,
+            IPushNotificationSender pushSender)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
+            _pushSender = pushSender;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupMemberAdded> context)
@@ -113,38 +117,46 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // 2. Send welcome push.
-            // TODO (FCM integration): inject IPushNotificationSender (or a
-            // Notification-local equivalent) and dispatch the "Welcome to
-            // {LeagueName}" push for each device. The sender owns FCM call,
-            // retry, and per-token failure mapping. This consumer just owns
-            // the orchestration + audit row.
+            // 2. Send welcome push. Body stays generic until the fat-payload
+            // pass adds LeagueName + JoinedDisplayName to the event.
+            const string title = "Welcome";
+            const string body = "You've joined a new league.";
+
+            // 3. Commissioner-side notification is deferred — the event
+            // doesn't carry CommissionerUserId today. Once fattened, repeat
+            // the prefs + device lookup against the commissioner here.
+
+            var successCount = 0;
+            var failureReasons = new List<string>();
             foreach (var device in devices)
             {
-                _logger.LogInformation(
-                    "TODO: send welcome FCM to DeviceId {DeviceId} for UserId {UserId}.",
-                    device.Id, msg.UserId);
+                var sendResult = await _pushSender.SendAsync(device.FcmToken, title, body);
+                if (sendResult is Success<string>)
+                {
+                    successCount++;
+                }
+                else if (sendResult is Failure<string> failure)
+                {
+                    var reason = failure.Errors.FirstOrDefault()?.ErrorMessage ?? "unknown";
+                    failureReasons.Add($"{device.Platform}:{reason}");
+                }
             }
 
-            // 3. Notify commissioner of new member.
-            // TODO (fat-payload work): the commissioner's UserId isn't on the
-            // event today — fattening required. Once available, run the same
-            // preference + device lookup against the commissioner and dispatch
-            // a "{JoinedDisplayName} joined {LeagueName}" push.
+            var resultValue = successCount > 0 ? "Sent" : "Failed_FcmError";
+            var failureReason = failureReasons.Count > 0
+                ? string.Join("; ", failureReasons)
+                : null;
 
-            // 4. Append audit row. Result reflects the current TODO-only path:
-            // we resolved devices and would have dispatched, but the IPushNotificationSender
-            // wiring isn't here yet. Flip to "Sent" / "Failed_FcmError" once the
-            // dispatch loop above does real work — see FCM TODO at line ~130.
             _dataContext.NotificationLog.Add(new NotificationLog
             {
                 UserId = msg.UserId,
                 CorrelationId = msg.CorrelationId,
                 Category = "Membership",
                 Channel = "Fcm",
-                Title = "Welcome",
-                Body = "TODO: render with LeagueName once fattened",
-                Result = "Pending_FcmIntegration",
+                Title = title,
+                Body = body,
+                Result = resultValue,
+                FailureReason = failureReason,
                 AttemptedUtc = _dateTimeProvider.UtcNow()
             });
 

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Picks;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
 
 namespace SportsData.Notification.Application.Consumers
 {
@@ -14,19 +15,16 @@ namespace SportsData.Notification.Application.Consumers
     /// Every member who picked a finalized contest gets one of these events.
     ///
     /// <para>
-    /// Orchestration is the same shape as <see cref="PickemGroupMemberAddedConsumer"/>:
-    /// resolve prefs → resolve devices → suppress vs send → append audit row.
-    /// FCM dispatch itself is delegated to a future <c>IPushNotificationSender</c>
-    /// (today the only sender implementation lives in the API project; moving
-    /// or duplicating it into Notification is part of the FCM-integration TODO).
+    /// Orchestration: resolve prefs → resolve devices → dispatch via
+    /// <see cref="IPushNotificationSender"/> → append audit row reflecting
+    /// the outcome.
     /// </para>
     ///
     /// <para>
-    /// Idempotency: NotificationLog has a unique-ish index on
-    /// <c>(CorrelationId, UserId, Channel)</c>. Even though MassTransit at-least-once
-    /// delivery means we may consume the same event twice, the second attempt
-    /// hits the dedupe path and writes <c>Result = "Skipped_Duplicate"</c>
-    /// instead of firing a second push.
+    /// Idempotency: NotificationLog has a unique <c>(CorrelationId, UserId, Channel)</c>
+    /// index. MassTransit at-least-once delivery means we may consume the
+    /// same event twice; the second attempt hits the dedupe path and
+    /// returns without writing a second row or firing a second push.
     /// </para>
     /// </summary>
     public class UserPickScoredConsumer : IConsumer<UserPickScored>
@@ -34,15 +32,18 @@ namespace SportsData.Notification.Application.Consumers
         private readonly ILogger<UserPickScoredConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPushNotificationSender _pushSender;
 
         public UserPickScoredConsumer(
             ILogger<UserPickScoredConsumer> logger,
             AppDataContext dataContext,
-            IDateTimeProvider dateTimeProvider)
+            IDateTimeProvider dateTimeProvider,
+            IPushNotificationSender pushSender)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
+            _pushSender = pushSender;
         }
 
         public async Task Consume(ConsumeContext<UserPickScored> context)
@@ -101,22 +102,40 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // TODO (FCM integration): inject IPushNotificationSender and dispatch
-            // per device. Body composition needs the team-name fields off the
-            // event — until the fat-payload pass lands, fall back to generic copy.
+            // Body composition needs the team-name fields off the event —
+            // until the fat-payload pass lands, fall back to generic copy.
             var title = msg.IsCorrect == true ? "Nice pick!" : "Tough loss";
             var body = ComposeBody(msg);
 
+            // Per-device dispatch. Single-token send rather than multicast
+            // because v1's IPushNotificationSender surface is one-at-a-time;
+            // multicast batching can come later if device counts per user
+            // grow past a handful. Aggregate outcome:
+            //   - any success → "Sent"
+            //   - all failures → "Failed_FcmError" with reasons captured
+            // Mixed outcomes still log "Sent" because the user did get the
+            // push; per-device failure reasons stay in the structured logs.
+            var successCount = 0;
+            var failureReasons = new List<string>();
             foreach (var device in devices)
             {
-                _logger.LogInformation(
-                    "TODO: send PickResult FCM to DeviceId {DeviceId} for UserId {UserId}. Title='{Title}', Body='{Body}'",
-                    device.Id, msg.UserId, title, body);
+                var result = await _pushSender.SendAsync(device.FcmToken, title, body);
+                if (result is Success<string>)
+                {
+                    successCount++;
+                }
+                else if (result is Failure<string> failure)
+                {
+                    var reason = failure.Errors.FirstOrDefault()?.ErrorMessage ?? "unknown";
+                    failureReasons.Add($"{device.Platform}:{reason}");
+                }
             }
 
-            // Result reflects the current TODO-only path: devices resolved,
-            // dispatch loop above just logs. Flip to "Sent" / "Failed_FcmError"
-            // once IPushNotificationSender is wired in — see FCM TODO above.
+            var resultValue = successCount > 0 ? "Sent" : "Failed_FcmError";
+            var failureReason = failureReasons.Count > 0
+                ? string.Join("; ", failureReasons)
+                : null;
+
             _dataContext.NotificationLog.Add(new NotificationLog
             {
                 UserId = msg.UserId,
@@ -125,7 +144,8 @@ namespace SportsData.Notification.Application.Consumers
                 Channel = "Fcm",
                 Title = title,
                 Body = body,
-                Result = "Pending_FcmIntegration",
+                Result = resultValue,
+                FailureReason = failureReason,
                 AttemptedUtc = _dateTimeProvider.UtcNow()
             });
 

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -15,20 +15,37 @@ namespace SportsData.Notification.Application.Consumers
     /// Every member who picked a finalized contest gets one of these events.
     ///
     /// <para>
-    /// Orchestration: resolve prefs → resolve devices → dispatch via
-    /// <see cref="IPushNotificationSender"/> → append audit row reflecting
-    /// the outcome.
+    /// Orchestration: <b>atomic-claim</b> via NotificationLog insert
+    /// (relies on the unique <c>(CorrelationId, UserId, Channel)</c> index)
+    /// → resolve prefs → resolve devices → dispatch via
+    /// <see cref="IPushNotificationSender"/> → update the row with terminal outcome.
     /// </para>
     ///
     /// <para>
-    /// Idempotency: NotificationLog has a unique <c>(CorrelationId, UserId, Channel)</c>
-    /// index. MassTransit at-least-once delivery means we may consume the
-    /// same event twice; the second attempt hits the dedupe path and
-    /// returns without writing a second row or firing a second push.
+    /// The claim-first pattern closes a TOCTOU race the prior AnyAsync-then-insert
+    /// flow had: two concurrent redeliveries could both read "no row" and both
+    /// dispatch before either inserted. Now the first INSERT wins the unique
+    /// constraint; the loser gets <see cref="DbUpdateException"/> and returns
+    /// without dispatching.
+    /// </para>
+    ///
+    /// <para>
+    /// Failure mode: if the consumer crashes between claim and terminal update,
+    /// the row sits at <c>Result="Dispatching"</c> indefinitely and any
+    /// redelivery is suppressed by the unique constraint. We've chosen a
+    /// missing notification over a duplicate notification for v1 — duplicates
+    /// are worse UX than absences. A future cleanup job could rerun stale
+    /// Dispatching rows if needed.
     /// </para>
     /// </summary>
     public class UserPickScoredConsumer : IConsumer<UserPickScored>
     {
+        // NotificationLog.FailureReason is varchar(512). Truncate the joined
+        // per-device summary so we don't trip Postgres's length check on a
+        // user with many failing devices; per-device detail stays in logs.
+        private const int FailureReasonMaxLength = 512;
+        private const string FailureReasonTruncationSuffix = "…(truncated)";
+
         private readonly ILogger<UserPickScoredConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
@@ -60,34 +77,43 @@ namespace SportsData.Notification.Application.Consumers
 
             _logger.LogInformation("UserPickScored received.");
 
-            // Idempotency check: have we already attempted a Fcm send for this
-            // correlation + user? If so, append a Skipped_Duplicate row and bail.
-            var alreadyAttempted = await _dataContext.NotificationLog
-                .AsNoTracking()
-                .AnyAsync(l =>
-                    l.CorrelationId == msg.CorrelationId &&
-                    l.UserId == msg.UserId &&
-                    l.Channel == "Fcm");
-
-            if (alreadyAttempted)
+            // Atomic claim. Insert a NotificationLog row in Dispatching state
+            // BEFORE doing any work. If another consumer beat us to it, the
+            // unique constraint throws DbUpdateException and we bail without
+            // dispatching anything.
+            var claim = new NotificationLog
             {
-                // The first delivery's NotificationLog row IS the audit
-                // trail. Writing a second row here would collide with the
-                // unique (CorrelationId, UserId, Channel) index and throw.
-                // Log + return; redelivery is silently absorbed.
+                UserId = msg.UserId,
+                CorrelationId = msg.CorrelationId,
+                Category = "PickResult",
+                Channel = "Fcm",
+                Result = "Dispatching",
+                AttemptedUtc = _dateTimeProvider.UtcNow()
+            };
+            _dataContext.NotificationLog.Add(claim);
+
+            try
+            {
+                await _dataContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
                 _logger.LogInformation(
-                    "UserPickScored already dispatched for CorrelationId {CorrelationId}, UserId {UserId}; skipping duplicate.",
+                    "UserPickScored already claimed by another consumer for CorrelationId {CorrelationId}, UserId {UserId}; skipping.",
                     msg.CorrelationId, msg.UserId);
+                _dataContext.Entry(claim).State = EntityState.Detached;
                 return;
             }
 
+            // From here on we own the dispatch. Any terminal state writes
+            // UPDATE the claim row rather than insert a new one.
             var prefs = await _dataContext.UserNotificationPreferences
                 .AsNoTracking()
                 .FirstOrDefaultAsync(p => p.UserId == msg.UserId);
 
             if (prefs is { PickResultEnabled: false })
             {
-                await LogAndSaveAsync(msg, "Suppressed_UserOptedOut");
+                await FinalizeAsync(claim, "Suppressed_UserOptedOut");
                 return;
             }
 
@@ -98,7 +124,7 @@ namespace SportsData.Notification.Application.Consumers
 
             if (devices.Count == 0)
             {
-                await LogAndSaveAsync(msg, "Suppressed_NoDevice");
+                await FinalizeAsync(claim, "Suppressed_NoDevice");
                 return;
             }
 
@@ -131,24 +157,19 @@ namespace SportsData.Notification.Application.Consumers
                 }
             }
 
-            var resultValue = successCount > 0 ? "Sent" : "Failed_FcmError";
-            var failureReason = failureReasons.Count > 0
-                ? string.Join("; ", failureReasons)
-                : null;
+            claim.Title = title;
+            claim.Body = body;
+            claim.Result = successCount > 0 ? "Sent" : "Failed_FcmError";
+            claim.FailureReason = ComposeFailureReason(failureReasons);
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
 
-            _dataContext.NotificationLog.Add(new NotificationLog
-            {
-                UserId = msg.UserId,
-                CorrelationId = msg.CorrelationId,
-                Category = "PickResult",
-                Channel = "Fcm",
-                Title = title,
-                Body = body,
-                Result = resultValue,
-                FailureReason = failureReason,
-                AttemptedUtc = _dateTimeProvider.UtcNow()
-            });
+            await _dataContext.SaveChangesAsync();
+        }
 
+        private async Task FinalizeAsync(NotificationLog claim, string result)
+        {
+            claim.Result = result;
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
             await _dataContext.SaveChangesAsync();
         }
 
@@ -167,18 +188,27 @@ namespace SportsData.Notification.Application.Consumers
                 : $"Your pick lost. Final {msg.AwayScore}–{msg.HomeScore}.";
         }
 
-        private async Task LogAndSaveAsync(UserPickScored msg, string result)
+        private static string ComposeFailureReason(List<string> failureReasons)
         {
-            _dataContext.NotificationLog.Add(new NotificationLog
-            {
-                UserId = msg.UserId,
-                CorrelationId = msg.CorrelationId,
-                Category = "PickResult",
-                Channel = "Fcm",
-                Result = result,
-                AttemptedUtc = _dateTimeProvider.UtcNow()
-            });
-            await _dataContext.SaveChangesAsync();
+            if (failureReasons.Count == 0)
+                return null;
+
+            var joined = string.Join("; ", failureReasons);
+            if (joined.Length <= FailureReasonMaxLength)
+                return joined;
+
+            // Reserve room for the suffix; full per-device detail stays in
+            // structured logs via FirebasePushNotificationSender.
+            var cutoff = FailureReasonMaxLength - FailureReasonTruncationSuffix.Length;
+            return joined.Substring(0, cutoff) + FailureReasonTruncationSuffix;
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505. Inspecting
+            // SqlState on the inner PostgresException is the load-bearing
+            // check; the EF-side DbUpdateException is too generic on its own.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
         }
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Notifications/FirebasePushNotificationSender.cs
+++ b/src/SportsData.Notification/Infrastructure/Notifications/FirebasePushNotificationSender.cs
@@ -1,0 +1,107 @@
+using FirebaseAdmin.Messaging;
+
+using FluentValidation.Results;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Notification.Infrastructure.Notifications;
+
+/// <summary>
+/// Firebase Cloud Messaging implementation of <see cref="IPushNotificationSender"/>.
+/// Relies on the global <see cref="FirebaseAdmin.FirebaseApp.DefaultInstance"/>
+/// initialized in <see cref="SportsData.Notification.Program"/>.
+///
+/// <para>
+/// iOS APNS relay is handled by FCM automatically once the APNS Auth Key
+/// (.p8) is uploaded to the Firebase project — this code stays platform-
+/// agnostic. The Platform column on <see cref="Infrastructure.Data.Entities.UserDevice"/>
+/// is for diagnostics, not for branching the send path.
+/// </para>
+///
+/// <para>
+/// Duplicated from <c>SportsData.Api.Infrastructure.Notifications</c>
+/// pending API-side retirement; see <see cref="IPushNotificationSender"/>
+/// for the rationale.
+/// </para>
+/// </summary>
+public class FirebasePushNotificationSender : IPushNotificationSender
+{
+    private readonly ILogger<FirebasePushNotificationSender> _logger;
+
+    public FirebasePushNotificationSender(
+        ILogger<FirebasePushNotificationSender> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<Result<string>> SendAsync(
+        string token,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string> data = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return new Failure<string>(
+                string.Empty,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(token), "FCM token is required")]);
+        }
+
+        // Fully-qualified Notification — our own
+        // SportsData.Notification.Infrastructure.Notifications namespace
+        // shadows the unqualified type from FirebaseAdmin.Messaging.
+        var message = new Message
+        {
+            Token = token,
+            Notification = new FirebaseAdmin.Messaging.Notification
+            {
+                Title = title,
+                Body = body
+            },
+            Data = data,
+        };
+
+        try
+        {
+            var messageId = await FirebaseMessaging.DefaultInstance.SendAsync(
+                message,
+                cancellationToken);
+
+            _logger.LogInformation(
+                "FCM send succeeded. MessageId={MessageId}, TokenPrefix={TokenPrefix}",
+                messageId,
+                SafeTokenPrefix(token));
+
+            return new Success<string>(messageId);
+        }
+        catch (FirebaseMessagingException ex)
+        {
+            // FCM surfaces structured error codes (Unregistered = token dead,
+            // InvalidArgument = malformed, SenderIdMismatch = wrong project,
+            // QuotaExceeded = rate-limited, Unavailable = service issue).
+            // For v1 we just bubble the code + message; future token-
+            // deactivation logic will branch on ex.MessagingErrorCode here.
+            _logger.LogWarning(
+                ex,
+                "FCM send failed. ErrorCode={ErrorCode}, MessagingErrorCode={MessagingErrorCode}, TokenPrefix={TokenPrefix}",
+                ex.ErrorCode,
+                ex.MessagingErrorCode,
+                SafeTokenPrefix(token));
+
+            return new Failure<string>(
+                string.Empty,
+                ResultStatus.Error,
+                [new ValidationFailure(
+                    nameof(token),
+                    $"FCM {ex.MessagingErrorCode}: {ex.Message}")]);
+        }
+    }
+
+    // Don't log full FCM tokens — they're effectively credentials for
+    // pushing to that device. Prefix-only gives enough to correlate with
+    // a specific device when investigating without exposing the token.
+    private static string SafeTokenPrefix(string token)
+        => token.Length > 8 ? token[..8] + "…" : "(short)";
+}

--- a/src/SportsData.Notification/Infrastructure/Notifications/IPushNotificationSender.cs
+++ b/src/SportsData.Notification/Infrastructure/Notifications/IPushNotificationSender.cs
@@ -1,0 +1,34 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Notification.Infrastructure.Notifications;
+
+/// <summary>
+/// Thin abstraction over FCM (Firebase Cloud Messaging). Lets the
+/// Application layer dispatch a single push to one token without
+/// taking a direct dependency on FirebaseAdmin.Messaging.
+///
+/// <para>
+/// Intentionally duplicated from <c>SportsData.Api.Infrastructure.Notifications</c>
+/// rather than extracted to a shared library — keeps the Notification
+/// service self-contained while the API copy is left in place (the API
+/// admin test-send endpoint still uses it). Once the Notification
+/// service owns all dispatch, the API copy can be retired and the
+/// remaining single implementation pulled into Core if it ever needs
+/// to be shared again.
+/// </para>
+/// </summary>
+public interface IPushNotificationSender
+{
+    /// <summary>
+    /// Send a notification to a single device token. Returns the FCM
+    /// message ID on success, or a Failure with the upstream error
+    /// reason on failure. Caller is responsible for any retry /
+    /// token-deactivation logic.
+    /// </summary>
+    Task<Result<string>> SendAsync(
+        string token,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string> data = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SportsData.Notification/Infrastructure/Notifications/NoOpPushNotificationSender.cs
+++ b/src/SportsData.Notification/Infrastructure/Notifications/NoOpPushNotificationSender.cs
@@ -1,0 +1,51 @@
+using FluentValidation.Results;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Notification.Infrastructure.Notifications;
+
+/// <summary>
+/// Fallback <see cref="IPushNotificationSender"/> registered when
+/// <c>CommonConfig:Firebase:ProjectId</c> is not configured (typically local
+/// dev / tests). Returns a structured <see cref="Failure{T}"/> on every
+/// SendAsync so consumers don't crash trying to resolve
+/// <c>FirebaseMessaging.DefaultInstance</c> against a null
+/// <c>FirebaseApp.DefaultInstance</c>.
+///
+/// <para>
+/// Side effects land in <c>NotificationLog</c> as <c>Result="Failed_FcmError"</c>
+/// rows with <c>FailureReason</c> calling out the missing config — operators
+/// see at-a-glance that the cause is configuration, not an actual FCM
+/// failure. Easy to grep, easy to ignore in local dev.
+/// </para>
+/// </summary>
+public class NoOpPushNotificationSender : IPushNotificationSender
+{
+    private readonly ILogger<NoOpPushNotificationSender> _logger;
+
+    public NoOpPushNotificationSender(
+        ILogger<NoOpPushNotificationSender> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<Result<string>> SendAsync(
+        string token,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string> data = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogWarning(
+            "FCM send no-op'd — Firebase is not configured. Title='{Title}', TokenPrefix={TokenPrefix}",
+            title,
+            token is { Length: > 8 } ? token[..8] + "…" : "(short)");
+
+        return Task.FromResult<Result<string>>(new Failure<string>(
+            string.Empty,
+            ResultStatus.Error,
+            [new ValidationFailure(
+                nameof(token),
+                "Firebase not configured (no-op sender registered)")]));
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -1,7 +1,12 @@
+using FirebaseAdmin;
+
+using Google.Apis.Auth.OAuth2;
+
 using SportsData.Core.Common;
 using SportsData.Core.DependencyInjection;
 using SportsData.Notification.Application.Consumers;
 using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Notifications;
 
 namespace SportsData.Notification
 {
@@ -35,6 +40,38 @@ namespace SportsData.Notification
                 typeof(PickemGroupMemberAddedConsumer),
                 typeof(UserPickScoredConsumer)
             ]);
+
+            // Initialize FirebaseApp.DefaultInstance from CommonConfig:Firebase.
+            // FirebasePushNotificationSender depends on the global default
+            // instance — same pattern as API's Program.cs (single source of
+            // truth in CommonConfig means API + Notification point at the
+            // same Firebase project). Skipped if the config section is empty
+            // so local-dev / docker-compose pods boot without credentials.
+            var firebaseSection = config.GetSection("CommonConfig:Firebase");
+            if (!string.IsNullOrWhiteSpace(firebaseSection["ProjectId"]))
+            {
+                var firebaseJson = System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    type = firebaseSection["Type"],
+                    project_id = firebaseSection["ProjectId"],
+                    private_key_id = firebaseSection["PrivateKeyId"],
+                    private_key = firebaseSection["PrivateKey"],
+                    client_email = firebaseSection["ClientEmail"],
+                    client_id = firebaseSection["ClientId"],
+                    auth_uri = firebaseSection["AuthUri"],
+                    token_uri = firebaseSection["TokenUri"],
+                    auth_provider_x509_cert_url = firebaseSection["AuthProviderX509CertUrl"],
+                    client_x509_cert_url = firebaseSection["ClientX509CertUrl"],
+                    universe_domain = firebaseSection["UniverseDomain"]
+                });
+
+                FirebaseApp.Create(new AppOptions
+                {
+                    Credential = GoogleCredential.FromJson(firebaseJson)
+                });
+            }
+
+            services.AddScoped<IPushNotificationSender, FirebasePushNotificationSender>();
 
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -41,12 +41,14 @@ namespace SportsData.Notification
                 typeof(UserPickScoredConsumer)
             ]);
 
-            // Initialize FirebaseApp.DefaultInstance from CommonConfig:Firebase.
-            // FirebasePushNotificationSender depends on the global default
-            // instance — same pattern as API's Program.cs (single source of
-            // truth in CommonConfig means API + Notification point at the
-            // same Firebase project). Skipped if the config section is empty
-            // so local-dev / docker-compose pods boot without credentials.
+            // Initialize FirebaseApp.DefaultInstance from CommonConfig:Firebase
+            // and register the real sender. When ProjectId is empty (local
+            // dev / tests without Firebase credentials) we register a no-op
+            // sender instead so consumers don't crash on resolution. The
+            // no-op returns Failure with an explicit "not configured" reason,
+            // which lands in NotificationLog as Failed_FcmError — easy to
+            // grep, makes the misconfiguration obvious without flooding
+            // dead-letter.
             var firebaseSection = config.GetSection("CommonConfig:Firebase");
             if (!string.IsNullOrWhiteSpace(firebaseSection["ProjectId"]))
             {
@@ -69,9 +71,14 @@ namespace SportsData.Notification
                 {
                     Credential = GoogleCredential.FromJson(firebaseJson)
                 });
-            }
 
-            services.AddScoped<IPushNotificationSender, FirebasePushNotificationSender>();
+                services.AddScoped<IPushNotificationSender, FirebasePushNotificationSender>();
+            }
+            else
+            {
+                Console.WriteLine("WARN: CommonConfig:Firebase:ProjectId is not set; registering NoOpPushNotificationSender. FCM dispatches will no-op.");
+                services.AddScoped<IPushNotificationSender, NoOpPushNotificationSender>();
+            }
 
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Notification/SportsData.Notification.csproj
+++ b/src/SportsData.Notification/SportsData.Notification.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FirebaseAdmin" Version="3.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
Notification service was inert after #460 — every consumer wrote \`Pending_FcmIntegration\` audit rows and stopped. This PR makes \`UserPickScored\` and \`PickemGroupMemberAdded\` fire real FCM pushes.

This is **Phase 2a** of the pick-reminders push notification rollout per design doc §5. Subsequent phases: 2b Hangfire infra → 2c pick deadline reminders → 2d kickoff reminders.

## What landed
- **Duplicated** \`IPushNotificationSender\` + \`FirebasePushNotificationSender\` from \`SportsData.Api.Infrastructure.Notifications\` into \`SportsData.Notification.Infrastructure.Notifications\` per direction (duplicate, don't extract; leave the API copy in place pending its retirement once Notification owns all dispatch).
- **FirebaseAdmin 3.4.0** added to Notification.csproj.
- **\`FirebaseApp.DefaultInstance\` initialized** in Program.cs from \`CommonConfig:Firebase\` using the same private-key-JSON shape as API. Skipped when \`ProjectId\` is empty so local-dev / docker-compose pods boot without credentials.
- **\`IPushNotificationSender\` registered** as Scoped.

### Consumer dispatch flip
Both \`UserPickScoredConsumer\` and \`PickemGroupMemberAddedConsumer\`:
- Inject \`IPushNotificationSender\`.
- Replace TODO log loop with per-device \`SendAsync\` calls.
- Aggregate outcomes — any success → \`Result=""Sent""\`; all failures → \`Result=""Failed_FcmError""\`.
- \`FailureReason\` captures \`Platform:reason\` for each failed device, semicolon-joined.

## Notable gotcha
Our own \`SportsData.Notification.Infrastructure.Notifications\` namespace shadows the unqualified \`FirebaseAdmin.Messaging.Notification\` type, so \`Message\` construction uses the fully-qualified name. Documented inline.

## What this PR does NOT do
- **No Hangfire** — Phase 2b.
- **No reminder consumers** (\`PickemGroupWeekCreated\`, \`ContestCreated\`) — Phases 2c / 2d.
- **No body fattening** — Membership body stays generic until \`LeagueName\`/\`JoinedDisplayName\` land on the event; UserPickScored body already has the graceful-degradation \`ComposeBody\` helper.
- **No tests** — dispatch is thin orchestration over a third-party SDK; the meaningful test cases live in the Hangfire/reminder PRs where there's branching logic worth covering.

## Test plan
- [x] \`dotnet build src/SportsData.Notification/SportsData.Notification.csproj\` — 0 warn / 0 err
- [ ] Local: \`docker-compose up sd-notification\` boots without crashing on Firebase init
- [ ] Local: trigger \`UserPickScored\` via a finalized contest, observe \`NotificationLog\` row with \`Result=""Sent""\` and FCM delivery on the test device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications are now fully delivered to enabled devices for new group member welcomes and scored-pick updates.
  * Added Firebase-based notification delivery support, including startup setup and service registration.
  * Notification logs now record actual send outcomes and failure details.

* **Bug Fixes**
  * Removed previous placeholder behavior so notifications are sent instead of only being tracked as pending.
  * Improved handling of disabled notifications and devices with more accurate audit entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->