### PR TITLE
feat(notification): device identity model — one token owner per device (#475)

### DIFF
--- a/docs/mobile/device-identity-and-push-ownership.md
+++ b/docs/mobile/device-identity-and-push-ownership.md
@@ -1,0 +1,63 @@
+# Device Identity & Push Ownership
+
+Status: implemented. Issue: #475.
+
+## Problem
+
+An FCM token is **per app-install, not per user** — one device has one token `T`
+regardless of who is signed in. The original model keyed a push registration on
+`(UserId, FcmToken)`, so every account that signed in on a device created its own
+row pointing at the same `T`. The dispatcher sends per user
+(`WHERE UserId == target && NotificationsEnabled` → push to `d.FcmToken`), so
+both accounts' notifications landed on whatever device held `T`, regardless of
+who was currently signed in. With no sign-out cleanup, a signed-out account kept
+receiving on the device. Low harm for one person's two accounts; a privacy leak
+for genuinely different users sharing a device.
+
+## Model
+
+Each physical install mints a **stable installation id** (a v4 UUID, persisted
+in `AsyncStorage`) that survives token rotation and account switches. The device
+row is keyed on `InstallationId` (unique), so a device has exactly **one current
+owner**:
+
+- **Register** (sign-in, token refresh): upsert by `InstallationId`; set
+  `UserId` + `FcmToken` to the current user/token. Registering under a different
+  account **reassigns** the row instead of adding a second one — the prior owner
+  immediately stops receiving on that device.
+- **Unregister** (sign-out): delete the row scoped to
+  `(InstallationId, UserId)` — best-effort, so it only removes your own current
+  ownership and never blocks sign-out.
+- **Dispatch**: unchanged (`WHERE UserId == target && NotificationsEnabled`).
+  Correct because each install row has a single owner.
+
+## Opt-out tradeoff
+
+`NotificationsEnabled` is per-row (per-device). On a same-owner re-register it is
+**preserved** (a token refresh must not silently re-enable a device the user
+turned off). On an **owner change** it **resets to `true`** — the new owner
+starts with notifications on. Today this is moot: per-device opt-out is not yet
+writable anywhere (nothing sets `false`). If/when per-device opt-out ships and we
+want a user's opt-out to survive switching away and back on a shared device, that
+needs a separate per-`(UserId, InstallationId)` preference store — captured as
+the deferred option in #475.
+
+## Components
+
+- Event contract: `SportsData.Core/Eventing/Events/Users/UserDeviceRegistered.cs`
+  (carries `InstallationId`), `UserDeviceUnregistered.cs`.
+- API: `SportsData.Api/Application/UI/Devices/` — `POST /ui/devices`,
+  `DELETE /ui/devices/{installationId}` (both JWT-scoped; user resolved from the
+  token, never the body).
+- Notification: `UserDeviceRegisteredConsumer` / `UserDeviceUnregisteredConsumer`
+  project into `UserDevices` (unique on `InstallationId`).
+- Mobile: `src/lib/device/installationId.ts` (mint/persist),
+  `src/hooks/useRegisterPushDevice.ts` (register), `app/(tabs)/profile.tsx`
+  (`performSignOut` unregister).
+
+## Migration note
+
+The `AddInstallationIdToUserDevice` migration **clears `UserDevices`** before
+adding the required, uniquely-indexed column — existing rows predate
+`InstallationId` and can't be backfilled. The table is a self-rebuilding
+projection: every device re-registers on its next app launch / token refresh.

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommand.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommand.cs
@@ -8,6 +8,8 @@ public class RegisterDeviceCommand
 {
     public Guid UserId { get; set; }
 
+    public required string InstallationId { get; set; }
+
     public required string FcmToken { get; set; }
 
     public required string Platform { get; set; }

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandHandler.cs
@@ -70,7 +70,7 @@ public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
             await _eventBus.Publish(
                 new UserDeviceRegistered(
                     UserId: command.UserId,
-                    InstallationId: command.InstallationId.Trim(),
+                    InstallationId: InstallationIdNormalizer.Normalize(command.InstallationId),
                     FcmToken: command.FcmToken.Trim(),
                     Platform: platform,
                     CorrelationId: correlationId,

--- a/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/RegisterDevice/RegisterDeviceCommandValidator.cs
@@ -4,15 +4,21 @@ namespace SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
 
 public class RegisterDeviceCommandValidator : AbstractValidator<RegisterDeviceCommand>
 {
-    // Mirrors the Notification UserDevices.FcmToken column (varchar(256)) so an
-    // overlong token fails fast here instead of blowing up the consumer's
-    // insert and dead-lettering the UserDeviceRegistered event.
+    // Mirror the Notification UserDevices column widths so overlong values fail
+    // fast here instead of blowing up the consumer's insert and dead-lettering
+    // the UserDeviceRegistered event.
     private const int FcmTokenMaxLength = 256;
+    private const int InstallationIdMaxLength = 128;
 
     private static readonly string[] AllowedPlatforms = { "ios", "android" };
 
     public RegisterDeviceCommandValidator()
     {
+        RuleFor(x => x.InstallationId)
+            .NotEmpty().WithMessage("InstallationId is required")
+            .MaximumLength(InstallationIdMaxLength)
+            .WithMessage($"InstallationId must not exceed {InstallationIdMaxLength} characters.");
+
         RuleFor(x => x.FcmToken)
             .NotEmpty().WithMessage("FcmToken is required")
             .MaximumLength(FcmTokenMaxLength)

--- a/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommand.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommand.cs
@@ -1,0 +1,14 @@
+namespace SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice;
+
+/// <summary>
+/// Unregisters a mobile device for the authenticated user (typically at
+/// sign-out). UserId is resolved from the JWT in the controller, never trusted
+/// from the client, so a caller can only ever unregister against its own
+/// identity.
+/// </summary>
+public class UnregisterDeviceCommand
+{
+    public Guid UserId { get; set; }
+
+    public required string InstallationId { get; set; }
+}

--- a/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommandHandler.cs
@@ -62,7 +62,7 @@ public class UnregisterDeviceCommandHandler : IUnregisterDeviceCommandHandler
             await _eventBus.Publish(
                 new UserDeviceUnregistered(
                     UserId: command.UserId,
-                    InstallationId: command.InstallationId.Trim(),
+                    InstallationId: InstallationIdNormalizer.Normalize(command.InstallationId),
                     CorrelationId: correlationId,
                     CausationId: Guid.NewGuid()),
                 cancellationToken);

--- a/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommandHandler.cs
@@ -4,40 +4,34 @@ using SportsData.Core.Common;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Users;
 
-namespace SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
+namespace SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice;
 
-public interface IRegisterDeviceCommandHandler
+public interface IUnregisterDeviceCommandHandler
 {
     Task<Result<bool>> ExecuteAsync(
-        RegisterDeviceCommand command,
+        UnregisterDeviceCommand command,
         CancellationToken cancellationToken = default);
 }
 
 /// <summary>
-/// Resolves nothing about identity itself (the controller already mapped the
-/// JWT to <see cref="RegisterDeviceCommand.UserId"/>) — it validates the
-/// payload and publishes <see cref="UserDeviceRegistered"/> for the
-/// Notification service to project into its UserDevices table.
-///
-/// <para>
-/// Stateless publish: no API-side entity write, so we publish with
-/// <see cref="DeliveryMode.Direct"/> rather than injecting a DbContext just to
-/// flush the outbox. Notification owns the device store; API only resolves the
-/// user and announces the registration.
-/// </para>
+/// Validates the request and publishes <see cref="UserDeviceUnregistered"/> for
+/// the Notification service to drop the device's row. Mirrors
+/// <see cref="RegisterDevice.RegisterDeviceCommandHandler"/>: stateless publish
+/// with <see cref="DeliveryMode.Direct"/> (no API-side DbContext write to
+/// bundle). Notification owns the device store.
 /// </summary>
-public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
+public class UnregisterDeviceCommandHandler : IUnregisterDeviceCommandHandler
 {
     private readonly IEventBus _eventBus;
     private readonly IMessageDeliveryScope _deliveryScope;
-    private readonly IValidator<RegisterDeviceCommand> _validator;
-    private readonly ILogger<RegisterDeviceCommandHandler> _logger;
+    private readonly IValidator<UnregisterDeviceCommand> _validator;
+    private readonly ILogger<UnregisterDeviceCommandHandler> _logger;
 
-    public RegisterDeviceCommandHandler(
+    public UnregisterDeviceCommandHandler(
         IEventBus eventBus,
         IMessageDeliveryScope deliveryScope,
-        IValidator<RegisterDeviceCommand> validator,
-        ILogger<RegisterDeviceCommandHandler> logger)
+        IValidator<UnregisterDeviceCommand> validator,
+        ILogger<UnregisterDeviceCommandHandler> logger)
     {
         _eventBus = eventBus;
         _deliveryScope = deliveryScope;
@@ -46,7 +40,7 @@ public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
     }
 
     public async Task<Result<bool>> ExecuteAsync(
-        RegisterDeviceCommand command,
+        UnregisterDeviceCommand command,
         CancellationToken cancellationToken = default)
     {
         var validation = await _validator.ValidateAsync(command, cancellationToken);
@@ -55,24 +49,20 @@ public class RegisterDeviceCommandHandler : IRegisterDeviceCommandHandler
             return new Failure<bool>(default!, ResultStatus.BadRequest, validation.Errors);
         }
 
-        var platform = command.Platform.Trim().ToLowerInvariant();
         var correlationId = Guid.NewGuid();
 
         _logger.LogInformation(
-            "Publishing UserDeviceRegistered. UserId={UserId}, Platform={Platform}, CorrelationId={CorrelationId}",
+            "Publishing UserDeviceUnregistered. UserId={UserId}, CorrelationId={CorrelationId}",
             command.UserId,
-            platform,
             correlationId);
 
         // Direct delivery — stateless publish, no DbContext write to bundle.
         using (_deliveryScope.Use(DeliveryMode.Direct))
         {
             await _eventBus.Publish(
-                new UserDeviceRegistered(
+                new UserDeviceUnregistered(
                     UserId: command.UserId,
                     InstallationId: command.InstallationId.Trim(),
-                    FcmToken: command.FcmToken.Trim(),
-                    Platform: platform,
                     CorrelationId: correlationId,
                     CausationId: Guid.NewGuid()),
                 cancellationToken);

--- a/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Commands/UnregisterDevice/UnregisterDeviceCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice;
+
+public class UnregisterDeviceCommandValidator : AbstractValidator<UnregisterDeviceCommand>
+{
+    private const int InstallationIdMaxLength = 128;
+
+    public UnregisterDeviceCommandValidator()
+    {
+        RuleFor(x => x.InstallationId)
+            .NotEmpty().WithMessage("InstallationId is required")
+            .MaximumLength(InstallationIdMaxLength)
+            .WithMessage($"InstallationId must not exceed {InstallationIdMaxLength} characters.");
+    }
+}

--- a/src/SportsData.Api/Application/UI/Devices/DevicesController.cs
+++ b/src/SportsData.Api/Application/UI/Devices/DevicesController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
+using SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice;
 using SportsData.Api.Application.UI.Devices.Dtos;
 using SportsData.Api.Extensions;
 using SportsData.Core.Common;
@@ -31,8 +32,38 @@ public class DevicesController : ApiControllerBase
         var command = new RegisterDeviceCommand
         {
             UserId = userId,
+            InstallationId = request.InstallationId,
             FcmToken = request.FcmToken,
             Platform = request.Platform
+        };
+
+        var result = await handler.ExecuteAsync(command, cancellationToken);
+
+        if (result.IsSuccess)
+            return NoContent();
+
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Unregisters the calling device (by its stable installation id) for the
+    /// authenticated user — typically at sign-out — so the Notification service
+    /// drops the device's row and stops sending this user's pushes to it.
+    /// Scoped to the JWT user, so a caller can only unregister its own device.
+    /// </summary>
+    [HttpDelete("{installationId}")]
+    [Authorize]
+    public async Task<ActionResult<bool>> UnregisterDevice(
+        string installationId,
+        [FromServices] IUnregisterDeviceCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+
+        var command = new UnregisterDeviceCommand
+        {
+            UserId = userId,
+            InstallationId = installationId
         };
 
         var result = await handler.ExecuteAsync(command, cancellationToken);

--- a/src/SportsData.Api/Application/UI/Devices/Dtos/RegisterDeviceRequest.cs
+++ b/src/SportsData.Api/Application/UI/Devices/Dtos/RegisterDeviceRequest.cs
@@ -7,6 +7,12 @@ namespace SportsData.Api.Application.UI.Devices.Dtos;
 /// </summary>
 public class RegisterDeviceRequest
 {
+    /// <summary>
+    /// Stable per-install device identifier minted and persisted by the client.
+    /// Identifies the device across token rotation and account switches.
+    /// </summary>
+    public required string InstallationId { get; set; }
+
     /// <summary>The FCM registration token from the device install.</summary>
     public required string FcmToken { get; set; }
 

--- a/src/SportsData.Api/Application/UI/Devices/InstallationIdNormalizer.cs
+++ b/src/SportsData.Api/Application/UI/Devices/InstallationIdNormalizer.cs
@@ -1,0 +1,19 @@
+namespace SportsData.Api.Application.UI.Devices;
+
+/// <summary>
+/// Canonicalizes a device <c>InstallationId</c> before it's published, so the
+/// register and unregister paths produce the same stable key for the same
+/// device. When the value is a GUID (the mobile client mints one via
+/// <c>Crypto.randomUUID()</c>), different text representations — uppercase,
+/// braces — would otherwise be distinct strings under the unique index and let
+/// the same device double-register. Non-GUID values fall through trimmed so the
+/// contract stays an opaque string.
+/// </summary>
+public static class InstallationIdNormalizer
+{
+    public static string Normalize(string installationId)
+    {
+        var trimmed = installationId.Trim();
+        return Guid.TryParse(trimmed, out var guid) ? guid.ToString() : trimmed;
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -132,6 +132,9 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<
                 SportsData.Api.Application.UI.Devices.Commands.RegisterDevice.IRegisterDeviceCommandHandler,
                 SportsData.Api.Application.UI.Devices.Commands.RegisterDevice.RegisterDeviceCommandHandler>();
+            services.AddScoped<
+                SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice.IUnregisterDeviceCommandHandler,
+                SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice.UnregisterDeviceCommandHandler>();
             services.AddScoped<IUpsertMatchupPreviewCommandHandler, UpsertMatchupPreviewCommandHandler>();
 
             // Notifications

--- a/src/SportsData.Core/Eventing/Events/Users/UserDeviceRegistered.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UserDeviceRegistered.cs
@@ -16,13 +16,17 @@ namespace SportsData.Core.Eventing.Events.Users
     ///
     /// <para>
     /// Consumer must be idempotent. At-least-once delivery means the same
-    /// <c>(UserId, FcmToken)</c> may arrive twice, and re-registration on
-    /// every app launch / token refresh republishes the same pair. Upsert on
-    /// the <c>(UserId, FcmToken)</c> natural key.
+    /// registration may arrive twice, and re-registration on every app launch
+    /// / token refresh republishes it. <see cref="InstallationId"/> is the
+    /// stable per-install device identifier (survives FCM token rotation and
+    /// account switches); the consumer upserts on it so a device has exactly
+    /// one current owner — re-registration by a different user reassigns the
+    /// device rather than creating a second row pointing at the same token.
     /// </para>
     /// </summary>
     public record UserDeviceRegistered(
         Guid UserId,
+        string InstallationId,
         string FcmToken,
         string Platform,
         Guid CorrelationId,

--- a/src/SportsData.Core/Eventing/Events/Users/UserDeviceUnregistered.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UserDeviceUnregistered.cs
@@ -1,0 +1,28 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Users
+{
+    /// <summary>
+    /// Emitted by the API when a mobile client unregisters its device —
+    /// typically at sign-out — so the Notification service can drop the
+    /// device's row from its local <c>UserDevices</c> table and stop sending
+    /// the signed-out user's pushes to that device. The API resolves the
+    /// authenticated Firebase token to the internal <see cref="UserId"/>
+    /// before publishing; the device is identified by its stable
+    /// <see cref="InstallationId"/>.
+    ///
+    /// <para>
+    /// Consumer must be idempotent: deletion is scoped to
+    /// <c>(InstallationId, UserId)</c> so a user only removes their own
+    /// ownership of the device, and a missing row is a no-op.
+    /// </para>
+    /// </summary>
+    public record UserDeviceUnregistered(
+        Guid UserId,
+        string InstallationId,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport.All, null, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/UserDeviceRegisteredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserDeviceRegisteredConsumer.cs
@@ -16,18 +16,21 @@ namespace SportsData.Notification.Application.Consumers
     /// <see cref="UserDataPublishedConsumer"/> projection pattern.
     ///
     /// <para>
-    /// Idempotent on the <c>(UserId, FcmToken)</c> natural key (unique index):
-    /// re-registration on every app launch / token refresh and at-least-once
-    /// redelivery all converge on one row. Race-safe insert — a concurrent
-    /// consumer losing the unique-constraint insert falls through to the
-    /// update path.
+    /// Idempotent on the <c>InstallationId</c> natural key (unique index): a
+    /// device has exactly one row regardless of how many accounts sign in on
+    /// it. Re-registration by the same user refreshes the row; re-registration
+    /// by a <em>different</em> user reassigns ownership (UserId + FcmToken), so
+    /// the prior owner stops receiving on that device. Race-safe insert — a
+    /// concurrent consumer losing the unique-constraint insert falls through to
+    /// the update path.
     /// </para>
     ///
     /// <para>
-    /// On re-registration we refresh <c>LastSeenUtc</c> and <c>Platform</c>
+    /// On a same-owner re-registration we refresh <c>LastSeenUtc</c>/<c>Platform</c>
     /// but deliberately do NOT reset <see cref="UserDevice.NotificationsEnabled"/>
     /// — that's the user's per-device opt-out and a token refresh must not
-    /// silently re-enable a device they turned off.
+    /// silently re-enable a device they turned off. On an owner change the flag
+    /// resets to the default (the new owner starts with notifications on).
     /// </para>
     /// </summary>
     public class UserDeviceRegisteredConsumer : IConsumer<UserDeviceRegistered>
@@ -60,7 +63,7 @@ namespace SportsData.Notification.Application.Consumers
 
             var existing = await _dataContext.UserDevices
                 .FirstOrDefaultAsync(
-                    d => d.UserId == msg.UserId && d.FcmToken == msg.FcmToken,
+                    d => d.InstallationId == msg.InstallationId,
                     context.CancellationToken);
 
             if (existing is null)
@@ -69,6 +72,7 @@ namespace SportsData.Notification.Application.Consumers
                 {
                     Id = Guid.NewGuid(),
                     UserId = msg.UserId,
+                    InstallationId = msg.InstallationId,
                     FcmToken = msg.FcmToken,
                     Platform = msg.Platform,
                     NotificationsEnabled = true,
@@ -86,17 +90,27 @@ namespace SportsData.Notification.Application.Consumers
                 }
                 catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
                 {
-                    // Race: another consumer inserted the same (UserId, FcmToken)
+                    // Race: another consumer inserted the same InstallationId
                     // first. Detach our orphan and fall through to update.
                     _dataContext.Entry(entity).State = EntityState.Detached;
                     existing = await _dataContext.UserDevices
                         .FirstAsync(
-                            d => d.UserId == msg.UserId && d.FcmToken == msg.FcmToken,
+                            d => d.InstallationId == msg.InstallationId,
                             context.CancellationToken);
                 }
             }
 
-            // Refresh liveness + platform; preserve the user's opt-out.
+            // Owner change (a different account signed in on this device): reassign
+            // the device and reset the opt-out to default for the new owner. On a
+            // same-owner re-register we preserve NotificationsEnabled so a token
+            // refresh doesn't silently re-enable a device the user turned off.
+            if (existing.UserId != msg.UserId)
+            {
+                existing.UserId = msg.UserId;
+                existing.NotificationsEnabled = true;
+            }
+
+            existing.FcmToken = msg.FcmToken;
             existing.LastSeenUtc = now;
             existing.Platform = msg.Platform;
             existing.ModifiedUtc = now;

--- a/src/SportsData.Notification/Application/Consumers/UserDeviceUnregisteredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserDeviceUnregisteredConsumer.cs
@@ -1,0 +1,62 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Infrastructure.Data;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// Removes a device's <see cref="Infrastructure.Data.Entities.UserDevice"/>
+    /// row when the mobile client unregisters (typically at sign-out), so the
+    /// signed-out user's pushes stop reaching that device. Counterpart to
+    /// <see cref="UserDeviceRegisteredConsumer"/>.
+    ///
+    /// <para>
+    /// Idempotent: deletion is scoped to <c>(InstallationId, UserId)</c> so a
+    /// user only removes their own current ownership of the device — if a
+    /// different account has already claimed the install, this is a no-op and
+    /// leaves the new owner's row intact. A missing row is also a no-op
+    /// (at-least-once redelivery, or a device that never registered).
+    /// </para>
+    /// </summary>
+    public class UserDeviceUnregisteredConsumer : IConsumer<UserDeviceUnregistered>
+    {
+        private readonly ILogger<UserDeviceUnregisteredConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+
+        public UserDeviceUnregisteredConsumer(
+            ILogger<UserDeviceUnregisteredConsumer> logger,
+            AppDataContext dataContext)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+        }
+
+        public async Task Consume(ConsumeContext<UserDeviceUnregistered> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["UserId"] = msg.UserId
+            });
+
+            var existing = await _dataContext.UserDevices
+                .FirstOrDefaultAsync(
+                    d => d.InstallationId == msg.InstallationId && d.UserId == msg.UserId,
+                    context.CancellationToken);
+
+            if (existing is null)
+            {
+                _logger.LogInformation("UserDevice unregister no-op (no matching row). UserId={UserId}", msg.UserId);
+                return;
+            }
+
+            _dataContext.UserDevices.Remove(existing);
+            await _dataContext.SaveChangesAsync(context.CancellationToken);
+            _logger.LogInformation("UserDevice unregistered. UserId={UserId}, DeviceId={DeviceId}", msg.UserId, existing.Id);
+        }
+    }
+}

--- a/src/SportsData.Notification/Application/Consumers/UserDeviceUnregisteredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserDeviceUnregisteredConsumer.cs
@@ -14,11 +14,26 @@ namespace SportsData.Notification.Application.Consumers
     /// <see cref="UserDeviceRegisteredConsumer"/>.
     ///
     /// <para>
-    /// Idempotent: deletion is scoped to <c>(InstallationId, UserId)</c> so a
-    /// user only removes their own current ownership of the device — if a
-    /// different account has already claimed the install, this is a no-op and
-    /// leaves the new owner's row intact. A missing row is also a no-op
-    /// (at-least-once redelivery, or a device that never registered).
+    /// Idempotent: the load filter is scoped to <c>(InstallationId, UserId)</c>
+    /// so a user only removes their own current ownership of the device — if a
+    /// different account has already claimed the install (the row's owner is no
+    /// longer this user), the load returns null and we no-op, leaving the new
+    /// owner's row intact. A missing row is also a no-op (at-least-once
+    /// redelivery, or a device that never registered).
+    /// </para>
+    ///
+    /// <para>
+    /// Accepted race: there is a narrow load-then-delete window. If a
+    /// registration reassigns this install to a new owner <em>after</em> our
+    /// load but <em>before</em> SaveChanges, the tracked delete (by primary key)
+    /// would remove the reassigned row. This is left unguarded deliberately: the
+    /// window requires a sub-second interleave of an unregister and a register
+    /// for the same install, and it is self-healing — the mobile client
+    /// re-registers the device on its next launch / auth change, restoring the
+    /// row. An atomic guard was considered (ExecuteDelete needs a relational test
+    /// provider whose only option pulls an unpatched high-severity native dep;
+    /// xmin concurrency is no longer cleanly supported in Npgsql 10) and judged
+    /// not worth the cost for a rare, self-correcting edge. See PR #477 / #475.
     /// </para>
     /// </summary>
     public class UserDeviceUnregisteredConsumer : IConsumer<UserDeviceUnregistered>

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -52,6 +52,14 @@ namespace SportsData.Notification.Infrastructure.Data
                 .HasIndex(d => d.InstallationId)
                 .IsUnique();
 
+            // The dominant read is the send flow ("all of user U's devices"):
+            // NotificationDispatcher and the per-event consumers all filter
+            // WHERE UserId == u && NotificationsEnabled. The unique InstallationId
+            // index doesn't serve that, so keep a UserId-prefixed access path
+            // (previously provided by the old (UserId, FcmToken) unique index).
+            modelBuilder.Entity<UserDevice>()
+                .HasIndex(d => d.UserId);
+
             // One preferences row per user.
             modelBuilder.Entity<UserNotificationPreferences>()
                 .HasIndex(p => p.UserId)

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -44,10 +44,12 @@ namespace SportsData.Notification.Infrastructure.Data
         {
             base.OnModelCreating(modelBuilder);
 
-            // One row per (user, device) — token is a stable per-install identifier
-            // from FCM; the same token must not double-register for one user.
+            // One row per physical install. InstallationId is the device's stable
+            // identity, so a device has exactly one current owner; re-registration
+            // by a different user reassigns the row (UserId + FcmToken) rather than
+            // creating a second row pointing at the same FCM token.
             modelBuilder.Entity<UserDevice>()
-                .HasIndex(d => new { d.UserId, d.FcmToken })
+                .HasIndex(d => d.InstallationId)
                 .IsUnique();
 
             // One preferences row per user.

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/UserDevice.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/UserDevice.cs
@@ -16,6 +16,18 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
     {
         public Guid UserId { get; set; }
 
+        /// <summary>
+        /// Stable per-install device identifier minted by the mobile client and
+        /// persisted across launches. Unlike <see cref="FcmToken"/> (which rotates)
+        /// or the signed-in <see cref="UserId"/> (which changes on account switch),
+        /// this is the device's identity: it is the natural key, so a device has
+        /// exactly one current owner. Re-registration by a different user reassigns
+        /// the row rather than creating a duplicate pointing at the same token.
+        /// </summary>
+        [Required]
+        [MaxLength(128)]
+        public string InstallationId { get; set; }
+
         [Required]
         [MaxLength(256)]
         public string FcmToken { get; set; }

--- a/src/SportsData.Notification/Migrations/20260628112244_AddInstallationIdToUserDevice.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260628112244_AddInstallationIdToUserDevice.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260628112244_AddInstallationIdToUserDevice")]
+    partial class AddInstallationIdToUserDevice
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260628112244_AddInstallationIdToUserDevice.cs
+++ b/src/SportsData.Notification/Migrations/20260628112244_AddInstallationIdToUserDevice.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstallationIdToUserDevice : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // UserDevices is a small, self-rebuilding projection: every device
+            // re-registers (with its InstallationId) on the next app launch /
+            // token refresh. Existing rows predate InstallationId and can't be
+            // backfilled with a real value, so clearing them is the only way to
+            // add a required, uniquely-indexed column without colliding on "".
+            migrationBuilder.Sql("DELETE FROM \"UserDevices\";");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserDevices_UserId_FcmToken",
+                table: "UserDevices");
+
+            migrationBuilder.AddColumn<string>(
+                name: "InstallationId",
+                table: "UserDevices",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserDevices_InstallationId",
+                table: "UserDevices",
+                column: "InstallationId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserDevices_InstallationId",
+                table: "UserDevices");
+
+            migrationBuilder.DropColumn(
+                name: "InstallationId",
+                table: "UserDevices");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserDevices_UserId_FcmToken",
+                table: "UserDevices",
+                columns: new[] { "UserId", "FcmToken" },
+                unique: true);
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260628125417_AddInstallationIdToUserDevice.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260628125417_AddInstallationIdToUserDevice.Designer.cs
@@ -12,7 +12,7 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    [Migration("20260628112244_AddInstallationIdToUserDevice")]
+    [Migration("20260628125417_AddInstallationIdToUserDevice")]
     partial class AddInstallationIdToUserDevice
     {
         /// <inheritdoc />
@@ -342,6 +342,8 @@ namespace SportsData.Notification.Migrations
 
                     b.HasIndex("InstallationId")
                         .IsUnique();
+
+                    b.HasIndex("UserId");
 
                     b.ToTable("UserDevices");
                 });

--- a/src/SportsData.Notification/Migrations/20260628125417_AddInstallationIdToUserDevice.cs
+++ b/src/SportsData.Notification/Migrations/20260628125417_AddInstallationIdToUserDevice.cs
@@ -21,13 +21,16 @@ namespace SportsData.Notification.Migrations
                 name: "IX_UserDevices_UserId_FcmToken",
                 table: "UserDevices");
 
+            // No defaultValue: the DELETE above empties the table, so the NOT NULL
+            // column adds cleanly without one. Omitting it means any future insert
+            // that fails to supply InstallationId errors loudly (NOT NULL) instead
+            // of silently landing an empty string on the unique natural key.
             migrationBuilder.AddColumn<string>(
                 name: "InstallationId",
                 table: "UserDevices",
                 type: "character varying(128)",
                 maxLength: 128,
-                nullable: false,
-                defaultValue: "");
+                nullable: false);
 
             migrationBuilder.CreateIndex(
                 name: "IX_UserDevices_InstallationId",

--- a/src/SportsData.Notification/Migrations/20260628125417_AddInstallationIdToUserDevice.cs
+++ b/src/SportsData.Notification/Migrations/20260628125417_AddInstallationIdToUserDevice.cs
@@ -34,6 +34,11 @@ namespace SportsData.Notification.Migrations
                 table: "UserDevices",
                 column: "InstallationId",
                 unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserDevices_UserId",
+                table: "UserDevices",
+                column: "UserId");
         }
 
         /// <inheritdoc />
@@ -41,6 +46,10 @@ namespace SportsData.Notification.Migrations
         {
             migrationBuilder.DropIndex(
                 name: "IX_UserDevices_InstallationId",
+                table: "UserDevices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserDevices_UserId",
                 table: "UserDevices");
 
             migrationBuilder.DropColumn(

--- a/src/SportsData.Notification/Migrations/AppDataContextModelSnapshot.cs
+++ b/src/SportsData.Notification/Migrations/AppDataContextModelSnapshot.cs
@@ -340,6 +340,8 @@ namespace SportsData.Notification.Migrations
                     b.HasIndex("InstallationId")
                         .IsUnique();
 
+                    b.HasIndex("UserId");
+
                     b.ToTable("UserDevices");
                 });
 

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -45,6 +45,7 @@ namespace SportsData.Notification
                 typeof(PickemGroupMemberAddedConsumer),
                 typeof(UserDataPublishedConsumer),
                 typeof(UserDeviceRegisteredConsumer),
+                typeof(UserDeviceUnregisteredConsumer),
                 typeof(UserPickScoredConsumer)
             ]);
 

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -20,6 +20,8 @@ import { useAuthStore } from '@/src/stores/authStore';
 import { useCurrentUser, standingsKeys } from '@/src/hooks/useStandings';
 import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
 import { usersApi } from '@/src/services/api/usersApi';
+import { devicesApi } from '@/src/services/api/devicesApi';
+import { getOrCreateInstallationId } from '@/src/lib/device/installationId';
 import { DEFAULT_TIMEZONE } from '@/src/utils/timeUtils';
 import { TimezonePickerModal } from '@/src/components/features/settings/TimezonePickerModal';
 
@@ -148,6 +150,18 @@ export default function ProfileScreen() {
         '[ProfileScreen] Google sign-out failed (continuing to Firebase sign-out)',
         err,
       );
+    }
+    // Unregister this device so the signed-out account stops receiving pushes
+    // on it. Best-effort and native-only (web never registers a device): the
+    // JWT is still valid here, and a failure must not block sign-out. Done
+    // before signOut(auth) so the Authorization header still attaches.
+    if (Platform.OS !== 'web') {
+      try {
+        const installationId = await getOrCreateInstallationId();
+        await devicesApi.unregisterDevice(installationId);
+      } catch (err) {
+        console.log('[ProfileScreen] device unregister failed (continuing to sign-out)', err);
+      }
     }
     try {
       await signOut(auth);

--- a/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
+++ b/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
@@ -4,6 +4,7 @@ import messaging from '@react-native-firebase/messaging';
 
 import { useAuth } from './useAuth';
 import { getFcmTokenIfGranted } from '@/src/lib/notifications/pushNotifications';
+import { getOrCreateInstallationId } from '@/src/lib/device/installationId';
 import { devicesApi } from '@/src/services/api/devicesApi';
 
 /**
@@ -56,7 +57,8 @@ export function useRegisterPushDevice(): void {
       if (registeredTokensRef.current.has(token)) return;
 
       try {
-        await devicesApi.registerDevice({ fcmToken: token, platform });
+        const installationId = await getOrCreateInstallationId();
+        await devicesApi.registerDevice({ installationId, fcmToken: token, platform });
         registeredTokensRef.current.add(token);
       } catch (err) {
         // Non-fatal: reminders just won't reach this device until a later

--- a/src/UI/sd-mobile/src/lib/device/installationId.ts
+++ b/src/UI/sd-mobile/src/lib/device/installationId.ts
@@ -1,0 +1,31 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Crypto from 'expo-crypto';
+
+/**
+ * Stable per-install device identifier. Minted once (a v4 UUID) and persisted,
+ * so it survives FCM token rotation and account switches — unlike the FCM token
+ * (rotates) or the signed-in user (changes on account switch).
+ *
+ * The backend keys a device's push registration on this id, giving each device
+ * exactly one current owner: registering under a new account reassigns the
+ * device instead of leaving a second row that cross-delivers to it. See
+ * docs/mobile/device-identity-and-push-ownership.md.
+ */
+const STORAGE_KEY = 'device-installation-id';
+
+let cached: string | null = null;
+
+export async function getOrCreateInstallationId(): Promise<string> {
+  if (cached) return cached;
+
+  const existing = await AsyncStorage.getItem(STORAGE_KEY);
+  if (existing) {
+    cached = existing;
+    return existing;
+  }
+
+  const id = Crypto.randomUUID();
+  await AsyncStorage.setItem(STORAGE_KEY, id);
+  cached = id;
+  return id;
+}

--- a/src/UI/sd-mobile/src/lib/device/installationId.ts
+++ b/src/UI/sd-mobile/src/lib/device/installationId.ts
@@ -14,18 +14,31 @@ import * as Crypto from 'expo-crypto';
 const STORAGE_KEY = 'device-installation-id';
 
 let cached: string | null = null;
+// Single-flight guard. Without it, two concurrent first-time callers (e.g. the
+// initial sign-in registration and an onTokenRefresh firing together on a fresh
+// install) could both miss the cache + AsyncStorage and mint different UUIDs,
+// double-registering the device. All concurrent callers await the same promise.
+let inFlight: Promise<string> | null = null;
 
-export async function getOrCreateInstallationId(): Promise<string> {
-  if (cached) return cached;
+export function getOrCreateInstallationId(): Promise<string> {
+  if (cached) return Promise.resolve(cached);
 
-  const existing = await AsyncStorage.getItem(STORAGE_KEY);
-  if (existing) {
-    cached = existing;
-    return existing;
+  if (!inFlight) {
+    inFlight = (async () => {
+      try {
+        const existing = await AsyncStorage.getItem(STORAGE_KEY);
+        const id = existing ?? Crypto.randomUUID();
+        if (!existing) {
+          await AsyncStorage.setItem(STORAGE_KEY, id);
+        }
+        cached = id;
+        return id;
+      } finally {
+        // Reset so a failed attempt can be retried; success is served from cache.
+        inFlight = null;
+      }
+    })();
   }
 
-  const id = Crypto.randomUUID();
-  await AsyncStorage.setItem(STORAGE_KEY, id);
-  cached = id;
-  return id;
+  return inFlight;
 }

--- a/src/UI/sd-mobile/src/services/api/devicesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/devicesApi.ts
@@ -1,17 +1,23 @@
 import { apiClient } from './client';
 
 export interface RegisterDevicePayload {
+  installationId: string;
   fcmToken: string;
   platform: 'ios' | 'android';
 }
 
 /**
- * Wrapper for /ui/devices. Registers (or refreshes) this device's FCM token
- * for the authenticated user. Server-side upsert is idempotent on
- * (UserId, FcmToken), so it's safe to call on every launch / token refresh.
+ * Wrapper for /ui/devices. Registration is idempotent server-side on the
+ * device's stable installationId, so it's safe to call on every launch / token
+ * refresh; registering under a new account reassigns the device to that user.
  */
 export const devicesApi = {
   // POST /ui/devices → 204
   registerDevice: (payload: RegisterDevicePayload) =>
     apiClient.post<void>('/ui/devices', payload),
+
+  // DELETE /ui/devices/{installationId} → 204. Called best-effort at sign-out
+  // so the signed-out user stops receiving pushes on this device.
+  unregisterDevice: (installationId: string) =>
+    apiClient.delete<void>(`/ui/devices/${encodeURIComponent(installationId)}`),
 };

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/DeviceCommandValidatorsTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/DeviceCommandValidatorsTests.cs
@@ -68,4 +68,14 @@ public class DeviceCommandValidatorsTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == nameof(UnregisterDeviceCommand.InstallationId));
     }
+
+    [Fact]
+    public void Unregister_Rejects_OverlongInstallationId()
+    {
+        var result = new UnregisterDeviceCommandValidator()
+            .Validate(new UnregisterDeviceCommand { UserId = Guid.NewGuid(), InstallationId = new string('a', 129) });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UnregisterDeviceCommand.InstallationId));
+    }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/DeviceCommandValidatorsTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/DeviceCommandValidatorsTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.UI.Devices.Commands.RegisterDevice;
+using SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Devices;
+
+public class DeviceCommandValidatorsTests
+{
+    private static RegisterDeviceCommand ValidRegister() => new()
+    {
+        UserId = Guid.NewGuid(),
+        InstallationId = "install-A",
+        FcmToken = "tok",
+        Platform = "ios"
+    };
+
+    [Fact]
+    public void Register_Accepts_ValidCommand()
+    {
+        var result = new RegisterDeviceCommandValidator().Validate(ValidRegister());
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Register_Rejects_BlankInstallationId(string installationId)
+    {
+        var cmd = ValidRegister();
+        cmd.InstallationId = installationId;
+
+        var result = new RegisterDeviceCommandValidator().Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(RegisterDeviceCommand.InstallationId));
+    }
+
+    [Fact]
+    public void Register_Rejects_OverlongInstallationId()
+    {
+        var cmd = ValidRegister();
+        cmd.InstallationId = new string('a', 129);
+
+        var result = new RegisterDeviceCommandValidator().Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(RegisterDeviceCommand.InstallationId));
+    }
+
+    [Fact]
+    public void Unregister_Accepts_ValidCommand()
+    {
+        var result = new UnregisterDeviceCommandValidator()
+            .Validate(new UnregisterDeviceCommand { UserId = Guid.NewGuid(), InstallationId = "install-A" });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Unregister_Rejects_BlankInstallationId()
+    {
+        var result = new UnregisterDeviceCommandValidator()
+            .Validate(new UnregisterDeviceCommand { UserId = Guid.NewGuid(), InstallationId = "" });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UnregisterDeviceCommand.InstallationId));
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/DeviceCommandValidatorsTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/DeviceCommandValidatorsTests.cs
@@ -59,11 +59,13 @@ public class DeviceCommandValidatorsTests
         result.IsValid.Should().BeTrue();
     }
 
-    [Fact]
-    public void Unregister_Rejects_BlankInstallationId()
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Unregister_Rejects_BlankInstallationId(string installationId)
     {
         var result = new UnregisterDeviceCommandValidator()
-            .Validate(new UnregisterDeviceCommand { UserId = Guid.NewGuid(), InstallationId = "" });
+            .Validate(new UnregisterDeviceCommand { UserId = Guid.NewGuid(), InstallationId = installationId });
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == nameof(UnregisterDeviceCommand.InstallationId));

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/InstallationIdNormalizerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/InstallationIdNormalizerTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.UI.Devices;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Devices;
+
+public class InstallationIdNormalizerTests
+{
+    [Fact]
+    public void Normalize_LowercasesAndCanonicalizes_UppercaseGuid()
+    {
+        var canonical = Guid.NewGuid().ToString(); // lowercase "D" form
+
+        InstallationIdNormalizer.Normalize(canonical.ToUpperInvariant())
+            .Should().Be(canonical);
+    }
+
+    [Fact]
+    public void Normalize_StripsBraces_FromGuid()
+    {
+        var guid = Guid.NewGuid();
+
+        InstallationIdNormalizer.Normalize($"{{{guid}}}")
+            .Should().Be(guid.ToString());
+    }
+
+    [Fact]
+    public void Normalize_TrimsWhitespace_AroundGuid()
+    {
+        var canonical = Guid.NewGuid().ToString();
+
+        InstallationIdNormalizer.Normalize($"  {canonical.ToUpperInvariant()}  ")
+            .Should().Be(canonical);
+    }
+
+    [Fact]
+    public void Normalize_PassesThroughTrimmed_NonGuid()
+    {
+        InstallationIdNormalizer.Normalize("  install-A  ")
+            .Should().Be("install-A");
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/UnregisterDeviceCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Devices/UnregisterDeviceCommandHandlerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using FluentValidation;
+
+using Moq;
+
+using SportsData.Api.Application.UI.Devices.Commands.UnregisterDevice;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Devices;
+
+public class UnregisterDeviceCommandHandlerTests : ApiTestBase<UnregisterDeviceCommandHandler>
+{
+    public UnregisterDeviceCommandHandlerTests()
+    {
+        Mocker.Use<IValidator<UnregisterDeviceCommand>>(new UnregisterDeviceCommandValidator());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PublishesUserDeviceUnregistered_WithJwtUser_AndTrimmedInstallationId()
+    {
+        var userId = Guid.NewGuid();
+        var handler = Mocker.CreateInstance<UnregisterDeviceCommandHandler>();
+        var command = new UnregisterDeviceCommand { UserId = userId, InstallationId = "  install-A  " };
+
+        var result = await handler.ExecuteAsync(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(x => x.Publish(
+            It.Is<UserDeviceUnregistered>(e => e.UserId == userId && e.InstallationId == "install-A"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsBadRequest_AndDoesNotPublish_WhenInstallationIdBlank()
+    {
+        var handler = Mocker.CreateInstance<UnregisterDeviceCommandHandler>();
+        var command = new UnregisterDeviceCommand { UserId = Guid.NewGuid(), InstallationId = "" };
+
+        var result = await handler.ExecuteAsync(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.BadRequest);
+        Mocker.GetMock<IEventBus>().Verify(x => x.Publish(
+            It.IsAny<UserDeviceUnregistered>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeviceRegisteredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeviceRegisteredConsumerTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class UserDeviceRegisteredConsumerTests : NotificationTestBase<UserDeviceRegisteredConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    public UserDeviceRegisteredConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    private static ConsumeContext<UserDeviceRegistered> ContextFor(UserDeviceRegistered msg)
+    {
+        var ctx = new Mock<ConsumeContext<UserDeviceRegistered>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private static UserDeviceRegistered Msg(Guid userId, string installationId, string token = "token-1", string platform = "ios")
+        => new(userId, installationId, token, platform, Guid.NewGuid(), Guid.NewGuid());
+
+    private async Task SeedDeviceAsync(Guid userId, string installationId, string token, bool notificationsEnabled)
+    {
+        DataContext.UserDevices.Add(new UserDevice
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstallationId = installationId,
+            FcmToken = token,
+            Platform = "ios",
+            NotificationsEnabled = notificationsEnabled,
+            LastSeenUtc = FixedNow.AddDays(-1),
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Consume_InsertsNewRow_WhenInstallationUnknown()
+    {
+        var userId = Guid.NewGuid();
+        var sut = Mocker.CreateInstance<UserDeviceRegisteredConsumer>();
+
+        await sut.Consume(ContextFor(Msg(userId, "install-A", "tok-A")));
+
+        var row = await DataContext.UserDevices.SingleAsync();
+        row.UserId.Should().Be(userId);
+        row.InstallationId.Should().Be("install-A");
+        row.FcmToken.Should().Be("tok-A");
+        row.NotificationsEnabled.Should().BeTrue();
+        row.LastSeenUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task Consume_SameOwnerReRegister_PreservesOptOut_AndUpdatesToken()
+    {
+        var userId = Guid.NewGuid();
+        await SeedDeviceAsync(userId, "install-A", "old-token", notificationsEnabled: false);
+
+        var sut = Mocker.CreateInstance<UserDeviceRegisteredConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, "install-A", "new-token")));
+
+        var row = await DataContext.UserDevices.SingleAsync();
+        row.UserId.Should().Be(userId);
+        row.FcmToken.Should().Be("new-token");
+        row.NotificationsEnabled.Should().BeFalse("a same-owner token refresh must not re-enable a device the user turned off");
+        row.LastSeenUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task Consume_OwnerChange_ReassignsUser_AndResetsOptOut()
+    {
+        var originalOwner = Guid.NewGuid();
+        var newOwner = Guid.NewGuid();
+        await SeedDeviceAsync(originalOwner, "install-A", "old-token", notificationsEnabled: false);
+
+        var sut = Mocker.CreateInstance<UserDeviceRegisteredConsumer>();
+        await sut.Consume(ContextFor(Msg(newOwner, "install-A", "new-token")));
+
+        // Still exactly one row for the install — reassigned, not duplicated.
+        var row = await DataContext.UserDevices.SingleAsync();
+        row.UserId.Should().Be(newOwner);
+        row.FcmToken.Should().Be("new-token");
+        row.NotificationsEnabled.Should().BeTrue("a new owner starts with notifications enabled");
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeviceUnregisteredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeviceUnregisteredConsumerTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class UserDeviceUnregisteredConsumerTests : NotificationTestBase<UserDeviceUnregisteredConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    private static ConsumeContext<UserDeviceUnregistered> ContextFor(UserDeviceUnregistered msg)
+    {
+        var ctx = new Mock<ConsumeContext<UserDeviceUnregistered>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private async Task SeedDeviceAsync(Guid userId, string installationId)
+    {
+        DataContext.UserDevices.Add(new UserDevice
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstallationId = installationId,
+            FcmToken = "tok",
+            Platform = "ios",
+            NotificationsEnabled = true,
+            LastSeenUtc = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Consume_DeletesOwnRow()
+    {
+        var userId = Guid.NewGuid();
+        await SeedDeviceAsync(userId, "install-A");
+
+        var sut = Mocker.CreateInstance<UserDeviceUnregisteredConsumer>();
+        await sut.Consume(ContextFor(new UserDeviceUnregistered(userId, "install-A", Guid.NewGuid(), Guid.NewGuid())));
+
+        (await DataContext.UserDevices.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Consume_DoesNotDeleteRowOwnedByDifferentUser()
+    {
+        var owner = Guid.NewGuid();
+        var someoneElse = Guid.NewGuid();
+        await SeedDeviceAsync(owner, "install-A");
+
+        var sut = Mocker.CreateInstance<UserDeviceUnregisteredConsumer>();
+        await sut.Consume(ContextFor(new UserDeviceUnregistered(someoneElse, "install-A", Guid.NewGuid(), Guid.NewGuid())));
+
+        var row = await DataContext.UserDevices.SingleAsync();
+        row.UserId.Should().Be(owner, "a user must not be able to unregister a device another account now owns");
+    }
+
+    [Fact]
+    public async Task Consume_IsNoOp_WhenRowAbsent()
+    {
+        var sut = Mocker.CreateInstance<UserDeviceUnregisteredConsumer>();
+
+        var act = async () => await sut.Consume(
+            ContextFor(new UserDeviceUnregistered(Guid.NewGuid(), "missing", Guid.NewGuid(), Guid.NewGuid())));
+
+        await act.Should().NotThrowAsync();
+        (await DataContext.UserDevices.AnyAsync()).Should().BeFalse();
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/NotificationTestBase.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/NotificationTestBase.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Tests.Shared;
+
+namespace SportsData.Notification.Tests.Unit
+{
+    public abstract class NotificationTestBase<T> : UnitTestBase<T>
+        where T : class
+    {
+        public AppDataContext DataContext { get; }
+
+        protected NotificationTestBase()
+        {
+            DataContext = new AppDataContext(GetAppDataContextOptions());
+            Mocker.Use(typeof(AppDataContext), DataContext);
+        }
+
+        private static DbContextOptions<AppDataContext> GetAppDataContextOptions()
+        {
+            var dbName = Guid.NewGuid().ToString()[..5];
+            return new DbContextOptionsBuilder<AppDataContext>()
+                .UseInMemoryDatabase(dbName)
+                .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+                .Options;
+        }
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/SportsData.Notification.Tests.Unit.csproj
+++ b/test/unit/SportsData.Notification.Tests.Unit/SportsData.Notification.Tests.Unit.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
@@ -17,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\SportsData.Notification\SportsData.Notification.csproj" />
+    <ProjectReference Include="..\..\SportsData.Tests.Shared\SportsData.Tests.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="xunit.runner.json">


### PR DESCRIPTION
Closes #475.

## Problem

An FCM token is **per app-install, not per user**, but device registration was keyed on `(UserId, FcmToken)`. Two accounts signing in on one physical device each created a row pointing at the **same** token, so the dispatcher (`WHERE UserId == target && NotificationsEnabled` → push to `FcmToken`) delivered **both** accounts' notifications to the device regardless of who was signed in — cross-delivery, and a privacy leak for genuinely different users sharing a device. There was also no sign-out cleanup.

## Approach

Each install mints a stable `InstallationId`; the device row is keyed on it (unique), so a device has exactly **one current owner**.

- **Register** (sign-in / token refresh): upsert by `InstallationId`, reassign `UserId` + `FcmToken`. Same-owner refresh **preserves** `NotificationsEnabled`; owner change **resets** it to default.
- **Unregister** (sign-out): delete scoped to `(InstallationId, UserId)`.
- **Dispatch**: unchanged — correct now that each install row has a single owner.

## Changes
- **Core**: `InstallationId` on `UserDeviceRegistered`; new `UserDeviceUnregistered`.
- **Notification**: `UserDevice.InstallationId` + unique index on it; reworked register consumer; new `UserDeviceUnregisteredConsumer`; `Program.cs` registration; migration `AddInstallationIdToUserDevice`.
- **API**: register payload carries `InstallationId`; new `DELETE /ui/devices/{installationId}` → `UserDeviceUnregistered` (Direct delivery); DI.
- **Mobile**: `installationId.ts` (UUID via `expo-crypto`, persisted in AsyncStorage); hook sends it; `profile.tsx` best-effort native-only unregister on sign-out.
- **Docs**: `docs/mobile/device-identity-and-push-ownership.md`.

## Migration note
`AddInstallationIdToUserDevice` **clears `UserDevices`** before adding the required, uniquely-indexed column — existing rows predate `InstallationId` and can't be backfilled. The table is a self-rebuilding projection: every device re-registers on next app launch.

## Tests / validation
- Notification consumer suite: insert / same-owner-preserves-opt-out / owner-change-resets+reassigns / unregister-own / won't-delete-other-user / no-op-when-absent.
- API: device validator + unregister-handler tests.
- Notification (7) + API (415) unit suites green; mobile `tsc --noEmit` clean; EF model snapshot no drift.

## Deploy ordering
The mobile registration payload now requires `installationId`. API must deploy **before** the new mobile build registers (natural — backend merges/deploys ahead of EAS). Migration should be validated against a real Postgres on first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device registration now requires a stable installation ID for better continuity across token refreshes and account switches.
  * Added an authenticated device unregistration endpoint; mobile sign-out now best-effort unregisters the current device.
* **Bug Fixes**
  * Push notification device ownership and idempotency are now based on the stable installation ID, with correct opt-out preservation and reset on ownership changes.
* **Tests**
  * Added unit tests for installation ID normalization, registration/unregistration validation, and notification device consumers.
* **Documentation**
  * Updated the device identity and push ownership design notes, including migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->