### PR TITLE
chore(mobile): use remote appVersionSource for EAS build numbers

### DIFF
--- a/docs/mobile/expo-deployment-model.md
+++ b/docs/mobile/expo-deployment-model.md
@@ -97,7 +97,7 @@ The build profiles live in `eas.json` at the project root. A typical setup:
 {
   "cli": {
     "version": ">= 10.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -246,7 +246,13 @@ From `src/UI/sd-mobile/`:
    ```bash
    eas build --platform ios --profile production
    ```
-   The `production` profile in `eas.json` already has `autoIncrement: true`, so the build number bumps automatically — Apple requires every TestFlight upload to have a unique, monotonically increasing build number.
+   The `production` profile in `eas.json` has `autoIncrement: true` and `cli.appVersionSource` is `remote`, so EAS tracks the build number server-side and bumps it on each production build — Apple requires every TestFlight upload to have a unique, monotonically increasing build number. `app.json`'s `ios.buildNumber` is a fallback and is ignored for production builds.
+
+   > **One-time bootstrap when switching to / re-initializing `remote`**: EAS seeds the remote build number from `app.json` the first time, which can collide with a number already on App Store Connect. Before the first production build, pin the remote value explicitly so the next `autoIncrement` is unique:
+   > ```bash
+   > eas build:version:set    # choose production / iOS, set to the last number ASC used
+   > ```
+   > Verify with `eas build:version:get`. This only needs to be done once (or any time the remote counter desyncs from App Store Connect).
 
 2. **Submit to TestFlight**:
    ```bash
@@ -279,5 +285,5 @@ Existing TestFlight installs pick up the update on next app launch. Native code 
 - **90-day build expiry**: TestFlight builds stop launching after 90 days. If a build sits unused that long, ship a new one before re-engaging testers.
 - **Export compliance**: `ITSAppUsesNonExemptEncryption: false` is already in `app.json` — keeps Apple from prompting on every upload. If the app ever adds custom crypto (beyond HTTPS), this has to change.
 - **Privacy nutrition labels**: TestFlight upload will warn if these are missing but won't block. The actual App Store submission will block — easier to fill them in once when creating the app record.
-- **Build numbers can't go backward**: if `autoIncrement` ever desynchronizes (e.g., you build outside EAS), App Store Connect rejects the upload. Fix is `eas build:version:set` to a number above the highest one already uploaded.
+- **Build numbers can't go backward**: with `appVersionSource: remote`, EAS owns the counter, but it can still desync from App Store Connect (e.g., a build uploaded outside EAS, or the first build after switching to `remote` — see the bootstrap note above). If ASC rejects an upload as a duplicate/stale build number, fix it with `eas build:version:set` to a number above the highest one already uploaded. Do **not** rely on bumping `app.json` — it's ignored under `remote`.
 - **Tester invite emails go to spam**: if a friend says they didn't get the email, point them at the public link instead — it always works.

--- a/src/UI/sd-mobile/eas.json
+++ b/src/UI/sd-mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 10.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {


### PR DESCRIPTION
## Why

`eas submit` rejected the iOS build: *"Build number 35 for app version 0.1.0 has already been used."*

Root cause is a config mismatch (not a code change): `eas.json` had `"appVersionSource": "local"` **and** `"autoIncrement": true`. On EAS **cloud** builds, `autoIncrement` writes the bumped build number to the build server's copy of `app.json` — never back to git. So every build re-reads the committed `buildNumber` (`34`) and reproduces `35`, colliding with the build already on App Store Connect. (Confirmed: committed `app.json` is `"34"`, the local working copy was left at `"35"` by a prior autoIncrement write-back.)

## Change

Set `appVersionSource: "remote"` so EAS tracks and increments the build number server-side. `autoIncrement: true` stays on the production profile. `app.json` `buildNumber` becomes a fallback and is ignored for production builds.

## Follow-up after merge (one-time)

EAS initializes the remote build number from `app.json` on first use, which could still land on 35. Before the next production build, set the remote number explicitly so the next autoIncrement is unique:

```
eas build:version:set    # production / iOS -> set to 35 (last used); next build = 36
```

Then `eas build -p ios --profile production` and resubmit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated mobile build versioning to use a centralized remote source for improved consistency across releases.
  * Refreshed iOS/TestFlight guidance to cover the required one-time setup after switching to remote, including how to set and verify the remote build counter.
  * Improved “gotchas” documentation around build numbers to reflect remote behavior and how to resolve duplicates or stale values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->