### PR TITLE
fix(producer): persist CompetitionLink additions on EventCompetition update path

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionDocumentProcessorBase.cs
@@ -232,6 +232,12 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
         // not require any scalar to shift.
         await ProcessNotesOnUpdate(dto, competition);
 
+        // Same bug class as Notes — Links is a navigation collection, so
+        // ESPN's link additions (e.g. boxscore, gamecast becoming
+        // available post-game) used to be silently dropped on the update
+        // path. Same dedupe-aware add pattern.
+        await ProcessLinksOnUpdate(dto, competition);
+
         await ProcessChildDocuments(command, dto, competition, isNew: false);
     }
 
@@ -419,6 +425,72 @@ public abstract class EventCompetitionDocumentProcessorBase<TDataContext> : Docu
         {
             _logger.LogInformation(
                 "Added {Count} new CompetitionNote(s) on update. CompetitionId={CompetitionId}",
+                addedCount, competition.Id);
+        }
+    }
+
+    /// <summary>
+    /// Dedupe-aware variant of <see cref="ProcessLinks"/> for the update path.
+    /// Same rationale as <see cref="ProcessNotesOnUpdate"/>: CurrentValues.SetValues
+    /// only copies scalar properties, so the Links navigation never reached
+    /// the DB on the update path. ESPN adds links post-game (boxscore,
+    /// gamecast, recap) that would have been silently dropped.
+    ///
+    /// <para>
+    /// Natural identity is <c>(CompetitionId, SourceUrlHash)</c> — the URL
+    /// itself uniquely identifies a link's target. Text changes on the same
+    /// URL (e.g. "Box Score" → "Box Score (Final)") aren't surfaced here;
+    /// they'd require a richer diff. Accepted trade-off for the same reason
+    /// as the notes case: a stale-text row beats a missing link.
+    /// </para>
+    /// </summary>
+    private async Task ProcessLinksOnUpdate(
+        EspnEventCompetitionDtoBase externalDto,
+        CompetitionBase competition)
+    {
+        if (externalDto.Links is null || externalDto.Links.Count == 0)
+        {
+            return;
+        }
+
+        var existingHashes = await _dataContext.Set<CompetitionLink>()
+            .AsNoTracking()
+            .Where(l => l.CompetitionId == competition.Id)
+            .Select(l => l.SourceUrlHash)
+            .ToListAsync();
+
+        var existingSet = existingHashes.ToHashSet();
+
+        var addedCount = 0;
+        foreach (var link in externalDto.Links)
+        {
+            var sourceUrlHash = HashProvider.GenerateHashFromUri(link.Href);
+
+            if (existingSet.Contains(sourceUrlHash))
+            {
+                continue;
+            }
+
+            _dataContext.Set<CompetitionLink>().Add(new CompetitionLink
+            {
+                Id = Guid.NewGuid(),
+                CompetitionId = competition.Id,
+                Rel = string.Join("|", link.Rel),
+                Href = link.Href.ToCleanUrl(),
+                Text = link.Text,
+                ShortText = link.ShortText,
+                IsExternal = link.IsExternal,
+                IsPremium = link.IsPremium,
+                SourceUrlHash = sourceUrlHash
+            });
+            existingSet.Add(sourceUrlHash);
+            addedCount++;
+        }
+
+        if (addedCount > 0)
+        {
+            _logger.LogInformation(
+                "Added {Count} new CompetitionLink(s) on update. CompetitionId={CompetitionId}",
                 addedCount, competition.Id);
         }
     }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
@@ -275,6 +275,81 @@ public class BaseballEventCompetitionDocumentProcessorTests
         notesAfterReplay.Should().Be(1);
     }
 
+    [Fact]
+    public async Task WhenReprocessed_WithNewLink_PersistsTheLinkOnUpdatePath()
+    {
+        // Parallel regression case to the notes fix (PR #468). Links is a
+        // navigation collection; CurrentValues.SetValues copies scalar
+        // properties only, so post-game link additions (boxscore, gamecast,
+        // recap) were silently dropped on the update path.
+        var (competitionId, _, cmd) = await SetupAndBuildCommand();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>();
+
+        // First pass: fixture has populated links — seeds the competition
+        // with the existing set.
+        await sut.ProcessAsync(cmd);
+
+        var initialLinkCount = await _baseballDataContext.Set<CompetitionLink>()
+            .AsNoTracking()
+            .CountAsync(l => l.CompetitionId == competitionId);
+        initialLinkCount.Should().BeGreaterThan(0);
+
+        // Mutate the fixture: inject a post-game-only link (e.g. recap)
+        // that wasn't there originally.
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
+        var dto = json.FromJson<EspnBaseballEventCompetitionDto>()!;
+
+        var newHref = new Uri("https://www.espn.com/mlb/recap/_/gameId/401814844-new-test");
+        dto.Links.Add(new SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common.EspnLinkFullDto
+        {
+            Language = "en-US",
+            Rel = ["recap", "desktop", "event"],
+            Href = newHref,
+            Text = "Recap",
+            ShortText = "Recap",
+            IsExternal = false,
+            IsPremium = false
+        });
+
+        var mutatedJson = dto.ToJson();
+        var mutatedCmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, cmd.ParentId)
+            .With(x => x.SeasonYear, cmd.SeasonYear)
+            .With(x => x.SourceDataProvider, cmd.SourceDataProvider)
+            .With(x => x.Sport, cmd.Sport)
+            .With(x => x.DocumentType, cmd.DocumentType)
+            .With(x => x.Document, mutatedJson)
+            .With(x => x.UrlHash, cmd.UrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, cmd.IncludeLinkedDocumentTypes)
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(mutatedCmd);
+
+        // assert: link is persisted, no duplicates of the existing ones.
+        var afterUpdateCount = await _baseballDataContext.Set<CompetitionLink>()
+            .AsNoTracking()
+            .CountAsync(l => l.CompetitionId == competitionId);
+        afterUpdateCount.Should().Be(initialLinkCount + 1);
+
+        var newHrefHash = SportsData.Core.Common.Hashing.HashProvider.GenerateHashFromUri(newHref);
+        var newLink = await _baseballDataContext.Set<CompetitionLink>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(l => l.CompetitionId == competitionId && l.SourceUrlHash == newHrefHash);
+        newLink.Should().NotBeNull();
+        newLink!.Text.Should().Be("Recap");
+
+        // Replay same payload — dedupe should keep the count stable.
+        await sut.ProcessAsync(mutatedCmd);
+
+        var afterReplayCount = await _baseballDataContext.Set<CompetitionLink>()
+            .AsNoTracking()
+            .CountAsync(l => l.CompetitionId == competitionId);
+        afterReplayCount.Should().Be(initialLinkCount + 1);
+    }
+
     private async Task<(Guid CompetitionId, Guid ContestId, ProcessDocumentCommand Cmd)> SetupAndBuildCommand()
     {
         var idGen = new ExternalRefIdentityGenerator();


### PR DESCRIPTION
## Summary
Follow-up to #468 closing the second half of the same bug. \`EventCompetitionDocumentProcessorBase\` had the **same anti-pattern on \`Links\`** as it did on \`Notes\` — \`CurrentValues.SetValues\` in \`ProcessUpdate\` copies scalar properties only, so any link ESPN added to the document after first sourcing (boxscore, gamecast, recap, etc. landing post-game) was silently dropped.

## Fix
New \`ProcessLinksOnUpdate\` mirroring the \`ProcessNotesOnUpdate\` pattern from #468. Reads existing \`SourceUrlHash\` values for the competition WITHOUT loading the Links nav onto the tracked entity (same no-Include rule that applies to Notes / Competitors per the \`ProcessInternal\` comment). Adds only links whose URL hash isn't already present.

## Natural identity
\`(CompetitionId, SourceUrlHash)\`. The URL itself uniquely identifies a link's target. Text changes on the same URL (\`""Box Score""\` → \`""Box Score (Final)""\`) wouldn't be reflected — same trade-off documented in #468 for notes (a stale-text row beats a missing link).

## Tests
- New \`WhenReprocessed_WithNewLink_PersistsTheLinkOnUpdatePath\` in \`BaseballEventCompetitionDocumentProcessorTests\`:
  - Seed via fixture (fixture has multiple existing links — captured as baseline).
  - Mutate to inject a Recap link with a unique URL.
  - Reprocess via update path → assert exactly one new row persisted with the expected text.
  - Replay → assert count unchanged (dedupe works).
- Full Baseball/Football event-competition processor suite: **14/14** (was 13; +1 new).

## Test plan
- [x] \`dotnet build src/SportsData.Producer\` — 0/0
- [x] Targeted test — passes
- [x] Full event-competition processor suite — 14/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Competition updates now retain newly added ESPN links instead of silently dropping them.
  * Duplicate links are prevented when the same update is processed more than once.
  
* **Tests**
  * Added regression coverage to verify new links are saved on reprocessing and do not create duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->