### PR TITLE
feat(notification): Phase 2b — Hangfire client + server

### DIFF
--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -4,6 +4,7 @@ using Google.Apis.Auth.OAuth2;
 
 using SportsData.Core.Common;
 using SportsData.Core.DependencyInjection;
+using SportsData.Core.Processing;
 using SportsData.Notification.Application.Consumers;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Notifications;
@@ -81,6 +82,17 @@ namespace SportsData.Notification
                 Console.WriteLine("WARN: CommonConfig:Firebase:ProjectId is not set; registering NoOpPushNotificationSender. FCM dispatches will no-op.");
                 services.AddScoped<IPushNotificationSender, NoOpPushNotificationSender>();
             }
+
+            // Hangfire — Notification hosts BOTH client (consumers schedule
+            // reminder dispatches) and server (those scheduled jobs run in-pod).
+            // Storage lives in its own database sdNotification.{mode}.Hangfire
+            // per the established AddHangfire helper convention; the DB must be
+            // pre-created (see PR description for the one-time provisioning
+            // step). No dashboard mounted — production dashboards aggregate
+            // via SportsData.JobsDashboard at jobs.sportdeets.com behind basic
+            // auth, per the convention reasserted in #463.
+            services.AddHangfire(config, builder.Environment.ApplicationName, mode);
+            services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
 
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);


### PR DESCRIPTION
## Summary
Wires Hangfire into Notification so consumers can schedule reminder dispatches and the same pod runs them. Prereq for Phase 2c (pick deadline reminders) and 2d (kickoff reminders) — pure infrastructure, no behavior change yet.

## Changes
- \`services.AddHangfire(config, appName, mode)\` — uses the same Core helper Producer + API use. Storage targets \`sdNotification.{mode}.Hangfire\`.
- \`services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>()\` — consumer-facing abstraction over \`IBackgroundJobClient\`.
- Both client and server registered in-process. No role split — Notification is a single-deployment service; the pod that consumes the trigger event is the same pod that fires the scheduled reminder.
- **No dashboard wired.** Production dashboards aggregate via \`SportsData.JobsDashboard\` at \`jobs.sportdeets.com\` behind basic auth — same convention #463 just reasserted on API.
- **No recurring jobs yet.** \`ConfigureHangfireJobs\` gets created in Phase 2c when there's something to schedule on a cron.

## Out-of-band prerequisite ⚠️
The \`sdNotification.{mode}.Hangfire\` database must exist in PostgreSQL before the pod boots. \`AddHangfire\` auto-creates the Hangfire schema on first connect but does NOT create the database itself (consistent with how Producer + API treat their Hangfire DBs).

**Local dev:** \`createdb sdNotification.All.Hangfire\` before \`docker-compose up sd-notification\`.

**Prod:** add the database manually on \`sdprod-data-0\` before deploying this PR.

## Test plan
- [x] \`dotnet build src/SportsData.Notification\` — 0/0
- [ ] Local: create \`sdNotification.All.Hangfire\` DB, boot Notification, verify Hangfire schema auto-creates on first connect, verify pod starts cleanly with no recurring jobs scheduled
- [ ] Local: smoke-test \`IProvideBackgroundJobs.Enqueue\` from a debugger / one-shot endpoint — verify the job lands in the Hangfire DB and the in-pod server picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background job scheduling and execution support for notifications.
  * Registered a background job provider so notification jobs can be handled automatically.
  * Configured job storage using the app’s existing environment-based settings convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->