### PR TITLE
feat(notification): kickoff reminders (Phase 2d)

### DIFF
--- a/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -108,32 +108,31 @@ namespace SportsData.Notification.Application.Consumers
             // for any league-week containing it, so a change requires a
             // re-evaluation pass. We query the projection AFTER the resync
             // above so MIN(StartDateUtc) uses the new value.
-            if (rowsAffected > 0)
-            {
-                var affectedScopes = await _dataContext.PickemGroupMatchups
-                    .AsNoTracking()
-                    .Where(m => m.ContestId == msg.ContestId)
-                    .Select(m => new { m.PickemGroupId, m.SeasonWeek })
-                    .Distinct()
-                    .ToListAsync(context.CancellationToken);
+            //
+            // Unconditional — NOT gated on rowsAffected. Same permanent-miss
+            // window as step 3: a crash between ExecuteUpdateAsync and this
+            // call would, on redelivery, see StartDateUpdatedAt already at
+            // msg.CreatedUtc, filter zero rows, and skip scheduling forever.
+            // The PickDeadline scheduler is idempotent (per-user
+            // ScheduledFireUtc == fireTime no-op, peer-takeover on 23505),
+            // so re-running against the current projection state is safe.
+            var affectedScopes = await _dataContext.PickemGroupMatchups
+                .AsNoTracking()
+                .Where(m => m.ContestId == msg.ContestId)
+                .Select(m => new { m.PickemGroupId, m.SeasonWeek })
+                .Distinct()
+                .ToListAsync(context.CancellationToken);
 
-                foreach (var scope in affectedScopes)
-                {
-                    await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
-                        scope.PickemGroupId, scope.SeasonWeek, context.CancellationToken);
-                }
+            foreach (var scope in affectedScopes)
+            {
+                await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                    scope.PickemGroupId, scope.SeasonWeek, context.CancellationToken);
             }
 
             // 3. Re-evaluate ContestStart reminders for every user across every
-            // league containing this contest. Unconditional — NOT gated on
-            // rowsAffected. The crash window between ExecuteUpdateAsync and
-            // this call would otherwise be a permanent miss: on redelivery,
-            // the projection's StartDateUpdatedAt already equals
-            // msg.CreatedUtc, so rowsAffected=0, and the gate would skip the
-            // scheduler forever. The scheduler itself is idempotent (per-user
-            // ScheduledFireUtc == fireTime no-ops, peer-takeover on 23505),
-            // so calling on every delivery — including truly-stale events
-            // that filtered out at SQL — is safe and reads current state.
+            // league containing this contest. Unconditional for the same
+            // reason as step 2 — gating on rowsAffected would leak a
+            // permanent-miss window between ExecuteUpdateAsync and this call.
             await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
                 msg.ContestId, context.CancellationToken);
         }

--- a/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -19,9 +19,9 @@ namespace SportsData.Notification.Application.Consumers
     ///   <item>Re-evaluate <c>PickDeadline</c> reminders for every
     ///   (league, week) touched by this contest — the contest's start time
     ///   IS the candidate deadline for any league-week containing it.</item>
-    ///   <item>Re-evaluate <c>Kickoff</c> reminders for the contest itself —
-    ///   one pass covers every user across every league with the contest, as
-    ///   the kickoff scope is per-contest.</item>
+    ///   <item>Re-evaluate <c>ContestStart</c> reminders for the contest
+    ///   itself — one pass covers every user across every league with the
+    ///   contest, as the contest-start scope is per-contest.</item>
     /// </list>
     ///
     /// <para>
@@ -44,20 +44,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPickDeadlineReminderScheduler _reminderScheduler;
-        private readonly IKickoffReminderScheduler _kickoffScheduler;
+        private readonly IContestStartReminderScheduler _contestStartScheduler;
 
         public ContestStartTimeUpdatedConsumer(
             ILogger<ContestStartTimeUpdatedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
             IPickDeadlineReminderScheduler reminderScheduler,
-            IKickoffReminderScheduler kickoffScheduler)
+            IContestStartReminderScheduler contestStartScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _reminderScheduler = reminderScheduler;
-            _kickoffScheduler = kickoffScheduler;
+            _contestStartScheduler = contestStartScheduler;
         }
 
         public async Task Consume(ConsumeContext<ContestStartTimeUpdated> context)
@@ -124,7 +124,7 @@ namespace SportsData.Notification.Application.Consumers
                 }
             }
 
-            // 3. Re-evaluate Kickoff reminders for every user across every
+            // 3. Re-evaluate ContestStart reminders for every user across every
             // league containing this contest. Single per-contest call covers
             // all of them — the scheduler's reschedule-or-noop branch handles
             // both "existing job moves" and "no row yet" cases. Gated on
@@ -132,7 +132,7 @@ namespace SportsData.Notification.Application.Consumers
             // PickDeadline gate above).
             if (rowsAffected > 0)
             {
-                await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
                     msg.ContestId, context.CancellationToken);
             }
         }

--- a/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -125,16 +125,17 @@ namespace SportsData.Notification.Application.Consumers
             }
 
             // 3. Re-evaluate ContestStart reminders for every user across every
-            // league containing this contest. Single per-contest call covers
-            // all of them — the scheduler's reschedule-or-noop branch handles
-            // both "existing job moves" and "no row yet" cases. Gated on
-            // rowsAffected to skip stale-event passes (consistent with the
-            // PickDeadline gate above).
-            if (rowsAffected > 0)
-            {
-                await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
-                    msg.ContestId, context.CancellationToken);
-            }
+            // league containing this contest. Unconditional — NOT gated on
+            // rowsAffected. The crash window between ExecuteUpdateAsync and
+            // this call would otherwise be a permanent miss: on redelivery,
+            // the projection's StartDateUpdatedAt already equals
+            // msg.CreatedUtc, so rowsAffected=0, and the gate would skip the
+            // scheduler forever. The scheduler itself is idempotent (per-user
+            // ScheduledFireUtc == fireTime no-ops, peer-takeover on 23505),
+            // so calling on every delivery — including truly-stale events
+            // that filtered out at SQL — is safe and reads current state.
+            await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
+                msg.ContestId, context.CancellationToken);
         }
     }
 }

--- a/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestStartTimeUpdatedConsumer.cs
@@ -10,29 +10,32 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Application.Consumers
 {
     /// <summary>
-    /// ESPN moved a game's start time. Two responsibilities:
+    /// ESPN moved a game's start time. Three responsibilities:
     /// <list type="number">
     ///   <item>Update the local <c>PickemGroupMatchup</c> projection — every
     ///   row referencing the contest (a single contest can appear in many
     ///   leagues) gets its <c>StartDateUtc</c> resynced via
     ///   <c>ExecuteUpdateAsync</c>.</item>
-    ///   <item>Reschedule any <c>PendingScheduledJob</c> kickoff reminders
-    ///   already on the Hangfire calendar for this contest (TODO — Phase 2c-main
-    ///   / 2d when the Hangfire dispatcher exists).</item>
+    ///   <item>Re-evaluate <c>PickDeadline</c> reminders for every
+    ///   (league, week) touched by this contest — the contest's start time
+    ///   IS the candidate deadline for any league-week containing it.</item>
+    ///   <item>Re-evaluate <c>Kickoff</c> reminders for the contest itself —
+    ///   one pass covers every user across every league with the contest, as
+    ///   the kickoff scope is per-contest.</item>
     /// </list>
     ///
     /// <para>
     /// Mirrors Producer's
     /// <c>CompetitionStreamScheduler.RescheduleForContestAsync</c> pattern for
     /// the Hangfire side: same drift threshold logic, same crash-safe ordering
-    /// (schedule-new → save → delete-old) once wired.
+    /// (schedule-new → save → delete-old).
     /// </para>
     ///
     /// <para>
     /// Per the cross-broker shovel design, this event arrives via a shovel
     /// from each per-sport Producer broker (NCAA / NFL / MLB). The handler
-    /// itself is sport-agnostic — both the projection write and the future
-    /// Hangfire reschedule operate entirely off ContestId.
+    /// itself is sport-agnostic — both the projection write and the Hangfire
+    /// reschedule operate entirely off ContestId.
     /// </para>
     /// </summary>
     public class ContestStartTimeUpdatedConsumer : IConsumer<ContestStartTimeUpdated>
@@ -41,17 +44,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPickDeadlineReminderScheduler _reminderScheduler;
+        private readonly IKickoffReminderScheduler _kickoffScheduler;
 
         public ContestStartTimeUpdatedConsumer(
             ILogger<ContestStartTimeUpdatedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
-            IPickDeadlineReminderScheduler reminderScheduler)
+            IPickDeadlineReminderScheduler reminderScheduler,
+            IKickoffReminderScheduler kickoffScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _reminderScheduler = reminderScheduler;
+            _kickoffScheduler = kickoffScheduler;
         }
 
         public async Task Consume(ConsumeContext<ContestStartTimeUpdated> context)
@@ -118,47 +124,16 @@ namespace SportsData.Notification.Application.Consumers
                 }
             }
 
-            // 3. Reschedule any kickoff-reminder Hangfire jobs already on the
-            // calendar for this contest. Today this is TODO pending the
-            // Kickoff dispatcher (Phase 2d). For now we log the intent so
-            // the recovery path is auditable.
-            var pendingJobs = await _dataContext.PendingScheduledJobs
-                .Where(j => j.JobKind == "Kickoff" && j.TargetId == msg.ContestId)
-                .ToListAsync(context.CancellationToken);
-
-            if (pendingJobs.Count == 0)
+            // 3. Re-evaluate Kickoff reminders for every user across every
+            // league containing this contest. Single per-contest call covers
+            // all of them — the scheduler's reschedule-or-noop branch handles
+            // both "existing job moves" and "no row yet" cases. Gated on
+            // rowsAffected to skip stale-event passes (consistent with the
+            // PickDeadline gate above).
+            if (rowsAffected > 0)
             {
-                _logger.LogInformation(
-                    "No PendingScheduledJob rows for ContestId {ContestId}; no kickoff reminders to reschedule.",
-                    msg.ContestId);
-                return;
-            }
-
-            _logger.LogInformation(
-                "TODO (Phase 2c-main / 2d): reschedule {Count} kickoff reminder(s) for ContestId {ContestId}.",
-                pendingJobs.Count, msg.ContestId);
-
-            foreach (var job in pendingJobs)
-            {
-                // TODO (Hangfire integration):
-                //   1. Compute newFireTime = msg.NewStartTime - leadMinutes
-                //   2. newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
-                //          d => d.SendKickoffReminderAsync(job.UserId, msg.ContestId),
-                //          newFireTime - now);
-                //   3. oldJobId = job.HangfireJobId
-                //   4. job.HangfireJobId = newJobId
-                //   5. job.ScheduledFireUtc = newFireTime
-                //   6. job.ModifiedUtc = now
-                //   7. SaveChanges  (commits the swap)
-                //   8. _backgroundJobProvider.Delete(oldJobId)  (best-effort)
-                //
-                // Crash-safety: schedule-then-save-then-delete order leaks an
-                // orphan job rather than orphaning the row on crash. FCM dedupe
-                // via NotificationLog (CorrelationId + UserId + Channel) absorbs
-                // the duplicate fire.
-                _logger.LogDebug(
-                    "Would reschedule Hangfire job {OldJobId} for UserId {UserId}.",
-                    job.HangfireJobId, job.UserId);
+                await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                    msg.ContestId, context.CancellationToken);
             }
         }
     }

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
@@ -38,20 +38,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPickDeadlineReminderScheduler _reminderScheduler;
-        private readonly IKickoffReminderScheduler _kickoffScheduler;
+        private readonly IContestStartReminderScheduler _contestStartScheduler;
 
         public PickemGroupMatchupCreatedConsumer(
             ILogger<PickemGroupMatchupCreatedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
             IPickDeadlineReminderScheduler reminderScheduler,
-            IKickoffReminderScheduler kickoffScheduler)
+            IContestStartReminderScheduler contestStartScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _reminderScheduler = reminderScheduler;
-            _kickoffScheduler = kickoffScheduler;
+            _contestStartScheduler = contestStartScheduler;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupMatchupCreated> context)
@@ -101,11 +101,11 @@ namespace SportsData.Notification.Application.Consumers
                     await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
                         msg.GroupId, msg.SeasonWeek, context.CancellationToken);
 
-                    // Kickoff reminders are per-contest, not per-league-week.
-                    // The unique index on (UserId, JobKind, ContestId, null)
-                    // collapses duplicates when the same contest is added to
-                    // multiple leagues for the same user.
-                    await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                    // ContestStart reminders are per-contest, not per-league-
+                    // week. The unique index on (UserId, JobKind, ContestId,
+                    // null) collapses duplicates when the same contest is
+                    // added to multiple leagues for the same user.
+                    await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
                         msg.ContestId, context.CancellationToken);
                     return;
                 }
@@ -171,13 +171,14 @@ namespace SportsData.Notification.Application.Consumers
                     msg.GroupId, msg.SeasonWeek, context.CancellationToken);
             }
 
-            // Kickoff fires when StartDateUtc moved — week changes alone
-            // (different bucket, same kickoff time) don't shift the kickoff
-            // reminder. ContestStartTimeUpdated owns the cross-league bulk
-            // path; this consumer's role is the per-matchup mirror.
+            // ContestStart fires when StartDateUtc moved — week changes
+            // alone (different bucket, same start time) don't shift the
+            // contest-start reminder. ContestStartTimeUpdated owns the
+            // cross-league bulk path; this consumer's role is the per-
+            // matchup mirror.
             if (startDateChanged)
             {
-                await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
                     msg.ContestId, context.CancellationToken);
             }
         }

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupCreatedConsumer.cs
@@ -38,17 +38,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPickDeadlineReminderScheduler _reminderScheduler;
+        private readonly IKickoffReminderScheduler _kickoffScheduler;
 
         public PickemGroupMatchupCreatedConsumer(
             ILogger<PickemGroupMatchupCreatedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
-            IPickDeadlineReminderScheduler reminderScheduler)
+            IPickDeadlineReminderScheduler reminderScheduler,
+            IKickoffReminderScheduler kickoffScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _reminderScheduler = reminderScheduler;
+            _kickoffScheduler = kickoffScheduler;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupMatchupCreated> context)
@@ -97,6 +100,13 @@ namespace SportsData.Notification.Application.Consumers
                     // may shift the deadline earlier.
                     await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
                         msg.GroupId, msg.SeasonWeek, context.CancellationToken);
+
+                    // Kickoff reminders are per-contest, not per-league-week.
+                    // The unique index on (UserId, JobKind, ContestId, null)
+                    // collapses duplicates when the same contest is added to
+                    // multiple leagues for the same user.
+                    await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                        msg.ContestId, context.CancellationToken);
                     return;
                 }
                 catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
@@ -159,6 +169,16 @@ namespace SportsData.Notification.Application.Consumers
                 }
                 await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
                     msg.GroupId, msg.SeasonWeek, context.CancellationToken);
+            }
+
+            // Kickoff fires when StartDateUtc moved — week changes alone
+            // (different bucket, same kickoff time) don't shift the kickoff
+            // reminder. ContestStartTimeUpdated owns the cross-league bulk
+            // path; this consumer's role is the per-matchup mirror.
+            if (startDateChanged)
+            {
+                await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                    msg.ContestId, context.CancellationToken);
             }
         }
 

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
@@ -34,17 +34,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPickDeadlineReminderScheduler _reminderScheduler;
+        private readonly IKickoffReminderScheduler _kickoffScheduler;
 
         public PickemGroupMatchupDataPublishedConsumer(
             ILogger<PickemGroupMatchupDataPublishedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
-            IPickDeadlineReminderScheduler reminderScheduler)
+            IPickDeadlineReminderScheduler reminderScheduler,
+            IKickoffReminderScheduler kickoffScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _reminderScheduler = reminderScheduler;
+            _kickoffScheduler = kickoffScheduler;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupMatchupDataPublished> context)
@@ -95,6 +98,9 @@ namespace SportsData.Notification.Application.Consumers
                     // creation consumer.
                     await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
                         msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
+
+                    await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                        msg.ContestId, context.CancellationToken);
                     return;
                 }
                 catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
@@ -150,6 +156,12 @@ namespace SportsData.Notification.Application.Consumers
                 }
                 await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
                     msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
+            }
+
+            if (startDateChanged)
+            {
+                await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                    msg.ContestId, context.CancellationToken);
             }
         }
 

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
@@ -34,20 +34,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPickDeadlineReminderScheduler _reminderScheduler;
-        private readonly IKickoffReminderScheduler _kickoffScheduler;
+        private readonly IContestStartReminderScheduler _contestStartScheduler;
 
         public PickemGroupMatchupDataPublishedConsumer(
             ILogger<PickemGroupMatchupDataPublishedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
             IPickDeadlineReminderScheduler reminderScheduler,
-            IKickoffReminderScheduler kickoffScheduler)
+            IContestStartReminderScheduler contestStartScheduler)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _reminderScheduler = reminderScheduler;
-            _kickoffScheduler = kickoffScheduler;
+            _contestStartScheduler = contestStartScheduler;
         }
 
         public async Task Consume(ConsumeContext<PickemGroupMatchupDataPublished> context)
@@ -99,7 +99,7 @@ namespace SportsData.Notification.Application.Consumers
                     await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
                         msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
 
-                    await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                    await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
                         msg.ContestId, context.CancellationToken);
                     return;
                 }
@@ -160,7 +160,7 @@ namespace SportsData.Notification.Application.Consumers
 
             if (startDateChanged)
             {
-                await _kickoffScheduler.EvaluateAndScheduleForContestAsync(
+                await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
                     msg.ContestId, context.CancellationToken);
             }
         }

--- a/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
@@ -2,10 +2,11 @@ namespace SportsData.Notification.Application.Dispatching
 {
     /// <summary>
     /// Hangfire-invoked entry point for time-scheduled push dispatches.
-    /// One method per category (PickDeadline today; Kickoff lands in
-    /// Phase 2d). Each method is responsible for: resolving the recipient's
-    /// preferences + devices, composing the body, dispatching via FCM, and
-    /// writing the atomic-claim audit row in <c>NotificationLog</c>.
+    /// One method per category — PickDeadline (per league-week) and
+    /// ContestStart (per contest, sport-aware copy). Each method is
+    /// responsible for: resolving the recipient's preferences + devices,
+    /// composing the body, dispatching via FCM, and writing the atomic-claim
+    /// audit row in <c>NotificationLog</c>.
     ///
     /// <para>
     /// Methods are designed to be safe under Hangfire's at-least-once
@@ -18,6 +19,6 @@ namespace SportsData.Notification.Application.Dispatching
     {
         Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek);
 
-        Task SendKickoffReminderAsync(Guid userId, Guid contestId);
+        Task SendContestStartReminderAsync(Guid userId, Guid contestId);
     }
 }

--- a/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
@@ -17,7 +17,7 @@ namespace SportsData.Notification.Application.Dispatching
     /// </summary>
     public interface INotificationDispatcher
     {
-        Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek);
+        Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek, DateTime deadlineUtc);
 
         Task SendContestStartReminderAsync(Guid userId, Guid contestId, DateTime startDateUtc);
     }

--- a/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
@@ -19,6 +19,6 @@ namespace SportsData.Notification.Application.Dispatching
     {
         Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek);
 
-        Task SendContestStartReminderAsync(Guid userId, Guid contestId);
+        Task SendContestStartReminderAsync(Guid userId, Guid contestId, DateTime startDateUtc);
     }
 }

--- a/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
@@ -17,5 +17,7 @@ namespace SportsData.Notification.Application.Dispatching
     public interface INotificationDispatcher
     {
         Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek);
+
+        Task SendKickoffReminderAsync(Guid userId, Guid contestId);
     }
 }

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -171,19 +171,27 @@ namespace SportsData.Notification.Application.Dispatching
             await _dataContext.SaveChangesAsync();
         }
 
-        public async Task SendContestStartReminderAsync(Guid userId, Guid contestId)
+        public async Task SendContestStartReminderAsync(Guid userId, Guid contestId, DateTime startDateUtc)
         {
-            // Qualifier is 0 because ContestStart is per-contest with no
-            // week/scope beyond ContestId — the (category, userId, contestId)
-            // triplet is already uniquely identifying for the dedupe key.
+            // Qualifier is StartDateUtc.Ticks — the version anchor. Without
+            // it, a rescheduled contest (ESPN moves start time, scheduler
+            // creates a new Hangfire job, TryDelete of the old job fails)
+            // would have the orphan job fire FIRST with the same
+            // (category, userId, contestId) key, claim the NotificationLog
+            // row, and silently suppress the correct-time fire. Including
+            // Ticks gives each fire-time its own dedupe key so the new
+            // reminder can land even when the orphan races it. Hangfire
+            // retries of the SAME logical fire still dedupe correctly
+            // because the serialized DateTime arg is stable across retries.
             var correlationId = DeterministicCorrelationId(
-                "ContestStart", userId, contestId, 0);
+                "ContestStart", userId, contestId, startDateUtc.Ticks);
 
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
                 ["CorrelationId"] = correlationId,
                 ["UserId"] = userId,
-                ["ContestId"] = contestId
+                ["ContestId"] = contestId,
+                ["StartDateUtc"] = startDateUtc
             });
 
             _logger.LogInformation("SendContestStartReminderAsync invoked.");
@@ -317,8 +325,12 @@ namespace SportsData.Notification.Application.Dispatching
         /// Guid, which makes the NotificationLog unique constraint catch
         /// Hangfire retries.
         /// </summary>
-        private static Guid DeterministicCorrelationId(string category, Guid userId, Guid scopeId, int qualifier)
+        private static Guid DeterministicCorrelationId(string category, Guid userId, Guid scopeId, long qualifier)
         {
+            // Qualifier is long so callers can pass a DateTime.Ticks version
+            // anchor (ContestStart). int qualifiers (PickDeadline's
+            // seasonWeek) implicitly widen and format identically — no hash
+            // drift for existing callers.
             var input = $"{category}|{userId:N}|{scopeId:N}|{qualifier}";
             var hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
             return new Guid(hash);

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -171,6 +171,112 @@ namespace SportsData.Notification.Application.Dispatching
             await _dataContext.SaveChangesAsync();
         }
 
+        public async Task SendKickoffReminderAsync(Guid userId, Guid contestId)
+        {
+            // Qualifier is 0 because Kickoff is per-contest with no week/scope
+            // beyond ContestId — the (category, userId, contestId) triplet is
+            // already uniquely identifying for the dedupe key.
+            var correlationId = DeterministicCorrelationId(
+                "Kickoff", userId, contestId, 0);
+
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = correlationId,
+                ["UserId"] = userId,
+                ["ContestId"] = contestId
+            });
+
+            _logger.LogInformation("SendKickoffReminderAsync invoked.");
+
+            var claim = new NotificationLog
+            {
+                UserId = userId,
+                CorrelationId = correlationId,
+                Category = "Kickoff",
+                Channel = "Fcm",
+                Result = "Dispatching",
+                AttemptedUtc = _dateTimeProvider.UtcNow()
+            };
+            _dataContext.NotificationLog.Add(claim);
+
+            try
+            {
+                await _dataContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                _logger.LogInformation(
+                    "Kickoff reminder already dispatched for CorrelationId {CorrelationId}; skipping (Hangfire retry).",
+                    correlationId);
+                _dataContext.Entry(claim).State = EntityState.Detached;
+                return;
+            }
+
+            var prefs = await _dataContext.UserNotificationPreferences
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.UserId == userId);
+
+            if (prefs is { KickoffReminderEnabled: false })
+            {
+                await FinalizeAsync(claim, "Suppressed_UserOptedOut");
+                return;
+            }
+
+            var devices = await _dataContext.UserDevices
+                .AsNoTracking()
+                .Where(d => d.UserId == userId && d.NotificationsEnabled)
+                .ToListAsync();
+
+            if (devices.Count == 0)
+            {
+                await FinalizeAsync(claim, "Suppressed_NoDevice");
+                return;
+            }
+
+            // Body stays generic for v1. A user can be in multiple leagues
+            // with the same contest, so naming one league in the body would
+            // be misleading (the dispatcher fires once per (UserId, ContestId)).
+            // FranchiseSeason team names aren't in the local projection —
+            // a richer body waits on either fattening the steady-state
+            // events or backfilling team data.
+            const string title = "Game starting soon";
+            const string body = "A game you've picked starts in about 30 minutes. Tap to follow live.";
+
+            var successCount = 0;
+            var failureReasons = new List<string>();
+            foreach (var device in devices)
+            {
+                try
+                {
+                    var result = await _pushSender.SendAsync(device.FcmToken, title, body);
+                    if (result is Success<string>)
+                    {
+                        successCount++;
+                    }
+                    else if (result is Failure<string> failure)
+                    {
+                        var reason = failure.Errors.FirstOrDefault()?.ErrorMessage ?? "unknown";
+                        failureReasons.Add($"{device.Platform}:{reason}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Unexpected exception sending FCM to DeviceId {DeviceId}.",
+                        device.Id);
+                    failureReasons.Add($"{device.Platform}:exception:{ex.GetType().Name}");
+                }
+            }
+
+            claim.Title = title;
+            claim.Body = body;
+            claim.Result = successCount > 0 ? "Sent" : "Failed_FcmError";
+            claim.FailureReason = ComposeFailureReason(failureReasons);
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+            await _dataContext.SaveChangesAsync();
+        }
+
         private async Task FinalizeAsync(NotificationLog claim, string result)
         {
             claim.Result = result;

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -171,13 +171,13 @@ namespace SportsData.Notification.Application.Dispatching
             await _dataContext.SaveChangesAsync();
         }
 
-        public async Task SendKickoffReminderAsync(Guid userId, Guid contestId)
+        public async Task SendContestStartReminderAsync(Guid userId, Guid contestId)
         {
-            // Qualifier is 0 because Kickoff is per-contest with no week/scope
-            // beyond ContestId — the (category, userId, contestId) triplet is
-            // already uniquely identifying for the dedupe key.
+            // Qualifier is 0 because ContestStart is per-contest with no
+            // week/scope beyond ContestId — the (category, userId, contestId)
+            // triplet is already uniquely identifying for the dedupe key.
             var correlationId = DeterministicCorrelationId(
-                "Kickoff", userId, contestId, 0);
+                "ContestStart", userId, contestId, 0);
 
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
@@ -186,13 +186,13 @@ namespace SportsData.Notification.Application.Dispatching
                 ["ContestId"] = contestId
             });
 
-            _logger.LogInformation("SendKickoffReminderAsync invoked.");
+            _logger.LogInformation("SendContestStartReminderAsync invoked.");
 
             var claim = new NotificationLog
             {
                 UserId = userId,
                 CorrelationId = correlationId,
-                Category = "Kickoff",
+                Category = "ContestStart",
                 Channel = "Fcm",
                 Result = "Dispatching",
                 AttemptedUtc = _dateTimeProvider.UtcNow()
@@ -206,7 +206,7 @@ namespace SportsData.Notification.Application.Dispatching
             catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
             {
                 _logger.LogInformation(
-                    "Kickoff reminder already dispatched for CorrelationId {CorrelationId}; skipping (Hangfire retry).",
+                    "ContestStart reminder already dispatched for CorrelationId {CorrelationId}; skipping (Hangfire retry).",
                     correlationId);
                 _dataContext.Entry(claim).State = EntityState.Detached;
                 return;
@@ -216,7 +216,7 @@ namespace SportsData.Notification.Application.Dispatching
                 .AsNoTracking()
                 .FirstOrDefaultAsync(p => p.UserId == userId);
 
-            if (prefs is { KickoffReminderEnabled: false })
+            if (prefs is { ContestStartReminderEnabled: false })
             {
                 await FinalizeAsync(claim, "Suppressed_UserOptedOut");
                 return;
@@ -233,14 +233,22 @@ namespace SportsData.Notification.Application.Dispatching
                 return;
             }
 
-            // Body stays generic for v1. A user can be in multiple leagues
-            // with the same contest, so naming one league in the body would
-            // be misleading (the dispatcher fires once per (UserId, ContestId)).
-            // FranchiseSeason team names aren't in the local projection —
-            // a richer body waits on either fattening the steady-state
-            // events or backfilling team data.
-            const string title = "Game starting soon";
-            const string body = "A game you've picked starts in about 30 minutes. Tap to follow live.";
+            // Resolve sport for the user-facing copy. A Contest is sport-
+            // specific, so every PickemGroup containing it shares one Sport
+            // value — any matchup row's PickemGroup is authoritative.
+            // Default to Sport.All when none found (defensive: sport lookup
+            // races membership deletion); the terminology helper falls back
+            // to generic "Game starting soon" copy in that case.
+            var sport = await _dataContext.PickemGroupMatchups
+                .AsNoTracking()
+                .Where(m => m.ContestId == contestId)
+                .Join(_dataContext.PickemGroups,
+                    m => m.PickemGroupId,
+                    g => g.Id,
+                    (m, g) => g.Sport)
+                .FirstOrDefaultAsync();
+
+            var (title, body) = SportTerminology.GetContestStartCopy(sport);
 
             var successCount = 0;
             var failureReasons = new List<string>();

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -48,17 +48,26 @@ namespace SportsData.Notification.Application.Dispatching
             _pushSender = pushSender;
         }
 
-        public async Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek)
+        public async Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek, DateTime deadlineUtc)
         {
+            // Qualifiers include deadlineUtc.Ticks as the version anchor for
+            // the same reason as ContestStart: a deadline shift (new matchup
+            // lands and pulls MIN(StartDateUtc) earlier, or
+            // ContestStartTimeUpdated moves the earliest game) reschedules
+            // the Hangfire job. If the old job's TryDelete fails and it
+            // fires first, the orphan would otherwise claim the
+            // NotificationLog slot and silently suppress the new
+            // correct-deadline reminder.
             var correlationId = DeterministicCorrelationId(
-                "PickDeadline", userId, pickemGroupId, seasonWeek);
+                "PickDeadline", userId, pickemGroupId, seasonWeek, deadlineUtc.Ticks);
 
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
                 ["CorrelationId"] = correlationId,
                 ["UserId"] = userId,
                 ["PickemGroupId"] = pickemGroupId,
-                ["SeasonWeek"] = seasonWeek
+                ["SeasonWeek"] = seasonWeek,
+                ["DeadlineUtc"] = deadlineUtc
             });
 
             _logger.LogInformation("SendPickDeadlineReminderAsync invoked.");
@@ -328,10 +337,21 @@ namespace SportsData.Notification.Application.Dispatching
         private static Guid DeterministicCorrelationId(string category, Guid userId, Guid scopeId, long qualifier)
         {
             // Qualifier is long so callers can pass a DateTime.Ticks version
-            // anchor (ContestStart). int qualifiers (PickDeadline's
-            // seasonWeek) implicitly widen and format identically — no hash
-            // drift for existing callers.
+            // anchor (ContestStart).
             var input = $"{category}|{userId:N}|{scopeId:N}|{qualifier}";
+            var hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
+            return new Guid(hash);
+        }
+
+        private static Guid DeterministicCorrelationId(string category, Guid userId, Guid scopeId, long q1, long q2)
+        {
+            // Two-qualifier overload for callers that need both a scope
+            // discriminator (e.g. PickDeadline's seasonWeek) AND a fire-time
+            // version anchor (deadline Ticks) in the same key. Keeping
+            // seasonWeek in the input means two different weeks of the same
+            // league with the same deadline (rare but theoretically
+            // possible across year boundaries) still hash distinctly.
+            var input = $"{category}|{userId:N}|{scopeId:N}|{q1}|{q2}";
             var hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
             return new Guid(hash);
         }

--- a/src/SportsData.Notification/Application/Dispatching/SportTerminology.cs
+++ b/src/SportsData.Notification/Application/Dispatching/SportTerminology.cs
@@ -1,0 +1,40 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Notification.Application.Dispatching
+{
+    /// <summary>
+    /// Maps <see cref="Sport"/> to user-facing push-copy fragments. Lives here
+    /// (next to the dispatcher) rather than in Core because the only consumers
+    /// are notification bodies, and Core has no business knowing how MLB calls
+    /// the start of a game vs how the NBA does.
+    ///
+    /// <para>
+    /// Sports not covered fall through to a generic label. Adding a sport is
+    /// a one-line switch entry — no plumbing changes elsewhere.
+    /// </para>
+    /// </summary>
+    public static class SportTerminology
+    {
+        public static (string Title, string Body) GetContestStartCopy(Sport sport)
+        {
+            return sport switch
+            {
+                Sport.BaseballMlb => (
+                    "First pitch soon",
+                    "A game you've picked has first pitch in about 30 minutes. Tap to follow live."),
+                Sport.BasketballNba => (
+                    "Tip-off soon",
+                    "A game you've picked tips off in about 30 minutes. Tap to follow live."),
+                Sport.FootballNcaa or Sport.FootballNfl => (
+                    "Kickoff soon",
+                    "A game you've picked kicks off in about 30 minutes. Tap to follow live."),
+                Sport.GolfPga => (
+                    "Round starting soon",
+                    "A round you've picked tees off in about 30 minutes. Tap to follow live."),
+                _ => (
+                    "Game starting soon",
+                    "A game you've picked starts in about 30 minutes. Tap to follow live.")
+            };
+        }
+    }
+}

--- a/src/SportsData.Notification/Application/Scheduling/ContestStartReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/ContestStartReminderScheduler.cs
@@ -151,13 +151,15 @@ namespace SportsData.Notification.Application.Scheduling
                 }
 
                 existingByUser.TryGetValue(userId, out var existing);
-                await ScheduleOrRescheduleAsync(userId, contestId, fireTime, existing, now, cancellationToken);
+                await ScheduleOrRescheduleAsync(
+                    userId, contestId, startDate.Value, fireTime, existing, now, cancellationToken);
             }
         }
 
         private async Task ScheduleOrRescheduleAsync(
             Guid userId,
             Guid contestId,
+            DateTime startDateUtc,
             DateTime fireTime,
             PendingScheduledJob existing,
             DateTime now,
@@ -172,8 +174,14 @@ namespace SportsData.Notification.Application.Scheduling
             // Schedule the new job FIRST, then persist, then delete the old.
             // Same crash-safe ordering as PickDeadlineReminderScheduler.
             var delay = fireTime - now;
+            // startDateUtc is forwarded to the dispatcher so its
+            // deterministic CorrelationId can include the version anchor.
+            // A reschedule (different StartDateUtc) yields a different
+            // CorrelationId, so an orphan Hangfire job that survived a
+            // failed best-effort delete can't claim the NotificationLog
+            // slot and suppress the new fire.
             var newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
-                d => d.SendContestStartReminderAsync(userId, contestId),
+                d => d.SendContestStartReminderAsync(userId, contestId, startDateUtc),
                 delay);
 
             if (existing is null)

--- a/src/SportsData.Notification/Application/Scheduling/ContestStartReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/ContestStartReminderScheduler.cs
@@ -8,15 +8,20 @@ using SportsData.Notification.Infrastructure.Data.Entities;
 
 namespace SportsData.Notification.Application.Scheduling
 {
-    public interface IKickoffReminderScheduler
+    public interface IContestStartReminderScheduler
     {
         Task EvaluateAndScheduleForContestAsync(Guid contestId, CancellationToken cancellationToken);
     }
 
     /// <summary>
-    /// Decides whether to schedule (or reschedule, or no-op) a kickoff-soon
+    /// Decides whether to schedule (or reschedule, or no-op) a contest-start
     /// reminder for every user who has the given contest in at least one of
-    /// their leagues. Trigger points mirror the PickDeadline scheduler:
+    /// their leagues. The user-facing copy is sport-aware (kickoff / first
+    /// pitch / tip-off / etc.) and resolved by the dispatcher at fire time;
+    /// the scheduler is sport-agnostic.
+    ///
+    /// <para>
+    /// Trigger points mirror the PickDeadline scheduler:
     /// <list type="bullet">
     ///   <item><c>PickemGroupMatchupCreatedConsumer</c> after upserting a new
     ///   matchup from the steady-state event.</item>
@@ -25,35 +30,36 @@ namespace SportsData.Notification.Application.Scheduling
     ///   <item><c>ContestStartTimeUpdatedConsumer</c> after resyncing
     ///   <c>StartDateUtc</c> for matchups referencing the changed contest.</item>
     /// </list>
+    /// </para>
     ///
     /// <para>
     /// Scope is per-contest, not per-league-week: a user in three leagues that
-    /// each contain the same contest gets ONE kickoff reminder. The unique
-    /// index on (UserId, JobKind, TargetId, SeasonWeek=null) collapses
-    /// duplicates across leagues for free — the second insert hits 23505 and
-    /// falls through to the reschedule branch against the winner's row.
+    /// each contain the same contest gets ONE reminder. The unique index on
+    /// <c>(UserId, JobKind, TargetId, SeasonWeek=null)</c> collapses duplicates
+    /// across leagues for free — the second insert hits 23505 and falls
+    /// through to the reschedule branch against the winner's row.
     /// </para>
     ///
     /// <para>
     /// Lead time is 30 minutes, hardcoded for v1 (vs PickDeadline's 1 hour) —
-    /// kickoff is a "live-game prep" nudge, not a "pick your games" reminder.
+    /// this is a "live-game prep" nudge, not a "pick your games" reminder.
     /// </para>
     /// </summary>
-    public class KickoffReminderScheduler : IKickoffReminderScheduler
+    public class ContestStartReminderScheduler : IContestStartReminderScheduler
     {
         // Hardcoded for v1 — per the design discussion. Will become a
         // per-user pref later when we surface notification timing controls.
-        private static readonly TimeSpan KickoffLeadTime = TimeSpan.FromMinutes(30);
+        private static readonly TimeSpan ContestStartLeadTime = TimeSpan.FromMinutes(30);
 
-        private const string JobKind = "Kickoff";
+        private const string JobKind = "ContestStart";
 
-        private readonly ILogger<KickoffReminderScheduler> _logger;
+        private readonly ILogger<ContestStartReminderScheduler> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
 
-        public KickoffReminderScheduler(
-            ILogger<KickoffReminderScheduler> logger,
+        public ContestStartReminderScheduler(
+            ILogger<ContestStartReminderScheduler> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
             IProvideBackgroundJobs backgroundJobProvider)
@@ -87,16 +93,16 @@ namespace SportsData.Notification.Application.Scheduling
                 return;
             }
 
-            var fireTime = startDate.Value - KickoffLeadTime;
+            var fireTime = startDate.Value - ContestStartLeadTime;
             var now = _dateTimeProvider.UtcNow();
 
             if (fireTime <= now)
             {
-                // Kickoff is past or within the 30-minute window. A "starts
-                // in 30 minutes" reminder fired 5 minutes pre-kickoff would
-                // be misleading; skip rather than send-immediate.
+                // Start is past or within the 30-minute window. A "starts in
+                // 30 minutes" reminder fired 5 minutes pre-start would be
+                // misleading; skip rather than send-immediate.
                 _logger.LogInformation(
-                    "Kickoff {StartDate} is past or within lead window from now {Now}; skipping schedule.",
+                    "Contest start {StartDate} is past or within lead window from now {Now}; skipping schedule.",
                     startDate, now);
                 return;
             }
@@ -122,17 +128,17 @@ namespace SportsData.Notification.Application.Scheduling
             }
 
             _logger.LogInformation(
-                "Evaluating Kickoff reminders for {MemberCount} distinct members. StartDate={StartDate}, FireTime={FireTime}",
+                "Evaluating ContestStart reminders for {MemberCount} distinct members. StartDate={StartDate}, FireTime={FireTime}",
                 memberIds.Count, startDate, fireTime);
 
-            // Existing kickoff jobs for this contest, across all users.
+            // Existing contest-start jobs for this contest, across all users.
             var existingByUser = await _dataContext.PendingScheduledJobs
                 .Where(j => j.JobKind == JobKind && j.TargetId == contestId)
                 .ToDictionaryAsync(j => j.UserId, cancellationToken);
 
             var optedOutUserIds = await _dataContext.UserNotificationPreferences
                 .AsNoTracking()
-                .Where(p => memberIds.Contains(p.UserId) && !p.KickoffReminderEnabled)
+                .Where(p => memberIds.Contains(p.UserId) && !p.ContestStartReminderEnabled)
                 .Select(p => p.UserId)
                 .ToListAsync(cancellationToken);
             var optedOut = optedOutUserIds.ToHashSet();
@@ -159,7 +165,7 @@ namespace SportsData.Notification.Application.Scheduling
         {
             if (existing is not null && existing.ScheduledFireUtc == fireTime)
             {
-                // Kickoff hasn't moved — no work.
+                // Start time hasn't moved — no work.
                 return;
             }
 
@@ -167,7 +173,7 @@ namespace SportsData.Notification.Application.Scheduling
             // Same crash-safe ordering as PickDeadlineReminderScheduler.
             var delay = fireTime - now;
             var newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
-                d => d.SendKickoffReminderAsync(userId, contestId),
+                d => d.SendContestStartReminderAsync(userId, contestId),
                 delay);
 
             if (existing is null)
@@ -192,9 +198,8 @@ namespace SportsData.Notification.Application.Scheduling
                 catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
                 {
                     // Peer-takeover branch — identical shape to PickDeadline.
-                    // Common cause for Kickoff: same contest is in N leagues
-                    // and we already scheduled this user from a sibling
-                    // matchup row.
+                    // Common cause here: same contest is in N leagues and we
+                    // already scheduled this user from a sibling matchup row.
                     _dataContext.Entry(entity).State = EntityState.Detached;
                     var winner = await _dataContext.PendingScheduledJobs
                         .FirstAsync(j => j.UserId == userId
@@ -233,7 +238,7 @@ namespace SportsData.Notification.Application.Scheduling
             }
 
             _logger.LogInformation(
-                "Scheduled Kickoff reminder. UserId={UserId}, FireTime={FireTime}, HangfireJobId={HangfireJobId}",
+                "Scheduled ContestStart reminder. UserId={UserId}, FireTime={FireTime}, HangfireJobId={HangfireJobId}",
                 userId, fireTime, newJobId);
         }
 

--- a/src/SportsData.Notification/Application/Scheduling/KickoffReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/KickoffReminderScheduler.cs
@@ -1,0 +1,259 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Notification.Application.Dispatching;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Scheduling
+{
+    public interface IKickoffReminderScheduler
+    {
+        Task EvaluateAndScheduleForContestAsync(Guid contestId, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Decides whether to schedule (or reschedule, or no-op) a kickoff-soon
+    /// reminder for every user who has the given contest in at least one of
+    /// their leagues. Trigger points mirror the PickDeadline scheduler:
+    /// <list type="bullet">
+    ///   <item><c>PickemGroupMatchupCreatedConsumer</c> after upserting a new
+    ///   matchup from the steady-state event.</item>
+    ///   <item><c>PickemGroupMatchupDataPublishedConsumer</c> after upserting
+    ///   a matchup from the operator-triggered backfill.</item>
+    ///   <item><c>ContestStartTimeUpdatedConsumer</c> after resyncing
+    ///   <c>StartDateUtc</c> for matchups referencing the changed contest.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Scope is per-contest, not per-league-week: a user in three leagues that
+    /// each contain the same contest gets ONE kickoff reminder. The unique
+    /// index on (UserId, JobKind, TargetId, SeasonWeek=null) collapses
+    /// duplicates across leagues for free — the second insert hits 23505 and
+    /// falls through to the reschedule branch against the winner's row.
+    /// </para>
+    ///
+    /// <para>
+    /// Lead time is 30 minutes, hardcoded for v1 (vs PickDeadline's 1 hour) —
+    /// kickoff is a "live-game prep" nudge, not a "pick your games" reminder.
+    /// </para>
+    /// </summary>
+    public class KickoffReminderScheduler : IKickoffReminderScheduler
+    {
+        // Hardcoded for v1 — per the design discussion. Will become a
+        // per-user pref later when we surface notification timing controls.
+        private static readonly TimeSpan KickoffLeadTime = TimeSpan.FromMinutes(30);
+
+        private const string JobKind = "Kickoff";
+
+        private readonly ILogger<KickoffReminderScheduler> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IProvideBackgroundJobs _backgroundJobProvider;
+
+        public KickoffReminderScheduler(
+            ILogger<KickoffReminderScheduler> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider,
+            IProvideBackgroundJobs backgroundJobProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+            _backgroundJobProvider = backgroundJobProvider;
+        }
+
+        public async Task EvaluateAndScheduleForContestAsync(
+            Guid contestId,
+            CancellationToken cancellationToken)
+        {
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["ContestId"] = contestId
+            });
+
+            // StartDateUtc is identical across every league's projection row
+            // for this contest (ContestStartTimeUpdated bulk-updates them all),
+            // so any row is fine. Use Min to be defensive about transient skew.
+            var startDate = await _dataContext.PickemGroupMatchups
+                .Where(m => m.ContestId == contestId)
+                .Select(m => (DateTime?)m.StartDateUtc)
+                .MinAsync(cancellationToken);
+
+            if (startDate is null)
+            {
+                _logger.LogDebug("No matchup projection rows for contest; nothing to schedule.");
+                return;
+            }
+
+            var fireTime = startDate.Value - KickoffLeadTime;
+            var now = _dateTimeProvider.UtcNow();
+
+            if (fireTime <= now)
+            {
+                // Kickoff is past or within the 30-minute window. A "starts
+                // in 30 minutes" reminder fired 5 minutes pre-kickoff would
+                // be misleading; skip rather than send-immediate.
+                _logger.LogInformation(
+                    "Kickoff {StartDate} is past or within lead window from now {Now}; skipping schedule.",
+                    startDate, now);
+                return;
+            }
+
+            // Distinct member ids across every league that contains this
+            // contest. Same user in three leagues = one fan-out target —
+            // the unique index collapses duplicates, but pre-deduping
+            // avoids 2 wasted Hangfire schedule+catch cycles per extra
+            // membership.
+            var memberIds = await _dataContext.PickemGroupMatchups
+                .Where(m => m.ContestId == contestId)
+                .Join(_dataContext.PickemGroupMembers,
+                    matchup => matchup.PickemGroupId,
+                    member => member.PickemGroupId,
+                    (matchup, member) => member.UserId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            if (memberIds.Count == 0)
+            {
+                _logger.LogDebug("No members across all leagues containing this contest; nothing to schedule.");
+                return;
+            }
+
+            _logger.LogInformation(
+                "Evaluating Kickoff reminders for {MemberCount} distinct members. StartDate={StartDate}, FireTime={FireTime}",
+                memberIds.Count, startDate, fireTime);
+
+            // Existing kickoff jobs for this contest, across all users.
+            var existingByUser = await _dataContext.PendingScheduledJobs
+                .Where(j => j.JobKind == JobKind && j.TargetId == contestId)
+                .ToDictionaryAsync(j => j.UserId, cancellationToken);
+
+            var optedOutUserIds = await _dataContext.UserNotificationPreferences
+                .AsNoTracking()
+                .Where(p => memberIds.Contains(p.UserId) && !p.KickoffReminderEnabled)
+                .Select(p => p.UserId)
+                .ToListAsync(cancellationToken);
+            var optedOut = optedOutUserIds.ToHashSet();
+
+            foreach (var userId in memberIds)
+            {
+                if (optedOut.Contains(userId))
+                {
+                    continue;
+                }
+
+                existingByUser.TryGetValue(userId, out var existing);
+                await ScheduleOrRescheduleAsync(userId, contestId, fireTime, existing, now, cancellationToken);
+            }
+        }
+
+        private async Task ScheduleOrRescheduleAsync(
+            Guid userId,
+            Guid contestId,
+            DateTime fireTime,
+            PendingScheduledJob existing,
+            DateTime now,
+            CancellationToken cancellationToken)
+        {
+            if (existing is not null && existing.ScheduledFireUtc == fireTime)
+            {
+                // Kickoff hasn't moved — no work.
+                return;
+            }
+
+            // Schedule the new job FIRST, then persist, then delete the old.
+            // Same crash-safe ordering as PickDeadlineReminderScheduler.
+            var delay = fireTime - now;
+            var newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
+                d => d.SendKickoffReminderAsync(userId, contestId),
+                delay);
+
+            if (existing is null)
+            {
+                var entity = new PendingScheduledJob
+                {
+                    UserId = userId,
+                    JobKind = JobKind,
+                    TargetId = contestId,
+                    SeasonWeek = null,
+                    HangfireJobId = newJobId,
+                    ScheduledFireUtc = fireTime,
+                    CreatedUtc = now,
+                    CreatedBy = Guid.Empty
+                };
+                _dataContext.PendingScheduledJobs.Add(entity);
+
+                try
+                {
+                    await _dataContext.SaveChangesAsync(cancellationToken);
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // Peer-takeover branch — identical shape to PickDeadline.
+                    // Common cause for Kickoff: same contest is in N leagues
+                    // and we already scheduled this user from a sibling
+                    // matchup row.
+                    _dataContext.Entry(entity).State = EntityState.Detached;
+                    var winner = await _dataContext.PendingScheduledJobs
+                        .FirstAsync(j => j.UserId == userId
+                                         && j.JobKind == JobKind
+                                         && j.TargetId == contestId
+                                         && j.SeasonWeek == null,
+                                    cancellationToken);
+
+                    if (winner.ScheduledFireUtc == fireTime)
+                    {
+                        TryDeleteHangfireJob(newJobId);
+                        return;
+                    }
+
+                    var winnerOldJobId = winner.HangfireJobId;
+                    winner.HangfireJobId = newJobId;
+                    winner.ScheduledFireUtc = fireTime;
+                    winner.ModifiedUtc = now;
+                    await _dataContext.SaveChangesAsync(cancellationToken);
+                    TryDeleteHangfireJob(winnerOldJobId);
+                    _logger.LogInformation(
+                        "Concurrent insert resolved; took over scheduling. UserId={UserId}, FireTime={FireTime}",
+                        userId, fireTime);
+                    return;
+                }
+            }
+            else
+            {
+                var oldJobId = existing.HangfireJobId;
+                existing.HangfireJobId = newJobId;
+                existing.ScheduledFireUtc = fireTime;
+                existing.ModifiedUtc = now;
+                await _dataContext.SaveChangesAsync(cancellationToken);
+
+                TryDeleteHangfireJob(oldJobId);
+            }
+
+            _logger.LogInformation(
+                "Scheduled Kickoff reminder. UserId={UserId}, FireTime={FireTime}, HangfireJobId={HangfireJobId}",
+                userId, fireTime, newJobId);
+        }
+
+        private void TryDeleteHangfireJob(string jobId)
+        {
+            try
+            {
+                _backgroundJobProvider.Delete(jobId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to delete Hangfire job {JobId}. Absorbed by dispatcher dedupe.",
+                    jobId);
+            }
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
+        }
+    }
+}

--- a/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
@@ -158,7 +158,8 @@ namespace SportsData.Notification.Application.Scheduling
                 }
 
                 existingByUser.TryGetValue(userId, out var existing);
-                await ScheduleOrRescheduleAsync(userId, pickemGroupId, seasonWeek, fireTime, existing, now, cancellationToken);
+                await ScheduleOrRescheduleAsync(
+                    userId, pickemGroupId, seasonWeek, deadline.Value, fireTime, existing, now, cancellationToken);
             }
         }
 
@@ -166,6 +167,7 @@ namespace SportsData.Notification.Application.Scheduling
             Guid userId,
             Guid pickemGroupId,
             int seasonWeek,
+            DateTime deadlineUtc,
             DateTime fireTime,
             PendingScheduledJob existing,
             DateTime now,
@@ -182,9 +184,14 @@ namespace SportsData.Notification.Application.Scheduling
             // an orphan Hangfire job (benign — dispatcher's dedupe absorbs
             // it). The alternative (delete-old first) could leave a row
             // pointing at a deleted job, silently missing the reminder.
+            // deadlineUtc is forwarded so the dispatcher's deterministic
+            // CorrelationId can include the version anchor. A deadline shift
+            // (new earliest matchup) yields a different key per fire-time,
+            // so an orphan from a failed best-effort TryDelete can't claim
+            // the NotificationLog slot and suppress the new reminder.
             var delay = fireTime - now;
             var newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
-                d => d.SendPickDeadlineReminderAsync(userId, pickemGroupId, seasonWeek),
+                d => d.SendPickDeadlineReminderAsync(userId, pickemGroupId, seasonWeek, deadlineUtc),
                 delay);
 
             if (existing is null)

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -59,7 +59,7 @@ namespace SportsData.Notification.Infrastructure.Data
             // prior Hangfire job to cancel/reschedule. SeasonWeek included
             // because PickDeadline rows are scoped per league per week —
             // omitting it would collide when a league has matchups generated
-            // multiple weeks ahead. Null SeasonWeek (Kickoff jobs) still
+            // multiple weeks ahead. Null SeasonWeek (ContestStart jobs) still
             // participates in the index per Postgres semantics.
             //
             // Unique because the natural-key invariant is "one scheduled row
@@ -69,11 +69,12 @@ namespace SportsData.Notification.Infrastructure.Data
             // DbUpdateException(23505) and fall through to the reschedule
             // path against the winner's row.
             //
-            // AreNullsDistinct(false): Kickoff jobs leave SeasonWeek null,
-            // and Postgres treats nulls as distinct by default. Without this,
-            // duplicate Kickoff rows for the same (User, "Kickoff", ContestId)
-            // tuple would slip through the unique index. Requires Postgres 15+
-            // (the live cluster runs 16, so we're fine).
+            // AreNullsDistinct(false): ContestStart jobs leave SeasonWeek
+            // null, and Postgres treats nulls as distinct by default. Without
+            // this, duplicate ContestStart rows for the same
+            // (User, "ContestStart", ContestId) tuple would slip through the
+            // unique index. Requires Postgres 15+ (the live cluster runs 16,
+            // so we're fine).
             modelBuilder.Entity<PendingScheduledJob>()
                 .HasIndex(j => new { j.UserId, j.JobKind, j.TargetId, j.SeasonWeek })
                 .IsUnique()

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationLog.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationLog.cs
@@ -26,7 +26,7 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
 
         /// <summary>
         /// Notification category — mirrors <see cref="UserNotificationPreferences"/>
-        /// flags. e.g. "PickResult", "PickDeadline", "Kickoff", "LeagueInvite",
+        /// flags. e.g. "PickResult", "PickDeadline", "ContestStart", "LeagueInvite",
         /// "Membership", "MatchupPreview", "ScheduleChange".
         /// </summary>
         [Required]

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PendingScheduledJob.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PendingScheduledJob.cs
@@ -5,11 +5,12 @@ using SportsData.Core.Infrastructure.Data.Entities;
 namespace SportsData.Notification.Infrastructure.Data.Entities
 {
     /// <summary>
-    /// Tracks Hangfire job ids for time-based notifications (pick deadline
-    /// reminder, kickoff reminder). The row exists so we can find + cancel
-    /// the prior Hangfire job when an upstream event reschedules the trigger
-    /// — e.g. ContestStartTimeUpdated moves a game earlier, the existing
-    /// kickoff-reminder job has to be cancelled and a new one scheduled.
+    /// Tracks Hangfire job ids for time-based notifications (pick-deadline
+    /// reminder, contest-start reminder). The row exists so we can find +
+    /// cancel the prior Hangfire job when an upstream event reschedules the
+    /// trigger — e.g. ContestStartTimeUpdated moves a game earlier, the
+    /// existing contest-start-reminder job has to be cancelled and a new
+    /// one scheduled.
     ///
     /// Same crash-safe pattern as Producer's CompetitionStream: persist the
     /// new Hangfire job id, save, then delete the old job. If delete fails
@@ -23,14 +24,14 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
         /// <summary>
         /// Discriminator for the kind of scheduled notification. Limited string
         /// rather than an enum so adding a category doesn't require a Core change.
-        /// Values today: "PickDeadline", "Kickoff".
+        /// Values today: "PickDeadline", "ContestStart".
         /// </summary>
         [Required]
         [MaxLength(32)]
         public string JobKind { get; set; }
 
         /// <summary>
-        /// Logical target the reminder is about. For "Kickoff" this is the
+        /// Logical target the reminder is about. For "ContestStart" this is the
         /// ContestId; for "PickDeadline" this is the PickemGroupId (paired
         /// with <see cref="SeasonWeek"/> in the unique constraint so the
         /// same league can have one row per week).
@@ -39,7 +40,7 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
 
         /// <summary>
         /// Only meaningful for <c>JobKind = "PickDeadline"</c>. Null for
-        /// Kickoff jobs (those are scoped to a single contest, not a week).
+        /// ContestStart jobs (those are scoped to a single contest, not a week).
         /// Part of the natural key for PickDeadline rows so a league with
         /// matchups generated weeks ahead can carry one scheduled-job row
         /// per upcoming week without collisions.

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/UserNotificationPreferences.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/UserNotificationPreferences.cs
@@ -18,7 +18,7 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
 
         public bool PickDeadlineReminderEnabled { get; set; } = true;
 
-        public bool KickoffReminderEnabled { get; set; } = true;
+        public bool ContestStartReminderEnabled { get; set; } = true;
 
         public bool LeagueInviteEnabled { get; set; } = true;
 

--- a/src/SportsData.Notification/Migrations/20260626092455_RenameKickoffReminderEnabledToContestStartReminderEnabled.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260626092455_RenameKickoffReminderEnabledToContestStartReminderEnabled.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260626092455_RenameKickoffReminderEnabledToContestStartReminderEnabled")]
+    partial class RenameKickoffReminderEnabledToContestStartReminderEnabled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260626092455_RenameKickoffReminderEnabledToContestStartReminderEnabled.cs
+++ b/src/SportsData.Notification/Migrations/20260626092455_RenameKickoffReminderEnabledToContestStartReminderEnabled.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameKickoffReminderEnabledToContestStartReminderEnabled : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "KickoffReminderEnabled",
+                table: "UserNotificationPreferences",
+                newName: "ContestStartReminderEnabled");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "ContestStartReminderEnabled",
+                table: "UserNotificationPreferences",
+                newName: "KickoffReminderEnabled");
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -98,11 +98,13 @@ namespace SportsData.Notification
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
 
             // Phase 2c-main: pick-deadline reminder scheduling + dispatch.
-            // Dispatcher is the Hangfire-invoked target; scheduler is the
-            // helper consumers call after every projection write that could
-            // affect a league-week's deadline.
+            // Phase 2d: kickoff reminder scheduling — same dispatcher, per-
+            // contest scope. Dispatcher is the Hangfire-invoked target; each
+            // scheduler is the helper consumers call after a projection write
+            // that could affect its respective scope.
             services.AddScoped<INotificationDispatcher, NotificationDispatcher>();
             services.AddScoped<IPickDeadlineReminderScheduler, PickDeadlineReminderScheduler>();
+            services.AddScoped<IKickoffReminderScheduler, KickoffReminderScheduler>();
 
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -98,13 +98,14 @@ namespace SportsData.Notification
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
 
             // Phase 2c-main: pick-deadline reminder scheduling + dispatch.
-            // Phase 2d: kickoff reminder scheduling — same dispatcher, per-
-            // contest scope. Dispatcher is the Hangfire-invoked target; each
-            // scheduler is the helper consumers call after a projection write
-            // that could affect its respective scope.
+            // Phase 2d: contest-start reminder scheduling — same dispatcher,
+            // per-contest scope, sport-aware copy at fire time. Dispatcher is
+            // the Hangfire-invoked target; each scheduler is the helper
+            // consumers call after a projection write that could affect its
+            // respective scope.
             services.AddScoped<INotificationDispatcher, NotificationDispatcher>();
             services.AddScoped<IPickDeadlineReminderScheduler, PickDeadlineReminderScheduler>();
-            services.AddScoped<IKickoffReminderScheduler, KickoffReminderScheduler>();
+            services.AddScoped<IContestStartReminderScheduler, ContestStartReminderScheduler>();
 
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);


### PR DESCRIPTION
## Summary
- Adds `SendKickoffReminderAsync(userId, contestId)` on `INotificationDispatcher` — atomic-claim shape mirroring PickDeadline, deterministic CorrelationId for Hangfire-retry idempotency, FCM dispatch with per-device try/catch and `KickoffReminderEnabled` prefs gate.
- Adds `KickoffReminderScheduler` — per-contest scope (`TargetId=ContestId`, `SeasonWeek=null`); distinct member-id fan-out across every league containing the contest; crash-safe schedule-new → save → delete-old reschedule ordering; peer-takeover on 23505. The unique index on `(UserId, JobKind, TargetId, SeasonWeek)` with `AreNullsDistinct(false)` collapses the same-contest-in-multiple-leagues case to one job per user.
- Wires the scheduler into three trigger points alongside the existing `PickDeadline` calls: `PickemGroupMatchupCreatedConsumer`, `PickemGroupMatchupDataPublishedConsumer`, and `ContestStartTimeUpdatedConsumer` (replaces the Phase 2c TODO with one bulk per-contest re-evaluation).

## Design notes
- **Lead time**: 30 minutes, hardcoded for v1 (vs PickDeadline's 1 hour). Per-user override waits on the notification-settings UI.
- **Body**: stays generic (`"A game you've picked starts in about 30 minutes. Tap to follow live."`). A user can have the same contest in multiple leagues; naming one would mislead. Team names aren't on the local projection — richer copy waits on a fatter steady-state event or a backfill expansion.
- **Update-path gating**: the per-matchup consumers re-evaluate kickoff only when `StartDateUtc` actually shifted. Week changes alone (same kickoff time, different bucket) don't move the kickoff reminder.
- **Stale-event guard inherited**: `ContestStartTimeUpdatedConsumer` already filters on `StartDateUpdatedAt` monotonic version in the bulk update; the new kickoff call is gated on `rowsAffected > 0` to skip stale-event passes.

## Test plan
- [ ] Build green (verified locally: `dotnet build src/SportsData.Notification` clean, 0 warnings, 0 errors).
- [ ] Schedule a future contest into a one-member league; confirm one `PendingScheduledJob` row with `JobKind="Kickoff"` and `ScheduledFireUtc = startDate - 30m`.
- [ ] Add the same contest to a second league for the same user; confirm a single row remains (unique index collapses).
- [ ] Publish `ContestStartTimeUpdated` moving start by ±2h; confirm the row's `HangfireJobId` flips and `ScheduledFireUtc` tracks the new fire-time; old Hangfire job deleted.
- [ ] Republish a stale `ContestStartTimeUpdated` (older `CreatedUtc`); confirm row untouched and no kickoff re-eval (rowsAffected=0).
- [ ] Toggle `KickoffReminderEnabled=false` on prefs; let a job fire; confirm `NotificationLog.Result = "Suppressed_UserOptedOut"`.
- [ ] Hangfire retry the same dispatch; confirm `Skipped_AlreadyDispatched` path via unique constraint catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contest start reminders for eligible users, including tailored notification text by sport.
  * Users can now opt in/out of contest start reminders in their notification preferences.
  * Contest start reminders are now scheduled and refreshed automatically when contest timing changes.

* **Bug Fixes**
  * Improved reminder updates when contest start times or matchup data change, reducing missed or stale notifications.

* **Chores**
  * Updated database schema and related app wiring to support the new reminder option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->