### PR TITLE
fix(producer): persist CompetitionNote additions on EventCompetition update path

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
@@ -223,6 +223,15 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
             _logger.LogInformation("No property changes detected. CompetitionId={CompetitionId}", competition.Id);
         }
 
+        // Notes are a navigation collection; CurrentValues.SetValues above
+        // copies scalar properties only, so additions to the ESPN document's
+        // notes array (e.g. "Inclement Weather - Makeup date July 23rd" when
+        // a rain-delayed game gets postponed) were never persisted on the
+        // update path. Process them independently — happens whether or not
+        // any scalar property changed, since a status-driven note add does
+        // not require any scalar to shift.
+        await ProcessNotesOnUpdate(dto, competition);
+
         await ProcessChildDocuments(command, dto, competition, isNew: false);
     }
 
@@ -345,6 +354,72 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
                 CompetitionId = competition.Id
             };
             competition.Notes.Add(newNote);
+        }
+    }
+
+    /// <summary>
+    /// Dedupe-aware variant of <see cref="ProcessNotes"/> for the update path.
+    /// The tracked competition arrives without its Notes navigation populated
+    /// (per the no-Include rule documented at ProcessInternal), so we query
+    /// the persisted (Type, Headline) tuples directly and only insert notes
+    /// that aren't already there.
+    ///
+    /// <para>
+    /// Natural identity is (Type, Headline) — the DTO carries no other
+    /// identifier. If ESPN ever edits an existing note's headline (vs. adding
+    /// a new note), this treats it as a NEW note and the prior note stays
+    /// in place. Accepted trade-off for v1: a duplicate-ish row beats the
+    /// alternative (missing the update entirely, which is the bug this
+    /// method exists to fix).
+    /// </para>
+    /// </summary>
+    private async Task ProcessNotesOnUpdate(
+        EspnEventCompetitionDtoBase externalDto,
+        CompetitionBase competition)
+    {
+        if (externalDto.Notes is null || externalDto.Notes.Count == 0)
+        {
+            return;
+        }
+
+        // Read existing notes WITHOUT pulling them into the change tracker
+        // via the parent's Notes navigation. Loading the nav on the tracked
+        // competition would trigger EF's optimistic-concurrency check on
+        // the collection — same concern documented at the top of
+        // ProcessInternal for Competitors.
+        var existingTuples = await _dataContext.Set<CompetitionNote>()
+            .AsNoTracking()
+            .Where(n => n.CompetitionId == competition.Id)
+            .Select(n => new { n.Type, n.Headline })
+            .ToListAsync();
+
+        var existingSet = existingTuples
+            .Select(t => (t.Type, t.Headline))
+            .ToHashSet();
+
+        var addedCount = 0;
+        foreach (var note in externalDto.Notes)
+        {
+            if (existingSet.Contains((note.Type, note.Headline)))
+            {
+                continue;
+            }
+
+            _dataContext.Set<CompetitionNote>().Add(new CompetitionNote
+            {
+                Type = note.Type,
+                Headline = note.Headline,
+                CompetitionId = competition.Id
+            });
+            existingSet.Add((note.Type, note.Headline));
+            addedCount++;
+        }
+
+        if (addedCount > 0)
+        {
+            _logger.LogInformation(
+                "Added {Count} new CompetitionNote(s) on update. CompetitionId={CompetitionId}",
+                addedCount, competition.Id);
         }
     }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
@@ -210,6 +210,71 @@ public class BaseballEventCompetitionDocumentProcessorTests
         refreshed.SeasonSeriesSummary.Should().Be(locked.SeasonSeriesSummary);
     }
 
+    [Fact]
+    public async Task WhenReprocessed_WithNewNote_PersistsTheNoteOnUpdatePath()
+    {
+        // Regression: CurrentValues.SetValues copies scalar properties only;
+        // Notes is a navigation collection, so update-path note additions
+        // (e.g. "Inclement Weather - Makeup date July 23rd" when a rain-
+        // delayed game gets postponed) used to be silently dropped.
+        var (competitionId, _, cmd) = await SetupAndBuildCommand();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>();
+
+        // First pass: fixture has empty notes array — competition seeded
+        // with zero notes.
+        await sut.ProcessAsync(cmd);
+
+        var initialNoteCount = await _baseballDataContext.Set<CompetitionNote>()
+            .AsNoTracking()
+            .CountAsync(n => n.CompetitionId == competitionId);
+        initialNoteCount.Should().Be(0);
+
+        // Mutate the fixture: inject a postponement note as ESPN would
+        // when a game transitions Rain Delay → Postponed.
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
+        var dto = json.FromJson<EspnBaseballEventCompetitionDto>()!;
+        dto.Notes.Add(new SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common.EspnEventCompetitionNoteDto
+        {
+            Type = "event",
+            Headline = "Inclement Weather - Makeup date July 23rd"
+        });
+
+        var mutatedJson = dto.ToJson();
+        var mutatedCmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, cmd.ParentId)
+            .With(x => x.SeasonYear, cmd.SeasonYear)
+            .With(x => x.SourceDataProvider, cmd.SourceDataProvider)
+            .With(x => x.Sport, cmd.Sport)
+            .With(x => x.DocumentType, cmd.DocumentType)
+            .With(x => x.Document, mutatedJson)
+            .With(x => x.UrlHash, cmd.UrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, cmd.IncludeLinkedDocumentTypes)
+            .OmitAutoProperties()
+            .Create();
+
+        // act: re-process via the update path.
+        await sut.ProcessAsync(mutatedCmd);
+
+        // assert: the note is persisted.
+        var notes = await _baseballDataContext.Set<CompetitionNote>()
+            .AsNoTracking()
+            .Where(n => n.CompetitionId == competitionId)
+            .ToListAsync();
+
+        notes.Should().HaveCount(1);
+        notes[0].Type.Should().Be("event");
+        notes[0].Headline.Should().Be("Inclement Weather - Makeup date July 23rd");
+
+        // Replay the same payload — dedupe should kick in, no duplicate row.
+        await sut.ProcessAsync(mutatedCmd);
+
+        var notesAfterReplay = await _baseballDataContext.Set<CompetitionNote>()
+            .AsNoTracking()
+            .CountAsync(n => n.CompetitionId == competitionId);
+        notesAfterReplay.Should().Be(1);
+    }
+
     private async Task<(Guid CompetitionId, Guid ContestId, ProcessDocumentCommand Cmd)> SetupAndBuildCommand()
     {
         var idGen = new ExternalRefIdentityGenerator();


### PR DESCRIPTION
## Summary
\`EventCompetitionDocumentProcessorBase.ProcessUpdate\` used \`CurrentValues.SetValues\` to copy DTO fields onto the tracked competition — which handles **scalar properties only**. The \`Notes\` navigation collection was silently ignored. Any note ESPN added after first sourcing (e.g., \`""Inclement Weather - Makeup date July 23rd""\` when a rain-delayed game gets postponed) never reached the DB.

## How it surfaced
An MLB game went Rain Delay → Postponed yesterday. \`CompetitionStatus\` flipped correctly, but the postponement note was missing from the projection.

## The fix
New \`ProcessNotesOnUpdate\` method invoked after the scalar-update branch in \`ProcessUpdate\`. Reads the persisted \`(Type, Headline)\` tuples WITHOUT loading them onto the tracked entity's nav (same no-Include rule the existing \`ProcessInternal\` comment cites for \`Competitors\` — avoids EF optimistic-concurrency false-positives on parallel processor writes). Adds only notes whose tuple isn't already in the set.

## Trade-off documented inline
ESPN's DTO carries no note identifier beyond Type+Headline, so this is the natural key. If ESPN ever EDITS an existing note's headline (vs. ADDS a new note), the prior row stays and the edit becomes a ""new"" row. A duplicate-ish row beats the alternative — silently dropping the update, which is the bug this method exists to fix.

## Scope notes
- \`ProcessLinks\` has the same anti-pattern in the same file (called in the create path, not the update path). **Left for a follow-up PR** — you surfaced the notes case specifically and I'm keeping scope tight. Flagging so it doesn't get lost.
- ESPN's note removal (rare): not handled. Notes are append-only in this implementation. If a removal scenario ever appears in the wild, a separate cleanup pass would handle it.

## Tests
- New \`WhenReprocessed_WithNewNote_PersistsTheNoteOnUpdatePath\` in \`BaseballEventCompetitionDocumentProcessorTests\`:
  1. First pass: empty-notes fixture → seeded competition with 0 notes.
  2. Mutate fixture: inject an \`""event""\` / \`""Inclement Weather - Makeup date July 23rd""\` note (the actual ESPN copy from the incident).
  3. Reprocess via update path → assert exactly one note persisted with correct Type + Headline.
  4. Replay same mutated payload → assert still exactly one note (dedupe works).
- Full \`Baseball/FootballEventCompetitionDocumentProcessor\` test suite: 13/13 passing.

## Test plan
- [x] \`dotnet build src/SportsData.Producer\` — 0/0
- [x] Targeted test — passes
- [x] Full event-competition processor suite — 13/13
- [ ] Manually re-source the stuck contest in prod (\`POST /admin/contests/{contestId}/refresh\` or equivalent) and verify the missing note lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Competition notes are now saved during reprocessing, even when no other event details change.
  * Duplicate notes are automatically ignored, so only new notes are added.

* **Bug Fixes**
  * Fixed an issue where newly added notes could be missed on update-style imports.
  * Improved reliability when processing repeated event updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->