### PR TITLE
fix(api): repair GetMapMatchups handler logic and unblock unit tests

### DIFF
--- a/src/SportsData.Api/Application/UI/Map/Queries/GetMapMatchups/GetMapMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Map/Queries/GetMapMatchups/GetMapMatchupsQueryHandler.cs
@@ -4,6 +4,7 @@ using SportsData.Api.Application.UI.Map.Dtos;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
 
 namespace SportsData.Api.Application.UI.Map.Queries.GetMapMatchups;
 
@@ -19,15 +20,18 @@ public class GetMapMatchupsQueryHandler : IGetMapMatchupsQueryHandler
     private readonly ILogger<GetMapMatchupsQueryHandler> _logger;
     private readonly AppDataContext _dataContext;
     private readonly IContestClientFactory _contestClientFactory;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     public GetMapMatchupsQueryHandler(
         ILogger<GetMapMatchupsQueryHandler> logger,
         AppDataContext dataContext,
-        IContestClientFactory contestClientFactory)
+        IContestClientFactory contestClientFactory,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
         _contestClientFactory = contestClientFactory;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<GetMapMatchupsResponse>> ExecuteAsync(
@@ -40,46 +44,36 @@ public class GetMapMatchupsQueryHandler : IGetMapMatchupsQueryHandler
             query.SeasonYear,
             query.WeekNumber);
 
-        var league = await _dataContext.PickemGroups.FirstOrDefaultAsync(x => x.Id == query.LeagueId, cancellationToken);
+        // The map is league-scoped: the league determines which sport's
+        // Producer to query. Without a resolvable league we can't pick a
+        // ContestClient, so a missing/unknown LeagueId is NotFound.
+        var league = await _dataContext.PickemGroups
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == query.LeagueId, cancellationToken);
 
         if (league == null)
         {
             return new Failure<GetMapMatchupsResponse>(new GetMapMatchupsResponse(), ResultStatus.NotFound, [new ValidationFailure("LeagueId", "League Not Found")]);
         }
 
-        if (query.LeagueId is null && query.WeekNumber is null)
-        {
-            // TODO: Honor WeekNumber when LeagueId is provided
-            var matchupsResult = await _contestClientFactory.Resolve(league.Sport).GetMatchupsForCurrentWeek(cancellationToken);
-            var matchups = matchupsResult.IsSuccess ? matchupsResult.Value : [];
+        var client = _contestClientFactory.Resolve(league.Sport);
 
-            return new Success<GetMapMatchupsResponse>(new GetMapMatchupsResponse
-            {
-                Matchups = matchups
-            });
-        }
-        else if (query.LeagueId is null)
+        Result<List<Matchup>> matchupsResult;
+        if (query.WeekNumber is not null)
         {
-            // we have a week, but no league
-            var seasonYear = query.SeasonYear ?? DateTime.UtcNow.Year;
-            var matchupsResult = await _contestClientFactory.Resolve(league.Sport).GetMatchupsForSeasonWeek(seasonYear, query.WeekNumber!.Value, cancellationToken);
-            var matchups = matchupsResult.IsSuccess ? matchupsResult.Value : [];
-
-            return new Success<GetMapMatchupsResponse>(new GetMapMatchupsResponse
-            {
-                Matchups = matchups
-            });
+            var seasonYear = query.SeasonYear ?? _dateTimeProvider.UtcNow().Year;
+            matchupsResult = await client.GetMatchupsForSeasonWeek(seasonYear, query.WeekNumber.Value, cancellationToken);
         }
         else
         {
-            // we have a league (and optionally a week)
-            var matchupsResult = await _contestClientFactory.Resolve(league.Sport).GetMatchupsForCurrentWeek(cancellationToken);
-            var matchups = matchupsResult.IsSuccess ? matchupsResult.Value : [];
-
-            return new Success<GetMapMatchupsResponse>(new GetMapMatchupsResponse
-            {
-                Matchups = matchups
-            });
+            matchupsResult = await client.GetMatchupsForCurrentWeek(cancellationToken);
         }
+
+        var matchups = matchupsResult.IsSuccess ? matchupsResult.Value : [];
+
+        return new Success<GetMapMatchupsResponse>(new GetMapMatchupsResponse
+        {
+            Matchups = matchups
+        });
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Map/Queries/GetMapMatchups/GetMapMatchupsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Map/Queries/GetMapMatchups/GetMapMatchupsQueryHandlerTests.cs
@@ -2,7 +2,9 @@ using FluentAssertions;
 
 using Moq;
 
+using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Map.Queries.GetMapMatchups;
+using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Infrastructure.Clients.Contest;
@@ -13,6 +15,9 @@ namespace SportsData.Api.Tests.Unit.Application.UI.Map.Queries.GetMapMatchups;
 
 public class GetMapMatchupsQueryHandlerTests : ApiTestBase<GetMapMatchupsQueryHandler>
 {
+    // Fixed "now" so the SeasonYear default (UtcNow().Year) is deterministic.
+    private static readonly DateTime FixedNow = new(2026, 6, 28, 0, 0, 0, DateTimeKind.Utc);
+
     private readonly Mock<IProvideContests> _contestClientMock = new();
 
     public GetMapMatchupsQueryHandlerTests()
@@ -20,7 +25,12 @@ public class GetMapMatchupsQueryHandlerTests : ApiTestBase<GetMapMatchupsQueryHa
         Mocker.GetMock<IContestClientFactory>()
             .Setup(x => x.Resolve(It.IsAny<Sport>()))
             .Returns(_contestClientMock.Object);
+
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
     }
+
     private static Matchup CreateMatchup() => new()
     {
         ContestId = Guid.NewGuid(),
@@ -28,10 +38,48 @@ public class GetMapMatchupsQueryHandlerTests : ApiTestBase<GetMapMatchupsQueryHa
         HomeSlug = "home-team"
     };
 
+    /// <summary>
+    /// Seeds a PickemGroup so the handler can resolve a league (and its sport).
+    /// The map is league-scoped — every reachable path requires one.
+    /// </summary>
+    private async Task<PickemGroup> SeedLeagueAsync(Sport sport = Sport.FootballNcaa)
+    {
+        var league = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test League",
+            Sport = sport,
+            League = League.NCAAF,
+            CommissionerUserId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        DataContext.PickemGroups.Add(league);
+        await DataContext.SaveChangesAsync();
+        return league;
+    }
+
     [Fact]
-    public async Task ExecuteAsync_ShouldGetCurrentWeekMatchups_WhenNoParametersProvided()
+    public async Task ExecuteAsync_ShouldReturnNotFound_WhenLeagueDoesNotExist()
     {
         // Arrange
+        var sut = Mocker.CreateInstance<GetMapMatchupsQueryHandler>();
+        var query = new GetMapMatchupsQuery { LeagueId = Guid.NewGuid() };
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldGetCurrentWeekMatchups_WhenNoWeekProvided()
+    {
+        // Arrange
+        var league = await SeedLeagueAsync();
         var expectedMatchups = new List<Matchup>
         {
             CreateMatchup(),
@@ -43,7 +91,7 @@ public class GetMapMatchupsQueryHandlerTests : ApiTestBase<GetMapMatchupsQueryHa
             .ReturnsAsync(new Success<List<Matchup>>(expectedMatchups));
 
         var sut = Mocker.CreateInstance<GetMapMatchupsQueryHandler>();
-        var query = new GetMapMatchupsQuery();
+        var query = new GetMapMatchupsQuery { LeagueId = league.Id };
 
         // Act
         var result = await sut.ExecuteAsync(query);
@@ -56,47 +104,68 @@ public class GetMapMatchupsQueryHandlerTests : ApiTestBase<GetMapMatchupsQueryHa
     }
 
     [Fact]
+    public async Task ExecuteAsync_ShouldResolveClientForLeagueSport()
+    {
+        // Arrange
+        var league = await SeedLeagueAsync(Sport.BaseballMlb);
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupsForCurrentWeek(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<Matchup>>(new List<Matchup>()));
+
+        var sut = Mocker.CreateInstance<GetMapMatchupsQueryHandler>();
+        var query = new GetMapMatchupsQuery { LeagueId = league.Id };
+
+        // Act
+        await sut.ExecuteAsync(query);
+
+        // Assert — resolved by the league's sport, not a hardcoded default.
+        Mocker.GetMock<IContestClientFactory>()
+            .Verify(x => x.Resolve(Sport.BaseballMlb), Times.Once);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ShouldGetMatchupsBySeasonWeek_WhenWeekNumberProvided()
     {
         // Arrange
+        var league = await SeedLeagueAsync();
         var weekNumber = 5;
-        var currentYear = DateTime.UtcNow.Year;
         var expectedMatchups = new List<Matchup>
         {
             CreateMatchup()
         };
 
         _contestClientMock
-            .Setup(x => x.GetMatchupsForSeasonWeek(currentYear, weekNumber, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetMatchupsForSeasonWeek(FixedNow.Year, weekNumber, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<List<Matchup>>(expectedMatchups));
 
         var sut = Mocker.CreateInstance<GetMapMatchupsQueryHandler>();
-        var query = new GetMapMatchupsQuery { WeekNumber = weekNumber };
+        var query = new GetMapMatchupsQuery { LeagueId = league.Id, WeekNumber = weekNumber };
 
         // Act
         var result = await sut.ExecuteAsync(query);
 
-        // Assert
+        // Assert — SeasonYear defaults to the current year from IDateTimeProvider.
         result.IsSuccess.Should().BeTrue();
         result.Value.Matchups.Should().HaveCount(1);
         _contestClientMock
-            .Verify(x => x.GetMatchupsForSeasonWeek(currentYear, weekNumber, It.IsAny<CancellationToken>()), Times.Once);
+            .Verify(x => x.GetMatchupsForSeasonWeek(FixedNow.Year, weekNumber, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task ExecuteAsync_ShouldUseProvidedSeasonYear_WhenSpecified()
     {
         // Arrange
+        var league = await SeedLeagueAsync();
         var weekNumber = 5;
         var seasonYear = 2024;
-        var expectedMatchups = new List<Matchup>();
 
         _contestClientMock
             .Setup(x => x.GetMatchupsForSeasonWeek(seasonYear, weekNumber, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<Matchup>>(expectedMatchups));
+            .ReturnsAsync(new Success<List<Matchup>>(new List<Matchup>()));
 
         var sut = Mocker.CreateInstance<GetMapMatchupsQueryHandler>();
-        var query = new GetMapMatchupsQuery { WeekNumber = weekNumber, SeasonYear = seasonYear };
+        var query = new GetMapMatchupsQuery { LeagueId = league.Id, WeekNumber = weekNumber, SeasonYear = seasonYear };
 
         // Act
         await sut.ExecuteAsync(query);
@@ -104,31 +173,5 @@ public class GetMapMatchupsQueryHandlerTests : ApiTestBase<GetMapMatchupsQueryHa
         // Assert
         _contestClientMock
             .Verify(x => x.GetMatchupsForSeasonWeek(seasonYear, weekNumber, It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_ShouldGetCurrentWeekMatchups_WhenLeagueIdProvided()
-    {
-        // Arrange
-        var leagueId = Guid.NewGuid();
-        var expectedMatchups = new List<Matchup>
-        {
-            CreateMatchup()
-        };
-
-        _contestClientMock
-            .Setup(x => x.GetMatchupsForCurrentWeek(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<Matchup>>(expectedMatchups));
-
-        var sut = Mocker.CreateInstance<GetMapMatchupsQueryHandler>();
-        var query = new GetMapMatchupsQuery { LeagueId = leagueId };
-
-        // Act
-        var result = await sut.ExecuteAsync(query);
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        _contestClientMock
-            .Verify(x => x.GetMatchupsForCurrentWeek(It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Why

The four `GetMapMatchupsQueryHandler` unit tests are failing and blocking the pipeline.

Root cause: PR #451 ("map matchups respect selected league's sport", merged with `@CodeRabbit ignore — nothing to review`) added an unconditional `PickemGroup` lookup that returns `NotFound` when the league is null — but left the two `LeagueId is null` branches in place. Those branches became **dead code** (a lookup on `Id == null` always returns null, so the `NotFound` guard fires first), and the single reachable path **ignored `WeekNumber` entirely**. The tests predate #451 and were never updated.

## What

Handler (`GetMapMatchupsQueryHandler`):
- Remove the unreachable no-league branches.
- Honor `WeekNumber`: when provided → `GetMatchupsForSeasonWeek(seasonYear, week)` where `seasonYear` defaults to the current year; otherwise → `GetMatchupsForCurrentWeek`.
- Resolve the `ContestClient` by `league.Sport` (the actual intent of #451).
- Use `IDateTimeProvider` for the year default instead of `DateTime.UtcNow` (project convention).
- Add `.AsNoTracking()` to the read query.

Tests:
- Seed a `PickemGroup` (the map is league-scoped; every reachable path needs one).
- Cover: NotFound when league missing, current-week path, sport-resolution by `league.Sport`, `WeekNumber` → season-week with default year, and explicit `SeasonYear`.

## Behavior impact

No regression on the deployed/used path: the map UI always sends a `leagueId`, and the missing-league case still returns `NotFound`. The change additionally makes `WeekNumber` actually work (previously silently ignored — the TODO in #451) and removes the dead branches.

## Test status

`dotnet test SportsData.Api.Tests.Unit` → **407 passed, 0 failed** (was 4 failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)