### PR TITLE
fix(producer): two bugs that stranded yesterday's stuck-Live MLB contest

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -246,8 +246,24 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
 
         switch (status.Type.Name)
         {
+            // STATUS_RAIN_DELAY and STATUS_DELAYED share the SCHEDULED branch's
+            // wait-and-poll semantics: ESPN will eventually flip the status
+            // back to STATUS_IN_PROGRESS (resume) or STATUS_FINAL (called).
+            // Falling to the default abort here would orphan the live pipeline
+            // — confirmed by the 2026-06-24 MLB stuck-Final incident where
+            // a rain-delayed game's streamer aborted at game start, no live
+            // sourcing ever attached, and the contest stuck at Live in the UI.
+            //
+            // STATUS_POSTPONED and STATUS_SUSPENDED are deliberately NOT folded
+            // in: postponed games typically reschedule to a different day, and
+            // suspended games may resume same-day or different-day. Waiting
+            // the full MaxStreamDuration on those would be wrong — better to
+            // abort and let the next-day cron re-pick them up. Add them here
+            // once we observe a case that justifies the wait semantics.
             case "STATUS_SCHEDULED":
-                _logger.LogInformation("Competition is scheduled. Waiting for competition to start...");
+            case "STATUS_RAIN_DELAY":
+            case "STATUS_DELAYED":
+                _logger.LogInformation("Competition status {Status}; waiting for next live transition...", status.Type.Name);
                 var startOutcome = await WaitForLiveStartAsync(statusUri, cancellationToken);
                 switch (startOutcome)
                 {

--- a/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
+++ b/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
@@ -155,7 +155,7 @@ public class CompetitorScoreUpdatedConsumerHandler : ICompetitorScoreUpdatedCons
                 .Select(x => x.StatusTypeName)
                 .FirstOrDefaultAsync();
 
-            if (statusTypeName == "STATUS_FINAL")
+            if (statusTypeName == ContestStatusValues.FinalRaw)
             {
                 var cmd = new EnrichContestCommand(contest.Id, evt.CorrelationId);
                 _backgroundJobProvider.Enqueue<IEnrichContests>(p => p.Process(cmd));

--- a/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
+++ b/src/SportsData.Producer/Application/Consumers/CompetitorScoreUpdatedConsumerHandler.cs
@@ -3,6 +3,8 @@ using Microsoft.EntityFrameworkCore;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Contests;
 using SportsData.Producer.Infrastructure.Data.Common;
 
 namespace SportsData.Producer.Application.Consumers;
@@ -19,6 +21,14 @@ public interface ICompetitorScoreUpdatedConsumerHandler
 ///
 /// Spawned by CompetitorScoreUpdatedConsumer (Ingest) and executed on Worker
 /// pods so Ingest stays thin.
+///
+/// <para>
+/// Also acts as the recovery trigger for stuck-Final contests: if scores
+/// arrive AFTER the canonical status flipped to STATUS_FINAL but enrichment
+/// hadn't yet completed (e.g., enrichment ran early and saw 0-0, then
+/// deferred), this handler re-enqueues <see cref="EnrichContestCommand"/>.
+/// See docs/ for the 2026-06-24 stuck-Final MLB incident.
+/// </para>
 /// </summary>
 public class CompetitorScoreUpdatedConsumerHandler : ICompetitorScoreUpdatedConsumerHandler
 {
@@ -26,17 +36,20 @@ public class CompetitorScoreUpdatedConsumerHandler : ICompetitorScoreUpdatedCons
     private readonly TeamSportDataContext _dataContext;
     private readonly IEventBus _eventBus;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IProvideBackgroundJobs _backgroundJobProvider;
 
     public CompetitorScoreUpdatedConsumerHandler(
         ILogger<CompetitorScoreUpdatedConsumerHandler> logger,
         TeamSportDataContext dataContext,
         IEventBus eventBus,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        IProvideBackgroundJobs backgroundJobProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
         _eventBus = eventBus;
         _dateTimeProvider = dateTimeProvider;
+        _backgroundJobProvider = backgroundJobProvider;
     }
 
     public async Task Process(CompetitorScoreUpdated evt)
@@ -122,6 +135,36 @@ public class CompetitorScoreUpdatedConsumerHandler : ICompetitorScoreUpdatedCons
         ));
 
         await _dataContext.SaveChangesAsync();
+
+        // Stuck-Final recovery: if the contest already saw STATUS_FINAL on
+        // the canonical status row but FinalizedUtc never got stamped,
+        // enrichment must have deferred (e.g., 0-0 implausible-final guard
+        // before scores were sourced). The score we just persisted is the
+        // missing input — re-enqueue enrichment now. Idempotent at the
+        // enrichment side via the contestAlreadyFinalized && no-unfinalized-
+        // odds short-circuit, so multiple score arrivals don't churn.
+        if (contest.FinalizedUtc is null)
+        {
+            var statusTypeName = await _dataContext.CompetitionStatuses
+                .AsNoTracking()
+                .Join(_dataContext.Competitions,
+                      s => s.CompetitionId,
+                      c => c.Id,
+                      (s, c) => new { s.StatusTypeName, c.ContestId })
+                .Where(x => x.ContestId == contest.Id)
+                .Select(x => x.StatusTypeName)
+                .FirstOrDefaultAsync();
+
+            if (statusTypeName == "STATUS_FINAL")
+            {
+                var cmd = new EnrichContestCommand(contest.Id, evt.CorrelationId);
+                _backgroundJobProvider.Enqueue<IEnrichContests>(p => p.Process(cmd));
+
+                _logger.LogInformation(
+                    "Re-enqueued EnrichContestCommand — contest status is STATUS_FINAL but FinalizedUtc is null. ContestId={ContestId}, CorrelationId={CorrelationId}",
+                    contest.Id, evt.CorrelationId);
+            }
+        }
 
         // Completion marker only. The event carries one team's score; the
         // mid-flow "Updated HomeScore. HomeScore=X" / "Updated AwayScore.

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/CompetitorScoreUpdatedConsumerHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/CompetitorScoreUpdatedConsumerHandlerTests.cs
@@ -21,6 +21,11 @@ namespace SportsData.Producer.Tests.Unit.Application.Consumers;
 public class CompetitorScoreUpdatedConsumerHandlerTests
     : ProducerTestBase<CompetitorScoreUpdatedConsumerHandler>
 {
+    // Deterministic seed timestamp for entity CreatedUtc / Date columns —
+    // never asserted against, just satisfies NOT NULL. Avoids DateTime.UtcNow
+    // in tests per the project rule.
+    private static readonly DateTime FixedTestNow = new(2026, 6, 24, 18, 0, 0, DateTimeKind.Utc);
+
     private static readonly Guid HomeFranchiseSeasonId = Guid.NewGuid();
     private static readonly Guid AwayFranchiseSeasonId = Guid.NewGuid();
 
@@ -268,9 +273,9 @@ public class CompetitorScoreUpdatedConsumerHandlerTests
         {
             Id = competitionId,
             ContestId = contestId,
-            Date = DateTime.UtcNow,
+            Date = FixedTestNow,
             CreatedBy = Guid.Empty,
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = FixedTestNow
         });
         FootballDataContext.CompetitionStatuses.Add(new FootballCompetitionStatus
         {
@@ -282,7 +287,7 @@ public class CompetitorScoreUpdatedConsumerHandlerTests
             StatusDescription = statusTypeName,
             StatusDetail = statusTypeName,
             CreatedBy = Guid.Empty,
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = FixedTestNow
         });
         await FootballDataContext.SaveChangesAsync();
     }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/CompetitorScoreUpdatedConsumerHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Consumers/CompetitorScoreUpdatedConsumerHandlerTests.cs
@@ -1,3 +1,5 @@
+using System.Linq.Expressions;
+
 using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
@@ -7,7 +9,9 @@ using Moq;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Processing;
 using SportsData.Producer.Application.Consumers;
+using SportsData.Producer.Application.Contests;
 using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 using Xunit;
@@ -177,7 +181,68 @@ public class CompetitorScoreUpdatedConsumerHandlerTests
                 Times.Once);
     }
 
-    private async Task SeedContest(Guid contestId, int? homeScore = null, int? awayScore = null)
+    [Fact]
+    public async Task Process_WhenContestFinalAndFinalizedUtcIsNull_ReEnqueuesEnrichContestCommand()
+    {
+        // Stuck-Final recovery: ContestEnrichment ran early (e.g. saw 0-0,
+        // deferred), then scores arrived later. Score handler should re-kick
+        // enrichment so the deferred contest finalizes against the now-correct
+        // DB state. See 2026-06-24 MLB stuck-Final incident.
+        var contestId = Guid.NewGuid();
+        await SeedContest(contestId);
+        await SeedCompetitionWithStatus(contestId, statusTypeName: "STATUS_FINAL");
+
+        var evt = BuildEvent(contestId, franchiseSeasonId: HomeFranchiseSeasonId, score: 4);
+
+        await _sut.Process(evt);
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Enqueue<IEnrichContests>(
+                It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task Process_WhenContestAlreadyFinalized_DoesNotReEnqueueEnrichContestCommand()
+    {
+        // FinalizedUtc is already set — enrichment ran to completion. No
+        // reason to re-fire it on subsequent score-doc redelivery / late
+        // odds-only score writes.
+        var contestId = Guid.NewGuid();
+        await SeedContest(contestId, finalizedUtc: new DateTime(2026, 6, 24, 23, 0, 0, DateTimeKind.Utc));
+        await SeedCompetitionWithStatus(contestId, statusTypeName: "STATUS_FINAL");
+
+        var evt = BuildEvent(contestId, franchiseSeasonId: HomeFranchiseSeasonId, score: 4);
+
+        await _sut.Process(evt);
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Enqueue<IEnrichContests>(
+                It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenStatusIsLiveAndNotFinalized_DoesNotReEnqueueEnrichContestCommand()
+    {
+        // Steady-state live-game score update — status is STATUS_IN_PROGRESS
+        // (not FINAL), FinalizedUtc is null. Re-kicking enrichment here would
+        // churn the entire game.
+        var contestId = Guid.NewGuid();
+        await SeedContest(contestId);
+        await SeedCompetitionWithStatus(contestId, statusTypeName: "STATUS_IN_PROGRESS");
+
+        var evt = BuildEvent(contestId, franchiseSeasonId: HomeFranchiseSeasonId, score: 7);
+
+        await _sut.Process(evt);
+
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Enqueue<IEnrichContests>(
+                It.IsAny<Expression<Func<IEnrichContests, Task>>>()),
+                Times.Never);
+    }
+
+    private async Task SeedContest(Guid contestId, int? homeScore = null, int? awayScore = null, DateTime? finalizedUtc = null)
     {
         FootballDataContext.Contests.Add(new FootballContest
         {
@@ -190,7 +255,34 @@ public class CompetitorScoreUpdatedConsumerHandlerTests
             HomeTeamFranchiseSeasonId = HomeFranchiseSeasonId,
             AwayTeamFranchiseSeasonId = AwayFranchiseSeasonId,
             HomeScore = homeScore,
-            AwayScore = awayScore
+            AwayScore = awayScore,
+            FinalizedUtc = finalizedUtc
+        });
+        await FootballDataContext.SaveChangesAsync();
+    }
+
+    private async Task SeedCompetitionWithStatus(Guid contestId, string statusTypeName)
+    {
+        var competitionId = Guid.NewGuid();
+        FootballDataContext.Competitions.Add(new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            Date = DateTime.UtcNow,
+            CreatedBy = Guid.Empty,
+            CreatedUtc = DateTime.UtcNow
+        });
+        FootballDataContext.CompetitionStatuses.Add(new FootballCompetitionStatus
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            StatusTypeName = statusTypeName,
+            StatusTypeId = "0",
+            StatusState = "post",
+            StatusDescription = statusTypeName,
+            StatusDetail = statusTypeName,
+            CreatedBy = Guid.Empty,
+            CreatedUtc = DateTime.UtcNow
         });
         await FootballDataContext.SaveChangesAsync();
     }


### PR DESCRIPTION
## Background
Yesterday (2026-06-24) one of 15 MLB games got stuck showing **Live** in the UI even after going final on ESPN. Two others went **Final in UI but not in the backend** (no picks scored). Investigation traced to two distinct architectural bugs that compounded on the worst-case contest \`2d86e408-b5c8-b9eb-cbab-f959b4da1c7c\`.

## Bug A — \`CompetitionStreamerBase\` aborts on \`STATUS_RAIN_DELAY\`
**Where:** \`CompetitionStreamerBase.cs:305-310\` — the \`default\` case on the status switch flips the stream to \`Failed\` for any unknown status string.

**What happened:** Streamer fired at game start 18:00:15 UTC, hit \`STATUS_RAIN_DELAY\`, aborted 330ms in. No streamer ever re-attached. Game went through Delay → Resume → Final with zero live polling — no score docs, no situation docs, no play docs sourced live.

**Fix:** Route \`STATUS_RAIN_DELAY\` and \`STATUS_DELAYED\` into the existing \`STATUS_SCHEDULED\` branch's \`WaitForLiveStartAsync\` wait-and-poll loop. On resume → \`StartDetected\` → continue normally. On game-called → \`AlreadyFinal\` publishes \`ContestCompleted\`. Explicitly NOT folding in \`STATUS_POSTPONED\` / \`STATUS_SUSPENDED\` — those typically reschedule to a different day and shouldn't burn \`MaxStreamDuration\` waiting.

## Bug B — Enrichment defer is terminal; \`CompetitorScoreUpdated\` didn't re-kick
**Where:** \`BaseballContestEnrichmentProcessor.cs:227-233\` — \"implausible final\" guard returns without scheduling any retry. \`CompetitorScoreUpdatedConsumerHandler\` has no path to \`EnrichContestCommand\`.

**What happened:** Status processor fired \`ContestCompleted\` (defensive) → SignalR \`Final\`. Enrichment ran 33s later, saw \`AwayMax=0, HomeMax=0\` (real scores hadn't been sourced because of Bug A), deferred terminal. Real scores landed 71min later via batch sourcing — but nothing re-fired enrichment. Contest sits with \`Status=FINAL\`, scores correct, \`FinalizedUtc=null\`, \`ContestFinalized\` never published, picks never scored.

**Fix:** In \`CompetitorScoreUpdatedConsumerHandler\` after the score is persisted, if \`contest.FinalizedUtc == null\` AND the competition's status row is \`STATUS_FINAL\`, enqueue \`EnrichContestCommand\`. The enrichment processor's \`contestAlreadyFinalized && unfinalizedOdds.Count == 0\` short-circuit makes multiple kicks idempotent. Status gate filters out live-game score updates so no churn during normal play.

This second fix also covers the **2 other stuck games** (Final-in-UI-but-not-backend) — even without a rain delay, any race between enrichment running and scores landing tripped Bug B. They'll auto-recover on the next score-doc redelivery or via the daily \`ContestEnrichmentJob\` backstop.

## Recovery for the stranded contest
DB now has correct 4-3 scores and \`STATUS_FINAL\`. Manually enqueue \`EnrichContestCommand\` for ContestId \`2d86e408-…\` and enrichment will finalize it on first attempt.

## Tests
- **3 new tests** on \`CompetitorScoreUpdatedConsumerHandler\` covering the re-enqueue gates:
  - Final + \`FinalizedUtc=null\` → \`Enqueue<IEnrichContests>\` Times.Once
  - Already finalized → Times.Never
  - Status \`STATUS_IN_PROGRESS\` → Times.Never
- **Fix #2 deliberately not tested.** Two case-label additions to a switch; existing \`BaseballCompetitionStreamerTests\` covers \`GetPollingTargets\`, not \`ExecuteAsync\`'s HTTP-driven status routing. Test would require introducing \`HttpClient\` mocking scaffolding that doesn't exist yet — skipping per established pattern (similar judgment to #461 shipping FCM dispatch without tests).
- Full Producer suite: **480/480** passing (was 477; +3 new).

## Test plan
- [x] \`dotnet build src/SportsData.Producer\` — 0/0
- [x] \`dotnet test test/unit/SportsData.Producer.Tests.Unit\` — 480 passed / 0 failed
- [ ] Manual: enqueue \`EnrichContestCommand\` for the stranded MLB contest, observe \`ContestFinalized\` published + picks scored
- [ ] Watch next rain-delayed MLB game for streamer routing through the wait branch instead of aborting
- [ ] Watch any future stuck-Final game for auto-recovery via score-doc → re-enqueue path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live-status handling so rain-delayed and delayed competitions now follow the same waiting flow as scheduled ones.
  * Added “stuck-final” recovery to re-enqueue contest enrichment when a contest is final but not fully finalized.
  * Avoided recovery when contests are already finalized or when they’re still in progress.
* **Tests**
  * Expanded unit coverage for re-enqueue vs. no-action scenarios, including richer test seeding and deterministic time setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->