### PR TITLE
fix(notification): stale-fire check in dispatcher

### DIFF
--- a/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/INotificationDispatcher.cs
@@ -17,8 +17,8 @@ namespace SportsData.Notification.Application.Dispatching
     /// </summary>
     public interface INotificationDispatcher
     {
-        Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek, DateTime deadlineUtc);
+        Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek, DateTime fireTimeUtc);
 
-        Task SendContestStartReminderAsync(Guid userId, Guid contestId, DateTime startDateUtc);
+        Task SendContestStartReminderAsync(Guid userId, Guid contestId, DateTime fireTimeUtc);
     }
 }

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -48,18 +48,17 @@ namespace SportsData.Notification.Application.Dispatching
             _pushSender = pushSender;
         }
 
-        public async Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek, DateTime deadlineUtc)
+        public async Task SendPickDeadlineReminderAsync(Guid userId, Guid pickemGroupId, int seasonWeek, DateTime fireTimeUtc)
         {
-            // Qualifiers include deadlineUtc.Ticks as the version anchor for
-            // the same reason as ContestStart: a deadline shift (new matchup
-            // lands and pulls MIN(StartDateUtc) earlier, or
-            // ContestStartTimeUpdated moves the earliest game) reschedules
-            // the Hangfire job. If the old job's TryDelete fails and it
-            // fires first, the orphan would otherwise claim the
-            // NotificationLog slot and silently suppress the new
-            // correct-deadline reminder.
+            // fireTimeUtc IS the version anchor — what the scheduler intended
+            // this job to fire at. Used both for the deterministic dedupe
+            // key (a reschedule produces a different key per fire-time, so
+            // an orphan can't suppress the new fire) and for the stale-fire
+            // check below (an orphan reads the PendingScheduledJob row, sees
+            // the scheduler has since moved to a different ScheduledFireUtc,
+            // and aborts before sending the wrong-time push).
             var correlationId = DeterministicCorrelationId(
-                "PickDeadline", userId, pickemGroupId, seasonWeek, deadlineUtc.Ticks);
+                "PickDeadline", userId, pickemGroupId, seasonWeek, fireTimeUtc.Ticks);
 
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
@@ -67,7 +66,7 @@ namespace SportsData.Notification.Application.Dispatching
                 ["UserId"] = userId,
                 ["PickemGroupId"] = pickemGroupId,
                 ["SeasonWeek"] = seasonWeek,
-                ["DeadlineUtc"] = deadlineUtc
+                ["FireTimeUtc"] = fireTimeUtc
             });
 
             _logger.LogInformation("SendPickDeadlineReminderAsync invoked.");
@@ -95,6 +94,17 @@ namespace SportsData.Notification.Application.Dispatching
                     "PickDeadline reminder already dispatched for CorrelationId {CorrelationId}; skipping (Hangfire retry).",
                     correlationId);
                 _dataContext.Entry(claim).State = EntityState.Detached;
+                return;
+            }
+
+            // Stale-fire check: am I still the scheduler's intended fire?
+            // Look up the PendingScheduledJob row by natural key. If the row
+            // is gone, or its ScheduledFireUtc no longer matches what I was
+            // called with, an orphan reschedule survived a failed best-
+            // effort TryDelete and I'm the wrong-time fire. Abort.
+            if (await IsStaleFireAsync(userId, "PickDeadline", pickemGroupId, seasonWeek, fireTimeUtc))
+            {
+                await FinalizeAsync(claim, "Suppressed_StaleFire");
                 return;
             }
 
@@ -180,27 +190,24 @@ namespace SportsData.Notification.Application.Dispatching
             await _dataContext.SaveChangesAsync();
         }
 
-        public async Task SendContestStartReminderAsync(Guid userId, Guid contestId, DateTime startDateUtc)
+        public async Task SendContestStartReminderAsync(Guid userId, Guid contestId, DateTime fireTimeUtc)
         {
-            // Qualifier is StartDateUtc.Ticks — the version anchor. Without
-            // it, a rescheduled contest (ESPN moves start time, scheduler
-            // creates a new Hangfire job, TryDelete of the old job fails)
-            // would have the orphan job fire FIRST with the same
-            // (category, userId, contestId) key, claim the NotificationLog
-            // row, and silently suppress the correct-time fire. Including
-            // Ticks gives each fire-time its own dedupe key so the new
-            // reminder can land even when the orphan races it. Hangfire
-            // retries of the SAME logical fire still dedupe correctly
-            // because the serialized DateTime arg is stable across retries.
+            // fireTimeUtc IS the version anchor — what the scheduler intended
+            // this job to fire at. Used both for the deterministic dedupe
+            // key (a reschedule produces a different key per fire-time) and
+            // for the stale-fire check below (an orphan reads the
+            // PendingScheduledJob row, sees the scheduler has since moved
+            // to a different ScheduledFireUtc, and aborts before sending
+            // the wrong-time push).
             var correlationId = DeterministicCorrelationId(
-                "ContestStart", userId, contestId, startDateUtc.Ticks);
+                "ContestStart", userId, contestId, fireTimeUtc.Ticks);
 
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
                 ["CorrelationId"] = correlationId,
                 ["UserId"] = userId,
                 ["ContestId"] = contestId,
-                ["StartDateUtc"] = startDateUtc
+                ["FireTimeUtc"] = fireTimeUtc
             });
 
             _logger.LogInformation("SendContestStartReminderAsync invoked.");
@@ -226,6 +233,15 @@ namespace SportsData.Notification.Application.Dispatching
                     "ContestStart reminder already dispatched for CorrelationId {CorrelationId}; skipping (Hangfire retry).",
                     correlationId);
                 _dataContext.Entry(claim).State = EntityState.Detached;
+                return;
+            }
+
+            // Stale-fire check: am I still the scheduler's intended fire?
+            // ContestStart rows leave SeasonWeek null, included in the
+            // natural key.
+            if (await IsStaleFireAsync(userId, "ContestStart", contestId, seasonWeek: null, fireTimeUtc))
+            {
+                await FinalizeAsync(claim, "Suppressed_StaleFire");
                 return;
             }
 
@@ -307,6 +323,49 @@ namespace SportsData.Notification.Application.Dispatching
             claim.Result = result;
             claim.ModifiedUtc = _dateTimeProvider.UtcNow();
             await _dataContext.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Returns true when the currently-firing Hangfire job is no longer
+        /// the scheduler's intended fire for this scope — either the row is
+        /// gone (cancelled) or the scheduler has since rescheduled to a
+        /// different fire-time. Callers should treat this as a no-op,
+        /// finalize the claim as <c>Suppressed_StaleFire</c>, and return.
+        ///
+        /// <para>
+        /// Lookup hits the natural-key unique index
+        /// (UserId, JobKind, TargetId, SeasonWeek) — cheap, one indexed read
+        /// per dispatch.
+        /// </para>
+        /// </summary>
+        private async Task<bool> IsStaleFireAsync(
+            Guid userId, string jobKind, Guid targetId, int? seasonWeek, DateTime fireTimeUtc)
+        {
+            var row = await _dataContext.PendingScheduledJobs
+                .AsNoTracking()
+                .FirstOrDefaultAsync(j =>
+                    j.UserId == userId &&
+                    j.JobKind == jobKind &&
+                    j.TargetId == targetId &&
+                    j.SeasonWeek == seasonWeek);
+
+            if (row is null)
+            {
+                _logger.LogInformation(
+                    "Stale fire: no PendingScheduledJob row for ({JobKind}, {TargetId}, week={SeasonWeek}); aborting.",
+                    jobKind, targetId, seasonWeek);
+                return true;
+            }
+
+            if (row.ScheduledFireUtc != fireTimeUtc)
+            {
+                _logger.LogInformation(
+                    "Stale fire: scheduler has moved to FireTime={CurrentFireTime}; this job was scheduled for {OrphanFireTime}. Aborting.",
+                    row.ScheduledFireUtc, fireTimeUtc);
+                return true;
+            }
+
+            return false;
         }
 
         private static string ComposeFailureReason(List<string> failureReasons)

--- a/src/SportsData.Notification/Application/Scheduling/ContestStartReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/ContestStartReminderScheduler.cs
@@ -152,14 +152,13 @@ namespace SportsData.Notification.Application.Scheduling
 
                 existingByUser.TryGetValue(userId, out var existing);
                 await ScheduleOrRescheduleAsync(
-                    userId, contestId, startDate.Value, fireTime, existing, now, cancellationToken);
+                    userId, contestId, fireTime, existing, now, cancellationToken);
             }
         }
 
         private async Task ScheduleOrRescheduleAsync(
             Guid userId,
             Guid contestId,
-            DateTime startDateUtc,
             DateTime fireTime,
             PendingScheduledJob existing,
             DateTime now,
@@ -174,14 +173,14 @@ namespace SportsData.Notification.Application.Scheduling
             // Schedule the new job FIRST, then persist, then delete the old.
             // Same crash-safe ordering as PickDeadlineReminderScheduler.
             var delay = fireTime - now;
-            // startDateUtc is forwarded to the dispatcher so its
-            // deterministic CorrelationId can include the version anchor.
-            // A reschedule (different StartDateUtc) yields a different
-            // CorrelationId, so an orphan Hangfire job that survived a
-            // failed best-effort delete can't claim the NotificationLog
-            // slot and suppress the new fire.
+            // fireTime is forwarded to the dispatcher as the version anchor.
+            // It feeds both the deterministic CorrelationId (so a reschedule
+            // gets a fresh dedupe key) AND the dispatcher's stale-fire check
+            // against PendingScheduledJob.ScheduledFireUtc — an orphan that
+            // survived a failed best-effort delete will see the row no
+            // longer matches its fireTime and abort before sending.
             var newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
-                d => d.SendContestStartReminderAsync(userId, contestId, startDateUtc),
+                d => d.SendContestStartReminderAsync(userId, contestId, fireTime),
                 delay);
 
             if (existing is null)

--- a/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
+++ b/src/SportsData.Notification/Application/Scheduling/PickDeadlineReminderScheduler.cs
@@ -159,7 +159,7 @@ namespace SportsData.Notification.Application.Scheduling
 
                 existingByUser.TryGetValue(userId, out var existing);
                 await ScheduleOrRescheduleAsync(
-                    userId, pickemGroupId, seasonWeek, deadline.Value, fireTime, existing, now, cancellationToken);
+                    userId, pickemGroupId, seasonWeek, fireTime, existing, now, cancellationToken);
             }
         }
 
@@ -167,7 +167,6 @@ namespace SportsData.Notification.Application.Scheduling
             Guid userId,
             Guid pickemGroupId,
             int seasonWeek,
-            DateTime deadlineUtc,
             DateTime fireTime,
             PendingScheduledJob existing,
             DateTime now,
@@ -184,14 +183,15 @@ namespace SportsData.Notification.Application.Scheduling
             // an orphan Hangfire job (benign — dispatcher's dedupe absorbs
             // it). The alternative (delete-old first) could leave a row
             // pointing at a deleted job, silently missing the reminder.
-            // deadlineUtc is forwarded so the dispatcher's deterministic
-            // CorrelationId can include the version anchor. A deadline shift
-            // (new earliest matchup) yields a different key per fire-time,
-            // so an orphan from a failed best-effort TryDelete can't claim
-            // the NotificationLog slot and suppress the new reminder.
+            // fireTime is forwarded to the dispatcher as the version anchor.
+            // It feeds both the deterministic CorrelationId (so a reschedule
+            // gets a fresh dedupe key) AND the dispatcher's stale-fire check
+            // against PendingScheduledJob.ScheduledFireUtc — an orphan that
+            // survived a failed best-effort delete will see the row no
+            // longer matches its fireTime and abort before sending.
             var delay = fireTime - now;
             var newJobId = _backgroundJobProvider.Schedule<INotificationDispatcher>(
-                d => d.SendPickDeadlineReminderAsync(userId, pickemGroupId, seasonWeek, deadlineUtc),
+                d => d.SendPickDeadlineReminderAsync(userId, pickemGroupId, seasonWeek, fireTime),
                 delay);
 
             if (existing is null)

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationLog.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationLog.cs
@@ -48,7 +48,7 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
 
         /// <summary>
         /// Outcome. e.g. "Sent", "Suppressed_UserOptedOut", "Suppressed_NoDevice",
-        /// "Failed_FcmError", "Skipped_Duplicate".
+        /// "Suppressed_StaleFire", "Failed_FcmError", "Skipped_Duplicate".
         /// </summary>
         [Required]
         [MaxLength(64)]


### PR DESCRIPTION
## Summary
Closes the second half of the orphan-Hangfire-fire race that PR #470 only half-fixed.

PR #470 made each rescheduled reminder its own dedupe key (so a surviving orphan can no longer silently *suppress* the new correct-time fire). The orphan still fires its own wrong-time push, though — so the user ends up with two notifications (wrong-time + correct-time) instead of one wrong-time. This PR adds the explicit stale-fire check at dispatch entry that drops the orphan before it sends.

## What changed
- **Version-anchor switched to `fireTimeUtc`**: `SendContestStartReminderAsync` and `SendPickDeadlineReminderAsync` now take `fireTimeUtc` instead of `startDateUtc` / `deadlineUtc`. Directly comparable to `PendingScheduledJob.ScheduledFireUtc` — no lead-time arithmetic coupling. The old anchors were a redundant denormalization for what the dispatcher actually needed.
- **`IsStaleFireAsync` helper**: after the atomic-claim insert, look up the `PendingScheduledJob` row by natural key `(UserId, JobKind, TargetId, SeasonWeek)`. Abort with `Suppressed_StaleFire` when:
  - The row is missing (cancelled by some future admin path), OR
  - `row.ScheduledFireUtc != fireTimeUtc` (the scheduler has since rescheduled and this Hangfire job is an orphan).
- **Hangfire retry of the *current* job**: same `fireTime`, lookup matches, dispatch proceeds. The dedupe-key from PR #470 still catches duplicate sends from genuine retries.
- **`NotificationLog.Result` doc** updated to list `Suppressed_StaleFire`.

## Why belt-and-suspenders
Both layers remain:
- Dedupe key keyed on `fireTimeUtc.Ticks` — protects against the orphan claiming the slot first and suppressing the correct fire.
- Stale-fire check at dispatch — protects against the orphan sending a wrong-time push at all.

Either alone has a gap. Together they close both halves of the race.

## Cost
One indexed read per dispatch on the existing unique constraint `(UserId, JobKind, TargetId, SeasonWeek)`. Negligible.

## Test plan
- [ ] Build green (verified locally: `dotnet build src/SportsData.Notification` clean, 0 warnings, 0 errors).
- [ ] Schedule a reminder for a future contest. Confirm `PendingScheduledJob` row + Hangfire job at expected `fireTime`. Fire manually; confirm `Sent`.
- [ ] Force a reschedule scenario: drop the projection's `StartDateUtc` change-detection path or manually advance `ScheduledFireUtc` on the row to simulate a "scheduler-moved-on" state. Trigger the original Hangfire job (older fire time). Confirm `NotificationLog.Result = "Suppressed_StaleFire"` and no push goes out.
- [ ] Delete the `PendingScheduledJob` row (simulating cancellation). Trigger the Hangfire job. Confirm `Suppressed_StaleFire`.
- [ ] Hangfire-retry the SAME live job: confirm dedupe-key path catches it (`already dispatched, skipping (Hangfire retry)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reminder notifications now better avoid sending outdated scheduled messages, reducing duplicate or stale reminders.
  * Pick deadline and contest start reminders now use the actual send time consistently, improving timing accuracy and reliability.

* **Documentation**
  * Updated notification result guidance to include a new suppressed-stale-fire outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->