### PR TITLE
feat(mobile): wire Sign in with Apple entitlement

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -80,7 +80,8 @@
         {
           "iosUrlScheme": "com.googleusercontent.apps.812654295319-fckkt2811fn0sr745366rmh62g5788da"
         }
-      ]
+      ],
+      "expo-apple-authentication"
     ],
     "experiments": {
       "typedRoutes": true


### PR DESCRIPTION
## Summary

The Apple Sign-In **client code is already implemented** (`src/lib/appleSignIn.ts` — full OIDC nonce → Firebase `OAuthProvider('apple.com')` flow — plus the native `AppleAuthenticationButton` on the sign-in screen). But the **`expo-apple-authentication` config plugin was missing from `app.json`**, so the iOS "Sign in with Apple" entitlement was never added to the native build → `isAvailableAsync()` returned false → the button was hidden and the flow was dead.

This adds the plugin so the entitlement is emitted on the next native build.

## Still required to make it work end-to-end (outside this repo)
1. **Apple Developer portal:** enable "Sign in with Apple" on App ID `com.sportdeets.mobile`; create a **Services ID** + **Sign in with Apple key (.p8)**.
2. **Firebase Console → Authentication:** enable the **Apple** provider; paste the Services ID + key.
3. **EAS rebuild** + test the Apple button on a physical iOS device.

## Why it matters
App Store Review Guideline 4.8: because the app offers Google Sign-In, Sign in with Apple is expected/required for iOS submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mobile app configuration for Google Sign-In and Apple Authentication plugins.
  * Improved configuration parsing and plugin loading reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->