### PR TITLE
feat(notification): line-move alerts for pickers

### DIFF
--- a/src/SportsData.Api/Application/Events/PickemGroupsRequestedConsumer.cs
+++ b/src/SportsData.Api/Application/Events/PickemGroupsRequestedConsumer.cs
@@ -64,6 +64,7 @@ namespace SportsData.Api.Application.Events
                     g.Name,
                     g.Sport,
                     g.CommissionerUserId,
+                    g.PickType,
                     Members = g.Members
                         .Select(m => new { m.UserId, Role = m.Role.ToString() })
                         .ToList()
@@ -85,6 +86,7 @@ namespace SportsData.Api.Application.Events
                     group.Id,
                     group.Name,
                     group.CommissionerUserId,
+                    group.PickType.ToString(),
                     group.Members
                         .Select(m => new PickemGroupMemberSnapshot(m.UserId, m.Role))
                         .ToList(),

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -199,6 +199,9 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
         // SaveChangesAsync silently loses the event when the DI scope disposes.
         var evt = new PickemGroupCreated(
             group.Id,
+            group.Name,
+            group.CommissionerUserId,
+            group.PickType.ToString(),
             null,
             group.Sport,
             seasonYear,

--- a/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
@@ -6,6 +6,8 @@ using SportsData.Api.Extensions;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Picks;
 
 using SportsData.Api.Application.Common.Enums;
 
@@ -22,13 +24,16 @@ public class SubmitPickCommandHandler : ISubmitPickCommandHandler
 {
     private readonly ILogger<SubmitPickCommandHandler> _logger;
     private readonly AppDataContext _dataContext;
+    private readonly IEventBus _eventBus;
 
     public SubmitPickCommandHandler(
         ILogger<SubmitPickCommandHandler> logger,
-        AppDataContext dataContext)
+        AppDataContext dataContext,
+        IEventBus eventBus)
     {
         _logger = logger;
         _dataContext = dataContext;
+        _eventBus = eventBus;
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
@@ -116,6 +121,23 @@ public class SubmitPickCommandHandler : ISubmitPickCommandHandler
 
             await _dataContext.UserPicks.AddAsync(pick, cancellationToken);
         }
+
+        // Announce the active pick so Notification can project who picked this
+        // contest (and target line-move / reminder notifications at pickers).
+        // Published BEFORE the commit: with the EF outbox, Publish enqueues into
+        // the DbContext tracker and SaveChangesAsync persists the pick and the
+        // outbox row atomically. Publishing after SaveChangesAsync would lose
+        // the event when the DI scope disposes.
+        await _eventBus.Publish(
+            new UserPickMade(
+                UserId: command.UserId,
+                ContestId: command.ContestId,
+                PickemGroupId: command.PickemGroupId,
+                Sport: group.Sport,
+                SeasonYear: matchup.SeasonYear,
+                CorrelationId: Guid.NewGuid(),
+                CausationId: Guid.NewGuid()),
+            cancellationToken);
 
         await _dataContext.SaveChangesAsync(cancellationToken);
 

--- a/src/SportsData.Core/Eventing/Events/Contests/ContestOddsUpdated.cs
+++ b/src/SportsData.Core/Eventing/Events/Contests/ContestOddsUpdated.cs
@@ -6,6 +6,12 @@ namespace SportsData.Core.Eventing.Events.Contests;
 public record ContestOddsUpdated(
     Guid ContestId,
     string Message,
+    string? ProviderId,
+    string? ProviderName,
+    decimal? OldSpread,
+    decimal? NewSpread,
+    decimal? OldOverUnder,
+    decimal? NewOverUnder,
     Uri? Ref,
     Sport Sport,
     int? SeasonYear,

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupCreated.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupCreated.cs
@@ -21,7 +21,7 @@ namespace SportsData.Core.Eventing.Events.PickemGroups
         Guid GroupId,
         string Name,
         Guid CommissionerUserId,
-        string PickType,
+        string? PickType,
         Uri? Ref,
         Sport Sport,
         int? SeasonYear,

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupCreated.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupCreated.cs
@@ -3,8 +3,25 @@ using SportsData.Core.Common;
 
 namespace SportsData.Core.Eventing.Events.PickemGroups
 {
+    /// <summary>
+    /// A league was created. Carries the league-level fields the Notification
+    /// projection needs so a new league is queryable immediately, without
+    /// waiting for an operator backfill (<see cref="PickemGroupsRequested"/>).
+    ///
+    /// <para>
+    /// <c>PickType</c> is the string form of API's <c>PickType</c> enum
+    /// (StraightUp / AgainstTheSpread / OverUnder) — same lighter-coupling
+    /// convention as <see cref="PickemGroupMemberSnapshot.Role"/>: a cross-
+    /// service string beats sharing the enum. Notification reads it to decide
+    /// whether a line move is relevant to a league's pickers (straight-up
+    /// leagues don't care about odds).
+    /// </para>
+    /// </summary>
     public record PickemGroupCreated(
         Guid GroupId,
+        string Name,
+        Guid CommissionerUserId,
+        string PickType,
         Uri? Ref,
         Sport Sport,
         int? SeasonYear,

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupDataPublished.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupDataPublished.cs
@@ -17,11 +17,17 @@ namespace SportsData.Core.Eventing.Events.PickemGroups
     /// semantics) — repeated backfills converge on the same projection rows.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <c>PickType</c> is nullable on the contract: a message published before
+    /// the field existed (in-flight in a queue during rollout) deserializes
+    /// with no value, so consumers must treat null as the safe odds-agnostic
+    /// default rather than persisting null into a required column.
+    /// </remarks>
     public record PickemGroupDataPublished(
         Guid GroupId,
         string Name,
         Guid CommissionerUserId,
-        string PickType,
+        string? PickType,
         IReadOnlyList<PickemGroupMemberSnapshot> Members,
         Sport Sport,
         int? SeasonYear,

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupDataPublished.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/PickemGroupDataPublished.cs
@@ -21,6 +21,7 @@ namespace SportsData.Core.Eventing.Events.PickemGroups
         Guid GroupId,
         string Name,
         Guid CommissionerUserId,
+        string PickType,
         IReadOnlyList<PickemGroupMemberSnapshot> Members,
         Sport Sport,
         int? SeasonYear,

--- a/src/SportsData.Core/Eventing/Events/Picks/UserPickMade.cs
+++ b/src/SportsData.Core/Eventing/Events/Picks/UserPickMade.cs
@@ -1,0 +1,28 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Picks
+{
+    /// <summary>
+    /// A user submitted (or changed) a pick for a contest. Published by the API
+    /// when a pick is persisted, so the Notification service can project who has
+    /// an active pick on a contest and target line-move / reminder notifications
+    /// at actual pickers rather than all league members.
+    ///
+    /// <para>
+    /// Idempotent projection target: the same (UserId, ContestId, PickemGroupId)
+    /// may be republished whenever the user changes their pick or on
+    /// at-least-once redelivery; the consumer upserts.
+    /// </para>
+    /// </summary>
+    public record UserPickMade(
+        Guid UserId,
+        Guid ContestId,
+        Guid PickemGroupId,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
@@ -154,6 +154,14 @@ namespace SportsData.Notification.Application.Consumers
             }
             catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
             {
+                // A prior attempt already claimed this (CorrelationId, UserId,
+                // Channel). We skip unconditionally — including when that row is
+                // still "Dispatching" from a crashed attempt. This is the same
+                // deliberate v1 tradeoff as UserPickScoredConsumer: a missing
+                // notification beats a duplicate one (a crash can land after the
+                // FCM send but before the terminal update, so resuming a stale
+                // claim risks re-sending). Stale Dispatching rows are left for a
+                // future cleanup job shared across consumers, not recovered here.
                 _logger.LogInformation(
                     "Line-move notification already claimed for CorrelationId {CorrelationId}, UserId {UserId}; skipping.",
                     msg.CorrelationId, userId);

--- a/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
@@ -1,0 +1,238 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// The betting line on a contest moved. Notify every user who already has a
+    /// pick on that contest — "you committed at one number, the market has since
+    /// moved" — so they can revisit before the contest locks.
+    ///
+    /// <para>
+    /// Targeting joins the local <see cref="UserPick"/> projection (fed by
+    /// <c>UserPickMade</c>) to the <see cref="PickemGroup"/> projection and
+    /// filters on the league's <c>PickType</c>: a line move only matters where
+    /// scoring depends on the odds. Spread movement targets
+    /// <see cref="LeaguePickType.AgainstTheSpread"/> leagues; total movement
+    /// targets <see cref="LeaguePickType.OverUnder"/> leagues;
+    /// <see cref="LeaguePickType.StraightUp"/> leagues never qualify (they don't
+    /// care about the line). Pickers only — NOT all league members. A user who
+    /// picked the same contest in several qualifying leagues is notified
+    /// <b>once</b> (the distinct on UserId dedups across leagues). The inner
+    /// join also means a pick whose league projection hasn't landed yet is
+    /// simply not notified rather than mis-targeted.
+    /// </para>
+    ///
+    /// <para>
+    /// Movement gate: only spread or total movement is actionable. The football
+    /// path carries Old/New spread &amp; total on the event; the MLB path
+    /// replaces a set of per-provider rows and so publishes all-null deltas —
+    /// with no single old/new pair there's nothing to report, and the equality
+    /// check below naturally treats "all null" as "no movement" and skips.
+    /// </para>
+    ///
+    /// <para>
+    /// Per-user dispatch mirrors <see cref="UserPickScoredConsumer"/>: atomic
+    /// NotificationLog claim on the unique <c>(CorrelationId, UserId, Channel)</c>
+    /// index (idempotent across redelivery and across pickers of the same
+    /// contest) → prefs → devices → send → terminal update. A claim race for one
+    /// user detaches and continues to the next; one user's failure never blocks
+    /// the rest of the fan-out.
+    /// </para>
+    /// </summary>
+    public class ContestOddsUpdatedConsumer : IConsumer<ContestOddsUpdated>
+    {
+        private readonly ILogger<ContestOddsUpdatedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPushNotificationSender _pushSender;
+
+        public ContestOddsUpdatedConsumer(
+            ILogger<ContestOddsUpdatedConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider,
+            IPushNotificationSender pushSender)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+            _pushSender = pushSender;
+        }
+
+        public async Task Consume(ConsumeContext<ContestOddsUpdated> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["ContestId"] = msg.ContestId,
+                ["Sport"] = msg.Sport
+            });
+
+            _logger.LogInformation("ContestOddsUpdated received.");
+
+            var spreadMoved = msg.OldSpread != msg.NewSpread;
+            var totalMoved = msg.OldOverUnder != msg.NewOverUnder;
+
+            if (!spreadMoved && !totalMoved)
+            {
+                _logger.LogInformation("No spread or total movement on the event; skipping.");
+                return;
+            }
+
+            // Pickers in leagues whose scoring depends on the moved dimension,
+            // deduped across leagues. The join to PickemGroups applies the
+            // PickType filter (ATS↔spread, OverUnder↔total, StraightUp never)
+            // and drops picks whose league projection hasn't landed yet. One
+            // physical line move → one push per user regardless of how many
+            // qualifying leagues they picked it in.
+            var userIds = await (
+                from p in _dataContext.UserPicks.AsNoTracking()
+                join g in _dataContext.PickemGroups.AsNoTracking() on p.PickemGroupId equals g.Id
+                where p.ContestId == msg.ContestId
+                    && ((spreadMoved && g.PickType == LeaguePickType.AgainstTheSpread)
+                        || (totalMoved && g.PickType == LeaguePickType.OverUnder))
+                select p.UserId)
+                .Distinct()
+                .ToListAsync(context.CancellationToken);
+
+            if (userIds.Count == 0)
+            {
+                _logger.LogInformation(
+                    "No pickers in odds-sensitive leagues for ContestId {ContestId}; nothing to notify.",
+                    msg.ContestId);
+                return;
+            }
+
+            var title = "Line moved";
+            var body = ComposeBody(msg, spreadMoved, totalMoved);
+
+            _logger.LogInformation(
+                "Dispatching line-move notification to {PickerCount} picker(s). SpreadMoved={SpreadMoved}, TotalMoved={TotalMoved}",
+                userIds.Count, spreadMoved, totalMoved);
+
+            foreach (var userId in userIds)
+            {
+                await DispatchToUserAsync(userId, msg, title, body, context.CancellationToken);
+            }
+        }
+
+        private async Task DispatchToUserAsync(
+            Guid userId,
+            ContestOddsUpdated msg,
+            string title,
+            string body,
+            CancellationToken cancellationToken)
+        {
+            using var _ = _logger.BeginScope(new Dictionary<string, object> { ["UserId"] = userId });
+
+            // Atomic claim per user, keyed on (CorrelationId, UserId, Channel).
+            // Same correlation across all pickers of this contest, so each user
+            // is claimed once even on redelivery; the loser of any race detaches
+            // and we move on without dispatching twice.
+            var claim = new NotificationLog
+            {
+                UserId = userId,
+                CorrelationId = msg.CorrelationId,
+                Category = "OddsChanged",
+                Channel = "Fcm",
+                Result = "Dispatching",
+                AttemptedUtc = _dateTimeProvider.UtcNow()
+            };
+            _dataContext.NotificationLog.Add(claim);
+
+            try
+            {
+                await _dataContext.SaveChangesAsync(cancellationToken);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                _logger.LogInformation(
+                    "Line-move notification already claimed for CorrelationId {CorrelationId}, UserId {UserId}; skipping.",
+                    msg.CorrelationId, userId);
+                _dataContext.Entry(claim).State = EntityState.Detached;
+                return;
+            }
+
+            var prefs = await _dataContext.UserNotificationPreferences
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+
+            if (prefs is { OddsChangedEnabled: false })
+            {
+                await FinalizeAsync(claim, "Suppressed_UserOptedOut", cancellationToken);
+                return;
+            }
+
+            var devices = await _dataContext.UserDevices
+                .AsNoTracking()
+                .Where(d => d.UserId == userId && d.NotificationsEnabled)
+                .ToListAsync(cancellationToken);
+
+            if (devices.Count == 0)
+            {
+                await FinalizeAsync(claim, "Suppressed_NoDevice", cancellationToken);
+                return;
+            }
+
+            var successCount = 0;
+            foreach (var device in devices)
+            {
+                var result = await _pushSender.SendAsync(device.FcmToken, title, body);
+                if (result is Success<string>)
+                    successCount++;
+            }
+
+            claim.Title = title;
+            claim.Body = body;
+            claim.Result = successCount > 0 ? "Sent" : "Failed_FcmError";
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+            await _dataContext.SaveChangesAsync(cancellationToken);
+        }
+
+        private async Task FinalizeAsync(NotificationLog claim, string result, CancellationToken cancellationToken)
+        {
+            claim.Result = result;
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+            await _dataContext.SaveChangesAsync(cancellationToken);
+        }
+
+        private static string ComposeBody(ContestOddsUpdated msg, bool spreadMoved, bool totalMoved)
+        {
+            // The event carries numbers but no team names, so the copy is
+            // number-only. Provider name is included when present to anchor the
+            // move ("per DraftKings"). MLB never reaches here (all-null deltas
+            // are gated out upstream), so this only formats football lines.
+            var via = string.IsNullOrWhiteSpace(msg.ProviderName) ? "" : $" ({msg.ProviderName})";
+
+            if (spreadMoved && totalMoved)
+                return $"The line moved on a game you picked: spread {FormatLine(msg.OldSpread)} → {FormatLine(msg.NewSpread)}, total {FormatLine(msg.OldOverUnder)} → {FormatLine(msg.NewOverUnder)}{via}.";
+
+            if (spreadMoved)
+                return $"The spread moved on a game you picked: {FormatLine(msg.OldSpread)} → {FormatLine(msg.NewSpread)}{via}.";
+
+            return $"The total moved on a game you picked: {FormatLine(msg.OldOverUnder)} → {FormatLine(msg.NewOverUnder)}{via}.";
+        }
+
+        private static string FormatLine(decimal? value)
+        {
+            // No value on one side means the number appeared/disappeared rather
+            // than shifting; show an em dash so the copy still reads.
+            return value?.ToString("0.#") ?? "—";
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
+        }
+    }
+}

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupCreatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupCreatedConsumer.cs
@@ -1,51 +1,123 @@
 using MassTransit;
 
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
 
 namespace SportsData.Notification.Application.Consumers
 {
     /// <summary>
-    /// PickemGroupCreated is a precondition / awareness event for Notification.
-    /// No user-facing notification fires on league creation today — the welcome
-    /// flow is driven by <see cref="PickemGroupMemberAddedConsumer"/> (which
-    /// fires for the commissioner-as-first-member too, via
-    /// <c>CreateLeagueCommandHandlerBase</c>'s synthetic membership).
+    /// Projects a newly created league into the local <see cref="PickemGroup"/>
+    /// table at creation time, so the projection is queryable immediately rather
+    /// than only after an operator backfill (<see cref="PickemGroupsRequested"/>).
+    /// This is what makes line-move targeting correct for brand-new leagues:
+    /// <see cref="ContestOddsUpdatedConsumer"/> reads <c>PickType</c> from this
+    /// row to decide whether a league's pickers care about the odds.
     ///
     /// <para>
-    /// Kept as a no-op handler because (a) we may layer in commissioner-side
-    /// "your league is live" notifications later and (b) projecting a minimal
-    /// league record locally for fast lookup during fan-out is on the table
-    /// (see design doc §3 — currently we lean on fat events instead).
+    /// Group-level fields only — members are NOT seeded here. The commissioner
+    /// (and any other members) arrive via <c>PickemGroupMemberAdded</c> and the
+    /// backfill's <c>PickemGroupDataPublished</c>; this consumer deliberately
+    /// leaves the roster alone so it can't race the member-sync path.
+    /// </para>
+    ///
+    /// <para>
+    /// Idempotent upsert keyed on the PK: race-safe insert (loser of the
+    /// unique-constraint insert falls through to the update path), and a
+    /// redelivery that finds the row unchanged is a no-op.
     /// </para>
     /// </summary>
     public class PickemGroupCreatedConsumer : IConsumer<PickemGroupCreated>
     {
         private readonly ILogger<PickemGroupCreatedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
-        public PickemGroupCreatedConsumer(ILogger<PickemGroupCreatedConsumer> logger)
+        public PickemGroupCreatedConsumer(
+            ILogger<PickemGroupCreatedConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
         }
 
-        public Task Consume(ConsumeContext<PickemGroupCreated> context)
+        public async Task Consume(ConsumeContext<PickemGroupCreated> context)
         {
+            var msg = context.Message;
             using var _ = _logger.BeginScope(new Dictionary<string, object>
             {
-                ["CorrelationId"] = context.Message.CorrelationId,
-                ["GroupId"] = context.Message.GroupId,
-                ["Sport"] = context.Message.Sport
+                ["CorrelationId"] = msg.CorrelationId,
+                ["GroupId"] = msg.GroupId,
+                ["Sport"] = msg.Sport
             });
 
-            _logger.LogInformation(
-                "PickemGroupCreated received; no notification fan-out today.");
+            var now = _dateTimeProvider.UtcNow();
 
-            // TODO (future): If we add commissioner-side "your league is live"
-            // notifications, look up the synthetic commissioner membership
-            // via a follow-up PickemGroupMemberAdded event (it carries the
-            // commissioner's UserId) — do NOT try to derive it here, since
-            // PickemGroupCreated does not carry the commissioner identity.
+            var group = await _dataContext.PickemGroups
+                .FirstOrDefaultAsync(g => g.Id == msg.GroupId, context.CancellationToken);
 
-            return Task.CompletedTask;
+            if (group is null)
+            {
+                _dataContext.PickemGroups.Add(new PickemGroup
+                {
+                    Id = msg.GroupId,
+                    Name = msg.Name,
+                    Sport = msg.Sport,
+                    CommissionerUserId = msg.CommissionerUserId,
+                    PickType = msg.PickType,
+                    CreatedUtc = now,
+                    CreatedBy = msg.CausationId
+                });
+
+                try
+                {
+                    await _dataContext.SaveChangesAsync(context.CancellationToken);
+                    _logger.LogInformation("PickemGroup projection inserted on create. GroupId={GroupId}", msg.GroupId);
+                    return;
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // Race: the backfill's PickemGroupDataPublished (or a
+                    // redelivery) inserted first. Re-read and fall through to
+                    // the change-detection update path.
+                    _dataContext.ChangeTracker.Clear();
+                    group = await _dataContext.PickemGroups
+                        .FirstAsync(g => g.Id == msg.GroupId, context.CancellationToken);
+                }
+            }
+
+            var changed =
+                group.Name != msg.Name
+                || group.Sport != msg.Sport
+                || group.CommissionerUserId != msg.CommissionerUserId
+                || group.PickType != msg.PickType;
+
+            if (!changed)
+            {
+                _logger.LogDebug("PickemGroup projection already current on create. GroupId={GroupId}", msg.GroupId);
+                return;
+            }
+
+            group.Name = msg.Name;
+            group.Sport = msg.Sport;
+            group.CommissionerUserId = msg.CommissionerUserId;
+            group.PickType = msg.PickType;
+            group.ModifiedUtc = now;
+            group.ModifiedBy = msg.CausationId;
+
+            await _dataContext.SaveChangesAsync(context.CancellationToken);
+            _logger.LogInformation("PickemGroup projection updated on create. GroupId={GroupId}", msg.GroupId);
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
         }
     }
 }

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupCreatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupCreatedConsumer.cs
@@ -58,6 +58,12 @@ namespace SportsData.Notification.Application.Consumers
 
             var now = _dateTimeProvider.UtcNow();
 
+            // Backward-compat: a message published before PickType existed (in
+            // flight during rollout) deserializes with null. Treat null as the
+            // safe odds-agnostic default so we never write null into the
+            // required column or over-notify on a line move.
+            var pickType = msg.PickType ?? LeaguePickType.StraightUp;
+
             var group = await _dataContext.PickemGroups
                 .FirstOrDefaultAsync(g => g.Id == msg.GroupId, context.CancellationToken);
 
@@ -69,7 +75,7 @@ namespace SportsData.Notification.Application.Consumers
                     Name = msg.Name,
                     Sport = msg.Sport,
                     CommissionerUserId = msg.CommissionerUserId,
-                    PickType = msg.PickType,
+                    PickType = pickType,
                     CreatedUtc = now,
                     CreatedBy = msg.CausationId
                 });
@@ -95,7 +101,7 @@ namespace SportsData.Notification.Application.Consumers
                 group.Name != msg.Name
                 || group.Sport != msg.Sport
                 || group.CommissionerUserId != msg.CommissionerUserId
-                || group.PickType != msg.PickType;
+                || group.PickType != pickType;
 
             if (!changed)
             {
@@ -106,7 +112,7 @@ namespace SportsData.Notification.Application.Consumers
             group.Name = msg.Name;
             group.Sport = msg.Sport;
             group.CommissionerUserId = msg.CommissionerUserId;
-            group.PickType = msg.PickType;
+            group.PickType = pickType;
             group.ModifiedUtc = now;
             group.ModifiedBy = msg.CausationId;
 

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
@@ -69,6 +69,7 @@ namespace SportsData.Notification.Application.Consumers
                     Name = msg.Name,
                     Sport = msg.Sport,
                     CommissionerUserId = msg.CommissionerUserId,
+                    PickType = msg.PickType,
                     CreatedUtc = now,
                     CreatedBy = msg.CausationId
                 };
@@ -181,7 +182,8 @@ namespace SportsData.Notification.Application.Consumers
             var changed =
                 group.Name != msg.Name
                 || group.Sport != msg.Sport
-                || group.CommissionerUserId != msg.CommissionerUserId;
+                || group.CommissionerUserId != msg.CommissionerUserId
+                || group.PickType != msg.PickType;
 
             if (!changed)
                 return false;
@@ -189,6 +191,7 @@ namespace SportsData.Notification.Application.Consumers
             group.Name = msg.Name;
             group.Sport = msg.Sport;
             group.CommissionerUserId = msg.CommissionerUserId;
+            group.PickType = msg.PickType;
             group.ModifiedUtc = now;
             group.ModifiedBy = msg.CausationId;
             return true;

--- a/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupDataPublishedConsumer.cs
@@ -56,6 +56,12 @@ namespace SportsData.Notification.Application.Consumers
 
             var now = _dateTimeProvider.UtcNow();
 
+            // Backward-compat: a message published before PickType existed (in
+            // flight during rollout) deserializes with null. Treat null as the
+            // safe odds-agnostic default so we never write null into the
+            // required column or over-notify on a line move.
+            var pickType = msg.PickType ?? LeaguePickType.StraightUp;
+
             // ---- Group row: upsert with race-safe insert + change detection.
             var group = await _dataContext.PickemGroups
                 .FirstOrDefaultAsync(g => g.Id == msg.GroupId, context.CancellationToken);
@@ -69,7 +75,7 @@ namespace SportsData.Notification.Application.Consumers
                     Name = msg.Name,
                     Sport = msg.Sport,
                     CommissionerUserId = msg.CommissionerUserId,
-                    PickType = msg.PickType,
+                    PickType = pickType,
                     CreatedUtc = now,
                     CreatedBy = msg.CausationId
                 };
@@ -88,12 +94,25 @@ namespace SportsData.Notification.Application.Consumers
                     _dataContext.Entry(entity).State = EntityState.Detached;
                     group = await _dataContext.PickemGroups
                         .FirstAsync(g => g.Id == msg.GroupId, context.CancellationToken);
-                    groupChanged = ApplyGroupUpdateIfChanged(group, msg, now);
+                    groupChanged = ApplyGroupUpdateIfChanged(group, msg, pickType, now);
                 }
             }
             else
             {
-                groupChanged = ApplyGroupUpdateIfChanged(group, msg, now);
+                groupChanged = ApplyGroupUpdateIfChanged(group, msg, pickType, now);
+            }
+
+            // Persist any group-level change (e.g. PickType, which drives
+            // line-move targeting) on its own, BEFORE the member sync. The
+            // member sync can hit a unique-constraint race on a concurrent
+            // member insert, and EF's SaveChanges is atomic — folding the group
+            // update into that same save would roll it back together with the
+            // racy insert, leaving the group stale while we report success.
+            // The group update is a pure UPDATE by PK with no unique index in
+            // play, so it carries no race of its own.
+            if (groupChanged)
+            {
+                await _dataContext.SaveChangesAsync(context.CancellationToken);
             }
 
             // ---- Members: diff/sync by UserId — modify survivors in place,
@@ -149,7 +168,7 @@ namespace SportsData.Notification.Application.Consumers
                 }
             }
 
-            if (groupChanged || membersChanged)
+            if (membersChanged)
             {
                 try
                 {
@@ -159,8 +178,8 @@ namespace SportsData.Notification.Application.Consumers
                 {
                     // A concurrent consumer inserted one of the same new
                     // members between our read and our save. Their write
-                    // won; ours is redundant. Log and treat as success —
-                    // the projection is now in the intended end-state.
+                    // won; ours is redundant. The group update is already
+                    // committed above, so the projection is in target state.
                     _logger.LogInformation(
                         "PickemGroup member sync hit a concurrent insert race for GroupId {GroupId}; another consumer's write won. Projection is in target state.",
                         msg.GroupId);
@@ -171,19 +190,23 @@ namespace SportsData.Notification.Application.Consumers
                     "PickemGroup roster synced. GroupId={GroupId}, MemberCount={MemberCount}, GroupChanged={GroupChanged}, MembersChanged={MembersChanged}",
                     msg.GroupId, msg.Members.Count, groupChanged, membersChanged);
             }
+            else if (groupChanged)
+            {
+                _logger.LogInformation("PickemGroup group fields updated. GroupId={GroupId}", msg.GroupId);
+            }
             else
             {
                 _logger.LogDebug("PickemGroup projection unchanged. GroupId={GroupId}", msg.GroupId);
             }
         }
 
-        private static bool ApplyGroupUpdateIfChanged(PickemGroup group, PickemGroupDataPublished msg, DateTime now)
+        private static bool ApplyGroupUpdateIfChanged(PickemGroup group, PickemGroupDataPublished msg, string pickType, DateTime now)
         {
             var changed =
                 group.Name != msg.Name
                 || group.Sport != msg.Sport
                 || group.CommissionerUserId != msg.CommissionerUserId
-                || group.PickType != msg.PickType;
+                || group.PickType != pickType;
 
             if (!changed)
                 return false;
@@ -191,7 +214,7 @@ namespace SportsData.Notification.Application.Consumers
             group.Name = msg.Name;
             group.Sport = msg.Sport;
             group.CommissionerUserId = msg.CommissionerUserId;
-            group.PickType = msg.PickType;
+            group.PickType = pickType;
             group.ModifiedUtc = now;
             group.ModifiedBy = msg.CausationId;
             return true;

--- a/src/SportsData.Notification/Application/Consumers/UserPickMadeConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickMadeConsumer.cs
@@ -1,0 +1,96 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// Projects an active user pick (from the API's <c>UserPickMade</c> event)
+    /// into the local <see cref="UserPick"/> table, so contest-level events —
+    /// e.g. <c>ContestOddsUpdated</c> — can be targeted at users who actually
+    /// picked the contest rather than all league members.
+    ///
+    /// <para>
+    /// Idempotent on the <c>(UserId, ContestId, PickemGroupId)</c> natural key:
+    /// re-submitting / changing a pick republishes the same key, and the row
+    /// only records that the pick exists (the picked side isn't needed for
+    /// line-move fan-out), so an existing row is a no-op. Race-safe insert — a
+    /// concurrent consumer losing the unique-constraint insert falls through to
+    /// the no-op path.
+    /// </para>
+    /// </summary>
+    public class UserPickMadeConsumer : IConsumer<UserPickMade>
+    {
+        private readonly ILogger<UserPickMadeConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public UserPickMadeConsumer(
+            ILogger<UserPickMadeConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task Consume(ConsumeContext<UserPickMade> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["UserId"] = msg.UserId,
+                ["ContestId"] = msg.ContestId
+            });
+
+            var exists = await _dataContext.UserPicks
+                .AnyAsync(
+                    p => p.UserId == msg.UserId &&
+                         p.ContestId == msg.ContestId &&
+                         p.PickemGroupId == msg.PickemGroupId,
+                    context.CancellationToken);
+
+            if (exists)
+            {
+                _logger.LogInformation("UserPick already projected; no-op. UserId={UserId}, ContestId={ContestId}", msg.UserId, msg.ContestId);
+                return;
+            }
+
+            var now = _dateTimeProvider.UtcNow();
+            _dataContext.UserPicks.Add(new UserPick
+            {
+                Id = Guid.NewGuid(),
+                UserId = msg.UserId,
+                ContestId = msg.ContestId,
+                PickemGroupId = msg.PickemGroupId,
+                CreatedUtc = now,
+                CreatedBy = msg.CausationId
+            });
+
+            try
+            {
+                await _dataContext.SaveChangesAsync(context.CancellationToken);
+                _logger.LogInformation("UserPick projected. UserId={UserId}, ContestId={ContestId}", msg.UserId, msg.ContestId);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                // Race: another consumer inserted the same (UserId, ContestId,
+                // PickemGroupId) first. The pick is projected either way — no-op.
+                _logger.LogInformation("UserPick already projected (insert race); no-op. UserId={UserId}, ContestId={ContestId}", msg.UserId, msg.ContestId);
+            }
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
+        }
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -34,6 +34,8 @@ namespace SportsData.Notification.Infrastructure.Data
 
         public DbSet<UserDevice> UserDevices => Set<UserDevice>();
 
+        public DbSet<UserPick> UserPicks => Set<UserPick>();
+
         public DbSet<UserNotificationPreferences> UserNotificationPreferences => Set<UserNotificationPreferences>();
 
         public DbSet<PendingScheduledJob> PendingScheduledJobs => Set<PendingScheduledJob>();
@@ -59,6 +61,16 @@ namespace SportsData.Notification.Infrastructure.Data
             // (previously provided by the old (UserId, FcmToken) unique index).
             modelBuilder.Entity<UserDevice>()
                 .HasIndex(d => d.UserId);
+
+            // One pick row per (user, contest, league); the consumer upserts on
+            // it. The dominant read is "who picked contest C" (odds/line-move
+            // fan-out), so ContestId leads a second index.
+            modelBuilder.Entity<UserPick>()
+                .HasIndex(p => new { p.UserId, p.ContestId, p.PickemGroupId })
+                .IsUnique();
+
+            modelBuilder.Entity<UserPick>()
+                .HasIndex(p => p.ContestId);
 
             // One preferences row per user.
             modelBuilder.Entity<UserNotificationPreferences>()

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/LeaguePickType.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/LeaguePickType.cs
@@ -1,0 +1,18 @@
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// String forms of API's <c>PickType</c> enum, carried across services as
+    /// strings (the same lighter-coupling convention as
+    /// <c>PickemGroupMemberSnapshot.Role</c> — a cross-service string beats
+    /// sharing the enum). These values are the <c>ToString()</c> of the API
+    /// enum members; keep them in sync if API ever renames a member.
+    /// </summary>
+    public static class LeaguePickType
+    {
+        public const string StraightUp = "StraightUp";
+
+        public const string AgainstTheSpread = "AgainstTheSpread";
+
+        public const string OverUnder = "OverUnder";
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroup.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PickemGroup.cs
@@ -6,14 +6,17 @@ using SportsData.Core.Infrastructure.Data.Entities;
 namespace SportsData.Notification.Infrastructure.Data.Entities
 {
     /// <summary>
-    /// Local read-side projection of API's PickemGroup. Seeded via the
-    /// PickemGroupsRequested → PickemGroupDataPublished backfill chain.
+    /// Local read-side projection of API's PickemGroup. Seeded at creation via
+    /// PickemGroupCreated and kept current via the PickemGroupsRequested →
+    /// PickemGroupDataPublished backfill chain.
     ///
     /// <para>
     /// Notification needs Name (notification copy: "You joined {Name}"),
-    /// Sport (so future per-sport notification logic can branch), and
+    /// Sport (so future per-sport notification logic can branch),
     /// CommissionerUserId (commissioner-side fan-out: "{NewMember} joined
-    /// your league").
+    /// your league"), and PickType (so line-move notifications target only
+    /// leagues whose scoring depends on the odds — ATS cares about spread,
+    /// OverUnder about the total, StraightUp about neither).
     /// </para>
     /// </summary>
     public class PickemGroup : CanonicalEntityBase<Guid>
@@ -25,5 +28,14 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
         public Sport Sport { get; set; }
 
         public Guid CommissionerUserId { get; set; }
+
+        /// <summary>
+        /// String form of API's PickType enum (see <see cref="LeaguePickType"/>).
+        /// Defaults to the odds-agnostic StraightUp so a row that predates this
+        /// field never over-notifies until a backfill refreshes it.
+        /// </summary>
+        [Required]
+        [MaxLength(40)]
+        public string PickType { get; set; } = LeaguePickType.StraightUp;
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/UserNotificationPreferences.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/UserNotificationPreferences.cs
@@ -27,5 +27,7 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
         public bool MatchupPreviewEnabled { get; set; } = true;
 
         public bool ScheduleChangeEnabled { get; set; } = true;
+
+        public bool OddsChangedEnabled { get; set; } = true;
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/UserPick.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/UserPick.cs
@@ -1,0 +1,20 @@
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Projection of an active user pick, fed by the <c>UserPickMade</c> event.
+    /// Lets the Notification service answer "who picked contest C" so contest-level
+    /// events (e.g. odds/line moves) can be targeted at actual pickers instead of
+    /// all league members. One row per (UserId, ContestId, PickemGroupId) — a user
+    /// can pick the same contest in multiple leagues.
+    /// </summary>
+    public class UserPick : CanonicalEntityBase<Guid>
+    {
+        public Guid UserId { get; set; }
+
+        public Guid ContestId { get; set; }
+
+        public Guid PickemGroupId { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260628160003_AddUserPickProjection.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260628160003_AddUserPickProjection.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260628160003_AddUserPickProjection")]
+    partial class AddUserPickProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -159,11 +162,6 @@ namespace SportsData.Notification.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
-
-                    b.Property<string>("PickType")
-                        .IsRequired()
-                        .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("Sport")
                         .HasColumnType("integer");
@@ -379,9 +377,6 @@ namespace SportsData.Notification.Migrations
 
                     b.Property<DateTime?>("ModifiedUtc")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<bool>("OddsChangedEnabled")
-                        .HasColumnType("boolean");
 
                     b.Property<bool>("PickDeadlineReminderEnabled")
                         .HasColumnType("boolean");

--- a/src/SportsData.Notification/Migrations/20260628160003_AddUserPickProjection.cs
+++ b/src/SportsData.Notification/Migrations/20260628160003_AddUserPickProjection.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserPickProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserPicks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContestId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PickemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserPicks", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPicks_ContestId",
+                table: "UserPicks",
+                column: "ContestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPicks_UserId_ContestId_PickemGroupId",
+                table: "UserPicks",
+                columns: new[] { "UserId", "ContestId", "PickemGroupId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserPicks");
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260628160319_AddOddsChangedNotificationPreference.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260628160319_AddOddsChangedNotificationPreference.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260628160319_AddOddsChangedNotificationPreference")]
+    partial class AddOddsChangedNotificationPreference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -159,11 +162,6 @@ namespace SportsData.Notification.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
-
-                    b.Property<string>("PickType")
-                        .IsRequired()
-                        .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("Sport")
                         .HasColumnType("integer");

--- a/src/SportsData.Notification/Migrations/20260628160319_AddOddsChangedNotificationPreference.cs
+++ b/src/SportsData.Notification/Migrations/20260628160319_AddOddsChangedNotificationPreference.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOddsChangedNotificationPreference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "OddsChangedEnabled",
+                table: "UserNotificationPreferences",
+                type: "boolean",
+                nullable: false,
+                // "Everything on" default (mirrors the entity initializer and
+                // the other *Enabled flags) so existing preference rows opt in
+                // to line-move pushes rather than being silently excluded.
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OddsChangedEnabled",
+                table: "UserNotificationPreferences");
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260628161845_AddPickTypeToPickemGroupProjection.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260628161845_AddPickTypeToPickemGroupProjection.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260628161845_AddPickTypeToPickemGroupProjection")]
+    partial class AddPickTypeToPickemGroupProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260628161845_AddPickTypeToPickemGroupProjection.cs
+++ b/src/SportsData.Notification/Migrations/20260628161845_AddPickTypeToPickemGroupProjection.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPickTypeToPickemGroupProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PickType",
+                table: "PickemGroups",
+                type: "character varying(40)",
+                maxLength: 40,
+                nullable: false,
+                // Odds-agnostic default (matches the entity initializer) so
+                // existing projected leagues never over-notify on a line move
+                // until a backfill refreshes them with the real pick type.
+                defaultValue: "StraightUp");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PickType",
+                table: "PickemGroups");
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -37,6 +37,7 @@ namespace SportsData.Notification
             services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode);
 
             services.AddMessaging(config, [
+                typeof(ContestOddsUpdatedConsumer),
                 typeof(ContestStartTimeUpdatedConsumer),
                 typeof(PickemGroupCreatedConsumer),
                 typeof(PickemGroupDataPublishedConsumer),
@@ -46,6 +47,7 @@ namespace SportsData.Notification
                 typeof(UserDataPublishedConsumer),
                 typeof(UserDeviceRegisteredConsumer),
                 typeof(UserDeviceUnregisteredConsumer),
+                typeof(UserPickMadeConsumer),
                 typeof(UserPickScoredConsumer)
             ]);
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
@@ -242,10 +242,21 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
         // contest's odds changed; per-provider granularity isn't useful yet.
         if (hadExisting)
         {
+            // Old/new line deltas are left null on the MLB path: this processor
+            // replaces a set of per-provider odds rows per wrapper document, so
+            // there's no single old->new spread/total pair to report. Football
+            // (single existing->incoming) populates them. Revisit if MLB needs a
+            // representative-provider delta.
             await _publishEndpoint.Publish(new ContestOddsUpdated(
                 competition.Contest.Id,
                 "ContestOddsUpdated",
-                null,
+                ProviderId: null,
+                ProviderName: null,
+                OldSpread: null,
+                NewSpread: null,
+                OldOverUnder: null,
+                NewOverUnder: null,
+                Ref: null,
                 command.Sport,
                 command.SeasonYear,
                 command.CorrelationId,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
@@ -173,6 +173,12 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
             await _publishEndpoint.Publish(new ContestOddsUpdated(
                 competition.Contest.Id,
                 "ContestOddsUpdated",
+                incoming.ProviderId,
+                incoming.ProviderName,
+                existing.Spread,
+                incoming.Spread,
+                existing.OverUnder,
+                incoming.OverUnder,
                 null,
                 command.Sport,
                 command.SeasonYear,

--- a/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/PickemGroupCreatedHandlerTests.cs
@@ -40,7 +40,8 @@ public class PickemGroupCreatedHandlerTests : ApiTestBase<PickemGroupCreatedHand
     {
         var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
         var context = ConsumeContextFor(new PickemGroupCreated(
-            Guid.NewGuid(), null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
+            Guid.NewGuid(), "Test", Guid.NewGuid(), PickType.StraightUp.ToString(),
+            null, Sport.BaseballMlb, 2026, Guid.NewGuid(), Guid.NewGuid()));
 
         var act = async () => await sut.Consume(context);
 
@@ -68,7 +69,8 @@ public class PickemGroupCreatedHandlerTests : ApiTestBase<PickemGroupCreatedHand
 
         var sut = Mocker.CreateInstance<PickemGroupCreatedHandler>();
         var context = ConsumeContextFor(new PickemGroupCreated(
-            groupId, null, Sport.BaseballMlb, 2026, correlationId, Guid.NewGuid()));
+            groupId, "Test", Guid.NewGuid(), PickType.StraightUp.ToString(),
+            null, Sport.BaseballMlb, 2026, correlationId, Guid.NewGuid()));
 
         await sut.Consume(context);
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
@@ -1,0 +1,246 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsUpdatedConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IPushNotificationSender> _pushSender;
+
+    public ContestOddsUpdatedConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+
+        _pushSender = Mocker.GetMock<IPushNotificationSender>();
+        _pushSender
+            .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<string>("msg-id"));
+    }
+
+    private static ConsumeContext<ContestOddsUpdated> ContextFor(ContestOddsUpdated msg)
+    {
+        var ctx = new Mock<ConsumeContext<ContestOddsUpdated>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private static ContestOddsUpdated Msg(
+        Guid contestId,
+        decimal? oldSpread = null, decimal? newSpread = null,
+        decimal? oldTotal = null, decimal? newTotal = null)
+        => new(contestId, "odds updated", "1", "DraftKings",
+            oldSpread, newSpread, oldTotal, newTotal,
+            null, Sport.FootballNcaa, 2026, Guid.NewGuid(), Guid.NewGuid());
+
+    private async Task SeedPickAsync(Guid userId, Guid contestId, Guid groupId, string pickType)
+    {
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = groupId,
+            Name = "League",
+            Sport = Sport.FootballNcaa,
+            CommissionerUserId = Guid.NewGuid(),
+            PickType = pickType,
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        DataContext.UserPicks.Add(new UserPick
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ContestId = contestId,
+            PickemGroupId = groupId,
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    private async Task SeedDeviceAsync(Guid userId, bool enabled = true)
+    {
+        DataContext.UserDevices.Add(new UserDevice
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstallationId = Guid.NewGuid().ToString(),
+            FcmToken = "tok",
+            Platform = "ios",
+            NotificationsEnabled = enabled,
+            LastSeenUtc = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    private void VerifySendCount(Times times) =>
+        _pushSender.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()), times);
+
+    [Fact]
+    public async Task Consume_NoMovement_DoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -3m, oldTotal: 50m, newTotal: 50m)));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_StraightUpLeague_DoesNotNotify_EvenWhenSpreadMoves()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.StraightUp);
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_AtsLeague_SpreadMoved_Notifies()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Once());
+    }
+
+    [Fact]
+    public async Task Consume_AtsLeague_OnlyTotalMoved_DoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldTotal: 50m, newTotal: 54m)));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_OverUnderLeague_TotalMoved_Notifies()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.OverUnder);
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldTotal: 50m, newTotal: 54m)));
+
+        VerifySendCount(Times.Once());
+    }
+
+    [Fact]
+    public async Task Consume_SamePickerInTwoQualifyingLeagues_NotifiesOnce()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        // One device, one user, deduped across leagues -> a single push.
+        VerifySendCount(Times.Once());
+    }
+
+    [Fact]
+    public async Task Consume_OptedOut_DoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+        DataContext.UserNotificationPreferences.Add(new UserNotificationPreferences
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            OddsChangedEnabled = false,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_NoEnabledDevice_DoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId, enabled: false);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_MissingLeagueProjection_DoesNotNotify()
+    {
+        // Pick exists but the PickemGroup projection hasn't landed yet — the
+        // inner join drops it rather than mis-targeting.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        DataContext.UserPicks.Add(new UserPick
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ContestId = contestId,
+            PickemGroupId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Never());
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/PickemGroupCreatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/PickemGroupCreatedConsumerTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class PickemGroupCreatedConsumerTests : NotificationTestBase<PickemGroupCreatedConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    public PickemGroupCreatedConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    private static ConsumeContext<PickemGroupCreated> ContextFor(PickemGroupCreated msg)
+    {
+        var ctx = new Mock<ConsumeContext<PickemGroupCreated>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private static PickemGroupCreated Msg(
+        Guid groupId,
+        string name = "Test League",
+        string pickType = LeaguePickType.AgainstTheSpread,
+        Guid? commissionerId = null)
+        => new(groupId, name, commissionerId ?? Guid.NewGuid(), pickType,
+            null, Sport.FootballNcaa, 2026, Guid.NewGuid(), Guid.NewGuid());
+
+    [Fact]
+    public async Task Consume_InsertsProjection_WithPickType()
+    {
+        var groupId = Guid.NewGuid();
+        var commissionerId = Guid.NewGuid();
+
+        var sut = Mocker.CreateInstance<PickemGroupCreatedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, "ATS League", LeaguePickType.AgainstTheSpread, commissionerId)));
+
+        var row = await DataContext.PickemGroups.SingleAsync();
+        row.Id.Should().Be(groupId);
+        row.Name.Should().Be("ATS League");
+        row.Sport.Should().Be(Sport.FootballNcaa);
+        row.CommissionerUserId.Should().Be(commissionerId);
+        row.PickType.Should().Be(LeaguePickType.AgainstTheSpread);
+        row.CreatedUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task Consume_UpdatesPickType_WhenChanged()
+    {
+        var groupId = Guid.NewGuid();
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = groupId,
+            Name = "Test League",
+            Sport = Sport.FootballNcaa,
+            CommissionerUserId = Guid.NewGuid(),
+            PickType = LeaguePickType.StraightUp,
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<PickemGroupCreatedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, "Test League", LeaguePickType.OverUnder)));
+
+        var row = await DataContext.PickemGroups.SingleAsync();
+        row.PickType.Should().Be(LeaguePickType.OverUnder);
+        row.ModifiedUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task Consume_IsNoOp_WhenUnchanged()
+    {
+        var groupId = Guid.NewGuid();
+        var commissionerId = Guid.NewGuid();
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = groupId,
+            Name = "Test League",
+            Sport = Sport.FootballNcaa,
+            CommissionerUserId = commissionerId,
+            PickType = LeaguePickType.AgainstTheSpread,
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<PickemGroupCreatedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, "Test League", LeaguePickType.AgainstTheSpread, commissionerId)));
+
+        var row = await DataContext.PickemGroups.SingleAsync();
+        row.ModifiedUtc.Should().BeNull("an unchanged redelivery must not bump ModifiedUtc");
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickMadeConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickMadeConsumerTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class UserPickMadeConsumerTests : NotificationTestBase<UserPickMadeConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    public UserPickMadeConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    private static ConsumeContext<UserPickMade> ContextFor(UserPickMade msg)
+    {
+        var ctx = new Mock<ConsumeContext<UserPickMade>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private static UserPickMade Msg(Guid userId, Guid contestId, Guid groupId)
+        => new(userId, contestId, groupId, Sport.FootballNcaa, 2026, Guid.NewGuid(), Guid.NewGuid());
+
+    [Fact]
+    public async Task Consume_InsertsRow_WhenAbsent()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        var sut = Mocker.CreateInstance<UserPickMadeConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, contestId, groupId)));
+
+        var row = await DataContext.UserPicks.SingleAsync();
+        row.UserId.Should().Be(userId);
+        row.ContestId.Should().Be(contestId);
+        row.PickemGroupId.Should().Be(groupId);
+        row.CreatedUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task Consume_IsNoOp_WhenAlreadyProjected()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        DataContext.UserPicks.Add(new UserPick
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ContestId = contestId,
+            PickemGroupId = groupId,
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<UserPickMadeConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, contestId, groupId)));
+
+        // Still exactly one row — re-publish of the same pick is a no-op.
+        (await DataContext.UserPicks.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Consume_InsertsSeparateRows_ForSameContestDifferentLeagues()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        var sut = Mocker.CreateInstance<UserPickMadeConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, contestId, Guid.NewGuid())));
+        await sut.Consume(ContextFor(Msg(userId, contestId, Guid.NewGuid())));
+
+        (await DataContext.UserPicks.CountAsync()).Should().Be(2);
+    }
+}


### PR DESCRIPTION
## What & why

Notify users who have **already picked a contest** when the betting line moves — but only in leagues whose scoring actually depends on the odds. If you committed to a number and the market moves, you should hear about it before the contest locks. Straight-up leagues don't care about the line, so their pickers are never notified.

## Pipeline

**Core**
- New `UserPickMade` event (published when a pick is persisted).
- Reshaped `ContestOddsUpdated` to carry old/new spread + total and the odds provider.
- Added `PickType` to `PickemGroupCreated` and `PickemGroupDataPublished`, carried as a cross-service string (same lighter-coupling convention as `PickemGroupMemberSnapshot.Role`).

**API**
- `SubmitPickCommandHandler` publishes `UserPickMade` via the outbox (before `SaveChanges`).
- League create (`CreateLeagueCommandHandlerBase`) and the backfill (`PickemGroupsRequestedConsumer`) now include `PickType` on the league events.

**Notification**
- New `UserPick` projection (who picked what), fed by an idempotent `UserPickMadeConsumer`.
- `PickType` added to the `PickemGroup` projection.
- `PickemGroupCreatedConsumer` upgraded from no-op to a **race-safe upsert** so new leagues are projected at creation, not only after an operator backfill.
- New `ContestOddsUpdatedConsumer`: joins `UserPicks → PickemGroups` and targets only odds-sensitive leagues — spread move → `AgainstTheSpread`, total move → `OverUnder`, `StraightUp` never. Deduped to one push per user across leagues; picks whose league projection hasn't landed are dropped, not mis-targeted. Per-user atomic `NotificationLog` claim mirrors `UserPickScoredConsumer`.
- New `OddsChangedEnabled` notification preference (default on).

## Migrations (Notification)

Three migrations, all applied + verified locally (no model drift):
- `AddUserPickProjection` — `UserPicks` table.
- `AddOddsChangedNotificationPreference` — `OddsChangedEnabled` column (default **true**).
- `AddPickTypeToPickemGroupProjection` — `PickType` column (default **StraightUp**).

EF-generated `defaultValue` was corrected on both new columns to the safe domain defaults so existing rows don't over-notify.

## Notification copy

Title `Line moved`; body e.g. *"The spread moved on a game you picked: -3 → -6 (DraftKings)."* — easy to tweak.

## Deploy note

`UserPickMade` (API→Notification) and `ContestOddsUpdated` (Producer→Notification) are new cross-broker events; they'll need the shovel/exchange pre-declare per the per-sport RabbitMQ setup.

## Testing

- `dotnet build` clean across Core, API, Producer, Notification.
- Notification unit suite: 22 pass (15 new — odds-filter matrix, dedup, opt-out, no-device, missing-projection; pick + league-created projection).
- API unit suite: 421 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pick tracking for notifications with a new user pick projection and automatic publishing/projection of “user pick made” events.
  * Added odds-change notifications for users with enabled picks, including line-move messaging and a new opt-in toggle for odds changes.
  * Added pick-type support so notifications and pick groups behave correctly for odds-agnostic vs odds-sensitive leagues.

* **Bug Fixes**
  * Improved odds-change and pick/projection idempotency to avoid duplicate processing on replays and race conditions.

* **Tests**
  * Added/expanded unit test coverage for pickem group persistence, odds-change notification behavior, and user pick projection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->