### PR TITLE
feat(api): unique username foundation (PR-A)

### DIFF
--- a/docs/username-identity-foundation.md
+++ b/docs/username-identity-foundation.md
@@ -20,7 +20,7 @@ PR2 (invite-by-username autocomplete) builds on it.
 
 ## Model
 
-```
+```text
 User (API, canonical):
   Username     string, required, UNIQUE (case-insensitive), 3–30, [a-z0-9_]
   DisplayName  string, required, NON-unique   (unchanged)
@@ -54,7 +54,7 @@ unique constraint can't be switched on directly. Three-step migration:
 
 ### Seed algorithm (per user)
 
-```
+```text
 seed = localPart(email)                 // text before '@'
 seed = lower(seed)
 seed = stripFrom('+', seed)             // drop plus-addressing tag

--- a/docs/username-identity-foundation.md
+++ b/docs/username-identity-foundation.md
@@ -1,0 +1,116 @@
+# Unique Username Foundation
+
+Status: design (PR-A of the username work)
+Last updated: 2026-06-30
+
+## Why
+
+Today `User.DisplayName` does double duty: it's the auto-generated handle
+(`clever_clam` via `DisplayNameGenerator`) **and** a user-settable free-text
+label, and it is **not unique**. We want to split those jobs:
+
+- **`Username`** — a stable, unique, lowercase handle (`jrandallsexton`) used
+  for search, invite-by-username (PR2), and any future @-mention.
+- **`DisplayName`** — unchanged role: a mutable, free-text label a user can set
+  to whatever they like (`YouWillAllLose`). Stays non-unique.
+
+This PR (PR-A) is the foundation: add `Username`, backfill every existing user
+with a unique value, enforce uniqueness, and give users a place to view/edit it.
+PR2 (invite-by-username autocomplete) builds on it.
+
+## Model
+
+```
+User (API, canonical):
+  Username     string, required, UNIQUE (case-insensitive), 3–30, [a-z0-9_]
+  DisplayName  string, required, NON-unique   (unchanged)
+```
+
+### Username rules
+
+- Charset `[a-z0-9_]`; length 3–30; stored lowercased.
+- **Case-insensitive uniqueness** — `JRandall` and `jrandall` collide. Enforced
+  by a unique index on a normalized (lowercased) value; simplest is to store
+  `Username` already-lowercased and index it directly.
+- Reserved-word blocklist (`admin`, `api`, `support`, `root`, `sportdeets`, …)
+  to keep impersonation/route-collision handles out.
+- Mutable. (Rate-limiting / username-history is out of scope for PR-A.)
+
+### Username vs DisplayName — surface mapping
+
+- **DisplayName** shows in leaderboards, standings, league-member lists — the
+  places that render `m.User.DisplayName` today (no change).
+- **Username** is the identity handle: PR2 invite autocomplete, search, future
+  @-mentions. Profile screens show both ("@username" + display label).
+
+## Backfill (the load-bearing part)
+
+Existing rows have no `Username` and `DisplayName` collisions exist, so the
+unique constraint can't be switched on directly. Three-step migration:
+
+1. Add **nullable** `Username` column (no constraint yet).
+2. **Backfill** every user with a unique value (data step, below).
+3. Add the **unique index** + flip the column to `NOT NULL`.
+
+### Seed algorithm (per user)
+
+```
+seed = localPart(email)                 // text before '@'
+seed = lower(seed)
+seed = stripFrom('+', seed)             // drop plus-addressing tag
+seed = keep([a-z0-9_], seed)            // strip dots, etc.
+if len(seed) < 3:  seed = slug(DisplayName)   // fallback 1
+if len(seed) < 3:  seed = "user"               // fallback 2
+seed = truncate(seed, 30)
+username = seed
+n = 2
+while taken(username):                  // case-insensitive
+    username = truncate(seed, 30 - len(n)) + n
+    n++
+```
+
+- **Local-part only — never the full email.** The domain is the privacy/spam/
+  enumeration risk; the local-part alone can't reconstruct the address. The
+  seed is just a default; users rename if they don't want their name public.
+- Collisions resolve with the shortest numeric suffix
+  (`jrandallsexton`, `jrandallsexton2`, …).
+- Deterministic and idempotent: re-running skips users that already have a
+  `Username`.
+
+The backfill runs as a **data step validated locally before the PR** (per
+project guardrail — never push an unvalidated migration). Implementation choice
+captured at build time: an idempotent EF data migration vs. a one-shot admin
+command. Leaning toward a data migration so prod gets it on deploy with no
+manual step, but it must be proven against a local copy of prod data first.
+
+## New-user flow
+
+`UpsertUserCommandHandler` already generates a `DisplayName` when none is
+supplied. It will additionally mint a unique `Username` for brand-new users
+using the same seed algorithm, retrying on the unique-constraint race it already
+handles for `FirebaseUid`. No new sign-up step — users land with a sensible
+default handle and can change it in profile. (A "pick your username" onboarding
+prompt is a possible follow-up, not PR-A.)
+
+## Touchpoints
+
+| Area | Files |
+|------|-------|
+| Entity + config | `src/SportsData.Api/Infrastructure/Data/Entities/User.cs` (add `Username`, unique index) |
+| Migration + backfill | new EF migration under `src/SportsData.Api/Migrations/` (nullable → backfill → unique+NOT NULL) |
+| New-user mint | `Application/User/Commands/UpsertUser/UpsertUserCommandHandler.cs` + a `UsernameGenerator`/seed helper (sibling to `DisplayNameGenerator`) |
+| Edit/validate | new `UpdateUsername` command + validator (charset/length/reserved/uniqueness); `UpsertUserCommandValidator` left as-is for DisplayName |
+| Read surface | `Application/User/Dtos/UserDto.cs` + `GetMeQueryHandler` expose `Username` |
+| Web | `src/UI/sd-ui/src/components/settings/SettingsPage.jsx` — show/edit username |
+| Mobile | `src/UI/sd-mobile/app/(tabs)/profile.tsx` — show/edit username |
+
+PR2 then adds the user-search endpoint + the league-overview autocomplete and
+reuses the `UserInvitedToPickemGroup` event/consumer already shipped in PR1.
+
+## Out of scope (PR-A)
+
+- Invite-by-username UI/search (that's PR2).
+- Username change history / rate-limiting / cooldowns.
+- "Choose your username" onboarding step.
+- Propagating `Username` into the Notification projection (not needed until a
+  surface there renders handles).

--- a/src/SportsData.Api/Application/User/Commands/UpdateUsername/UpdateUsernameCommand.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUsername/UpdateUsernameCommand.cs
@@ -1,0 +1,6 @@
+namespace SportsData.Api.Application.User.Commands.UpdateUsername;
+
+public class UpdateUsernameCommand
+{
+    public string Username { get; init; } = string.Empty;
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateUsername/UpdateUsernameCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUsername/UpdateUsernameCommandHandler.cs
@@ -1,0 +1,95 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+
+namespace SportsData.Api.Application.User.Commands.UpdateUsername;
+
+public interface IUpdateUsernameCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateUsernameCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+public class UpdateUsernameCommandHandler : IUpdateUsernameCommandHandler
+{
+    private readonly AppDataContext _db;
+    private readonly ILogger<UpdateUsernameCommandHandler> _logger;
+    private readonly IValidator<UpdateUsernameCommand> _validator;
+
+    public UpdateUsernameCommandHandler(
+        AppDataContext db,
+        ILogger<UpdateUsernameCommandHandler> logger,
+        IValidator<UpdateUsernameCommand> validator)
+    {
+        _db = db;
+        _logger = logger;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateUsernameCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default!, ResultStatus.BadRequest, validation.Errors);
+        }
+
+        // Store lowercased — the unique index is on the stored value, so
+        // lowercasing here is what makes uniqueness case-insensitive.
+        var normalized = UsernameNormalizer.Normalize(command.Username);
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
+        }
+
+        // No-op if unchanged (also lets the user re-submit their own handle).
+        if (string.Equals(user.Username, normalized, StringComparison.Ordinal))
+        {
+            return new Success<Guid>(user.Id);
+        }
+
+        var taken = await _db.Users
+            .AnyAsync(u => u.Username == normalized && u.Id != userId, cancellationToken);
+        if (taken)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.Username), "That username is already taken.")]);
+        }
+
+        user.Username = normalized;
+
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
+        {
+            // Lost a race to another writer between the check and the save.
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.Username), "That username is already taken.")]);
+        }
+
+        _logger.LogInformation("Username updated. UserId={UserId}, Username={Username}", user.Id, normalized);
+
+        return new Success<Guid>(user.Id);
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateUsername/UpdateUsernameCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUsername/UpdateUsernameCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.User.Commands.UpdateUsername;
+
+public class UpdateUsernameCommandValidator : AbstractValidator<UpdateUsernameCommand>
+{
+    public UpdateUsernameCommandValidator()
+    {
+        RuleFor(x => x.Username)
+            .Must(UsernameNormalizer.IsValid)
+            .WithMessage(
+                $"Username must be {UsernameNormalizer.MinLength}–{UsernameNormalizer.MaxLength} characters, "
+                + "use only letters, numbers, or underscores, and not be reserved.");
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpsertUser/UpsertUserCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpsertUser/UpsertUserCommandHandler.cs
@@ -205,9 +205,13 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
     /// <summary>
     /// Mints a unique username for a brand-new user: a seed from the email
     /// local-part (or display name), then the shortest numeric suffix not
-    /// already taken. A concurrent mint of the identical seed is theoretically
-    /// possible and would surface as the unique-constraint violation the caller
-    /// already handles; for this user base it's vanishingly unlikely.
+    /// already taken. Reserved handles (e.g. an "admin@" email seeding "admin")
+    /// are rejected too, so a suffixed alternative is used instead — the
+    /// reserved list contains no numbered entries, so a candidate like "admin2"
+    /// clears the guard. A concurrent mint of the identical seed is
+    /// theoretically possible and would surface as the unique-constraint
+    /// violation the caller already handles; for this user base it's vanishingly
+    /// unlikely.
     /// </summary>
     private async Task<string> ResolveUniqueUsernameAsync(
         string email,
@@ -216,14 +220,22 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
     {
         var seed = UsernameGenerator.BuildSeed(email, displayName);
 
-        if (!await _db.Users.AnyAsync(u => u.Username == seed, cancellationToken))
+        if (await IsUsernameAvailableAsync(seed, cancellationToken))
             return seed;
 
         for (var n = 2; ; n++)
         {
             var candidate = UsernameGenerator.WithSuffix(seed, n);
-            if (!await _db.Users.AnyAsync(u => u.Username == candidate, cancellationToken))
+            if (await IsUsernameAvailableAsync(candidate, cancellationToken))
                 return candidate;
         }
+    }
+
+    private async Task<bool> IsUsernameAvailableAsync(string candidate, CancellationToken cancellationToken)
+    {
+        if (UsernameNormalizer.IsReserved(candidate))
+            return false;
+
+        return !await _db.Users.AnyAsync(u => u.Username == candidate, cancellationToken);
     }
 }

--- a/src/SportsData.Api/Application/User/Commands/UpsertUser/UpsertUserCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpsertUser/UpsertUserCommandHandler.cs
@@ -148,6 +148,7 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
                 EmailVerified = false,
                 SignInProvider = signInProvider,
                 DisplayName = command.DisplayName ?? DisplayNameGenerator.Generate(),
+                Username = await ResolveUniqueUsernameAsync(command.Email, command.DisplayName, cancellationToken),
                 LastLoginUtc = DateTime.UtcNow,
                 CreatedUtc = DateTime.UtcNow
             };
@@ -199,5 +200,30 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
         _logger.LogInformation("User upserted successfully. UserId={UserId}", user.Id);
 
         return new Success<Guid>(user.Id);
+    }
+
+    /// <summary>
+    /// Mints a unique username for a brand-new user: a seed from the email
+    /// local-part (or display name), then the shortest numeric suffix not
+    /// already taken. A concurrent mint of the identical seed is theoretically
+    /// possible and would surface as the unique-constraint violation the caller
+    /// already handles; for this user base it's vanishingly unlikely.
+    /// </summary>
+    private async Task<string> ResolveUniqueUsernameAsync(
+        string email,
+        string? displayName,
+        CancellationToken cancellationToken)
+    {
+        var seed = UsernameGenerator.BuildSeed(email, displayName);
+
+        if (!await _db.Users.AnyAsync(u => u.Username == seed, cancellationToken))
+            return seed;
+
+        for (var n = 2; ; n++)
+        {
+            var candidate = UsernameGenerator.WithSuffix(seed, n);
+            if (!await _db.Users.AnyAsync(u => u.Username == candidate, cancellationToken))
+                return candidate;
+        }
     }
 }

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -15,6 +15,8 @@ public class UserDto
 
     public string? DisplayName { get; set; }
 
+    public string? Username { get; set; }
+
     public string? PhotoUrl { get; set; }
 
     public string? Timezone { get; set; }

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -57,6 +57,7 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                 FirebaseUid = user.FirebaseUid,
                 Email = user.Email,
                 DisplayName = user.DisplayName,
+                Username = user.Username,
                 Timezone = user.Timezone,
                 LastLoginUtc = user.LastLoginUtc,
                 IsAdmin = user.IsAdmin || user.Id == _config.UserIdSystem,

--- a/src/SportsData.Api/Application/User/UserController.cs
+++ b/src/SportsData.Api/Application/User/UserController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Dtos;
@@ -57,6 +58,18 @@ public class UserController : ApiControllerBase
     public async Task<ActionResult<Guid>> UpdateTimezone(
         [FromBody] UpdateUserTimezoneCommand command,
         [FromServices] IUpdateUserTimezoneCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await handler.ExecuteAsync(userId, command, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpPatch("me/username")]
+    [Authorize]
+    public async Task<ActionResult<Guid>> UpdateUsername(
+        [FromBody] UpdateUsernameCommand command,
+        [FromServices] IUpdateUsernameCommandHandler handler,
         CancellationToken cancellationToken)
     {
         var userId = HttpContext.GetCurrentUserId();

--- a/src/SportsData.Api/Application/User/UsernameGenerator.cs
+++ b/src/SportsData.Api/Application/User/UsernameGenerator.cs
@@ -1,0 +1,65 @@
+namespace SportsData.Api.Application.User
+{
+    /// <summary>
+    /// Builds a default username <i>seed</i> from a user's email (or display
+    /// name as fallback). The seed is a normalized, length-bounded base; the
+    /// caller resolves it to a unique value by appending the shortest numeric
+    /// suffix that isn't taken (the suffix loop needs DB access, so it lives in
+    /// the handler / backfill, not here). See docs/username-identity-foundation.md.
+    /// </summary>
+    public static class UsernameGenerator
+    {
+        private const string LastResortSeed = "user";
+
+        /// <summary>
+        /// Seed priority: sanitized email local-part → sanitized display name →
+        /// "user". Local-part only, never the full email — the domain is the
+        /// privacy/enumeration risk and the local-part alone can't reconstruct
+        /// the address. Result is normalized and truncated to
+        /// <see cref="UsernameNormalizer.MaxLength"/>; never shorter than
+        /// <see cref="UsernameNormalizer.MinLength"/>.
+        /// </summary>
+        public static string BuildSeed(string? email, string? displayName)
+        {
+            var fromEmail = UsernameNormalizer.Normalize(LocalPart(email));
+            if (fromEmail.Length >= UsernameNormalizer.MinLength)
+                return Truncate(fromEmail);
+
+            var fromDisplay = UsernameNormalizer.Normalize(displayName);
+            if (fromDisplay.Length >= UsernameNormalizer.MinLength)
+                return Truncate(fromDisplay);
+
+            return LastResortSeed;
+        }
+
+        /// <summary>
+        /// Appends <paramref name="suffix"/> to the seed, trimming the seed so
+        /// the combined handle stays within <see cref="UsernameNormalizer.MaxLength"/>.
+        /// </summary>
+        public static string WithSuffix(string seed, int suffix)
+        {
+            var tag = suffix.ToString();
+            var room = UsernameNormalizer.MaxLength - tag.Length;
+            var trimmed = seed.Length > room ? seed[..room] : seed;
+            return trimmed + tag;
+        }
+
+        // Local-part = text before '@', minus any '+tag' plus-addressing.
+        private static string LocalPart(string? email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                return string.Empty;
+
+            var at = email.IndexOf('@');
+            var local = at >= 0 ? email[..at] : email;
+
+            var plus = local.IndexOf('+');
+            return plus >= 0 ? local[..plus] : local;
+        }
+
+        private static string Truncate(string value) =>
+            value.Length > UsernameNormalizer.MaxLength
+                ? value[..UsernameNormalizer.MaxLength]
+                : value;
+    }
+}

--- a/src/SportsData.Api/Application/User/UsernameNormalizer.cs
+++ b/src/SportsData.Api/Application/User/UsernameNormalizer.cs
@@ -1,0 +1,64 @@
+using System.Text.RegularExpressions;
+
+namespace SportsData.Api.Application.User
+{
+    /// <summary>
+    /// Username rules + normalization, shared by the new-user mint
+    /// (<see cref="Commands.UpsertUser.UpsertUserCommandHandler"/>), the
+    /// edit/validate path, and the backfill. Usernames are stored
+    /// already-lowercased so the unique index gives case-insensitive
+    /// uniqueness for free. See docs/username-identity-foundation.md.
+    /// </summary>
+    public static partial class UsernameNormalizer
+    {
+        public const int MinLength = 3;
+        public const int MaxLength = 30;
+
+        // Handles that would enable impersonation or collide with routes.
+        private static readonly HashSet<string> Reserved = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "admin", "administrator", "api", "root", "support", "help",
+            "sportdeets", "system", "moderator", "mod", "null", "undefined"
+        };
+
+        [GeneratedRegex("[^a-z0-9_]")]
+        private static partial Regex InvalidChars();
+
+        /// <summary>
+        /// Lowercases and strips any character outside <c>[a-z0-9_]</c>. Does NOT
+        /// enforce length — callers decide how to handle a too-short result
+        /// (the generator falls back to another seed; validation rejects it).
+        /// </summary>
+        public static string Normalize(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return string.Empty;
+
+            return InvalidChars().Replace(raw.Trim().ToLowerInvariant(), string.Empty);
+        }
+
+        public static bool IsReserved(string normalized) => Reserved.Contains(normalized);
+
+        /// <summary>
+        /// True when <paramref name="raw"/> normalizes to a valid handle: the
+        /// normalized form is unchanged (no illegal chars were dropped), within
+        /// length bounds, and not reserved.
+        /// </summary>
+        public static bool IsValid(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return false;
+
+            var trimmed = raw.Trim();
+            var normalized = Normalize(trimmed);
+
+            // Reject if normalization had to change anything (spaces, caps,
+            // punctuation) — callers must submit the already-clean handle.
+            if (!string.Equals(normalized, trimmed.ToLowerInvariant(), StringComparison.Ordinal))
+                return false;
+
+            return normalized.Length is >= MinLength and <= MaxLength
+                && !IsReserved(normalized);
+        }
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -78,6 +78,7 @@ using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamMetrics;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamFinalizedGames;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamStatistics;
 using SportsData.Api.Application.User;
+using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Queries.GetMe;
@@ -242,6 +243,7 @@ namespace SportsData.Api.DependencyInjection
             // User Commands
             services.AddScoped<IUpsertUserCommandHandler, UpsertUserCommandHandler>();
             services.AddScoped<IUpdateUserTimezoneCommandHandler, UpdateUserTimezoneCommandHandler>();
+            services.AddScoped<IUpdateUsernameCommandHandler, UpdateUsernameCommandHandler>();
             
             // User Validators
             services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -59,7 +59,8 @@ public class AppDataContext : DbContext
             SignInProvider = "password",
             CreatedUtc = seedTime,
             LastLoginUtc = seedTime,
-            DisplayName = "sportDeets"
+            DisplayName = "sportDeets",
+            Username = "sportdeets"
         });
 
         modelBuilder.AddInboxStateEntity(cfg =>

--- a/src/SportsData.Api/Infrastructure/Data/Entities/User.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/User.cs
@@ -23,6 +23,15 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public required string DisplayName { get; set; }
 
+        /// <summary>
+        /// Stable, unique, lowercase handle (e.g. "jrandallsexton") for search,
+        /// invite-by-username, and @-mentions. Distinct from <see cref="DisplayName"/>,
+        /// which stays a mutable, non-unique label. Charset [a-z0-9_], 3–30 chars,
+        /// case-insensitive unique (stored already-lowercased). See
+        /// docs/username-identity-foundation.md.
+        /// </summary>
+        public required string Username { get; set; }
+
         public string? Timezone { get; set; }
 
         public bool IsSynthetic { get; set; }
@@ -64,6 +73,15 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
                 builder.Property(u => u.DisplayName)
                     .HasMaxLength(100);
+
+                builder.Property(u => u.Username)
+                    .IsRequired()
+                    .HasMaxLength(30);
+
+                // Case-insensitive uniqueness is achieved by storing Username
+                // already-lowercased (see UsernameNormalizer) and indexing the
+                // stored value directly.
+                builder.HasIndex(u => u.Username).IsUnique();
 
                 builder.Property(u => u.Timezone)
                     .HasMaxLength(100);

--- a/src/SportsData.Api/Migrations/20260630141625_30JunV1_UserUsername.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260630141625_30JunV1_UserUsername.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260630141625_30JunV1_UserUsername")]
+    partial class _30JunV1_UserUsername
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260630141625_30JunV1_UserUsername.cs
+++ b/src/SportsData.Api/Migrations/20260630141625_30JunV1_UserUsername.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class _30JunV1_UserUsername : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Existing rows have no username and DisplayName collisions exist, so
+            // the unique constraint can't be switched on directly. Add nullable,
+            // backfill unique values, then enforce. See
+            // docs/username-identity-foundation.md.
+
+            // 1) Nullable column (no default — backfill provides every value).
+            migrationBuilder.AddColumn<string>(
+                name: "Username",
+                table: "User",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: true);
+
+            // 2) Pin the seed user first so the generic backfill skips it
+            //    (matches the HasData value).
+            migrationBuilder.UpdateData(
+                table: "User",
+                keyColumn: "Id",
+                keyValue: new Guid("11111111-1111-1111-1111-111111111111"),
+                column: "Username",
+                value: "sportdeets");
+
+            // 3) Backfill remaining rows. Seed = sanitized email local-part
+            //    (lowercased, '+tag' and illegal chars stripped); fall back to a
+            //    DisplayName slug, then "user". Collisions within a seed get the
+            //    shortest numeric suffix via row_number(). The full email is never
+            //    used (privacy) — only the local-part.
+            migrationBuilder.Sql(@"
+                WITH base AS (
+                    SELECT ""Id"",
+                           CASE
+                               WHEN length(es) >= 3 THEN left(es, 30)
+                               WHEN length(ds) >= 3 THEN left(ds, 30)
+                               ELSE 'user'
+                           END AS seed
+                    FROM (
+                        SELECT ""Id"",
+                               regexp_replace(split_part(split_part(lower(""Email""), '@', 1), '+', 1), '[^a-z0-9_]', '', 'g') AS es,
+                               regexp_replace(lower(""DisplayName""), '[^a-z0-9_]', '', 'g') AS ds
+                        FROM ""User""
+                        WHERE ""Username"" IS NULL
+                    ) s
+                ),
+                ranked AS (
+                    SELECT ""Id"", seed,
+                           row_number() OVER (PARTITION BY seed ORDER BY ""Id"") AS rn
+                    FROM base
+                )
+                UPDATE ""User"" u
+                SET ""Username"" = CASE
+                        WHEN r.rn = 1 THEN r.seed
+                        ELSE left(r.seed, 30 - length(r.rn::text)) || r.rn::text
+                    END
+                FROM ranked r
+                WHERE u.""Id"" = r.""Id"";
+            ");
+
+            // 4) Enforce NOT NULL now that every row has a value.
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "User",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(30)",
+                oldMaxLength: 30,
+                oldNullable: true);
+
+            // 5) Case-insensitive uniqueness (values are stored already-lowercased).
+            migrationBuilder.CreateIndex(
+                name: "IX_User_Username",
+                table: "User",
+                column: "Username",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_User_Username",
+                table: "User");
+
+            migrationBuilder.DropColumn(
+                name: "Username",
+                table: "User");
+        }
+    }
+}

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -344,14 +344,27 @@ export default function ProfileScreen() {
                 editable={!usernameSaving}
                 placeholder="username"
                 placeholderTextColor={theme.textMuted}
+                accessibilityLabel="Username"
                 style={[styles.usernameInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.background }]}
               />
-              <TouchableOpacity onPress={handleUsernameSave} disabled={usernameSaving}>
+              <TouchableOpacity
+                onPress={handleUsernameSave}
+                disabled={usernameSaving}
+                accessibilityRole="button"
+                accessibilityLabel="Save username"
+                accessibilityState={{ disabled: usernameSaving }}
+              >
                 <Text style={[styles.usernameAction, { color: theme.tint }]}>
                   {usernameSaving ? 'Saving…' : 'Save'}
                 </Text>
               </TouchableOpacity>
-              <TouchableOpacity onPress={() => setEditingUsername(false)} disabled={usernameSaving}>
+              <TouchableOpacity
+                onPress={() => setEditingUsername(false)}
+                disabled={usernameSaving}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel username edit"
+                accessibilityState={{ disabled: usernameSaving }}
+              >
                 <Text style={[styles.usernameAction, { color: theme.textMuted }]}>Cancel</Text>
               </TouchableOpacity>
             </View>

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -3,6 +3,7 @@ import {
   View,
   StyleSheet,
   TouchableOpacity,
+  TextInput,
   Alert,
   Platform,
   ScrollView,
@@ -122,6 +123,11 @@ export default function ProfileScreen() {
   const [tzPickerOpen, setTzPickerOpen] = useState(false);
   const [tzMessage, setTzMessage] = useState('');
 
+  const [editingUsername, setEditingUsername] = useState(false);
+  const [usernameInput, setUsernameInput] = useState('');
+  const [usernameSaving, setUsernameSaving] = useState(false);
+  const [usernameMessage, setUsernameMessage] = useState('');
+
   // The zone the user has saved, or the device default if nothing saved yet.
   // The picker uses this to highlight the current selection. The user-set
   // value is what the API persists; the device value is purely a sensible
@@ -203,6 +209,32 @@ export default function ProfileScreen() {
     ]);
   };
 
+  const beginEditUsername = () => {
+    setUsernameInput(me?.username ?? '');
+    setUsernameMessage('');
+    setEditingUsername(true);
+  };
+
+  const handleUsernameSave = async () => {
+    const next = usernameInput.trim();
+    if (!next || next.toLowerCase() === (me?.username ?? '').toLowerCase()) {
+      setEditingUsername(false);
+      return;
+    }
+    setUsernameSaving(true);
+    setUsernameMessage('');
+    try {
+      await usersApi.updateUsername(next);
+      await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
+      setEditingUsername(false);
+    } catch (err) {
+      console.warn('[ProfileScreen] username update failed', err);
+      setUsernameMessage('That username is taken or invalid. Try another.');
+    } finally {
+      setUsernameSaving(false);
+    }
+  };
+
   const handleTimezoneSelect = async (newTz: string) => {
     if (!newTz) return;
     setTzMessage('');
@@ -245,6 +277,11 @@ export default function ProfileScreen() {
           </Text>
         </View>
         <Text style={[styles.heroName, { color: theme.textOnAccent }]}>{displayName}</Text>
+        {me?.username ? (
+          <Text style={[styles.heroEmail, { color: theme.textOnAccent, opacity: 0.85 }]}>
+            @{me.username}
+          </Text>
+        ) : null}
         <Text style={[styles.heroEmail, { color: theme.textOnAccent, opacity: 0.7 }]}>
           {user?.email}
         </Text>
@@ -294,12 +331,46 @@ export default function ProfileScreen() {
       {/* Account */}
       <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
         <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>Account</Text>
+        {editingUsername ? (
+          <View style={[styles.usernameEditor, { borderBottomColor: theme.separator }]}>
+            <Text style={[styles.settingsLabel, { color: theme.text }]}>Username</Text>
+            <View style={styles.usernameEditRow}>
+              <TextInput
+                value={usernameInput}
+                onChangeText={setUsernameInput}
+                autoCapitalize="none"
+                autoCorrect={false}
+                maxLength={30}
+                editable={!usernameSaving}
+                placeholder="username"
+                placeholderTextColor={theme.textMuted}
+                style={[styles.usernameInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.background }]}
+              />
+              <TouchableOpacity onPress={handleUsernameSave} disabled={usernameSaving}>
+                <Text style={[styles.usernameAction, { color: theme.tint }]}>
+                  {usernameSaving ? 'Saving…' : 'Save'}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={() => setEditingUsername(false)} disabled={usernameSaving}>
+                <Text style={[styles.usernameAction, { color: theme.textMuted }]}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+            {usernameMessage ? (
+              <Text style={[styles.usernameError, { color: theme.error }]}>{usernameMessage}</Text>
+            ) : null}
+          </View>
+        ) : (
+          <SettingsRow
+            label="Username"
+            value={me?.username ? `@${me.username}` : 'Set username'}
+            onPress={beginEditUsername}
+          />
+        )}
         <SettingsRow
           label="Timezone"
           value={isUserSet ? effectiveTimezone : `${effectiveTimezone} (device)`}
           onPress={() => setTzPickerOpen(true)}
         />
-        <SettingsRow label="Edit Profile" onPress={() => {}} />
         <SettingsRow label="Notifications" onPress={() => {}} />
         <SettingsRow label="Sign Out" onPress={handleSignOut} destructive />
       </View>
@@ -405,4 +476,25 @@ const styles = StyleSheet.create({
   settingsLabel: { fontSize: 16 },
   settingsValue: { fontSize: 14 },
   destructive: { fontWeight: '600' },
+  usernameEditor: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 8,
+  },
+  usernameEditRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  usernameInput: {
+    flex: 1,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    fontSize: 16,
+  },
+  usernameAction: { fontSize: 15, fontWeight: '600' },
+  usernameError: { fontSize: 13 },
 });

--- a/src/UI/sd-mobile/src/services/api/usersApi.ts
+++ b/src/UI/sd-mobile/src/services/api/usersApi.ts
@@ -14,4 +14,9 @@ export const usersApi = {
   // Backend validates via TimeZoneInfo.TryFindSystemTimeZoneById.
   updateTimezone: (timezone: string | null) =>
     apiClient.patch('/user/me/timezone', { timezone }),
+
+  // PATCH /user/me/username — unique handle ([a-z0-9_], 3–30, case-insensitive).
+  // Backend rejects invalid/taken handles with a 4xx.
+  updateUsername: (username: string) =>
+    apiClient.patch('/user/me/username', { username }),
 };

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -295,6 +295,7 @@ export interface UserDto {
   firebaseUid?: string | null;
   email: string;
   displayName?: string | null;
+  username?: string | null;
   photoUrl?: string | null;
   timezone?: string | null;
   lastLoginUtc: string;

--- a/src/UI/sd-ui/src/api/usersApi.js
+++ b/src/UI/sd-ui/src/api/usersApi.js
@@ -3,7 +3,8 @@ import apiClient from "./apiClient";
 const UsersApi = {
   createOrUpdateUser: (userData) => apiClient.post("/user", userData),
   getCurrentUser: () => apiClient.get("/user/me"),
-  updateTimezone: (timezone) => apiClient.patch("/user/me/timezone", { timezone })
+  updateTimezone: (timezone) => apiClient.patch("/user/me/timezone", { timezone }),
+  updateUsername: (username) => apiClient.patch("/user/me/username", { username })
 };
 
 export default UsersApi;

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -48,6 +48,10 @@ function SettingsPage() {
   const [tzSaving, setTzSaving] = useState(false);
   const [tzMessage, setTzMessage] = useState("");
 
+  const [usernameInput, setUsernameInput] = useState("");
+  const [usernameSaving, setUsernameSaving] = useState(false);
+  const [usernameMessage, setUsernameMessage] = useState("");
+
   const allZones = useMemo(() => getAllIanaZones(), []);
   const browserTz = useMemo(() => detectBrowserTimezone(), []);
 
@@ -59,6 +63,7 @@ function SettingsPage() {
         const response = await apiWrapper.Users.getCurrentUser();
         if (isMounted) {
           setUser(response.data);
+          setUsernameInput(response.data?.username || "");
           setIsLoading(false);
         }
       } catch (err) {
@@ -83,6 +88,29 @@ function SettingsPage() {
 
   const effectiveTimezone = user?.timezone || browserTz;
   const isCurated = CURATED_TIMEZONES.some((z) => z.value === effectiveTimezone);
+
+  const handleUsernameSave = async () => {
+    const next = usernameInput.trim();
+    if (!next || next.toLowerCase() === (user?.username || "").toLowerCase()) return;
+    setUsernameSaving(true);
+    setUsernameMessage("");
+    try {
+      await apiWrapper.Users.updateUsername(next);
+      const lowered = next.toLowerCase();
+      setUser((prev) => (prev ? { ...prev, username: lowered } : prev));
+      setUsernameInput(lowered);
+      await refreshUserDto();
+      setUsernameMessage("Saved.");
+    } catch (err) {
+      console.error("Failed to update username:", err);
+      const serverMsg =
+        err?.response?.data?.errors?.Username?.[0] ||
+        err?.response?.data?.title;
+      setUsernameMessage(serverMsg || "Could not save username (it may be taken or invalid).");
+    } finally {
+      setUsernameSaving(false);
+    }
+  };
 
   const handleTimezoneChange = async (newTz) => {
     if (!newTz) return;
@@ -121,6 +149,25 @@ function SettingsPage() {
           <div className="settings-item">
             <span className="label">Display Name:</span>
             <span>{user?.displayName || "Not set"}</span>
+          </div>
+          <div className="settings-item">
+            <span className="label">Username:</span>
+            <span>
+              <input
+                type="text"
+                value={usernameInput}
+                onChange={(e) => setUsernameInput(e.target.value)}
+                disabled={usernameSaving}
+                maxLength={30}
+                style={{ marginRight: 8 }}
+              />
+              <button onClick={handleUsernameSave} disabled={usernameSaving}>
+                {usernameSaving ? "Saving…" : "Save"}
+              </button>
+              {usernameMessage && (
+                <span style={{ marginLeft: 8, fontSize: "0.85em" }}>{usernameMessage}</span>
+              )}
+            </span>
           </div>
           <div className="settings-item">
             <span className="label">Timezone:</span>

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -155,6 +155,7 @@ function SettingsPage() {
             <span>
               <input
                 type="text"
+                aria-label="Username"
                 value={usernameInput}
                 onChange={(e) => setUsernameInput(e.target.value)}
                 disabled={usernameSaving}

--- a/test/integration/SportsData.Api.Tests.Integration/Fixtures/ApiIntegrationFixture.cs
+++ b/test/integration/SportsData.Api.Tests.Integration/Fixtures/ApiIntegrationFixture.cs
@@ -102,6 +102,7 @@ public sealed class ApiIntegrationFixture : IAsyncLifetime
             EmailVerified = true,
             SignInProvider = "test",
             DisplayName = TestIdentity.DisplayName,
+            Username = "integration_test_user",
             IsAdmin = true,
             LastLoginUtc = clock.UtcNow(),
         };

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandlerTests.cs
@@ -102,6 +102,7 @@ public class CreateBaseballMlbLeagueCommandHandlerTests : ApiTestBase<CreateBase
 
         var synthetic = new UserEntity
         {
+            Username = "test_user_1",
             Id = Guid.NewGuid(),
             FirebaseUid = "synthetic",
             Email = "synthetic@sportdeets.test",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
@@ -130,6 +130,7 @@ public class CreateFootballNcaaLeagueCommandHandlerTests : ApiTestBase<CreateFoo
         // Seed a synthetic user so the synthetic-member branch is exercised.
         var synthetic = new UserEntity
         {
+            Username = "test_user_2",
             Id = Guid.NewGuid(),
             FirebaseUid = "synthetic",
             Email = "synthetic@sportdeets.test",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandlerTests.cs
@@ -110,6 +110,7 @@ public class CreateFootballNflLeagueCommandHandlerTests : ApiTestBase<CreateFoot
 
         var synthetic = new UserEntity
         {
+            Username = "test_user_3",
             Id = Guid.NewGuid(),
             FirebaseUid = "synthetic",
             Email = "synthetic@sportdeets.test",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
@@ -53,7 +53,8 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = email,
             SignInProvider = "password",
-            DisplayName = "Invitee"
+            DisplayName = "Invitee",
+            Username = email.Split('@')[0]
         };
         await DataContext.Users.AddAsync(user);
         await DataContext.SaveChangesAsync();

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueScoresByWeek/GetLeagueScoresByWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueScoresByWeek/GetLeagueScoresByWeekQueryHandlerTests.cs
@@ -198,6 +198,7 @@ public class GetLeagueScoresByWeekQueryHandlerTests : ApiTestBase<GetLeagueScore
     {
         return new UserEntity
         {
+            Username = "test_user_4",
             Id = Guid.NewGuid(),
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = $"{displayName.Replace(" ", "").ToLowerInvariant()}@test.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueScoresByWeek/GetLeagueScoresByWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueScoresByWeek/GetLeagueScoresByWeekQueryHandlerTests.cs
@@ -198,7 +198,7 @@ public class GetLeagueScoresByWeekQueryHandlerTests : ApiTestBase<GetLeagueScore
     {
         return new UserEntity
         {
-            Username = "test_user_4",
+            Username = displayName.Replace(" ", "").ToLowerInvariant(),
             Id = Guid.NewGuid(),
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = $"{displayName.Replace(" ", "").ToLowerInvariant()}@test.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
@@ -314,7 +314,7 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
     {
         return new UserEntity
         {
-            Username = "test_user_5",
+            Username = displayName.Replace(" ", "").ToLowerInvariant(),
             Id = Guid.NewGuid(),
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = $"{displayName.Replace(" ", "").ToLowerInvariant()}@test.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
@@ -314,6 +314,7 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
     {
         return new UserEntity
         {
+            Username = "test_user_5",
             Id = Guid.NewGuid(),
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = $"{displayName.Replace(" ", "").ToLowerInvariant()}@test.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandlerTests.cs
@@ -23,6 +23,7 @@ public class GetUserLeaguesQueryHandlerTests : ApiTestBase<GetUserLeaguesQueryHa
 
         var user = new UserEntity
         {
+            Username = "test_user_6",
             Id = userId,
             FirebaseUid = "firebase-dead-league",
             Email = "u@example.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetPickAccuracyByWeek/GetPickAccuracyByWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetPickAccuracyByWeek/GetPickAccuracyByWeekQueryHandlerTests.cs
@@ -21,6 +21,7 @@ public class GetPickAccuracyByWeekQueryHandlerTests : ApiTestBase<GetPickAccurac
         var userId = Guid.NewGuid();
         var user = new UserEntity
         {
+            Username = "test_user_7",
             Id = userId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test@test.com",
@@ -55,6 +56,7 @@ public class GetPickAccuracyByWeekQueryHandlerTests : ApiTestBase<GetPickAccurac
 
         var user = new UserEntity
         {
+            Username = "test_user_8",
             Id = userId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test@test.com",
@@ -179,6 +181,7 @@ public class GetPickAccuracyByWeekQueryHandlerTests : ApiTestBase<GetPickAccurac
 
         var syntheticUser = new UserEntity
         {
+            Username = "test_user_9",
             Id = syntheticUserId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "synthetic@test.com",
@@ -248,6 +251,7 @@ public class GetPickAccuracyByWeekQueryHandlerTests : ApiTestBase<GetPickAccurac
 
         var syntheticUser = new UserEntity
         {
+            Username = "test_user_10",
             Id = syntheticUserId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "synthetic@test.com",
@@ -331,6 +335,7 @@ public class GetPickAccuracyByWeekQueryHandlerTests : ApiTestBase<GetPickAccurac
 
         var syntheticUser = new UserEntity
         {
+            Username = "test_user_11",
             Id = syntheticUserId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "synthetic@test.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetPickRecordWidget/GetPickRecordWidgetQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetPickRecordWidget/GetPickRecordWidgetQueryHandlerTests.cs
@@ -64,6 +64,7 @@ public class GetPickRecordWidgetQueryHandlerTests : ApiTestBase<GetPickRecordWid
 
         var user = new UserEntity
         {
+            Username = "test_user_12",
             Id = userId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test@test.com",
@@ -139,6 +140,7 @@ public class GetPickRecordWidgetQueryHandlerTests : ApiTestBase<GetPickRecordWid
 
         var user = new UserEntity
         {
+            Username = "test_user_13",
             Id = userId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test@test.com",
@@ -199,6 +201,7 @@ public class GetPickRecordWidgetQueryHandlerTests : ApiTestBase<GetPickRecordWid
 
         var user = new UserEntity
         {
+            Username = "test_user_14",
             Id = userId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test@test.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
@@ -44,6 +44,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
 
         var user = new UserEntity
         {
+            Username = "test_user_15",
             Id = userId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test@test.com",
@@ -101,6 +102,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
 
         var user = new UserEntity
         {
+            Username = "test_user_16",
             Id = userId,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test@test.com",
@@ -160,6 +162,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
 
         var user1 = new UserEntity
         {
+            Username = "test_user_17",
             Id = userId1,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test1@test.com",
@@ -169,6 +172,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         };
         var user2 = new UserEntity
         {
+            Username = "test_user_18",
             Id = userId2,
             FirebaseUid = Guid.NewGuid().ToString(),
             Email = "test2@test.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateUsername/UpdateUsernameCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateUsername/UpdateUsernameCommandHandlerTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+
+using FluentValidation;
+
+using SportsData.Api.Application.User.Commands.UpdateUsername;
+using SportsData.Core.Common;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.User.Commands.UpdateUsername;
+
+public class UpdateUsernameCommandHandlerTests : ApiTestBase<UpdateUsernameCommandHandler>
+{
+    public UpdateUsernameCommandHandlerTests()
+    {
+        Mocker.Use<IValidator<UpdateUsernameCommand>>(new UpdateUsernameCommandValidator());
+    }
+
+    private async Task<Guid> SeedUserAsync(string username, string email = "u@x.com")
+    {
+        var id = Guid.NewGuid();
+        await DataContext.Users.AddAsync(new UserEntity
+        {
+            Id = id,
+            FirebaseUid = Guid.NewGuid().ToString(),
+            Email = email,
+            SignInProvider = "password",
+            DisplayName = "Display",
+            Username = username
+        });
+        await DataContext.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task Execute_SetsUsername_WhenValidAndAvailable()
+    {
+        var userId = await SeedUserAsync("oldhandle");
+        var handler = Mocker.CreateInstance<UpdateUsernameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateUsernameCommand { Username = "NewHandle" });
+
+        result.IsSuccess.Should().BeTrue();
+        var user = await DataContext.Users.FindAsync(userId);
+        user!.Username.Should().Be("newhandle"); // stored lowercased
+    }
+
+    [Fact]
+    public async Task Execute_Rejects_WhenTaken()
+    {
+        await SeedUserAsync("taken", "a@x.com");
+        var userId = await SeedUserAsync("mine", "b@x.com");
+        var handler = Mocker.CreateInstance<UpdateUsernameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateUsernameCommand { Username = "Taken" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task Execute_NoOp_WhenSameHandleDifferentCase()
+    {
+        var userId = await SeedUserAsync("jrandall");
+        var handler = Mocker.CreateInstance<UpdateUsernameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateUsernameCommand { Username = "JRandall" });
+
+        result.IsSuccess.Should().BeTrue();
+        var user = await DataContext.Users.FindAsync(userId);
+        user!.Username.Should().Be("jrandall");
+    }
+
+    [Fact]
+    public async Task Execute_Rejects_WhenInvalid()
+    {
+        var userId = await SeedUserAsync("validhandle");
+        var handler = Mocker.CreateInstance<UpdateUsernameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateUsernameCommand { Username = "no spaces" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.BadRequest);
+    }
+
+    [Fact]
+    public async Task Execute_NotFound_WhenUserMissing()
+    {
+        var handler = Mocker.CreateInstance<UpdateUsernameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(Guid.NewGuid(), new UpdateUsernameCommand { Username = "ghosthandle" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using SportsData.Api.Application.User;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
@@ -38,6 +39,23 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
         result.Status.Should().Be(ResultStatus.BadRequest);
         result.Should().BeOfType<Failure<Guid>>();
         ((Failure<Guid>)result).Errors.Should().Contain(e => e.PropertyName == "FirebaseUid");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MintsNonReservedUsername_WhenEmailSeedIsReserved()
+    {
+        // "admin@..." seeds the reserved handle "admin"; the mint must skip it.
+        var handler = Mocker.CreateInstance<UpsertUserCommandHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new UpsertUserCommand { Email = "admin@example.com" },
+            "firebase-reserved-seed",
+            "password");
+
+        result.IsSuccess.Should().BeTrue();
+        var user = await DataContext.Users.FirstAsync(u => u.FirebaseUid == "firebase-reserved-seed");
+        user.Username.Should().NotBe("admin");
+        UsernameNormalizer.IsReserved(user.Username).Should().BeFalse();
     }
 
     [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
@@ -149,6 +149,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
 
         var existingUser = new UserEntity
         {
+            Username = "test_user_19",
             Id = userId,
             FirebaseUid = firebaseUid,
             Email = "old@example.com",
@@ -198,6 +199,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
 
         var existingUser = new UserEntity
         {
+            Username = "test_user_20",
             Id = userId,
             FirebaseUid = firebaseUid,
             Email = "old@example.com",
@@ -241,6 +243,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
 
         var existingUser = new UserEntity
         {
+            Username = "test_user_21",
             Id = userId,
             FirebaseUid = firebaseUid,
             Email = "old@example.com",
@@ -285,6 +288,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
 
         var existingUser = new UserEntity
         {
+            Username = "test_user_22",
             Id = userId,
             FirebaseUid = firebaseUid,
             Email = "test@example.com",
@@ -386,6 +390,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
         // First, create a user directly in the database (simulating it was created by another request)
         var existingUser = new UserEntity
         {
+            Username = "test_user_23",
             Id = Guid.NewGuid(),
             FirebaseUid = firebaseUid,
             Email = "original@example.com",
@@ -540,6 +545,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
         
         var existingUser = new UserEntity
         {
+            Username = "test_user_24",
             Id = Guid.NewGuid(),
             FirebaseUid = firebaseUid,
             Email = "original@example.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetMe/GetMeQueryHandlerTests.cs
@@ -66,6 +66,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         var userId = Guid.NewGuid();
         var user = new UserEntity
         {
+            Username = "test_user_25",
             Id = userId,
             FirebaseUid = "firebase-123",
             Email = "test@example.com",
@@ -109,6 +110,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
 
         var user = new UserEntity
         {
+            Username = "test_user_26",
             Id = userId,
             FirebaseUid = "firebase-456",
             Email = "league@example.com",
@@ -179,6 +181,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
 
         var user = new UserEntity
         {
+            Username = "test_user_27",
             Id = userId,
             FirebaseUid = "firebase-789",
             Email = "weeks@example.com",
@@ -287,6 +290,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
 
         var user = new UserEntity
         {
+            Username = "test_user_28",
             Id = userId,
             FirebaseUid = "firebase-current-week",
             Email = "currentweek@example.com",
@@ -405,6 +409,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
 
         var user = new UserEntity
         {
+            Username = "test_user_29",
             Id = userId,
             FirebaseUid = "firebase-season-over",
             Email = "seasonover@example.com",
@@ -498,6 +503,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         var adminId = Guid.Parse("11111111-1111-1111-1111-111111111111");
         var user = new UserEntity
         {
+            Username = "test_user_30",
             Id = adminId,
             FirebaseUid = "firebase-admin",
             Email = "admin@example.com",
@@ -532,6 +538,7 @@ public class GetMeQueryHandlerTests : ApiTestBase<GetMeQueryHandler>
         var userId = Guid.NewGuid();
         var user = new UserEntity
         {
+            Username = "test_user_31",
             Id = userId,
             FirebaseUid = "firebase-admin2",
             Email = "admin2@example.com",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/UsernameRulesTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/UsernameRulesTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.User;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.User;
+
+public class UsernameRulesTests
+{
+    [Theory]
+    [InlineData("JRandall", "jrandall")]
+    [InlineData("  Foo_Bar ", "foo_bar")]
+    [InlineData("a.b.c", "abc")]
+    [InlineData("hi there!", "hithere")]
+    [InlineData(null, "")]
+    public void Normalize_LowercasesAndStripsIllegalChars(string? raw, string expected)
+    {
+        UsernameNormalizer.Normalize(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("jrandallsexton")]
+    [InlineData("JRandall")]          // caps allowed (lowercased on store)
+    [InlineData("a_b_c")]
+    [InlineData("user99")]
+    public void IsValid_AcceptsCleanHandles(string raw)
+    {
+        UsernameNormalizer.IsValid(raw).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("ab")]                // too short
+    [InlineData("john smith")]        // space
+    [InlineData("a.b")]               // punctuation
+    [InlineData("admin")]             // reserved
+    [InlineData("SportDeets")]        // reserved (case-insensitive)
+    [InlineData("this_handle_is_way_too_long_to_pass")] // > 30
+    [InlineData("")]
+    public void IsValid_RejectsBadHandles(string raw)
+    {
+        UsernameNormalizer.IsValid(raw).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("jrandallsexton@gmail.com", null, "jrandallsexton")]
+    [InlineData("foo+spam@bar.com", null, "foo")]               // strips +tag
+    [InlineData("a.b.c@x.com", null, "abc")]                    // strips dots
+    [InlineData("x@y.com", "Snarky Name", "snarkyname")]        // local-part too short -> displayName
+    [InlineData("x@y.com", "!!", "user")]                       // both too short -> last resort
+    public void BuildSeed_PrefersEmailLocalPart_ThenDisplayName_ThenUser(
+        string email, string? displayName, string expected)
+    {
+        UsernameGenerator.BuildSeed(email, displayName).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildSeed_TruncatesToMaxLength()
+    {
+        var seed = UsernameGenerator.BuildSeed("abcdefghijklmnopqrstuvwxyzabcdefghij@x.com", null);
+        seed.Length.Should().Be(UsernameNormalizer.MaxLength);
+    }
+
+    [Fact]
+    public void WithSuffix_TrimsSeedSoCombinedFitsMaxLength()
+    {
+        var seed = new string('a', UsernameNormalizer.MaxLength);
+        var result = UsernameGenerator.WithSuffix(seed, 12);
+        result.Length.Should().Be(UsernameNormalizer.MaxLength);
+        result.Should().EndWith("12");
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for invite-by-username. Splits the dual-duty `DisplayName` into two fields:

- **`Username`** — stable, unique, lowercase handle (`jrandallsexton`) for search, invite-by-username (PR2), and future @-mentions.
- **`DisplayName`** — unchanged: a mutable, non-unique label a user can set to anything (`YouWillAllLose`).

Design note: `docs/username-identity-foundation.md`.

## Changes

**API**
- `User.Username`: `required`, unique index, max 30, **stored lowercased** so the unique index gives case-insensitive uniqueness. Seed user → `"sportdeets"`.
- `UsernameNormalizer` (charset `[a-z0-9_]`, 3–30, reserved-word blocklist) + `UsernameGenerator` (seed from email local-part → DisplayName slug → `"user"`, collision-suffixed).
- `UpsertUserCommandHandler` mints a unique username for new users.
- `UpdateUsername` command/handler/validator + `PATCH /user/me/username` (rejects taken/invalid; catches the lost-race unique violation on save).
- `UserDto` + `GetMe` expose `Username`.

**Migration `30JunV1_UserUsername`** (hand-written; **validated locally against real data**)
- Add nullable column → pin seed user → SQL backfill (sanitized email **local-part only**, collision-suffixed via `row_number()`) → `NOT NULL` → unique index.
- Local-part only by design — the full email is never used as the seed (privacy/enumeration).

**UI**
- Web `SettingsPage`: editable Username row.
- Mobile `profile.tsx`: editable Username row + `@username` in the hero (replaced the no-op "Edit Profile" row).

## Testing
- `UsernameRulesTests` (normalizer + generator), `UpdateUsernameCommandHandlerTests` (set/taken/no-op/invalid/not-found).
- 31 existing `User` fixtures updated for the new required field; full API unit suite green.
- Mobile `tsc --noEmit` clean; migration applied cleanly to a local copy of prod data.

## Follow-up
- **PR2:** invite-by-username autocomplete on the league overview (web + mobile) — adds the user-search endpoint and reuses the `UserInvitedToPickemGroup` event/consumer shipped in PR1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unique, stable usernames for accounts, including normalization/validation and automatic generation for new users.
  * Added an authenticated endpoint to update your username.
  * Updated profile/settings UI to display and edit your username, syncing across mobile and web.

* **Bug Fixes**
  * Prevents invalid or duplicate usernames (including race-condition-safe handling) and avoids unnecessary updates.
  * Backfilled existing accounts with generated usernames and enforced uniqueness at the database level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->