### PR TITLE
feat(mobile): enable native iPad support (full screen, portrait-only)

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -13,14 +13,15 @@
       "backgroundColor": "#0d1117"
     },
     "ios": {
-      "supportsTablet": false,
+      "supportsTablet": true,
       "bundleIdentifier": "com.sportdeets.mobile",
       "googleServicesFile": "./GoogleService-Info.plist",
       "entitlements": {
         "aps-environment": "production"
       },
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "UIRequiresFullScreen": true
       },
       "buildNumber": "34"
     },


### PR DESCRIPTION
## Summary

The app installed on iPad but ran in a small scaled iPhone-compatibility window because `ios.supportsTablet` was `false`. Enable native iPad support so it fills the screen.

- `ios.supportsTablet: true` — installs the native iPad build (full screen).
- Keep the existing portrait lock and add `UIRequiresFullScreen: true` — opts the app out of iPad multitasking (Split View), which avoids Apple's requirement that multitasking apps support all orientations. Chosen over full landscape support to keep this scoped.

## Notes
- **Native config change** — requires a new EAS build to take effect (not OTA).
- Phone-width layouts will now span the full iPad canvas, so expect stretched/sparse screens until we add responsive polish (max-width content, multi-column). That layout work is a deliberate follow-up, not in this PR.
- `buildNumber` intentionally unchanged here (managed locally per build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the iOS app on tablets.
  * Configured the app to use full-screen mode on iPad devices.
  * Updated encryption declaration settings for App Store compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->