### PR TITLE
feat(notification): Phase 2c-prereq — PickemGroupMatchup projection + backfill chain

### DIFF
--- a/src/SportsData.Api/Application/Events/PickemGroupMatchupsRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/PickemGroupMatchupsRequestedConsumer.cs
@@ -1,0 +1,120 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
+
+namespace SportsData.Api.Application.Events
+{
+    /// <summary>
+    /// Backfill responder for the Notification service's local matchup
+    /// projection. Iterates <c>PickemGroupMatchup</c> filtered to future
+    /// games only (<c>StartDateUtc &gt; UtcNow</c>) and emits one
+    /// <see cref="PickemGroupMatchupDataPublished"/> per row.
+    ///
+    /// <para>
+    /// Read-only on the API side; publishes via
+    /// <see cref="IMessageDeliveryScope"/> Direct mode + PublishBatch — same
+    /// pattern as <c>UsersRequestedConsumer</c> /
+    /// <c>PickemGroupsRequestedConsumer</c>. PublishBatch bypasses
+    /// EventBus.Publish's per-call 1-second delay (the "give consumers time
+    /// to commit" hack), which would be fatal for a wide fan-out.
+    /// </para>
+    ///
+    /// <para>
+    /// Past matchups are intentionally excluded — picks have locked, no
+    /// reminder is meaningful, and republishing the entire history would
+    /// flood Rabbit with events for events.
+    /// </para>
+    /// </summary>
+    public class PickemGroupMatchupsRequestedConsumer : IConsumer<PickemGroupMatchupsRequested>
+    {
+        private readonly ILogger<PickemGroupMatchupsRequestedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IEventBus _eventBus;
+        private readonly IMessageDeliveryScope _deliveryScope;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public PickemGroupMatchupsRequestedConsumer(
+            ILogger<PickemGroupMatchupsRequestedConsumer> logger,
+            AppDataContext dataContext,
+            IEventBus eventBus,
+            IMessageDeliveryScope deliveryScope,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _eventBus = eventBus;
+            _deliveryScope = deliveryScope;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task Consume(ConsumeContext<PickemGroupMatchupsRequested> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["Sport"] = msg.Sport
+            });
+
+            var now = _dateTimeProvider.UtcNow();
+
+            // PickemGroupMatchup carries Sport via its parent PickemGroup —
+            // join through to filter so Sport.All requests fan-out cleanly
+            // and per-sport requests don't return foreign data.
+            var query = _dataContext.PickemGroupMatchups
+                .AsNoTracking()
+                .Join(_dataContext.PickemGroups,
+                      m => m.GroupId,
+                      g => g.Id,
+                      (m, g) => new { Matchup = m, g.Sport })
+                .Where(x => x.Matchup.StartDateUtc > now);
+
+            if (msg.Sport != Sport.All)
+            {
+                query = query.Where(x => x.Sport == msg.Sport);
+            }
+
+            var matchups = await query
+                .Select(x => new
+                {
+                    x.Matchup.GroupId,
+                    x.Matchup.ContestId,
+                    x.Matchup.StartDateUtc,
+                    x.Matchup.SeasonYear,
+                    x.Matchup.SeasonWeek,
+                    x.Sport
+                })
+                .ToListAsync(context.CancellationToken);
+
+            _logger.LogInformation(
+                "PickemGroupMatchupsRequested received; publishing PickemGroupMatchupDataPublished for {Count} future matchups.",
+                matchups.Count);
+
+            var events = matchups
+                .Select(m => new PickemGroupMatchupDataPublished(
+                    m.GroupId,
+                    m.ContestId,
+                    m.StartDateUtc,
+                    m.SeasonWeek,
+                    m.Sport,
+                    m.SeasonYear,
+                    msg.CorrelationId,
+                    Guid.NewGuid()))
+                .ToList();
+
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                await _eventBus.PublishBatch(events, context.CancellationToken);
+            }
+
+            _logger.LogInformation(
+                "PickemGroupMatchupsRequested backfill complete; published {Count} PickemGroupMatchupDataPublished events.",
+                matchups.Count);
+        }
+    }
+}

--- a/src/SportsData.Api/Application/Events/PickemGroupMatchupsRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/PickemGroupMatchupsRequestedConsumer.cs
@@ -32,6 +32,11 @@ namespace SportsData.Api.Application.Events
     /// </summary>
     public class PickemGroupMatchupsRequestedConsumer : IConsumer<PickemGroupMatchupsRequested>
     {
+        // Bounded page size so memory stays flat regardless of dataset size.
+        // Each page allocates ~PageSize event objects; PublishBatch will
+        // further chunk to 256 internally for Task.WhenAll fan-out.
+        private const int PageSize = 500;
+
         private readonly ILogger<PickemGroupMatchupsRequestedConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IEventBus _eventBus;
@@ -79,7 +84,18 @@ namespace SportsData.Api.Application.Events
                 query = query.Where(x => x.Sport == msg.Sport);
             }
 
-            var matchups = await query
+            // Honor SeasonYear when supplied so a future controller variant
+            // can scope a backfill (e.g., "just 2026"). Today the controller
+            // hardcodes null, which falls through here.
+            if (msg.SeasonYear is int seasonYear)
+            {
+                query = query.Where(x => x.Matchup.SeasonYear == seasonYear);
+            }
+
+            // Deterministic ordering needed for Skip/Take to page safely.
+            // PickemGroupMatchup.Id (PK) is stable and unique.
+            var pagedQuery = query
+                .OrderBy(x => x.Matchup.Id)
                 .Select(x => new
                 {
                     x.Matchup.GroupId,
@@ -88,33 +104,63 @@ namespace SportsData.Api.Application.Events
                     x.Matchup.SeasonYear,
                     x.Matchup.SeasonWeek,
                     x.Sport
-                })
-                .ToListAsync(context.CancellationToken);
+                });
 
             _logger.LogInformation(
-                "PickemGroupMatchupsRequested received; publishing PickemGroupMatchupDataPublished for {Count} future matchups.",
-                matchups.Count);
+                "PickemGroupMatchupsRequested received; paging through future matchups in chunks of {PageSize}.",
+                PageSize);
 
-            var events = matchups
-                .Select(m => new PickemGroupMatchupDataPublished(
-                    m.GroupId,
-                    m.ContestId,
-                    m.StartDateUtc,
-                    m.SeasonWeek,
-                    m.Sport,
-                    m.SeasonYear,
-                    msg.CorrelationId,
-                    Guid.NewGuid()))
-                .ToList();
-
+            // Hold the Direct scope across pages — same AsyncLocal value
+            // applies for the lifetime of the using block.
             using (_deliveryScope.Use(DeliveryMode.Direct))
             {
-                await _eventBus.PublishBatch(events, context.CancellationToken);
-            }
+                var totalPublished = 0;
+                var offset = 0;
 
-            _logger.LogInformation(
-                "PickemGroupMatchupsRequested backfill complete; published {Count} PickemGroupMatchupDataPublished events.",
-                matchups.Count);
+                while (true)
+                {
+                    var page = await pagedQuery
+                        .Skip(offset)
+                        .Take(PageSize)
+                        .ToListAsync(context.CancellationToken);
+
+                    if (page.Count == 0)
+                        break;
+
+                    var events = page
+                        .Select(m => new PickemGroupMatchupDataPublished(
+                            m.GroupId,
+                            m.ContestId,
+                            m.StartDateUtc,
+                            m.SeasonWeek,
+                            m.Sport,
+                            m.SeasonYear,
+                            msg.CorrelationId,
+                            Guid.NewGuid()))
+                        .ToList();
+
+                    await _eventBus.PublishBatch(events, context.CancellationToken);
+
+                    totalPublished += events.Count;
+                    offset += PageSize;
+
+                    _logger.LogDebug(
+                        "Published page of {Count} events; running total {Total}.",
+                        events.Count, totalPublished);
+
+                    // Last page detection — short-circuits one extra empty
+                    // query at the end. Safe under concurrent inserts: a new
+                    // matchup landing mid-backfill gets a higher Id and just
+                    // appears on a later page, never displaces a row we've
+                    // already paged.
+                    if (page.Count < PageSize)
+                        break;
+                }
+
+                _logger.LogInformation(
+                    "PickemGroupMatchupsRequested backfill complete; published {Count} PickemGroupMatchupDataPublished events.",
+                    totalPublished);
+            }
         }
     }
 }

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -173,7 +173,7 @@ namespace SportsData.Api.Application.Processors
             var existingByContestId = groupWeek.Matchups
                 .ToDictionary(m => m.ContestId, m => m);
             var insertedCount = 0;
-            var insertedContestIds = new List<Guid>();
+            var insertedMatchups = new List<(Guid ContestId, DateTime StartDateUtc)>();
 
             foreach (var groupMatchup in groupMatchups)
             {
@@ -233,7 +233,7 @@ namespace SportsData.Api.Application.Processors
                         UnderOdds = groupMatchup.UnderOdds
                     });
                     insertedCount++;
-                    insertedContestIds.Add(groupMatchup.ContestId);
+                    insertedMatchups.Add((groupMatchup.ContestId, groupMatchup.StartDateUtc));
                 }
             }
 
@@ -293,11 +293,13 @@ namespace SportsData.Api.Application.Processors
             // newly-inserted matchup (refresh-only updates are intentionally
             // silent here — Notification cares about "this league now has this
             // contest," not about line/rank churn on already-known matchups).
-            foreach (var contestId in insertedContestIds)
+            foreach (var (contestId, startDateUtc) in insertedMatchups)
             {
                 await _eventBus.Publish(new PickemGroupMatchupCreated(
                         group.Id,
                         contestId,
+                        startDateUtc,
+                        groupWeek.SeasonWeek,
                         group.Sport,
                         command.SeasonYear,
                         command.CorrelationId,

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -281,6 +281,7 @@ namespace SportsData.Api
                     typeof(FootballPlayCompletedHandler),
                     typeof(PickemGroupCreatedHandler),
                     typeof(PickemGroupMatchupAddedHandler),
+                    typeof(PickemGroupMatchupsRequestedConsumer),
                     typeof(PickemGroupsRequestedConsumer),
                     typeof(PickemGroupWeekMatchupsGeneratedHandler),
                     typeof(PreviewGeneratedHandler),

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupCreated.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupCreated.cs
@@ -7,6 +7,8 @@ namespace SportsData.Core.Eventing.Events.PickemGroups
     public record PickemGroupMatchupCreated(
         Guid GroupId,
         Guid ContestId,
+        DateTime StartDateUtc,
+        int SeasonWeek,
         Sport Sport,
         int? SeasonYear,
         Guid CorrelationId,

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupDataPublished.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupDataPublished.cs
@@ -1,0 +1,33 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.PickemGroups
+{
+    /// <summary>
+    /// Per-matchup backfill snapshot. Carries the fields Notification needs
+    /// to schedule pick-deadline + kickoff reminders without re-querying API:
+    /// the league this matchup belongs to, the contest, and the kickoff
+    /// time. Status is intentionally NOT on the payload — API doesn't store
+    /// canonical contest status. Notification defaults it to
+    /// <c>"STATUS_SCHEDULED"</c> on insert and updates it via steady-state
+    /// <c>ContestStatusChanged</c> consumption (Phase 2c-main / 2d).
+    ///
+    /// <para>
+    /// One event per matchup. Consumer is responsible for idempotent upsert.
+    /// At-least-once delivery means the same (PickemGroupId, ContestId) may
+    /// arrive twice; repeated backfill requests will republish the entire
+    /// set.
+    /// </para>
+    /// </summary>
+    public record PickemGroupMatchupDataPublished(
+        Guid PickemGroupId,
+        Guid ContestId,
+        DateTime StartDateUtc,
+        int SeasonWeek,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupsRequested.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupMatchupsRequested.cs
@@ -1,0 +1,27 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.PickemGroups
+{
+    /// <summary>
+    /// Backfill trigger asking the API to publish a
+    /// <see cref="PickemGroupMatchupDataPublished"/> event for every future
+    /// matchup on file (filter: <c>PickemGroupMatchup.StartDateUtc &gt; UtcNow</c>).
+    /// Companion to <see cref="Users.UsersRequested"/> /
+    /// <see cref="PickemGroupsRequested"/> — same operator-triggered shape.
+    ///
+    /// <para>
+    /// Scope rationale: Notification only cares about contests that are
+    /// actually picked in some league. Past matchups are excluded — picks
+    /// have already locked and no reminder is meaningful. Filtering at the
+    /// publisher keeps the projection small and skips events for events.
+    /// </para>
+    /// </summary>
+    public record PickemGroupMatchupsRequested(
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -64,23 +64,33 @@ namespace SportsData.Notification.Application.Consumers
             _logger.LogInformation("ContestStartTimeUpdated received.");
 
             // 1. Resync the local PickemGroupMatchup projection. Bulk
-            // ExecuteUpdateAsync avoids loading + tracking; ModifiedUtc and
-            // ModifiedBy stamped as part of the SET clause. Straight overwrite
-            // — no diff filter, the extra write on a no-op redelivery is
-            // cheaper than the extra read.
+            // ExecuteUpdateAsync avoids loading + tracking; ModifiedUtc /
+            // ModifiedBy / StartDateUpdatedAt stamped in the SET clause.
+            //
+            // Out-of-order delivery guard: only apply when the event's
+            // CreatedUtc is newer than the projection's last-applied stamp.
+            // Producer's CompetitionStreamScheduler solved this for itself
+            // by reading from DB (PR #457); we solve it here by versioning
+            // the projection field with the event's own monotonic timestamp.
+            // The check lives in the WHERE clause so stale events are
+            // filtered at the SQL layer with no read round-trip.
             var now = _dateTimeProvider.UtcNow();
+            var eventCreatedUtc = msg.CreatedUtc;
             var rowsAffected = await _dataContext.PickemGroupMatchups
-                .Where(m => m.ContestId == msg.ContestId)
+                .Where(m =>
+                    m.ContestId == msg.ContestId &&
+                    (m.StartDateUpdatedAt == null || m.StartDateUpdatedAt < eventCreatedUtc))
                 .ExecuteUpdateAsync(
                     s => s
                         .SetProperty(m => m.StartDateUtc, msg.NewStartTime)
+                        .SetProperty(m => m.StartDateUpdatedAt, (DateTime?)eventCreatedUtc)
                         .SetProperty(m => m.ModifiedUtc, (DateTime?)now)
                         .SetProperty(m => m.ModifiedBy, (Guid?)msg.CausationId),
                     context.CancellationToken);
 
             _logger.LogInformation(
-                "PickemGroupMatchup projection resynced. RowsAffected={RowsAffected}",
-                rowsAffected);
+                "PickemGroupMatchup projection resynced. RowsAffected={RowsAffected}, EventCreatedUtc={EventCreatedUtc}",
+                rowsAffected, eventCreatedUtc);
 
             // 2. Reschedule any kickoff-reminder Hangfire jobs already on the
             // calendar for this contest. Today this is TODO pending the

--- a/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -2,42 +2,52 @@ using MassTransit;
 
 using Microsoft.EntityFrameworkCore;
 
+using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Notification.Infrastructure.Data;
 
 namespace SportsData.Notification.Application.Consumers
 {
     /// <summary>
-    /// ESPN moved a game's start time. For every user who had a kickoff
-    /// reminder scheduled for this contest, cancel the existing Hangfire job
-    /// and schedule a new one at <c>NewStartTime - leadMinutes</c>.
+    /// ESPN moved a game's start time. Two responsibilities:
+    /// <list type="number">
+    ///   <item>Update the local <c>PickemGroupMatchup</c> projection — every
+    ///   row referencing the contest (a single contest can appear in many
+    ///   leagues) gets its <c>StartDateUtc</c> resynced via
+    ///   <c>ExecuteUpdateAsync</c>.</item>
+    ///   <item>Reschedule any <c>PendingScheduledJob</c> kickoff reminders
+    ///   already on the Hangfire calendar for this contest (TODO — Phase 2c-main
+    ///   / 2d when the Hangfire dispatcher exists).</item>
+    /// </list>
     ///
     /// <para>
-    /// Mirrors Producer's <c>CompetitionStreamScheduler.RescheduleForContestAsync</c>
-    /// pattern but operates on the Notification side: same drift threshold
-    /// logic, same crash-safe ordering (schedule-new → save → delete-old),
-    /// just against the local <see cref="Infrastructure.Data.Entities.PendingScheduledJob"/>
-    /// table instead of <c>CompetitionStream</c>.
+    /// Mirrors Producer's
+    /// <c>CompetitionStreamScheduler.RescheduleForContestAsync</c> pattern for
+    /// the Hangfire side: same drift threshold logic, same crash-safe ordering
+    /// (schedule-new → save → delete-old) once wired.
     /// </para>
     ///
     /// <para>
     /// Per the cross-broker shovel design, this event arrives via a shovel
     /// from each per-sport Producer broker (NCAA / NFL / MLB). The handler
-    /// itself is sport-agnostic — it operates entirely off
-    /// <c>PendingScheduledJob.TargetId == ContestId</c>.
+    /// itself is sport-agnostic — both the projection write and the future
+    /// Hangfire reschedule operate entirely off ContestId.
     /// </para>
     /// </summary>
     public class ContestStartTimeUpdatedConsumer : IConsumer<ContestStartTimeUpdated>
     {
         private readonly ILogger<ContestStartTimeUpdatedConsumer> _logger;
         private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public ContestStartTimeUpdatedConsumer(
             ILogger<ContestStartTimeUpdatedConsumer> logger,
-            AppDataContext dataContext)
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task Consume(ConsumeContext<ContestStartTimeUpdated> context)
@@ -53,20 +63,43 @@ namespace SportsData.Notification.Application.Consumers
 
             _logger.LogInformation("ContestStartTimeUpdated received.");
 
+            // 1. Resync the local PickemGroupMatchup projection. Bulk
+            // ExecuteUpdateAsync avoids loading + tracking; ModifiedUtc and
+            // ModifiedBy stamped as part of the SET clause. Straight overwrite
+            // — no diff filter, the extra write on a no-op redelivery is
+            // cheaper than the extra read.
+            var now = _dateTimeProvider.UtcNow();
+            var rowsAffected = await _dataContext.PickemGroupMatchups
+                .Where(m => m.ContestId == msg.ContestId)
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(m => m.StartDateUtc, msg.NewStartTime)
+                        .SetProperty(m => m.ModifiedUtc, (DateTime?)now)
+                        .SetProperty(m => m.ModifiedBy, (Guid?)msg.CausationId),
+                    context.CancellationToken);
+
+            _logger.LogInformation(
+                "PickemGroupMatchup projection resynced. RowsAffected={RowsAffected}",
+                rowsAffected);
+
+            // 2. Reschedule any kickoff-reminder Hangfire jobs already on the
+            // calendar for this contest. Today this is TODO pending the
+            // Hangfire dispatcher (Phase 2c-main / 2d). For now we log the
+            // intent so the recovery path is auditable.
             var pendingJobs = await _dataContext.PendingScheduledJobs
                 .Where(j => j.JobKind == "Kickoff" && j.TargetId == msg.ContestId)
-                .ToListAsync();
+                .ToListAsync(context.CancellationToken);
 
             if (pendingJobs.Count == 0)
             {
                 _logger.LogInformation(
-                    "No PendingScheduledJob rows for ContestId {ContestId}; nothing to reschedule.",
+                    "No PendingScheduledJob rows for ContestId {ContestId}; no kickoff reminders to reschedule.",
                     msg.ContestId);
                 return;
             }
 
             _logger.LogInformation(
-                "Rescheduling {Count} kickoff reminder(s) for ContestId {ContestId}.",
+                "TODO (Phase 2c-main / 2d): reschedule {Count} kickoff reminder(s) for ContestId {ContestId}.",
                 pendingJobs.Count, msg.ContestId);
 
             foreach (var job in pendingJobs)
@@ -75,7 +108,7 @@ namespace SportsData.Notification.Application.Consumers
                 //   1. Compute newFireTime = msg.NewStartTime - leadMinutes
                 //   2. newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
                 //          d => d.SendKickoffReminderAsync(job.UserId, msg.ContestId),
-                //          newFireTime - _dateTimeProvider.UtcNow());
+                //          newFireTime - now);
                 //   3. oldJobId = job.HangfireJobId
                 //   4. job.HangfireJobId = newJobId
                 //   5. job.ScheduledFireUtc = newFireTime
@@ -83,17 +116,14 @@ namespace SportsData.Notification.Application.Consumers
                 //   7. SaveChanges  (commits the swap)
                 //   8. _backgroundJobProvider.Delete(oldJobId)  (best-effort)
                 //
-                // Crash-safety: schedule-then-save-then-delete order means a
-                // crashed run leaks an orphan job rather than orphaning the row.
-                // FCM dedupe via NotificationLog (CorrelationId + UserId + Channel)
-                // absorbs the duplicate fire.
-
-                _logger.LogInformation(
-                    "TODO: reschedule Hangfire job {OldJobId} for UserId {UserId} (ContestId {ContestId}).",
-                    job.HangfireJobId, job.UserId, msg.ContestId);
+                // Crash-safety: schedule-then-save-then-delete order leaks an
+                // orphan job rather than orphaning the row on crash. FCM dedupe
+                // via NotificationLog (CorrelationId + UserId + Channel) absorbs
+                // the duplicate fire.
+                _logger.LogDebug(
+                    "Would reschedule Hangfire job {OldJobId} for UserId {UserId}.",
+                    job.HangfireJobId, job.UserId);
             }
-
-            await _dataContext.SaveChangesAsync();
         }
     }
 }

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
@@ -72,6 +72,9 @@ namespace SportsData.Notification.Application.Consumers
                     PickemGroupId = msg.GroupId,
                     ContestId = msg.ContestId,
                     StartDateUtc = msg.StartDateUtc,
+                    // See PickemGroupMatchupDataPublishedConsumer for the
+                    // rationale on stamping StartDateUpdatedAt on insert.
+                    StartDateUpdatedAt = msg.CreatedUtc,
                     SeasonYear = msg.SeasonYear ?? 0,
                     SeasonWeek = msg.SeasonWeek,
                     StatusTypeName = DefaultStatusTypeName,
@@ -113,7 +116,15 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
+            // Refresh StartDateUpdatedAt only when StartDateUtc actually
+            // shifted — matches the seed consumer's discipline.
+            var startDateChanged = existing.StartDateUtc != msg.StartDateUtc;
+
             existing.StartDateUtc = msg.StartDateUtc;
+            if (startDateChanged)
+            {
+                existing.StartDateUpdatedAt = msg.CreatedUtc;
+            }
             existing.SeasonYear = msg.SeasonYear ?? 0;
             existing.SeasonWeek = msg.SeasonWeek;
             existing.ModifiedUtc = now;

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
@@ -10,35 +10,31 @@ using SportsData.Notification.Infrastructure.Data.Entities;
 namespace SportsData.Notification.Application.Consumers
 {
     /// <summary>
-    /// Steady-state: a new matchup landed in a league. Upserts the local
-    /// <see cref="PickemGroupMatchup"/> projection so subsequent reminder
-    /// scheduling work has the data it needs.
+    /// Upserts the local <see cref="PickemGroupMatchup"/> projection from a
+    /// backfill snapshot. Race-safe insert via the unique
+    /// <c>(PickemGroupId, ContestId)</c> index; change detection avoids
+    /// flipping <see cref="PickemGroupMatchup.ModifiedUtc"/> on no-op
+    /// redeliveries — same pattern as
+    /// <see cref="UserDataPublishedConsumer"/> and
+    /// <see cref="PickemGroupDataPublishedConsumer"/>.
     ///
     /// <para>
-    /// Shares the projection contract with
-    /// <see cref="PickemGroupMatchupDataPublishedConsumer"/> (the backfill
-    /// path). Either consumer can run first depending on operator timing,
-    /// so both use the same race-safe insert + change-detect pattern. The
-    /// unique <c>(PickemGroupId, ContestId)</c> index makes the race tractable.
-    /// </para>
-    ///
-    /// <para>
-    /// Reminder scheduling itself (Hangfire job per league member at
-    /// <c>StartDateUtc - leadTime</c>) is Phase 2c-main. This consumer is
-    /// scoped to projection upkeep only — the reminder consumer (or this
-    /// one expanded later) will read from the projection and schedule.
+    /// <see cref="PickemGroupMatchup.StatusTypeName"/> is initialized to
+    /// <c>"STATUS_SCHEDULED"</c> on insert and NEVER overwritten here. Status
+    /// is owned by a future <c>ContestStatusChanged</c> consumer; this
+    /// backfill consumer would clobber live state if it touched status.
     /// </para>
     /// </summary>
-    public class PickemGroupMatchupCreatedConsumer : IConsumer<PickemGroupMatchupCreated>
+    public class PickemGroupMatchupDataPublishedConsumer : IConsumer<PickemGroupMatchupDataPublished>
     {
         private const string DefaultStatusTypeName = "STATUS_SCHEDULED";
 
-        private readonly ILogger<PickemGroupMatchupCreatedConsumer> _logger;
+        private readonly ILogger<PickemGroupMatchupDataPublishedConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
 
-        public PickemGroupMatchupCreatedConsumer(
-            ILogger<PickemGroupMatchupCreatedConsumer> logger,
+        public PickemGroupMatchupDataPublishedConsumer(
+            ILogger<PickemGroupMatchupDataPublishedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider)
         {
@@ -47,29 +43,28 @@ namespace SportsData.Notification.Application.Consumers
             _dateTimeProvider = dateTimeProvider;
         }
 
-        public async Task Consume(ConsumeContext<PickemGroupMatchupCreated> context)
+        public async Task Consume(ConsumeContext<PickemGroupMatchupDataPublished> context)
         {
             var msg = context.Message;
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
                 ["CorrelationId"] = msg.CorrelationId,
-                ["GroupId"] = msg.GroupId,
-                ["ContestId"] = msg.ContestId,
-                ["Sport"] = msg.Sport
+                ["PickemGroupId"] = msg.PickemGroupId,
+                ["ContestId"] = msg.ContestId
             });
 
             var now = _dateTimeProvider.UtcNow();
 
             var existing = await _dataContext.PickemGroupMatchups
                 .FirstOrDefaultAsync(
-                    m => m.PickemGroupId == msg.GroupId && m.ContestId == msg.ContestId,
+                    m => m.PickemGroupId == msg.PickemGroupId && m.ContestId == msg.ContestId,
                     context.CancellationToken);
 
             if (existing is null)
             {
                 var entity = new PickemGroupMatchup
                 {
-                    PickemGroupId = msg.GroupId,
+                    PickemGroupId = msg.PickemGroupId,
                     ContestId = msg.ContestId,
                     StartDateUtc = msg.StartDateUtc,
                     SeasonYear = msg.SeasonYear ?? 0,
@@ -83,25 +78,24 @@ namespace SportsData.Notification.Application.Consumers
                 try
                 {
                     await _dataContext.SaveChangesAsync(context.CancellationToken);
-                    _logger.LogInformation("PickemGroupMatchup projection inserted from creation event.");
+                    _logger.LogInformation("PickemGroupMatchup projection inserted.");
                     return;
                 }
                 catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
                 {
-                    // Race with the backfill consumer (or another redelivery)
-                    // — peer write won, our orphan detaches, fall through to
-                    // update.
                     _dataContext.Entry(entity).State = EntityState.Detached;
                     existing = await _dataContext.PickemGroupMatchups
                         .FirstAsync(
-                            m => m.PickemGroupId == msg.GroupId && m.ContestId == msg.ContestId,
+                            m => m.PickemGroupId == msg.PickemGroupId && m.ContestId == msg.ContestId,
                             context.CancellationToken);
                 }
             }
 
-            // Update path. StatusTypeName intentionally untouched — owned by
-            // future ContestStatusChanged consumer, same rationale as the
-            // backfill consumer.
+            // Update path — touch Modified* only when a business field
+            // actually differs. StatusTypeName is NOT considered: it's
+            // owned by the (future) ContestStatusChanged consumer; this
+            // backfill data event would clobber live state if we let it
+            // overwrite.
             var changed =
                 existing.StartDateUtc != msg.StartDateUtc
                 || existing.SeasonYear != (msg.SeasonYear ?? 0)
@@ -109,7 +103,7 @@ namespace SportsData.Notification.Application.Consumers
 
             if (!changed)
             {
-                _logger.LogDebug("PickemGroupMatchup projection unchanged on creation redelivery.");
+                _logger.LogDebug("PickemGroupMatchup projection unchanged.");
                 return;
             }
 
@@ -120,7 +114,7 @@ namespace SportsData.Notification.Application.Consumers
             existing.ModifiedBy = msg.CausationId;
 
             await _dataContext.SaveChangesAsync(context.CancellationToken);
-            _logger.LogInformation("PickemGroupMatchup projection updated from creation event.");
+            _logger.LogInformation("PickemGroupMatchup projection updated.");
         }
 
         private static bool IsUniqueConstraintViolation(DbUpdateException ex)

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
@@ -67,6 +67,12 @@ namespace SportsData.Notification.Application.Consumers
                     PickemGroupId = msg.PickemGroupId,
                     ContestId = msg.ContestId,
                     StartDateUtc = msg.StartDateUtc,
+                    // Seed event's CreatedUtc establishes the version
+                    // baseline. Subsequent ContestStartTimeUpdated events
+                    // with older CreatedUtc are rejected — they were
+                    // already reflected in API's data at the moment the
+                    // backfill responder published this seed.
+                    StartDateUpdatedAt = msg.CreatedUtc,
                     SeasonYear = msg.SeasonYear ?? 0,
                     SeasonWeek = msg.SeasonWeek,
                     StatusTypeName = DefaultStatusTypeName,
@@ -107,7 +113,15 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
+            // Refresh StartDateUpdatedAt only when StartDateUtc actually
+            // shifted — keeps the version stable when other fields churn.
+            var startDateChanged = existing.StartDateUtc != msg.StartDateUtc;
+
             existing.StartDateUtc = msg.StartDateUtc;
+            if (startDateChanged)
+            {
+                existing.StartDateUpdatedAt = msg.CreatedUtc;
+            }
             existing.SeasonYear = msg.SeasonYear ?? 0;
             existing.SeasonWeek = msg.SeasonWeek;
             existing.ModifiedUtc = now;

--- a/src/SportsData.Notification/Controllers/BackfillController.cs
+++ b/src/SportsData.Notification/Controllers/BackfillController.cs
@@ -100,5 +100,34 @@ namespace SportsData.Notification.Controllers
 
             return Accepted(new { correlationId });
         }
+
+        /// <summary>
+        /// Triggers a full backfill of the local <c>PickemGroupMatchup</c>
+        /// projection by publishing <see cref="PickemGroupMatchupsRequested"/>.
+        /// The API consumer responds with one <c>PickemGroupMatchupDataPublished</c>
+        /// per future matchup (StartDateUtc &gt; UtcNow filter — past games
+        /// excluded), and Notification's own consumer upserts each row.
+        /// </summary>
+        [HttpPost("pickemgroupmatchups")]
+        public async Task<IActionResult> RequestPickemGroupMatchups(CancellationToken cancellationToken)
+        {
+            var correlationId = Guid.NewGuid();
+
+            _logger.LogInformation(
+                "Publishing PickemGroupMatchupsRequested. CorrelationId={CorrelationId}",
+                correlationId);
+
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                await _eventBus.Publish(new PickemGroupMatchupsRequested(
+                        Sport.All,
+                        null,
+                        correlationId,
+                        Guid.NewGuid()),
+                    cancellationToken);
+            }
+
+            return Accepted(new { correlationId });
+        }
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -26,6 +26,8 @@ namespace SportsData.Notification.Infrastructure.Data
 
         public DbSet<PickemGroup> PickemGroups => Set<PickemGroup>();
 
+        public DbSet<PickemGroupMatchup> PickemGroupMatchups => Set<PickemGroupMatchup>();
+
         public DbSet<PickemGroupMember> PickemGroupMembers => Set<PickemGroupMember>();
 
         public DbSet<User> Users => Set<User>();
@@ -76,6 +78,20 @@ namespace SportsData.Notification.Infrastructure.Data
             modelBuilder.Entity<PickemGroupMember>()
                 .HasIndex(m => new { m.PickemGroupId, m.UserId })
                 .IsUnique();
+
+            // Matchup uniqueness key — same contest can appear in many
+            // leagues, but no league should ever have the same contest
+            // twice. Lookup queries also hit by ContestId alone (e.g.,
+            // ContestStartTimeUpdated → update every matchup row for the
+            // contest) so the leading column is PickemGroupId for fan-out
+            // ("which contests are in this league this week") and a
+            // separate non-unique index on ContestId carries the per-
+            // contest update path.
+            modelBuilder.Entity<PickemGroupMatchup>()
+                .HasIndex(m => new { m.PickemGroupId, m.ContestId })
+                .IsUnique();
+            modelBuilder.Entity<PickemGroupMatchup>()
+                .HasIndex(m => m.ContestId);
         }
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroupMatchup.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroupMatchup.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Local read-side projection of API's PickemGroupMatchup. Seeded via the
+    /// <c>PickemGroupMatchupsRequested</c> → <c>PickemGroupMatchupDataPublished</c>
+    /// backfill chain (future matchups only — picks have already locked on
+    /// past games). Kept fresh by:
+    /// <list type="bullet">
+    ///   <item>Steady-state <c>PickemGroupMatchupCreated</c> when API adds a
+    ///   new matchup to a league.</item>
+    ///   <item>Steady-state <c>ContestStartTimeUpdated</c> when Producer
+    ///   detects an ESPN start-time change (updates <see cref="StartDateUtc"/>
+    ///   on all rows for the contest).</item>
+    /// </list>
+    ///
+    /// <para>
+    /// <see cref="StatusTypeName"/> is intentionally defaulted to
+    /// <c>"STATUS_SCHEDULED"</c> at insert. API doesn't store canonical
+    /// contest status; future <c>ContestStatusChanged</c> consumption updates
+    /// this column over time (Phase 2c-main / 2d). Status defaulting is safe
+    /// in practice because the backfill filter is
+    /// <c>StartDateUtc &gt; UtcNow</c> — any matchup we project hasn't
+    /// started yet, so it really is STATUS_SCHEDULED at insert.
+    /// </para>
+    /// </summary>
+    public class PickemGroupMatchup : CanonicalEntityBase<Guid>
+    {
+        public Guid PickemGroupId { get; set; }
+
+        public Guid ContestId { get; set; }
+
+        public DateTime StartDateUtc { get; set; }
+
+        public int SeasonYear { get; set; }
+
+        public int SeasonWeek { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public string StatusTypeName { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroupMatchup.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroupMatchup.cs
@@ -42,5 +42,15 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
         [Required]
         [MaxLength(50)]
         public string StatusTypeName { get; set; }
+
+        /// <summary>
+        /// EventBase.CreatedUtc of the last event that wrote
+        /// <see cref="StartDateUtc"/>. Used as a monotonic version key to
+        /// reject stale <c>ContestStartTimeUpdated</c> events under
+        /// out-of-order delivery — only events with a newer CreatedUtc
+        /// can update StartDateUtc. Null on rows that haven't yet been
+        /// touched by an update event (first write sets this).
+        /// </summary>
+        public DateTime? StartDateUpdatedAt { get; set; }
     }
 }

--- a/src/SportsData.Notification/Migrations/20260625104355_AddPickemGroupMatchupProjection.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260625104355_AddPickemGroupMatchupProjection.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260625104355_AddPickemGroupMatchupProjection")]
+    partial class AddPickemGroupMatchupProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260625104355_AddPickemGroupMatchupProjection.cs
+++ b/src/SportsData.Notification/Migrations/20260625104355_AddPickemGroupMatchupProjection.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPickemGroupMatchupProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PickemGroupMatchups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PickemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContestId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StartDateUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SeasonYear = table.Column<int>(type: "integer", nullable: false),
+                    SeasonWeek = table.Column<int>(type: "integer", nullable: false),
+                    StatusTypeName = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PickemGroupMatchups", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PickemGroupMatchups_ContestId",
+                table: "PickemGroupMatchups",
+                column: "ContestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PickemGroupMatchups_PickemGroupId_ContestId",
+                table: "PickemGroupMatchups",
+                columns: new[] { "PickemGroupId", "ContestId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PickemGroupMatchups");
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260625111200_AddStartDateUpdatedAtToMatchupProjection.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260625111200_AddStartDateUpdatedAtToMatchupProjection.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260625111200_AddStartDateUpdatedAtToMatchupProjection")]
+    partial class AddStartDateUpdatedAtToMatchupProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260625111200_AddStartDateUpdatedAtToMatchupProjection.cs
+++ b/src/SportsData.Notification/Migrations/20260625111200_AddStartDateUpdatedAtToMatchupProjection.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStartDateUpdatedAtToMatchupProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "StartDateUpdatedAt",
+                table: "PickemGroupMatchups",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StartDateUpdatedAt",
+                table: "PickemGroupMatchups");
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -39,6 +39,7 @@ namespace SportsData.Notification
                 typeof(PickemGroupCreatedConsumer),
                 typeof(PickemGroupDataPublishedConsumer),
                 typeof(PickemGroupMatchupCreatedConsumer),
+                typeof(PickemGroupMatchupDataPublishedConsumer),
                 typeof(PickemGroupMemberAddedConsumer),
                 typeof(UserDataPublishedConsumer),
                 typeof(UserPickScoredConsumer)


### PR DESCRIPTION
## Summary
Stands up Notification's local \`PickemGroupMatchup\` projection. This is the data foundation for pick deadline reminders (Phase 2c-main) and kickoff reminders (Phase 2d) — both need to know which contests are in which leagues and when they start.

Scope per the design discussion:
- **API owns the relevance filter** — Notification only cares about contests that are picked in some league.
- **Future games only** — backfill filter is \`StartDateUtc > UtcNow\`. Past matchups have no reminder meaning.
- **\`StatusTypeName\` defaults to \`STATUS_SCHEDULED\`** — API doesn't store canonical status, and the backfill filter guarantees the projection only ever holds pre-game matchups. A future \`ContestStatusChanged\` consumer (out of scope here) will update status going forward.

## Two seed paths
| Path | Trigger | Consumer |
|---|---|---|
| One-shot backfill | \`POST /admin/backfill/pickemgroupmatchups\` | \`PickemGroupMatchupsRequestedConsumer\` (API) → \`PickemGroupMatchupDataPublishedConsumer\` (Notification) |
| Steady-state new matchup | Existing \`PickemGroupMatchupCreated\` event (now fattened) | \`PickemGroupMatchupCreatedConsumer\` (Notification — was no-op, now upserts) |

Either path can run first. Both use the same race-safe insert + \`DbUpdateException\` catch on SqlState 23505 + change detection.

## Steady-state freshness for start time changes
\`ContestStartTimeUpdatedConsumer\` (existing) extended to also bulk-update \`PickemGroupMatchup.StartDateUtc\` via \`ExecuteUpdateAsync\` in addition to the existing Hangfire reschedule TODO.

API's side of this was already done in 77a0e66 (2025-09-12) — \`ContestStartTimeUpdatedHandler\` already updates \`PickemGroupMatchup.StartDateUtc\` on the API table. Both downstream services now react independently to the same upstream Producer event.

## Core event changes
- **New**: \`PickemGroupMatchupsRequested\`, \`PickemGroupMatchupDataPublished\`.
- **Fattened**: \`PickemGroupMatchupCreated\` gains \`StartDateUtc\` + \`SeasonWeek\`. Publisher (\`MatchupScheduleProcessor\`) updated; \`insertedContestIds\` tuple-promoted to \`insertedMatchups: List<(ContestId, StartDateUtc)>\`.

## Notification side
- \`PickemGroupMatchup\` entity (\`PickemGroupId, ContestId, StartDateUtc, SeasonYear, SeasonWeek, StatusTypeName\`).
- Unique \`(PickemGroupId, ContestId)\` index for race-safe upsert; non-unique \`ContestId\` index for the per-contest update path.
- \`AddPickemGroupMatchupProjection\` migration.

## Out of scope (follow-ups)
- **\`ContestStatusChanged\` consumer + Producer→Notification shovels** for it. Status defaults to \`STATUS_SCHEDULED\` until that lands. Shovel infra is a sister-repo Flux change.
- **Phase 2c-main reminder scheduling itself** — Hangfire jobs per league member at \`min(StartDateUtc) - 1h\`.

## Test plan
- [x] \`dotnet build src/SportsData.Api\` — 0/0
- [x] \`dotnet build src/SportsData.Notification\` — 0/0
- [ ] Local: \`dotnet ef database update\` against \`sdNotification.All\` — applies \`AddPickemGroupMatchupProjection\` cleanly
- [ ] Local: \`POST /admin/backfill/pickemgroupmatchups\` with valid X-Api-Key → 202; observe per-matchup events flow, projection populated for future-only matchups
- [ ] Local: create a new matchup in API → observe steady-state \`PickemGroupMatchupCreated\` event flows, Notification projection picks it up
- [ ] Local: trigger \`ContestStartTimeUpdated\` (real or replayed) → both API \`PickemGroupMatchup\` and Notification projection update independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin backfill action to request future matchup data and return a tracking ID.
  * Introduced automated publishing and projection upsertion for pick’em group matchup data (including sport/season/week details).
* **Bug Fixes**
  * Improved matchup updates to be race-safe and idempotent, preventing duplicates and only applying meaningful changes.
  * Matchup timing and season details are refreshed when contest start times change, with safer reminder handling behavior.
* **Chores**
  * Added a new matchup projection table and schema updates to support tracked start-time updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->