### PR TITLE
fix(pools): clamp leaf-service connection pools + tag Application Name

### DIFF
--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -252,13 +252,13 @@ namespace SportsData.Api
 
             if (!isTestingEnv)
             {
-                services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, apiAppDataPoolSize);
+                services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, apiAppDataPoolSize, role: "Api");
             }
 
             string? sigRConnString = null;
             if (!isTestingEnv)
             {
-                services.AddHangfire(config, builder.Environment.ApplicationName, mode, maxPoolSize: apiHangfirePoolSize);
+                services.AddHangfire(config, builder.Environment.ApplicationName, mode, maxPoolSize: apiHangfirePoolSize, role: "Api");
 
                 // IMPORTANT: any new consumer added below also needs a paired
                 // RabbitMQ shovel per Producer broker in sports-data-config under

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -252,13 +252,13 @@ namespace SportsData.Api
 
             if (!isTestingEnv)
             {
-                services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, apiAppDataPoolSize, role: "Api");
+                services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, apiAppDataPoolSize);
             }
 
             string? sigRConnString = null;
             if (!isTestingEnv)
             {
-                services.AddHangfire(config, builder.Environment.ApplicationName, mode, maxPoolSize: apiHangfirePoolSize, role: "Api");
+                services.AddHangfire(config, builder.Environment.ApplicationName, mode, maxPoolSize: apiHangfirePoolSize);
 
                 // IMPORTANT: any new consumer added below also needs a paired
                 // RabbitMQ shovel per Producer broker in sports-data-config under

--- a/src/SportsData.Contest/Program.cs
+++ b/src/SportsData.Contest/Program.cs
@@ -35,9 +35,7 @@ namespace SportsData.Contest
             // Clamp the connection pool — default leaves Npgsql at 100/pool, which
             // summed across services can exceed PG max_connections.
             // See docs/infrastructure/postgres-connection-budget.md.
-            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
-                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
+            services.AddDataPersistenceWithClampedPool<AppDataContext>(config, builder.Environment.ApplicationName, mode);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Contest/Program.cs
+++ b/src/SportsData.Contest/Program.cs
@@ -32,7 +32,12 @@ namespace SportsData.Contest
             builder.UseCommon();
 
             services.AddClients(config);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode);
+            // Clamp the connection pool — default leaves Npgsql at 100/pool, which
+            // summed across services can exceed PG max_connections.
+            // See docs/infrastructure/postgres-connection-budget.md.
+            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
+            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -79,9 +79,14 @@ namespace SportsData.Core.DependencyInjection
         private static string ApplyApplicationName(string connString, string applicationName, string? role, string poolKind)
         {
             var svc = applicationName.Replace("SportsData.", string.Empty);
-            var tag = string.IsNullOrWhiteSpace(role)
-                ? $"sd{svc}.{poolKind}"
-                : $"sd{svc}.{role}.{poolKind}";
+            // Omit the role segment when it just repeats the service name (e.g. the
+            // Api service with role "Api") — produces sd{svc}.{poolKind} rather than
+            // sd{svc}.{svc}.{poolKind}.
+            var includeRole = !string.IsNullOrWhiteSpace(role)
+                && !string.Equals(role, svc, StringComparison.OrdinalIgnoreCase);
+            var tag = includeRole
+                ? $"sd{svc}.{role}.{poolKind}"
+                : $"sd{svc}.{poolKind}";
 
             // Drop any Application Name already on the base connection string, then set ours.
             connString = System.Text.RegularExpressions.Regex.Replace(
@@ -167,6 +172,26 @@ namespace SportsData.Core.DependencyInjection
             });
 
             return services;
+        }
+
+        /// <summary>
+        /// Convenience wrapper for the single-pool services: resolves a clamped pool
+        /// size (App Config key <c>{applicationName}:ConnectionPool:{poolConfigKey}</c>,
+        /// falling back to <paramref name="defaultPoolSize"/>) and registers the
+        /// DbContext with it. Keeps the leaf services from repeating the
+        /// ResolvePoolSize + AddDataPersistence boilerplate.
+        /// </summary>
+        public static IServiceCollection AddDataPersistenceWithClampedPool<T>(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            string applicationName,
+            Sport mode,
+            string poolConfigKey = "Default",
+            int defaultPoolSize = 10,
+            string? role = null) where T : DbContext
+        {
+            var poolSize = ResolvePoolSize(configuration, applicationName, poolConfigKey, defaultPoolSize);
+            return services.AddDataPersistence<T>(configuration, applicationName, mode, poolSize, role);
         }
 
         /// <summary>

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -70,6 +70,28 @@ namespace SportsData.Core.DependencyInjection
             return Math.Min(resolved, MaxAllowedPoolSize);
         }
 
+        /// <summary>
+        /// Sets the connection's <c>Application Name</c> to <c>sd{Service}[.{role}].{poolKind}</c>
+        /// so <c>pg_stat_activity.application_name</c> distinguishes each service's data vs
+        /// Hangfire pool (and, where a role is supplied, Worker vs Ingest pods).
+        /// See docs/infrastructure/postgres-connection-budget.md §6.
+        /// </summary>
+        private static string ApplyApplicationName(string connString, string applicationName, string? role, string poolKind)
+        {
+            var svc = applicationName.Replace("SportsData.", string.Empty);
+            var tag = string.IsNullOrWhiteSpace(role)
+                ? $"sd{svc}.{poolKind}"
+                : $"sd{svc}.{role}.{poolKind}";
+
+            // Drop any Application Name already on the base connection string, then set ours.
+            connString = System.Text.RegularExpressions.Regex.Replace(
+                connString,
+                @"Application Name=[^;]*;?",
+                string.Empty,
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            return $"{connString.TrimEnd(';')};Application Name={tag};";
+        }
+
         public static IServiceCollection AddCaching(this IServiceCollection services, IConfiguration config)
         {
             var redisConnectionString = config[CommonConfigKeys.CacheServiceUri];
@@ -102,7 +124,8 @@ namespace SportsData.Core.DependencyInjection
             IConfiguration configuration,
             string applicationName,
             Sport mode,
-            int? maxPoolSize = null) where T : DbContext
+            int? maxPoolSize = null,
+            string? role = null) where T : DbContext
         {
             // TODO: Clean up this hacky mess
             var cc = configuration.GetSection("CommonConfig")["SqlBaseConnectionString"];
@@ -117,6 +140,10 @@ namespace SportsData.Core.DependencyInjection
                     System.Text.RegularExpressions.RegexOptions.IgnoreCase);
                 connString = $"{connString.TrimEnd(';')};Maximum Pool Size={maxPoolSize.Value};";
             }
+
+            // Tag the data pool so pg_stat_activity.application_name distinguishes
+            // it from the Hangfire pool (and, with role, Worker vs Ingest pods).
+            connString = ApplyApplicationName(connString, applicationName, role, "Data");
 
             Console.WriteLine($"PostgreSQL: {connString}");
 
@@ -214,7 +241,8 @@ namespace SportsData.Core.DependencyInjection
             Sport mode,
             bool includeServer = true,
             int? maxPoolSize = null,
-            string[]? queues = null)
+            string[]? queues = null,
+            string? role = null)
         {
             // TODO: Clean up this hacky mess
             var cc = configuration.GetSection("CommonConfig")["SqlBaseConnectionString"];
@@ -229,6 +257,9 @@ namespace SportsData.Core.DependencyInjection
                     System.Text.RegularExpressions.RegexOptions.IgnoreCase);
                 connString = $"{connString.TrimEnd(';')};Maximum Pool Size={maxPoolSize.Value};";
             }
+
+            // Tag the Hangfire pool distinctly from the data pool (see AddDataPersistence).
+            connString = ApplyApplicationName(connString, applicationName, role, "Hangfire");
 
             var minWorkersConfigValue = configuration[$"{applicationName}:BackgroundProcessor:MinWorkers"];
             var minWorkers = int.TryParse(minWorkersConfigValue, out var parsedMinWorkers)

--- a/src/SportsData.Franchise/Program.cs
+++ b/src/SportsData.Franchise/Program.cs
@@ -30,7 +30,10 @@ namespace SportsData.Franchise
             builder.UseCommon();
 
             services.AddClients(config);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode);
+            // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
+            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
+            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Franchise/Program.cs
+++ b/src/SportsData.Franchise/Program.cs
@@ -31,9 +31,7 @@ namespace SportsData.Franchise
 
             services.AddClients(config);
             // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
-            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
-                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
+            services.AddDataPersistenceWithClampedPool<AppDataContext>(config, builder.Environment.ApplicationName, mode);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -34,7 +34,13 @@ namespace SportsData.Notification
             services.AddControllers();
             services.AddEndpointsApiExplorer();
             services.AddSwaggerGen();
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode);
+            // Clamp the data + Hangfire pools — default leaves Npgsql at 100 each
+            // (200/pod). See docs/infrastructure/postgres-connection-budget.md.
+            var dataPoolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "AppData", defaultPoolSize: 15);
+            var hangfirePoolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "Hangfire", defaultPoolSize: 15);
+            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, dataPoolSize);
 
             services.AddMessaging(config, [
                 typeof(ContestOddsUpdatedConsumer),
@@ -101,7 +107,7 @@ namespace SportsData.Notification
             // step). No dashboard mounted — production dashboards aggregate
             // via SportsData.JobsDashboard at jobs.sportdeets.com behind basic
             // auth, per the convention reasserted in #463.
-            services.AddHangfire(config, builder.Environment.ApplicationName, mode);
+            services.AddHangfire(config, builder.Environment.ApplicationName, mode, maxPoolSize: hangfirePoolSize);
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
 
             // Phase 2c-main: pick-deadline reminder scheduling + dispatch.

--- a/src/SportsData.Player/Program.cs
+++ b/src/SportsData.Player/Program.cs
@@ -31,9 +31,7 @@ namespace SportsData.Player
 
             services.AddClients(config);
             // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
-            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
-                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
+            services.AddDataPersistenceWithClampedPool<AppDataContext>(config, builder.Environment.ApplicationName, mode);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Player/Program.cs
+++ b/src/SportsData.Player/Program.cs
@@ -30,7 +30,10 @@ namespace SportsData.Player
             builder.UseCommon();
 
             services.AddClients(config);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode);
+            // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
+            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
+            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -96,11 +96,11 @@ public class Program
         switch (mode)
         {
             case Sport.GolfPga:
-                services.AddDataPersistence<GolfDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize);
+                services.AddDataPersistence<GolfDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize, role: roleName);
                 break;
             case Sport.FootballNcaa:
             case Sport.FootballNfl:
-                services.AddDataPersistence<FootballDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize);
+                services.AddDataPersistence<FootballDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize, role: roleName);
 
                 // Abstract type registrations needed for services that inject them directly
                 // Note: These are NOT used by document processors (factories inject FootballDataContext)
@@ -109,7 +109,7 @@ public class Program
                 services.AddScoped<BaseDataContext, FootballDataContext>();
                 break;
             case Sport.BaseballMlb:
-                services.AddDataPersistence<BaseballDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize);
+                services.AddDataPersistence<BaseballDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize, role: roleName);
                 services.AddScoped<TeamSportDataContext, BaseballDataContext>();
                 services.AddScoped<BaseDataContext, BaseballDataContext>();
                 break;
@@ -143,7 +143,7 @@ public class Program
             _ => null
         };
         services.AddHangfire(config, builder.Environment.ApplicationName, mode,
-            includeServer: needsHangfireServer, maxPoolSize: maxPoolSize, queues: hangfireQueues);
+            includeServer: needsHangfireServer, maxPoolSize: maxPoolSize, queues: hangfireQueues, role: roleName);
 
         // MassTransit consumers — only for Ingest role
         if (role.HasFlag(ProducerRole.Ingest))

--- a/src/SportsData.Provider/Program.cs
+++ b/src/SportsData.Provider/Program.cs
@@ -84,13 +84,13 @@ namespace SportsData.Provider
             };
             int? maxPoolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(config, builder.Environment.ApplicationName, roleName, defaultPoolSize);
             Console.WriteLine($"Role: {roleName}, ConnectionPool MaxSize: {maxPoolSize}");
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize);
+            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, maxPoolSize, role: roleName);
 
             // Hangfire — Worker gets client + server; Ingest and Api get client only
             // Api needs client so controllers can enqueue jobs; Ingest needs it to enqueue from MassTransit consumers
             var needsHangfireServer = role.HasFlag(ProviderRole.Worker);
             services.AddHangfire(config, builder.Environment.ApplicationName, mode,
-                includeServer: needsHangfireServer, maxPoolSize: maxPoolSize);
+                includeServer: needsHangfireServer, maxPoolSize: maxPoolSize, role: roleName);
 
             // MassTransit consumers — only for Ingest role
             if (role.HasFlag(ProviderRole.Ingest))

--- a/src/SportsData.Season/Program.cs
+++ b/src/SportsData.Season/Program.cs
@@ -30,7 +30,10 @@ namespace SportsData.Season
             builder.UseCommon();
 
             services.AddClients(config);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode);
+            // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
+            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
+            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Season/Program.cs
+++ b/src/SportsData.Season/Program.cs
@@ -31,9 +31,7 @@ namespace SportsData.Season
 
             services.AddClients(config);
             // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
-            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
-                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, mode, poolSize);
+            services.AddDataPersistenceWithClampedPool<AppDataContext>(config, builder.Environment.ApplicationName, mode);
             services.AddMessaging(config, null);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddHealthChecks<AppDataContext>(builder.Environment.ApplicationName, mode);

--- a/src/SportsData.Venue/Program.cs
+++ b/src/SportsData.Venue/Program.cs
@@ -59,7 +59,10 @@ namespace SportsData.Venue
             services.AddEndpointsApiExplorer();
             services.AddSwaggerGen();
             services.AddClients(config);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, Sport.All);
+            // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
+            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
+                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
+            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, Sport.All, poolSize);
             services.AddMessaging(config, [typeof(VenueCreatedHandler)]);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddCaching(config);

--- a/src/SportsData.Venue/Program.cs
+++ b/src/SportsData.Venue/Program.cs
@@ -60,9 +60,7 @@ namespace SportsData.Venue
             services.AddSwaggerGen();
             services.AddClients(config);
             // Clamp the connection pool — see docs/infrastructure/postgres-connection-budget.md.
-            var poolSize = Core.DependencyInjection.ServiceRegistration.ResolvePoolSize(
-                config, builder.Environment.ApplicationName, "Default", defaultPoolSize: 10);
-            services.AddDataPersistence<AppDataContext>(config, builder.Environment.ApplicationName, Sport.All, poolSize);
+            services.AddDataPersistenceWithClampedPool<AppDataContext>(config, builder.Environment.ApplicationName, Sport.All);
             services.AddMessaging(config, [typeof(VenueCreatedHandler)]);
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
             services.AddCaching(config);


### PR DESCRIPTION
Implements **§1** and **§6** of the connection-budget design doc (#500). First of the rollout PRs after `max_connections`→700 and the KEDA MLB cap.

## §1 — clamp the six unguarded services
These silently used Npgsql's **default 100/pool** — the largest unguarded ceiling behind the 53300 spikes (~620 connections at one pod each):

| Service | Before | After |
|---|---|---|
| Contest, Franchise, Player, Season, Venue | data 100 | data **10** |
| Notification | data 100 + HF 100 (**200/pod**) | data **15** + HF **15** |

All via the existing `ResolvePoolSize()` so they remain AppConfig-overridable like Provider/Producer/Api.

## §6 — Application Name per pool
Every connection now sets `Application Name = sd{Service}[.{Role}].Data | .Hangfire`, so `pg_stat_activity.application_name` attributes connections by **service and pool** (and Worker-vs-Ingest where a role exists):
- Provider/Producer pass their `roleName` → e.g. `sdProducer.Worker.Data`
- Api tags `Api`; leaf services get `sdContest.Data`
- Shared `ApplyApplicationName` helper in Core

This makes the validation query in the doc (§Validation) actually resolve to real names.

## Deliberately NOT here
**§2 (Worker `MinWorkers` 25 → 18)** lives in AppConfig (`sports-data-provision/manifest.json`), and *lowering workers* — not enlarging the pool — is what fixes the Worker 22<25 starvation while keeping the per-pod footprint down. Sequenced as a companion change so code never shrinks the pool before workers drop (which would make starvation worse). I'll tee that up separately.

## Validation
- [x] `dotnet build sports-data.sln` — clean (0/0)
- [x] Core unit tests — 221 passed
- [ ] Post-deploy: `pg_stat_activity` grouped by `application_name` shows the new `sd{Service}.{Role}.Data/.Hangfire` rows; leaf-service connection counts capped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved database connection management across services to help prevent connection limits from being exceeded.
  * Balanced background-processing and application connections for more consistent service performance.

* **Monitoring**
  * Improved database activity identification, making it easier to distinguish application components and operational roles during diagnostics.

* **Configuration**
  * Added more consistent role-aware handling for data and background-processing connections across supported services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->