### PR TITLE
feat(notifications): user notification preferences (API-canonical + web/mobile)

### DIFF
--- a/docs/mobile/notification-preferences.md
+++ b/docs/mobile/notification-preferences.md
@@ -1,0 +1,91 @@
+# Notification preferences
+
+Per-category push-notification opt-out. A user can turn off any of eight
+notification categories from **Profile → Notifications**. Defaults are
+everything-on: this is a pick'em product where the notifications *are* the
+engagement layer, so opting out is the rare path.
+
+## Ownership & data flow
+
+The **API is the canonical owner**. The **Notification service** keeps a local
+projection that its dispatchers read to gate sends. They stay in sync over an
+event — the API never calls the Notification service directly.
+
+```
+Mobile settings screen
+  GET  /user/me/notification-preferences   → current flags (all-on if never set)
+  PATCH /user/me/notification-preferences  → full replacement of all 8 flags
+        │
+        ▼
+API: UpdateNotificationPreferencesCommandHandler
+  - upserts canonical UserNotificationPreferences row (one per user)
+  - publishes UserNotificationPreferencesUpdated (EF outbox, atomic with the write)
+        │
+        ▼ (MassTransit)
+Notification: UserNotificationPreferencesUpdatedConsumer
+  - upserts the local UserNotificationPreferences projection (idempotent by UserId)
+        │
+        ▼
+Notification dispatchers / schedulers / consumers
+  - read the projection; a "false" flag suppresses that category
+```
+
+### Why event projection, not a service-to-service call
+
+Every other cross-service user fact (User, UserDevice, UserPick, membership)
+already flows API → Notification as an event-sourced projection. Preferences
+follow the same pattern rather than adding a synchronous
+Notification-reads-from-API (or API-reads-from-Notification) hop. The
+Notification service stays authoritative for *dispatch* while the API stays
+authoritative for *intent*.
+
+## The eight categories
+
+| UI label                    | Flag                          | Enforced by |
+|-----------------------------|-------------------------------|-------------|
+| Pick results                | `PickResultEnabled`           | `UserPickScoredConsumer` |
+| Pick deadline reminders     | `PickDeadlineReminderEnabled` | `NotificationDispatcher`, `PickDeadlineReminderScheduler` |
+| Kickoff reminders           | `ContestStartReminderEnabled` | `NotificationDispatcher`, `ContestStartReminderScheduler` |
+| League invites              | `LeagueInviteEnabled`         | `UserInvitedToPickemGroupConsumer` |
+| League membership updates   | `MembershipEnabled`           | `PickemGroupMemberAddedConsumer` |
+| Matchup previews            | `MatchupPreviewEnabled`       | *projected only — not yet gated* |
+| Schedule changes            | `ScheduleChangeEnabled`       | *projected only — not yet gated* |
+| Line moves                  | `OddsChangedEnabled`          | `ContestOddsUpdatedConsumer` |
+
+Six categories are actively gated in the dispatch path today. **Matchup previews**
+and **schedule changes** are projected and stored but no dispatcher consults them
+yet — the toggles are exposed now (forward-looking) and go live the moment those
+notification types start honoring the flag. Flip the switch in the corresponding
+consumer with the same `prefs is { XEnabled: false }` guard the others use; no
+schema or contract change is needed.
+
+## Absent-row semantics
+
+A user with **no** preferences row is treated as **all-enabled**. The row is
+created lazily on the first PATCH (first time the user changes any setting):
+
+- **API GET** projects all-true defaults when the row is missing (never 404s).
+- **Dispatchers** use the `prefs is { XEnabled: false }` pattern, so a null
+  projection (`prefs == null`) never suppresses anything.
+
+This keeps the tables small — only users who have actually opted something out
+carry a row on either side.
+
+## Idempotency
+
+- The **event carries the full flag set**, so the consumer is a straight upsert
+  by `UserId`. At-least-once redelivery and republish-on-every-change both
+  converge on the same row.
+- Race-safe insert: two concurrent "doesn't exist" inserts let the unique-index
+  loser (Postgres `23505`) fall through to the update path — same pattern as
+  `UserDataPublishedConsumer`.
+- Account deletion purges the projection via `UserDeletedConsumer` (already
+  wired; preferences were in its purge set before this feature shipped).
+
+## Mobile
+
+- `usersApi.getNotificationPreferences()` / `updateNotificationPreferences(prefs)`
+  wrap the two endpoints.
+- `app/settings/notifications.tsx` holds the full flag set in local state and
+  PATCHes the whole set on each toggle (optimistic, with revert on failure).
+  Reached from the "Notifications" row in `app/(tabs)/profile.tsx`.

--- a/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommand.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommand.cs
@@ -1,0 +1,18 @@
+namespace SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
+
+/// <summary>
+/// Full replacement of a user's per-category notification opt-in flags. The
+/// client always sends the complete set (the settings screen holds every toggle
+/// in state), so this is a PUT-style overwrite rather than a partial patch.
+/// </summary>
+public class UpdateNotificationPreferencesCommand
+{
+    public bool PickResultEnabled { get; init; } = true;
+    public bool PickDeadlineReminderEnabled { get; init; } = true;
+    public bool ContestStartReminderEnabled { get; init; } = true;
+    public bool LeagueInviteEnabled { get; init; } = true;
+    public bool MembershipEnabled { get; init; } = true;
+    public bool MatchupPreviewEnabled { get; init; } = true;
+    public bool ScheduleChangeEnabled { get; init; } = true;
+    public bool OddsChangedEnabled { get; init; } = true;
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandler.cs
@@ -1,0 +1,124 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+
+namespace SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
+
+public interface IUpdateNotificationPreferencesCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateNotificationPreferencesCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Persists a user's per-category notification opt-in flags (canonical owner is
+/// the API) and publishes <see cref="UserNotificationPreferencesUpdated"/> so the
+/// Notification service projects the new values into the table its dispatchers
+/// read. First change creates the row; later changes overwrite it in place.
+/// See docs/mobile/notification-preferences.md.
+/// </summary>
+public class UpdateNotificationPreferencesCommandHandler : IUpdateNotificationPreferencesCommandHandler
+{
+    private readonly AppDataContext _db;
+    private readonly IEventBus _eventBus;
+    private readonly IDateTimeProvider _clock;
+    private readonly IValidator<UpdateNotificationPreferencesCommand> _validator;
+    private readonly ILogger<UpdateNotificationPreferencesCommandHandler> _logger;
+
+    public UpdateNotificationPreferencesCommandHandler(
+        AppDataContext db,
+        IEventBus eventBus,
+        IDateTimeProvider clock,
+        IValidator<UpdateNotificationPreferencesCommand> validator,
+        ILogger<UpdateNotificationPreferencesCommandHandler> logger)
+    {
+        _db = db;
+        _eventBus = eventBus;
+        _clock = clock;
+        _validator = validator;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateNotificationPreferencesCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default!, ResultStatus.BadRequest, validation.Errors);
+        }
+
+        var userExists = await _db.Users.AnyAsync(u => u.Id == userId, cancellationToken);
+        if (!userExists)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
+        }
+
+        var now = _clock.UtcNow();
+
+        var prefs = await _db.UserNotificationPreferences
+            .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+
+        if (prefs is null)
+        {
+            prefs = new UserNotificationPreferences
+            {
+                UserId = userId,
+                CreatedUtc = now,
+                CreatedBy = userId
+            };
+            await _db.UserNotificationPreferences.AddAsync(prefs, cancellationToken);
+        }
+        else
+        {
+            prefs.ModifiedUtc = now;
+            prefs.ModifiedBy = userId;
+        }
+
+        prefs.PickResultEnabled = command.PickResultEnabled;
+        prefs.PickDeadlineReminderEnabled = command.PickDeadlineReminderEnabled;
+        prefs.ContestStartReminderEnabled = command.ContestStartReminderEnabled;
+        prefs.LeagueInviteEnabled = command.LeagueInviteEnabled;
+        prefs.MembershipEnabled = command.MembershipEnabled;
+        prefs.MatchupPreviewEnabled = command.MatchupPreviewEnabled;
+        prefs.ScheduleChangeEnabled = command.ScheduleChangeEnabled;
+        prefs.OddsChangedEnabled = command.OddsChangedEnabled;
+
+        // Publish before SaveChanges so the outbox row persists atomically with the
+        // preference write (EF bus outbox flushes on save).
+        await _eventBus.Publish(
+            new UserNotificationPreferencesUpdated(
+                userId,
+                command.PickResultEnabled,
+                command.PickDeadlineReminderEnabled,
+                command.ContestStartReminderEnabled,
+                command.LeagueInviteEnabled,
+                command.MembershipEnabled,
+                command.MatchupPreviewEnabled,
+                command.ScheduleChangeEnabled,
+                command.OddsChangedEnabled,
+                Guid.NewGuid(),
+                Guid.NewGuid()),
+            cancellationToken);
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Notification preferences updated. UserId={UserId}", userId);
+
+        return new Success<Guid>(userId);
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
+
+/// <summary>
+/// No field-level rules today — every property is a non-nullable bool, so any
+/// deserialized command is structurally valid. Kept (and auto-registered) so the
+/// handler's <c>IValidator&lt;T&gt;</c> dependency resolves and there's a home for
+/// future cross-field rules.
+/// </summary>
+public class UpdateNotificationPreferencesCommandValidator
+    : AbstractValidator<UpdateNotificationPreferencesCommand>
+{
+    public UpdateNotificationPreferencesCommandValidator()
+    {
+    }
+}

--- a/src/SportsData.Api/Application/User/Dtos/NotificationPreferencesDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/NotificationPreferencesDto.cs
@@ -1,0 +1,17 @@
+namespace SportsData.Api.Application.User.Dtos;
+
+/// <summary>
+/// Per-category notification opt-in flags. Returned by GET and accepted (full
+/// set) by the PATCH on /user/me/notification-preferences.
+/// </summary>
+public class NotificationPreferencesDto
+{
+    public bool PickResultEnabled { get; set; } = true;
+    public bool PickDeadlineReminderEnabled { get; set; } = true;
+    public bool ContestStartReminderEnabled { get; set; } = true;
+    public bool LeagueInviteEnabled { get; set; } = true;
+    public bool MembershipEnabled { get; set; } = true;
+    public bool MatchupPreviewEnabled { get; set; } = true;
+    public bool ScheduleChangeEnabled { get; set; } = true;
+    public bool OddsChangedEnabled { get; set; } = true;
+}

--- a/src/SportsData.Api/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQuery.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQuery.cs
@@ -1,0 +1,6 @@
+namespace SportsData.Api.Application.User.Queries.GetNotificationPreferences;
+
+public class GetNotificationPreferencesQuery
+{
+    public Guid UserId { get; init; }
+}

--- a/src/SportsData.Api/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQueryHandler.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.User.Dtos;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.User.Queries.GetNotificationPreferences;
+
+public interface IGetNotificationPreferencesQueryHandler
+{
+    Task<Result<NotificationPreferencesDto>> ExecuteAsync(
+        GetNotificationPreferencesQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+public class GetNotificationPreferencesQueryHandler : IGetNotificationPreferencesQueryHandler
+{
+    private readonly AppDataContext _db;
+    private readonly ILogger<GetNotificationPreferencesQueryHandler> _logger;
+
+    public GetNotificationPreferencesQueryHandler(
+        AppDataContext db,
+        ILogger<GetNotificationPreferencesQueryHandler> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<Result<NotificationPreferencesDto>> ExecuteAsync(
+        GetNotificationPreferencesQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Getting notification preferences for UserId={UserId}", query.UserId);
+
+        // No row = user has never changed a setting = all categories enabled.
+        // Project defaults rather than 404 so the client always gets a full set.
+        var dto = await _db.UserNotificationPreferences
+            .AsNoTracking()
+            .Where(p => p.UserId == query.UserId)
+            .Select(p => new NotificationPreferencesDto
+            {
+                PickResultEnabled = p.PickResultEnabled,
+                PickDeadlineReminderEnabled = p.PickDeadlineReminderEnabled,
+                ContestStartReminderEnabled = p.ContestStartReminderEnabled,
+                LeagueInviteEnabled = p.LeagueInviteEnabled,
+                MembershipEnabled = p.MembershipEnabled,
+                MatchupPreviewEnabled = p.MatchupPreviewEnabled,
+                ScheduleChangeEnabled = p.ScheduleChangeEnabled,
+                OddsChangedEnabled = p.OddsChangedEnabled
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // All-defaults (everything on) when absent.
+        return new Success<NotificationPreferencesDto>(dto ?? new NotificationPreferencesDto());
+    }
+}

--- a/src/SportsData.Api/Application/User/UserController.cs
+++ b/src/SportsData.Api/Application/User/UserController.cs
@@ -3,11 +3,13 @@ using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Api.Application.User.Commands.DeleteAccount;
 using SportsData.Api.Application.User.Commands.UpdateDisplayName;
+using SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Dtos;
 using SportsData.Api.Application.User.Queries.GetMe;
+using SportsData.Api.Application.User.Queries.GetNotificationPreferences;
 using SportsData.Api.Extensions;
 using SportsData.Core.Common;
 using SportsData.Core.Extensions;
@@ -84,6 +86,29 @@ public class UserController : ApiControllerBase
     public async Task<ActionResult<Guid>> UpdateDisplayName(
         [FromBody] UpdateDisplayNameCommand command,
         [FromServices] IUpdateDisplayNameCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await handler.ExecuteAsync(userId, command, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpGet("me/notification-preferences")]
+    [Authorize]
+    public async Task<ActionResult<NotificationPreferencesDto>> GetNotificationPreferences(
+        [FromServices] IGetNotificationPreferencesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetNotificationPreferencesQuery { UserId = HttpContext.GetCurrentUserId() };
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpPatch("me/notification-preferences")]
+    [Authorize]
+    public async Task<ActionResult<Guid>> UpdateNotificationPreferences(
+        [FromBody] UpdateNotificationPreferencesCommand command,
+        [FromServices] IUpdateNotificationPreferencesCommandHandler handler,
         CancellationToken cancellationToken)
     {
         var userId = HttpContext.GetCurrentUserId();

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -82,10 +82,12 @@ using SportsData.Api.Application.UI.TeamCard.Queries.GetTeamStatistics;
 using SportsData.Api.Application.User;
 using SportsData.Api.Application.User.Commands.DeleteAccount;
 using SportsData.Api.Application.User.Commands.UpdateDisplayName;
+using SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Queries.GetMe;
+using SportsData.Api.Application.User.Queries.GetNotificationPreferences;
 using SportsData.Api.Config;
 using SportsData.Api.Infrastructure.Auth;
 using SportsData.Api.Infrastructure.Data.Canonical;
@@ -253,6 +255,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IUpdateUsernameCommandHandler, UpdateUsernameCommandHandler>();
             services.AddScoped<IUpdateDisplayNameCommandHandler, UpdateDisplayNameCommandHandler>();
             services.AddScoped<IDeleteAccountCommandHandler, DeleteAccountCommandHandler>();
+            services.AddScoped<IUpdateNotificationPreferencesCommandHandler, UpdateNotificationPreferencesCommandHandler>();
             services.AddSingleton<IFirebaseUserAdmin, FirebaseUserAdmin>();
 
             // User Validators
@@ -260,6 +263,7 @@ namespace SportsData.Api.DependencyInjection
 
             // User Queries
             services.AddScoped<IGetMeQueryHandler, GetMeQueryHandler>();
+            services.AddScoped<IGetNotificationPreferencesQueryHandler, GetNotificationPreferencesQueryHandler>();
 
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<MatchupPreviewGenerator>();

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -15,6 +15,8 @@ public class AppDataContext : DbContext
 
     public DbSet<User> Users { get; set; }
 
+    public DbSet<UserNotificationPreferences> UserNotificationPreferences { get; set; }
+
     public DbSet<ContestPrediction> ContestPredictions { get; set; }
 
     public DbSet<PickemGroup> PickemGroups { get; set; }

--- a/src/SportsData.Api/Infrastructure/Data/Entities/UserNotificationPreferences.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/UserNotificationPreferences.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Canonical per-user, per-category notification opt-in flags. One row per
+    /// user. The API owns these; changes are projected to the Notification
+    /// service (which gates sends) via <c>UserNotificationPreferencesUpdated</c>.
+    /// Defaults are "everything on" — notifications are the engagement layer, so
+    /// opting out is the rare path. A user with no row is treated as all-enabled;
+    /// a row is only created when the user first changes a setting.
+    /// See docs/mobile/notification-preferences.md.
+    /// </summary>
+    public class UserNotificationPreferences : CanonicalEntityBase<Guid>
+    {
+        public Guid UserId { get; set; }
+
+        public User User { get; set; } = null!;
+
+        public bool PickResultEnabled { get; set; } = true;
+
+        public bool PickDeadlineReminderEnabled { get; set; } = true;
+
+        public bool ContestStartReminderEnabled { get; set; } = true;
+
+        public bool LeagueInviteEnabled { get; set; } = true;
+
+        public bool MembershipEnabled { get; set; } = true;
+
+        public bool MatchupPreviewEnabled { get; set; } = true;
+
+        public bool ScheduleChangeEnabled { get; set; } = true;
+
+        public bool OddsChangedEnabled { get; set; } = true;
+
+        public class EntityConfiguration : IEntityTypeConfiguration<UserNotificationPreferences>
+        {
+            public void Configure(EntityTypeBuilder<UserNotificationPreferences> builder)
+            {
+                builder.ToTable(nameof(UserNotificationPreferences));
+
+                builder.HasKey(x => x.Id);
+
+                // One row per user.
+                builder.HasIndex(x => x.UserId).IsUnique();
+
+                builder.HasOne(x => x.User)
+                    .WithMany()
+                    .HasForeignKey(x => x.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260711162152_11JulV2_UserNotificationPreferences.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260711162152_11JulV2_UserNotificationPreferences.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260711162152_11JulV2_UserNotificationPreferences")]
+    partial class _11JulV2_UserNotificationPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260711162152_11JulV2_UserNotificationPreferences.cs
+++ b/src/SportsData.Api/Migrations/20260711162152_11JulV2_UserNotificationPreferences.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class _11JulV2_UserNotificationPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserNotificationPreferences",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PickResultEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    PickDeadlineReminderEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    ContestStartReminderEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    LeagueInviteEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    MembershipEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    MatchupPreviewEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    ScheduleChangeEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    OddsChangedEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserNotificationPreferences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserNotificationPreferences_User_UserId",
+                        column: x => x.UserId,
+                        principalTable: "User",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserNotificationPreferences_UserId",
+                table: "UserNotificationPreferences",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserNotificationPreferences");
+        }
+    }
+}

--- a/src/SportsData.Core/Eventing/Events/Users/UserNotificationPreferencesUpdated.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UserNotificationPreferencesUpdated.cs
@@ -1,0 +1,30 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Users
+{
+    /// <summary>
+    /// A user changed their per-category notification opt-in flags. Published by
+    /// the API (canonical owner) so the Notification service projects the new
+    /// values into its local <c>UserNotificationPreferences</c> table, which its
+    /// dispatch consumers read to gate sends. Carries the full flag set so the
+    /// consumer is a straight upsert.
+    ///
+    /// <para>Idempotent projection target: republished on every change / at-least-
+    /// once redelivery; the consumer upserts by UserId.</para>
+    /// </summary>
+    public record UserNotificationPreferencesUpdated(
+        Guid UserId,
+        bool PickResultEnabled,
+        bool PickDeadlineReminderEnabled,
+        bool ContestStartReminderEnabled,
+        bool LeagueInviteEnabled,
+        bool MembershipEnabled,
+        bool MatchupPreviewEnabled,
+        bool ScheduleChangeEnabled,
+        bool OddsChangedEnabled,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(null, Sport.All, null, CorrelationId, CausationId);
+}

--- a/src/SportsData.Notification/Application/Consumers/UserNotificationPreferencesUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserNotificationPreferencesUpdatedConsumer.cs
@@ -1,0 +1,108 @@
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Consumers
+{
+    /// <summary>
+    /// Projects a user's per-category notification opt-in flags into the local
+    /// <see cref="UserNotificationPreferences"/> table (the API is the canonical
+    /// owner; it publishes <see cref="UserNotificationPreferencesUpdated"/> on
+    /// every change). The dispatch consumers read this projection to gate sends;
+    /// a user with no row is treated as all-enabled.
+    ///
+    /// <para>Idempotent by UserId — the event carries the full flag set, so this
+    /// is a straight upsert. Race-safe insert: concurrent "doesn't exist" inserts
+    /// let the unique-index loser (SQLSTATE 23505) fall through to the update
+    /// path.</para>
+    /// </summary>
+    public class UserNotificationPreferencesUpdatedConsumer : IConsumer<UserNotificationPreferencesUpdated>
+    {
+        private readonly ILogger<UserNotificationPreferencesUpdatedConsumer> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public UserNotificationPreferencesUpdatedConsumer(
+            ILogger<UserNotificationPreferencesUpdatedConsumer> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task Consume(ConsumeContext<UserNotificationPreferencesUpdated> context)
+        {
+            var msg = context.Message;
+            using var _ = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["CorrelationId"] = msg.CorrelationId,
+                ["UserId"] = msg.UserId
+            });
+
+            var ct = context.CancellationToken;
+            var now = _dateTimeProvider.UtcNow();
+
+            var existing = await _dataContext.UserNotificationPreferences
+                .FirstOrDefaultAsync(p => p.UserId == msg.UserId, ct);
+
+            if (existing is null)
+            {
+                var entity = new UserNotificationPreferences
+                {
+                    UserId = msg.UserId,
+                    CreatedUtc = now,
+                    CreatedBy = msg.CausationId
+                };
+                Apply(entity, msg);
+                _dataContext.UserNotificationPreferences.Add(entity);
+
+                try
+                {
+                    await _dataContext.SaveChangesAsync(ct);
+                    _logger.LogInformation("Notification preferences projection inserted. UserId={UserId}", msg.UserId);
+                    return;
+                }
+                catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+                {
+                    // Race: another consumer inserted first. Detach our orphan and
+                    // fall through to the update path.
+                    _dataContext.Entry(entity).State = EntityState.Detached;
+                    existing = await _dataContext.UserNotificationPreferences
+                        .FirstAsync(p => p.UserId == msg.UserId, ct);
+                }
+            }
+
+            Apply(existing, msg);
+            existing.ModifiedUtc = now;
+            existing.ModifiedBy = msg.CausationId;
+
+            await _dataContext.SaveChangesAsync(ct);
+            _logger.LogInformation("Notification preferences projection updated. UserId={UserId}", msg.UserId);
+        }
+
+        private static void Apply(UserNotificationPreferences entity, UserNotificationPreferencesUpdated msg)
+        {
+            entity.PickResultEnabled = msg.PickResultEnabled;
+            entity.PickDeadlineReminderEnabled = msg.PickDeadlineReminderEnabled;
+            entity.ContestStartReminderEnabled = msg.ContestStartReminderEnabled;
+            entity.LeagueInviteEnabled = msg.LeagueInviteEnabled;
+            entity.MembershipEnabled = msg.MembershipEnabled;
+            entity.MatchupPreviewEnabled = msg.MatchupPreviewEnabled;
+            entity.ScheduleChangeEnabled = msg.ScheduleChangeEnabled;
+            entity.OddsChangedEnabled = msg.OddsChangedEnabled;
+        }
+
+        private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+        {
+            // Npgsql surfaces unique-violation as SQLSTATE 23505.
+            return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -49,6 +49,7 @@ namespace SportsData.Notification
                 typeof(UserDeviceRegisteredConsumer),
                 typeof(UserDeviceUnregisteredConsumer),
                 typeof(UserInvitedToPickemGroupConsumer),
+                typeof(UserNotificationPreferencesUpdatedConsumer),
                 typeof(UserPickMadeConsumer),
                 typeof(UserPickScoredConsumer)
             ]);

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -440,7 +440,7 @@ export default function ProfileScreen() {
           value={isUserSet ? effectiveTimezone : `${effectiveTimezone} (device)`}
           onPress={() => setTzPickerOpen(true)}
         />
-        <SettingsRow label="Notifications" onPress={() => {}} />
+        <SettingsRow label="Notifications" onPress={() => router.push('/settings/notifications')} />
         <SettingsRow label="Sign Out" onPress={handleSignOut} destructive />
         <SettingsRow label="Delete Account" onPress={handleDeleteAccount} destructive />
       </View>

--- a/src/UI/sd-mobile/app/settings/notifications.tsx
+++ b/src/UI/sd-mobile/app/settings/notifications.tsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, ScrollView, Switch, ActivityIndicator } from 'react-native';
+import { Stack } from 'expo-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { usersApi } from '@/src/services/api/usersApi';
+import type { NotificationPreferences } from '@/src/types/models';
+
+// Per-category push-notification opt-out screen. The API owns these flags
+// (canonical); it publishes an event the Notification service projects into the
+// table its dispatchers read to gate sends. A user with no saved row is treated
+// as fully opted-in, so the defaults here are all-on.
+// See docs/mobile/notification-preferences.md.
+
+const notificationKeys = {
+  preferences: ['user', 'me', 'notification-preferences'] as const,
+};
+
+// Field key → user-facing label + one-line description. Grouped into sections
+// below. Order within a section is deliberate (most-valued first).
+type PrefKey = keyof NotificationPreferences;
+
+interface ToggleMeta {
+  key: PrefKey;
+  label: string;
+  description: string;
+}
+
+interface Section {
+  title: string;
+  items: ToggleMeta[];
+}
+
+const SECTIONS: Section[] = [
+  {
+    title: 'Your picks',
+    items: [
+      {
+        key: 'pickResultEnabled',
+        label: 'Pick results',
+        description: 'When your picks are graded after a game finalizes.',
+      },
+      {
+        key: 'pickDeadlineReminderEnabled',
+        label: 'Pick deadline reminders',
+        description: "A nudge before a week's picks lock.",
+      },
+      {
+        key: 'contestStartReminderEnabled',
+        label: 'Kickoff reminders',
+        description: 'When a game you picked is about to start.',
+      },
+    ],
+  },
+  {
+    title: 'Leagues',
+    items: [
+      {
+        key: 'leagueInviteEnabled',
+        label: 'League invites',
+        description: "When someone invites you to a pick'em league.",
+      },
+      {
+        key: 'membershipEnabled',
+        label: 'League membership updates',
+        description: 'When members join or leave your leagues.',
+      },
+    ],
+  },
+  {
+    title: 'Games',
+    items: [
+      {
+        key: 'matchupPreviewEnabled',
+        label: 'Matchup previews',
+        description: 'AI-generated previews for your upcoming matchups.',
+      },
+      {
+        key: 'scheduleChangeEnabled',
+        label: 'Schedule changes',
+        description: 'When a game you picked is rescheduled.',
+      },
+      {
+        key: 'oddsChangedEnabled',
+        label: 'Line moves',
+        description: 'When the spread or total for your games shifts.',
+      },
+    ],
+  },
+];
+
+const ALL_ENABLED: NotificationPreferences = {
+  pickResultEnabled: true,
+  pickDeadlineReminderEnabled: true,
+  contestStartReminderEnabled: true,
+  leagueInviteEnabled: true,
+  membershipEnabled: true,
+  matchupPreviewEnabled: true,
+  scheduleChangeEnabled: true,
+  oddsChangedEnabled: true,
+};
+
+export default function NotificationSettingsScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const queryClient = useQueryClient();
+
+  const {
+    data: serverPrefs,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<NotificationPreferences>({
+    queryKey: notificationKeys.preferences,
+    queryFn: () => usersApi.getNotificationPreferences().then((r) => r.data),
+  });
+
+  // Local mirror so toggles feel instant. Seeded from the server once loaded,
+  // and re-seeded whenever a fresh server copy arrives.
+  const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
+  useEffect(() => {
+    if (serverPrefs) setPrefs(serverPrefs);
+  }, [serverPrefs]);
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const mutation = useMutation<
+    unknown,
+    unknown,
+    NotificationPreferences,
+    { previous: NotificationPreferences }
+  >({
+    mutationFn: (next) => usersApi.updateNotificationPreferences(next),
+    // Snapshot pre-change state (for revert) and optimistically apply it.
+    onMutate: (next) => {
+      const previous = prefs ?? ALL_ENABLED;
+      setPrefs(next);
+      setErrorMessage(null);
+      return { previous };
+    },
+    onError: (_err, _next, context) => {
+      if (context) setPrefs(context.previous);
+      setErrorMessage('Could not save that change. Please try again.');
+    },
+    onSuccess: (_data, next) => {
+      // Keep the cache in step so navigating away/back shows the saved state.
+      queryClient.setQueryData(notificationKeys.preferences, next);
+    },
+  });
+
+  const toggle = (key: PrefKey) => {
+    if (!prefs) return;
+    // Full-replacement PATCH — send the whole set with this one flag flipped.
+    mutation.mutate({ ...prefs, [key]: !prefs[key] });
+  };
+
+  const effective = prefs ?? ALL_ENABLED;
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Notifications', headerBackTitle: 'Back' }} />
+      <ScrollView
+        style={[styles.container, { backgroundColor: theme.background }]}
+        contentContainerStyle={styles.content}
+      >
+        {isLoading ? (
+          <View style={styles.centered}>
+            <ActivityIndicator color={theme.tint} />
+          </View>
+        ) : isError ? (
+          <View style={styles.centered}>
+            <Text style={[styles.errorText, { color: theme.error }]}>
+              Couldn't load your notification settings.
+            </Text>
+            <Text
+              style={[styles.retry, { color: theme.tint }]}
+              onPress={() => refetch()}
+            >
+              Tap to retry
+            </Text>
+          </View>
+        ) : (
+          <>
+            <Text style={[styles.intro, { color: theme.textMuted }]}>
+              Choose which push notifications you'd like to receive. Turning one
+              off stops that kind of notification everywhere.
+            </Text>
+
+            {errorMessage ? (
+              <Text style={[styles.errorBanner, { color: theme.error }]}>
+                {errorMessage}
+              </Text>
+            ) : null}
+
+            {SECTIONS.map((section) => (
+              <View key={section.title} style={styles.section}>
+                <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>
+                  {section.title}
+                </Text>
+                <View
+                  style={[
+                    styles.card,
+                    { backgroundColor: theme.card, borderColor: theme.border },
+                  ]}
+                >
+                  {section.items.map((item, idx) => (
+                    <View
+                      key={item.key}
+                      style={[
+                        styles.row,
+                        idx > 0 && {
+                          borderTopColor: theme.border,
+                          borderTopWidth: StyleSheet.hairlineWidth,
+                        },
+                      ]}
+                    >
+                      <View style={styles.rowText}>
+                        <Text style={[styles.rowLabel, { color: theme.text }]}>
+                          {item.label}
+                        </Text>
+                        <Text style={[styles.rowDesc, { color: theme.textMuted }]}>
+                          {item.description}
+                        </Text>
+                      </View>
+                      <Switch
+                        value={effective[item.key]}
+                        onValueChange={() => toggle(item.key)}
+                        trackColor={{ true: theme.tint, false: theme.border }}
+                        accessibilityLabel={item.label}
+                      />
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ))}
+          </>
+        )}
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, gap: 8, paddingBottom: 40 },
+  centered: { paddingVertical: 60, alignItems: 'center', gap: 10 },
+  errorText: { fontSize: 14 },
+  retry: { fontSize: 14, fontWeight: '700' },
+  intro: { fontSize: 13, lineHeight: 18, marginBottom: 4 },
+  errorBanner: { fontSize: 13, fontWeight: '600', marginBottom: 4 },
+  section: { gap: 8, marginTop: 8 },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    marginLeft: 4,
+  },
+  card: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 14,
+    gap: 12,
+  },
+  rowText: { flex: 1, gap: 2 },
+  rowLabel: { fontSize: 15, fontWeight: '600' },
+  rowDesc: { fontSize: 12, lineHeight: 16 },
+});

--- a/src/UI/sd-mobile/src/services/api/usersApi.ts
+++ b/src/UI/sd-mobile/src/services/api/usersApi.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { UserDto } from '@/src/types/models';
+import type { NotificationPreferences, UserDto } from '@/src/types/models';
 
 /**
  * Wrapper for /user/* endpoints. Mirrors the web app's `src/api/usersApi.js`.
@@ -27,4 +27,13 @@ export const usersApi = {
   // DELETE /user/me — deletes the account. Server anonymizes the record and
   // removes the Firebase login; caller signs out afterward.
   deleteAccount: () => apiClient.delete('/user/me'),
+
+  // GET /user/me/notification-preferences → full flag set (all-enabled defaults
+  // when the user has never changed a setting).
+  getNotificationPreferences: () =>
+    apiClient.get<NotificationPreferences>('/user/me/notification-preferences'),
+
+  // PATCH /user/me/notification-preferences — full replacement; send every flag.
+  updateNotificationPreferences: (prefs: NotificationPreferences) =>
+    apiClient.patch('/user/me/notification-preferences', prefs),
 };

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -304,6 +304,23 @@ export interface UserDto {
   isReadOnly?: boolean;
 }
 
+/**
+ * Per-category push-notification opt-in flags. Mirrors the API's
+ * NotificationPreferencesDto — every field defaults to `true` (a user with no
+ * saved row is treated as fully opted-in). The settings screen holds the whole
+ * set in state and PATCHes it back as a full replacement.
+ */
+export interface NotificationPreferences {
+  pickResultEnabled: boolean;
+  pickDeadlineReminderEnabled: boolean;
+  contestStartReminderEnabled: boolean;
+  leagueInviteEnabled: boolean;
+  membershipEnabled: boolean;
+  matchupPreviewEnabled: boolean;
+  scheduleChangeEnabled: boolean;
+  oddsChangedEnabled: boolean;
+}
+
 // ─── Contest Overview ─────────────────────────────────────────────────────────
 
 export interface ContestOverviewTeam {

--- a/src/UI/sd-ui/src/api/usersApi.js
+++ b/src/UI/sd-ui/src/api/usersApi.js
@@ -5,7 +5,12 @@ const UsersApi = {
   getCurrentUser: () => apiClient.get("/user/me"),
   updateTimezone: (timezone) => apiClient.patch("/user/me/timezone", { timezone }),
   updateUsername: (username) => apiClient.patch("/user/me/username", { username }),
-  updateDisplayName: (displayName) => apiClient.patch("/user/me/displayname", { displayName })
+  updateDisplayName: (displayName) => apiClient.patch("/user/me/displayname", { displayName }),
+  // Per-category push-notification opt-in flags. GET returns all-on defaults
+  // when the user has never changed a setting; PATCH is a full-set replacement.
+  getNotificationPreferences: () => apiClient.get("/user/me/notification-preferences"),
+  updateNotificationPreferences: (prefs) =>
+    apiClient.patch("/user/me/notification-preferences", prefs)
 };
 
 export default UsersApi;

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -7,6 +7,22 @@ import { DEFAULT_TIMEZONE } from "../../utils/timeUtils";
 import "./SettingsPage.css";
 import BadgesPanel from "../../components/badges/BadgesPanel.tsx";
 
+// Notification categories, in the same order as the mobile settings screen.
+// The API owns these flags (canonical) and projects changes to the Notification
+// service, which gates sends. Six are actively enforced today; matchup previews
+// and schedule changes are projected-but-not-yet-gated (exposed for parity).
+// See docs/mobile/notification-preferences.md.
+const NOTIFICATION_CATEGORIES = [
+  { key: "pickResultEnabled", label: "Pick results" },
+  { key: "pickDeadlineReminderEnabled", label: "Pick deadline reminders" },
+  { key: "contestStartReminderEnabled", label: "Kickoff reminders" },
+  { key: "leagueInviteEnabled", label: "League invites" },
+  { key: "membershipEnabled", label: "League membership updates" },
+  { key: "matchupPreviewEnabled", label: "Matchup previews" },
+  { key: "scheduleChangeEnabled", label: "Schedule changes" },
+  { key: "oddsChangedEnabled", label: "Line moves" },
+];
+
 const CURATED_TIMEZONES = [
   { value: "America/New_York",    label: "Eastern (New York)" },
   { value: "America/Chicago",     label: "Central (Chicago)" },
@@ -52,6 +68,11 @@ function SettingsPage() {
   const [displayNameSaving, setDisplayNameSaving] = useState(false);
   const [displayNameMessage, setDisplayNameMessage] = useState("");
 
+  const [prefs, setPrefs] = useState(null);
+  const [prefsError, setPrefsError] = useState("");
+  const [prefsSaving, setPrefsSaving] = useState(false);
+  const [prefsMessage, setPrefsMessage] = useState("");
+
   const allZones = useMemo(() => getAllIanaZones(), []);
   const browserTz = useMemo(() => detectBrowserTimezone(), []);
 
@@ -86,6 +107,28 @@ function SettingsPage() {
     };
   }, [navigate]);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchPrefs = async () => {
+      try {
+        const response = await apiWrapper.Users.getNotificationPreferences();
+        if (isMounted) setPrefs(response.data);
+      } catch (err) {
+        console.error("Failed to load notification preferences:", err);
+        // Leave prefs null so the section shows an error rather than a
+        // misleading all-on state the user might accidentally save over.
+        if (isMounted) setPrefsError("Could not load notification settings.");
+      }
+    };
+
+    fetchPrefs();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   const effectiveTimezone = user?.timezone || browserTz;
   const isCurated = CURATED_TIMEZONES.some((z) => z.value === effectiveTimezone);
 
@@ -112,6 +155,26 @@ function SettingsPage() {
       setDisplayNameMessage(serverMsg || "Could not save display name.");
     } finally {
       setDisplayNameSaving(false);
+    }
+  };
+
+  const handleToggleNotification = async (key) => {
+    if (!prefs || prefsSaving) return;
+    const previous = prefs;
+    // Full-replacement PATCH — send the whole set with this one flag flipped.
+    const next = { ...prefs, [key]: !prefs[key] };
+    setPrefs(next); // optimistic
+    setPrefsSaving(true);
+    setPrefsMessage("");
+    try {
+      await apiWrapper.Users.updateNotificationPreferences(next);
+      setPrefsMessage("Saved.");
+    } catch (err) {
+      console.error("Failed to update notification preferences:", err);
+      setPrefs(previous); // revert
+      setPrefsMessage("Could not save. Please try again.");
+    } finally {
+      setPrefsSaving(false);
     }
   };
 
@@ -237,14 +300,32 @@ function SettingsPage() {
 
         <section className="settings-section">
           <h2>Notifications</h2>
-          <div className="settings-item">
-            <span className="label">Email Alerts:</span>
-            <input type="checkbox" disabled />
-          </div>
-          <div className="settings-item">
-            <span className="label">Push Notifications:</span>
-            <input type="checkbox" disabled />
-          </div>
+          <p style={{ fontSize: "0.85em", opacity: 0.7, marginTop: 0 }}>
+            Choose which push notifications you receive on your devices.
+          </p>
+          {prefsError ? (
+            <p className="error">{prefsError}</p>
+          ) : !prefs ? (
+            <p style={{ fontSize: "0.85em", opacity: 0.7 }}>Loading…</p>
+          ) : (
+            <>
+              {NOTIFICATION_CATEGORIES.map(({ key, label }) => (
+                <div className="settings-item" key={key}>
+                  <span className="label">{label}:</span>
+                  <input
+                    type="checkbox"
+                    aria-label={label}
+                    checked={!!prefs[key]}
+                    disabled={prefsSaving}
+                    onChange={() => handleToggleNotification(key)}
+                  />
+                </div>
+              ))}
+              {prefsMessage && (
+                <span style={{ fontSize: "0.85em" }}>{prefsMessage}</span>
+              )}
+            </>
+          )}
         </section>
       </div>
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+
+using FluentValidation;
+
+using Moq;
+
+using SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Users;
+
+using Xunit;
+
+using PrefsEntity = SportsData.Api.Infrastructure.Data.Entities.UserNotificationPreferences;
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.User.Commands.UpdateNotificationPreferences;
+
+public class UpdateNotificationPreferencesCommandHandlerTests
+    : ApiTestBase<UpdateNotificationPreferencesCommandHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    public UpdateNotificationPreferencesCommandHandlerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use<IValidator<UpdateNotificationPreferencesCommand>>(
+            new UpdateNotificationPreferencesCommandValidator());
+    }
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        var id = Guid.NewGuid();
+        await DataContext.Users.AddAsync(new UserEntity
+        {
+            Id = id,
+            FirebaseUid = $"uid-{id:N}",
+            Email = "real@person.com",
+            SignInProvider = "apple.com",
+            DisplayName = "Real Person",
+            Username = $"user{id:N}"[..12]
+        });
+        await DataContext.SaveChangesAsync();
+        return id;
+    }
+
+    private static UpdateNotificationPreferencesCommand AllOff()
+        => new()
+        {
+            PickResultEnabled = false,
+            PickDeadlineReminderEnabled = false,
+            ContestStartReminderEnabled = false,
+            LeagueInviteEnabled = false,
+            MembershipEnabled = false,
+            MatchupPreviewEnabled = false,
+            ScheduleChangeEnabled = false,
+            OddsChangedEnabled = false
+        };
+
+    [Fact]
+    public async Task Execute_CreatesRow_WhenNoneExists_AndPublishes()
+    {
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+
+        var command = AllOff();
+
+        var result = await handler.ExecuteAsync(userId, command);
+
+        result.IsSuccess.Should().BeTrue();
+
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(
+                It.Is<UserNotificationPreferencesUpdated>(e =>
+                    e.UserId == userId &&
+                    e.PickResultEnabled == false &&
+                    e.OddsChangedEnabled == false),
+                It.IsAny<CancellationToken>()),
+            Times.Once());
+
+        DataContext.ChangeTracker.Clear();
+        var prefs = DataContext.UserNotificationPreferences.Single(p => p.UserId == userId);
+        prefs.PickResultEnabled.Should().BeFalse();
+        prefs.OddsChangedEnabled.Should().BeFalse();
+        prefs.CreatedUtc.Should().Be(FixedNow);
+        prefs.CreatedBy.Should().Be(userId);
+    }
+
+    [Fact]
+    public async Task Execute_UpdatesExistingRow_InPlace()
+    {
+        var userId = await SeedUserAsync();
+        await DataContext.UserNotificationPreferences.AddAsync(new PrefsEntity
+        {
+            UserId = userId,
+            CreatedUtc = FixedNow.AddDays(-3),
+            CreatedBy = userId
+            // all flags default true
+        });
+        await DataContext.SaveChangesAsync();
+        DataContext.ChangeTracker.Clear();
+
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+
+        var command = new UpdateNotificationPreferencesCommand
+        {
+            PickResultEnabled = true,
+            PickDeadlineReminderEnabled = false,
+            ContestStartReminderEnabled = true,
+            LeagueInviteEnabled = true,
+            MembershipEnabled = true,
+            MatchupPreviewEnabled = true,
+            ScheduleChangeEnabled = true,
+            OddsChangedEnabled = false
+        };
+
+        var result = await handler.ExecuteAsync(userId, command);
+
+        result.IsSuccess.Should().BeTrue();
+
+        DataContext.ChangeTracker.Clear();
+        var rows = DataContext.UserNotificationPreferences.Where(p => p.UserId == userId).ToList();
+        rows.Should().HaveCount(1); // updated, not duplicated
+        var prefs = rows.Single();
+        prefs.PickDeadlineReminderEnabled.Should().BeFalse();
+        prefs.OddsChangedEnabled.Should().BeFalse();
+        prefs.PickResultEnabled.Should().BeTrue();
+        prefs.ModifiedUtc.Should().Be(FixedNow);
+        prefs.ModifiedBy.Should().Be(userId);
+    }
+
+    [Fact]
+    public async Task Execute_NotFound_WhenUserMissing()
+    {
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+
+        var result = await handler.ExecuteAsync(Guid.NewGuid(), new UpdateNotificationPreferencesCommand());
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(It.IsAny<UserNotificationPreferencesUpdated>(), It.IsAny<CancellationToken>()),
+            Times.Never());
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQueryHandlerTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.User.Queries.GetNotificationPreferences;
+using SportsData.Core.Common;
+
+using Xunit;
+
+using PrefsEntity = SportsData.Api.Infrastructure.Data.Entities.UserNotificationPreferences;
+
+namespace SportsData.Api.Tests.Unit.Application.User.Queries.GetNotificationPreferences;
+
+public class GetNotificationPreferencesQueryHandlerTests
+    : ApiTestBase<GetNotificationPreferencesQueryHandler>
+{
+    [Fact]
+    public async Task Execute_ReturnsAllEnabledDefaults_WhenNoRow()
+    {
+        var handler = Mocker.CreateInstance<GetNotificationPreferencesQueryHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new GetNotificationPreferencesQuery { UserId = Guid.NewGuid() });
+
+        result.IsSuccess.Should().BeTrue();
+        var dto = result.Value;
+        dto.PickResultEnabled.Should().BeTrue();
+        dto.PickDeadlineReminderEnabled.Should().BeTrue();
+        dto.ContestStartReminderEnabled.Should().BeTrue();
+        dto.LeagueInviteEnabled.Should().BeTrue();
+        dto.MembershipEnabled.Should().BeTrue();
+        dto.MatchupPreviewEnabled.Should().BeTrue();
+        dto.ScheduleChangeEnabled.Should().BeTrue();
+        dto.OddsChangedEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Execute_ReturnsSavedValues_WhenRowExists()
+    {
+        var userId = Guid.NewGuid();
+        await DataContext.UserNotificationPreferences.AddAsync(new PrefsEntity
+        {
+            UserId = userId,
+            PickResultEnabled = false,
+            OddsChangedEnabled = false
+            // remaining flags default true
+        });
+        await DataContext.SaveChangesAsync();
+        DataContext.ChangeTracker.Clear();
+
+        var handler = Mocker.CreateInstance<GetNotificationPreferencesQueryHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new GetNotificationPreferencesQuery { UserId = userId });
+
+        result.IsSuccess.Should().BeTrue();
+        var dto = result.Value;
+        dto.PickResultEnabled.Should().BeFalse();
+        dto.OddsChangedEnabled.Should().BeFalse();
+        dto.MembershipEnabled.Should().BeTrue();
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserNotificationPreferencesUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserNotificationPreferencesUpdatedConsumerTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Users;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class UserNotificationPreferencesUpdatedConsumerTests
+    : NotificationTestBase<UserNotificationPreferencesUpdatedConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    public UserNotificationPreferencesUpdatedConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+    }
+
+    private static ConsumeContext<UserNotificationPreferencesUpdated> ContextFor(
+        UserNotificationPreferencesUpdated msg)
+    {
+        var ctx = new Mock<ConsumeContext<UserNotificationPreferencesUpdated>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private static UserNotificationPreferencesUpdated MessageFor(
+        Guid userId,
+        bool pickResult = true,
+        bool oddsChanged = true)
+        => new(
+            userId,
+            PickResultEnabled: pickResult,
+            PickDeadlineReminderEnabled: true,
+            ContestStartReminderEnabled: true,
+            LeagueInviteEnabled: true,
+            MembershipEnabled: true,
+            MatchupPreviewEnabled: true,
+            ScheduleChangeEnabled: true,
+            OddsChangedEnabled: oddsChanged,
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid());
+
+    [Fact]
+    public async Task Consume_InsertsRow_WhenNoneExists()
+    {
+        var userId = Guid.NewGuid();
+        var sut = Mocker.CreateInstance<UserNotificationPreferencesUpdatedConsumer>();
+
+        await sut.Consume(ContextFor(MessageFor(userId, pickResult: false, oddsChanged: false)));
+
+        var prefs = await DataContext.UserNotificationPreferences
+            .SingleAsync(p => p.UserId == userId);
+        prefs.PickResultEnabled.Should().BeFalse();
+        prefs.OddsChangedEnabled.Should().BeFalse();
+        prefs.MembershipEnabled.Should().BeTrue();
+        prefs.CreatedUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task Consume_UpdatesExistingRow_WithoutDuplicating()
+    {
+        var userId = Guid.NewGuid();
+        DataContext.UserNotificationPreferences.Add(new UserNotificationPreferences
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            CreatedUtc = FixedNow.AddDays(-2),
+            CreatedBy = Guid.NewGuid()
+            // all flags default true
+        });
+        await DataContext.SaveChangesAsync();
+        DataContext.ChangeTracker.Clear();
+
+        var sut = Mocker.CreateInstance<UserNotificationPreferencesUpdatedConsumer>();
+
+        await sut.Consume(ContextFor(MessageFor(userId, pickResult: false, oddsChanged: false)));
+
+        var rows = await DataContext.UserNotificationPreferences
+            .Where(p => p.UserId == userId).ToListAsync();
+        rows.Should().HaveCount(1);
+        rows[0].PickResultEnabled.Should().BeFalse();
+        rows[0].OddsChangedEnabled.Should().BeFalse();
+        rows[0].ModifiedUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task Consume_SameMessageTwice_IsIdempotent()
+    {
+        var userId = Guid.NewGuid();
+        var sut = Mocker.CreateInstance<UserNotificationPreferencesUpdatedConsumer>();
+        var msg = MessageFor(userId, pickResult: false, oddsChanged: true);
+
+        await sut.Consume(ContextFor(msg));
+        var act = async () => await sut.Consume(ContextFor(msg));
+        await act.Should().NotThrowAsync();
+
+        var rows = await DataContext.UserNotificationPreferences
+            .Where(p => p.UserId == userId).ToListAsync();
+        rows.Should().HaveCount(1);
+        rows[0].PickResultEnabled.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Adds per-category push-notification **opt-in preferences**, controllable from both the mobile app and the web app.

The **API is the canonical owner**: `GET`/`PATCH /user/me/notification-preferences` persist an eight-flag set and publish `UserNotificationPreferencesUpdated`. The **Notification service projects** that event into the `UserNotificationPreferences` table its dispatchers already read to gate sends. No service-to-service call — same event-projection pattern used for every other user fact (User, UserDevice, UserPick, membership).

Until now these flags had **no writer anywhere** — the dispatchers read them (treating "no row" as all-enabled) but nothing could set them. This PR supplies the writer and the two client UIs.

## Architecture

```
Mobile / Web settings
  GET  /user/me/notification-preferences   -> current flags (all-on if never set)
  PATCH /user/me/notification-preferences  -> full replacement of all 8 flags
        |
        v
API UpdateNotificationPreferencesCommandHandler
  - upserts canonical row (one per user; lazily created on first change)
  - publishes UserNotificationPreferencesUpdated (EF outbox, atomic with write)
        |
        v (MassTransit)
Notification UserNotificationPreferencesUpdatedConsumer
  - idempotent upsert by UserId (23505 race-safe, mirrors UserDataPublishedConsumer)
        |
        v
Dispatchers / schedulers / consumers  ->  a "false" flag suppresses that category
```

## Changes

**Core**
- `UserNotificationPreferencesUpdated` event (full flag set)

**API**
- Canonical `UserNotificationPreferences` entity + DbSet + migration `11JulV2` (validated locally with `dotnet ef database update`)
- `GetNotificationPreferences` query (returns all-on defaults when no row; never 404s)
- `UpdateNotificationPreferences` command + validator + handler (EF-outbox publish, idempotent upsert)
- `GET`/`PATCH` endpoints on `UserController`; DI registrations

**Notification**
- `UserNotificationPreferencesUpdatedConsumer` (idempotent by UserId); registered in `Program.cs`

**Mobile (`sd-mobile`)**
- `usersApi` get/update methods + `NotificationPreferences` type
- `app/settings/notifications.tsx` — 8 toggles in 3 sections, optimistic with revert-on-failure; reached from the profile "Notifications" row

**Web (`sd-ui`)**
- `usersApi` get/update methods
- `SettingsPage` — 8 real toggles replacing the disabled Email/Push placeholders. Flags are **account-level / channel-agnostic**, so managing them from the web affects mobile push delivery (web push delivery itself is a separate future project). `eslint --max-warnings=0` clean.

**Docs**
- `docs/mobile/notification-preferences.md` — ownership, data flow, absent-row semantics, idempotency, per-category enforcement status

## Enforcement note

Six categories are **actively gated** in the dispatch path today (pick results, pick-deadline, kickoff, invites, membership, line moves). **Matchup previews** and **schedule changes** are projected-and-stored but **no dispatcher consults them yet** — exposed now for parity; they go live when those consumers add the same `prefs is { XEnabled: false }` guard (no schema/contract change needed).

## Tests

- API: `UpdateNotificationPreferencesCommandHandler` (create/update/404), `GetNotificationPreferencesQueryHandler` (defaults/saved)
- Notification: `UserNotificationPreferencesUpdatedConsumer` (insert/update/idempotent)
- Full suites green: **478 API, 31 Notification**

## Validation done / remaining

- [x] Migration applied locally (`dotnet ef database update`)
- [x] `dotnet build` + full unit suites pass
- [x] Web `eslint --max-warnings=0` clean
- [ ] On-device (mobile) + in-browser (web) E2E toggle -> confirm projection lands and a suppressed category no longer fires

## Follow-up (next PR)

Web account-deletion (`DELETE /user/me`) — mobile already has it (#490); web does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification preference management for mobile and web.
  * Users can enable or disable eight notification categories, including reminders, invites, membership, schedule changes, and odds updates.
  * Added settings screens with loading, saving, and error feedback.
  * Preferences are retrieved and saved through new account settings endpoints.
  * Users without saved preferences receive all notifications by default.

* **Documentation**
  * Added documentation covering preference behavior, synchronization, and client integration.

* **Tests**
  * Added coverage for saving, retrieval defaults, synchronization, updates, and idempotent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->