### PR TITLE
fix(notifications): address CodeRabbit review on #492

### DIFF
--- a/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandler.cs
@@ -8,6 +8,7 @@ using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Users;
+using SportsData.Core.Extensions;
 
 namespace SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
 
@@ -73,7 +74,8 @@ public class UpdateNotificationPreferencesCommandHandler : IUpdateNotificationPr
         var prefs = await _db.UserNotificationPreferences
             .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
 
-        if (prefs is null)
+        var isInsert = prefs is null;
+        if (isInsert)
         {
             prefs = new UserNotificationPreferences
             {
@@ -81,22 +83,15 @@ public class UpdateNotificationPreferencesCommandHandler : IUpdateNotificationPr
                 CreatedUtc = now,
                 CreatedBy = userId
             };
+            Apply(prefs, command);
             await _db.UserNotificationPreferences.AddAsync(prefs, cancellationToken);
         }
         else
         {
-            prefs.ModifiedUtc = now;
+            Apply(prefs!, command);
+            prefs!.ModifiedUtc = now;
             prefs.ModifiedBy = userId;
         }
-
-        prefs.PickResultEnabled = command.PickResultEnabled;
-        prefs.PickDeadlineReminderEnabled = command.PickDeadlineReminderEnabled;
-        prefs.ContestStartReminderEnabled = command.ContestStartReminderEnabled;
-        prefs.LeagueInviteEnabled = command.LeagueInviteEnabled;
-        prefs.MembershipEnabled = command.MembershipEnabled;
-        prefs.MatchupPreviewEnabled = command.MatchupPreviewEnabled;
-        prefs.ScheduleChangeEnabled = command.ScheduleChangeEnabled;
-        prefs.OddsChangedEnabled = command.OddsChangedEnabled;
 
         // Publish before SaveChanges so the outbox row persists atomically with the
         // preference write (EF bus outbox flushes on save).
@@ -115,10 +110,45 @@ public class UpdateNotificationPreferencesCommandHandler : IUpdateNotificationPr
                 Guid.NewGuid()),
             cancellationToken);
 
-        await _db.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (isInsert && ex.IsUniqueConstraintViolation())
+        {
+            // Race: a concurrent first-time request inserted this user's row between
+            // our FirstOrDefault check and SaveChanges. The unique index on UserId
+            // rejects our insert. Detach the orphan, re-query the winner's row, apply
+            // the requested flags, and retry as an update. The outbox message stays
+            // tracked (Added), so the event still fires exactly once on the retry.
+            _logger.LogWarning(ex,
+                "Concurrent insert of notification preferences. UserId={UserId}. Retrying as update.", userId);
+
+            _db.Entry(prefs!).State = EntityState.Detached;
+
+            var existing = await _db.UserNotificationPreferences
+                .FirstAsync(p => p.UserId == userId, cancellationToken);
+            Apply(existing, command);
+            existing.ModifiedUtc = now;
+            existing.ModifiedBy = userId;
+
+            await _db.SaveChangesAsync(cancellationToken);
+        }
 
         _logger.LogInformation("Notification preferences updated. UserId={UserId}", userId);
 
         return new Success<Guid>(userId);
+    }
+
+    private static void Apply(UserNotificationPreferences prefs, UpdateNotificationPreferencesCommand command)
+    {
+        prefs.PickResultEnabled = command.PickResultEnabled;
+        prefs.PickDeadlineReminderEnabled = command.PickDeadlineReminderEnabled;
+        prefs.ContestStartReminderEnabled = command.ContestStartReminderEnabled;
+        prefs.LeagueInviteEnabled = command.LeagueInviteEnabled;
+        prefs.MembershipEnabled = command.MembershipEnabled;
+        prefs.MatchupPreviewEnabled = command.MatchupPreviewEnabled;
+        prefs.ScheduleChangeEnabled = command.ScheduleChangeEnabled;
+        prefs.OddsChangedEnabled = command.OddsChangedEnabled;
     }
 }

--- a/src/UI/sd-mobile/app/settings/notifications.tsx
+++ b/src/UI/sd-mobile/app/settings/notifications.tsx
@@ -151,7 +151,10 @@ export default function NotificationSettingsScreen() {
   });
 
   const toggle = (key: PrefKey) => {
-    if (!prefs) return;
+    // Ignore taps while a save is in flight — each PATCH is a full replacement,
+    // so a second toggle built from a stale `prefs` could clobber the pending
+    // change. The switches are also disabled below; this guards the race in code.
+    if (!prefs || mutation.isPending) return;
     // Full-replacement PATCH — send the whole set with this one flag flipped.
     mutation.mutate({ ...prefs, [key]: !prefs[key] });
   };
@@ -227,6 +230,7 @@ export default function NotificationSettingsScreen() {
                       <Switch
                         value={effective[item.key]}
                         onValueChange={() => toggle(item.key)}
+                        disabled={mutation.isPending}
                         trackColor={{ true: theme.tint, false: theme.border }}
                         accessibilityLabel={item.label}
                       />

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
@@ -32,18 +32,22 @@ public class UpdateNotificationPreferencesCommandHandlerTests
             new UpdateNotificationPreferencesCommandValidator());
     }
 
+    // Single source for the User required-field shape, shared by SeedUserAsync
+    // (ApiTestBase's DataContext) and the race test's sidecar seed (its own options).
+    private static UserEntity NewUser(Guid id) => new()
+    {
+        Id = id,
+        FirebaseUid = $"uid-{id:N}",
+        Email = "real@person.com",
+        SignInProvider = "apple.com",
+        DisplayName = "Real Person",
+        Username = $"user{id:N}"[..12]
+    };
+
     private async Task<Guid> SeedUserAsync()
     {
         var id = Guid.NewGuid();
-        await DataContext.Users.AddAsync(new UserEntity
-        {
-            Id = id,
-            FirebaseUid = $"uid-{id:N}",
-            Email = "real@person.com",
-            SignInProvider = "apple.com",
-            DisplayName = "Real Person",
-            Username = $"user{id:N}"[..12]
-        });
+        await DataContext.Users.AddAsync(NewUser(id));
         await DataContext.SaveChangesAsync();
         return id;
     }
@@ -235,15 +239,7 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         var userId = Guid.NewGuid();
         await using (var seed = new AppDataContext(options))
         {
-            seed.Users.Add(new UserEntity
-            {
-                Id = userId,
-                FirebaseUid = $"uid-{userId:N}",
-                Email = "real@person.com",
-                SignInProvider = "apple.com",
-                DisplayName = "Real Person",
-                Username = $"user{userId:N}"[..12]
-            });
+            seed.Users.Add(NewUser(userId));
             await seed.SaveChangesAsync();
         }
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
@@ -2,9 +2,13 @@ using FluentAssertions;
 
 using FluentValidation;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
 using Moq;
 
 using SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
+using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Users;
@@ -87,6 +91,23 @@ public class UpdateNotificationPreferencesCommandHandlerTests
            && e.ScheduleChangeEnabled == c.ScheduleChangeEnabled
            && e.OddsChangedEnabled == c.OddsChangedEnabled;
 
+    // The event was published exactly once with the full flag set (payload-specific),
+    // AND exactly one UserNotificationPreferencesUpdated was published in total. The
+    // second Verify is the count guard: the payload-specific one alone would pass even
+    // if a second event with a different payload were also published.
+    private void VerifyPublishedOnce(Guid userId, UpdateNotificationPreferencesCommand command)
+    {
+        var bus = Mocker.GetMock<IEventBus>();
+        bus.Verify(
+            b => b.Publish(
+                It.Is<UserNotificationPreferencesUpdated>(e => EventMatches(e, userId, command)),
+                It.IsAny<CancellationToken>()),
+            Times.Once());
+        bus.Verify(
+            b => b.Publish(It.IsAny<UserNotificationPreferencesUpdated>(), It.IsAny<CancellationToken>()),
+            Times.Once());
+    }
+
     [Fact]
     public async Task Execute_CreatesRow_WhenNoneExists_AndPublishes()
     {
@@ -100,11 +121,7 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
 
         // Event carries the complete flag set + userId, published exactly once.
-        Mocker.GetMock<IEventBus>().Verify(
-            b => b.Publish(
-                It.Is<UserNotificationPreferencesUpdated>(e => EventMatches(e, userId, command)),
-                It.IsAny<CancellationToken>()),
-            Times.Once());
+        VerifyPublishedOnce(userId, command);
 
         DataContext.ChangeTracker.Clear();
         var prefs = DataContext.UserNotificationPreferences.Single(p => p.UserId == userId);
@@ -136,11 +153,7 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
 
         // Update path still publishes the complete flag set exactly once.
-        Mocker.GetMock<IEventBus>().Verify(
-            b => b.Publish(
-                It.Is<UserNotificationPreferencesUpdated>(e => EventMatches(e, userId, command)),
-                It.IsAny<CancellationToken>()),
-            Times.Once());
+        VerifyPublishedOnce(userId, command);
 
         DataContext.ChangeTracker.Clear();
         var rows = DataContext.UserNotificationPreferences.Where(p => p.UserId == userId).ToList();
@@ -149,6 +162,45 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         AssertFlags(prefs, command);
         prefs.ModifiedUtc.Should().Be(FixedNow);
         prefs.ModifiedBy.Should().Be(userId);
+    }
+
+    // Full field-mapping verification. The first three vectors' per-field columns
+    // are the distinct 3-bit codes 000..111, so every pair of fields differs in at
+    // least one vector — any swapped or copied same-valued mapping in Apply() or
+    // the published event is exposed. The all-false vector catches a field left at
+    // its true entity-default (never assigned) on the insert path.
+    [Theory]
+    [InlineData(false, false, false, false, true,  true,  true,  true)]
+    [InlineData(false, false, true,  true,  false, false, true,  true)]
+    [InlineData(false, true,  false, true,  false, true,  false, true)]
+    [InlineData(false, false, false, false, false, false, false, false)]
+    public async Task Execute_MapsEveryFlag_ToEntityAndEvent(
+        bool pickResult, bool pickDeadline, bool contestStart, bool leagueInvite,
+        bool membership, bool matchupPreview, bool scheduleChange, bool oddsChanged)
+    {
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+
+        var command = new UpdateNotificationPreferencesCommand
+        {
+            PickResultEnabled = pickResult,
+            PickDeadlineReminderEnabled = pickDeadline,
+            ContestStartReminderEnabled = contestStart,
+            LeagueInviteEnabled = leagueInvite,
+            MembershipEnabled = membership,
+            MatchupPreviewEnabled = matchupPreview,
+            ScheduleChangeEnabled = scheduleChange,
+            OddsChangedEnabled = oddsChanged
+        };
+
+        var result = await handler.ExecuteAsync(userId, command);
+        result.IsSuccess.Should().BeTrue();
+
+        VerifyPublishedOnce(userId, command);
+
+        DataContext.ChangeTracker.Clear();
+        var prefs = DataContext.UserNotificationPreferences.Single(p => p.UserId == userId);
+        AssertFlags(prefs, command);
     }
 
     [Fact]
@@ -163,5 +215,115 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         Mocker.GetMock<IEventBus>().Verify(
             b => b.Publish(It.IsAny<UserNotificationPreferencesUpdated>(), It.IsAny<CancellationToken>()),
             Times.Never());
+    }
+
+    [Fact]
+    public async Task Execute_RecoversFromConcurrentInsert_PersistsOneRow_AndPublishesOnce()
+    {
+        // Deterministically exercise the unique-constraint recovery path: on the
+        // handler's first SaveChanges (its insert), a "winner" row is inserted via a
+        // sidecar context — so the post-catch re-query finds it — and then a
+        // unique-violation DbUpdateException is thrown. The handler must detach its
+        // orphan, re-query the winner, apply the flags, and retry as an update.
+        // The InMemory provider can't raise a real 23505, so we drive it through a
+        // throwing AppDataContext (matched via the extension's string fallback).
+        var options = new DbContextOptionsBuilder<AppDataContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        var userId = Guid.NewGuid();
+        await using (var seed = new AppDataContext(options))
+        {
+            seed.Users.Add(new UserEntity
+            {
+                Id = userId,
+                FirebaseUid = $"uid-{userId:N}",
+                Email = "real@person.com",
+                SignInProvider = "apple.com",
+                DisplayName = "Real Person",
+                Username = $"user{userId:N}"[..12]
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        // Swap the handler's DbContext for the throwing one (overrides ApiTestBase's
+        // registration) and point it at the same store the assertions read from.
+        await using var raceContext = new RaceOnFirstInsertDataContext(options, userId, FixedNow);
+        Mocker.Use<AppDataContext>(raceContext);
+
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+        var command = DistinctFlags();
+
+        var result = await handler.ExecuteAsync(userId, command);
+
+        result.IsSuccess.Should().BeTrue();
+        raceContext.ThrewOnce.Should().BeTrue("the recovery path must have been exercised");
+
+        // Published exactly once — the retry must not re-publish.
+        VerifyPublishedOnce(userId, command);
+
+        // Exactly one row survived (the winner), carrying the requested flags.
+        await using var verify = new AppDataContext(options);
+        var rows = await verify.UserNotificationPreferences
+            .Where(p => p.UserId == userId).ToListAsync();
+        rows.Should().HaveCount(1);
+        AssertFlags(rows.Single(), command);
+    }
+
+    /// <summary>
+    /// AppDataContext whose first <see cref="SaveChangesAsync"/> simulates losing a
+    /// concurrent first-insert race: it inserts a competing "winner" row (via a
+    /// sidecar context sharing the same InMemory store) and then throws a
+    /// unique-violation <see cref="DbUpdateException"/>. Later saves delegate to the
+    /// base so the handler's retry-as-update succeeds.
+    /// </summary>
+    private sealed class RaceOnFirstInsertDataContext : AppDataContext
+    {
+        private readonly DbContextOptions<AppDataContext> _options;
+        private readonly Guid _userId;
+        private readonly DateTime _createdUtc;
+        private bool _thrown;
+
+        public RaceOnFirstInsertDataContext(
+            DbContextOptions<AppDataContext> options, Guid userId, DateTime createdUtc)
+            : base(options)
+        {
+            _options = options;
+            _userId = userId;
+            _createdUtc = createdUtc;
+        }
+
+        public bool ThrewOnce => _thrown;
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (!_thrown)
+            {
+                _thrown = true;
+
+                // The concurrent winner lands between our null-check and our save.
+                await using (var sidecar = new AppDataContext(_options))
+                {
+                    sidecar.UserNotificationPreferences.Add(new PrefsEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        UserId = _userId,
+                        CreatedUtc = _createdUtc,
+                        CreatedBy = _userId
+                    });
+                    await sidecar.SaveChangesAsync(cancellationToken);
+                }
+
+                // The unique index rejects our insert. Message trips the extension's
+                // string fallback (InMemory can't produce a real Npgsql 23505).
+                throw new DbUpdateException(
+                    "insert failed",
+                    new InvalidOperationException(
+                        "duplicate key value violates unique constraint \"IX_UserNotificationPreferences_UserId\""));
+            }
+
+            return await base.SaveChangesAsync(cancellationToken);
+        }
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
@@ -44,18 +44,48 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         return id;
     }
 
-    private static UpdateNotificationPreferencesCommand AllOff()
+    // A deliberately asymmetric flag pattern (T F T T F T F T). Because no two
+    // adjacent flags share a value in the same way, a mis-mapped line in the
+    // handler's Apply() (e.g. copying command.ScheduleChange into
+    // OddsChangedEnabled) flips at least one assertion.
+    private static UpdateNotificationPreferencesCommand DistinctFlags()
         => new()
         {
-            PickResultEnabled = false,
+            PickResultEnabled = true,
             PickDeadlineReminderEnabled = false,
-            ContestStartReminderEnabled = false,
-            LeagueInviteEnabled = false,
+            ContestStartReminderEnabled = true,
+            LeagueInviteEnabled = true,
             MembershipEnabled = false,
-            MatchupPreviewEnabled = false,
+            MatchupPreviewEnabled = true,
             ScheduleChangeEnabled = false,
-            OddsChangedEnabled = false
+            OddsChangedEnabled = true
         };
+
+    // Assert all eight flags on the persisted entity match the command.
+    private static void AssertFlags(PrefsEntity prefs, UpdateNotificationPreferencesCommand c)
+    {
+        prefs.PickResultEnabled.Should().Be(c.PickResultEnabled);
+        prefs.PickDeadlineReminderEnabled.Should().Be(c.PickDeadlineReminderEnabled);
+        prefs.ContestStartReminderEnabled.Should().Be(c.ContestStartReminderEnabled);
+        prefs.LeagueInviteEnabled.Should().Be(c.LeagueInviteEnabled);
+        prefs.MembershipEnabled.Should().Be(c.MembershipEnabled);
+        prefs.MatchupPreviewEnabled.Should().Be(c.MatchupPreviewEnabled);
+        prefs.ScheduleChangeEnabled.Should().Be(c.ScheduleChangeEnabled);
+        prefs.OddsChangedEnabled.Should().Be(c.OddsChangedEnabled);
+    }
+
+    // All eight flags on the published event match the command (plus UserId).
+    private static bool EventMatches(
+        UserNotificationPreferencesUpdated e, Guid userId, UpdateNotificationPreferencesCommand c)
+        => e.UserId == userId
+           && e.PickResultEnabled == c.PickResultEnabled
+           && e.PickDeadlineReminderEnabled == c.PickDeadlineReminderEnabled
+           && e.ContestStartReminderEnabled == c.ContestStartReminderEnabled
+           && e.LeagueInviteEnabled == c.LeagueInviteEnabled
+           && e.MembershipEnabled == c.MembershipEnabled
+           && e.MatchupPreviewEnabled == c.MatchupPreviewEnabled
+           && e.ScheduleChangeEnabled == c.ScheduleChangeEnabled
+           && e.OddsChangedEnabled == c.OddsChangedEnabled;
 
     [Fact]
     public async Task Execute_CreatesRow_WhenNoneExists_AndPublishes()
@@ -63,25 +93,22 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         var userId = await SeedUserAsync();
         var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
 
-        var command = AllOff();
+        var command = DistinctFlags();
 
         var result = await handler.ExecuteAsync(userId, command);
 
         result.IsSuccess.Should().BeTrue();
 
+        // Event carries the complete flag set + userId, published exactly once.
         Mocker.GetMock<IEventBus>().Verify(
             b => b.Publish(
-                It.Is<UserNotificationPreferencesUpdated>(e =>
-                    e.UserId == userId &&
-                    e.PickResultEnabled == false &&
-                    e.OddsChangedEnabled == false),
+                It.Is<UserNotificationPreferencesUpdated>(e => EventMatches(e, userId, command)),
                 It.IsAny<CancellationToken>()),
             Times.Once());
 
         DataContext.ChangeTracker.Clear();
         var prefs = DataContext.UserNotificationPreferences.Single(p => p.UserId == userId);
-        prefs.PickResultEnabled.Should().BeFalse();
-        prefs.OddsChangedEnabled.Should().BeFalse();
+        AssertFlags(prefs, command);
         prefs.CreatedUtc.Should().Be(FixedNow);
         prefs.CreatedBy.Should().Be(userId);
     }
@@ -102,29 +129,24 @@ public class UpdateNotificationPreferencesCommandHandlerTests
 
         var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
 
-        var command = new UpdateNotificationPreferencesCommand
-        {
-            PickResultEnabled = true,
-            PickDeadlineReminderEnabled = false,
-            ContestStartReminderEnabled = true,
-            LeagueInviteEnabled = true,
-            MembershipEnabled = true,
-            MatchupPreviewEnabled = true,
-            ScheduleChangeEnabled = true,
-            OddsChangedEnabled = false
-        };
+        var command = DistinctFlags();
 
         var result = await handler.ExecuteAsync(userId, command);
 
         result.IsSuccess.Should().BeTrue();
 
+        // Update path still publishes the complete flag set exactly once.
+        Mocker.GetMock<IEventBus>().Verify(
+            b => b.Publish(
+                It.Is<UserNotificationPreferencesUpdated>(e => EventMatches(e, userId, command)),
+                It.IsAny<CancellationToken>()),
+            Times.Once());
+
         DataContext.ChangeTracker.Clear();
         var rows = DataContext.UserNotificationPreferences.Where(p => p.UserId == userId).ToList();
         rows.Should().HaveCount(1); // updated, not duplicated
         var prefs = rows.Single();
-        prefs.PickDeadlineReminderEnabled.Should().BeFalse();
-        prefs.OddsChangedEnabled.Should().BeFalse();
-        prefs.PickResultEnabled.Should().BeTrue();
+        AssertFlags(prefs, command);
         prefs.ModifiedUtc.Should().Be(FixedNow);
         prefs.ModifiedBy.Should().Be(userId);
     }


### PR DESCRIPTION
Follow-up to #492. Addresses the CodeRabbit review; each finding was verified against current code before acting.

## Fixed

**1. Concurrent-insert race in `UpdateNotificationPreferencesCommandHandler`**
The first-ever PATCH for a user inserts a row against the `UserId` unique index. Two concurrent first-time requests could both insert → the loser's `SaveChanges` threw an unhandled 500. Now caught via the shared `IsUniqueConstraintViolation()` extension (SQLSTATE 23505), mirroring `UpsertUser`/`UpdateUsername`: detach the orphan, re-query the winner's row, apply the flags, retry as an update. The outbox event still fires exactly once (message stays tracked across the retry). Flag-copy factored into a private `Apply()` helper.

**3. Mobile — concurrent toggles while a save is in flight**
Every `Switch` is now `disabled={mutation.isPending}`, and `toggle()` bails when `isPending`. Prevents a rapid second toggle built from stale `prefs` from clobbering the in-flight full-replacement PATCH. Brings mobile to parity with the web toggles (which already guarded this).

**4. Test coverage**
Both create- and update-path tests now assert **all eight** flags on the persisted entity *and* the published event, using a distinctive `T F T T F T F T` pattern that catches a mis-mapped `Apply()` line. Added the missing `IEventBus.Publish`-once verification to the update-path test.

## Skipped (verified not applicable)

**2. `IValidator<GetNotificationPreferencesQuery>` guarding `Guid.Empty`**
`GetCurrentUserId()` returns the auth-middleware-resolved user's `Id` and **throws** `UnauthorizedAccessException` if absent — it never yields `Guid.Empty`, and the endpoint is `[Authorize]` (server-derived id, not user input). The parallel `GetMe` query has no validator either. Adding one would guard an unreachable state and break read-path consistency.

## Validation

- [x] `dotnet build` API — clean
- [x] Full API unit suite — **478 passing**
- [x] Mobile `tsc --noEmit` — clean
- [ ] On-device / in-browser re-check of rapid-toggle behavior (nice-to-have; behavior is unchanged for normal single taps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of notification preference updates during simultaneous saves so only one preferences row is created.
  - Disabled notification toggle controls while updates are saving to prevent conflicting or stale changes.
  - Strengthened first-time preference creation to avoid uniqueness conflicts.

- **Tests**
  - Expanded unit tests to verify all notification flags are persisted and fully reflected in the published update event.
  - Added coverage for concurrent first-insert recovery, ensuring correct single-row persistence and exactly-once event publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->