### PR TITLE
feat(notification): device registration endpoint + mobile auto-register

### DIFF
--- a/bruno/api/devices-register.yml
+++ b/bruno/api/devices-register.yml
@@ -1,0 +1,22 @@
+info:
+  name: devices-register
+  type: http
+  seq: 100
+
+http:
+  method: POST
+  url: "{{baseUrlApi}}/ui/devices"
+  body:
+    type: json
+    data: |-
+      {
+        "fcmToken": "REPLACE_WITH_DEVICE_TOKEN",
+        "platform": "ios"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommand.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommand.cs
@@ -1,0 +1,14 @@
+namespace SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
+
+/// <summary>
+/// Registers a mobile device's FCM token for the authenticated user. UserId
+/// is resolved from the JWT in the controller, never trusted from the client.
+/// </summary>
+public class RegisterDeviceCommand
+{
+    public Guid UserId { get; set; }
+
+    public required string FcmToken { get; set; }
+
+    public required string Platform { get; set; }
+}

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
@@ -1,0 +1,91 @@
+using FluentValidation.Results;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+
+namespace SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
+
+public interface IRegisterDeviceCommandHandler
+{
+    Task<Result<bool>> ExecuteAsync(
+        RegisterDeviceCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Resolves nothing about identity itself (the controller already mapped the
+/// JWT to <see cref="RegisterDeviceCommand.UserId"/>) — it validates the
+/// payload and publishes <see cref="UserDeviceRegistered"/> for the
+/// Notification service to project into its UserDevices table.
+///
+/// <para>
+/// Stateless publish: no API-side entity write, so we publish with
+/// <see cref="DeliveryMode.Direct"/> rather than injecting a DbContext just to
+/// flush the outbox. Notification owns the device store; API only resolves the
+/// user and announces the registration.
+/// </para>
+/// </summary>
+public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
+{
+    private static readonly string[] AllowedPlatforms = { "ios", "android" };
+
+    private readonly IEventBus _eventBus;
+    private readonly IMessageDeliveryScope _deliveryScope;
+    private readonly ILogger<RegisterDeviceCommandHandler> _logger;
+
+    public RegisterDeviceCommandHandler(
+        IEventBus eventBus,
+        IMessageDeliveryScope deliveryScope,
+        ILogger<RegisterDeviceCommandHandler> logger)
+    {
+        _eventBus = eventBus;
+        _deliveryScope = deliveryScope;
+        _logger = logger;
+    }
+
+    public async Task<Result<bool>> ExecuteAsync(
+        RegisterDeviceCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(command.FcmToken))
+        {
+            return new Failure<bool>(
+                false,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(command.FcmToken), "FcmToken is required")]);
+        }
+
+        var platform = command.Platform?.Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(platform) || !AllowedPlatforms.Contains(platform))
+        {
+            return new Failure<bool>(
+                false,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(command.Platform), "Platform must be 'ios' or 'android'")]);
+        }
+
+        var correlationId = Guid.NewGuid();
+
+        _logger.LogInformation(
+            "Publishing UserDeviceRegistered. UserId={UserId}, Platform={Platform}, CorrelationId={CorrelationId}",
+            command.UserId,
+            platform,
+            correlationId);
+
+        // Direct delivery — stateless publish, no DbContext write to bundle.
+        using (_deliveryScope.Use(DeliveryMode.Direct))
+        {
+            await _eventBus.Publish(
+                new UserDeviceRegistered(
+                    UserId: command.UserId,
+                    FcmToken: command.FcmToken.Trim(),
+                    Platform: platform,
+                    CorrelationId: correlationId,
+                    CausationId: Guid.NewGuid()),
+                cancellationToken);
+        }
+
+        return new Success<bool>(true);
+    }
+}

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
@@ -1,4 +1,4 @@
-using FluentValidation.Results;
+using FluentValidation;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
@@ -28,19 +28,20 @@ public interface IRegisterDeviceCommandHandler
 /// </summary>
 public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
 {
-    private static readonly string[] AllowedPlatforms = { "ios", "android" };
-
     private readonly IEventBus _eventBus;
     private readonly IMessageDeliveryScope _deliveryScope;
+    private readonly IValidator<RegisterDeviceCommand> _validator;
     private readonly ILogger<RegisterDeviceCommandHandler> _logger;
 
     public RegisterDeviceCommandHandler(
         IEventBus eventBus,
         IMessageDeliveryScope deliveryScope,
+        IValidator<RegisterDeviceCommand> validator,
         ILogger<RegisterDeviceCommandHandler> logger)
     {
         _eventBus = eventBus;
         _deliveryScope = deliveryScope;
+        _validator = validator;
         _logger = logger;
     }
 
@@ -48,23 +49,13 @@ public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
         RegisterDeviceCommand command,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(command.FcmToken))
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
         {
-            return new Failure<bool>(
-                false,
-                ResultStatus.BadRequest,
-                [new ValidationFailure(nameof(command.FcmToken), "FcmToken is required")]);
+            return new Failure<bool>(false, ResultStatus.BadRequest, validation.Errors);
         }
 
-        var platform = command.Platform?.Trim().ToLowerInvariant();
-        if (string.IsNullOrEmpty(platform) || !AllowedPlatforms.Contains(platform))
-        {
-            return new Failure<bool>(
-                false,
-                ResultStatus.BadRequest,
-                [new ValidationFailure(nameof(command.Platform), "Platform must be 'ios' or 'android'")]);
-        }
-
+        var platform = command.Platform.Trim().ToLowerInvariant();
         var correlationId = Guid.NewGuid();
 
         _logger.LogInformation(

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
@@ -52,7 +52,7 @@ public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
         var validation = await _validator.ValidateAsync(command, cancellationToken);
         if (!validation.IsValid)
         {
-            return new Failure<bool>(false, ResultStatus.BadRequest, validation.Errors);
+            return new Failure<bool>(default!, ResultStatus.BadRequest, validation.Errors);
         }
 
         var platform = command.Platform.Trim().ToLowerInvariant();

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandValidator.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
+
+public class RegisterDeviceCommandValidator : AbstractValidator<RegisterDeviceCommand>
+{
+    // Mirrors the Notification UserDevices.FcmToken column (varchar(256)) so an
+    // overlong token fails fast here instead of blowing up the consumer's
+    // insert and dead-lettering the UserDeviceRegistered event.
+    private const int FcmTokenMaxLength = 256;
+
+    private static readonly string[] AllowedPlatforms = { "ios", "android" };
+
+    public RegisterDeviceCommandValidator()
+    {
+        RuleFor(x => x.FcmToken)
+            .NotEmpty().WithMessage("FcmToken is required")
+            .MaximumLength(FcmTokenMaxLength)
+            .WithMessage($"FcmToken must not exceed {FcmTokenMaxLength} characters.");
+
+        RuleFor(x => x.Platform)
+            .Must(BeAnAllowedPlatform)
+            .WithMessage("Platform must be 'ios' or 'android'");
+    }
+
+    private static bool BeAnAllowedPlatform(string? platform)
+    {
+        if (string.IsNullOrWhiteSpace(platform))
+            return false;
+
+        return AllowedPlatforms.Contains(platform.Trim().ToLowerInvariant());
+    }
+}

--- a/src/SportsData.Api/Application/UI/Devices/DevicesController.cs
+++ b/src/SportsData.Api/Application/UI/Devices/DevicesController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
+using SportsData.Api.Application.UI.Devices.Dtos;
+using SportsData.Api.Extensions;
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+
+namespace SportsData.Api.Application.UI.Devices;
+
+[ApiController]
+[Route("ui/devices")]
+public class DevicesController : ApiControllerBase
+{
+    /// <summary>
+    /// Registers (or refreshes) the calling device's FCM token for the
+    /// authenticated user. Idempotent downstream: the Notification consumer
+    /// upserts on (UserId, FcmToken), so the mobile client can safely call
+    /// this on every launch / token refresh.
+    /// </summary>
+    [HttpPost]
+    [Authorize]
+    public async Task<ActionResult<bool>> RegisterDevice(
+        [FromBody] RegisterDeviceRequest request,
+        [FromServices] IRegisterDeviceCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+
+        var command = new RegisterDeviceCommand
+        {
+            UserId = userId,
+            FcmToken = request.FcmToken,
+            Platform = request.Platform
+        };
+
+        var result = await handler.ExecuteAsync(command, cancellationToken);
+
+        if (result.IsSuccess)
+            return NoContent();
+
+        return result.ToActionResult();
+    }
+}

--- a/src/SportsData.Api/Application/UI/Devices/Dtos/RegisterDeviceRequest.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Dtos/RegisterDeviceRequest.cs
@@ -1,0 +1,15 @@
+namespace SportsData.Api.Application.UI.Devices.Dtos;
+
+/// <summary>
+/// Mobile-supplied payload for FCM device registration. The user is NOT in
+/// the body — it's resolved server-side from the JWT — so a client can only
+/// ever register a device against its own authenticated identity.
+/// </summary>
+public class RegisterDeviceRequest
+{
+    /// <summary>The FCM registration token from the device install.</summary>
+    public required string FcmToken { get; set; }
+
+    /// <summary>"ios" or "android".</summary>
+    public required string Platform { get; set; }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -129,6 +129,9 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IReenrichContestCommandHandler, ReenrichContestCommandHandler>();
             services.AddScoped<IRefreshAiExistenceCommandHandler, RefreshAiExistenceCommandHandler>();
             services.AddScoped<ISendTestPushNotificationCommandHandler, SendTestPushNotificationCommandHandler>();
+            services.AddScoped<
+                SportsData.Api.Application.UI.Devices.Commands.RegisterDevice.IRegisterDeviceCommandHandler,
+                SportsData.Api.Application.UI.Devices.Commands.RegisterDevice.RegisterDeviceCommandHandler>();
             services.AddScoped<IUpsertMatchupPreviewCommandHandler, UpsertMatchupPreviewCommandHandler>();
 
             // Notifications

--- a/src/SportsData.Core/Eventing/Events/Users/UserDeviceRegistered.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UserDeviceRegistered.cs
@@ -1,0 +1,31 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Users
+{
+    /// <summary>
+    /// Emitted by the API when a mobile client registers (or refreshes) its
+    /// FCM device token — typically at sign-in or on token rotation. The API
+    /// owns identity resolution: it maps the authenticated Firebase token to
+    /// the internal <see cref="UserId"/> before publishing, so the
+    /// Notification service can project the device into its local
+    /// <c>UserDevices</c> table without taking on any auth / identity
+    /// responsibility of its own. Mirrors the existing API → Notification
+    /// projection pattern (UserDataPublished, PickemGroupDataPublished).
+    ///
+    /// <para>
+    /// Consumer must be idempotent. At-least-once delivery means the same
+    /// <c>(UserId, FcmToken)</c> may arrive twice, and re-registration on
+    /// every app launch / token refresh republishes the same pair. Upsert on
+    /// the <c>(UserId, FcmToken)</c> natural key.
+    /// </para>
+    /// </summary>
+    public record UserDeviceRegistered(
+        Guid UserId,
+        string FcmToken,
+        string Platform,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport.All, null, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/UserDeviceRegisteredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserDeviceRegisteredConsumer.cs
@@ -1,0 +1,115 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// Projects an FCM device registration from the API into the local
+    /// <see cref="UserDevice"/> table — the store every reminder/result
+    /// dispatch reads to find a user's tokens. Mirrors the
+    /// <see cref="UserDataPublishedConsumer"/> projection pattern.
+    ///
+    /// <para>
+    /// Idempotent on the <c>(UserId, FcmToken)</c> natural key (unique index):
+    /// re-registration on every app launch / token refresh and at-least-once
+    /// redelivery all converge on one row. Race-safe insert — a concurrent
+    /// consumer losing the unique-constraint insert falls through to the
+    /// update path.
+    /// </para>
+    ///
+    /// <para>
+    /// On re-registration we refresh <c>LastSeenUtc</c> and <c>Platform</c>
+    /// but deliberately do NOT reset <see cref="UserDevice.NotificationsEnabled"/>
+    /// — that's the user's per-device opt-out and a token refresh must not
+    /// silently re-enable a device they turned off.
+    /// </para>
+    /// </summary>
+    public class UserDeviceRegisteredConsumer : IConsumer<UserDeviceRegistered>
+    {
+        private readonly ILogger<UserDeviceRegisteredConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public UserDeviceRegisteredConsumer(
+            ILogger<UserDeviceRegisteredConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task Consume(ConsumeContext<UserDeviceRegistered> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["UserId"] = msg.UserId,
+                ["Platform"] = msg.Platform
+            });
+
+            var now = _dateTimeProvider.UtcNow();
+
+            var existing = await _dataContext.UserDevices
+                .FirstOrDefaultAsync(
+                    d => d.UserId == msg.UserId && d.FcmToken == msg.FcmToken,
+                    context.CancellationToken);
+
+            if (existing is null)
+            {
+                var entity = new UserDevice
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = msg.UserId,
+                    FcmToken = msg.FcmToken,
+                    Platform = msg.Platform,
+                    NotificationsEnabled = true,
+                    LastSeenUtc = now,
+                    CreatedUtc = now,
+                    CreatedBy = msg.CausationId
+                };
+                _dataContext.UserDevices.Add(entity);
+
+                try
+                {
+                    await _dataContext.SaveChangesAsync(context.CancellationToken);
+                    _logger.LogInformation("UserDevice registered. UserId={UserId}, DeviceId={DeviceId}", msg.UserId, entity.Id);
+                    return;
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // Race: another consumer inserted the same (UserId, FcmToken)
+                    // first. Detach our orphan and fall through to update.
+                    _dataContext.Entry(entity).State = EntityState.Detached;
+                    existing = await _dataContext.UserDevices
+                        .FirstAsync(
+                            d => d.UserId == msg.UserId && d.FcmToken == msg.FcmToken,
+                            context.CancellationToken);
+                }
+            }
+
+            // Refresh liveness + platform; preserve the user's opt-out.
+            existing.LastSeenUtc = now;
+            existing.Platform = msg.Platform;
+            existing.ModifiedUtc = now;
+            existing.ModifiedBy = msg.CausationId;
+
+            await _dataContext.SaveChangesAsync(context.CancellationToken);
+            _logger.LogInformation("UserDevice refreshed. UserId={UserId}, DeviceId={DeviceId}", msg.UserId, existing.Id);
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -44,6 +44,7 @@ namespace SportsData.Notification
                 typeof(PickemGroupMatchupDataPublishedConsumer),
                 typeof(PickemGroupMemberAddedConsumer),
                 typeof(UserDataPublishedConsumer),
+                typeof(UserDeviceRegisteredConsumer),
                 typeof(UserPickScoredConsumer)
             ]);
 

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import 'react-native-reanimated';
 
 import { queryClient } from '@/src/lib/queryClient';
 import { useAuthInit, useAuth } from '@/src/hooks/useAuth';
+import { useRegisterPushDevice } from '@/src/hooks/useRegisterPushDevice';
 import { ThemeProvider, useThemeMode } from '@/src/lib/theme/ThemeContext';
 import { TextSizeProvider, useTextSize } from '@/src/lib/textSize/TextSizeContext';
 import { SignalRGate } from '@/src/components/signalR/SignalRGate';
@@ -203,6 +204,17 @@ function NativePushDiagnostics() {
   return null;
 }
 
+/**
+ * Native-only side-effect component: silently registers this device's FCM
+ * token with the API once the user is authenticated and permission is already
+ * granted. Rendered (not just hook-called) so it sits alongside the other
+ * native-only push surfaces and never executes on web.
+ */
+function PushDeviceRegistrar() {
+  useRegisterPushDevice();
+  return null;
+}
+
 function RootLayoutNav() {
   // Feed the user-resolved scheme into React Navigation so native header
   // transitions and focus rings match the chosen theme.
@@ -228,7 +240,12 @@ function RootLayoutNav() {
       </Stack>
       <AuthGuard />
       <SignalRGate />
-      {Platform.OS !== 'web' ? <NativePushDiagnostics /> : null}
+      {Platform.OS !== 'web' ? (
+        <>
+          <NativePushDiagnostics />
+          <PushDeviceRegistrar />
+        </>
+      ) : null}
     </NavThemeProvider>
   );
 }

--- a/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
+++ b/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import messaging from '@react-native-firebase/messaging';
+
+import { useAuth } from './useAuth';
+import { getFcmTokenIfGranted } from '@/src/lib/notifications/pushNotifications';
+import { devicesApi } from '@/src/services/api/devicesApi';
+
+/**
+ * Silently registers this device's FCM token with the API once the user is
+ * authenticated and notification permission has already been granted. Replaces
+ * the manual copy-paste step on the admin push-token screen.
+ *
+ * Design choices:
+ * - NO permission prompt. We use {@link getFcmTokenIfGranted}, which only
+ *   returns a token when permission is already granted, so sign-in never fires
+ *   an unsolicited iOS prompt. Requesting permission (with context) is a
+ *   separate product flow.
+ * - Native-only. expo-notifications / RN-Firebase messaging have no web
+ *   equivalent; the hook no-ops on web.
+ * - Idempotent + cheap. The backend upserts on (UserId, FcmToken), so repeat
+ *   calls are harmless; the per-session token set just avoids needless POSTs.
+ * - Token rotation. Subscribes to onTokenRefresh so a mid-session FCM token
+ *   rotation re-registers without waiting for the next launch.
+ *
+ * Call once from the root layout (native-only).
+ */
+export function useRegisterPushDevice(): void {
+  const { isAuthenticated, user } = useAuth();
+
+  // Tokens already registered this app session. Backend idempotency makes this
+  // a chattiness guard, not a correctness one.
+  const registeredTokensRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+
+    if (!isAuthenticated) {
+      // Signed out — forget what we registered so the next user's device
+      // re-registers cleanly.
+      registeredTokensRef.current.clear();
+      return;
+    }
+
+    let cancelled = false;
+    const platform = Platform.OS === 'ios' ? 'ios' : 'android';
+
+    const register = async (token: string | null) => {
+      if (cancelled || !token) return;
+      if (registeredTokensRef.current.has(token)) return;
+
+      try {
+        await devicesApi.registerDevice({ fcmToken: token, platform });
+        registeredTokensRef.current.add(token);
+      } catch (err) {
+        // Non-fatal: reminders just won't reach this device until a later
+        // retry (next launch / token refresh). Never surface to the user.
+        const message = err instanceof Error ? err.message : String(err);
+        console.log('[push] device registration failed', { message });
+      }
+    };
+
+    // Initial registration for this sign-in.
+    void (async () => {
+      const token = await getFcmTokenIfGranted();
+      await register(token);
+    })();
+
+    // Re-register if FCM rotates the token while signed in.
+    const unsubscribe = messaging().onTokenRefresh((token) => {
+      void register(token);
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [isAuthenticated, user?.uid]);
+}

--- a/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
+++ b/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
@@ -42,6 +42,12 @@ export function useRegisterPushDevice(): void {
       return;
     }
 
+    // Fresh start for this sign-in. The effect also re-runs on a direct
+    // account switch (user?.uid A -> B with no intermediate sign-out); since
+    // the device's FCM token is the same across accounts, a stale cached token
+    // would otherwise suppress the new user's registration POST.
+    registeredTokensRef.current.clear();
+
     let cancelled = false;
     const platform = Platform.OS === 'ios' ? 'ios' : 'android';
 

--- a/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.web.ts
+++ b/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.web.ts
@@ -1,0 +1,11 @@
+/**
+ * Web no-op for {@link useRegisterPushDevice}.
+ *
+ * Device push registration depends on `@react-native-firebase/messaging`, which
+ * has no web implementation. Metro resolves this `.web` variant for the web
+ * bundle, so the native dependency is never pulled in by the root layout's
+ * static import. The native implementation lives in `useRegisterPushDevice.ts`.
+ */
+export function useRegisterPushDevice(): void {
+  // Intentionally empty — no push registration on web.
+}

--- a/src/UI/sd-mobile/src/lib/notifications/pushNotifications.ts
+++ b/src/UI/sd-mobile/src/lib/notifications/pushNotifications.ts
@@ -91,3 +91,30 @@ export async function getFcmToken(): Promise<FcmTokenResult> {
     return { token: null, permissionStatus, error: message };
   }
 }
+
+/**
+ * Like {@link getFcmToken}, but NEVER prompts. Returns the FCM token only
+ * when notification permission has ALREADY been granted; returns null
+ * otherwise (denied / undetermined / web / error).
+ *
+ * Used for silent automatic device registration at sign-in so we don't fire
+ * an unsolicited iOS permission prompt on launch. Permission is requested
+ * explicitly elsewhere (the admin push-token screen today; a priming flow in
+ * the future), and once granted this picks the token up on the next sign-in.
+ */
+export async function getFcmTokenIfGranted(): Promise<string | null> {
+  if (Platform.OS === 'web') return null;
+  try {
+    const { status } = await Notifications.getPermissionsAsync();
+    if (status !== 'granted') return null;
+
+    if (Platform.OS === 'ios') {
+      await messaging().registerDeviceForRemoteMessages();
+    }
+
+    const token = await messaging().getToken();
+    return token || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/UI/sd-mobile/src/services/api/devicesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/devicesApi.ts
@@ -1,0 +1,17 @@
+import { apiClient } from './client';
+
+export interface RegisterDevicePayload {
+  fcmToken: string;
+  platform: 'ios' | 'android';
+}
+
+/**
+ * Wrapper for /ui/devices. Registers (or refreshes) this device's FCM token
+ * for the authenticated user. Server-side upsert is idempotent on
+ * (UserId, FcmToken), so it's safe to call on every launch / token refresh.
+ */
+export const devicesApi = {
+  // POST /ui/devices → 204
+  registerDevice: (payload: RegisterDevicePayload) =>
+    apiClient.post<void>('/ui/devices', payload),
+};


### PR DESCRIPTION
## What
Adds FCM device-token registration so reminder / pick-result pushes have a device to send to. Until now the Notification dispatcher always hit `Suppressed_NoDevice` because nothing ever populated `UserDevices`.

## Architecture
**API endpoint → event → Notification projection** (mirrors the existing User / PickemGroup projection flow; identity resolution stays in API only).

- **Core** — `UserDeviceRegistered` event (`UserId`, `FcmToken`, `Platform`).
- **API** — `POST /ui/devices` (`[Authorize]`). Resolves `UserId` from the JWT (never trusts it from the client). `RegisterDeviceCommandHandler` validates token + platform and publishes via `DeliveryMode.Direct` (stateless — no DbContext write to bundle).
- **Notification** — `UserDeviceRegisteredConsumer` upserts `UserDevices`, idempotent on the `(UserId, FcmToken)` unique key; refreshes `LastSeenUtc`/`Platform` but **preserves** the user's per-device `NotificationsEnabled` opt-out.
- **Mobile** — silent auto-registration on sign-in + FCM `onTokenRefresh`. Uses `getFcmTokenIfGranted()` so it **never fires an unsolicited permission prompt** (registers only when permission is already granted). Native-only.
- **Bruno** — `devices-register` request.

## Deliberate decision
Registration is **silent** — no permission prompt at sign-in. A permission-priming flow for general users is intentionally deferred (single-tester app today); regular users won't register until permission is requested somewhere.

## Testing
- `dotnet build` clean on API + Notification.
- API unit tests: 402 pass; the 4 pre-existing `GetMapMatchups` failures are unrelated to this change.
- Mobile `tsc --noEmit` clean.
- Device round-trip will be validated on-device after EAS publish/submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated mobile push device registration flow using the `/ui/devices` endpoint.
  * On native (iOS/Android), the app registers and refreshes the FCM token after notification permission is already granted; web remains unaffected.
  * Server-side device registrations are idempotent for the same user/token pair.

* **Bug Fixes**
  * Re-registration updates token liveness and platform details while preserving the user’s per-device notification enabled setting.
  * Improved reliability by handling validation issues and concurrent registrations gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->