### PR TITLE
feat(notification): Phase 2c-main — pick-deadline reminders end-to-end

### DIFF
--- a/src/SportsData.Api/Application/Events/PickemGroupMatchupsRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/PickemGroupMatchupsRequestedConsumer.cs
@@ -92,8 +92,16 @@ namespace SportsData.Api.Application.Events
                 query = query.Where(x => x.Matchup.SeasonYear == seasonYear);
             }
 
-            // Deterministic ordering needed for Skip/Take to page safely.
-            // PickemGroupMatchup.Id (PK) is stable and unique.
+            // OrderBy is purely so Skip/Take has deterministic results within
+            // a single page query — it does NOT guarantee stable paging
+            // across concurrent inserts/deletes (PK is a Guid, not a
+            // monotonic sequence; new rows can land at any position in the
+            // ordering). Duplicate or skipped rows are possible if the
+            // table mutates mid-backfill. Acceptable here because the
+            // downstream consumer is idempotent (race-safe upsert with
+            // change-detect), so a row seen twice is a no-op and a row
+            // missed will be picked up by the next backfill or by the
+            // steady-state PickemGroupMatchupCreated event.
             var pagedQuery = query
                 .OrderBy(x => x.Matchup.Id)
                 .Select(x => new

--- a/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Notification.Application.Scheduling;
 using SportsData.Notification.Infrastructure.Data;
 
 namespace SportsData.Notification.Application.Consumers
@@ -39,15 +40,18 @@ namespace SportsData.Notification.Application.Consumers
         private readonly ILogger<ContestStartTimeUpdatedConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPickDeadlineReminderScheduler _reminderScheduler;
 
         public ContestStartTimeUpdatedConsumer(
             ILogger<ContestStartTimeUpdatedConsumer> logger,
             AppDataContext dataContext,
-            IDateTimeProvider dateTimeProvider)
+            IDateTimeProvider dateTimeProvider,
+            IPickDeadlineReminderScheduler reminderScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
+            _reminderScheduler = reminderScheduler;
         }
 
         public async Task Consume(ConsumeContext<ContestStartTimeUpdated> context)
@@ -92,10 +96,32 @@ namespace SportsData.Notification.Application.Consumers
                 "PickemGroupMatchup projection resynced. RowsAffected={RowsAffected}, EventCreatedUtc={EventCreatedUtc}",
                 rowsAffected, eventCreatedUtc);
 
-            // 2. Reschedule any kickoff-reminder Hangfire jobs already on the
+            // 2. Re-evaluate pick-deadline reminders for every (league, week)
+            // touched by this contest. The same contest can appear in many
+            // leagues; the contest's start time IS the candidate deadline
+            // for any league-week containing it, so a change requires a
+            // re-evaluation pass. We query the projection AFTER the resync
+            // above so MIN(StartDateUtc) uses the new value.
+            if (rowsAffected > 0)
+            {
+                var affectedScopes = await _dataContext.PickemGroupMatchups
+                    .AsNoTracking()
+                    .Where(m => m.ContestId == msg.ContestId)
+                    .Select(m => new { m.PickemGroupId, m.SeasonWeek })
+                    .Distinct()
+                    .ToListAsync(context.CancellationToken);
+
+                foreach (var scope in affectedScopes)
+                {
+                    await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                        scope.PickemGroupId, scope.SeasonWeek, context.CancellationToken);
+                }
+            }
+
+            // 3. Reschedule any kickoff-reminder Hangfire jobs already on the
             // calendar for this contest. Today this is TODO pending the
-            // Hangfire dispatcher (Phase 2c-main / 2d). For now we log the
-            // intent so the recovery path is auditable.
+            // Kickoff dispatcher (Phase 2d). For now we log the intent so
+            // the recovery path is auditable.
             var pendingJobs = await _dataContext.PendingScheduledJobs
                 .Where(j => j.JobKind == "Kickoff" && j.TargetId == msg.ContestId)
                 .ToListAsync(context.CancellationToken);

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Application.Scheduling;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Data.Entities;
 
@@ -36,15 +37,18 @@ namespace SportsData.Notification.Application.Consumers
         private readonly ILogger<PickemGroupMatchupCreatedConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPickDeadlineReminderScheduler _reminderScheduler;
 
         public PickemGroupMatchupCreatedConsumer(
             ILogger<PickemGroupMatchupCreatedConsumer> logger,
             AppDataContext dataContext,
-            IDateTimeProvider dateTimeProvider)
+            IDateTimeProvider dateTimeProvider,
+            IPickDeadlineReminderScheduler reminderScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
+            _reminderScheduler = reminderScheduler;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupMatchupCreated> context)
@@ -87,6 +91,12 @@ namespace SportsData.Notification.Application.Consumers
                 {
                     await _dataContext.SaveChangesAsync(context.CancellationToken);
                     _logger.LogInformation("PickemGroupMatchup projection inserted from creation event.");
+
+                    // New matchup → re-evaluate the league-week's pick-deadline
+                    // reminders. First matchup will create them; later additions
+                    // may shift the deadline earlier.
+                    await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                        msg.GroupId, msg.SeasonWeek, context.CancellationToken);
                     return;
                 }
                 catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
@@ -116,9 +126,11 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // Refresh StartDateUpdatedAt only when StartDateUtc actually
-            // shifted — matches the seed consumer's discipline.
+            // Capture pre-update values for the reminder-rescheduling decision
+            // before the assignments below clobber them.
             var startDateChanged = existing.StartDateUtc != msg.StartDateUtc;
+            var weekChanged = existing.SeasonWeek != msg.SeasonWeek;
+            var priorSeasonWeek = existing.SeasonWeek;
 
             existing.StartDateUtc = msg.StartDateUtc;
             if (startDateChanged)
@@ -132,6 +144,22 @@ namespace SportsData.Notification.Application.Consumers
 
             await _dataContext.SaveChangesAsync(context.CancellationToken);
             _logger.LogInformation("PickemGroupMatchup projection updated from creation event.");
+
+            // Re-evaluate reminders only when StartDateUtc or SeasonWeek
+            // changed — other field churn doesn't affect the deadline.
+            if (startDateChanged || weekChanged)
+            {
+                // If the week itself shifted, both old and new league-weeks
+                // may need re-evaluation (the matchup left one bucket and
+                // entered another).
+                if (weekChanged)
+                {
+                    await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                        msg.GroupId, priorSeasonWeek, context.CancellationToken);
+                }
+                await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                    msg.GroupId, msg.SeasonWeek, context.CancellationToken);
+            }
         }
 
         private static bool IsUniqueConstraintViolation(DbUpdateException ex)

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Application.Scheduling;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Data.Entities;
 
@@ -32,15 +33,18 @@ namespace SportsData.Notification.Application.Consumers
         private readonly ILogger<PickemGroupMatchupDataPublishedConsumer> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPickDeadlineReminderScheduler _reminderScheduler;
 
         public PickemGroupMatchupDataPublishedConsumer(
             ILogger<PickemGroupMatchupDataPublishedConsumer> logger,
             AppDataContext dataContext,
-            IDateTimeProvider dateTimeProvider)
+            IDateTimeProvider dateTimeProvider,
+            IPickDeadlineReminderScheduler reminderScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
+            _reminderScheduler = reminderScheduler;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupMatchupDataPublished> context)
@@ -85,6 +89,12 @@ namespace SportsData.Notification.Application.Consumers
                 {
                     await _dataContext.SaveChangesAsync(context.CancellationToken);
                     _logger.LogInformation("PickemGroupMatchup projection inserted.");
+
+                    // Backfill arrival → re-evaluate the league-week's
+                    // pick-deadline reminders. Same pattern as the
+                    // creation consumer.
+                    await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                        msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
                     return;
                 }
                 catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
@@ -113,9 +123,10 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // Refresh StartDateUpdatedAt only when StartDateUtc actually
-            // shifted — keeps the version stable when other fields churn.
+            // Capture pre-update values for the reminder decision.
             var startDateChanged = existing.StartDateUtc != msg.StartDateUtc;
+            var weekChanged = existing.SeasonWeek != msg.SeasonWeek;
+            var priorSeasonWeek = existing.SeasonWeek;
 
             existing.StartDateUtc = msg.StartDateUtc;
             if (startDateChanged)
@@ -129,6 +140,17 @@ namespace SportsData.Notification.Application.Consumers
 
             await _dataContext.SaveChangesAsync(context.CancellationToken);
             _logger.LogInformation("PickemGroupMatchup projection updated.");
+
+            if (startDateChanged || weekChanged)
+            {
+                if (weekChanged)
+                {
+                    await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                        msg.PickemGroupId, priorSeasonWeek, context.CancellationToken);
+                }
+                await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                    msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
+            }
         }
 
         private static bool IsUniqueConstraintViolation(DbUpdateException ex)

--- a/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
@@ -1,0 +1,21 @@
+namespace SportsData.Notification.Application.Dispatching
+{
+    /// <summary>
+    /// Hangfire-invoked entry point for time-scheduled push dispatches.
+    /// One method per category (PickDeadline today; Kickoff lands in
+    /// Phase 2d). Each method is responsible for: resolving the recipient's
+    /// preferences + devices, composing the body, dispatching via FCM, and
+    /// writing the atomic-claim audit row in <c>NotificationLog</c>.
+    ///
+    /// <para>
+    /// Methods are designed to be safe under Hangfire's at-least-once
+    /// invocation semantics — a deterministic CorrelationId derived from
+    /// the input parameters keeps the <c>NotificationLog</c> dedupe
+    /// constraint catching retries that would otherwise duplicate.
+    /// </para>
+    /// </summary>
+    public interface INotificationDispatcher
+    {
+        Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek);
+    }
+}

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -1,0 +1,193 @@
+using System.Security.Cryptography;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
+
+namespace SportsData.Notification.Application.Dispatching
+{
+    /// <summary>
+    /// Default <see cref="INotificationDispatcher"/>. Implements the
+    /// atomic-claim + dispatch pattern shared with the event-driven consumers
+    /// (<see cref="Consumers.UserPickScoredConsumer"/> etc.).
+    ///
+    /// <para>
+    /// Deterministic CorrelationId: each method derives a stable Guid from
+    /// its parameters via MD5(input bytes). Hangfire retrying the same call
+    /// produces the same CorrelationId and collides on the
+    /// <c>NotificationLog (CorrelationId, UserId, Channel)</c> unique
+    /// constraint — Postgres rejects the second insert, the consumer falls
+    /// through to the "already claimed" branch, and no duplicate push goes
+    /// out. MD5 is fine here: this is a dedupe key, not a cryptographic
+    /// signature.
+    /// </para>
+    /// </summary>
+    public class NotificationDispatcher : INotificationDispatcher
+    {
+        private const int FailureReasonMaxLength = 512;
+        private const string FailureReasonTruncationSuffix = "…(truncated)";
+
+        private readonly ILogger<NotificationDispatcher> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPushNotificationSender _pushSender;
+
+        public NotificationDispatcher(
+            ILogger<NotificationDispatcher> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider,
+            IPushNotificationSender pushSender)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+            _pushSender = pushSender;
+        }
+
+        public async Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek)
+        {
+            var correlationId = DeterministicCorrelationId(
+                "PickDeadline", userId, pickemGroupId, seasonWeek);
+
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = correlationId,
+                ["UserId"] = userId,
+                ["PickemGroupId"] = pickemGroupId,
+                ["SeasonWeek"] = seasonWeek
+            });
+
+            _logger.LogInformation("SendPickDeadlineReminderAsync invoked.");
+
+            // Atomic claim — see UserPickScoredConsumer for the full
+            // rationale (TOCTOU race, crash-vs-duplicate trade-off).
+            var claim = new NotificationLog
+            {
+                UserId = userId,
+                CorrelationId = correlationId,
+                Category = "PickDeadline",
+                Channel = "Fcm",
+                Result = "Dispatching",
+                AttemptedUtc = _dateTimeProvider.UtcNow()
+            };
+            _dataContext.NotificationLog.Add(claim);
+
+            try
+            {
+                await _dataContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                _logger.LogInformation(
+                    "PickDeadline reminder already dispatched for CorrelationId {CorrelationId}; skipping (Hangfire retry).",
+                    correlationId);
+                _dataContext.Entry(claim).State = EntityState.Detached;
+                return;
+            }
+
+            // Prefs gate.
+            var prefs = await _dataContext.UserNotificationPreferences
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.UserId == userId);
+
+            if (prefs is { PickDeadlineReminderEnabled: false })
+            {
+                await FinalizeAsync(claim, "Suppressed_UserOptedOut");
+                return;
+            }
+
+            // Device gate.
+            var devices = await _dataContext.UserDevices
+                .AsNoTracking()
+                .Where(d => d.UserId == userId && d.NotificationsEnabled)
+                .ToListAsync();
+
+            if (devices.Count == 0)
+            {
+                await FinalizeAsync(claim, "Suppressed_NoDevice");
+                return;
+            }
+
+            // Body composition — league name from the local projection.
+            var leagueName = await _dataContext.PickemGroups
+                .AsNoTracking()
+                .Where(g => g.Id == pickemGroupId)
+                .Select(g => g.Name)
+                .FirstOrDefaultAsync();
+
+            const string title = "Picks due soon";
+            var body = leagueName is not null
+                ? $"Your picks for {leagueName} (Week {seasonWeek}) are due in about an hour."
+                : $"Your picks for Week {seasonWeek} are due in about an hour.";
+
+            // Per-device dispatch. Aggregate outcome same as the other
+            // consumers (any success → "Sent"; all failures → "Failed_FcmError").
+            var successCount = 0;
+            var failureReasons = new List<string>();
+            foreach (var device in devices)
+            {
+                var result = await _pushSender.SendAsync(device.FcmToken, title, body);
+                if (result is Success<string>)
+                {
+                    successCount++;
+                }
+                else if (result is Failure<string> failure)
+                {
+                    var reason = failure.Errors.FirstOrDefault()?.ErrorMessage ?? "unknown";
+                    failureReasons.Add($"{device.Platform}:{reason}");
+                }
+            }
+
+            claim.Title = title;
+            claim.Body = body;
+            claim.Result = successCount > 0 ? "Sent" : "Failed_FcmError";
+            claim.FailureReason = ComposeFailureReason(failureReasons);
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+            await _dataContext.SaveChangesAsync();
+        }
+
+        private async Task FinalizeAsync(NotificationLog claim, string result)
+        {
+            claim.Result = result;
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+            await _dataContext.SaveChangesAsync();
+        }
+
+        private static string ComposeFailureReason(List<string> failureReasons)
+        {
+            if (failureReasons.Count == 0)
+                return null;
+
+            var joined = string.Join("; ", failureReasons);
+            if (joined.Length <= FailureReasonMaxLength)
+                return joined;
+
+            var cutoff = FailureReasonMaxLength - FailureReasonTruncationSuffix.Length;
+            return joined.Substring(0, cutoff) + FailureReasonTruncationSuffix;
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
+        }
+
+        /// <summary>
+        /// MD5 over a canonical parameter encoding. Used only as a dedupe key —
+        /// not cryptographic. Two calls with the same inputs produce the same
+        /// Guid, which makes the NotificationLog unique constraint catch
+        /// Hangfire retries.
+        /// </summary>
+        private static Guid DeterministicCorrelationId(string category, Guid userId, Guid scopeId, int qualifier)
+        {
+            var input = $"{category}|{userId:N}|{scopeId:N}|{qualifier}";
+            var hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
+            return new Guid(hash);
+        }
+    }
+}

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -126,19 +126,39 @@ namespace SportsData.Notification.Application.Dispatching
 
             // Per-device dispatch. Aggregate outcome same as the other
             // consumers (any success → "Sent"; all failures → "Failed_FcmError").
+            //
+            // Per-device try/catch: an unhandled exception from SendAsync
+            // (e.g. network failure, TaskCanceledException, anything outside
+            // FirebaseMessagingException which FirebasePushNotificationSender
+            // already maps to Failure<string>) would otherwise escape before
+            // claim finalization. The row would sit at "Dispatching"
+            // permanently — Hangfire retries collide on the unique-constraint
+            // dedupe path and short-circuit. Catching here lets one failing
+            // device fail loudly in the audit log without blocking the
+            // remaining devices or the terminal save.
             var successCount = 0;
             var failureReasons = new List<string>();
             foreach (var device in devices)
             {
-                var result = await _pushSender.SendAsync(device.FcmToken, title, body);
-                if (result is Success<string>)
+                try
                 {
-                    successCount++;
+                    var result = await _pushSender.SendAsync(device.FcmToken, title, body);
+                    if (result is Success<string>)
+                    {
+                        successCount++;
+                    }
+                    else if (result is Failure<string> failure)
+                    {
+                        var reason = failure.Errors.FirstOrDefault()?.ErrorMessage ?? "unknown";
+                        failureReasons.Add($"{device.Platform}:{reason}");
+                    }
                 }
-                else if (result is Failure<string> failure)
+                catch (Exception ex)
                 {
-                    var reason = failure.Errors.FirstOrDefault()?.ErrorMessage ?? "unknown";
-                    failureReasons.Add($"{device.Platform}:{reason}");
+                    _logger.LogWarning(ex,
+                        "Unexpected exception sending FCM to DeviceId {DeviceId}.",
+                        device.Id);
+                    failureReasons.Add($"{device.Platform}:exception:{ex.GetType().Name}");
                 }
             }
 

--- a/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
@@ -1,0 +1,234 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Notification.Application.Dispatching;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Scheduling
+{
+    public interface IPickDeadlineReminderScheduler
+    {
+        Task EvaluateAndScheduleForLeagueWeekAsync(Guid pickemGroupId, int seasonWeek, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Decides whether to schedule (or reschedule, or no-op) a pick-deadline
+    /// reminder for every member of a given league-week. The trigger is
+    /// "this league-week's matchup state may have changed" — fired by:
+    /// <list type="bullet">
+    ///   <item><c>PickemGroupMatchupCreatedConsumer</c> after upserting a new
+    ///   matchup from the steady-state event.</item>
+    ///   <item><c>PickemGroupMatchupDataPublishedConsumer</c> after upserting
+    ///   a matchup from the operator-triggered backfill.</item>
+    ///   <item><c>ContestStartTimeUpdatedConsumer</c> after resyncing
+    ///   <c>StartDateUtc</c> for matchups referencing the changed contest.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Computes the deadline as <c>MIN(StartDateUtc)</c> of all matchups in
+    /// the (group, week) — picks lock when the first game starts. Fires at
+    /// <c>deadline - leadTime</c> (currently 1 hour, hardcoded for v1).
+    /// </para>
+    ///
+    /// <para>
+    /// Per-user, the scheduler walks the <c>PendingScheduledJob</c> entries
+    /// for <c>(UserId, "PickDeadline", PickemGroupId, SeasonWeek)</c> and:
+    /// <list type="bullet">
+    ///   <item>Inserts + schedules if no row exists and the deadline is still
+    ///   in the future.</item>
+    ///   <item>Reschedules (schedule-new → save → delete-old, same crash-safe
+    ///   ordering as Producer's <c>CompetitionStreamScheduler</c>) when the
+    ///   deadline has moved.</item>
+    ///   <item>No-ops when the deadline is unchanged or already past.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public class PickDeadlineReminderScheduler : IPickDeadlineReminderScheduler
+    {
+        // Hardcoded for v1 — per the design discussion. Will become a
+        // per-user pref later when we surface notification timing controls.
+        private static readonly TimeSpan PickDeadlineLeadTime = TimeSpan.FromHours(1);
+
+        private const string JobKind = "PickDeadline";
+
+        private readonly ILogger<PickDeadlineReminderScheduler> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IProvideBackgroundJobs _backgroundJobProvider;
+
+        public PickDeadlineReminderScheduler(
+            ILogger<PickDeadlineReminderScheduler> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider,
+            IProvideBackgroundJobs backgroundJobProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+            _backgroundJobProvider = backgroundJobProvider;
+        }
+
+        public async Task EvaluateAndScheduleForLeagueWeekAsync(
+            Guid pickemGroupId,
+            int seasonWeek,
+            CancellationToken cancellationToken)
+        {
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["PickemGroupId"] = pickemGroupId,
+                ["SeasonWeek"] = seasonWeek
+            });
+
+            // Compute deadline from current DB state. Null = no matchups
+            // for this league-week (e.g., matchups got deleted) → nothing
+            // to schedule, but if existing rows reference this scope they
+            // should arguably be cancelled. v1 leaves them alone; the
+            // dispatcher's prefs/device gates will absorb a stale fire.
+            var deadline = await _dataContext.PickemGroupMatchups
+                .Where(m => m.PickemGroupId == pickemGroupId && m.SeasonWeek == seasonWeek)
+                .Select(m => (DateTime?)m.StartDateUtc)
+                .MinAsync(cancellationToken);
+
+            if (deadline is null)
+            {
+                _logger.LogDebug("No matchups for league-week; nothing to schedule.");
+                return;
+            }
+
+            var fireTime = deadline.Value - PickDeadlineLeadTime;
+            var now = _dateTimeProvider.UtcNow();
+
+            if (fireTime <= now)
+            {
+                // Deadline already past or within the lead window — too late
+                // to schedule a "soon" reminder. We could send-immediate
+                // instead, but v1 just skips: the user is presumably already
+                // making picks if they're going to.
+                _logger.LogInformation(
+                    "Deadline {Deadline} is past or within lead window from now {Now}; skipping schedule.",
+                    deadline, now);
+                return;
+            }
+
+            // Resolve members of the league. The local PickemGroupMember
+            // projection is the source of truth.
+            var memberIds = await _dataContext.PickemGroupMembers
+                .AsNoTracking()
+                .Where(m => m.PickemGroupId == pickemGroupId)
+                .Select(m => m.UserId)
+                .ToListAsync(cancellationToken);
+
+            if (memberIds.Count == 0)
+            {
+                _logger.LogDebug("No members for league; nothing to schedule.");
+                return;
+            }
+
+            _logger.LogInformation(
+                "Evaluating PickDeadline reminders for {MemberCount} members. Deadline={Deadline}, FireTime={FireTime}",
+                memberIds.Count, deadline, fireTime);
+
+            // Pull existing jobs for the whole league-week in one query —
+            // cheaper than per-user round trips for a 30-person league.
+            var existingByUser = await _dataContext.PendingScheduledJobs
+                .Where(j => j.JobKind == JobKind
+                            && j.TargetId == pickemGroupId
+                            && j.SeasonWeek == seasonWeek)
+                .ToDictionaryAsync(j => j.UserId, cancellationToken);
+
+            // Skip the per-user prefs lookup inside the loop by batching.
+            var optedOutUserIds = await _dataContext.UserNotificationPreferences
+                .AsNoTracking()
+                .Where(p => memberIds.Contains(p.UserId) && !p.PickDeadlineReminderEnabled)
+                .Select(p => p.UserId)
+                .ToListAsync(cancellationToken);
+            var optedOut = optedOutUserIds.ToHashSet();
+
+            foreach (var userId in memberIds)
+            {
+                if (optedOut.Contains(userId))
+                {
+                    // Honor opted-out users by NOT scheduling. If a stale row
+                    // exists for them from a prior pass (they opted out
+                    // after), leave it — the dispatcher's prefs gate will
+                    // suppress the fire and audit it.
+                    continue;
+                }
+
+                existingByUser.TryGetValue(userId, out var existing);
+                await ScheduleOrRescheduleAsync(userId, pickemGroupId, seasonWeek, fireTime, existing, now, cancellationToken);
+            }
+        }
+
+        private async Task ScheduleOrRescheduleAsync(
+            Guid userId,
+            Guid pickemGroupId,
+            int seasonWeek,
+            DateTime fireTime,
+            PendingScheduledJob existing,
+            DateTime now,
+            CancellationToken cancellationToken)
+        {
+            if (existing is not null && existing.ScheduledFireUtc == fireTime)
+            {
+                // Deadline hasn't moved — no work.
+                return;
+            }
+
+            // Schedule the new job FIRST, then persist, then delete the old.
+            // Crash-safe ordering: a crash between schedule and save leaks
+            // an orphan Hangfire job (benign — dispatcher's dedupe absorbs
+            // it). The alternative (delete-old first) could leave a row
+            // pointing at a deleted job, silently missing the reminder.
+            var delay = fireTime - now;
+            var newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
+                d => d.SendPickDeadlineReminderAsync(userId, pickemGroupId, seasonWeek),
+                delay);
+
+            if (existing is null)
+            {
+                _dataContext.PendingScheduledJobs.Add(new PendingScheduledJob
+                {
+                    UserId = userId,
+                    JobKind = JobKind,
+                    TargetId = pickemGroupId,
+                    SeasonWeek = seasonWeek,
+                    HangfireJobId = newJobId,
+                    ScheduledFireUtc = fireTime,
+                    CreatedUtc = now,
+                    CreatedBy = Guid.Empty
+                });
+                await _dataContext.SaveChangesAsync(cancellationToken);
+            }
+            else
+            {
+                var oldJobId = existing.HangfireJobId;
+                existing.HangfireJobId = newJobId;
+                existing.ScheduledFireUtc = fireTime;
+                existing.ModifiedUtc = now;
+                await _dataContext.SaveChangesAsync(cancellationToken);
+
+                // Best-effort cancellation of the old Hangfire job. If it
+                // already fired or is already deleted, Delete returns false
+                // and we don't care — the dispatcher dedupe still protects
+                // against a double send.
+                try
+                {
+                    _backgroundJobProvider.Delete(oldJobId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to delete old Hangfire job {OldJobId} after reschedule. Will be absorbed by dispatcher dedupe.",
+                        oldJobId);
+                }
+            }
+
+            _logger.LogInformation(
+                "Scheduled PickDeadline reminder. UserId={UserId}, FireTime={FireTime}, HangfireJobId={HangfireJobId}",
+                userId, fireTime, newJobId);
+        }
+    }
+}

--- a/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
@@ -189,7 +189,7 @@ namespace SportsData.Notification.Application.Scheduling
 
             if (existing is null)
             {
-                _dataContext.PendingScheduledJobs.Add(new PendingScheduledJob
+                var entity = new PendingScheduledJob
                 {
                     UserId = userId,
                     JobKind = JobKind,
@@ -199,8 +199,50 @@ namespace SportsData.Notification.Application.Scheduling
                     ScheduledFireUtc = fireTime,
                     CreatedUtc = now,
                     CreatedBy = Guid.Empty
-                });
-                await _dataContext.SaveChangesAsync(cancellationToken);
+                };
+                _dataContext.PendingScheduledJobs.Add(entity);
+
+                try
+                {
+                    await _dataContext.SaveChangesAsync(cancellationToken);
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // A peer scheduler run (concurrent consumer for the same
+                    // league-week) inserted first. Detach our orphan, fetch
+                    // the winner's row, and continue down the reschedule
+                    // branch — if the peer scheduled the same fireTime we
+                    // no-op below; otherwise we reschedule. The Hangfire job
+                    // we just scheduled becomes the orphan to delete.
+                    _dataContext.Entry(entity).State = EntityState.Detached;
+                    var winner = await _dataContext.PendingScheduledJobs
+                        .FirstAsync(j => j.UserId == userId
+                                         && j.JobKind == JobKind
+                                         && j.TargetId == pickemGroupId
+                                         && j.SeasonWeek == seasonWeek,
+                                    cancellationToken);
+
+                    if (winner.ScheduledFireUtc == fireTime)
+                    {
+                        // Same fireTime — peer already covered it. Clean up
+                        // our orphan and exit.
+                        TryDeleteHangfireJob(newJobId);
+                        return;
+                    }
+
+                    // Different fireTime — we take over the scheduling. Old
+                    // jobId is the winner's; new is ours.
+                    var winnerOldJobId = winner.HangfireJobId;
+                    winner.HangfireJobId = newJobId;
+                    winner.ScheduledFireUtc = fireTime;
+                    winner.ModifiedUtc = now;
+                    await _dataContext.SaveChangesAsync(cancellationToken);
+                    TryDeleteHangfireJob(winnerOldJobId);
+                    _logger.LogInformation(
+                        "Concurrent insert resolved; took over scheduling. UserId={UserId}, FireTime={FireTime}",
+                        userId, fireTime);
+                    return;
+                }
             }
             else
             {
@@ -210,25 +252,35 @@ namespace SportsData.Notification.Application.Scheduling
                 existing.ModifiedUtc = now;
                 await _dataContext.SaveChangesAsync(cancellationToken);
 
-                // Best-effort cancellation of the old Hangfire job. If it
-                // already fired or is already deleted, Delete returns false
-                // and we don't care — the dispatcher dedupe still protects
-                // against a double send.
-                try
-                {
-                    _backgroundJobProvider.Delete(oldJobId);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex,
-                        "Failed to delete old Hangfire job {OldJobId} after reschedule. Will be absorbed by dispatcher dedupe.",
-                        oldJobId);
-                }
+                TryDeleteHangfireJob(oldJobId);
             }
 
             _logger.LogInformation(
                 "Scheduled PickDeadline reminder. UserId={UserId}, FireTime={FireTime}, HangfireJobId={HangfireJobId}",
                 userId, fireTime, newJobId);
+        }
+
+        // Best-effort cancellation. Hangfire returns false if the job is
+        // already in a terminal state — the dispatcher's NotificationLog
+        // dedupe absorbs any duplicate fire from a missed delete.
+        private void TryDeleteHangfireJob(string jobId)
+        {
+            try
+            {
+                _backgroundJobProvider.Delete(jobId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to delete Hangfire job {JobId}. Absorbed by dispatcher dedupe.",
+                    jobId);
+            }
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
         }
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -55,10 +55,14 @@ namespace SportsData.Notification.Infrastructure.Data
                 .HasIndex(p => p.UserId)
                 .IsUnique();
 
-            // Quick lookup when an upstream event needs to find the prior
-            // Hangfire job to cancel/reschedule.
+            // Natural-key lookup when an upstream event needs to find the
+            // prior Hangfire job to cancel/reschedule. SeasonWeek included
+            // because PickDeadline rows are scoped per league per week —
+            // omitting it would collide when a league has matchups generated
+            // multiple weeks ahead. Null SeasonWeek (Kickoff jobs) still
+            // participates in the index per Postgres semantics.
             modelBuilder.Entity<PendingScheduledJob>()
-                .HasIndex(j => new { j.UserId, j.JobKind, j.TargetId });
+                .HasIndex(j => new { j.UserId, j.JobKind, j.TargetId, j.SeasonWeek });
 
             // Idempotency key on FCM dispatch: same correlation + user +
             // channel = same logical send, even on RabbitMQ redelivery.

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -61,8 +61,23 @@ namespace SportsData.Notification.Infrastructure.Data
             // omitting it would collide when a league has matchups generated
             // multiple weeks ahead. Null SeasonWeek (Kickoff jobs) still
             // participates in the index per Postgres semantics.
+            //
+            // Unique because the natural-key invariant is "one scheduled row
+            // per user per scope" — two consumer runs racing to schedule the
+            // same reminder would otherwise persist duplicates and break the
+            // scheduler's ToDictionaryAsync lookup. Race losers catch
+            // DbUpdateException(23505) and fall through to the reschedule
+            // path against the winner's row.
+            //
+            // AreNullsDistinct(false): Kickoff jobs leave SeasonWeek null,
+            // and Postgres treats nulls as distinct by default. Without this,
+            // duplicate Kickoff rows for the same (User, "Kickoff", ContestId)
+            // tuple would slip through the unique index. Requires Postgres 15+
+            // (the live cluster runs 16, so we're fine).
             modelBuilder.Entity<PendingScheduledJob>()
-                .HasIndex(j => new { j.UserId, j.JobKind, j.TargetId, j.SeasonWeek });
+                .HasIndex(j => new { j.UserId, j.JobKind, j.TargetId, j.SeasonWeek })
+                .IsUnique()
+                .AreNullsDistinct(false);
 
             // Idempotency key on FCM dispatch: same correlation + user +
             // channel = same logical send, even on RabbitMQ redelivery.

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PendingScheduledJob.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PendingScheduledJob.cs
@@ -31,10 +31,20 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
 
         /// <summary>
         /// Logical target the reminder is about. For "Kickoff" this is the
-        /// ContestId; for "PickDeadline" this is the PickemGroupWeek row id
-        /// (one deadline reminder per user per league per week).
+        /// ContestId; for "PickDeadline" this is the PickemGroupId (paired
+        /// with <see cref="SeasonWeek"/> in the unique constraint so the
+        /// same league can have one row per week).
         /// </summary>
         public Guid TargetId { get; set; }
+
+        /// <summary>
+        /// Only meaningful for <c>JobKind = "PickDeadline"</c>. Null for
+        /// Kickoff jobs (those are scoped to a single contest, not a week).
+        /// Part of the natural key for PickDeadline rows so a league with
+        /// matchups generated weeks ahead can carry one scheduled-job row
+        /// per upcoming week without collisions.
+        /// </summary>
+        public int? SeasonWeek { get; set; }
 
         [Required]
         [MaxLength(64)]

--- a/src/SportsData.Notification/Migrations/20260625114339_AddSeasonWeekToPendingScheduledJob.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260625114339_AddSeasonWeekToPendingScheduledJob.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260625114339_AddSeasonWeekToPendingScheduledJob")]
+    partial class AddSeasonWeekToPendingScheduledJob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260625114339_AddSeasonWeekToPendingScheduledJob.cs
+++ b/src/SportsData.Notification/Migrations/20260625114339_AddSeasonWeekToPendingScheduledJob.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSeasonWeekToPendingScheduledJob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId",
+                table: "PendingScheduledJobs");
+
+            migrationBuilder.AddColumn<int>(
+                name: "SeasonWeek",
+                table: "PendingScheduledJobs",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs",
+                columns: new[] { "UserId", "JobKind", "TargetId", "SeasonWeek" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs");
+
+            migrationBuilder.DropColumn(
+                name: "SeasonWeek",
+                table: "PendingScheduledJobs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId",
+                table: "PendingScheduledJobs",
+                columns: new[] { "UserId", "JobKind", "TargetId" });
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260625123413_MakePendingScheduledJobIndexUnique.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260625123413_MakePendingScheduledJobIndexUnique.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260625123413_MakePendingScheduledJobIndexUnique")]
+    partial class MakePendingScheduledJobIndexUnique
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -128,8 +131,6 @@ namespace SportsData.Notification.Migrations
 
                     b.HasIndex("UserId", "JobKind", "TargetId", "SeasonWeek")
                         .IsUnique();
-
-                    NpgsqlIndexBuilderExtensions.AreNullsDistinct(b.HasIndex("UserId", "JobKind", "TargetId", "SeasonWeek"), false);
 
                     b.ToTable("PendingScheduledJobs");
                 });

--- a/src/SportsData.Notification/Migrations/20260625123413_MakePendingScheduledJobIndexUnique.cs
+++ b/src/SportsData.Notification/Migrations/20260625123413_MakePendingScheduledJobIndexUnique.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakePendingScheduledJobIndexUnique : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs",
+                columns: new[] { "UserId", "JobKind", "TargetId", "SeasonWeek" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs",
+                columns: new[] { "UserId", "JobKind", "TargetId", "SeasonWeek" });
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260625133516_PendingScheduledJobIndexNullsNotDistinct.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260625133516_PendingScheduledJobIndexNullsNotDistinct.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260625133516_PendingScheduledJobIndexNullsNotDistinct")]
+    partial class PendingScheduledJobIndexNullsNotDistinct
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260625133516_PendingScheduledJobIndexNullsNotDistinct.cs
+++ b/src/SportsData.Notification/Migrations/20260625133516_PendingScheduledJobIndexNullsNotDistinct.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class PendingScheduledJobIndexNullsNotDistinct : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs",
+                columns: new[] { "UserId", "JobKind", "TargetId", "SeasonWeek" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingScheduledJobs_UserId_JobKind_TargetId_SeasonWeek",
+                table: "PendingScheduledJobs",
+                columns: new[] { "UserId", "JobKind", "TargetId", "SeasonWeek" },
+                unique: true);
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -6,6 +6,8 @@ using SportsData.Core.Common;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Application.Dispatching;
+using SportsData.Notification.Application.Scheduling;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Notifications;
 
@@ -94,6 +96,13 @@ namespace SportsData.Notification
             // auth, per the convention reasserted in #463.
             services.AddHangfire(config, builder.Environment.ApplicationName, mode);
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
+
+            // Phase 2c-main: pick-deadline reminder scheduling + dispatch.
+            // Dispatcher is the Hangfire-invoked target; scheduler is the
+            // helper consumers call after every projection write that could
+            // affect a league-week's deadline.
+            services.AddScoped<INotificationDispatcher, NotificationDispatcher>();
+            services.AddScoped<IPickDeadlineReminderScheduler, PickDeadlineReminderScheduler>();
 
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);


### PR DESCRIPTION
## Summary
Closes out the ""at least pick reminders"" arc. Hangfire fires a per-user push **1 hour before the league-week's earliest matchup**, with full reschedule-on-change behavior:

- Per-user scheduling re-evaluates on every projection write that could shift the deadline.
- Locked design from the prior discussion: \`A1\` (\`SeasonWeek\` column on \`PendingScheduledJob\`) + \`B1\` (per-matchup re-evaluate, robust to event ordering).

## Schema
- \`PendingScheduledJob.SeasonWeek\` (\`int?\`) — only meaningful for \`PickDeadline\` jobs (null for Kickoff). Index now \`(UserId, JobKind, TargetId, SeasonWeek)\` so a league with matchups generated multiple weeks ahead carries one row per week without collisions.
- Migration: \`AddSeasonWeekToPendingScheduledJob\`.

## Dispatching
- \`INotificationDispatcher\` + \`NotificationDispatcher\` with \`SendPickDeadlineReminderAsync(userId, pickemGroupId, seasonWeek)\`.
- Atomic-claim + dispatch pattern matches the existing event-driven consumers.
- **Deterministic CorrelationId** (MD5 over canonical params) so Hangfire retries collide on the \`NotificationLog (CorrelationId, UserId, Channel)\` unique constraint — no duplicate sends from retry behavior.
- Body composed via local \`PickemGroup\` projection: \`""Your picks for {LeagueName} (Week N) are due in about an hour.""\` Graceful fallback when projection hasn't seen the group.

## Scheduling
- \`IPickDeadlineReminderScheduler.EvaluateAndScheduleForLeagueWeekAsync\` — computes deadline = \`MIN(StartDateUtc)\` for matchups in (group, week), fires at \`deadline - 1h\`, walks members, honors \`PickDeadlineReminderEnabled\`, then schedules/reschedules/no-ops based on the existing \`PendingScheduledJob\` row.
- Crash-safe ordering on reschedule (schedule-new → save → delete-old) — same pattern Producer's \`CompetitionStreamScheduler\` uses in #457. Old job delete is best-effort; orphan absorbed by dispatcher dedupe.
- Lead time **hardcoded to 1 hour for v1** per the locked design call.

## Consumer wiring
- **\`PickemGroupMatchupCreatedConsumer\`** + **\`PickemGroupMatchupDataPublishedConsumer\`**: trigger re-evaluation after upsert. Insert path always; update path only when \`StartDateUtc\` or \`SeasonWeek\` changed. Week-change case re-evaluates BOTH old and new week buckets (matchup left one bucket, entered another).
- **\`ContestStartTimeUpdatedConsumer\`**: after the projection resync, re-evaluates every \`(PickemGroupId, SeasonWeek)\` touching the contest — a single contest can appear in many leagues.

## Drive-by: deferred PR #466 CR comment fix
The paging comment in \`PickemGroupMatchupsRequestedConsumer\` was rewritten to drop the false ""monotonic Id"" claim (PK is a Guid, not a sequence). \`OrderBy\` is for deterministic per-page Skip/Take only; downstream upsert idempotency is what actually keeps the backfill safe against concurrent inserts.

## Out of scope
- **Phase 2d: Kickoff reminders**. The existing \`ContestStartTimeUpdatedConsumer\` Hangfire-reschedule TODO sits in the same file waiting on the Kickoff dispatcher. Same scheduling/dispatcher pattern will apply.

## Test plan
- [x] \`dotnet build src/SportsData.Notification\` — 0/0
- [x] \`dotnet build src/SportsData.Api\` — 0/0
- [ ] Local: apply migration \`AddSeasonWeekToPendingScheduledJob\` against \`sdNotification.All\`
- [ ] Local: trigger \`POST /admin/backfill/pickemgroupmatchups\` against a backfilled league with members + prefs enabled. Observe \`PendingScheduledJob\` rows created with \`JobKind=PickDeadline\` and \`ScheduledFireUtc\` = MIN(StartDateUtc) − 1h. Confirm a Hangfire job is scheduled per row.
- [ ] Local: manually fire one of the scheduled jobs early — observe \`NotificationLog\` row with \`Result=Sent\` (or \`Suppressed_*\` if device/pref gates kick in), body contains league name + week
- [ ] Local: replay a \`ContestStartTimeUpdated\` event (moves a game earlier) — observe \`PendingScheduledJob\` rows updated, old Hangfire jobs deleted, new ones scheduled at the new fire time
- [ ] Local: trigger same dispatch twice (simulate Hangfire retry by manually invoking the dispatcher with the same params) — observe second call short-circuits on the unique-constraint dedupe path, no duplicate \`NotificationLog\` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pick-deadline reminder scheduling and rescheduling when contest or matchup timing changes.
  * Introduced a dedicated push notification dispatch flow for pick-deadline reminders.
  * Added league-week–based tracking so reminders are evaluated per season week.

* **Bug Fixes**
  * Improved reminder updates when matchup start dates or season weeks change (including rescheduling for the prior week when needed).
  * Reduced duplicate or missed reminders by strengthening deduplication and crash-safe rescheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->