### PR TITLE
ci(sd-ui): gate the image push on the Vitest suite

### DIFF
--- a/src/UI/sd-ui/azure-pipelines.yml
+++ b/src/UI/sd-ui/azure-pipelines.yml
@@ -78,8 +78,7 @@ stages:
   # jsdom 16's http-proxy-agent breaks require() on modern Node). Vitest handles
   # all of that natively on Node 20. --legacy-peer-deps is required for install
   # (React 19 vs react-scripts@5's React 18 peer). Runs in parallel with
-  # BuildAndTest (dependsOn: []) and does NOT gate the image push yet — once the
-  # suite is trusted, a one-line change makes the push depend on it.
+  # BuildAndTest and now gates the image push (see BuildImagePushACR.dependsOn).
   - stage: Test
     displayName: 'Test: sd-ui'
     dependsOn: []
@@ -106,7 +105,9 @@ stages:
 
   - stage: BuildImagePushACR
     displayName: 'Build UI Image & Push to ACR'
-    dependsOn: BuildAndTest
+    dependsOn:
+      - BuildAndTest
+      - Test
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     jobs:
       - job: BuildImage


### PR DESCRIPTION
Follow-up to #495. Now that the web Vitest suite runs green in CI, make it a real gate.

## Change

`BuildImagePushACR` now `dependsOn: [BuildAndTest, Test]` (was just `BuildAndTest`). Its `condition: and(succeeded(), <main-only>)` therefore requires **both** the build/lint stage and the Vitest stage to pass before the prod image is built and pushed to ACR.

- `Test` still runs in parallel (`dependsOn: []`) — only the image push waits on it, so a red test no longer lets a broken build ship.
- Main-only condition unchanged; nothing changes for PR builds (which don't push images anyway).

One line of YAML; validated that it parses and the stage graph is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline so container images are built and pushed only after both standard and Vitest checks complete successfully.
  * Clarified pipeline stage gating for improved deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->