### PR TITLE
feat(web): in-app account deletion (parity with mobile)

### DIFF
--- a/docs/mobile/account-deletion.md
+++ b/docs/mobile/account-deletion.md
@@ -73,7 +73,33 @@ Sign-in with a provider whose email already exists under a different provider
 The mobile sign-in libs catch it and show a clear message ("already registered
 with X — use that method"). Full auto-linking is a deferred follow-up.
 
+## Returning users (re-signup after deletion)
+
+A deleted user can sign up again cleanly — the model is built for it:
+
+- The Firebase user is **hard-deleted** (not disabled), so the email is released
+  on Firebase's side and the next sign-in mints a **new `FirebaseUid`**.
+- Anonymization frees our only two unique indexes (`FirebaseUid → deleted-{id}`,
+  `Username → del_{id}`); `Email` is not unique-constrained.
+- `UpsertUser` looks a user up **by `FirebaseUid`**, so the new uid isn't found
+  and a **fresh `User` row** is created (new generated username, real email
+  reused).
+
+Consequences (by design, not bugs):
+- **It's a brand-new account.** Old picks/standings stay anonymized as "Deleted
+  user"; there is no restore or merge. "Same email = my old account back" is a
+  UX expectation to manage in copy, not a behavior we provide.
+- The old username is freed but **not reclaimed** — the returning user gets a
+  generated handle.
+
+Robustness note: the handler deletes the Firebase login **before** anonymizing +
+`SaveChanges`. If the Firebase delete succeeds but the save fails and nothing
+retries, an un-anonymized orphan row can linger (real email/name, `DeletedUtc`
+null → not excluded from invites). A retried delete self-heals it; a
+reconciliation sweep for "dangling deletions" is a possible future hardening.
+
 ## Out of scope
 - Auto-linking providers for the same email.
 - User-initiated data export.
 - Undo / grace-period restore (deletion is immediate).
+- Restoring/merging a returning user's prior history (they return as a new account).

--- a/docs/mobile/account-deletion.md
+++ b/docs/mobile/account-deletion.md
@@ -1,7 +1,7 @@
 # Account Deletion (anonymize model)
 
-Status: implemented
-Last updated: 2026-07-11
+Status: implemented (mobile + web)
+Last updated: 2026-07-12
 
 ## Why
 
@@ -46,6 +46,14 @@ Notification UserDeletedConsumer:
   purge UserDevice, UserNotificationPreferences, User projection,
   PendingScheduledJob, NotificationLog for that UserId
 ```
+
+The **web app** (`sd-ui`) offers the same deletion from Settings → Account. It
+hits the identical `DELETE /user/me` endpoint (server logic is unchanged), then
+tears the local session down exactly like web sign-out — `Auth.clearToken()` →
+Firebase `signOut()` → toast → redirect to `/`. The confirmation is a two-step
+inline confirm (deliberately **not** the shared `ConfirmationDialog`, whose
+"Do not ask me again" option is unsafe for a permanent, irreversible action).
+Web registers no push devices, so there is nothing device-side to unregister.
 
 ### Anonymization sentinels (canonical `User`)
 - `FirebaseUid` → `deleted-{id:N}` (keeps the unique index satisfied; login already gone)

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -45,8 +45,14 @@ function MainApp() {
 
   const handleSignOut = async () => {
     const auth = getAuth();
+    // Best-effort server-side token clear; it must not block the actual
+    // sign-out, so it runs in its own try/catch.
     try {
       await apiWrapper.Auth.clearToken();
+    } catch (error) {
+      console.warn("clear-token failed (continuing to sign-out):", error);
+    }
+    try {
       await signOut(auth);
       toast.success("Signed out successfully 👋");
       navigate("/");

--- a/src/UI/sd-ui/src/api/usersApi.js
+++ b/src/UI/sd-ui/src/api/usersApi.js
@@ -10,7 +10,10 @@ const UsersApi = {
   // when the user has never changed a setting; PATCH is a full-set replacement.
   getNotificationPreferences: () => apiClient.get("/user/me/notification-preferences"),
   updateNotificationPreferences: (prefs) =>
-    apiClient.patch("/user/me/notification-preferences", prefs)
+    apiClient.patch("/user/me/notification-preferences", prefs),
+  // DELETE /user/me — server anonymizes the record and removes the Firebase
+  // login; caller signs out afterward. Mirrors the mobile app's deleteAccount.
+  deleteAccount: () => apiClient.delete("/user/me")
 };
 
 export default UsersApi;

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.css
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.css
@@ -107,3 +107,50 @@ select {
   background-color: var(--accent);
   color: var(--text-on-accent);
 }
+
+/* No shared button class exists app-wide, so scope a themed default to the
+   settings page — matching the accent-primary look of the MatchupCard pick
+   buttons and the confirmation dialog. Covers the Profile "Save" button, the
+   delete trigger, and the confirm/cancel buttons. (The theme toggle is a
+   <div role="button">, so it's unaffected.) */
+.settings-page button {
+  padding: 8px 16px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.settings-page button:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+}
+
+.settings-page button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* Neutral secondary action (e.g. Cancel). */
+.settings-page button.settings-button-secondary {
+  background-color: var(--border-strong);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.settings-page button.settings-button-secondary:hover:not(:disabled) {
+  background-color: var(--active-bg);
+}
+
+/* Destructive action (delete account confirm). */
+.settings-page button.settings-button-danger {
+  background-color: var(--error);
+  color: #fff;
+}
+
+.settings-page button.settings-button-danger:hover:not(:disabled) {
+  opacity: 0.9;
+}

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import { getAuth, signOut } from "firebase/auth";
+import { toast } from "react-hot-toast";
 import { useTheme } from "../../contexts/ThemeContext";
 import { useUserDto } from "../../contexts/UserContext";
 import apiWrapper from "../../api/apiWrapper";
@@ -72,6 +74,10 @@ function SettingsPage() {
   const [prefsError, setPrefsError] = useState("");
   const [prefsSaving, setPrefsSaving] = useState(false);
   const [prefsMessage, setPrefsMessage] = useState("");
+
+  const [deleteConfirming, setDeleteConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
 
   const allZones = useMemo(() => getAllIanaZones(), []);
   const browserTz = useMemo(() => detectBrowserTimezone(), []);
@@ -193,6 +199,29 @@ function SettingsPage() {
     } finally {
       setTzSaving(false);
     }
+  };
+
+  const handleDeleteAccount = async () => {
+    setDeleting(true);
+    setDeleteError("");
+    try {
+      await apiWrapper.Users.deleteAccount();
+    } catch (err) {
+      console.error("Account deletion failed:", err);
+      setDeleteError("We could not delete your account. Please try again.");
+      setDeleting(false);
+      return;
+    }
+    // The account (including the Firebase login) is gone server-side. Tear the
+    // local session down the same way sign-out does, then leave the authed app.
+    try {
+      await apiWrapper.Auth.clearToken();
+      await signOut(getAuth());
+    } catch (err) {
+      console.warn("Sign-out after deletion failed (account already gone):", err);
+    }
+    toast.success("Your account has been deleted.");
+    navigate("/");
   };
 
   if (isLoading) {
@@ -325,6 +354,45 @@ function SettingsPage() {
                 <span style={{ fontSize: "0.85em" }}>{prefsMessage}</span>
               )}
             </>
+          )}
+        </section>
+
+        <section className="settings-section">
+          <h2>Account</h2>
+          {!deleteConfirming ? (
+            <div className="settings-item">
+              <span className="label">Delete Account:</span>
+              <button
+                onClick={() => {
+                  setDeleteError("");
+                  setDeleteConfirming(true);
+                }}
+              >
+                Delete…
+              </button>
+            </div>
+          ) : (
+            <div>
+              <p style={{ fontSize: "0.85em", marginTop: 0 }}>
+                This permanently deletes your account and removes your personal
+                data. Your league history stays (anonymized). This cannot be undone.
+              </p>
+              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <button onClick={() => setDeleteConfirming(false)} disabled={deleting}>
+                  Cancel
+                </button>
+                <button
+                  onClick={handleDeleteAccount}
+                  disabled={deleting}
+                  style={{ background: "#b00020", color: "#fff" }}
+                >
+                  {deleting ? "Deleting…" : "Yes, delete my account"}
+                </button>
+              </div>
+              {deleteError && (
+                <p className="error" style={{ marginTop: 8 }}>{deleteError}</p>
+              )}
+            </div>
           )}
         </section>
       </div>

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -378,13 +378,17 @@ function SettingsPage() {
                 data. Your league history stays (anonymized). This cannot be undone.
               </p>
               <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                <button onClick={() => setDeleteConfirming(false)} disabled={deleting}>
+                <button
+                  className="settings-button-secondary"
+                  onClick={() => setDeleteConfirming(false)}
+                  disabled={deleting}
+                >
                   Cancel
                 </button>
                 <button
+                  className="settings-button-danger"
                   onClick={handleDeleteAccount}
                   disabled={deleting}
-                  style={{ background: "#b00020", color: "#fff" }}
                 >
                   {deleting ? "Deleting…" : "Yes, delete my account"}
                 </button>

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -213,12 +213,18 @@ function SettingsPage() {
       return;
     }
     // The account (including the Firebase login) is gone server-side. Tear the
-    // local session down the same way sign-out does, then leave the authed app.
+    // local session down the same way sign-out does. clear-token is best-effort;
+    // it must not block the load-bearing Firebase sign-out, so each runs in its
+    // own try/catch.
     try {
       await apiWrapper.Auth.clearToken();
+    } catch (err) {
+      console.warn("clear-token after deletion failed (continuing to sign-out):", err);
+    }
+    try {
       await signOut(getAuth());
     } catch (err) {
-      console.warn("Sign-out after deletion failed (account already gone):", err);
+      console.warn("Firebase sign-out after deletion failed (account already gone):", err);
     }
     toast.success("Your account has been deleted.");
     navigate("/");

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.test.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.test.jsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import SettingsPage from "./SettingsPage";
+import apiWrapper from "../../api/apiWrapper";
+
+// Only the account-deletion flow is covered here (SettingsPage's other sections
+// are simple display/edit fields). We mock every collaborator the delete handler
+// touches so we can assert the success/failure branches in isolation.
+
+jest.mock("../../api/apiWrapper", () => ({
+  Users: {
+    getCurrentUser: jest.fn(),
+    getNotificationPreferences: jest.fn(),
+    deleteAccount: jest.fn(),
+  },
+  Auth: {
+    clearToken: jest.fn(),
+  },
+}));
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockSignOut = jest.fn();
+jest.mock("firebase/auth", () => ({
+  getAuth: jest.fn(() => ({})),
+  signOut: (...args) => mockSignOut(...args),
+}));
+
+const mockToastSuccess = jest.fn();
+jest.mock("react-hot-toast", () => ({
+  toast: { success: (...args) => mockToastSuccess(...args) },
+}));
+
+jest.mock("../../contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: "dark", toggleTheme: jest.fn() }),
+}));
+
+jest.mock("../../contexts/UserContext", () => ({
+  useUserDto: () => ({ refreshUserDto: jest.fn() }),
+}));
+
+// BadgesPanel pulls its own data; irrelevant to these tests.
+jest.mock("../../components/badges/BadgesPanel.tsx", () => () => null);
+
+const mockUser = {
+  email: "real@person.com",
+  username: "randall",
+  displayName: "Randall",
+  timezone: "America/New_York",
+};
+
+const allPrefsOn = {
+  pickResultEnabled: true,
+  pickDeadlineReminderEnabled: true,
+  contestStartReminderEnabled: true,
+  leagueInviteEnabled: true,
+  membershipEnabled: true,
+  matchupPreviewEnabled: true,
+  scheduleChangeEnabled: true,
+  oddsChangedEnabled: true,
+};
+
+function renderSettings() {
+  return render(
+    <MemoryRouter>
+      <SettingsPage />
+    </MemoryRouter>
+  );
+}
+
+async function openDeleteConfirm() {
+  await userEvent.click(await screen.findByRole("button", { name: /^Delete/i }));
+  await userEvent.click(
+    await screen.findByRole("button", { name: /yes, delete my account/i })
+  );
+}
+
+describe("SettingsPage — account deletion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    apiWrapper.Users.getCurrentUser.mockResolvedValue({ data: mockUser });
+    apiWrapper.Users.getNotificationPreferences.mockResolvedValue({ data: allPrefsOn });
+  });
+
+  it("on success: clears token, signs out, toasts, and navigates home", async () => {
+    apiWrapper.Users.deleteAccount.mockResolvedValue({});
+    apiWrapper.Auth.clearToken.mockResolvedValue({});
+    mockSignOut.mockResolvedValue(undefined);
+
+    renderSettings();
+    await openDeleteConfirm();
+
+    await waitFor(() =>
+      expect(apiWrapper.Users.deleteAccount).toHaveBeenCalledTimes(1)
+    );
+    expect(apiWrapper.Auth.clearToken).toHaveBeenCalledTimes(1);
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+
+  it("on failure: shows error, stays put, and skips cleanup + navigation", async () => {
+    apiWrapper.Users.deleteAccount.mockRejectedValue(new Error("boom"));
+
+    renderSettings();
+    await openDeleteConfirm();
+
+    expect(
+      await screen.findByText("We could not delete your account. Please try again.")
+    ).toBeInTheDocument();
+
+    expect(apiWrapper.Auth.clearToken).not.toHaveBeenCalled();
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // deleting state cleared → user can retry.
+    expect(
+      screen.getByRole("button", { name: /yes, delete my account/i })
+    ).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
Adds in-app account deletion to the **web app** (`sd-ui`), reaching parity with mobile (#490). Follow-up we deferred while shipping notification preferences.

## What

Settings → **Account** → **Delete Account**. Hits the existing `DELETE /user/me` endpoint — **no backend changes**; the server-side anonymize (PII → sentinels, `DeletedUtc` stamped) + Firebase-login removal + `UserDeleted` fan-out all come from #490.

On success the local session is torn down exactly like web sign-out:
`Auth.clearToken()` → Firebase `signOut()` → toast → redirect to `/`.

## Notable choices

- **Two-step inline confirm, not the shared `ConfirmationDialog`.** That dialog always renders a "Do not ask me again" checkbox — fine for sign-out, unsafe for a permanent, irreversible delete. The inline confirm (Delete… → warning + "Yes, delete my account" / Cancel) matches the page's existing inline-edit idiom and avoids that affordance.
- **No device unregister step** (unlike mobile) — the web app registers no push devices, so there's nothing device-side to clean up.
- Warning copy mirrors mobile: permanent, personal data removed, league history stays (anonymized), cannot be undone.

## Changes

- `api/usersApi.js` — `deleteAccount()` → `DELETE /user/me`
- `components/settings/SettingsPage.jsx` — Account section + inline confirm + teardown handler
- `docs/mobile/account-deletion.md` — document the web surface

## Validation

- [x] `eslint --max-warnings=0` clean (this gate blocks `npm start`)
- [ ] In-browser: delete a throwaway account → confirm redirect to landing, login removed, and the record reads "Deleted user" in standings

## Notes

No new web tests — the flow is a thin UI wrapper over the already-tested `DELETE /user/me`, and it matches how the web notification toggles shipped (web coverage here is plain-hooks, no component tests). Backend deletion logic is covered by the API/Notification suites from #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added account deletion to the web app’s Settings → Account section with a two-step confirmation flow.
  - Includes progress/disabled controls, success notification, and redirect to the home page after deletion.
- **Bug Fixes**
  - Improved cleanup behavior by making local token clearing best-effort while continuing Firebase sign-out.
- **Documentation**
  - Updated mobile/web account-deletion documentation, including the web settings walkthrough and re-signup notes.
- **Style**
  - Added scoped button styling for the Settings page, including a destructive action variant.
- **Tests**
  - Added automated coverage for the account-deletion success and failure flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->