### PR TITLE
chore(deps): pin Microsoft.OpenApi 2.7.5 (clears NU1903)

### DIFF
--- a/src/SportsData.Api/SportsData.Api.csproj
+++ b/src/SportsData.Api/SportsData.Api.csproj
@@ -90,6 +90,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Twilio" Version="7.14.1" />
   </ItemGroup>
 

--- a/src/SportsData.Api/SportsData.Api.csproj
+++ b/src/SportsData.Api/SportsData.Api.csproj
@@ -89,8 +89,7 @@
     <PackageReference Include="SendGrid" Version="9.29.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="Twilio" Version="7.14.1" />
   </ItemGroup>
 

--- a/src/SportsData.Contest/SportsData.Contest.csproj
+++ b/src/SportsData.Contest/SportsData.Contest.csproj
@@ -15,8 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Contest/SportsData.Contest.csproj
+++ b/src/SportsData.Contest/SportsData.Contest.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Core/SportsData.Core.csproj
+++ b/src/SportsData.Core/SportsData.Core.csproj
@@ -63,8 +63,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/SportsData.Core/SportsData.Core.csproj
+++ b/src/SportsData.Core/SportsData.Core.csproj
@@ -64,6 +64,7 @@
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/SportsData.Franchise/SportsData.Franchise.csproj
+++ b/src/SportsData.Franchise/SportsData.Franchise.csproj
@@ -21,8 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Franchise/SportsData.Franchise.csproj
+++ b/src/SportsData.Franchise/SportsData.Franchise.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Notification/SportsData.Notification.csproj
+++ b/src/SportsData.Notification/SportsData.Notification.csproj
@@ -23,8 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Notification/SportsData.Notification.csproj
+++ b/src/SportsData.Notification/SportsData.Notification.csproj
@@ -24,6 +24,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Player/SportsData.Player.csproj
+++ b/src/SportsData.Player/SportsData.Player.csproj
@@ -14,8 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Player/SportsData.Player.csproj
+++ b/src/SportsData.Player/SportsData.Player.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Producer/SportsData.Producer.csproj
+++ b/src/SportsData.Producer/SportsData.Producer.csproj
@@ -31,8 +31,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Scrutor" Version="6.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Producer/SportsData.Producer.csproj
+++ b/src/SportsData.Producer/SportsData.Producer.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Scrutor" Version="6.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Provider/SportsData.Provider.csproj
+++ b/src/SportsData.Provider/SportsData.Provider.csproj
@@ -37,8 +37,7 @@
     -->
     <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Provider/SportsData.Provider.csproj
+++ b/src/SportsData.Provider/SportsData.Provider.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Season/SportsData.Season.csproj
+++ b/src/SportsData.Season/SportsData.Season.csproj
@@ -14,8 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Season/SportsData.Season.csproj
+++ b/src/SportsData.Season/SportsData.Season.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Venue/SportsData.Venue.csproj
+++ b/src/SportsData.Venue/SportsData.Venue.csproj
@@ -21,8 +21,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SportsData.Venue/SportsData.Venue.csproj
+++ b/src/SportsData.Venue/SportsData.Venue.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/unit/SportsData.Contest.Tests.Unit/SportsData.Contest.Tests.Unit.csproj
+++ b/test/unit/SportsData.Contest.Tests.Unit/SportsData.Contest.Tests.Unit.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.6.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/test/unit/SportsData.Notification.Tests.Unit/SportsData.Notification.Tests.Unit.csproj
+++ b/test/unit/SportsData.Notification.Tests.Unit/SportsData.Notification.Tests.Unit.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.6.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/test/unit/SportsData.Player.Tests.Unit/SportsData.Player.Tests.Unit.csproj
+++ b/test/unit/SportsData.Player.Tests.Unit/SportsData.Player.Tests.Unit.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.6.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/test/unit/SportsData.Producer.Tests.Unit/SportsData.Producer.Tests.Unit.csproj
+++ b/test/unit/SportsData.Producer.Tests.Unit/SportsData.Producer.Tests.Unit.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/unit/SportsData.Provider.Tests.Unit/SportsData.Provider.Tests.Unit.csproj
+++ b/test/unit/SportsData.Provider.Tests.Unit/SportsData.Provider.Tests.Unit.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/test/unit/SportsData.Season.Tests.Unit/SportsData.Season.Tests.Unit.csproj
+++ b/test/unit/SportsData.Season.Tests.Unit/SportsData.Season.Tests.Unit.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.6.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/test/unit/SportsData.Venue.Tests.Unit/SportsData.Venue.Tests.Unit.csproj
+++ b/test/unit/SportsData.Venue.Tests.Unit/SportsData.Venue.Tests.Unit.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq.AutoMock" Version="3.6.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

A high-severity advisory (`GHSA-v5pm-xwqc-g5wc` — circular schema references can terminate OpenAPI parsing) was just published for `Microsoft.OpenApi` (vulnerable `<= 2.7.4`, patched **2.7.5**). `Swashbuckle.AspNetCore` 10.1.0 pulls `Microsoft.OpenApi` **2.3.0** transitively, so `NuGetAudit` (warnings-as-errors) now **fails `dotnet restore` on every service** — e.g. #484's pipeline:

```
error NU1903: Warning As Error: Package 'Microsoft.OpenApi' 2.3.0 has a known high severity vulnerability
```

## Fix

Pin a direct `Microsoft.OpenApi` `2.7.5` reference in all 10 projects that reference Swashbuckle. 2.7.5 satisfies Swashbuckle's `>= 2.3.0` and stays on the same 2.x line, so no API breakage. Restore + build verified clean locally (no NU1903).

## After merge
Other open PRs (#484 display-name, #485 diagnostic) will go green once they pick up `main` — use **Update branch** on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Swagger/OpenAPI tooling to the latest patch version across the API services.
  * Applied the same Swagger/OpenAPI tooling update to the unit test projects to keep documentation-related behavior consistent during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->