### PR TITLE
feat(notification): personalize push body via local PickemGroup projection

### DIFF
--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMemberAddedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMemberAddedConsumer.cs
@@ -128,14 +128,27 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // 2. Send welcome push. Body stays generic until the fat-payload
-            // pass adds LeagueName + JoinedDisplayName to the event.
-            const string title = "Welcome";
-            const string body = "You've joined a new league.";
+            // 2. Send welcome push. League name comes from the local
+            // PickemGroup projection (seeded by the backfill chain). When the
+            // projection is missing — Notification booted before backfill ran,
+            // or the league is brand-new and the projection hasn't caught up —
+            // fall back to the unscoped copy.
+            var leagueName = await _dataContext.PickemGroups
+                .AsNoTracking()
+                .Where(g => g.Id == msg.GroupId)
+                .Select(g => g.Name)
+                .FirstOrDefaultAsync();
 
-            // 3. Commissioner-side notification is deferred — the event
-            // doesn't carry CommissionerUserId today. Once fattened, repeat
-            // the prefs + device lookup against the commissioner here.
+            const string title = "Welcome";
+            var body = leagueName is not null
+                ? $"You've joined {leagueName}!"
+                : "You've joined a new league.";
+
+            // 3. Commissioner-side notification is deferred. We now have
+            // CommissionerUserId locally via the PickemGroup projection — the
+            // remaining missing piece is the joining user's DisplayName lookup
+            // and a second dispatch loop against the commissioner's prefs +
+            // devices. Layered in as a follow-up.
 
             var successCount = 0;
             var failureReasons = new List<string>();

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -128,10 +128,21 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // Body composition needs the team-name fields off the event —
-            // until the fat-payload pass lands, fall back to generic copy.
+            // Body personalization via the local PickemGroup projection (seeded
+            // by the PickemGroupsRequested → PickemGroupDataPublished backfill
+            // chain). When the projection is missing — Notification booted
+            // before the backfill ran, or the league is brand-new and the
+            // projection hasn't caught up — fall back to the unscoped copy.
+            // Team names still ride on the event (nullable on the contract)
+            // and are absent when the publisher hasn't fattened them yet.
+            var leagueName = await _dataContext.PickemGroups
+                .AsNoTracking()
+                .Where(g => g.Id == msg.LeagueId)
+                .Select(g => g.Name)
+                .FirstOrDefaultAsync();
+
             var title = msg.IsCorrect == true ? "Nice pick!" : "Tough loss";
-            var body = ComposeBody(msg);
+            var body = ComposeBody(msg, leagueName);
 
             // Per-device dispatch. Single-token send rather than multicast
             // because v1's IPushNotificationSender surface is one-at-a-time;
@@ -173,19 +184,27 @@ namespace SportsData.Notification.Application.Consumers
             await _dataContext.SaveChangesAsync();
         }
 
-        private static string ComposeBody(UserPickScored msg)
+        private static string ComposeBody(UserPickScored msg, string leagueName)
         {
-            // Fat-payload fields not yet populated by the publisher fall back
-            // to a generic line. Once AwayName/HomeName/PickValue land, swap
-            // in: "{PickValue} {Won/Lost} — final {AwayName} {AwayScore} @ {HomeName} {HomeScore}"
-            if (msg.AwayName is not null && msg.HomeName is not null)
-            {
-                return $"Final: {msg.AwayName} {msg.AwayScore} @ {msg.HomeName} {msg.HomeScore}";
-            }
+            // Four shapes by what we have. League name comes from the local
+            // projection; team names are nullable on the event payload until
+            // publisher-side fattening lands (FranchiseSeason joins).
+            var outcome = msg.IsCorrect == true ? "Your pick won." : "Your pick lost.";
+            var scoreLine = $"Final {msg.AwayScore}–{msg.HomeScore}.";
 
-            return msg.IsCorrect == true
-                ? $"Your pick won. Final {msg.AwayScore}–{msg.HomeScore}."
-                : $"Your pick lost. Final {msg.AwayScore}–{msg.HomeScore}.";
+            var haveTeams = msg.AwayName is not null && msg.HomeName is not null;
+            var teamLine = haveTeams
+                ? $"{msg.AwayName} {msg.AwayScore} @ {msg.HomeName} {msg.HomeScore}"
+                : null;
+
+            if (leagueName is not null && haveTeams)
+                return $"{leagueName}: {outcome} {teamLine}.";
+            if (leagueName is not null)
+                return $"{leagueName}: {outcome} {scoreLine}";
+            if (haveTeams)
+                return $"Final: {teamLine}";
+
+            return $"{outcome} {scoreLine}";
         }
 
         private static string ComposeFailureReason(List<string> failureReasons)


### PR DESCRIPTION
## Summary
With the backfill chain landed (#462), Notification has \`User\` + \`PickemGroup\` + \`PickemGroupMember\` projections locally. This PR starts cashing in on that: consumers \`JOIN\` against the local projection at dispatch time instead of waiting on publisher-side fattening of events.

First pass touches the two active consumers — \`UserPickScoredConsumer\` and \`PickemGroupMemberAddedConsumer\` — and adds the league name into the FCM body. Team names (\`AwayName\` / \`HomeName\`) and \`PickValue\` still ride on the event as nullable contract fields and remain absent until \`FranchiseSeason\` either rides on the event or gets its own backfill.

## Changes

**\`UserPickScoredConsumer\`** — \`ComposeBody\` now handles four shapes:

| Have | Shape |
|---|---|
| League + teams | \`{LeagueName}: Your pick won. {Away} {a} @ {Home} {h}.\` |
| League only | \`{LeagueName}: Your pick won. Final {a}–{h}.\` |
| Teams only | \`Final: {Away} {a} @ {Home} {h}\` |
| Nothing | \`Your pick won. Final {a}–{h}.\` (existing fallback) |

**\`PickemGroupMemberAddedConsumer\`** — body is now \`""You've joined {LeagueName}!""\` when the local projection has the league, falls back to \`""You've joined a new league.""\` when missing (Notification booted before backfill ran, or league newer than the most recent backfill run).

Title stays \`""Welcome""\` — short titles read better in FCM banners.

## Why no tests

The Notification test project is a skeleton (one placeholder \`DevOpsTests.cs\`, no fixture infrastructure). Building \`ProducerTestBase\`-equivalent scaffolding for in-memory \`AppDataContext\` + AutoMock fixtures is non-trivial scope for a body-refresh PR. **Test infra build-out is the natural next follow-up** — once it lands, retrofitting tests for the four ComposeBody shapes + projection-missing fallback is trivial.

## Out of scope (follow-ups)

- Commissioner-side notification on membership. We now have \`CommissionerUserId\` locally; remaining missing piece is the joining-user \`DisplayName\` lookup + second dispatch loop.
- Team names on \`UserPickScored\`. Either fattening the publisher with \`FranchiseSeason\` joins or a third backfill chain for \`FranchiseSeason\`.

## Test plan
- [x] \`dotnet build src/SportsData.Notification\` — 0/0
- [ ] Local: trigger a UserPickScored against a backfilled league → observe body with league name; trigger against an unknown league → observe fallback body
- [ ] Local: trigger a PickemGroupMemberAdded against a backfilled league → \`""You've joined {LeagueName}!""\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications now include the league name when available, making messages more personalized.
  * Join notifications now say “You’ve joined {leagueName}!” when the league can be identified.

* **Bug Fixes**
  * Improved fallback messaging when league details are unavailable.
  * Enhanced win/loss notification text to better handle missing team names and still show a clear result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->