### PR TITLE
fix(settings): edit display name, not username (web + mobile)

### DIFF
--- a/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommand.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommand.cs
@@ -1,0 +1,6 @@
+namespace SportsData.Api.Application.User.Commands.UpdateDisplayName;
+
+public class UpdateDisplayNameCommand
+{
+    public string DisplayName { get; init; } = string.Empty;
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandHandler.cs
@@ -1,0 +1,64 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.User.Commands.UpdateDisplayName;
+
+public interface IUpdateDisplayNameCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateDisplayNameCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+public class UpdateDisplayNameCommandHandler : IUpdateDisplayNameCommandHandler
+{
+    private readonly AppDataContext _db;
+    private readonly ILogger<UpdateDisplayNameCommandHandler> _logger;
+    private readonly IValidator<UpdateDisplayNameCommand> _validator;
+
+    public UpdateDisplayNameCommandHandler(
+        AppDataContext db,
+        ILogger<UpdateDisplayNameCommandHandler> logger,
+        IValidator<UpdateDisplayNameCommand> validator)
+    {
+        _db = db;
+        _logger = logger;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateDisplayNameCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default!, ResultStatus.BadRequest, validation.Errors);
+        }
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
+        }
+
+        // Free-text label — trimmed and stored as-is (non-unique, unlike Username).
+        user.DisplayName = command.DisplayName.Trim();
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Display name updated. UserId={UserId}", user.Id);
+
+        return new Success<Guid>(user.Id);
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.User.Commands.UpdateDisplayName;
+
+public class UpdateDisplayNameCommandValidator : AbstractValidator<UpdateDisplayNameCommand>
+{
+    public UpdateDisplayNameCommandValidator()
+    {
+        RuleFor(x => x.DisplayName)
+            .Must(v => !string.IsNullOrWhiteSpace(v))
+            .WithMessage("Display name is required.");
+
+        // Free-text label (non-unique). Matches the UpsertUser cap.
+        RuleFor(x => x.DisplayName)
+            .MaximumLength(100)
+            .When(x => !string.IsNullOrWhiteSpace(x.DisplayName))
+            .WithMessage("Display name must not exceed 100 characters.");
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandValidator.cs
@@ -4,16 +4,19 @@ namespace SportsData.Api.Application.User.Commands.UpdateDisplayName;
 
 public class UpdateDisplayNameCommandValidator : AbstractValidator<UpdateDisplayNameCommand>
 {
+    // Short free-text label (non-unique). The DB column allows more, but a
+    // display name has no reason to be long; the web/mobile inputs cap to match.
+    public const int MaxLength = 25;
+
     public UpdateDisplayNameCommandValidator()
     {
         RuleFor(x => x.DisplayName)
             .Must(v => !string.IsNullOrWhiteSpace(v))
             .WithMessage("Display name is required.");
 
-        // Free-text label (non-unique). Matches the UpsertUser cap.
         RuleFor(x => x.DisplayName)
-            .MaximumLength(100)
+            .MaximumLength(MaxLength)
             .When(x => !string.IsNullOrWhiteSpace(x.DisplayName))
-            .WithMessage("Display name must not exceed 100 characters.");
+            .WithMessage($"Display name must not exceed {MaxLength} characters.");
     }
 }

--- a/src/SportsData.Api/Application/User/UserController.cs
+++ b/src/SportsData.Api/Application/User/UserController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Api.Application.User.Commands.UpdateDisplayName;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
@@ -70,6 +71,18 @@ public class UserController : ApiControllerBase
     public async Task<ActionResult<Guid>> UpdateUsername(
         [FromBody] UpdateUsernameCommand command,
         [FromServices] IUpdateUsernameCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await handler.ExecuteAsync(userId, command, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpPatch("me/displayname")]
+    [Authorize]
+    public async Task<ActionResult<Guid>> UpdateDisplayName(
+        [FromBody] UpdateDisplayNameCommand command,
+        [FromServices] IUpdateDisplayNameCommandHandler handler,
         CancellationToken cancellationToken)
     {
         var userId = HttpContext.GetCurrentUserId();

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -80,6 +80,7 @@ using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamMetrics;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamFinalizedGames;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamStatistics;
 using SportsData.Api.Application.User;
+using SportsData.Api.Application.User.Commands.UpdateDisplayName;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
@@ -248,6 +249,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IUpsertUserCommandHandler, UpsertUserCommandHandler>();
             services.AddScoped<IUpdateUserTimezoneCommandHandler, UpdateUserTimezoneCommandHandler>();
             services.AddScoped<IUpdateUsernameCommandHandler, UpdateUsernameCommandHandler>();
+            services.AddScoped<IUpdateDisplayNameCommandHandler, UpdateDisplayNameCommandHandler>();
             
             // User Validators
             services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -217,7 +217,13 @@ export default function ProfileScreen() {
 
   const handleDisplayNameSave = async () => {
     const next = displayNameInput.trim();
-    if (!next || next === (me?.displayName ?? '')) {
+    if (!next) {
+      // Don't discard the edit silently — tell the user and keep the editor open.
+      setDisplayNameMessage('Display name is required.');
+      return;
+    }
+    if (next === (me?.displayName ?? '')) {
+      // No change — nothing to save; just close.
       setEditingDisplayName(false);
       return;
     }
@@ -343,7 +349,7 @@ export default function ProfileScreen() {
               <TextInput
                 value={displayNameInput}
                 onChangeText={setDisplayNameInput}
-                maxLength={100}
+                maxLength={25}
                 editable={!displayNameSaving}
                 placeholder="display name"
                 placeholderTextColor={theme.textMuted}

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -123,10 +123,10 @@ export default function ProfileScreen() {
   const [tzPickerOpen, setTzPickerOpen] = useState(false);
   const [tzMessage, setTzMessage] = useState('');
 
-  const [editingUsername, setEditingUsername] = useState(false);
-  const [usernameInput, setUsernameInput] = useState('');
-  const [usernameSaving, setUsernameSaving] = useState(false);
-  const [usernameMessage, setUsernameMessage] = useState('');
+  const [editingDisplayName, setEditingDisplayName] = useState(false);
+  const [displayNameInput, setDisplayNameInput] = useState('');
+  const [displayNameSaving, setDisplayNameSaving] = useState(false);
+  const [displayNameMessage, setDisplayNameMessage] = useState('');
 
   // The zone the user has saved, or the device default if nothing saved yet.
   // The picker uses this to highlight the current selection. The user-set
@@ -209,29 +209,29 @@ export default function ProfileScreen() {
     ]);
   };
 
-  const beginEditUsername = () => {
-    setUsernameInput(me?.username ?? '');
-    setUsernameMessage('');
-    setEditingUsername(true);
+  const beginEditDisplayName = () => {
+    setDisplayNameInput(me?.displayName ?? '');
+    setDisplayNameMessage('');
+    setEditingDisplayName(true);
   };
 
-  const handleUsernameSave = async () => {
-    const next = usernameInput.trim();
-    if (!next || next.toLowerCase() === (me?.username ?? '').toLowerCase()) {
-      setEditingUsername(false);
+  const handleDisplayNameSave = async () => {
+    const next = displayNameInput.trim();
+    if (!next || next === (me?.displayName ?? '')) {
+      setEditingDisplayName(false);
       return;
     }
-    setUsernameSaving(true);
-    setUsernameMessage('');
+    setDisplayNameSaving(true);
+    setDisplayNameMessage('');
     try {
-      await usersApi.updateUsername(next);
+      await usersApi.updateDisplayName(next);
       await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
-      setEditingUsername(false);
+      setEditingDisplayName(false);
     } catch (err) {
-      console.warn('[ProfileScreen] username update failed', err);
-      setUsernameMessage('That username is taken or invalid. Try another.');
+      console.warn('[ProfileScreen] display name update failed', err);
+      setDisplayNameMessage('Could not save display name. Try again.');
     } finally {
-      setUsernameSaving(false);
+      setDisplayNameSaving(false);
     }
   };
 
@@ -331,52 +331,55 @@ export default function ProfileScreen() {
       {/* Account */}
       <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
         <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>Account</Text>
-        {editingUsername ? (
-          <View style={[styles.usernameEditor, { borderBottomColor: theme.separator }]}>
-            <Text style={[styles.settingsLabel, { color: theme.text }]}>Username</Text>
-            <View style={styles.usernameEditRow}>
+        {/* Username is a stable handle — shown read-only. */}
+        <SettingsRow
+          label="Username"
+          value={me?.username ? `@${me.username}` : '—'}
+        />
+        {editingDisplayName ? (
+          <View style={[styles.fieldEditor, { borderBottomColor: theme.separator }]}>
+            <Text style={[styles.settingsLabel, { color: theme.text }]}>Display Name</Text>
+            <View style={styles.fieldEditRow}>
               <TextInput
-                value={usernameInput}
-                onChangeText={setUsernameInput}
-                autoCapitalize="none"
-                autoCorrect={false}
-                maxLength={30}
-                editable={!usernameSaving}
-                placeholder="username"
+                value={displayNameInput}
+                onChangeText={setDisplayNameInput}
+                maxLength={100}
+                editable={!displayNameSaving}
+                placeholder="display name"
                 placeholderTextColor={theme.textMuted}
-                accessibilityLabel="Username"
-                style={[styles.usernameInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.background }]}
+                accessibilityLabel="Display name"
+                style={[styles.fieldInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.background }]}
               />
               <TouchableOpacity
-                onPress={handleUsernameSave}
-                disabled={usernameSaving}
+                onPress={handleDisplayNameSave}
+                disabled={displayNameSaving}
                 accessibilityRole="button"
-                accessibilityLabel="Save username"
-                accessibilityState={{ disabled: usernameSaving }}
+                accessibilityLabel="Save display name"
+                accessibilityState={{ disabled: displayNameSaving }}
               >
-                <Text style={[styles.usernameAction, { color: theme.tint }]}>
-                  {usernameSaving ? 'Saving…' : 'Save'}
+                <Text style={[styles.fieldAction, { color: theme.tint }]}>
+                  {displayNameSaving ? 'Saving…' : 'Save'}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
-                onPress={() => setEditingUsername(false)}
-                disabled={usernameSaving}
+                onPress={() => setEditingDisplayName(false)}
+                disabled={displayNameSaving}
                 accessibilityRole="button"
-                accessibilityLabel="Cancel username edit"
-                accessibilityState={{ disabled: usernameSaving }}
+                accessibilityLabel="Cancel display name edit"
+                accessibilityState={{ disabled: displayNameSaving }}
               >
-                <Text style={[styles.usernameAction, { color: theme.textMuted }]}>Cancel</Text>
+                <Text style={[styles.fieldAction, { color: theme.textMuted }]}>Cancel</Text>
               </TouchableOpacity>
             </View>
-            {usernameMessage ? (
-              <Text style={[styles.usernameError, { color: theme.error }]}>{usernameMessage}</Text>
+            {displayNameMessage ? (
+              <Text style={[styles.fieldError, { color: theme.error }]}>{displayNameMessage}</Text>
             ) : null}
           </View>
         ) : (
           <SettingsRow
-            label="Username"
-            value={me?.username ? `@${me.username}` : 'Set username'}
-            onPress={beginEditUsername}
+            label="Display Name"
+            value={me?.displayName ?? 'Set display name'}
+            onPress={beginEditDisplayName}
           />
         )}
         <SettingsRow
@@ -489,18 +492,18 @@ const styles = StyleSheet.create({
   settingsLabel: { fontSize: 16 },
   settingsValue: { fontSize: 14 },
   destructive: { fontWeight: '600' },
-  usernameEditor: {
+  fieldEditor: {
     paddingHorizontal: 16,
     paddingVertical: 14,
     borderBottomWidth: StyleSheet.hairlineWidth,
     gap: 8,
   },
-  usernameEditRow: {
+  fieldEditRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,
   },
-  usernameInput: {
+  fieldInput: {
     flex: 1,
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 8,
@@ -508,6 +511,6 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     fontSize: 16,
   },
-  usernameAction: { fontSize: 15, fontWeight: '600' },
-  usernameError: { fontSize: 13 },
+  fieldAction: { fontSize: 15, fontWeight: '600' },
+  fieldError: { fontSize: 13 },
 });

--- a/src/UI/sd-mobile/src/services/api/usersApi.ts
+++ b/src/UI/sd-mobile/src/services/api/usersApi.ts
@@ -19,4 +19,8 @@ export const usersApi = {
   // Backend rejects invalid/taken handles with a 4xx.
   updateUsername: (username: string) =>
     apiClient.patch('/user/me/username', { username }),
+
+  // PATCH /user/me/displayname — free-text label (non-unique, max 100).
+  updateDisplayName: (displayName: string) =>
+    apiClient.patch('/user/me/displayname', { displayName }),
 };

--- a/src/UI/sd-ui/src/api/usersApi.js
+++ b/src/UI/sd-ui/src/api/usersApi.js
@@ -4,7 +4,8 @@ const UsersApi = {
   createOrUpdateUser: (userData) => apiClient.post("/user", userData),
   getCurrentUser: () => apiClient.get("/user/me"),
   updateTimezone: (timezone) => apiClient.patch("/user/me/timezone", { timezone }),
-  updateUsername: (username) => apiClient.patch("/user/me/username", { username })
+  updateUsername: (username) => apiClient.patch("/user/me/username", { username }),
+  updateDisplayName: (displayName) => apiClient.patch("/user/me/displayname", { displayName })
 };
 
 export default UsersApi;

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -48,9 +48,9 @@ function SettingsPage() {
   const [tzSaving, setTzSaving] = useState(false);
   const [tzMessage, setTzMessage] = useState("");
 
-  const [usernameInput, setUsernameInput] = useState("");
-  const [usernameSaving, setUsernameSaving] = useState(false);
-  const [usernameMessage, setUsernameMessage] = useState("");
+  const [displayNameInput, setDisplayNameInput] = useState("");
+  const [displayNameSaving, setDisplayNameSaving] = useState(false);
+  const [displayNameMessage, setDisplayNameMessage] = useState("");
 
   const allZones = useMemo(() => getAllIanaZones(), []);
   const browserTz = useMemo(() => detectBrowserTimezone(), []);
@@ -63,7 +63,7 @@ function SettingsPage() {
         const response = await apiWrapper.Users.getCurrentUser();
         if (isMounted) {
           setUser(response.data);
-          setUsernameInput(response.data?.username || "");
+          setDisplayNameInput(response.data?.displayName || "");
           setIsLoading(false);
         }
       } catch (err) {
@@ -89,26 +89,25 @@ function SettingsPage() {
   const effectiveTimezone = user?.timezone || browserTz;
   const isCurated = CURATED_TIMEZONES.some((z) => z.value === effectiveTimezone);
 
-  const handleUsernameSave = async () => {
-    const next = usernameInput.trim();
-    if (!next || next.toLowerCase() === (user?.username || "").toLowerCase()) return;
-    setUsernameSaving(true);
-    setUsernameMessage("");
+  const handleDisplayNameSave = async () => {
+    const next = displayNameInput.trim();
+    if (!next || next === (user?.displayName || "")) return;
+    setDisplayNameSaving(true);
+    setDisplayNameMessage("");
     try {
-      await apiWrapper.Users.updateUsername(next);
-      const lowered = next.toLowerCase();
-      setUser((prev) => (prev ? { ...prev, username: lowered } : prev));
-      setUsernameInput(lowered);
+      await apiWrapper.Users.updateDisplayName(next);
+      setUser((prev) => (prev ? { ...prev, displayName: next } : prev));
+      setDisplayNameInput(next);
       await refreshUserDto();
-      setUsernameMessage("Saved.");
+      setDisplayNameMessage("Saved.");
     } catch (err) {
-      console.error("Failed to update username:", err);
+      console.error("Failed to update display name:", err);
       const serverMsg =
-        err?.response?.data?.errors?.Username?.[0] ||
+        err?.response?.data?.errors?.DisplayName?.[0] ||
         err?.response?.data?.title;
-      setUsernameMessage(serverMsg || "Could not save username (it may be taken or invalid).");
+      setDisplayNameMessage(serverMsg || "Could not save display name.");
     } finally {
-      setUsernameSaving(false);
+      setDisplayNameSaving(false);
     }
   };
 
@@ -147,26 +146,26 @@ function SettingsPage() {
             <span>{user?.email || "Not set"}</span>
           </div>
           <div className="settings-item">
-            <span className="label">Display Name:</span>
-            <span>{user?.displayName || "Not set"}</span>
+            <span className="label">Username:</span>
+            <span>{user?.username ? `@${user.username}` : "Not set"}</span>
           </div>
           <div className="settings-item">
-            <span className="label">Username:</span>
+            <span className="label">Display Name:</span>
             <span>
               <input
                 type="text"
-                aria-label="Username"
-                value={usernameInput}
-                onChange={(e) => setUsernameInput(e.target.value)}
-                disabled={usernameSaving}
-                maxLength={30}
+                aria-label="Display Name"
+                value={displayNameInput}
+                onChange={(e) => setDisplayNameInput(e.target.value)}
+                disabled={displayNameSaving}
+                maxLength={100}
                 style={{ marginRight: 8 }}
               />
-              <button onClick={handleUsernameSave} disabled={usernameSaving}>
-                {usernameSaving ? "Saving…" : "Save"}
+              <button onClick={handleDisplayNameSave} disabled={displayNameSaving}>
+                {displayNameSaving ? "Saving…" : "Save"}
               </button>
-              {usernameMessage && (
-                <span style={{ marginLeft: 8, fontSize: "0.85em" }}>{usernameMessage}</span>
+              {displayNameMessage && (
+                <span style={{ marginLeft: 8, fontSize: "0.85em" }}>{displayNameMessage}</span>
               )}
             </span>
           </div>

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -102,8 +102,12 @@ function SettingsPage() {
       setDisplayNameMessage("Saved.");
     } catch (err) {
       console.error("Failed to update display name:", err);
+      // ToActionResult() returns validation failures as an array:
+      // { errors: [ { propertyName, errorMessage }, ... ] }.
       const serverMsg =
-        err?.response?.data?.errors?.DisplayName?.[0] ||
+        err?.response?.data?.errors?.find?.(
+          (e) => e.propertyName === "DisplayName"
+        )?.errorMessage ||
         err?.response?.data?.title;
       setDisplayNameMessage(serverMsg || "Could not save display name.");
     } finally {
@@ -158,7 +162,7 @@ function SettingsPage() {
                 value={displayNameInput}
                 onChange={(e) => setDisplayNameInput(e.target.value)}
                 disabled={displayNameSaving}
-                maxLength={100}
+                maxLength={25}
                 style={{ marginRight: 8 }}
               />
               <button onClick={handleDisplayNameSave} disabled={displayNameSaving}>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandHandlerTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+
+using FluentValidation;
+
+using SportsData.Api.Application.User.Commands.UpdateDisplayName;
+using SportsData.Core.Common;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.User.Commands.UpdateDisplayName;
+
+public class UpdateDisplayNameCommandHandlerTests : ApiTestBase<UpdateDisplayNameCommandHandler>
+{
+    public UpdateDisplayNameCommandHandlerTests()
+    {
+        Mocker.Use<IValidator<UpdateDisplayNameCommand>>(new UpdateDisplayNameCommandValidator());
+    }
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        var id = Guid.NewGuid();
+        await DataContext.Users.AddAsync(new UserEntity
+        {
+            Id = id,
+            FirebaseUid = Guid.NewGuid().ToString(),
+            Email = "u@x.com",
+            SignInProvider = "password",
+            DisplayName = "Old Name",
+            Username = "handle"
+        });
+        await DataContext.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task Execute_UpdatesDisplayName_AndTrims()
+    {
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateDisplayNameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateDisplayNameCommand { DisplayName = "  YouWillAllLose  " });
+
+        result.IsSuccess.Should().BeTrue();
+        var user = await DataContext.Users.FindAsync(userId);
+        user!.DisplayName.Should().Be("YouWillAllLose");
+    }
+
+    [Fact]
+    public async Task Execute_Rejects_WhenBlank()
+    {
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateDisplayNameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateDisplayNameCommand { DisplayName = "   " });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.BadRequest);
+    }
+
+    [Fact]
+    public async Task Execute_NotFound_WhenUserMissing()
+    {
+        var handler = Mocker.CreateInstance<UpdateDisplayNameCommandHandler>();
+
+        var result = await handler.ExecuteAsync(Guid.NewGuid(), new UpdateDisplayNameCommand { DisplayName = "Ghost" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandHandlerTests.cs
@@ -60,6 +60,19 @@ public class UpdateDisplayNameCommandHandlerTests : ApiTestBase<UpdateDisplayNam
     }
 
     [Fact]
+    public async Task Execute_Rejects_WhenTooLong()
+    {
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateDisplayNameCommandHandler>();
+        var tooLong = new string('a', UpdateDisplayNameCommandValidator.MaxLength + 1);
+
+        var result = await handler.ExecuteAsync(userId, new UpdateDisplayNameCommand { DisplayName = tooLong });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.BadRequest);
+    }
+
+    [Fact]
     public async Task Execute_NotFound_WhenUserMissing()
     {
         var handler = Mocker.CreateInstance<UpdateDisplayNameCommandHandler>();


### PR DESCRIPTION
## Summary

Settings on web (and the mobile profile) let users edit their **username** — but username is the stable handle for search/invite/@-mentions; the **display name** is the label users should be able to rename. This inverts that.

## Changes

**API**
- New `UpdateDisplayName` command/handler/validator + `PATCH /user/me/displayname` (not-empty, max 100, trimmed; non-unique). The `UpdateUsername` endpoint is kept in place but no longer used by the UI (leaves a future "choose your handle" onboarding option open).

**Web (`SettingsPage`)**
- Display Name is now the editable field (→ `updateDisplayName`); Username is shown read-only as `@handle`.

**Mobile (`profile.tsx`)**
- Username is a read-only row; Display Name is the inline-editable one (→ `updateDisplayName`). Editor styles renamed `username*` → `field*`. Hero already shows display name + `@username`.

Net: username = stable handle everywhere; display name = the thing users rename. Consistent across web + mobile.

## Testing
- `UpdateDisplayNameCommandHandlerTests` (updates + trims / rejects blank / not-found).
- API builds; full API unit suite green; mobile `tsc --noEmit` clean.
- Web/mobile UI validated locally.

## Note
Independent of #483 (email-invite membership) — different files, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating a user’s display name across the app and mobile/web settings screens.
  * Introduced a new profile update action that saves display-name changes and refreshes the current profile data.

* **Bug Fixes**
  * Display names are now trimmed before saving.
  * Blank or overly long display names are rejected with clear validation feedback.

* **Tests**
  * Added coverage for successful updates, invalid input, and missing-user cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->