### PR TITLE
feat(notification): backfill User + PickemGroup (with members) projections via operator-triggered events

### DIFF
--- a/src/SportsData.Api/Application/Events/PickemGroupsRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/PickemGroupsRequestedConsumer.cs
@@ -74,25 +74,29 @@ namespace SportsData.Api.Application.Events
                 "PickemGroupsRequested received; publishing PickemGroupDataPublished for {Count} groups.",
                 groups.Count);
 
+            // Batch via PublishBatch to dodge EventBus.Publish's per-call
+            // 1-second Direct-mode delay (EventBus.cs:102). At dozens of
+            // leagues that's already meaningful sleep time; per-call is
+            // strictly worse than batch. See sibling notes in
+            // UsersRequestedConsumer for the trade-off (no header-side
+            // X-Correlation-Id stamp; event body still carries it).
+            var events = groups
+                .Select(group => new PickemGroupDataPublished(
+                    group.Id,
+                    group.Name,
+                    group.CommissionerUserId,
+                    group.Members
+                        .Select(m => new PickemGroupMemberSnapshot(m.UserId, m.Role))
+                        .ToList(),
+                    group.Sport,
+                    msg.SeasonYear,
+                    msg.CorrelationId,
+                    Guid.NewGuid()))
+                .ToList();
+
             using (_deliveryScope.Use(DeliveryMode.Direct))
             {
-                foreach (var group in groups)
-                {
-                    var members = group.Members
-                        .Select(m => new PickemGroupMemberSnapshot(m.UserId, m.Role))
-                        .ToList();
-
-                    await _eventBus.Publish(new PickemGroupDataPublished(
-                            group.Id,
-                            group.Name,
-                            group.CommissionerUserId,
-                            members,
-                            group.Sport,
-                            msg.SeasonYear,
-                            msg.CorrelationId,
-                            Guid.NewGuid()),
-                        context.CancellationToken);
-                }
+                await _eventBus.PublishBatch(events, context.CancellationToken);
             }
 
             _logger.LogInformation(

--- a/src/SportsData.Api/Application/Events/PickemGroupsRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/PickemGroupsRequestedConsumer.cs
@@ -1,0 +1,103 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
+
+namespace SportsData.Api.Application.Events
+{
+    /// <summary>
+    /// Backfill responder for PickemGroups. Iterates the API's PickemGroups
+    /// table and emits one <see cref="PickemGroupDataPublished"/> per league
+    /// with the member roster bundled into the payload. Bundle (vs separate
+    /// per-member events) keeps the projection insert atomic on the
+    /// Notification side and avoids the parent-before-child race.
+    ///
+    /// <para>
+    /// Read-only; uses <see cref="IMessageDeliveryScope"/> Direct mode to
+    /// bypass the outbox — same pattern as
+    /// <see cref="UsersRequestedConsumer"/> and
+    /// <see cref="PickemGroups.PickemGroupCreatedHandler"/>'s sibling flows.
+    /// </para>
+    /// </summary>
+    public class PickemGroupsRequestedConsumer : IConsumer<PickemGroupsRequested>
+    {
+        private readonly ILogger<PickemGroupsRequestedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IEventBus _eventBus;
+        private readonly IMessageDeliveryScope _deliveryScope;
+
+        public PickemGroupsRequestedConsumer(
+            ILogger<PickemGroupsRequestedConsumer> logger,
+            AppDataContext dataContext,
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _eventBus = eventBus;
+            _deliveryScope = deliveryScope;
+        }
+
+        public async Task Consume(ConsumeContext<PickemGroupsRequested> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["Sport"] = msg.Sport
+            });
+
+            // Single round-trip to load groups + members. AsSplitQuery avoids
+            // the cartesian explosion that .Include() would cause on a wide
+            // membership table.
+            var groups = await _dataContext.PickemGroups
+                .AsNoTracking()
+                .Include(g => g.Members)
+                .AsSplitQuery()
+                .Select(g => new
+                {
+                    g.Id,
+                    g.Name,
+                    g.Sport,
+                    g.CommissionerUserId,
+                    Members = g.Members
+                        .Select(m => new { m.UserId, Role = m.Role.ToString() })
+                        .ToList()
+                })
+                .ToListAsync(context.CancellationToken);
+
+            _logger.LogInformation(
+                "PickemGroupsRequested received; publishing PickemGroupDataPublished for {Count} groups.",
+                groups.Count);
+
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                foreach (var group in groups)
+                {
+                    var members = group.Members
+                        .Select(m => new PickemGroupMemberSnapshot(m.UserId, m.Role))
+                        .ToList();
+
+                    await _eventBus.Publish(new PickemGroupDataPublished(
+                            group.Id,
+                            group.Name,
+                            group.CommissionerUserId,
+                            members,
+                            group.Sport,
+                            msg.SeasonYear,
+                            msg.CorrelationId,
+                            Guid.NewGuid()),
+                        context.CancellationToken);
+                }
+            }
+
+            _logger.LogInformation(
+                "PickemGroupsRequested backfill complete; published {Count} PickemGroupDataPublished events.",
+                groups.Count);
+        }
+    }
+}

--- a/src/SportsData.Api/Application/Events/UsersRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/UsersRequestedConsumer.cs
@@ -67,21 +67,30 @@ namespace SportsData.Api.Application.Events
                 "UsersRequested received; publishing UserDataPublished for {Count} users.",
                 users.Count);
 
+            // Batch via PublishBatch rather than foreach _eventBus.Publish.
+            // EventBus.Publish in Direct mode pays a 1-second Task.Delay per
+            // call (the "give consumers time to commit" hack at EventBus.cs:102)
+            // — fatal for batch fan-out: N users would mean N seconds of
+            // sleep. PublishBatch calls _bus.Publish directly in 256-chunk
+            // Task.WhenAll batches, bypassing the delay. Trade-off: PublishBatch
+            // doesn't auto-stamp the X-Correlation-Id header, but every event
+            // body already carries CorrelationId as a positional record field;
+            // consumers read from the body.
+            var events = users
+                .Select(user => new UserDataPublished(
+                    user.Id,
+                    user.DisplayName,
+                    user.Email,
+                    user.Timezone ?? string.Empty,
+                    msg.Sport,
+                    msg.SeasonYear,
+                    msg.CorrelationId,
+                    Guid.NewGuid()))
+                .ToList();
+
             using (_deliveryScope.Use(DeliveryMode.Direct))
             {
-                foreach (var user in users)
-                {
-                    await _eventBus.Publish(new UserDataPublished(
-                            user.Id,
-                            user.DisplayName,
-                            user.Email,
-                            user.Timezone ?? string.Empty,
-                            msg.Sport,
-                            msg.SeasonYear,
-                            msg.CorrelationId,
-                            Guid.NewGuid()),
-                        context.CancellationToken);
-                }
+                await _eventBus.PublishBatch(events, context.CancellationToken);
             }
 
             _logger.LogInformation(

--- a/src/SportsData.Api/Application/Events/UsersRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/UsersRequestedConsumer.cs
@@ -1,0 +1,92 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+
+namespace SportsData.Api.Application.Events
+{
+    /// <summary>
+    /// Backfill responder. The Notification service (or any future consumer
+    /// needing to seed its local User projection) publishes
+    /// <see cref="UsersRequested"/>; this handler iterates the API's Users
+    /// table and emits one <see cref="UserDataPublished"/> per user.
+    ///
+    /// <para>
+    /// Read-only on the API side — no DbContext writes, so publishes go
+    /// through <see cref="IMessageDeliveryScope"/> in Direct mode to bypass
+    /// the bus-outbox (consistent with PickemGroupWeekMatchupsGeneratedHandler
+    /// and the existing direct-publish pattern in this project).
+    /// </para>
+    ///
+    /// <para>
+    /// Synthetic users are intentionally INCLUDED — Notification's local
+    /// projection is a faithful mirror of who's on file; filtering belongs
+    /// in the dispatch path (don't notify synthetic users), not here.
+    /// Repeated invocations republish the full set; consumer-side upsert
+    /// makes that safe.
+    /// </para>
+    /// </summary>
+    public class UsersRequestedConsumer : IConsumer<UsersRequested>
+    {
+        private readonly ILogger<UsersRequestedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IEventBus _eventBus;
+        private readonly IMessageDeliveryScope _deliveryScope;
+
+        public UsersRequestedConsumer(
+            ILogger<UsersRequestedConsumer> logger,
+            AppDataContext dataContext,
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _eventBus = eventBus;
+            _deliveryScope = deliveryScope;
+        }
+
+        public async Task Consume(ConsumeContext<UsersRequested> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["Sport"] = msg.Sport
+            });
+
+            var users = await _dataContext.Users
+                .AsNoTracking()
+                .Select(u => new { u.Id, u.DisplayName, u.Email, u.Timezone })
+                .ToListAsync(context.CancellationToken);
+
+            _logger.LogInformation(
+                "UsersRequested received; publishing UserDataPublished for {Count} users.",
+                users.Count);
+
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                foreach (var user in users)
+                {
+                    await _eventBus.Publish(new UserDataPublished(
+                            user.Id,
+                            user.DisplayName,
+                            user.Email,
+                            user.Timezone ?? string.Empty,
+                            msg.Sport,
+                            msg.SeasonYear,
+                            msg.CorrelationId,
+                            Guid.NewGuid()),
+                        context.CancellationToken);
+                }
+            }
+
+            _logger.LogInformation(
+                "UsersRequested backfill complete; published {Count} UserDataPublished events.",
+                users.Count);
+        }
+    }
+}

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -281,6 +281,7 @@ namespace SportsData.Api
                     typeof(FootballPlayCompletedHandler),
                     typeof(PickemGroupCreatedHandler),
                     typeof(PickemGroupMatchupAddedHandler),
+                    typeof(PickemGroupsRequestedConsumer),
                     typeof(PickemGroupWeekMatchupsGeneratedHandler),
                     typeof(PreviewGeneratedHandler),
                     typeof(SeasonPollWeekCreatedHandler),

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -283,7 +283,8 @@ namespace SportsData.Api
                     typeof(PickemGroupMatchupAddedHandler),
                     typeof(PickemGroupWeekMatchupsGeneratedHandler),
                     typeof(PreviewGeneratedHandler),
-                    typeof(SeasonPollWeekCreatedHandler)
+                    typeof(SeasonPollWeekCreatedHandler),
+                    typeof(UsersRequestedConsumer)
                 ]);
 
                 sigRConnString = config["CommonConfig:AzureSignalR:ConnectionString"];
@@ -418,10 +419,10 @@ namespace SportsData.Api
                 app.Services.ConfigureHangfireJobs(mode);
             }
 
-            //app.UseHangfireDashboard("/dashboard", new DashboardOptions
-            //{
-            //    Authorization = Array.Empty<IDashboardAuthorizationFilter>()
-            //});
+            app.UseHangfireDashboard("/dashboard", new DashboardOptions
+            {
+                Authorization = Array.Empty<IDashboardAuthorizationFilter>()
+            });
 
             await app.RunAsync();
         }

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -420,10 +420,10 @@ namespace SportsData.Api
                 app.Services.ConfigureHangfireJobs(mode);
             }
 
-            app.UseHangfireDashboard("/dashboard", new DashboardOptions
-            {
-                Authorization = Array.Empty<IDashboardAuthorizationFilter>()
-            });
+            //app.UseHangfireDashboard("/dashboard", new DashboardOptions
+            //{
+            //    Authorization = Array.Empty<IDashboardAuthorizationFilter>()
+            //});
 
             await app.RunAsync();
         }

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupDataPublished.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupDataPublished.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.PickemGroups
+{
+    /// <summary>
+    /// Per-league backfill snapshot. Members are bundled into the payload
+    /// rather than published as separate per-member events — at solo-dev scale
+    /// (dozens of leagues, hundreds of members total) the bundle keeps the
+    /// projection insert atomic and eliminates the parent-before-child race
+    /// that separate events would introduce.
+    ///
+    /// <para>
+    /// Consumer is responsible for idempotent upsert (replace-members
+    /// semantics) — repeated backfills converge on the same projection rows.
+    /// </para>
+    /// </summary>
+    public record PickemGroupDataPublished(
+        Guid GroupId,
+        string Name,
+        Guid CommissionerUserId,
+        IReadOnlyList<PickemGroupMemberSnapshot> Members,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+
+    /// <summary>
+    /// Embedded member row carried inside <see cref="PickemGroupDataPublished"/>.
+    /// Role is the string form of <c>LeagueRole</c> (lives in API today; cross-
+    /// service string is the lighter coupling than sharing the enum).
+    /// </summary>
+    public record PickemGroupMemberSnapshot(
+        Guid UserId,
+        string Role
+    );
+}

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupsRequested.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupsRequested.cs
@@ -1,0 +1,19 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.PickemGroups
+{
+    /// <summary>
+    /// Backfill trigger asking the API to publish a
+    /// <see cref="PickemGroupDataPublished"/> event for every league on file
+    /// (with member roster bundled into each payload). Companion to
+    /// <see cref="Users.UsersRequested"/> — same operator-triggered shape.
+    /// </summary>
+    public record PickemGroupsRequested(
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Core/Eventing/Events/Users/UserDataPublished.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UserDataPublished.cs
@@ -1,0 +1,29 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Users
+{
+    /// <summary>
+    /// Per-user backfill snapshot emitted by the API in response to a
+    /// <see cref="UsersRequested"/> trigger. Carries the fields the
+    /// Notification service projects locally so it can render notification
+    /// copy without an HTTP round-trip back to API.
+    ///
+    /// <para>
+    /// One event per user. Consumer is responsible for idempotent upsert —
+    /// at-least-once delivery means the same UserId may arrive twice, and
+    /// repeated backfill requests will republish the entire set.
+    /// </para>
+    /// </summary>
+    public record UserDataPublished(
+        Guid UserId,
+        string DisplayName,
+        string Email,
+        string Timezone,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Core/Eventing/Events/Users/UsersRequested.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UsersRequested.cs
@@ -1,0 +1,25 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Users
+{
+    /// <summary>
+    /// Request issued by the Notification service (or any other service that
+    /// needs to backfill its local <c>User</c> projection) asking the API to
+    /// publish a <see cref="UserDataPublished"/> event for every user on file.
+    ///
+    /// <para>
+    /// Not a "user created" or "user updated" event. This is a one-off backfill
+    /// trigger — the API consumer iterates its <c>Users</c> table and emits
+    /// one fat data event per row. Going forward, ongoing user lifecycle is
+    /// expected to flow through separate steady-state events (TBD).
+    /// </para>
+    /// </summary>
+    public record UsersRequested(
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
@@ -95,39 +95,77 @@ namespace SportsData.Notification.Application.Consumers
                 groupChanged = ApplyGroupUpdateIfChanged(group, msg, now);
             }
 
-            // ---- Members: set-equality check before replace.
+            // ---- Members: diff/sync by UserId — modify survivors in place,
+            // only delete/insert for actual set changes. Avoids the
+            // delete-then-insert collision on the unique (PickemGroupId,
+            // UserId) index that a wholesale replace produces when two
+            // concurrent PickemGroupDataPublished events for the same group
+            // interleave. Role-only changes become a single UPDATE rather
+            // than a DELETE + INSERT of the same key.
             var existingMembers = await _dataContext.PickemGroupMembers
                 .Where(m => m.PickemGroupId == msg.GroupId)
                 .ToListAsync(context.CancellationToken);
 
-            var existingSet = existingMembers
-                .Select(m => (m.UserId, m.Role))
-                .ToHashSet();
-            var snapshotSet = msg.Members
-                .Select(m => (m.UserId, m.Role))
-                .ToHashSet();
+            var existingByUserId = existingMembers.ToDictionary(m => m.UserId);
+            var snapshotByUserId = msg.Members.ToDictionary(m => m.UserId);
 
-            var membersChanged = !existingSet.SetEquals(snapshotSet);
+            var membersChanged = false;
 
-            if (membersChanged)
+            // Removals: existing not in snapshot.
+            foreach (var (userId, member) in existingByUserId)
             {
-                _dataContext.PickemGroupMembers.RemoveRange(existingMembers);
-                foreach (var snapshot in msg.Members)
+                if (!snapshotByUserId.ContainsKey(userId))
+                {
+                    _dataContext.PickemGroupMembers.Remove(member);
+                    membersChanged = true;
+                }
+            }
+
+            // Inserts + in-place updates.
+            foreach (var (userId, snapshot) in snapshotByUserId)
+            {
+                if (existingByUserId.TryGetValue(userId, out var existing))
+                {
+                    if (existing.Role != snapshot.Role)
+                    {
+                        existing.Role = snapshot.Role;
+                        existing.ModifiedUtc = now;
+                        existing.ModifiedBy = msg.CausationId;
+                        membersChanged = true;
+                    }
+                }
+                else
                 {
                     _dataContext.PickemGroupMembers.Add(new PickemGroupMember
                     {
                         PickemGroupId = msg.GroupId,
-                        UserId = snapshot.UserId,
+                        UserId = userId,
                         Role = snapshot.Role,
                         CreatedUtc = now,
                         CreatedBy = msg.CausationId
                     });
+                    membersChanged = true;
                 }
             }
 
             if (groupChanged || membersChanged)
             {
-                await _dataContext.SaveChangesAsync(context.CancellationToken);
+                try
+                {
+                    await _dataContext.SaveChangesAsync(context.CancellationToken);
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // A concurrent consumer inserted one of the same new
+                    // members between our read and our save. Their write
+                    // won; ours is redundant. Log and treat as success —
+                    // the projection is now in the intended end-state.
+                    _logger.LogInformation(
+                        "PickemGroup member sync hit a concurrent insert race for GroupId {GroupId}; another consumer's write won. Projection is in target state.",
+                        msg.GroupId);
+                    return;
+                }
+
                 _logger.LogInformation(
                     "PickemGroup roster synced. GroupId={GroupId}, MemberCount={MemberCount}, GroupChanged={GroupChanged}, MembersChanged={MembersChanged}",
                     msg.GroupId, msg.Members.Count, groupChanged, membersChanged);

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
@@ -1,0 +1,102 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// Upserts the local <see cref="PickemGroup"/> projection from a backfill
+    /// snapshot. Member rows use replace-semantics: existing memberships for
+    /// the group are deleted and the event's bundled member list is inserted
+    /// fresh. That keeps the local roster a faithful mirror of API's
+    /// source-of-truth — including handling removed memberships that the
+    /// upstream might no longer carry.
+    /// </summary>
+    public class PickemGroupDataPublishedConsumer : IConsumer<PickemGroupDataPublished>
+    {
+        private readonly ILogger<PickemGroupDataPublishedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public PickemGroupDataPublishedConsumer(
+            ILogger<PickemGroupDataPublishedConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task Consume(ConsumeContext<PickemGroupDataPublished> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["GroupId"] = msg.GroupId,
+                ["Sport"] = msg.Sport
+            });
+
+            var now = _dateTimeProvider.UtcNow();
+
+            // Upsert the group row.
+            var group = await _dataContext.PickemGroups
+                .FirstOrDefaultAsync(g => g.Id == msg.GroupId, context.CancellationToken);
+
+            if (group is null)
+            {
+                _dataContext.PickemGroups.Add(new PickemGroup
+                {
+                    Id = msg.GroupId,
+                    Name = msg.Name,
+                    Sport = msg.Sport,
+                    CommissionerUserId = msg.CommissionerUserId,
+                    CreatedUtc = now,
+                    CreatedBy = msg.CausationId
+                });
+                _logger.LogInformation("PickemGroup projection inserted. GroupId={GroupId}", msg.GroupId);
+            }
+            else
+            {
+                group.Name = msg.Name;
+                group.Sport = msg.Sport;
+                group.CommissionerUserId = msg.CommissionerUserId;
+                group.ModifiedUtc = now;
+                group.ModifiedBy = msg.CausationId;
+                _logger.LogInformation("PickemGroup projection updated. GroupId={GroupId}", msg.GroupId);
+            }
+
+            // Replace members: delete existing rows for this group, then
+            // insert the snapshot's set. Keeps the local roster a faithful
+            // mirror including removals upstream.
+            var existingMembers = await _dataContext.PickemGroupMembers
+                .Where(m => m.PickemGroupId == msg.GroupId)
+                .ToListAsync(context.CancellationToken);
+            _dataContext.PickemGroupMembers.RemoveRange(existingMembers);
+
+            foreach (var snapshot in msg.Members)
+            {
+                _dataContext.PickemGroupMembers.Add(new PickemGroupMember
+                {
+                    PickemGroupId = msg.GroupId,
+                    UserId = snapshot.UserId,
+                    Role = snapshot.Role,
+                    CreatedUtc = now,
+                    CreatedBy = msg.CausationId
+                });
+            }
+
+            await _dataContext.SaveChangesAsync(context.CancellationToken);
+
+            _logger.LogInformation(
+                "PickemGroup roster synced. GroupId={GroupId}, MemberCount={MemberCount}",
+                msg.GroupId, msg.Members.Count);
+        }
+    }
+}

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
@@ -11,11 +11,22 @@ namespace SportsData.Notification.Application.Consumers
 {
     /// <summary>
     /// Upserts the local <see cref="PickemGroup"/> projection from a backfill
-    /// snapshot. Member rows use replace-semantics: existing memberships for
-    /// the group are deleted and the event's bundled member list is inserted
-    /// fresh. That keeps the local roster a faithful mirror of API's
-    /// source-of-truth — including handling removed memberships that the
-    /// upstream might no longer carry.
+    /// snapshot. Member rows use replace-semantics: when the snapshot set
+    /// differs from the local set, existing rows for the group are deleted
+    /// and the snapshot's set is inserted fresh. Keeps the local roster a
+    /// faithful mirror of API's source-of-truth — including removals.
+    ///
+    /// <para>
+    /// Race-safe insert: two concurrent consumers seeing "doesn't exist"
+    /// can both try; the PK-unique constraint catches the loser via
+    /// <see cref="DbUpdateException"/> and we fall through to update.
+    /// </para>
+    ///
+    /// <para>
+    /// Churn-free redelivery: business fields are diffed before applying.
+    /// If neither the group row nor the member set differs, no writes
+    /// happen and <c>ModifiedUtc</c> stays put.
+    /// </para>
     /// </summary>
     public class PickemGroupDataPublishedConsumer : IConsumer<PickemGroupDataPublished>
     {
@@ -45,13 +56,14 @@ namespace SportsData.Notification.Application.Consumers
 
             var now = _dateTimeProvider.UtcNow();
 
-            // Upsert the group row.
+            // ---- Group row: upsert with race-safe insert + change detection.
             var group = await _dataContext.PickemGroups
                 .FirstOrDefaultAsync(g => g.Id == msg.GroupId, context.CancellationToken);
 
+            var groupChanged = false;
             if (group is null)
             {
-                _dataContext.PickemGroups.Add(new PickemGroup
+                var entity = new PickemGroup
                 {
                     Id = msg.GroupId,
                     Name = msg.Name,
@@ -59,44 +71,95 @@ namespace SportsData.Notification.Application.Consumers
                     CommissionerUserId = msg.CommissionerUserId,
                     CreatedUtc = now,
                     CreatedBy = msg.CausationId
-                });
-                _logger.LogInformation("PickemGroup projection inserted. GroupId={GroupId}", msg.GroupId);
+                };
+                _dataContext.PickemGroups.Add(entity);
+
+                try
+                {
+                    await _dataContext.SaveChangesAsync(context.CancellationToken);
+                    _logger.LogInformation("PickemGroup projection inserted. GroupId={GroupId}", msg.GroupId);
+                    group = entity;
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // Race: another consumer inserted first. Detach our
+                    // orphan and fall through to the update path.
+                    _dataContext.Entry(entity).State = EntityState.Detached;
+                    group = await _dataContext.PickemGroups
+                        .FirstAsync(g => g.Id == msg.GroupId, context.CancellationToken);
+                    groupChanged = ApplyGroupUpdateIfChanged(group, msg, now);
+                }
             }
             else
             {
-                group.Name = msg.Name;
-                group.Sport = msg.Sport;
-                group.CommissionerUserId = msg.CommissionerUserId;
-                group.ModifiedUtc = now;
-                group.ModifiedBy = msg.CausationId;
-                _logger.LogInformation("PickemGroup projection updated. GroupId={GroupId}", msg.GroupId);
+                groupChanged = ApplyGroupUpdateIfChanged(group, msg, now);
             }
 
-            // Replace members: delete existing rows for this group, then
-            // insert the snapshot's set. Keeps the local roster a faithful
-            // mirror including removals upstream.
+            // ---- Members: set-equality check before replace.
             var existingMembers = await _dataContext.PickemGroupMembers
                 .Where(m => m.PickemGroupId == msg.GroupId)
                 .ToListAsync(context.CancellationToken);
-            _dataContext.PickemGroupMembers.RemoveRange(existingMembers);
 
-            foreach (var snapshot in msg.Members)
+            var existingSet = existingMembers
+                .Select(m => (m.UserId, m.Role))
+                .ToHashSet();
+            var snapshotSet = msg.Members
+                .Select(m => (m.UserId, m.Role))
+                .ToHashSet();
+
+            var membersChanged = !existingSet.SetEquals(snapshotSet);
+
+            if (membersChanged)
             {
-                _dataContext.PickemGroupMembers.Add(new PickemGroupMember
+                _dataContext.PickemGroupMembers.RemoveRange(existingMembers);
+                foreach (var snapshot in msg.Members)
                 {
-                    PickemGroupId = msg.GroupId,
-                    UserId = snapshot.UserId,
-                    Role = snapshot.Role,
-                    CreatedUtc = now,
-                    CreatedBy = msg.CausationId
-                });
+                    _dataContext.PickemGroupMembers.Add(new PickemGroupMember
+                    {
+                        PickemGroupId = msg.GroupId,
+                        UserId = snapshot.UserId,
+                        Role = snapshot.Role,
+                        CreatedUtc = now,
+                        CreatedBy = msg.CausationId
+                    });
+                }
             }
 
-            await _dataContext.SaveChangesAsync(context.CancellationToken);
+            if (groupChanged || membersChanged)
+            {
+                await _dataContext.SaveChangesAsync(context.CancellationToken);
+                _logger.LogInformation(
+                    "PickemGroup roster synced. GroupId={GroupId}, MemberCount={MemberCount}, GroupChanged={GroupChanged}, MembersChanged={MembersChanged}",
+                    msg.GroupId, msg.Members.Count, groupChanged, membersChanged);
+            }
+            else
+            {
+                _logger.LogDebug("PickemGroup projection unchanged. GroupId={GroupId}", msg.GroupId);
+            }
+        }
 
-            _logger.LogInformation(
-                "PickemGroup roster synced. GroupId={GroupId}, MemberCount={MemberCount}",
-                msg.GroupId, msg.Members.Count);
+        private static bool ApplyGroupUpdateIfChanged(PickemGroup group, PickemGroupDataPublished msg, DateTime now)
+        {
+            var changed =
+                group.Name != msg.Name
+                || group.Sport != msg.Sport
+                || group.CommissionerUserId != msg.CommissionerUserId;
+
+            if (!changed)
+                return false;
+
+            group.Name = msg.Name;
+            group.Sport = msg.Sport;
+            group.CommissionerUserId = msg.CommissionerUserId;
+            group.ModifiedUtc = now;
+            group.ModifiedBy = msg.CausationId;
+            return true;
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
         }
     }
 }

--- a/src/SportsData.Notification/Application/Consumers/UserDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserDataPublishedConsumer.cs
@@ -16,6 +16,20 @@ namespace SportsData.Notification.Application.Consumers
     /// and post-backfill steady-state updates all converge on the same row.
     ///
     /// <para>
+    /// Two specific idempotency properties:
+    /// <list type="bullet">
+    ///   <item><b>Race-safe insert.</b> Two concurrent consumers seeing
+    ///   "doesn't exist" can both try to insert. The PK-unique constraint
+    ///   catches the loser via <see cref="DbUpdateException"/>; we detach
+    ///   the orphan entity and fall through to the update path.</item>
+    ///   <item><b>No-op redelivery.</b> If the snapshot's business fields
+    ///   match what's already in the projection, we don't touch
+    ///   <c>ModifiedUtc</c>/<c>ModifiedBy</c> and skip the SaveChanges
+    ///   round-trip entirely.</item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>
     /// No notification side effects here — this consumer's job is purely to
     /// keep the local projection fresh. Whether a notification fires on
     /// user creation / update is the responsibility of a future
@@ -48,37 +62,68 @@ namespace SportsData.Notification.Application.Consumers
                 ["UserId"] = msg.UserId
             });
 
+            var normalizedTimezone = string.IsNullOrEmpty(msg.Timezone) ? null : msg.Timezone;
+            var now = _dateTimeProvider.UtcNow();
+
             var existing = await _dataContext.Users
                 .FirstOrDefaultAsync(u => u.Id == msg.UserId, context.CancellationToken);
 
-            var now = _dateTimeProvider.UtcNow();
-
             if (existing is null)
             {
-                _dataContext.Users.Add(new User
+                var entity = new User
                 {
                     Id = msg.UserId,
                     DisplayName = msg.DisplayName,
                     Email = msg.Email,
-                    Timezone = string.IsNullOrEmpty(msg.Timezone) ? null : msg.Timezone,
+                    Timezone = normalizedTimezone,
                     CreatedUtc = now,
                     CreatedBy = msg.CausationId
-                });
+                };
+                _dataContext.Users.Add(entity);
 
-                _logger.LogInformation("User projection inserted. UserId={UserId}", msg.UserId);
+                try
+                {
+                    await _dataContext.SaveChangesAsync(context.CancellationToken);
+                    _logger.LogInformation("User projection inserted. UserId={UserId}", msg.UserId);
+                    return;
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // Race: another consumer inserted first. Detach our orphan
+                    // and fall through to the update path.
+                    _dataContext.Entry(entity).State = EntityState.Detached;
+                    existing = await _dataContext.Users
+                        .FirstAsync(u => u.Id == msg.UserId, context.CancellationToken);
+                }
             }
-            else
+
+            // Update path — only touch Modified* if a business field actually
+            // changed. Repeated identical deliveries leave the row stable.
+            var changed =
+                existing.DisplayName != msg.DisplayName
+                || existing.Email != msg.Email
+                || existing.Timezone != normalizedTimezone;
+
+            if (!changed)
             {
-                existing.DisplayName = msg.DisplayName;
-                existing.Email = msg.Email;
-                existing.Timezone = string.IsNullOrEmpty(msg.Timezone) ? null : msg.Timezone;
-                existing.ModifiedUtc = now;
-                existing.ModifiedBy = msg.CausationId;
-
-                _logger.LogInformation("User projection updated. UserId={UserId}", msg.UserId);
+                _logger.LogDebug("User projection unchanged. UserId={UserId}", msg.UserId);
+                return;
             }
+
+            existing.DisplayName = msg.DisplayName;
+            existing.Email = msg.Email;
+            existing.Timezone = normalizedTimezone;
+            existing.ModifiedUtc = now;
+            existing.ModifiedBy = msg.CausationId;
 
             await _dataContext.SaveChangesAsync(context.CancellationToken);
+            _logger.LogInformation("User projection updated. UserId={UserId}", msg.UserId);
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
         }
     }
 }

--- a/src/SportsData.Notification/Application/Consumers/UserDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserDataPublishedConsumer.cs
@@ -1,0 +1,84 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// Upserts the local <see cref="User"/> projection from a backfill snapshot
+    /// (or any future per-user data event) published by the API. Idempotent
+    /// by design — repeated backfills, MassTransit at-least-once redelivery,
+    /// and post-backfill steady-state updates all converge on the same row.
+    ///
+    /// <para>
+    /// No notification side effects here — this consumer's job is purely to
+    /// keep the local projection fresh. Whether a notification fires on
+    /// user creation / update is the responsibility of a future
+    /// steady-state consumer (e.g. <c>UserCreated</c>), not this backfill
+    /// path.
+    /// </para>
+    /// </summary>
+    public class UserDataPublishedConsumer : IConsumer<UserDataPublished>
+    {
+        private readonly ILogger<UserDataPublishedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public UserDataPublishedConsumer(
+            ILogger<UserDataPublishedConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task Consume(ConsumeContext<UserDataPublished> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["UserId"] = msg.UserId
+            });
+
+            var existing = await _dataContext.Users
+                .FirstOrDefaultAsync(u => u.Id == msg.UserId, context.CancellationToken);
+
+            var now = _dateTimeProvider.UtcNow();
+
+            if (existing is null)
+            {
+                _dataContext.Users.Add(new User
+                {
+                    Id = msg.UserId,
+                    DisplayName = msg.DisplayName,
+                    Email = msg.Email,
+                    Timezone = string.IsNullOrEmpty(msg.Timezone) ? null : msg.Timezone,
+                    CreatedUtc = now,
+                    CreatedBy = msg.CausationId
+                });
+
+                _logger.LogInformation("User projection inserted. UserId={UserId}", msg.UserId);
+            }
+            else
+            {
+                existing.DisplayName = msg.DisplayName;
+                existing.Email = msg.Email;
+                existing.Timezone = string.IsNullOrEmpty(msg.Timezone) ? null : msg.Timezone;
+                existing.ModifiedUtc = now;
+                existing.ModifiedBy = msg.CausationId;
+
+                _logger.LogInformation("User projection updated. UserId={UserId}", msg.UserId);
+            }
+
+            await _dataContext.SaveChangesAsync(context.CancellationToken);
+        }
+    }
+}

--- a/src/SportsData.Notification/Controllers/BackfillController.cs
+++ b/src/SportsData.Notification/Controllers/BackfillController.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Infrastructure.Auth;
+
+namespace SportsData.Notification.Controllers
+{
+    /// <summary>
+    /// Operator-triggered endpoints that emit backfill request events. Each
+    /// endpoint is a thin shim: validate, publish the request event, return
+    /// 202. The actual per-entity fan-out happens on the API side (it owns
+    /// the source data), and the per-entity data events arrive back here on
+    /// Notification's own consumers.
+    ///
+    /// <para>
+    /// Protected by <see cref="ApiKeyAuthAttribute"/>. Not part of the
+    /// user-facing surface — Notification's regular routes (device
+    /// registration, preferences) authenticate via JWT like the rest of
+    /// the platform; the API-key gate is just for these admin operations.
+    /// </para>
+    /// </summary>
+    [ApiController]
+    [Route("admin/backfill")]
+    [ApiKeyAuth]
+    public class BackfillController : ControllerBase
+    {
+        private readonly ILogger<BackfillController> _logger;
+        private readonly IEventBus _eventBus;
+        private readonly IMessageDeliveryScope _deliveryScope;
+
+        public BackfillController(
+            ILogger<BackfillController> logger,
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope)
+        {
+            _logger = logger;
+            _eventBus = eventBus;
+            _deliveryScope = deliveryScope;
+        }
+
+        /// <summary>
+        /// Triggers a full backfill of the local <c>User</c> projection by
+        /// publishing <see cref="UsersRequested"/>. The API consumer responds
+        /// with one <c>UserDataPublished</c> per user, and Notification's
+        /// own <c>UserDataPublishedConsumer</c> upserts them locally.
+        /// </summary>
+        [HttpPost("users")]
+        public async Task<IActionResult> RequestUsers(CancellationToken cancellationToken)
+        {
+            var correlationId = Guid.NewGuid();
+
+            _logger.LogInformation(
+                "Publishing UsersRequested. CorrelationId={CorrelationId}",
+                correlationId);
+
+            // Direct publish — Notification has no DbContext write to bundle
+            // this with, and the bus-outbox isn't registered for this service.
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                await _eventBus.Publish(new UsersRequested(
+                        Sport.All,
+                        null,
+                        correlationId,
+                        Guid.NewGuid()),
+                    cancellationToken);
+            }
+
+            return Accepted(new { correlationId });
+        }
+    }
+}

--- a/src/SportsData.Notification/Controllers/BackfillController.cs
+++ b/src/SportsData.Notification/Controllers/BackfillController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Eventing.Events.Users;
 using SportsData.Notification.Infrastructure.Auth;
 
@@ -60,6 +61,36 @@ namespace SportsData.Notification.Controllers
             using (_deliveryScope.Use(DeliveryMode.Direct))
             {
                 await _eventBus.Publish(new UsersRequested(
+                        Sport.All,
+                        null,
+                        correlationId,
+                        Guid.NewGuid()),
+                    cancellationToken);
+            }
+
+            return Accepted(new { correlationId });
+        }
+
+        /// <summary>
+        /// Triggers a full backfill of the local <c>PickemGroup</c> +
+        /// <c>PickemGroupMember</c> projections by publishing
+        /// <see cref="PickemGroupsRequested"/>. The API consumer responds with
+        /// one bundled <c>PickemGroupDataPublished</c> per league (members
+        /// embedded in the payload), and Notification's own consumer
+        /// upserts each group + replaces its member roster.
+        /// </summary>
+        [HttpPost("pickemgroups")]
+        public async Task<IActionResult> RequestPickemGroups(CancellationToken cancellationToken)
+        {
+            var correlationId = Guid.NewGuid();
+
+            _logger.LogInformation(
+                "Publishing PickemGroupsRequested. CorrelationId={CorrelationId}",
+                correlationId);
+
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                await _eventBus.Publish(new PickemGroupsRequested(
                         Sport.All,
                         null,
                         correlationId,

--- a/src/SportsData.Notification/Infrastructure/Auth/ApiKeyAuthAttribute.cs
+++ b/src/SportsData.Notification/Infrastructure/Auth/ApiKeyAuthAttribute.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace SportsData.Notification.Infrastructure.Auth
+{
+    /// <summary>
+    /// Per-endpoint API-key auth filter for Notification's admin / backfill
+    /// surface. Reads the expected key from <c>CommonConfig:Notification:AdminApiKey</c>
+    /// at request time so a key rotation through Azure App Config takes effect
+    /// without a redeploy.
+    ///
+    /// <para>
+    /// Intentionally minimal: header-only (<c>X-Api-Key</c>), constant-time
+    /// comparison via <see cref="System.Security.Cryptography.CryptographicOperations.FixedTimeEquals"/>
+    /// to avoid timing-side-channel inference of the expected key, 401 on
+    /// missing/wrong, 500 if the server-side config slot is unset (refuse to
+    /// auto-pass with an unconfigured key — better to fail loud than silently
+    /// allow).
+    /// </para>
+    ///
+    /// <para>
+    /// Not a replacement for the JWT auth API uses for end-user routes.
+    /// Admin / backfill endpoints in Notification are operator-triggered
+    /// and don't have a user identity to authenticate against; an API key
+    /// is the right shape.
+    /// </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+    public class ApiKeyAuthAttribute : Attribute, IAsyncAuthorizationFilter
+    {
+        public const string HeaderName = "X-Api-Key";
+        public const string ConfigKey = "CommonConfig:Notification:AdminApiKey";
+
+        public Task OnAuthorizationAsync(AuthorizationFilterContext context)
+        {
+            if (!context.HttpContext.Request.Headers.TryGetValue(HeaderName, out var providedKey)
+                || string.IsNullOrWhiteSpace(providedKey))
+            {
+                context.Result = new UnauthorizedResult();
+                return Task.CompletedTask;
+            }
+
+            var config = context.HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+            var expectedKey = config[ConfigKey];
+
+            if (string.IsNullOrWhiteSpace(expectedKey))
+            {
+                // Refuse to auto-pass when the server has no key configured.
+                // Surfaces as 500 in logs so the operator knows the config is
+                // missing rather than silently letting any request through.
+                var logger = context.HttpContext.RequestServices
+                    .GetRequiredService<ILogger<ApiKeyAuthAttribute>>();
+                logger.LogError(
+                    "ApiKeyAuthAttribute rejected request: server config slot {ConfigKey} is unset.",
+                    ConfigKey);
+                context.Result = new StatusCodeResult(StatusCodes.Status500InternalServerError);
+                return Task.CompletedTask;
+            }
+
+            var providedBytes = System.Text.Encoding.UTF8.GetBytes(providedKey.ToString());
+            var expectedBytes = System.Text.Encoding.UTF8.GetBytes(expectedKey);
+
+            if (providedBytes.Length != expectedBytes.Length
+                || !System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(providedBytes, expectedBytes))
+            {
+                context.Result = new UnauthorizedResult();
+                return Task.CompletedTask;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -11,17 +11,22 @@ namespace SportsData.Notification.Infrastructure.Data
     /// job ids, audit log — and pushed everything else onto fat events.
     ///
     /// <para>
-    /// The <c>User</c> projection added here is a deliberate expansion of
-    /// that model for operational queries: the backfill chain
-    /// (<c>UsersRequested</c> → <c>UserDataPublished</c>) seeds it, and
-    /// future broadcast / commissioner-side flows that need to look up
-    /// users without round-tripping to API will read from it.
+    /// The <c>User</c>, <c>PickemGroup</c>, and <c>PickemGroupMember</c>
+    /// projections are deliberate expansions of that model for operational
+    /// queries: the backfill chains (<c>UsersRequested</c>/<c>UserDataPublished</c>
+    /// and <c>PickemGroupsRequested</c>/<c>PickemGroupDataPublished</c>) seed
+    /// them, and league-wide fan-out flows that need to look up entities
+    /// without round-tripping to API will read from them.
     /// </para>
     /// </summary>
     public class AppDataContext : DbContext
     {
         public AppDataContext(DbContextOptions<AppDataContext> options)
             : base(options) { }
+
+        public DbSet<PickemGroup> PickemGroups => Set<PickemGroup>();
+
+        public DbSet<PickemGroupMember> PickemGroupMembers => Set<PickemGroupMember>();
 
         public DbSet<User> Users => Set<User>();
 
@@ -62,6 +67,14 @@ namespace SportsData.Notification.Infrastructure.Data
             // insert race window that this constraint closes.
             modelBuilder.Entity<NotificationLog>()
                 .HasIndex(l => new { l.CorrelationId, l.UserId, l.Channel })
+                .IsUnique();
+
+            // League-wide fan-out is the dominant query against this join
+            // ("for every member of league X..."), so index on GroupId.
+            // Unique (PickemGroupId, UserId) catches duplicate memberships at
+            // the DB layer if a backfill ever races itself.
+            modelBuilder.Entity<PickemGroupMember>()
+                .HasIndex(m => new { m.PickemGroupId, m.UserId })
                 .IsUnique();
         }
     }

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -5,17 +5,25 @@ using SportsData.Notification.Infrastructure.Data.Entities;
 namespace SportsData.Notification.Infrastructure.Data
 {
     /// <summary>
-    /// Notification service's local read/write store. Per the design doc
-    /// (docs/architecture/notification-service-events-and-state.md §3),
-    /// Notification consumes fat events and projects only the state that
-    /// genuinely belongs to it: device tokens, user preferences, scheduled
-    /// job ids, and the audit log. It does NOT project User, League,
-    /// Membership, Contest, or Pick — those facts ride on the events.
+    /// Notification service's local read/write store. The original design
+    /// doc (docs/architecture/notification-service-events-and-state.md §3)
+    /// kept this to 4 tables — device tokens, user preferences, scheduled
+    /// job ids, audit log — and pushed everything else onto fat events.
+    ///
+    /// <para>
+    /// The <c>User</c> projection added here is a deliberate expansion of
+    /// that model for operational queries: the backfill chain
+    /// (<c>UsersRequested</c> → <c>UserDataPublished</c>) seeds it, and
+    /// future broadcast / commissioner-side flows that need to look up
+    /// users without round-tripping to API will read from it.
+    /// </para>
     /// </summary>
     public class AppDataContext : DbContext
     {
         public AppDataContext(DbContextOptions<AppDataContext> options)
             : base(options) { }
+
+        public DbSet<User> Users => Set<User>();
 
         public DbSet<UserDevice> UserDevices => Set<UserDevice>();
 

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroup.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroup.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Local read-side projection of API's PickemGroup. Seeded via the
+    /// PickemGroupsRequested → PickemGroupDataPublished backfill chain.
+    ///
+    /// <para>
+    /// Notification needs Name (notification copy: "You joined {Name}"),
+    /// Sport (so future per-sport notification logic can branch), and
+    /// CommissionerUserId (commissioner-side fan-out: "{NewMember} joined
+    /// your league").
+    /// </para>
+    /// </summary>
+    public class PickemGroup : CanonicalEntityBase<Guid>
+    {
+        [Required]
+        [MaxLength(200)]
+        public string Name { get; set; }
+
+        public Sport Sport { get; set; }
+
+        public Guid CommissionerUserId { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroupMember.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroupMember.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Membership join row — which users belong to which leagues. Drives
+    /// league-wide fan-out queries ("for every member of league X, look up
+    /// devices and dispatch"). Backfill consumer replaces all members for a
+    /// given GroupId on each PickemGroupDataPublished arrival, so repeated
+    /// backfills converge on the source-of-truth set.
+    /// </summary>
+    public class PickemGroupMember : CanonicalEntityBase<Guid>
+    {
+        public Guid PickemGroupId { get; set; }
+
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// "Commissioner" | "Member" (string form of API's LeagueRole). Avoid
+        /// taking a dependency on the API enum cross-service.
+        /// </summary>
+        [Required]
+        [MaxLength(32)]
+        public string Role { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/User.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/User.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Local read-side projection of the API's User aggregate. Notification
+    /// keeps a minimal copy of the fields it needs to render notification
+    /// copy (DisplayName for personalization, Email for the future email
+    /// channel, Timezone for time-formatted bodies).
+    ///
+    /// <para>
+    /// Populated via two paths: the one-off backfill (<c>UsersRequested</c>
+    /// → API publishes <c>UserDataPublished</c> per user) and any
+    /// steady-state user-lifecycle event that lands later. The consumer
+    /// upserts by <see cref="CanonicalEntityBase{T}.Id"/> = UserId so both
+    /// paths converge on the same row.
+    /// </para>
+    ///
+    /// <para>
+    /// FirebaseUid, IsAdmin, IsSynthetic, etc. live on the API's User entity
+    /// but are intentionally NOT projected here — Notification has no
+    /// authorization or identity-resolution responsibilities; those stay
+    /// in API.
+    /// </para>
+    /// </summary>
+    public class User : CanonicalEntityBase<Guid>
+    {
+        [Required]
+        [MaxLength(100)]
+        public string DisplayName { get; set; }
+
+        [Required]
+        [MaxLength(256)]
+        public string Email { get; set; }
+
+        [MaxLength(100)]
+        public string Timezone { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260624125453_AddUserProjection.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260624125453_AddUserProjection.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260624125453_AddUserProjection")]
+    partial class AddUserProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260624125453_AddUserProjection.cs
+++ b/src/SportsData.Notification/Migrations/20260624125453_AddUserProjection.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Timezone = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Users");
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260624134249_AddPickemGroupProjections.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260624134249_AddPickemGroupProjections.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260624134249_AddPickemGroupProjections")]
+    partial class AddPickemGroupProjections
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260624134249_AddPickemGroupProjections.cs
+++ b/src/SportsData.Notification/Migrations/20260624134249_AddPickemGroupProjections.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPickemGroupProjections : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PickemGroupMembers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PickemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Role = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PickemGroupMembers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PickemGroups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Sport = table.Column<int>(type: "integer", nullable: false),
+                    CommissionerUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PickemGroups", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PickemGroupMembers_PickemGroupId_UserId",
+                table: "PickemGroupMembers",
+                columns: new[] { "PickemGroupId", "UserId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PickemGroupMembers");
+
+            migrationBuilder.DropTable(
+                name: "PickemGroups");
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -38,6 +38,7 @@ namespace SportsData.Notification
                 typeof(PickemGroupCreatedConsumer),
                 typeof(PickemGroupMatchupCreatedConsumer),
                 typeof(PickemGroupMemberAddedConsumer),
+                typeof(UserDataPublishedConsumer),
                 typeof(UserPickScoredConsumer)
             ]);
 

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -36,6 +36,7 @@ namespace SportsData.Notification
             services.AddMessaging(config, [
                 typeof(ContestStartTimeUpdatedConsumer),
                 typeof(PickemGroupCreatedConsumer),
+                typeof(PickemGroupDataPublishedConsumer),
                 typeof(PickemGroupMatchupCreatedConsumer),
                 typeof(PickemGroupMemberAddedConsumer),
                 typeof(UserDataPublishedConsumer),


### PR DESCRIPTION
## Summary
Stands up the operator-triggered backfill chain so Notification can seed its local projections from API's source-of-truth tables. Two parallel flows, same shape, both gated by API-key on the Notification side.

| Flow | Trigger event | Response event | Local projection(s) |
|---|---|---|---|
| Users | \`UsersRequested\` | \`UserDataPublished\` (one per user) | \`User\` |
| PickemGroups | \`PickemGroupsRequested\` | \`PickemGroupDataPublished\` (one per league, members bundled) | \`PickemGroup\` + \`PickemGroupMember\` |

## Flow
1. Operator hits \`POST /admin/backfill/users\` or \`POST /admin/backfill/pickemgroups\` on Notification (API-key gated).
2. Notification publishes the request event.
3. API's responder consumer iterates its source table and publishes one snapshot per entity.
4. Notification's per-event consumer upserts each row.

## Bundle vs separate (members)
\`PickemGroupDataPublished\` carries members embedded as \`Members: [{UserId, Role}, ...]\`. Bundle was chosen over separate per-member events at solo-dev scale:
- Single event per league, atomic projection insert.
- Replace-members semantics: consumer deletes existing rows for the group, then inserts the snapshot's set — keeps the local roster a faithful mirror including removals upstream.
- Avoids the parent-before-child race that separate events would introduce.
- Trade-off: payload size grows with member count. Currently dozens of leagues × dozens of members = trivial. If leagues ever grow to thousands of members, revisit.

## New Core events
- **\`UsersRequested\`** + **\`UserDataPublished\`** — UserId, DisplayName, Email, Timezone.
- **\`PickemGroupsRequested\`** + **\`PickemGroupDataPublished\`** — GroupId, Name, Sport, CommissionerUserId, plus \`PickemGroupMemberSnapshot[]\` (UserId, Role-as-string to avoid cross-service enum coupling).

## Notification side
- New entities: \`User\`, \`PickemGroup\`, \`PickemGroupMember\` — deliberate expansions of the design-doc §3 four-table model. Documented inline in AppDataContext why.
- \`PickemGroupMember\` has unique \`(PickemGroupId, UserId)\` index — catches duplicate inserts at the DB layer if a backfill ever races itself.
- Two migrations: \`AddUserProjection\`, \`AddPickemGroupProjections\`.
- Two consumers: \`UserDataPublishedConsumer\` (upsert by UserId), \`PickemGroupDataPublishedConsumer\` (upsert by GroupId + replace member set).
- \`BackfillController\` exposes \`POST /admin/backfill/users\` and \`POST /admin/backfill/pickemgroups\`. Both return 202 with the CorrelationId for downstream trace correlation in Seq.
- \`ApiKeyAuthAttribute\` — first inbound API-key auth in the platform. Per-endpoint attribute. Reads expected key from \`CommonConfig:Notification:AdminApiKey\` at request time (rotation via Azure App Config without redeploy). Constant-time comparison. Refuses to auto-pass when the server config slot is unset.

## API side
- \`UsersRequestedConsumer\`: iterates Users, publishes per user via Direct delivery.
- \`PickemGroupsRequestedConsumer\`: iterates PickemGroups + Members with \`AsSplitQuery\` (avoids cartesian explosion), publishes one bundled event per league via Direct delivery.

## Out-of-band before this can run in prod
- Set \`CommonConfig:Notification:AdminApiKey\` in Azure App Config (Prod.All) — otherwise the endpoints return 500.
- Shovels from API broker to Notification broker for \`UserDataPublished\` and \`PickemGroupDataPublished\`.

## Test plan
- [x] \`dotnet build src/SportsData.Api/SportsData.Api.csproj\` — 0/0
- [x] \`dotnet build src/SportsData.Notification/SportsData.Notification.csproj\` — 0/0
- [ ] Local: apply migrations \`AddUserProjection\` + \`AddPickemGroupProjections\` against \`sdNotification.All\`
- [ ] Local: \`POST /admin/backfill/users\` with valid X-Api-Key → 202; Users projection populated
- [ ] Local: \`POST /admin/backfill/pickemgroups\` with valid X-Api-Key → 202; PickemGroups + PickemGroupMembers projections populated; replace-members semantics verified by removing a member from API and re-running
- [ ] Local: missing/wrong X-Api-Key → 401; config slot unset → 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API-key-protected admin backfill endpoints (`admin/backfill/users` and `admin/backfill/pickemgroups`) that trigger full data syncs and return a correlation id.
  * Enabled backfill event publishing/consumption to project per-user and per-pickem-group snapshots into the notification read models.
  * Introduced new notification projection tables for users and pickem groups (including group members).

* **Bug Fixes**
  * Improved idempotent upsert/update behavior so repeated backfills don’t create duplicates.
  * Added concurrency-safe handling to gracefully resolve unique-constraint conflicts during simultaneous member updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->