### PR TITLE
feat(jobs-dashboard): add /notifications Hangfire route

### DIFF
--- a/src/SportsData.JobsDashboard/Program.cs
+++ b/src/SportsData.JobsDashboard/Program.cs
@@ -68,6 +68,10 @@ public class Program
         var apiStorage = new PostgreSqlStorage($"{cleanBase};Database=sdApi.All.Hangfire;{poolOpts}");
         app.UseHangfireDashboard("/api", dashboardOptions, apiStorage);
 
+        // Notification (shared across all sports)
+        var notificationStorage = new PostgreSqlStorage($"{cleanBase};Database=sdNotification.All.Hangfire;{poolOpts}");
+        app.UseHangfireDashboard("/notifications", dashboardOptions, notificationStorage);
+
         // Root landing page with links to all dashboards
         app.MapGet("/", () => Results.Content(
             """
@@ -92,6 +96,7 @@ public class Program
             <h3>Shared</h3>
             <ul>
               <li><a href="/api">API</a></li>
+              <li><a href="/notifications">Notification</a></li>
             </ul>
             </body></html>
             """, "text/html"));


### PR DESCRIPTION
## Summary
Mirrors the existing `/api` shared route. New `PostgreSqlStorage` pointed at `sdNotification.All.Hangfire`, registered at `/notifications` on the Hangfire dashboard, with a landing-page link added under the Shared section. Pool size 5, same as the other dashboards (read-only).

Pairs with sister-repo change `sports-data-config@6d4e1c0` that exposes Notification at `notifications.sportdeets.com` (cert + Traefik IngressRoute). The dashboard route is independent and additive — works whether or not the external Notification ingress is up.

## Test plan
- [ ] Build green (verified locally: `dotnet build src/SportsData.JobsDashboard` clean, 0 warnings, 0 errors).
- [ ] After deploy, hit `https://jobs.sportdeets.com/notifications` (basic-auth gated by the existing middleware) — confirm Hangfire dashboard renders against the Notification Hangfire DB.
- [ ] Confirm landing page at `https://jobs.sportdeets.com/` shows the new "Notification" link under Shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Notifications dashboard accessible from the app’s main landing page.
  * Included a direct “Notification” link to the dashboard for easier navigation.
  * The dashboard uses the same access controls and presentation style as the existing dashboard experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->