### PR TITLE
fix(api): require league membership to send email invites

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandler.cs
@@ -57,6 +57,19 @@ public class SendLeagueInviteCommandHandler : ISendLeagueInviteCommandHandler
                 ResultStatus.NotFound,
                 [new ValidationFailure(nameof(command.LeagueId), $"League with ID {command.LeagueId} not found.")]);
 
+        // Authorization: only a member of the league may invite others. Checked
+        // before the email is sent so a non-member can't blast invites into a
+        // league they don't belong to. Mirrors InviteUserToLeagueCommandHandler.
+        var inviterIsMember = await _dbContext.PickemGroupMembers
+            .AsNoTracking()
+            .AnyAsync(m => m.PickemGroupId == league.Id && m.UserId == command.InvitedByUserId, cancellationToken);
+
+        if (!inviterIsMember)
+            return new Failure<bool>(
+                false,
+                ResultStatus.Forbid,
+                [new ValidationFailure(nameof(command.InvitedByUserId), "Only league members can invite others.")]);
+
         // TODO: Dynamically set the domain based on environment
         var inviteUrl = $"https://{_notificationConfig.Email.UrlBase}/app/join/{league.Id.ToString().Replace("-", string.Empty)}";
 

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -213,6 +213,7 @@ public class LeagueController : ApiControllerBase
         return result.Status switch
         {
             ResultStatus.NotFound => NotFound(),
+            ResultStatus.Forbid => Forbid(),
             _ => BadRequest()
         };
     }

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -188,7 +188,7 @@ public class LeagueController : ApiControllerBase
 
     [HttpPost("{id}/invite")]
     [Authorize]
-    public async Task<IActionResult> SendInvite(
+    public async Task<ActionResult<bool>> SendInvite(
         Guid id,
         [FromBody] SendLeagueInviteRequest request,
         [FromServices] ISendLeagueInviteCommandHandler handler,
@@ -206,16 +206,7 @@ public class LeagueController : ApiControllerBase
         };
 
         var result = await handler.ExecuteAsync(command, cancellationToken);
-
-        if (result.IsSuccess)
-            return Ok(new { Message = "Invite sent." });
-
-        return result.Status switch
-        {
-            ResultStatus.NotFound => NotFound(),
-            ResultStatus.Forbid => Forbid(),
-            _ => BadRequest()
-        };
+        return result.ToActionResult();
     }
 
     [HttpGet("{id}/invite/search")]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/SendLeagueInvite/SendLeagueInviteCommandHandlerTests.cs
@@ -61,9 +61,24 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
         return user;
     }
 
+    private async Task AddMemberAsync(Guid leagueId, Guid userId)
+    {
+        await DataContext.PickemGroupMembers.AddAsync(new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            UserId = userId
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
     private void VerifyPublish(Times times) =>
         Mocker.GetMock<IEventBus>().Verify(
             b => b.Publish(It.IsAny<UserInvitedToPickemGroup>(), It.IsAny<CancellationToken>()), times);
+
+    private void VerifyEmailSent(Times times) =>
+        Mocker.GetMock<INotificationService>().Verify(
+            n => n.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>()), times);
 
     [Fact]
     public async Task ExecuteAsync_ReturnsNotFound_WhenLeagueMissing()
@@ -86,16 +101,19 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
     public async Task ExecuteAsync_UnregisteredEmail_SendsEmailOnly_NoEvent()
     {
         var league = await SeedLeagueAsync();
+        var invitedBy = Guid.NewGuid();
+        await AddMemberAsync(league.Id, invitedBy);
         var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
 
         var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
         {
             LeagueId = league.Id,
             Email = "stranger@x.com",
-            InvitedByUserId = Guid.NewGuid()
+            InvitedByUserId = invitedBy
         });
 
         result.IsSuccess.Should().BeTrue();
+        VerifyEmailSent(Times.Once());
         VerifyPublish(Times.Never());
     }
 
@@ -105,6 +123,7 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
         var league = await SeedLeagueAsync();
         var invitee = await SeedUserAsync("friend@x.com");
         var invitedBy = Guid.NewGuid();
+        await AddMemberAsync(league.Id, invitedBy);
         var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
 
         var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
@@ -133,13 +152,9 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
     {
         var league = await SeedLeagueAsync();
         var invitee = await SeedUserAsync("member@x.com");
-        await DataContext.PickemGroupMembers.AddAsync(new PickemGroupMember
-        {
-            Id = Guid.NewGuid(),
-            PickemGroupId = league.Id,
-            UserId = invitee.Id
-        });
-        await DataContext.SaveChangesAsync();
+        await AddMemberAsync(league.Id, invitee.Id);
+        var invitedBy = Guid.NewGuid();
+        await AddMemberAsync(league.Id, invitedBy);
 
         var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
 
@@ -147,10 +162,29 @@ public class SendLeagueInviteCommandHandlerTests : ApiTestBase<SendLeagueInviteC
         {
             LeagueId = league.Id,
             Email = "member@x.com",
-            InvitedByUserId = Guid.NewGuid()
+            InvitedByUserId = invitedBy
         });
 
         result.IsSuccess.Should().BeTrue();
+        VerifyPublish(Times.Never());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Forbids_WhenInviterNotAMember()
+    {
+        var league = await SeedLeagueAsync();
+        var handler = Mocker.CreateInstance<SendLeagueInviteCommandHandler>();
+
+        var result = await handler.ExecuteAsync(new SendLeagueInviteCommand
+        {
+            LeagueId = league.Id,
+            Email = "stranger@x.com",
+            InvitedByUserId = Guid.NewGuid() // not a member of the league
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Forbid);
+        VerifyEmailSent(Times.Never());
         VerifyPublish(Times.Never());
     }
 }


### PR DESCRIPTION
## Summary

Makes the two invite endpoints consistent: `SendLeagueInvite` (email) now requires the **inviter** to be a member of the target league, matching `InviteUserToLeague` (username). Previously any authenticated user could email-invite into a league they don't belong to.

- The membership check runs right after the league lookup, **before** the email is sent, and returns `Forbid` (→403) for a non-member.
- The **invitee** side is unchanged — inviting people who aren't registered on sportDeets is still fully supported; the check is on the sender, not the recipient.

## Testing
- New `Forbids_WhenInviterNotAMember` (verifies no email sent, no event published).
- Seeded the inviter as a member in the three existing positive tests; added an explicit "email sent once" assertion on the unregistered-email test.
- Build clean, handler suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invite requests now return **403 Forbidden** when the inviter is not a member of the target league.
  * Invite handling now performs an authorization check before sending emails, preventing unauthorized invites from being processed.
  * API invite responses were standardized to consistently reflect success/failure status codes.
* **Tests**
  * Updated league invite command tests with clearer membership setup.
  * Added stronger assertions to confirm no email is sent and no events are published for forbidden/invalid scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->