### PR TITLE
feat(notification): league-invite push + deep-link (PR1)

### DIFF
--- a/docs/mobile/league-invite-deep-link.md
+++ b/docs/mobile/league-invite-deep-link.md
@@ -1,0 +1,125 @@
+# League Invite Push + Deep-Link
+
+Status: implemented (PR1 of the league-invite work)
+Last updated: 2026-06-30
+
+## Goal
+
+GIVEN a user is already registered on sportDeets, WHEN someone invites that
+user to a league, THEN the invitee receives a push notification whose tap
+deep-links to a **league-invite preview** with a single **Join** CTA. No
+auto-join — tapping a notification is not consent to join.
+
+This is the first notification to actually populate the FCM `data` payload and
+the first real deep-link tap handler (the broader plan lives in
+`notification-deep-linking.md`; this note covers the invite case end to end).
+
+## Scope (PR1)
+
+Triggered off the **existing email-invite path**. The current
+`SendLeagueInviteCommandHandler` sends a SendGrid template email and returns.
+PR1 adds: if the invited email belongs to a **registered user who is not
+already a member**, also publish a domain event so the Notification service can
+push. Unregistered email → email only, unchanged. Inviting by username
+(autocomplete) is a later PR and rides the same event.
+
+## Wire contract
+
+### Domain event (Core)
+
+`SportsData.Core/Eventing/Events/PickemGroups/UserInvitedToPickemGroup`:
+
+```csharp
+record UserInvitedToPickemGroup(
+    Guid InviteeUserId,
+    Guid GroupId,
+    string LeagueName,        // carried so the consumer needs no group lookup
+    Guid InvitedByUserId,
+    Sport Sport,
+    int? SeasonYear,
+    Guid CorrelationId,
+    Guid CausationId) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+```
+
+`LeagueName` rides on the event to keep the consumer free of a PickemGroup
+projection read (and the race that comes with it).
+
+### FCM `data` payload
+
+```jsonc
+{ "kind": "LeagueInvite", "target": "invite-preview", "leagueId": "<groupId>" }
+```
+
+FCM data values are strings. The picks page already resolves sport/league from
+IDs, so the payload carries IDs only — no slug, no sport/league route strings.
+
+## Backend
+
+### API — publish on registered-non-member match
+
+`SendLeagueInviteCommandHandler`, after the email send:
+
+1. Look up `User` by `command.Email`.
+2. If found AND not already a `PickemGroupMember` of the league, publish
+   `UserInvitedToPickemGroup`.
+3. Publish via `IMessageDeliveryScope.Use(DeliveryMode.Direct)` — the handler
+   has no DbContext write, so it bypasses the MassTransit outbox (same pattern
+   as `AdminController`). Unregistered / already-member → no event.
+
+### Notification — consume and push
+
+New `UserInvitedToPickemGroupConsumer`, mirroring `ContestOddsUpdatedConsumer`:
+
+- Atomic `NotificationLog` claim keyed on the unique
+  `(CorrelationId, UserId, Channel)` index, `Category = "LeagueInvite"` —
+  idempotent across redelivery.
+- `UserNotificationPreferences.LeagueInviteEnabled` gate (already exists in the
+  schema; default `true`).
+- `UserDevices` (NotificationsEnabled) → `SendAsync(token, title, body, data)`
+  with the `data` dict above. Title "You're invited", body
+  "You've been invited to {LeagueName}."
+- Registered in `Program.cs`.
+
+No new migration: `LeagueInviteEnabled` shipped in the Initial migration.
+
+## Mobile
+
+### Tap handler (`app/_layout.tsx`)
+
+Implement the `handleTap` dispatch (design-only until now). Keep the existing
+non-content breadcrumb log; add navigation:
+
+- `kind === "LeagueInvite"` → route to the invite-preview screen with
+  `leagueId`.
+- Cold-start: if the router/auth tree isn't mounted yet, stash the intended
+  route in a ref and flush once auth resolves (the
+  `useLastNotificationResponse()` race called out in `notification-deep-linking.md`).
+
+### Invite-preview screen
+
+A small screen showing league name, description, member count, and
+public/private, fetched via `GET /ui/leagues/{id}` (`LeagueDetailDto`), with
+one **Join** action. (Sport and inviter aren't on that DTO today; if the
+preview wants them later, widen the DTO or carry them on the event.)
+
+- **Join** → `joinLeague(leagueId)` → forward into that league's picks page
+  (`/(tabs)/picks?leagueId=...`), now a member so the page populates normally.
+- **Decline / close** → dismiss; no state change.
+
+Keeping membership acquisition on this screen leaves `picks.tsx` free of
+half-membership states.
+
+## Tests
+
+- API: publishes `UserInvitedToPickemGroup` on a registered-email, non-member
+  match; no publish for an unregistered email; no publish when the email is
+  already a member.
+- Notification: claim/dedupe on redelivery; suppress on `LeagueInviteEnabled =
+  false`; suppress on no device; sends with the `data` payload populated.
+
+## Out of scope (later PRs)
+
+- **Unique-username foundation** + **invite-by-username autocomplete** on the
+  league overview (web + mobile). Both reuse this same event and consumer.
+- Persisting `PickemGroupInvitation` rows / an in-app invite inbox. PR1 stays
+  fire-and-notify; the entity exists but is still unused.

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommand.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommand.cs
@@ -5,4 +5,5 @@ public class SendLeagueInviteCommand
     public required Guid LeagueId { get; init; }
     public required string Email { get; init; }
     public string? InviteeName { get; init; }
+    public required Guid InvitedByUserId { get; init; }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandler.cs
@@ -86,28 +86,43 @@ public class SendLeagueInviteCommandHandler : ISendLeagueInviteCommandHandler
 
             if (!alreadyMember)
             {
+                // Best-effort: the invite email has already been sent (and is
+                // non-idempotent — a retry re-sends it), so a broker outage must
+                // not fail the request. Swallow + log publish errors; losing the
+                // push is acceptable, re-emailing on retry is not.
+                //
                 // No DbContext write here, so bypass the MassTransit outbox and
                 // publish straight to the broker (UseBusOutbox would otherwise
                 // require a SaveChangesAsync to flush, which we have nothing to
                 // save).
-                using (_deliveryScope.Use(DeliveryMode.Direct))
+                try
                 {
-                    await _eventBus.Publish(
-                        new UserInvitedToPickemGroup(
-                            InviteeUserId: invitee.Id,
-                            GroupId: league.Id,
-                            LeagueName: league.Name,
-                            InvitedByUserId: command.InvitedByUserId,
-                            Sport: league.Sport,
-                            SeasonYear: null,
-                            CorrelationId: Guid.NewGuid(),
-                            CausationId: Guid.NewGuid()),
-                        cancellationToken);
-                }
+                    using (_deliveryScope.Use(DeliveryMode.Direct))
+                    {
+                        await _eventBus.Publish(
+                            new UserInvitedToPickemGroup(
+                                InviteeUserId: invitee.Id,
+                                GroupId: league.Id,
+                                LeagueName: league.Name,
+                                InvitedByUserId: command.InvitedByUserId,
+                                Sport: league.Sport,
+                                SeasonYear: null,
+                                CorrelationId: Guid.NewGuid(),
+                                CausationId: Guid.NewGuid()),
+                            cancellationToken);
+                    }
 
-                _logger.LogInformation(
-                    "Published UserInvitedToPickemGroup for registered invitee. LeagueId={LeagueId}, InviteeUserId={InviteeUserId}",
-                    league.Id, invitee.Id);
+                    _logger.LogInformation(
+                        "Published UserInvitedToPickemGroup for registered invitee. LeagueId={LeagueId}, InviteeUserId={InviteeUserId}",
+                        league.Id, invitee.Id);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Failed to publish UserInvitedToPickemGroup; invite email already sent so continuing. LeagueId={LeagueId}, InviteeUserId={InviteeUserId}",
+                        league.Id, invitee.Id);
+                }
             }
         }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandler.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Options;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Infrastructure.Notifications;
 using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
 
 using SportsData.Api.Application.Common.Enums;
 
@@ -21,15 +23,24 @@ public class SendLeagueInviteCommandHandler : ISendLeagueInviteCommandHandler
     private readonly AppDataContext _dbContext;
     private readonly INotificationService _notificationService;
     private readonly NotificationConfig _notificationConfig;
+    private readonly IEventBus _eventBus;
+    private readonly IMessageDeliveryScope _deliveryScope;
+    private readonly ILogger<SendLeagueInviteCommandHandler> _logger;
 
     public SendLeagueInviteCommandHandler(
         AppDataContext dbContext,
         INotificationService notificationService,
-        IOptions<NotificationConfig> notificationConfig)
+        IOptions<NotificationConfig> notificationConfig,
+        IEventBus eventBus,
+        IMessageDeliveryScope deliveryScope,
+        ILogger<SendLeagueInviteCommandHandler> logger)
     {
         _dbContext = dbContext;
         _notificationService = notificationService;
         _notificationConfig = notificationConfig.Value;
+        _eventBus = eventBus;
+        _deliveryScope = deliveryScope;
+        _logger = logger;
     }
 
     public async Task<Result<bool>> ExecuteAsync(
@@ -58,6 +69,47 @@ public class SendLeagueInviteCommandHandler : ISendLeagueInviteCommandHandler
                 leagueName = league.Name,
                 joinUrl = inviteUrl
             });
+
+        // If the invited email belongs to a registered user who isn't already a
+        // member, also announce the invite so the Notification service can push
+        // a deep-link to the league-invite preview. Unregistered email →
+        // email-only, unchanged.
+        var invitee = await _dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Email == command.Email, cancellationToken);
+
+        if (invitee is not null)
+        {
+            var alreadyMember = await _dbContext.PickemGroupMembers
+                .AsNoTracking()
+                .AnyAsync(m => m.PickemGroupId == league.Id && m.UserId == invitee.Id, cancellationToken);
+
+            if (!alreadyMember)
+            {
+                // No DbContext write here, so bypass the MassTransit outbox and
+                // publish straight to the broker (UseBusOutbox would otherwise
+                // require a SaveChangesAsync to flush, which we have nothing to
+                // save).
+                using (_deliveryScope.Use(DeliveryMode.Direct))
+                {
+                    await _eventBus.Publish(
+                        new UserInvitedToPickemGroup(
+                            InviteeUserId: invitee.Id,
+                            GroupId: league.Id,
+                            LeagueName: league.Name,
+                            InvitedByUserId: command.InvitedByUserId,
+                            Sport: league.Sport,
+                            SeasonYear: null,
+                            CorrelationId: Guid.NewGuid(),
+                            CausationId: Guid.NewGuid()),
+                        cancellationToken);
+                }
+
+                _logger.LogInformation(
+                    "Published UserInvitedToPickemGroup for registered invitee. LeagueId={LeagueId}, InviteeUserId={InviteeUserId}",
+                    league.Id, invitee.Id);
+            }
+        }
 
         return new Success<bool>(true);
     }

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -199,7 +199,8 @@ public class LeagueController : ApiControllerBase
         {
             LeagueId = id,
             Email = request.Email,
-            InviteeName = request.InviteeName
+            InviteeName = request.InviteeName,
+            InvitedByUserId = HttpContext.GetCurrentUserId()
         };
 
         var result = await handler.ExecuteAsync(command, cancellationToken);

--- a/src/SportsData.Core/Eventing/Events/PickemGroups/UserInvitedToPickemGroup.cs
+++ b/src/SportsData.Core/Eventing/Events/PickemGroups/UserInvitedToPickemGroup.cs
@@ -1,0 +1,29 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.PickemGroups
+{
+    /// <summary>
+    /// A registered user was invited to a league. Published by the API when an
+    /// invite (today: the email path) resolves to an existing user who is not
+    /// already a member, so the Notification service can push an invite with a
+    /// deep-link to the league-invite preview.
+    ///
+    /// <para>
+    /// <c>LeagueName</c> rides on the event so the consumer needs no PickemGroup
+    /// projection read (and dodges the race of that projection not having landed
+    /// yet). Inviting by username (autocomplete) will publish this same event.
+    /// </para>
+    /// </summary>
+    public record UserInvitedToPickemGroup(
+        Guid InviteeUserId,
+        Guid GroupId,
+        string LeagueName,
+        Guid InvitedByUserId,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/UserInvitedToPickemGroupConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserInvitedToPickemGroupConsumer.cs
@@ -1,0 +1,155 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// A registered user was invited to a league. Push an invite whose tap
+    /// deep-links to the league-invite preview (league name + Join CTA). The
+    /// API only publishes this for an existing, non-member invitee, so there's
+    /// no membership re-check here — just dispatch.
+    ///
+    /// <para>
+    /// First notification to populate the FCM <c>data</c> payload. The mobile
+    /// tap handler dispatches on <c>kind</c>; <c>leagueId</c> drives the
+    /// preview + subsequent join. See
+    /// <c>docs/mobile/league-invite-deep-link.md</c>.
+    /// </para>
+    ///
+    /// <para>
+    /// Single-recipient dispatch mirrors <see cref="ContestOddsUpdatedConsumer"/>:
+    /// atomic NotificationLog claim on the unique
+    /// <c>(CorrelationId, UserId, Channel)</c> index (idempotent across
+    /// redelivery) → prefs → devices → send → terminal update.
+    /// </para>
+    /// </summary>
+    public class UserInvitedToPickemGroupConsumer : IConsumer<UserInvitedToPickemGroup>
+    {
+        private readonly ILogger<UserInvitedToPickemGroupConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IPushNotificationSender _pushSender;
+
+        public UserInvitedToPickemGroupConsumer(
+            ILogger<UserInvitedToPickemGroupConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider,
+            IPushNotificationSender pushSender)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+            _pushSender = pushSender;
+        }
+
+        public async Task Consume(ConsumeContext<UserInvitedToPickemGroup> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["GroupId"] = msg.GroupId,
+                ["InviteeUserId"] = msg.InviteeUserId
+            });
+
+            _logger.LogInformation("UserInvitedToPickemGroup received.");
+
+            // Atomic claim keyed on (CorrelationId, UserId, Channel): idempotent
+            // across redelivery of the same invite.
+            var claim = new NotificationLog
+            {
+                UserId = msg.InviteeUserId,
+                CorrelationId = msg.CorrelationId,
+                Category = "LeagueInvite",
+                Channel = "Fcm",
+                Result = "Dispatching",
+                AttemptedUtc = _dateTimeProvider.UtcNow()
+            };
+            _dataContext.NotificationLog.Add(claim);
+
+            try
+            {
+                await _dataContext.SaveChangesAsync(context.CancellationToken);
+            }
+            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+            {
+                // Already claimed by a prior attempt. Skip unconditionally —
+                // including a stale "Dispatching" row from a crash — for the same
+                // deliberate v1 reason as the other consumers: a missing
+                // notification beats a duplicate. Stale rows are a future cleanup
+                // job, not recovered here.
+                _logger.LogInformation(
+                    "League-invite notification already claimed for CorrelationId {CorrelationId}, UserId {UserId}; skipping.",
+                    msg.CorrelationId, msg.InviteeUserId);
+                _dataContext.Entry(claim).State = EntityState.Detached;
+                return;
+            }
+
+            var prefs = await _dataContext.UserNotificationPreferences
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.UserId == msg.InviteeUserId, context.CancellationToken);
+
+            if (prefs is { LeagueInviteEnabled: false })
+            {
+                await FinalizeAsync(claim, "Suppressed_UserOptedOut", context.CancellationToken);
+                return;
+            }
+
+            var devices = await _dataContext.UserDevices
+                .AsNoTracking()
+                .Where(d => d.UserId == msg.InviteeUserId && d.NotificationsEnabled)
+                .ToListAsync(context.CancellationToken);
+
+            if (devices.Count == 0)
+            {
+                await FinalizeAsync(claim, "Suppressed_NoDevice", context.CancellationToken);
+                return;
+            }
+
+            var title = "You're invited";
+            var body = $"You've been invited to {msg.LeagueName}.";
+            var data = new Dictionary<string, string>
+            {
+                ["kind"] = "LeagueInvite",
+                ["target"] = "invite-preview",
+                ["leagueId"] = msg.GroupId.ToString()
+            };
+
+            var successCount = 0;
+            foreach (var device in devices)
+            {
+                var result = await _pushSender.SendAsync(
+                    device.FcmToken, title, body, data, context.CancellationToken);
+                if (result is Success<string>)
+                    successCount++;
+            }
+
+            claim.Title = title;
+            claim.Body = body;
+            claim.Result = successCount > 0 ? "Sent" : "Failed_FcmError";
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+            await _dataContext.SaveChangesAsync(context.CancellationToken);
+        }
+
+        private async Task FinalizeAsync(NotificationLog claim, string result, CancellationToken cancellationToken)
+        {
+            claim.Result = result;
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+            await _dataContext.SaveChangesAsync(cancellationToken);
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -47,6 +47,7 @@ namespace SportsData.Notification
                 typeof(UserDataPublishedConsumer),
                 typeof(UserDeviceRegisteredConsumer),
                 typeof(UserDeviceUnregisteredConsumer),
+                typeof(UserInvitedToPickemGroupConsumer),
                 typeof(UserPickMadeConsumer),
                 typeof(UserPickScoredConsumer)
             ]);

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -15,7 +15,7 @@ import { Poppins_400Regular, Poppins_700Bold_Italic } from '@expo-google-fonts/p
 import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Notifications from 'expo-notifications';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Platform } from 'react-native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react-native';
@@ -141,10 +141,10 @@ function RootLayout() {
 export default Sentry.wrap(RootLayout);
 
 /**
- * Native-only push notification receive + tap diagnostics. v1 just
- * logs — actual deep-link routing (notification → /(tabs)/picks?
- * leagueId=…&contestId=…) lands in a follow-up once the test-push
- * round-trip is proven.
+ * Native-only push notification receive + tap handling. Logs a privacy-safe
+ * breadcrumb and dispatches deep-links by notification "kind". The first
+ * wired kind is LeagueInvite → the league-invite preview (see
+ * docs/mobile/league-invite-deep-link.md).
  *
  * Cold-start coverage: useLastNotificationResponse resolves to the
  * response that launched the app when the user tapped a notification
@@ -155,6 +155,12 @@ export default Sentry.wrap(RootLayout);
  * against any later listener delivery of the same response so the tap
  * handler doesn't run twice for a single user action.
  *
+ * Navigation is deferred through pendingLeagueId rather than fired inline:
+ * on cold start the launching tap can resolve before AuthGuard has settled
+ * the initial route, so a direct router.push would race (and lose to) the
+ * sign-in redirect. The auth-gated effect below flushes the route once the
+ * user is authenticated and the nav tree is mounted.
+ *
  * Rendered only when Platform.OS !== 'web' (see RootLayoutNav). The
  * hooks here all touch expo-notifications native modules that aren't
  * implemented on web.
@@ -162,26 +168,35 @@ export default Sentry.wrap(RootLayout);
 function NativePushDiagnostics() {
   const lastResponse = Notifications.useLastNotificationResponse();
   const handledTapIdsRef = useRef<Set<string>>(new Set());
+  const router = useRouter();
+  const { user, isInitialized } = useAuth();
+  const [pendingLeagueId, setPendingLeagueId] = useState<string | null>(null);
 
   useEffect(() => {
     // Privacy: log only non-content fields. console.log feeds Sentry
     // breadcrumbs through Sentry's console integration, so anything we
     // emit here ships with crash reports. notification title / body /
-    // arbitrary data payload may carry user-specific content (future
-    // LeagueInvite / CommissionerAnnouncement kinds, contestId /
-    // leagueId UUIDs tied to the recipient). The notification
-    // identifier is a system-generated UUID — anonymous on its own —
-    // and "kind" is a category label from our wire contract, not user
-    // state. Keep both for correlation, drop the rest.
+    // arbitrary data payload may carry user-specific content (LeagueInvite
+    // leagueId, future contestId UUIDs tied to the recipient). The
+    // notification identifier is a system-generated UUID — anonymous on
+    // its own — and "kind" is a category label from our wire contract, not
+    // user state. Keep both for correlation, drop the rest.
     const handleTap = (response: Notifications.NotificationResponse) => {
       const id = response.notification.request.identifier;
       if (handledTapIdsRef.current.has(id)) return;
       handledTapIdsRef.current.add(id);
+      const data = response.notification.request.content.data ?? {};
       console.log('[push] tapped', {
         id,
-        kind: response.notification.request.content.data?.kind,
+        kind: data.kind,
         actionIdentifier: response.actionIdentifier,
       });
+
+      // Deep-link dispatch. Stash the target; the auth-gated effect below
+      // navigates once the router/auth tree is ready.
+      if (data.kind === 'LeagueInvite' && typeof data.leagueId === 'string') {
+        setPendingLeagueId(data.leagueId);
+      }
     };
 
     if (lastResponse) {
@@ -200,6 +215,18 @@ function NativePushDiagnostics() {
       responseSub.remove();
     };
   }, [lastResponse]);
+
+  // Flush a pending deep-link once the user is authenticated and the nav
+  // tree is ready — guards the cold-start race described above.
+  useEffect(() => {
+    if (!pendingLeagueId || !isInitialized || !user) return;
+    const leagueId = pendingLeagueId;
+    setPendingLeagueId(null);
+    router.push({
+      pathname: '/league-invite/[leagueId]',
+      params: { leagueId },
+    } as never);
+  }, [pendingLeagueId, isInitialized, user, router]);
 
   return null;
 }
@@ -235,6 +262,7 @@ function RootLayoutNav() {
         <Stack.Screen name="(auth)" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="create-league" options={{ presentation: 'modal' }} />
+        <Stack.Screen name="league-invite/[leagueId]" options={{ presentation: 'modal' }} />
         <Stack.Screen name="admin/push-token" options={{ title: 'Push Token' }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -169,6 +169,7 @@ function NativePushDiagnostics() {
   const lastResponse = Notifications.useLastNotificationResponse();
   const handledTapIdsRef = useRef<Set<string>>(new Set());
   const router = useRouter();
+  const segments = useSegments();
   const { user, isInitialized } = useAuth();
   const [pendingLeagueId, setPendingLeagueId] = useState<string | null>(null);
 
@@ -217,16 +218,22 @@ function NativePushDiagnostics() {
   }, [lastResponse]);
 
   // Flush a pending deep-link once the user is authenticated and the nav
-  // tree is ready — guards the cold-start race described above.
+  // tree is ready — guards the cold-start race described above. Also wait
+  // until AuthGuard has finished leaving the (auth) group: while the user is
+  // still in (auth) right after sign-in, AuthGuard's router.replace('/(tabs)')
+  // fires on the same render and would clobber our push. segments is the same
+  // signal AuthGuard keys off, so once it's no longer '(auth)' the redirect
+  // has settled. Keep pendingLeagueId cached until then.
   useEffect(() => {
     if (!pendingLeagueId || !isInitialized || !user) return;
+    if (segments[0] === '(auth)') return;
     const leagueId = pendingLeagueId;
     setPendingLeagueId(null);
     router.push({
       pathname: '/league-invite/[leagueId]',
       params: { leagueId },
     } as never);
-  }, [pendingLeagueId, isInitialized, user, router]);
+  }, [pendingLeagueId, isInitialized, user, router, segments]);
 
   return null;
 }

--- a/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { View, StyleSheet, ScrollView, ActivityIndicator } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { Text } from '@/src/components/ui/AppText';
+import { Button } from '@/src/components/ui/Button';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { leaguesApi } from '@/src/services/api/leaguesApi';
+import { standingsKeys } from '@/src/hooks/useStandings';
+
+/**
+ * League-invite preview. Reached by tapping a LeagueInvite push (see
+ * docs/mobile/league-invite-deep-link.md). Shows the league and a single Join
+ * CTA — tapping a notification is not consent to join. On Join we add the user
+ * to the league, refresh /user/me so the league is in their list, then forward
+ * into that league's picks page. Dismiss just closes with no state change.
+ */
+export default function LeagueInviteScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { leagueId } = useLocalSearchParams<{ leagueId?: string }>();
+
+  const {
+    data: league,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['league', leagueId],
+    enabled: !!leagueId,
+    queryFn: async () => (await leaguesApi.getLeagueById(leagueId!)).data,
+  });
+
+  const joinMutation = useMutation({
+    mutationFn: () => leaguesApi.joinLeague(leagueId!),
+    onSuccess: async () => {
+      // Refresh /user/me so the just-joined league appears in the leagues
+      // list the picks screen selects from.
+      await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
+      router.replace({ pathname: '/(tabs)/picks', params: { leagueId } } as never);
+    },
+  });
+
+  const dismiss = () => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/(tabs)' as never);
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <Stack.Screen options={{ title: 'League Invite', presentation: 'modal' }} />
+
+      <ScrollView contentContainerStyle={styles.content}>
+        {isLoading ? (
+          <ActivityIndicator color={theme.tint} style={styles.spinner} />
+        ) : isError || !league ? (
+          <View style={styles.centered}>
+            <Text style={[styles.title, { color: theme.text }]}>
+              Invite unavailable
+            </Text>
+            <Text style={[styles.subtitle, { color: theme.textMuted }]}>
+              This invite couldn&apos;t be loaded. It may have been revoked.
+            </Text>
+            <Button title="Close" variant="secondary" onPress={dismiss} />
+          </View>
+        ) : (
+          <>
+            <Text style={[styles.kicker, { color: theme.textMuted }]}>
+              You&apos;ve been invited to
+            </Text>
+            <Text style={[styles.title, { color: theme.text }]}>{league.name}</Text>
+
+            {league.description ? (
+              <Text style={[styles.subtitle, { color: theme.textMuted }]}>
+                {league.description}
+              </Text>
+            ) : null}
+
+            <View style={[styles.metaCard, { backgroundColor: theme.card, borderColor: theme.border }]}>
+              <Text style={[styles.metaRow, { color: theme.text }]}>
+                {league.members.length}{' '}
+                {league.members.length === 1 ? 'member' : 'members'}
+              </Text>
+              <Text style={[styles.metaRow, { color: theme.textMuted }]}>
+                {league.isPublic ? 'Public league' : 'Private league'}
+              </Text>
+            </View>
+
+            <View style={styles.actions}>
+              <Button
+                title={joinMutation.isPending ? 'Joining…' : 'Join League'}
+                onPress={() => joinMutation.mutate()}
+                loading={joinMutation.isPending}
+              />
+              <Button title="Not now" variant="ghost" onPress={dismiss} />
+            </View>
+
+            {joinMutation.isError ? (
+              <Text style={[styles.errorText, { color: theme.error }]}>
+                Couldn&apos;t join the league. Please try again.
+              </Text>
+            ) : null}
+          </>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 24, gap: 12 },
+  centered: { gap: 12, alignItems: 'center', marginTop: 48 },
+  spinner: { marginTop: 64 },
+  kicker: { fontSize: 14, textTransform: 'uppercase', letterSpacing: 1 },
+  title: { fontSize: 26, fontWeight: '700' },
+  subtitle: { fontSize: 15, lineHeight: 21 },
+  metaCard: { borderWidth: 1, borderRadius: 12, padding: 16, gap: 6, marginTop: 8 },
+  metaRow: { fontSize: 15 },
+  actions: { gap: 10, marginTop: 16 },
+  errorText: { fontSize: 14, marginTop: 8 },
+});

--- a/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
@@ -10,6 +10,11 @@ import { getTheme } from '@/constants/Colors';
 import { leaguesApi } from '@/src/services/api/leaguesApi';
 import { standingsKeys } from '@/src/hooks/useStandings';
 
+// League ids are GUIDs. Used to reject malformed/array-like route params
+// before any request is built.
+const GUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 /**
  * League-invite preview. Reached by tapping a LeagueInvite push (see
  * docs/mobile/league-invite-deep-link.md). Shows the league and a single Join
@@ -22,7 +27,15 @@ export default function LeagueInviteScreen() {
   const theme = getTheme(scheme);
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { leagueId } = useLocalSearchParams<{ leagueId?: string }>();
+  const params = useLocalSearchParams<{ leagueId?: string | string[] }>();
+  // Route params can arrive as undefined or an array (duplicate keys); only a
+  // single, GUID-shaped string is a real league id. Anything else stays
+  // undefined, which disables the query (so league is never populated) and
+  // renders the existing "Invite unavailable" path — no API request is built.
+  const leagueId =
+    typeof params.leagueId === 'string' && GUID_RE.test(params.leagueId)
+      ? params.leagueId
+      : undefined;
 
   const {
     data: league,

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -50,6 +50,22 @@ export interface CreateLeagueResponse {
   id: string;
 }
 
+export interface LeagueMember {
+  userId: string;
+  username: string;
+  role: string;
+}
+
+// Subset of the BE LeagueDetailDto the invite preview needs.
+export interface LeagueDetail {
+  id: string;
+  name: string;
+  description: string | null;
+  pickType: PickType;
+  isPublic: boolean;
+  members: LeagueMember[];
+}
+
 export const leaguesApi = {
   // POST /ui/leagues/football/ncaa
   createFootballNcaaLeague: (payload: CreateFootballNcaaLeagueRequest) =>
@@ -62,4 +78,12 @@ export const leaguesApi = {
   // POST /ui/leagues/baseball/mlb — admin-gated on the BE.
   createBaseballMlbLeague: (payload: CreateBaseballMlbLeagueRequest) =>
     apiClient.post<CreateLeagueResponse>('/ui/leagues/baseball/mlb', payload),
+
+  // GET /ui/leagues/{id} — league detail for the invite preview.
+  getLeagueById: (id: string) =>
+    apiClient.get<LeagueDetail>(`/ui/leagues/${id}`),
+
+  // POST /ui/leagues/{id}/join — join a league by id.
+  joinLeague: (id: string) =>
+    apiClient.post<void>(`/ui/leagues/${id}/join`),
 };

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
@@ -103,13 +103,14 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
     {
         var league = await SeedLeagueAsync();
         var invitee = await SeedUserAsync("friend@x.com");
+        var invitedBy = Guid.NewGuid();
         var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
 
         var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
         {
             LeagueId = league.Id,
             Email = "friend@x.com",
-            InvitedByUserId = Guid.NewGuid()
+            InvitedByUserId = invitedBy
         });
 
         result.IsSuccess.Should().BeTrue();
@@ -118,7 +119,10 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
                 It.Is<UserInvitedToPickemGroup>(e =>
                     e.InviteeUserId == invitee.Id &&
                     e.GroupId == league.Id &&
-                    e.LeagueName == league.Name),
+                    e.LeagueName == league.Name &&
+                    e.InvitedByUserId == invitedBy &&
+                    e.Sport == league.Sport &&
+                    e.SeasonYear == null),
                 It.IsAny<CancellationToken>()),
             Times.Once());
     }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using SportsData.Api.Application.UI.Leagues.Commands.SendLeagueInvite;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Api.Infrastructure.Notifications;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Commands.SendLeagueInvite;
+
+public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteCommandHandler>
+{
+    public SendLeagueInviteCommandHandlerTests()
+    {
+        Mocker.Use<IOptions<NotificationConfig>>(Options.Create(new NotificationConfig
+        {
+            Email = new NotificationConfig.EmailConfig
+            {
+                ApiKey = "key",
+                FromEmail = "no-reply@sportdeets.com",
+                TemplateIdInvitation = "tmpl",
+                UrlBase = "www.sportdeets.com"
+            }
+        }));
+    }
+
+    private async Task<PickemGroup> SeedLeagueAsync()
+    {
+        var league = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Saturday Smackdown",
+            Sport = Sport.FootballNcaa,
+            League = SportsData.Api.Application.Common.Enums.League.NCAAF
+        };
+        await DataContext.PickemGroups.AddAsync(league);
+        await DataContext.SaveChangesAsync();
+        return league;
+    }
+
+    private async Task<SportsData.Api.Infrastructure.Data.Entities.User> SeedUserAsync(string email)
+    {
+        var user = new SportsData.Api.Infrastructure.Data.Entities.User
+        {
+            Id = Guid.NewGuid(),
+            FirebaseUid = Guid.NewGuid().ToString(),
+            Email = email,
+            SignInProvider = "password",
+            DisplayName = "Invitee"
+        };
+        await DataContext.Users.AddAsync(user);
+        await DataContext.SaveChangesAsync();
+        return user;
+    }
+
+    private void VerifyPublish(Times times) =>
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.IsAny<UserInvitedToPickemGroup>(), It.IsAny<CancellationToken>()), times);
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNotFound_WhenLeagueMissing()
+    {
+        var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
+
+        var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
+        {
+            LeagueId = Guid.NewGuid(),
+            Email = "nobody@x.com",
+            InvitedByUserId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        VerifyPublish(Times.Never());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnregisteredEmail_SendsEmailOnly_NoEvent()
+    {
+        var league = await SeedLeagueAsync();
+        var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
+
+        var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
+        {
+            LeagueId = league.Id,
+            Email = "stranger@x.com",
+            InvitedByUserId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        VerifyPublish(Times.Never());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RegisteredNonMember_PublishesInviteEvent()
+    {
+        var league = await SeedLeagueAsync();
+        var invitee = await SeedUserAsync("friend@x.com");
+        var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
+
+        var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
+        {
+            LeagueId = league.Id,
+            Email = "friend@x.com",
+            InvitedByUserId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(
+                It.Is<UserInvitedToPickemGroup>(e =>
+                    e.InviteeUserId == invitee.Id &&
+                    e.GroupId == league.Id &&
+                    e.LeagueName == league.Name),
+                It.IsAny<CancellationToken>()),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RegisteredButAlreadyMember_NoEvent()
+    {
+        var league = await SeedLeagueAsync();
+        var invitee = await SeedUserAsync("member@x.com");
+        await DataContext.PickemGroupMembers.AddAsync(new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = league.Id,
+            UserId = invitee.Id
+        });
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
+
+        var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
+        {
+            LeagueId = league.Id,
+            Email = "member@x.com",
+            InvitedByUserId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        VerifyPublish(Times.Never());
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserInvitedToPickemGroupConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserInvitedToPickemGroupConsumerTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class UserInvitedToPickemGroupConsumerTests : NotificationTestBase<UserInvitedToPickemGroupConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 30, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IPushNotificationSender> _pushSender;
+
+    public UserInvitedToPickemGroupConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+
+        _pushSender = Mocker.GetMock<IPushNotificationSender>();
+        _pushSender
+            .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<string>("msg-id"));
+    }
+
+    private static ConsumeContext<UserInvitedToPickemGroup> ContextFor(UserInvitedToPickemGroup msg)
+    {
+        var ctx = new Mock<ConsumeContext<UserInvitedToPickemGroup>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private static UserInvitedToPickemGroup Msg(Guid inviteeUserId, Guid groupId)
+        => new(inviteeUserId, groupId, "Saturday Smackdown", Guid.NewGuid(),
+            Sport.FootballNcaa, 2026, Guid.NewGuid(), Guid.NewGuid());
+
+    private async Task SeedDeviceAsync(Guid userId, bool enabled = true)
+    {
+        DataContext.UserDevices.Add(new UserDevice
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstallationId = Guid.NewGuid().ToString(),
+            FcmToken = "tok",
+            Platform = "ios",
+            NotificationsEnabled = enabled,
+            LastSeenUtc = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    private void VerifySendCount(Times times) =>
+        _pushSender.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()), times);
+
+    [Fact]
+    public async Task Consume_RegisteredInviteeWithDevice_Notifies()
+    {
+        var userId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<UserInvitedToPickemGroupConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, Guid.NewGuid())));
+
+        VerifySendCount(Times.Once());
+    }
+
+    [Fact]
+    public async Task Consume_OptedOut_DoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+        DataContext.UserNotificationPreferences.Add(new UserNotificationPreferences
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            LeagueInviteEnabled = false,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<UserInvitedToPickemGroupConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, Guid.NewGuid())));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_NoEnabledDevice_DoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        await SeedDeviceAsync(userId, enabled: false);
+
+        var sut = Mocker.CreateInstance<UserInvitedToPickemGroupConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, Guid.NewGuid())));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_PopulatesDeepLinkDataPayload()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+
+        IReadOnlyDictionary<string, string> captured = null;
+        _pushSender
+            .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, IReadOnlyDictionary<string, string>, CancellationToken>(
+                (_, _, _, data, _) => captured = data)
+            .ReturnsAsync(new Success<string>("msg-id"));
+
+        var sut = Mocker.CreateInstance<UserInvitedToPickemGroupConsumer>();
+        await sut.Consume(ContextFor(Msg(userId, groupId)));
+
+        captured.Should().NotBeNull();
+        captured["kind"].Should().Be("LeagueInvite");
+        captured["target"].Should().Be("invite-preview");
+        captured["leagueId"].Should().Be(groupId.ToString());
+    }
+}


### PR DESCRIPTION
## Summary

PR1 of the league-invite work: when someone invites a **registered** user to a league, the invitee gets a push notification whose tap deep-links to a **league-invite preview** with an explicit **Join** CTA. No auto-join — tapping a notification is not consent to join.

Triggered off the **existing email-invite path** (no UI change required to ship this): if the invited email belongs to a registered user who isn't already a member, the API publishes a domain event the Notification service turns into a push. Unregistered / already-member → email-only, unchanged.

This is the first notification to populate the FCM `data` payload and the first real deep-link tap handler. Design note: `docs/mobile/league-invite-deep-link.md`.

## Changes

**Core**
- New `UserInvitedToPickemGroup` event (carries `LeagueName` so the consumer needs no group projection read).

**API**
- `SendLeagueInviteCommandHandler` looks up the invited email; registered non-member → direct-publish the event (outbox bypass, no DbContext write).
- Add `InvitedByUserId` to the command, sourced from the JWT in the controller.

**Notification**
- `UserInvitedToPickemGroupConsumer`: atomic `NotificationLog` claim → `LeagueInviteEnabled` gate → devices → push with `data { kind:LeagueInvite, target:invite-preview, leagueId }`. Registered in `Program.cs`. **No migration** — `LeagueInviteEnabled` already shipped in the Initial migration.

**Mobile**
- `leaguesApi`: `getLeagueById` + `joinLeague` (+ `LeagueDetail` type).
- New `app/league-invite/[leagueId].tsx` preview screen; Join → `joinLeague` → invalidate `/user/me` → forward to `picks?leagueId`.
- `_layout.tsx` tap handler dispatches `kind:LeagueInvite` to the preview, deferred through `pendingLeagueId` to dodge the cold-start auth-redirect race; screen registered as a modal.

## Testing
- Notification consumer suite (4) + API handler suite (4) — all pass.
- Core / API / Notification build clean; mobile `tsc --noEmit` clean.
- Locally validated by author.

> Note: a pre-existing flaky test (`DisplayNameGeneratorTests.Should_Generate_Unique_DisplayNames`, random-sample collision) is unrelated to this PR.

## Follow-ups (separate PRs)
- **PR-A:** unique-username foundation (column + backfill + collision handling + profile UI).
- **PR2:** invite-by-username autocomplete on the league overview — reuses this same event + consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added league invite deep-link support from push notification to a new invite preview screen.
  * Users can review league details and join directly from the invite flow.

* **Bug Fixes**
  * Invite notifications now only send to eligible recipients and respect notification preferences and available devices.
  * Tap handling now waits for sign-in state before opening the invite screen, improving reliability on app launch.

* **Tests**
  * Added coverage for invite event publishing, notification delivery, opt-out handling, and deep-link payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->