### PR TITLE
feat(notifications): pick-type-aware pick-result push copy

### DIFF
--- a/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
+using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common;
@@ -188,26 +189,51 @@ namespace SportsData.Api.Application.Scoring
                     pick.ModifiedUtc = _dateTimeProvider.UtcNow();
                     pick.ModifiedBy = CausationId.Api.PickScoringProcessor;
 
+                    // Which side did the user pick? UserPick stores FranchiseId
+                    // (SU/ATS); the matchup result carries the per-side FranchiseId.
+                    // Null for Over/Under picks (no FranchiseId) or an unresolved
+                    // match — the consumer falls back to the generic copy.
+                    bool? pickedIsHome = pick.FranchiseId.HasValue
+                        ? pick.FranchiseId == result.HomeFranchiseId ? true
+                          : pick.FranchiseId == result.AwayFranchiseId ? false
+                          : (bool?)null
+                        : null;
+
+                    // Structured spread for the picked side (ATS only): home =
+                    // matchup spread, away = its negation. Uses result.Spread —
+                    // the same value scoring ran on — so the consumer's rendered
+                    // line reconciles with the ✓/✗. Null for straight-up picks
+                    // (or ATS with no/zero spread); the consumer omits the spread
+                    // then. The consumer owns all string formatting.
+                    double? pickedSpread = null;
+                    if (pickedIsHome.HasValue
+                        && group.PickType == PickType.AgainstTheSpread
+                        && result.Spread is not null && result.Spread.Value != 0)
+                    {
+                        pickedSpread = pickedIsHome.Value ? result.Spread.Value : -result.Spread.Value;
+                    }
+
                     // Fat-event for the Notification service (design doc §4 /
                     // §5 v1). Publish BEFORE SaveChanges so the bus-outbox
                     // interceptor commits this together with the pick update;
                     // an at-least-once redelivery is fine — Notification's
                     // NotificationLog dedupe on (CorrelationId, UserId, Channel)
-                    // absorbs it. Today's payload populates the cheap fields;
-                    // DisplayName, AwayName/HomeName, and PickValue require
-                    // additional joins (User + FranchiseSeason) and are
-                    // intentionally nullable in the contract until that
-                    // fattening pass lands.
+                    // absorbs it. Structured facts only (abbreviations,
+                    // PickedIsHome, PickedSpread); the consumer composes the copy.
+                    // DisplayName and full AwayName/HomeName stay null (unused).
                     await _bus.Publish(new UserPickScored(
                             pick.UserId,
                             null,
                             command.ContestId,
                             null,
                             null,
+                            result.AwayAbbreviation,
+                            result.HomeAbbreviation,
                             result.AwayScore,
                             result.HomeScore,
-                            null,
                             pick.IsCorrect,
+                            pickedIsHome,
+                            pickedSpread,
                             group.Id,
                             group.Name,
                             group.Sport,

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupResultByContestId.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupResultByContestId.sql
@@ -8,9 +8,16 @@
   c."HomeScore",
   c."WinnerFranchiseSeasonId",
   c."SpreadWinnerFranchiseSeasonId",
-  c."FinalizedUtc"
+  c."FinalizedUtc",
+  afs."Abbreviation" as "AwayAbbreviation",
+  afs."FranchiseId" as "AwayFranchiseId",
+  hfs."Abbreviation" as "HomeAbbreviation",
+  hfs."FranchiseId" as "HomeFranchiseId"
 from public."Contest" c
 inner join public."Competition" co on co."ContestId" = c."Id"
+-- Team abbreviations + franchise ids for notification copy / picked-side resolution.
+left join public."FranchiseSeason" afs on afs."Id" = c."AwayTeamFranchiseSeasonId"
+left join public."FranchiseSeason" hfs on hfs."Id" = c."HomeTeamFranchiseSeasonId"
 
 -- Use LATERAL join to prioritize ESPN (58) over DraftKings (100)
 LEFT JOIN LATERAL (

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupResultByContestId.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupResultByContestId.sql
@@ -30,3 +30,9 @@ LEFT JOIN LATERAL (
 ) coo ON TRUE
 
 where c."Id" = @ContestId
+  -- Scoring callers cannot tolerate pre-enrichment rows. WinnerFranchiseSeasonId,
+  -- SpreadWinnerFranchiseSeasonId, and the final HomeScore/AwayScore are all
+  -- populated atomically by ContestEnrichmentProcessor alongside
+  -- FinalizedUtc. Returning a row before that point produced silent
+  -- Guid.Empty/0-0 scoring (PickScoringProcessor / PickScoringService).
+  and c."FinalizedUtc" is not null

--- a/src/SportsData.Core/Dtos/Canonical/MatchupResult.cs
+++ b/src/SportsData.Core/Dtos/Canonical/MatchupResult.cs
@@ -27,5 +27,17 @@ using System;
         // Nullable: NULL until enrichment runs. PickScoringProcessor/Service
         // gate on this — the canonical "is this contest scoreable" signal.
         public DateTime? FinalizedUtc { get; set; }
+
+        // Team abbreviations + franchise ids (from the FranchiseSeason join).
+        // Used to compose the pick-result notification and to resolve which side
+        // the user picked — UserPick stores FranchiseId, not FranchiseSeasonId.
+        // Nullable — a franchise-season without an abbreviation degrades gracefully.
+        public string? AwayAbbreviation { get; set; }
+
+        public string? HomeAbbreviation { get; set; }
+
+        public Guid? AwayFranchiseId { get; set; }
+
+        public Guid? HomeFranchiseId { get; set; }
     }
 }

--- a/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
+++ b/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
@@ -13,11 +13,14 @@ namespace SportsData.Core.Eventing.Events.Picks
     ///
     /// <para>
     /// Fat-event by design: Notification doesn't project User, Contest, or
-    /// League, so the publisher carries the display facts that compose the
-    /// notification copy. Today's publisher (<c>PickScoringProcessor</c>)
-    /// populates the cheap fields; the team-name fields and
-    /// <see cref="DisplayName"/> are <c>null</c> pending fat-payload joins.
-    /// Consumers must degrade gracefully on the nullable fields.
+    /// League, so the publisher carries the <b>structured display facts</b> and
+    /// the Notification consumer composes the copy. <c>PickScoringProcessor</c>
+    /// populates the team abbreviations, <see cref="PickedIsHome"/>, and
+    /// <see cref="PickedSpread"/> (via the FranchiseSeason join on the matchup
+    /// result); the full team-name fields and <see cref="DisplayName"/> remain
+    /// <c>null</c> (unused by current copy). The publisher deliberately sends no
+    /// pre-composed strings — formatting lives in the consumer. Consumers must
+    /// degrade gracefully on the nullable fields.
     /// </para>
     /// </summary>
     public record UserPickScored(
@@ -26,10 +29,20 @@ namespace SportsData.Core.Eventing.Events.Picks
         Guid ContestId,
         string? AwayName,
         string? HomeName,
+        string? AwayAbbreviation,
+        string? HomeAbbreviation,
         int AwayScore,
         int HomeScore,
-        string? PickValue,
         bool? IsCorrect,
+        // Which side the user picked, resolved publisher-side (UserPick stores
+        // FranchiseId; the matchup result carries the per-side FranchiseId).
+        // Null for Over/Under picks or when it can't be resolved — the consumer
+        // falls back to the generic copy.
+        bool? PickedIsHome,
+        // The picked side's spread as a signed number (home = matchup spread,
+        // away = its negation), the same value scoring ran on. Null for straight-
+        // up picks (or ATS with no/zero spread). The consumer formats it.
+        double? PickedSpread,
         Guid LeagueId,
         string LeagueName,
         Sport Sport,

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 using MassTransit;
 
 using Microsoft.EntityFrameworkCore;
@@ -184,9 +186,49 @@ namespace SportsData.Notification.Application.Consumers
             await _dataContext.SaveChangesAsync();
         }
 
+        // "BOS" for a straight-up pick; "BOS +2.5" / "BOS -3" for ATS. The spread
+        // is a signed number from the picked team's perspective (negative =
+        // favored). Invariant formatting so a comma-decimal server locale can't
+        // render "2,5".
+        private static string FormatPickLabel(string abbreviation, double? pickedSpread)
+        {
+            if (pickedSpread is not { } spread)
+                return abbreviation;
+
+            var sign = spread > 0 ? "+" : string.Empty;
+            return $"{abbreviation} {sign}{spread.ToString("0.#", CultureInfo.InvariantCulture)}";
+        }
+
         private static string ComposeBody(UserPickScored msg, string leagueName)
         {
-            // Four shapes by what we have. League name comes from the local
+            // Preferred shape (scoreline + mark), picked team first. This service
+            // owns the copy: the event carries structured facts (abbreviations,
+            // PickedIsHome, PickedSpread) and we format here. The "you picked"
+            // clause appends the picked side's spread for ATS so a covered loss /
+            // uncovered win reads correctly:
+            //   "{League}: BOS 3, NYY 2 — you picked BOS ✓"          (SU win)
+            //   "{League}: BOS 2, NYY 3 — you picked BOS +2.5 ✓"     (ATS, covered loss)
+            // Requires the fattened fields; falls through to the generic shapes
+            // below for Over/Under picks or older/unfattened events.
+            if (msg.AwayAbbreviation is not null
+                && msg.HomeAbbreviation is not null
+                && msg.PickedIsHome is not null)
+            {
+                var pickedIsHome = msg.PickedIsHome.Value;
+                var pickedAbbr = pickedIsHome ? msg.HomeAbbreviation : msg.AwayAbbreviation;
+                var oppAbbr = pickedIsHome ? msg.AwayAbbreviation : msg.HomeAbbreviation;
+                var pickedScore = pickedIsHome ? msg.HomeScore : msg.AwayScore;
+                var oppScore = pickedIsHome ? msg.AwayScore : msg.HomeScore;
+                var mark = msg.IsCorrect == true ? "✓" : "✗";
+                var pickLabel = FormatPickLabel(pickedAbbr, msg.PickedSpread);
+
+                // League always present: prefer the local projection, fall back
+                // to the name carried on the event.
+                var league = leagueName ?? msg.LeagueName;
+                return $"{league}: {pickedAbbr} {pickedScore}, {oppAbbr} {oppScore} — you picked {pickLabel} {mark}";
+            }
+
+            // Fallback shapes by what we have. League name comes from the local
             // projection; team names are nullable on the event payload until
             // publisher-side fattening lands (FranchiseSeason joins).
             var outcome = msg.IsCorrect == true ? "Your pick won." : "Your pick lost.";

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupResultByContestId.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupResultByContestId.sql
@@ -8,9 +8,16 @@ SELECT
   c."HomeScore",
   c."WinnerFranchiseSeasonId",
   c."SpreadWinnerFranchiseSeasonId",
-  c."FinalizedUtc"
+  c."FinalizedUtc",
+  afs."Abbreviation" AS "AwayAbbreviation",
+  afs."FranchiseId" AS "AwayFranchiseId",
+  hfs."Abbreviation" AS "HomeAbbreviation",
+  hfs."FranchiseId" AS "HomeFranchiseId"
 FROM public."Contest" c
 INNER JOIN public."Competition" co ON co."ContestId" = c."Id"
+-- Team abbreviations + franchise ids for notification copy / picked-side resolution.
+LEFT JOIN public."FranchiseSeason" afs ON afs."Id" = c."AwayTeamFranchiseSeasonId"
+LEFT JOIN public."FranchiseSeason" hfs ON hfs."Id" = c."HomeTeamFranchiseSeasonId"
 LEFT JOIN LATERAL (
   SELECT *
   FROM public."CompetitionOdds"

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+// Covers the message composition (ComposeBody) via the public Consume path —
+// the point of moving formatting into this service. The push sender is mocked
+// to capture the rendered title/body.
+public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 7, 13, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IPushNotificationSender> _pushSender;
+    private string _capturedTitle;
+    private string _capturedBody;
+
+    public UserPickScoredConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+
+        _pushSender = Mocker.GetMock<IPushNotificationSender>();
+        _pushSender
+            .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, IReadOnlyDictionary<string, string>, CancellationToken>(
+                (_, title, body, _, _) => { _capturedTitle = title; _capturedBody = body; })
+            .ReturnsAsync(new Success<string>("msg-id"));
+    }
+
+    private static ConsumeContext<UserPickScored> ContextFor(UserPickScored msg)
+    {
+        var ctx = new Mock<ConsumeContext<UserPickScored>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private async Task SeedDeviceAsync(Guid userId)
+    {
+        DataContext.UserDevices.Add(new UserDevice
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstallationId = Guid.NewGuid().ToString(),
+            FcmToken = "tok",
+            Platform = "ios",
+            NotificationsEnabled = true,
+            LastSeenUtc = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    private static UserPickScored Msg(
+        Guid userId,
+        string awayAbbr,
+        string homeAbbr,
+        int awayScore,
+        int homeScore,
+        bool? isCorrect,
+        bool? pickedIsHome,
+        double? pickedSpread,
+        string leagueName = "Sluggers")
+        => new(
+            userId, null, Guid.NewGuid(), null, null,
+            awayAbbr, homeAbbr, awayScore, homeScore,
+            isCorrect, pickedIsHome, pickedSpread,
+            Guid.NewGuid(), leagueName, Sport.BaseballMlb, 2026,
+            Guid.NewGuid(), Guid.NewGuid());
+
+    private async Task<string> RunAndCaptureBodyAsync(UserPickScored msg)
+    {
+        await SeedDeviceAsync(msg.UserId);
+        var sut = Mocker.CreateInstance<UserPickScoredConsumer>();
+        await sut.Consume(ContextFor(msg));
+        return _capturedBody;
+    }
+
+    [Fact]
+    public async Task Consume_StraightUpWin_PickedAway_ComposesScorelineFirst()
+    {
+        // BOS (away) picked, won 3-2. No spread.
+        var body = await RunAndCaptureBodyAsync(
+            Msg(Guid.NewGuid(), "BOS", "NYY", awayScore: 3, homeScore: 2,
+                isCorrect: true, pickedIsHome: false, pickedSpread: null));
+
+        body.Should().Be("Sluggers: BOS 3, NYY 2 — you picked BOS ✓");
+        _capturedTitle.Should().Be("Nice pick!");
+    }
+
+    [Fact]
+    public async Task Consume_StraightUpLoss_PickedHome_MarksIncorrect()
+    {
+        // NYY (home) picked, lost 3-2 (away won). No spread.
+        var body = await RunAndCaptureBodyAsync(
+            Msg(Guid.NewGuid(), "BOS", "NYY", awayScore: 3, homeScore: 2,
+                isCorrect: false, pickedIsHome: true, pickedSpread: null));
+
+        body.Should().Be("Sluggers: NYY 2, BOS 3 — you picked NYY ✗");
+        _capturedTitle.Should().Be("Tough loss");
+    }
+
+    [Fact]
+    public async Task Consume_AtsCoveredLoss_PickedAwayDog_ShowsSpreadAndCheck()
+    {
+        // BOS (away) +2.5 picked, lost 2-3 (covered by losing < 2.5) → ✓.
+        var body = await RunAndCaptureBodyAsync(
+            Msg(Guid.NewGuid(), "BOS", "NYY", awayScore: 2, homeScore: 3,
+                isCorrect: true, pickedIsHome: false, pickedSpread: 2.5));
+
+        body.Should().Be("Sluggers: BOS 2, NYY 3 — you picked BOS +2.5 ✓");
+    }
+
+    [Fact]
+    public async Task Consume_AtsUncoveredWin_PickedHomeFavorite_ShowsSpreadAndCross()
+    {
+        // NYY (home) -3 picked, won 3-2 (won by 1, didn't cover) → ✗.
+        var body = await RunAndCaptureBodyAsync(
+            Msg(Guid.NewGuid(), "BOS", "NYY", awayScore: 2, homeScore: 3,
+                isCorrect: false, pickedIsHome: true, pickedSpread: -3));
+
+        body.Should().Be("Sluggers: NYY 3, BOS 2 — you picked NYY -3 ✗");
+    }
+
+    [Fact]
+    public async Task Consume_MissingAbbreviations_FallsBackToGenericCopy()
+    {
+        // Unfattened event (no abbreviations) → generic shape, no crash.
+        var body = await RunAndCaptureBodyAsync(
+            Msg(Guid.NewGuid(), awayAbbr: null, homeAbbr: null, awayScore: 3, homeScore: 2,
+                isCorrect: true, pickedIsHome: null, pickedSpread: null));
+
+        body.Should().Contain("Your pick won.");
+        body.Should().NotContain("you picked");
+    }
+}


### PR DESCRIPTION
Reworks the pick-result push so it actually says *what happened* — the pick, the opponent, the score, and (for ATS) the spread — instead of the uninformative `Nice Pick! Your pick won. Final 3-2`.

## Copy
| Pick type | Message |
|---|---|
| Straight-up win | `Sluggers: BOS 3, NYY 2 — you picked BOS ✓` |
| ATS covered loss | `Sluggers: BOS 2, NYY 3 — you picked BOS +2.5 ✓` |
| ATS uncovered win | `Sluggers: NYY 3, BOS 2 — you picked NYY -3 ✗` |

**Why the spread matters:** for ATS, `IsCorrect` means *covered*, not *won* — so without the line a notification can look self-contradictory (team lost but ✓, or won but ✗) and read as a bug. Showing the picked-side spread keeps the mark legible.

## Design
- **Event carries structured facts only; the Notification service composes the copy.** `UserPickScored` gains `AwayAbbreviation`, `HomeAbbreviation`, `PickedIsHome`, `PickedSpread` (signed, picked-side) and **drops the pre-composed `PickValue` string**. All formatting lives in `ComposeBody`.
- **`MatchupResult` + both `GetMatchupResultByContestId.sql` copies:** `LEFT JOIN FranchiseSeason` → return away/home `Abbreviation` + `FranchiseId`. The `FranchiseId` bridges the mismatch: the pick stores `FranchiseId`, the result had only `FranchiseSeasonId`. Dapper auto-maps the new columns (additive, nullable).
- **`PickScoringProcessor`** resolves `PickedIsHome`/`PickedSpread` and uses `result.Spread` — the *same value scoring ran on* — so the rendered line always reconciles with the ✓/✗.
- **Scope guard:** Over/Under scoring is an unimplemented TODO, so O/U picks (and any older/unfattened event) fall through to the **existing generic copy**. Deliberate deferral, not an oversight — `PickedSpread`/`PickedIsHome` null → fallback.

## Tests
`UserPickScoredConsumerTests` (5) exercise `ComposeBody` through the public `Consume` path (push sender mocked to capture the body): SU win/loss, ATS covered-loss / uncovered-win, and the missing-abbreviation fallback. Locks in the exact copy, picked-first scoreline reordering, and spread sign/format.

## Validation
- [x] `dotnet build sports-data.sln` clean (0/0)
- [x] Notification unit suite **36 pass** (31 + 5 new); API scoring **55 pass**
- Nullable fields → additive / back-compatible; **no migration**; deploy order flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sports result notifications now clearly show which team side was picked.
  - Against-the-spread notifications now present the selected spread alongside the outcome.
  - Notifications now include “you picked…” messaging with visual correctness indicators.

- **Bug Fixes**
  - Improved notification copy to handle missing team details gracefully with a generic fallback.
  - Spread values are now formatted consistently using culture-invariant positive/negative display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->