### PR TITLE
fix(sd-ui): npm ci --legacy-peer-deps in Dockerfile (fixes image build)

### DIFF
--- a/src/UI/sd-ui/Dockerfile
+++ b/src/UI/sd-ui/Dockerfile
@@ -6,8 +6,11 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install all dependencies (including devDependencies needed for build)
-RUN npm ci
+# Install all dependencies (including devDependencies needed for build).
+# --legacy-peer-deps is required: the app is on React 19 while react-scripts@5
+# declares a React 18 peer, so the lockfile is resolved (and must be installed)
+# in legacy-peer mode. Matches the pipeline's npm ci steps.
+RUN npm ci --legacy-peer-deps
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Broken-main hotfix

The `sd-ui` **image build fails on main** at `RUN npm ci`:

```
npm ci can only install packages when your package.json and package-lock.json are in sync
Invalid: lock file's picomatch@2.3.1 does not satisfy picomatch@4.0.5
Invalid: lock file's yaml@1.10.2 does not satisfy yaml@2.9.0
```

## Cause

The committed `package-lock.json` is resolved in **legacy-peer mode** (React 19 vs `react-scripts@5`'s React 18 peer), so `npm ci` must run with `--legacy-peer-deps`. The #495 Vitest migration updated the **pipeline's** `npm ci` steps but missed the **Dockerfile's** `RUN npm ci`.

It didn't surface in PR CI because `BuildImagePushACR` only runs **post-merge** on `main` — the PR pipeline (lint + build + vitest) doesn't build the Docker image.

## Fix

`Dockerfile` line 10 → `RUN npm ci --legacy-peer-deps`, matching the pipeline.

## Validation

Ran a local `docker build` of the image with the fix — `npm ci --legacy-peer-deps` and `npx react-scripts build` both succeed and the image exports cleanly. (Pre-existing `SecretsUsedInArgOrEnv` warnings on `GOOGLE_MAPS_API_KEY` are unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application build process to install dependencies successfully despite peer dependency compatibility constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->