### PR TITLE
feat(user): in-app account deletion (anonymize) + provider collision message

### DIFF
--- a/docs/mobile/account-deletion.md
+++ b/docs/mobile/account-deletion.md
@@ -1,0 +1,71 @@
+# Account Deletion (anonymize model)
+
+Status: implemented
+Last updated: 2026-07-11
+
+## Why
+
+App Store Guideline 5.1.1(v) requires any app with account sign-up to offer
+**in-app account deletion** (not just deactivation). GDPR/CCPA similarly require
+removal of personal data on request.
+
+## Model: anonymize, keep game history
+
+sportDeets is a pick'em product built on shared league history and standings. A
+hard delete of a departing user would corrupt co-players' leagues (their picks
+feed weekly results and standings). So deletion **anonymizes** the user rather
+than removing their rows:
+
+- **Removed / neutralized:** login (Firebase auth user deleted), and all PII on
+  the canonical `User` — email, username, display name, timezone, FirebaseUid —
+  replaced with per-id sentinels. `DeletedUtc` is stamped.
+- **Retained (anonymized):** picks, league memberships, standings, week results
+  — so other users' leagues stay intact. In any UI the user now reads as
+  "Deleted user".
+- **Purged downstream:** the Notification service drops the user's devices,
+  notification preferences, projection rows, and scheduled jobs (stops all push
+  and reminders).
+
+This satisfies "account deleted, can't log in, personal data removed" while
+preserving the shared product.
+
+## Flow
+
+```text
+Mobile (profile → Delete account → confirm)
+  └─ DELETE /user/me
+       API DeleteAccountCommandHandler:
+         1. load User (by JWT user id); capture FirebaseUid
+         2. Firebase Admin DeleteUserAsync(firebaseUid)   // kills login
+         3. anonymize User row (PII → sentinels, DeletedUtc = now)
+         4. SaveChanges
+         5. publish UserDeleted
+  └─ on 2xx: signOut() → welcome screen
+
+Notification UserDeletedConsumer:
+  purge UserDevice, UserNotificationPreferences, User projection,
+  PendingScheduledJob, NotificationLog for that UserId
+```
+
+### Anonymization sentinels (canonical `User`)
+- `FirebaseUid` → `deleted-{id:N}` (keeps the unique index satisfied; login already gone)
+- `Email` → `deleted-{id:N}@deleted.invalid`
+- `Username` → `del_{id:N}`, truncated to 30 (unique index)
+- `DisplayName` → `Deleted user`
+- `Timezone` → null; `EmailVerified` → false
+- `DeletedUtc` → now
+
+`GetInviteableUsers` excludes `DeletedUtc != null` so deleted users can't be
+invited. Leaderboards/standings still show them as "Deleted user".
+
+## Collision handling (folded in)
+
+Sign-in with a provider whose email already exists under a different provider
+(e.g. Google then Apple) surfaces Firebase `auth/account-exists-with-different-credential`.
+The mobile sign-in libs catch it and show a clear message ("already registered
+with X — use that method"). Full auto-linking is a deferred follow-up.
+
+## Out of scope
+- Auto-linking providers for the same email.
+- User-initiated data export.
+- Undo / grace-period restore (deletion is immediate).

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetInviteableUsers/GetInviteableUsersQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetInviteableUsers/GetInviteableUsersQueryHandler.cs
@@ -61,6 +61,7 @@ public class GetInviteableUsersQueryHandler : IGetInviteableUsersQueryHandler
             .AsNoTracking()
             .Where(u => u.Id != query.RequestingUserId
                 && !u.IsSynthetic
+                && u.DeletedUtc == null
                 && !memberIds.Contains(u.Id)
                 && (u.Username.Contains(lowered) || u.DisplayName.ToLower().Contains(lowered)))
             .OrderBy(u => u.Username)

--- a/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommand.cs
+++ b/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommand.cs
@@ -1,0 +1,7 @@
+namespace SportsData.Api.Application.User.Commands.DeleteAccount;
+
+public class DeleteAccountCommand
+{
+    /// <summary>The authenticated user to delete (resolved from the JWT).</summary>
+    public required Guid UserId { get; init; }
+}

--- a/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandler.cs
@@ -1,0 +1,93 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Auth;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+
+namespace SportsData.Api.Application.User.Commands.DeleteAccount;
+
+public interface IDeleteAccountCommandHandler
+{
+    Task<Result<bool>> ExecuteAsync(Guid userId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Deletes a user's account (App Store 5.1.1(v) / GDPR). Anonymizes the
+/// canonical <c>User</c> — PII stripped, login removed — while retaining game
+/// history so co-players' leagues stay intact, then publishes
+/// <see cref="UserDeleted"/> so the Notification service purges the user's
+/// devices/preferences/scheduled jobs. See docs/mobile/account-deletion.md.
+/// </summary>
+public class DeleteAccountCommandHandler : IDeleteAccountCommandHandler
+{
+    private readonly AppDataContext _db;
+    private readonly IFirebaseUserAdmin _firebase;
+    private readonly IEventBus _eventBus;
+    private readonly IDateTimeProvider _clock;
+    private readonly ILogger<DeleteAccountCommandHandler> _logger;
+
+    public DeleteAccountCommandHandler(
+        AppDataContext db,
+        IFirebaseUserAdmin firebase,
+        IEventBus eventBus,
+        IDateTimeProvider clock,
+        ILogger<DeleteAccountCommandHandler> logger)
+    {
+        _db = db;
+        _firebase = firebase;
+        _eventBus = eventBus;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<Result<bool>> ExecuteAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return new Failure<bool>(
+                false,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
+        }
+
+        // Idempotent: already deleted → nothing to do.
+        if (user.DeletedUtc is not null)
+        {
+            return new Success<bool>(true);
+        }
+
+        // Kill the login first. If this throws (broker/network), we abort before
+        // mutating any data. The wrapper treats an already-absent uid as success,
+        // so a retried delete re-anonymizes cleanly.
+        await _firebase.DeleteUserAsync(user.FirebaseUid, cancellationToken);
+
+        // Anonymize in place — keep the row so picks/memberships/standings FKs
+        // stay valid. Sentinels keep the unique indexes (FirebaseUid, Username)
+        // satisfied.
+        var idN = user.Id.ToString("N");
+        user.FirebaseUid = $"deleted-{idN}";
+        user.Email = $"deleted-{idN}@deleted.invalid";
+        user.EmailVerified = false;
+        user.Username = $"del_{idN}"[..30];
+        user.DisplayName = "Deleted user";
+        user.Timezone = null;
+        user.DeletedUtc = _clock.UtcNow();
+
+        // Publish before SaveChanges so the outbox row persists atomically with
+        // the anonymization (EF bus outbox flushes on save).
+        await _eventBus.Publish(
+            new UserDeleted(user.Id, Guid.NewGuid(), Guid.NewGuid()),
+            cancellationToken);
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Account deleted (anonymized). UserId={UserId}", userId);
+
+        return new Success<bool>(true);
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandler.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
@@ -12,7 +13,7 @@ namespace SportsData.Api.Application.User.Commands.DeleteAccount;
 
 public interface IDeleteAccountCommandHandler
 {
-    Task<Result<bool>> ExecuteAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<Result<bool>> ExecuteAsync(DeleteAccountCommand command, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -28,6 +29,7 @@ public class DeleteAccountCommandHandler : IDeleteAccountCommandHandler
     private readonly IFirebaseUserAdmin _firebase;
     private readonly IEventBus _eventBus;
     private readonly IDateTimeProvider _clock;
+    private readonly IValidator<DeleteAccountCommand> _validator;
     private readonly ILogger<DeleteAccountCommandHandler> _logger;
 
     public DeleteAccountCommandHandler(
@@ -35,24 +37,34 @@ public class DeleteAccountCommandHandler : IDeleteAccountCommandHandler
         IFirebaseUserAdmin firebase,
         IEventBus eventBus,
         IDateTimeProvider clock,
+        IValidator<DeleteAccountCommand> validator,
         ILogger<DeleteAccountCommandHandler> logger)
     {
         _db = db;
         _firebase = firebase;
         _eventBus = eventBus;
         _clock = clock;
+        _validator = validator;
         _logger = logger;
     }
 
-    public async Task<Result<bool>> ExecuteAsync(Guid userId, CancellationToken cancellationToken = default)
+    public async Task<Result<bool>> ExecuteAsync(DeleteAccountCommand command, CancellationToken cancellationToken = default)
     {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<bool>(false, ResultStatus.BadRequest, validation.Errors);
+        }
+
+        var userId = command.UserId;
+
         var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
         if (user is null)
         {
             return new Failure<bool>(
                 false,
                 ResultStatus.NotFound,
-                [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
+                [new ValidationFailure(nameof(command.UserId), $"User with ID {userId} not found.")]);
         }
 
         // Idempotent: already deleted → nothing to do.

--- a/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.User.Commands.DeleteAccount;
+
+public class DeleteAccountCommandValidator : AbstractValidator<DeleteAccountCommand>
+{
+    public DeleteAccountCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("User id is required.");
+    }
+}

--- a/src/SportsData.Api/Application/User/UserController.cs
+++ b/src/SportsData.Api/Application/User/UserController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Api.Application.User.Commands.DeleteAccount;
 using SportsData.Api.Application.User.Commands.UpdateDisplayName;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
@@ -87,6 +88,17 @@ public class UserController : ApiControllerBase
     {
         var userId = HttpContext.GetCurrentUserId();
         var result = await handler.ExecuteAsync(userId, command, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpDelete("me")]
+    [Authorize]
+    public async Task<ActionResult<bool>> DeleteMe(
+        [FromServices] IDeleteAccountCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await handler.ExecuteAsync(userId, cancellationToken);
         return result.ToActionResult();
     }
 }

--- a/src/SportsData.Api/Application/User/UserController.cs
+++ b/src/SportsData.Api/Application/User/UserController.cs
@@ -97,8 +97,8 @@ public class UserController : ApiControllerBase
         [FromServices] IDeleteAccountCommandHandler handler,
         CancellationToken cancellationToken)
     {
-        var userId = HttpContext.GetCurrentUserId();
-        var result = await handler.ExecuteAsync(userId, cancellationToken);
+        var command = new DeleteAccountCommand { UserId = HttpContext.GetCurrentUserId() };
+        var result = await handler.ExecuteAsync(command, cancellationToken);
         return result.ToActionResult();
     }
 }

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -80,12 +80,14 @@ using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamMetrics;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamFinalizedGames;
 using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamStatistics;
 using SportsData.Api.Application.User;
+using SportsData.Api.Application.User.Commands.DeleteAccount;
 using SportsData.Api.Application.User.Commands.UpdateDisplayName;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Queries.GetMe;
 using SportsData.Api.Config;
+using SportsData.Api.Infrastructure.Auth;
 using SportsData.Api.Infrastructure.Data.Canonical;
 using SportsData.Api.Infrastructure.Notifications;
 using SportsData.Api.Infrastructure.Prompts;
@@ -250,7 +252,9 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IUpdateUserTimezoneCommandHandler, UpdateUserTimezoneCommandHandler>();
             services.AddScoped<IUpdateUsernameCommandHandler, UpdateUsernameCommandHandler>();
             services.AddScoped<IUpdateDisplayNameCommandHandler, UpdateDisplayNameCommandHandler>();
-            
+            services.AddScoped<IDeleteAccountCommandHandler, DeleteAccountCommandHandler>();
+            services.AddSingleton<IFirebaseUserAdmin, FirebaseUserAdmin>();
+
             // User Validators
             services.AddValidatorsFromAssemblyContaining<Program>();
 

--- a/src/SportsData.Api/Infrastructure/Auth/FirebaseUserAdmin.cs
+++ b/src/SportsData.Api/Infrastructure/Auth/FirebaseUserAdmin.cs
@@ -1,0 +1,20 @@
+using FirebaseAdmin.Auth;
+
+namespace SportsData.Api.Infrastructure.Auth;
+
+/// <inheritdoc />
+public class FirebaseUserAdmin : IFirebaseUserAdmin
+{
+    public async Task DeleteUserAsync(string firebaseUid, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await FirebaseAuth.DefaultInstance.DeleteUserAsync(firebaseUid, cancellationToken);
+        }
+        catch (FirebaseAuthException ex) when (ex.AuthErrorCode == AuthErrorCode.UserNotFound)
+        {
+            // Already gone (e.g. a retried delete). Treat as success so the
+            // caller can proceed to anonymize idempotently.
+        }
+    }
+}

--- a/src/SportsData.Api/Infrastructure/Auth/IFirebaseUserAdmin.cs
+++ b/src/SportsData.Api/Infrastructure/Auth/IFirebaseUserAdmin.cs
@@ -1,0 +1,14 @@
+namespace SportsData.Api.Infrastructure.Auth;
+
+/// <summary>
+/// Thin, injectable wrapper over Firebase Admin user management so command
+/// handlers can be unit-tested without the static <c>FirebaseAuth.DefaultInstance</c>.
+/// </summary>
+public interface IFirebaseUserAdmin
+{
+    /// <summary>
+    /// Deletes the Firebase auth user (removes the login). Idempotent: a
+    /// no-longer-existing uid is treated as success.
+    /// </summary>
+    Task DeleteUserAsync(string firebaseUid, CancellationToken cancellationToken = default);
+}

--- a/src/SportsData.Api/Infrastructure/Data/Entities/User.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/User.cs
@@ -47,6 +47,14 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public bool IsReadOnly { get; set; }
 
+        /// <summary>
+        /// Set when the user deletes their account. The row is retained but
+        /// anonymized (PII stripped, login removed) so league history/standings
+        /// stay intact; this stamp marks it deleted for filtering (e.g. excluded
+        /// from invite search). Null = active. See docs/mobile/account-deletion.md.
+        /// </summary>
+        public DateTime? DeletedUtc { get; set; }
+
         public ICollection<PickemGroupMember> GroupMemberships { get; set; } = [];
 
         public class EntityConfiguration : IEntityTypeConfiguration<User>

--- a/src/SportsData.Api/Migrations/20260711131327_11JulV1_UserDeletedUtc.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260711131327_11JulV1_UserDeletedUtc.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260711131327_11JulV1_UserDeletedUtc")]
+    partial class _11JulV1_UserDeletedUtc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260711131327_11JulV1_UserDeletedUtc.cs
+++ b/src/SportsData.Api/Migrations/20260711131327_11JulV1_UserDeletedUtc.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class _11JulV1_UserDeletedUtc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedUtc",
+                table: "User",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "User",
+                keyColumn: "Id",
+                keyValue: new Guid("11111111-1111-1111-1111-111111111111"),
+                column: "DeletedUtc",
+                value: null);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedUtc",
+                table: "User");
+        }
+    }
+}

--- a/src/SportsData.Core/Eventing/Events/Users/UserDeleted.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UserDeleted.cs
@@ -1,0 +1,25 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Users
+{
+    /// <summary>
+    /// Emitted by the API when a user deletes their account. The canonical
+    /// <c>User</c> is anonymized (PII stripped, login removed) but game history
+    /// is retained; this event tells the Notification service to purge the
+    /// user's downstream footprint — devices, notification preferences, its
+    /// <c>User</c> projection, scheduled jobs, and logs — so all push and
+    /// reminders stop.
+    ///
+    /// <para>
+    /// Consumer must be idempotent: purge is by <see cref="UserId"/> and a
+    /// missing row is a no-op.
+    /// </para>
+    /// </summary>
+    public record UserDeleted(
+        Guid UserId,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport.All, null, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/UserDeletedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserDeletedConsumer.cs
@@ -1,0 +1,69 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Infrastructure.Data;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// A user deleted their account (the API anonymized the canonical record and
+    /// published <see cref="UserDeleted"/>). Purge the user's entire footprint in
+    /// the Notification store — devices, preferences, pick projection, scheduled
+    /// jobs, delivery logs, membership projection, and the user projection — so no
+    /// further push or reminder can target them.
+    ///
+    /// <para>Idempotent: purge is by UserId; a redelivery that finds nothing is a
+    /// no-op.</para>
+    /// </summary>
+    public class UserDeletedConsumer : IConsumer<UserDeleted>
+    {
+        private readonly ILogger<UserDeletedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+
+        public UserDeletedConsumer(
+            ILogger<UserDeletedConsumer> logger,
+            AppDataContext dataContext)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+        }
+
+        public async Task Consume(ConsumeContext<UserDeleted> context)
+        {
+            var msg = context.Message;
+            var userId = msg.UserId;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["UserId"] = userId
+            });
+
+            var ct = context.CancellationToken;
+
+            var devices = await _dataContext.UserDevices.Where(x => x.UserId == userId).ToListAsync(ct);
+            var prefs = await _dataContext.UserNotificationPreferences.Where(x => x.UserId == userId).ToListAsync(ct);
+            var picks = await _dataContext.UserPicks.Where(x => x.UserId == userId).ToListAsync(ct);
+            var jobs = await _dataContext.PendingScheduledJobs.Where(x => x.UserId == userId).ToListAsync(ct);
+            var logs = await _dataContext.NotificationLog.Where(x => x.UserId == userId).ToListAsync(ct);
+            var memberships = await _dataContext.PickemGroupMembers.Where(x => x.UserId == userId).ToListAsync(ct);
+            var user = await _dataContext.Users.FirstOrDefaultAsync(x => x.Id == userId, ct);
+
+            _dataContext.UserDevices.RemoveRange(devices);
+            _dataContext.UserNotificationPreferences.RemoveRange(prefs);
+            _dataContext.UserPicks.RemoveRange(picks);
+            _dataContext.PendingScheduledJobs.RemoveRange(jobs);
+            _dataContext.NotificationLog.RemoveRange(logs);
+            _dataContext.PickemGroupMembers.RemoveRange(memberships);
+            if (user is not null)
+                _dataContext.Users.Remove(user);
+
+            await _dataContext.SaveChangesAsync(ct);
+
+            _logger.LogInformation(
+                "Purged deleted-user footprint. Devices={Devices}, Prefs={Prefs}, Picks={Picks}, Jobs={Jobs}, Logs={Logs}, Memberships={Memberships}, User={UserPurged}",
+                devices.Count, prefs.Count, picks.Count, jobs.Count, logs.Count, memberships.Count, user is not null);
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -45,6 +45,7 @@ namespace SportsData.Notification
                 typeof(PickemGroupMatchupDataPublishedConsumer),
                 typeof(PickemGroupMemberAddedConsumer),
                 typeof(UserDataPublishedConsumer),
+                typeof(UserDeletedConsumer),
                 typeof(UserDeviceRegisteredConsumer),
                 typeof(UserDeviceUnregisteredConsumer),
                 typeof(UserInvitedToPickemGroupConsumer),

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -173,7 +173,9 @@ export default function ProfileScreen() {
       await signOut(auth);
       // Success path: useAuthInit's onAuthStateChanged listener observes
       // the auth flip → AuthGuard handles the redirect to /(auth)/welcome.
-      // No local state cleanup required.
+      // Drop all cached queries (current user, leagues, picks, …) so the next
+      // login can't flash the previous user's cached identity before refetch.
+      queryClient.clear();
     } catch (err) {
       console.error('[ProfileScreen] Firebase sign-out failed', err);
       Alert.alert(
@@ -227,6 +229,9 @@ export default function ProfileScreen() {
     } catch (err) {
       console.warn('[ProfileScreen] sign-out after deletion failed (already gone)', err);
     }
+    // Always drop cached queries — the account is gone regardless of the signOut
+    // result, so no cached identity/data may survive into the next login.
+    queryClient.clear();
   };
 
   const handleDeleteAccount = () => {

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -209,6 +209,48 @@ export default function ProfileScreen() {
     ]);
   };
 
+  const performAccountDeletion = async () => {
+    try {
+      await usersApi.deleteAccount();
+    } catch (err) {
+      console.error('[ProfileScreen] account deletion failed', err);
+      Alert.alert(
+        'Deletion Failed',
+        'We could not delete your account. Please check your connection and try again.',
+      );
+      return;
+    }
+    // The account (including the Firebase login) is gone server-side; clear the
+    // local session so AuthGuard redirects to the welcome screen.
+    try {
+      await signOut(auth);
+    } catch (err) {
+      console.warn('[ProfileScreen] sign-out after deletion failed (already gone)', err);
+    }
+  };
+
+  const handleDeleteAccount = () => {
+    const message =
+      'This permanently deletes your account and removes your personal data. '
+      + 'Your league history stays (anonymized). This cannot be undone.';
+    if (Platform.OS === 'web') {
+      if (typeof window !== 'undefined' && window.confirm(message)) {
+        void performAccountDeletion();
+      }
+      return;
+    }
+    Alert.alert('Delete Account?', message, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => {
+          void performAccountDeletion();
+        },
+      },
+    ]);
+  };
+
   const beginEditDisplayName = () => {
     setDisplayNameInput(me?.displayName ?? '');
     setDisplayNameMessage('');
@@ -395,6 +437,7 @@ export default function ProfileScreen() {
         />
         <SettingsRow label="Notifications" onPress={() => {}} />
         <SettingsRow label="Sign Out" onPress={handleSignOut} destructive />
+        <SettingsRow label="Delete Account" onPress={handleDeleteAccount} destructive />
       </View>
 
       {/* Developer — admin-only diagnostics. Gated on isAdmin so it

--- a/src/UI/sd-mobile/src/lib/appleSignIn.ts
+++ b/src/UI/sd-mobile/src/lib/appleSignIn.ts
@@ -3,6 +3,10 @@ import * as Crypto from 'expo-crypto';
 import { OAuthProvider, signInWithCredential } from 'firebase/auth';
 import { Platform } from 'react-native';
 import { auth } from './firebase';
+import {
+  AccountExistsWithDifferentCredentialError,
+  isAccountExistsWithDifferentCredential,
+} from './authErrors';
 
 /**
  * Generates an OIDC nonce pair for the Apple sign-in flow:
@@ -105,5 +109,12 @@ export async function signInWithApple(): Promise<void> {
     idToken: identityToken,
     rawNonce,
   });
-  await signInWithCredential(auth, firebaseCredential);
+  try {
+    await signInWithCredential(auth, firebaseCredential);
+  } catch (err) {
+    if (isAccountExistsWithDifferentCredential(err)) {
+      throw new AccountExistsWithDifferentCredentialError();
+    }
+    throw err;
+  }
 }

--- a/src/UI/sd-mobile/src/lib/authErrors.ts
+++ b/src/UI/sd-mobile/src/lib/authErrors.ts
@@ -1,0 +1,22 @@
+/**
+ * Firebase throws `auth/account-exists-with-different-credential` when the
+ * email is already registered under a different provider (e.g. the user signed
+ * up with Google, then tries Apple with the same email). Both provider flows
+ * surface a clear, actionable message instead of the raw code.
+ */
+export function isAccountExistsWithDifferentCredential(err: unknown): boolean {
+  return (
+    (err as { code?: string })?.code ===
+    'auth/account-exists-with-different-credential'
+  );
+}
+
+export class AccountExistsWithDifferentCredentialError extends Error {
+  constructor() {
+    super(
+      'That email is already registered with a different sign-in method. '
+        + 'Please sign in with that method instead.',
+    );
+    this.name = 'AccountExistsWithDifferentCredentialError';
+  }
+}

--- a/src/UI/sd-mobile/src/lib/googleSignIn.ts
+++ b/src/UI/sd-mobile/src/lib/googleSignIn.ts
@@ -7,6 +7,10 @@ import {
 import { GoogleAuthProvider, signInWithCredential } from 'firebase/auth';
 import { Platform } from 'react-native';
 import { auth } from './firebase';
+import {
+  AccountExistsWithDifferentCredentialError,
+  isAccountExistsWithDifferentCredential,
+} from './authErrors';
 
 // Native-module-only library: @react-native-google-signin doesn't have a
 // web implementation. On web, any call into GoogleSignin throws (or
@@ -96,7 +100,14 @@ export async function signInWithGoogle(): Promise<void> {
   }
 
   const credential = GoogleAuthProvider.credential(idToken);
-  await signInWithCredential(auth, credential);
+  try {
+    await signInWithCredential(auth, credential);
+  } catch (err) {
+    if (isAccountExistsWithDifferentCredential(err)) {
+      throw new AccountExistsWithDifferentCredentialError();
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/UI/sd-mobile/src/services/api/usersApi.ts
+++ b/src/UI/sd-mobile/src/services/api/usersApi.ts
@@ -20,7 +20,11 @@ export const usersApi = {
   updateUsername: (username: string) =>
     apiClient.patch('/user/me/username', { username }),
 
-  // PATCH /user/me/displayname — free-text label (non-unique, max 100).
+  // PATCH /user/me/displayname — free-text label (non-unique, max 25).
   updateDisplayName: (displayName: string) =>
     apiClient.patch('/user/me/displayname', { displayName }),
+
+  // DELETE /user/me — deletes the account. Server anonymizes the record and
+  // removes the Firebase login; caller signs out afterward.
+  deleteAccount: () => apiClient.delete('/user/me'),
 };

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandlerTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.User.Commands.DeleteAccount;
+using SportsData.Api.Infrastructure.Auth;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.User.Commands.DeleteAccount;
+
+public class DeleteAccountCommandHandlerTests : ApiTestBase<DeleteAccountCommandHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    public DeleteAccountCommandHandlerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+    }
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        var id = Guid.NewGuid();
+        await DataContext.Users.AddAsync(new UserEntity
+        {
+            Id = id,
+            FirebaseUid = "firebase-uid-abc",
+            Email = "real@person.com",
+            SignInProvider = "apple.com",
+            DisplayName = "Real Person",
+            Username = "realperson",
+            Timezone = "America/New_York"
+        });
+        await DataContext.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task Execute_AnonymizesUser_DeletesFirebaseUser_AndPublishes()
+    {
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<DeleteAccountCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId);
+
+        result.IsSuccess.Should().BeTrue();
+
+        // Firebase login removed (by the original uid).
+        Mocker.GetMock<IFirebaseUserAdmin>().Verify(
+            x => x.DeleteUserAsync("firebase-uid-abc", It.IsAny<CancellationToken>()), Times.Once());
+
+        // Downstream purge announced.
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.Is<UserDeleted>(e => e.UserId == userId), It.IsAny<CancellationToken>()),
+            Times.Once());
+
+        var user = await DataContext.Users.FindAsync(userId);
+        user!.DeletedUtc.Should().Be(FixedNow);
+        user.Email.Should().NotBe("real@person.com");
+        user.Email.Should().StartWith("deleted-");
+        user.Username.Should().NotBe("realperson");
+        user.DisplayName.Should().Be("Deleted user");
+        user.FirebaseUid.Should().StartWith("deleted-");
+        user.Timezone.Should().BeNull();
+        user.Username.Length.Should().BeLessThanOrEqualTo(30);
+    }
+
+    [Fact]
+    public async Task Execute_NotFound_WhenUserMissing()
+    {
+        var handler = Mocker.CreateInstance<DeleteAccountCommandHandler>();
+
+        var result = await handler.ExecuteAsync(Guid.NewGuid());
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        Mocker.GetMock<IFirebaseUserAdmin>().Verify(
+            x => x.DeleteUserAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.IsAny<UserDeleted>(), It.IsAny<CancellationToken>()), Times.Never());
+    }
+
+    [Fact]
+    public async Task Execute_Idempotent_WhenAlreadyDeleted()
+    {
+        var userId = await SeedUserAsync();
+        var user = await DataContext.Users.FindAsync(userId);
+        user!.DeletedUtc = FixedNow.AddDays(-1);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<DeleteAccountCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId);
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IFirebaseUserAdmin>().Verify(
+            x => x.DeleteUserAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.IsAny<UserDeleted>(), It.IsAny<CancellationToken>()), Times.Never());
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandlerTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 
+using FluentValidation;
+
 using Moq;
 
 using SportsData.Api.Application.User.Commands.DeleteAccount;
@@ -21,6 +23,7 @@ public class DeleteAccountCommandHandlerTests : ApiTestBase<DeleteAccountCommand
     public DeleteAccountCommandHandlerTests()
     {
         Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use<IValidator<DeleteAccountCommand>>(new DeleteAccountCommandValidator());
     }
 
     private async Task<Guid> SeedUserAsync()
@@ -46,7 +49,7 @@ public class DeleteAccountCommandHandlerTests : ApiTestBase<DeleteAccountCommand
         var userId = await SeedUserAsync();
         var handler = Mocker.CreateInstance<DeleteAccountCommandHandler>();
 
-        var result = await handler.ExecuteAsync(userId);
+        var result = await handler.ExecuteAsync(new DeleteAccountCommand { UserId = userId });
 
         result.IsSuccess.Should().BeTrue();
 
@@ -59,6 +62,9 @@ public class DeleteAccountCommandHandlerTests : ApiTestBase<DeleteAccountCommand
             b => b.Publish(It.Is<UserDeleted>(e => e.UserId == userId), It.IsAny<CancellationToken>()),
             Times.Once());
 
+        // Reload from the store (not the tracked instance the handler mutated)
+        // so these assertions validate persisted state, i.e. that SaveChanges ran.
+        DataContext.ChangeTracker.Clear();
         var user = await DataContext.Users.FindAsync(userId);
         user!.DeletedUtc.Should().Be(FixedNow);
         user.Email.Should().NotBe("real@person.com");
@@ -75,7 +81,7 @@ public class DeleteAccountCommandHandlerTests : ApiTestBase<DeleteAccountCommand
     {
         var handler = Mocker.CreateInstance<DeleteAccountCommandHandler>();
 
-        var result = await handler.ExecuteAsync(Guid.NewGuid());
+        var result = await handler.ExecuteAsync(new DeleteAccountCommand { UserId = Guid.NewGuid() });
 
         result.IsSuccess.Should().BeFalse();
         result.Status.Should().Be(ResultStatus.NotFound);
@@ -86,21 +92,36 @@ public class DeleteAccountCommandHandlerTests : ApiTestBase<DeleteAccountCommand
     }
 
     [Fact]
-    public async Task Execute_Idempotent_WhenAlreadyDeleted()
+    public async Task Execute_Idempotent_WhenAlreadyDeleted_LeavesRowUntouched()
     {
+        // Seed an already-deleted (anonymized) account.
         var userId = await SeedUserAsync();
+        var deletedAt = FixedNow.AddDays(-1);
         var user = await DataContext.Users.FindAsync(userId);
-        user!.DeletedUtc = FixedNow.AddDays(-1);
+        user!.DeletedUtc = deletedAt;
+        user.Email = "deleted-prior@deleted.invalid";
+        user.Username = "del_prior";
+        user.DisplayName = "Deleted user";
+        user.FirebaseUid = "deleted-prior";
         await DataContext.SaveChangesAsync();
 
         var handler = Mocker.CreateInstance<DeleteAccountCommandHandler>();
 
-        var result = await handler.ExecuteAsync(userId);
+        var result = await handler.ExecuteAsync(new DeleteAccountCommand { UserId = userId });
 
         result.IsSuccess.Should().BeTrue();
         Mocker.GetMock<IFirebaseUserAdmin>().Verify(
             x => x.DeleteUserAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
         Mocker.GetMock<IEventBus>().Verify(
             b => b.Publish(It.IsAny<UserDeleted>(), It.IsAny<CancellationToken>()), Times.Never());
+
+        // The idempotent retry must not re-touch the row — reload from the store.
+        DataContext.ChangeTracker.Clear();
+        var reloaded = await DataContext.Users.FindAsync(userId);
+        reloaded!.DeletedUtc.Should().Be(deletedAt);
+        reloaded.Email.Should().Be("deleted-prior@deleted.invalid");
+        reloaded.Username.Should().Be("del_prior");
+        reloaded.DisplayName.Should().Be("Deleted user");
+        reloaded.FirebaseUid.Should().Be("deleted-prior");
     }
 }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeletedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeletedConsumerTests.cs
@@ -16,6 +16,8 @@ namespace SportsData.Notification.Tests.Unit.Application.Consumers;
 
 public class UserDeletedConsumerTests : NotificationTestBase<UserDeletedConsumer>
 {
+    private static readonly DateTime FixedNow = new(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
     private static ConsumeContext<UserDeleted> ContextFor(UserDeleted msg)
     {
         var ctx = new Mock<ConsumeContext<UserDeleted>>();
@@ -34,8 +36,8 @@ public class UserDeletedConsumerTests : NotificationTestBase<UserDeletedConsumer
         });
         DataContext.UserNotificationPreferences.Add(new UserNotificationPreferences { Id = Guid.NewGuid(), UserId = userId, CreatedBy = Guid.NewGuid() });
         DataContext.UserPicks.Add(new UserPick { Id = Guid.NewGuid(), UserId = userId, ContestId = Guid.NewGuid(), PickemGroupId = Guid.NewGuid(), CreatedBy = Guid.NewGuid() });
-        DataContext.PendingScheduledJobs.Add(new PendingScheduledJob { Id = Guid.NewGuid(), UserId = userId, JobKind = "k", TargetId = Guid.NewGuid(), HangfireJobId = "hf", ScheduledFireUtc = DateTime.UtcNow, CreatedBy = Guid.NewGuid() });
-        DataContext.NotificationLog.Add(new NotificationLog { Id = Guid.NewGuid(), UserId = userId, CorrelationId = Guid.NewGuid(), Category = "c", Channel = "Fcm", Result = "Sent", AttemptedUtc = DateTime.UtcNow, CreatedBy = Guid.NewGuid() });
+        DataContext.PendingScheduledJobs.Add(new PendingScheduledJob { Id = Guid.NewGuid(), UserId = userId, JobKind = "k", TargetId = Guid.NewGuid(), HangfireJobId = "hf", ScheduledFireUtc = FixedNow, CreatedBy = Guid.NewGuid() });
+        DataContext.NotificationLog.Add(new NotificationLog { Id = Guid.NewGuid(), UserId = userId, CorrelationId = Guid.NewGuid(), Category = "c", Channel = "Fcm", Result = "Sent", AttemptedUtc = FixedNow, CreatedBy = Guid.NewGuid() });
         DataContext.PickemGroupMembers.Add(new PickemGroupMember { Id = Guid.NewGuid(), UserId = userId, PickemGroupId = Guid.NewGuid(), Role = "Member", CreatedBy = Guid.NewGuid() });
         await DataContext.SaveChangesAsync();
     }
@@ -59,18 +61,31 @@ public class UserDeletedConsumerTests : NotificationTestBase<UserDeletedConsumer
         (await DataContext.NotificationLog.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
         (await DataContext.PickemGroupMembers.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
 
-        // Other user's footprint is untouched.
+        // Other user's footprint is untouched across every purged table.
         (await DataContext.Users.AnyAsync(x => x.Id == otherUserId)).Should().BeTrue();
         (await DataContext.UserDevices.AnyAsync(x => x.UserId == otherUserId)).Should().BeTrue();
+        (await DataContext.UserNotificationPreferences.AnyAsync(x => x.UserId == otherUserId)).Should().BeTrue();
+        (await DataContext.UserPicks.AnyAsync(x => x.UserId == otherUserId)).Should().BeTrue();
+        (await DataContext.PendingScheduledJobs.AnyAsync(x => x.UserId == otherUserId)).Should().BeTrue();
+        (await DataContext.NotificationLog.AnyAsync(x => x.UserId == otherUserId)).Should().BeTrue();
+        (await DataContext.PickemGroupMembers.AnyAsync(x => x.UserId == otherUserId)).Should().BeTrue();
     }
 
     [Fact]
-    public async Task Consume_NoRows_IsNoOp()
+    public async Task Consume_SameMessageTwice_IsIdempotent()
     {
+        var userId = Guid.NewGuid();
+        await SeedFootprintAsync(userId);
         var sut = Mocker.CreateInstance<UserDeletedConsumer>();
+        var msg = new UserDeleted(userId, Guid.NewGuid(), Guid.NewGuid());
 
-        var act = async () => await sut.Consume(ContextFor(new UserDeleted(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid())));
+        await sut.Consume(ContextFor(msg)); // first delivery purges everything
 
+        // At-least-once redelivery: the second consume finds no rows and must be
+        // a harmless no-op rather than throwing.
+        var act = async () => await sut.Consume(ContextFor(msg));
         await act.Should().NotThrowAsync();
+
+        (await DataContext.UserDevices.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
     }
 }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeletedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeletedConsumerTests.cs
@@ -86,6 +86,13 @@ public class UserDeletedConsumerTests : NotificationTestBase<UserDeletedConsumer
         var act = async () => await sut.Consume(ContextFor(msg));
         await act.Should().NotThrowAsync();
 
+        // Every purged table stays empty for the user after the redelivery.
+        (await DataContext.Users.AnyAsync(x => x.Id == userId)).Should().BeFalse();
         (await DataContext.UserDevices.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.UserNotificationPreferences.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.UserPicks.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.PendingScheduledJobs.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.NotificationLog.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.PickemGroupMembers.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
     }
 }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeletedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserDeletedConsumerTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class UserDeletedConsumerTests : NotificationTestBase<UserDeletedConsumer>
+{
+    private static ConsumeContext<UserDeleted> ContextFor(UserDeleted msg)
+    {
+        var ctx = new Mock<ConsumeContext<UserDeleted>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private async Task SeedFootprintAsync(Guid userId)
+    {
+        DataContext.Users.Add(new User { Id = userId, DisplayName = "X", Email = "x@x.com", CreatedBy = Guid.NewGuid() });
+        DataContext.UserDevices.Add(new UserDevice
+        {
+            Id = Guid.NewGuid(), UserId = userId, InstallationId = Guid.NewGuid().ToString(),
+            FcmToken = "t", Platform = "ios", NotificationsEnabled = true, CreatedBy = Guid.NewGuid()
+        });
+        DataContext.UserNotificationPreferences.Add(new UserNotificationPreferences { Id = Guid.NewGuid(), UserId = userId, CreatedBy = Guid.NewGuid() });
+        DataContext.UserPicks.Add(new UserPick { Id = Guid.NewGuid(), UserId = userId, ContestId = Guid.NewGuid(), PickemGroupId = Guid.NewGuid(), CreatedBy = Guid.NewGuid() });
+        DataContext.PendingScheduledJobs.Add(new PendingScheduledJob { Id = Guid.NewGuid(), UserId = userId, JobKind = "k", TargetId = Guid.NewGuid(), HangfireJobId = "hf", ScheduledFireUtc = DateTime.UtcNow, CreatedBy = Guid.NewGuid() });
+        DataContext.NotificationLog.Add(new NotificationLog { Id = Guid.NewGuid(), UserId = userId, CorrelationId = Guid.NewGuid(), Category = "c", Channel = "Fcm", Result = "Sent", AttemptedUtc = DateTime.UtcNow, CreatedBy = Guid.NewGuid() });
+        DataContext.PickemGroupMembers.Add(new PickemGroupMember { Id = Guid.NewGuid(), UserId = userId, PickemGroupId = Guid.NewGuid(), Role = "Member", CreatedBy = Guid.NewGuid() });
+        await DataContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Consume_PurgesEverythingForThatUser_LeavesOthers()
+    {
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        await SeedFootprintAsync(userId);
+        await SeedFootprintAsync(otherUserId);
+
+        var sut = Mocker.CreateInstance<UserDeletedConsumer>();
+        await sut.Consume(ContextFor(new UserDeleted(userId, Guid.NewGuid(), Guid.NewGuid())));
+
+        (await DataContext.Users.AnyAsync(x => x.Id == userId)).Should().BeFalse();
+        (await DataContext.UserDevices.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.UserNotificationPreferences.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.UserPicks.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.PendingScheduledJobs.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.NotificationLog.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+        (await DataContext.PickemGroupMembers.AnyAsync(x => x.UserId == userId)).Should().BeFalse();
+
+        // Other user's footprint is untouched.
+        (await DataContext.Users.AnyAsync(x => x.Id == otherUserId)).Should().BeTrue();
+        (await DataContext.UserDevices.AnyAsync(x => x.UserId == otherUserId)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Consume_NoRows_IsNoOp()
+    {
+        var sut = Mocker.CreateInstance<UserDeletedConsumer>();
+
+        var act = async () => await sut.Consume(ContextFor(new UserDeleted(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid())));
+
+        await act.Should().NotThrowAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Two App Store / auth gaps for launch:

1. **Account deletion** (Guideline 5.1.1(v) / GDPR) — users can now delete their account in-app.
2. **Provider collision** — signing in with a second provider for an already-registered email now shows a clear message instead of a raw Firebase error.

Design note: `docs/mobile/account-deletion.md`.

### Deletion model: anonymize, keep history
sportDeets is built on shared league history, so a hard delete would corrupt co-players' standings. Instead we **anonymize**: strip all PII + the Firebase login, retain picks/memberships as an anonymized "Deleted user", and purge the notification footprint.

## Changes

**Core:** `UserDeleted` event.

**API**
- `User.DeletedUtc` column (migration `11JulV1_UserDeletedUtc` — add-column only; **validated locally**).
- `IFirebaseUserAdmin` injectable wrapper over Firebase Admin (deletes the login; an already-gone uid is treated as success) → handler is unit-testable.
- `DeleteAccountCommandHandler`: delete Firebase login → anonymize `User` (PII → per-id sentinels that keep the unique `FirebaseUid`/`Username` indexes valid) → stamp `DeletedUtc` → publish `UserDeleted`. Idempotent (already-deleted → no-op).
- `DELETE /user/me`; `GetInviteableUsers` excludes deleted users.

**Notification:** `UserDeletedConsumer` purges the user's devices, preferences, pick projection, scheduled jobs, delivery logs, membership projection, and user projection.

**Mobile**
- `usersApi.deleteAccount()` + a destructive **Delete Account** flow in profile (confirm → delete → sign out).
- Collision: shared `authErrors.ts`; `appleSignIn`/`googleSignIn` catch `auth/account-exists-with-different-credential` → clear "already registered with a different method" message.

## Testing
- `DeleteAccountCommandHandlerTests` (3: anonymize+firebase-delete+publish, not-found, idempotent), `UserDeletedConsumerTests` (2: full purge / no-op).
- Full API + Notification unit suites green (aside from the known-flaky `DisplayNameGenerator` test); mobile `tsc` clean; migration applied cleanly to a local DB.

## Scope note
Deletion UI is **mobile** (the App Store gate). A web "delete account" surface is a sensible GDPR-parity follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated **DELETE /me** to delete accounts via anonymization.
  * Added mobile **Delete Account** flow with confirmation and post-deletion sign-out.
  * Deletions are **idempotent**, set a deletion timestamp, and update user data to preserve shared league history.
  * Deleted accounts are **excluded from inviteable** user search and shown as **“Deleted user”** on leaderboards/standings.
  * Automatically purges related notification footprint after deletion events.
* **Bug Fixes**
  * Clears cached profile data after sign-out to prevent identity flashing.
  * Improves messaging for **“account exists with different credential”** during sign-in.
* **Documentation**
  * Documented mobile-to-API deletion behavior, anonymization rules, and out-of-scope items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->