### PR TITLE
feat(notifications): typed NotificationUserPick table + pick-result dedup fix

### DIFF
--- a/docs/architecture/notification-log-table-per-type.md
+++ b/docs/architecture/notification-log-table-per-type.md
@@ -1,6 +1,8 @@
 # Notification logging: table-per-type
 
-**Status:** Draft — awaiting sign-off before implementation.
+**Status:** Approved. **PR1 (PickResult → `NotificationUserPick`) implemented in
+the PR that introduces this doc.** PRs 2–5 (see "Migration & rollout") are
+planned and not yet started.
 **Owner:** Randall.
 **Scope:** `SportsData.Notification` service (+ one additive field on a `SportsData.Core` event).
 
@@ -130,6 +132,7 @@ Naming follows the pattern the two named examples set (`NotificationUserPick`,
 `NotificationLeagueInvitation`): `Notification` + subject.
 
 ### 1. `NotificationUserPick` — PickResult
+
 Source: `UserPickScored`. **Requires an event change** — add `PickId` (see below).
 
 | Metadata column | Type   | Source                        |
@@ -151,6 +154,7 @@ three distinct `PickId`s), which the current key wrongly drops.
 > contest?"), not a schema change. We are **not** deciding this now.
 
 ### 2. `NotificationLeagueInvitation` — LeagueInvite
+
 Source: `UserInvitedToPickemGroup` (`InviteeUserId`, `GroupId`, `InvitedByUserId`).
 
 | Metadata column   | Type   | Source                                |
@@ -168,6 +172,7 @@ and sends. If an explicit `InvitationId` is ever added to the event, prefer it
 over `CorrelationId` in the key.
 
 ### 3. `NotificationMembership` — Membership
+
 Source: `PickemGroupMemberAdded` (`UserId`, `GroupId` — minimal payload; the
 consumer docstring already flags this event as under-fattened).
 
@@ -182,6 +187,7 @@ consumer docstring already flags this event as under-fattened).
 > the dedup key only needs `(UserId, GroupId)`.
 
 ### 4. `NotificationOddsChange` — OddsChanged
+
 Source: `ContestOddsUpdated` — **broadcast, fanned out per user** at dispatch
 (consumer joins `UserPicks ⋈ PickemGroups`, filtered to the movement type). Event
 carries `ContestId` only.
@@ -200,6 +206,7 @@ carries `ContestId` only.
 > dedup may be *intentional*.
 
 ### 5. `NotificationPickDeadline` — PickDeadline (reminder)
+
 Source: `NotificationDispatcher.SendPickDeadlineReminderAsync(userId,
 pickemGroupId, seasonWeek, fireTimeUtc)`. Already deterministic.
 
@@ -214,6 +221,7 @@ pickemGroupId, seasonWeek, fireTimeUtc)`. Already deterministic.
 reminder re-fires; a Hangfire retry of the same fire does not).
 
 ### 6. `NotificationContestStart` — ContestStart (reminder)
+
 Source: `NotificationDispatcher.SendContestStartReminderAsync(userId, contestId,
 fireTimeUtc)`. Already deterministic.
 

--- a/docs/architecture/notification-log-table-per-type.md
+++ b/docs/architecture/notification-log-table-per-type.md
@@ -1,0 +1,307 @@
+# Notification logging: table-per-type
+
+**Status:** Draft — awaiting sign-off before implementation.
+**Owner:** Randall.
+**Scope:** `SportsData.Notification` service (+ one additive field on a `SportsData.Core` event).
+
+## Motivation
+
+Today every notification the service emits — six distinct kinds — writes one row to a
+single catch-all `NotificationLog` table. That table doubles as the idempotency
+store via a unique index on `(CorrelationId, UserId, Channel)`.
+
+The catch-all has two problems:
+
+1. **Visibility (primary).** The row records *that* we sent something, but not
+   *what it was about*. There is no `PickId`, `ContestId`, or `LeagueId` — just a
+   free-text `Category` discriminator and a `CorrelationId`. Answering "did we
+   notify this user about this pick?" means correlating opaque guids across
+   services. A per-type table with typed, `NOT NULL` metadata columns makes the
+   log directly queryable and self-documenting.
+
+2. **Duplicate detection (secondary).** Users have received duplicate pushes for
+   some pick results. Root cause below. Typed tables let each notification kind
+   enforce its *natural* dedup key as a plain `UNIQUE` index instead of leaning
+   on a transport correlation id.
+
+Splitting is chosen for **visibility first**; cleaner dedup is a welcome side
+benefit. This is a modeling improvement, **not** the only way to stop the
+duplicates — see "Why the duplicates happen" — but it gives us an enforced,
+legible place to fix them.
+
+## Current state
+
+`NotificationLog` (`Infrastructure/Data/Entities/NotificationLog.cs`) columns:
+`Id, UserId, CorrelationId, Category, Channel, Title, Body, Result, FailureReason,
+AttemptedUtc` + audit fields from `CanonicalEntityBase<Guid>`. Unique index:
+`(CorrelationId, UserId, Channel)` (`AppDataContext.cs`).
+
+Six categories write to it, via **two different dedup strategies**:
+
+| Category      | Source                                              | CorrelationId source        |
+|---------------|-----------------------------------------------------|-----------------------------|
+| PickResult    | `UserPickScoredConsumer` ← `UserPickScored`         | **transport** (event's)     |
+| LeagueInvite  | `UserInvitedToPickemGroupConsumer` ← `UserInvitedToPickemGroup` | **transport**    |
+| Membership    | `PickemGroupMemberAddedConsumer` ← `PickemGroupMemberAdded`     | **transport**    |
+| OddsChanged   | `ContestOddsUpdatedConsumer` ← `ContestOddsUpdated` (fan-out)   | **transport**    |
+| PickDeadline  | `NotificationDispatcher.SendPickDeadlineReminderAsync`         | **derived** (deterministic) |
+| ContestStart  | `NotificationDispatcher.SendContestStartReminderAsync`        | **derived** (deterministic) |
+
+### Why the duplicates happen
+
+The two reminder paths derive `CorrelationId` from
+`DeterministicCorrelationId(category, userId, scopeId, qualifier…)` — a stable
+hash of the notification's *semantic identity*. A re-fire produces the same guid,
+collides on the unique index, and is suppressed. **These are idempotent by
+construction and do not duplicate.**
+
+The event-driven paths use the **transport** `CorrelationId` carried on the
+inbound event. That is the leak, in *both* directions for `PickResult`:
+
+- **Under-suppression (duplicates).** The same logical "your pick resolved" can
+  arrive from two correlation chains — the `ContestFinalized` event *and* the
+  cron finalization backstop — with two different CorrelationIds. Neither
+  collides with the other → two pushes.
+- **Over-suppression (dropped notifications).** Within a single scoring run,
+  `PickScoringProcessor` publishes one `UserPickScored` per pick. A user in three
+  leagues who picked the same game gets three events **sharing one**
+  `command.CorrelationId`. The current index collapses them to **one** push,
+  silently dropping the other two league notifications.
+
+The transport CorrelationId is simply the wrong dedup key for these events. The
+right key is the notification's semantic identity (for a pick result: the pick).
+
+## Goals / non-goals
+
+**Goals**
+- One typed table per notification kind, each with rich `NOT NULL` metadata.
+- Each table enforces its own natural dedup key as a `UNIQUE` index.
+- Preserve the existing atomic-claim idempotency pattern (claim row first, then
+  dispatch, then finalize) — it moves from `NotificationLog` to the typed table.
+- Keep `NotificationLog` in place, frozen, until it is inspected and dropped in a
+  later PR. **This doc does not remove it.**
+
+**Non-goals**
+- The notification **fan-out policy** (do we actually send three pushes when a
+  user picked one game in three leagues, or coalesce to one "your picks
+  resolved"?) is explicitly **out of scope** and deferred. The schema is designed
+  so this stays a send-side decision, not a re-model (see PickResult).
+- No change to the two reminder paths' behavior — they already dedupe correctly;
+  they just move to typed tables.
+- No user-facing surface. These tables remain audit/debug/idempotency stores,
+  never read by the app.
+
+## Design principles
+
+1. **Independent tables, not inheritance.** No EF TPT/TPH, no shared base
+   *entity*. Each table is self-contained and carries its own copy of the common
+   columns. Cost: a cross-type "everything we sent user X" query needs a `UNION`
+   — acceptable for an audit/debug store that has no hot-path reader.
+2. **Shared column *shape*, documented once.** Every typed table carries the
+   common columns below plus its typed metadata. Consistency by convention, not
+   by a base class.
+3. **Capture more IDs than the dedup key needs.** Store every identifier
+   available at creation time even if the current dedup key ignores it. This is
+   the whole point (visibility) and it keeps future dedup/rollup changes to an
+   index/query change rather than a migration + event change.
+
+### Common column shape (every typed table)
+
+From `CanonicalEntityBase<Guid>`: `Id, CreatedUtc, ModifiedUtc, CreatedBy,
+ModifiedBy`. Plus, on every notification table:
+
+| Column         | Type          | Notes                                                        |
+|----------------|---------------|--------------------------------------------------------------|
+| `UserId`       | `Guid`        | Recipient. Required.                                         |
+| `Channel`      | `varchar(16)` | `"Fcm"` today; reserved for `Email`/`Sms`.                  |
+| `Title`        | `varchar(256)`| Rendered push title (nullable until dispatched).            |
+| `Body`         | `varchar(1024)`| Rendered push body (nullable until dispatched).            |
+| `Result`       | `varchar(64)` | `Dispatching`→`Sent`/`Suppressed_*`/`Failed_*`. Required.   |
+| `FailureReason`| `varchar(512)`| Truncated per-device summary; nullable.                     |
+| `AttemptedUtc` | `timestamptz` | Claim time.                                                 |
+| `CorrelationId`| `Guid`        | Retained for cross-service tracing, **not** the dedup key.  |
+
+The typed dedup key replaces `(CorrelationId, UserId, Channel)` — `CorrelationId`
+stays as a column for tracing but no longer participates in uniqueness.
+
+## The six tables
+
+Naming follows the pattern the two named examples set (`NotificationUserPick`,
+`NotificationLeagueInvitation`): `Notification` + subject.
+
+### 1. `NotificationUserPick` — PickResult
+Source: `UserPickScored`. **Requires an event change** — add `PickId` (see below).
+
+| Metadata column | Type   | Source                        |
+|-----------------|--------|-------------------------------|
+| `PickId`        | `Guid` | **new** on `UserPickScored`   |
+| `ContestId`     | `Guid` | `UserPickScored.ContestId`    |
+| `LeagueId`      | `Guid` | `UserPickScored.LeagueId`     |
+
+**Dedup index:** `UNIQUE (UserId, PickId)` — the correctness floor. A pick is
+scored once; this guarantees at most one push per pick and stops the cross-run
+duplicate. It also *preserves* legitimate per-league notifications (three picks =
+three distinct `PickId`s), which the current key wrongly drops.
+
+> **Open — fan-out policy (deferred).** `UNIQUE (UserId, PickId)` permits three
+> pushes for a user who picked one game in three leagues. Whether we *want* that
+> or should coalesce to one rolled-up notification is a **send-side** decision to
+> make later. Because the table stores `PickId`, `ContestId`, and `LeagueId`, a
+> future rollup is a query/dispatch change ("have I sent for any pick in this
+> contest?"), not a schema change. We are **not** deciding this now.
+
+### 2. `NotificationLeagueInvitation` — LeagueInvite
+Source: `UserInvitedToPickemGroup` (`InviteeUserId`, `GroupId`, `InvitedByUserId`).
+
+| Metadata column   | Type   | Source                                |
+|-------------------|--------|---------------------------------------|
+| `LeagueId`        | `Guid` | `GroupId`                             |
+| `InvitedByUserId` | `Guid` | `InvitedByUserId`                     |
+
+**Dedup index:** `UNIQUE (UserId, LeagueId, CorrelationId)` — **re-invites
+re-notify** (decided: the user may have missed the first, so send again). Each
+invite *action* has its own `CorrelationId` (stable across at-least-once
+redelivery, distinct across separate invites), so this is the one event-driven
+category where correlation-level dedup is *correct*: redelivery of one invite
+collides and is suppressed; a genuine second invite has a new `CorrelationId`
+and sends. If an explicit `InvitationId` is ever added to the event, prefer it
+over `CorrelationId` in the key.
+
+### 3. `NotificationMembership` — Membership
+Source: `PickemGroupMemberAdded` (`UserId`, `GroupId` — minimal payload; the
+consumer docstring already flags this event as under-fattened).
+
+| Metadata column | Type   | Source    |
+|-----------------|--------|-----------|
+| `LeagueId`      | `Guid` | `GroupId` |
+
+**Dedup index:** `UNIQUE (UserId, LeagueId)`.
+
+> Note: this event is the poorest in context. Fattening it (LeagueName,
+> CommissionerUserId) is tracked separately and is **not** a prerequisite here —
+> the dedup key only needs `(UserId, GroupId)`.
+
+### 4. `NotificationOddsChange` — OddsChanged
+Source: `ContestOddsUpdated` — **broadcast, fanned out per user** at dispatch
+(consumer joins `UserPicks ⋈ PickemGroups`, filtered to the movement type). Event
+carries `ContestId` only.
+
+| Metadata column | Type   | Source      |
+|-----------------|--------|-------------|
+| `ContestId`     | `Guid` | `ContestId` |
+
+> **Open — dedup grain.** Odds legitimately move multiple times for one contest;
+> we *want* a notification per meaningful movement but not per redelivery of the
+> same movement. `UNIQUE (UserId, ContestId)` is too coarse (suppresses the 2nd
+> real move). Options: keep a per-movement qualifier column (e.g. an odds
+> snapshot id or the event's CorrelationId) in the unique key, i.e.
+> `UNIQUE (UserId, ContestId, MovementKey)`. Needs a decision during
+> implementation; this is the one category where the current correlation-level
+> dedup may be *intentional*.
+
+### 5. `NotificationPickDeadline` — PickDeadline (reminder)
+Source: `NotificationDispatcher.SendPickDeadlineReminderAsync(userId,
+pickemGroupId, seasonWeek, fireTimeUtc)`. Already deterministic.
+
+| Metadata column | Type   | Source           |
+|-----------------|--------|------------------|
+| `LeagueId`      | `Guid` | `pickemGroupId`  |
+| `SeasonWeek`    | `int`  | `seasonWeek`     |
+| `FireTimeUtc`   | `timestamptz` | `fireTimeUtc` (versioning) |
+
+**Dedup index:** `UNIQUE (UserId, LeagueId, SeasonWeek, FireTimeUtc)`. The
+`FireTimeUtc` component preserves today's fire-time versioning (a rescheduled
+reminder re-fires; a Hangfire retry of the same fire does not).
+
+### 6. `NotificationContestStart` — ContestStart (reminder)
+Source: `NotificationDispatcher.SendContestStartReminderAsync(userId, contestId,
+fireTimeUtc)`. Already deterministic.
+
+| Metadata column | Type          | Source        |
+|-----------------|---------------|---------------|
+| `ContestId`     | `Guid`        | `contestId`   |
+| `FireTimeUtc`   | `timestamptz` | `fireTimeUtc` |
+
+**Dedup index:** `UNIQUE (UserId, ContestId, FireTimeUtc)`.
+
+## Event contract change
+
+Only one event needs to change:
+
+- **`UserPickScored`** (`SportsData.Core/Eventing/Events/Picks/UserPickScored.cs`)
+  — add `Guid PickId`. `PickScoringProcessor` already has the pick in hand
+  (`pick.Id`) inside the publish loop, so populating it is a one-line change.
+
+  *Deploy consideration:* it is a positional record, so adding the field is a
+  compile-time change to the single publisher. In-flight messages queued before
+  deploy would deserialize `PickId` as `Guid.Empty`, and because `PickId` is the
+  dedup key, two such messages for one user could false-collide. **In the current
+  environment this is moot** — MLB has a single user, yesterday's picks are all
+  scored and notified, and the pick-scored queue is empty. Ship the additive
+  field as-is; no drain or `Empty` guard required. (Revisit if this lands during
+  an active multi-user scoring window before a football season.)
+
+No other event changes — LeagueInvite, Membership, OddsChanged, and both
+reminders already carry (or derive) everything their dedup key needs.
+
+## Migration & rollout
+
+`NotificationLog` **stays** — frozen. Each consumer is cut over to write **only**
+its typed table (the atomic claim + audit row moves there). `NotificationLog`
+simply stops receiving new rows and remains for historical inspection until a
+later PR drops it. No dual-write: a given consumer claims in exactly one table,
+so cutover is clean per consumer and idempotency is never split across two
+indexes.
+
+**Sequencing** (all-in overall, phased across PRs to keep each reviewable):
+
+1. **PR 1 — PickResult.** Add `PickId` to `UserPickScored`; add
+   `NotificationUserPick` entity + migration + unique index; cut
+   `UserPickScoredConsumer` over; tests. *This carries the duplicate fix — highest
+   value, do first.*
+2. **PR 2 — LeagueInvitation + Membership.** Both are `(UserId, LeagueId)`;
+   natural to land together.
+3. **PR 3 — ContestStart + PickDeadline.** Reminders; move the deterministic
+   claim into the typed tables (behavior-preserving).
+4. **PR 4 — OddsChange.** Requires the movement-grain decision above; lowest
+   urgency, most design.
+5. **PR 5 (later, separate) — retire `NotificationLog`** once you've finished
+   picking through it: drop the table + entity + index.
+
+Each migration is additive (new table + indexes only) and independently
+reversible. **Migrations validated locally before each PR** per project guardrail
+(`memory/feedback_test_migrations_locally`).
+
+## Testing
+
+Per typed table (mirror `UserPickScoredConsumerTests` / the dispatcher tests):
+
+- Claim inserts a `Dispatching` row with all metadata populated.
+- Redelivery with the same natural key hits the unique constraint → the
+  "already claimed" branch → no duplicate dispatch.
+- **PickResult specifically:** three picks (same user, same contest, three
+  leagues) each produce a distinct row and three dispatches (proving the
+  over-suppression bug is fixed); a second scoring run of the same pick (distinct
+  transport CorrelationId) collides and is suppressed (proving the
+  under-suppression/duplicate bug is fixed).
+- Suppression paths (`Suppressed_UserOptedOut`, `Suppressed_NoDevice`) still
+  finalize the typed row.
+
+## Risks / tradeoffs
+
+- **`UNION` for cross-type audit.** No hot-path reader, acceptable.
+- **Six migrations + six near-identical entities.** Boilerplate, but each is
+  small and self-contained; independence is the explicit design choice.
+- **`UserPickScored` field add** during deploy overlap — mitigated above.
+- **OddsChange movement grain** is a genuine open question, isolated to PR 4.
+
+## Open decisions to confirm before / during implementation
+
+1. **PickResult fan-out policy** — deferred; schema is built to not force it now.
+2. **OddsChange dedup grain** — per-movement qualifier in the unique key vs.
+   correlation-level; decide in PR 4.
+3. ~~Re-invite re-notify~~ — **decided: re-notify.** `NotificationLeagueInvitation`
+   keys on `(UserId, LeagueId, CorrelationId)`. (Membership stays `(UserId,
+   LeagueId)` — a re-add is rare; revisit only if it becomes a real case.)
+4. ~~Deploy strategy for the `UserPickScored` field add~~ — **moot.** Single MLB
+   user, empty pick-scored queue; ship the additive field as-is.

--- a/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
@@ -217,14 +217,17 @@ namespace SportsData.Api.Application.Scoring
                     // §5 v1). Publish BEFORE SaveChanges so the bus-outbox
                     // interceptor commits this together with the pick update;
                     // an at-least-once redelivery is fine — Notification's
-                    // NotificationLog dedupe on (CorrelationId, UserId, Channel)
-                    // absorbs it. Structured facts only (abbreviations,
+                    // NotificationUserPick dedupe on (UserId, PickId) absorbs it,
+                    // and a re-score from a different correlation chain (cron
+                    // backstop) collides on the same PickId too. Structured facts
+                    // only (abbreviations,
                     // PickedIsHome, PickedSpread); the consumer composes the copy.
                     // DisplayName and full AwayName/HomeName stay null (unused).
                     await _bus.Publish(new UserPickScored(
                             pick.UserId,
                             null,
                             command.ContestId,
+                            pick.Id,
                             null,
                             null,
                             result.AwayAbbreviation,

--- a/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
+++ b/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
@@ -27,6 +27,10 @@ namespace SportsData.Core.Eventing.Events.Picks
         Guid UserId,
         string? DisplayName,
         Guid ContestId,
+        // The scored pick (PickemGroupUserPick.Id). The Notification service's
+        // typed pick-result table dedupes on (UserId, PickId) — one push per
+        // pick — so this must be the real pick id, not defaulted.
+        Guid PickId,
         string? AwayName,
         string? HomeName,
         string? AwayAbbreviation,

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -17,8 +17,8 @@ namespace SportsData.Notification.Application.Consumers
     /// Every member who picked a finalized contest gets one of these events.
     ///
     /// <para>
-    /// Orchestration: <b>atomic-claim</b> via NotificationLog insert
-    /// (relies on the unique <c>(CorrelationId, UserId, Channel)</c> index)
+    /// Orchestration: <b>atomic-claim</b> via NotificationUserPick insert
+    /// (relies on the unique <c>(UserId, PickId)</c> index)
     /// → resolve prefs → resolve devices → dispatch via
     /// <see cref="IPushNotificationSender"/> → update the row with terminal outcome.
     /// </para>
@@ -42,7 +42,7 @@ namespace SportsData.Notification.Application.Consumers
     /// </summary>
     public class UserPickScoredConsumer : IConsumer<UserPickScored>
     {
-        // NotificationLog.FailureReason is varchar(512). Truncate the joined
+        // NotificationUserPick.FailureReason is varchar(512). Truncate the joined
         // per-device summary so we don't trip Postgres's length check on a
         // user with many failing devices; per-device detail stays in logs.
         private const int FailureReasonMaxLength = 512;
@@ -79,20 +79,25 @@ namespace SportsData.Notification.Application.Consumers
 
             _logger.LogInformation("UserPickScored received.");
 
-            // Atomic claim. Insert a NotificationLog row in Dispatching state
-            // BEFORE doing any work. If another consumer beat us to it, the
-            // unique constraint throws DbUpdateException and we bail without
-            // dispatching anything.
-            var claim = new NotificationLog
+            // Atomic claim. Insert a NotificationUserPick row in Dispatching
+            // state BEFORE doing any work. The (UserId, PickId) unique index is
+            // the idempotency key — one push per pick, ever. If another consumer
+            // (redelivery, or a re-score from the cron backstop on a different
+            // correlation chain) beat us to it, the unique constraint throws
+            // DbUpdateException and we bail without dispatching anything.
+            // CorrelationId is carried for tracing only, not part of the key.
+            var claim = new NotificationUserPick
             {
                 UserId = msg.UserId,
+                PickId = msg.PickId,
+                ContestId = msg.ContestId,
+                LeagueId = msg.LeagueId,
                 CorrelationId = msg.CorrelationId,
-                Category = "PickResult",
                 Channel = "Fcm",
                 Result = "Dispatching",
                 AttemptedUtc = _dateTimeProvider.UtcNow()
             };
-            _dataContext.NotificationLog.Add(claim);
+            _dataContext.NotificationUserPicks.Add(claim);
 
             try
             {
@@ -101,8 +106,8 @@ namespace SportsData.Notification.Application.Consumers
             catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
             {
                 _logger.LogInformation(
-                    "UserPickScored already claimed by another consumer for CorrelationId {CorrelationId}, UserId {UserId}; skipping.",
-                    msg.CorrelationId, msg.UserId);
+                    "UserPickScored already claimed for PickId {PickId}, UserId {UserId} (CorrelationId {CorrelationId}); skipping.",
+                    msg.PickId, msg.UserId, msg.CorrelationId);
                 _dataContext.Entry(claim).State = EntityState.Detached;
                 return;
             }
@@ -179,7 +184,7 @@ namespace SportsData.Notification.Application.Consumers
             await _dataContext.SaveChangesAsync();
         }
 
-        private async Task FinalizeAsync(NotificationLog claim, string result)
+        private async Task FinalizeAsync(NotificationUserPick claim, string result)
         {
             claim.Result = result;
             claim.ModifiedUtc = _dateTimeProvider.UtcNow();

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -42,6 +42,8 @@ namespace SportsData.Notification.Infrastructure.Data
 
         public DbSet<NotificationLog> NotificationLog => Set<NotificationLog>();
 
+        public DbSet<NotificationUserPick> NotificationUserPicks => Set<NotificationUserPick>();
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -111,6 +113,18 @@ namespace SportsData.Notification.Infrastructure.Data
             // insert race window that this constraint closes.
             modelBuilder.Entity<NotificationLog>()
                 .HasIndex(l => new { l.CorrelationId, l.UserId, l.Channel })
+                .IsUnique();
+
+            // Typed pick-result idempotency key: one push per pick, ever. A pick
+            // is scored exactly once, so (UserId, PickId) both stops the cross-run
+            // duplicate the old CorrelationId-based key let through AND preserves
+            // the per-league notifications it wrongly collapsed (a user in N
+            // leagues who picked one game has N distinct PickIds). CorrelationId
+            // is a tracing column here, not part of the key. Replaces the
+            // NotificationLog claim for the PickResult path.
+            // See docs/architecture/notification-log-table-per-type.md.
+            modelBuilder.Entity<NotificationUserPick>()
+                .HasIndex(l => new { l.UserId, l.PickId })
                 .IsUnique();
 
             // League-wide fan-out is the dominant query against this join

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationUserPick.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationUserPick.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel.DataAnnotations;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Audit + idempotency row for a <b>pick-result</b> push (the notification a
+    /// user gets when a contest they picked finalizes). First of the typed
+    /// notification tables replacing the catch-all <see cref="NotificationLog"/>
+    /// (see <c>docs/architecture/notification-log-table-per-type.md</c>).
+    ///
+    /// <para>
+    /// Unlike <see cref="NotificationLog"/> this table carries the notification's
+    /// <b>subject</b> — <see cref="PickId"/>, <see cref="ContestId"/>,
+    /// <see cref="LeagueId"/> — as first-class, queryable columns. The dedup key
+    /// is <c>(UserId, PickId)</c>: a pick is scored once, so this guarantees at
+    /// most one push per pick and stops the cross-run duplicate the old
+    /// <c>(CorrelationId, UserId, Channel)</c> key let through, while preserving
+    /// the legitimately-distinct per-league notifications that same key wrongly
+    /// suppressed. <see cref="CorrelationId"/> is retained for cross-service
+    /// tracing only and does not participate in uniqueness.
+    /// </para>
+    ///
+    /// <para>
+    /// Never read by the user-facing app — audit / debugging / idempotency only.
+    /// The atomic-claim dispatch pattern (insert Dispatching → resolve prefs /
+    /// devices → send → finalize) matches <see cref="NotificationLog"/>.
+    /// </para>
+    /// </summary>
+    public class NotificationUserPick : CanonicalEntityBase<Guid>
+    {
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// The scored pick (<c>PickemGroupUserPick.Id</c>). Dedup key with
+        /// <see cref="UserId"/> — one pick-result push per pick, ever.
+        /// </summary>
+        public Guid PickId { get; set; }
+
+        /// <summary>Contest the pick was on. Captured for visibility / future rollup.</summary>
+        public Guid ContestId { get; set; }
+
+        /// <summary>League (PickemGroup) the pick belongs to. Captured for visibility / future rollup.</summary>
+        public Guid LeagueId { get; set; }
+
+        /// <summary>
+        /// CorrelationId from the originating <c>UserPickScored</c> event.
+        /// Retained for tracing only; NOT part of the dedup key.
+        /// </summary>
+        public Guid CorrelationId { get; set; }
+
+        /// <summary>Channel used. Today "Fcm" only; reserved for future "Email", "Sms".</summary>
+        [Required]
+        [MaxLength(16)]
+        public string Channel { get; set; }
+
+        [MaxLength(256)]
+        public string Title { get; set; }
+
+        [MaxLength(1024)]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Outcome. e.g. "Dispatching", "Sent", "Suppressed_UserOptedOut",
+        /// "Suppressed_NoDevice", "Failed_FcmError".
+        /// </summary>
+        [Required]
+        [MaxLength(64)]
+        public string Result { get; set; }
+
+        [MaxLength(512)]
+        public string FailureReason { get; set; }
+
+        public DateTime AttemptedUtc { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260713131346_AddNotificationUserPick.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260713131346_AddNotificationUserPick.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260713131346_AddNotificationUserPick")]
+    partial class AddNotificationUserPick
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260713131346_AddNotificationUserPick.cs
+++ b/src/SportsData.Notification/Migrations/20260713131346_AddNotificationUserPick.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotificationUserPick : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NotificationUserPicks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PickId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContestId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LeagueId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Channel = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Body = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    Result = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    FailureReason = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    AttemptedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationUserPicks", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationUserPicks_UserId_PickId",
+                table: "NotificationUserPicks",
+                columns: new[] { "UserId", "PickId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NotificationUserPicks");
+        }
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
@@ -77,13 +77,14 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
         string leagueName = "Sluggers",
         Guid? pickId = null,
         Guid? contestId = null,
-        Guid? leagueId = null)
+        Guid? leagueId = null,
+        Guid? correlationId = null)
         => new(
             userId, null, contestId ?? Guid.NewGuid(), pickId ?? Guid.NewGuid(), null, null,
             awayAbbr, homeAbbr, awayScore, homeScore,
             isCorrect, pickedIsHome, pickedSpread,
             leagueId ?? Guid.NewGuid(), leagueName, Sport.BaseballMlb, 2026,
-            Guid.NewGuid(), Guid.NewGuid());
+            correlationId ?? Guid.NewGuid(), Guid.NewGuid());
 
     private async Task<string> RunAndCaptureBodyAsync(UserPickScored msg)
     {
@@ -181,18 +182,22 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
     public async Task Consume_SameUserAndContest_DistinctPicks_EachNotifies()
     {
         // A user in three leagues who picked the same game has three distinct
-        // PickIds. The old (CorrelationId, UserId, Channel) key collapsed these
-        // to one push; (UserId, PickId) preserves all three. One device, three
-        // picks → three rows and three sends.
+        // PickIds — but all three events come from ONE scoring run and therefore
+        // share ONE CorrelationId. The old (CorrelationId, UserId, Channel) key
+        // collapsed them to a single push; (UserId, PickId) preserves all three.
+        // The shared CorrelationId is the whole point: it's exactly what the old
+        // key keyed on. One device, three picks → three rows and three sends.
         var userId = Guid.NewGuid();
         var contestId = Guid.NewGuid();
+        var correlationId = Guid.NewGuid();
         await SeedDeviceAsync(userId);
 
         foreach (var _ in Enumerable.Range(0, 3))
         {
             var msg = Msg(userId, "BOS", "NYY", awayScore: 3, homeScore: 2,
                 isCorrect: true, pickedIsHome: false, pickedSpread: null,
-                pickId: Guid.NewGuid(), contestId: contestId, leagueId: Guid.NewGuid());
+                pickId: Guid.NewGuid(), contestId: contestId, leagueId: Guid.NewGuid(),
+                correlationId: correlationId);
             var sut = Mocker.CreateInstance<UserPickScoredConsumer>();
             await sut.Consume(ContextFor(msg));
         }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 
 using MassTransit;
 
+using Microsoft.EntityFrameworkCore;
+
 using Moq;
 
 using SportsData.Core.Common;
@@ -72,12 +74,15 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
         bool? isCorrect,
         bool? pickedIsHome,
         double? pickedSpread,
-        string leagueName = "Sluggers")
+        string leagueName = "Sluggers",
+        Guid? pickId = null,
+        Guid? contestId = null,
+        Guid? leagueId = null)
         => new(
-            userId, null, Guid.NewGuid(), null, null,
+            userId, null, contestId ?? Guid.NewGuid(), pickId ?? Guid.NewGuid(), null, null,
             awayAbbr, homeAbbr, awayScore, homeScore,
             isCorrect, pickedIsHome, pickedSpread,
-            Guid.NewGuid(), leagueName, Sport.BaseballMlb, 2026,
+            leagueId ?? Guid.NewGuid(), leagueName, Sport.BaseballMlb, 2026,
             Guid.NewGuid(), Guid.NewGuid());
 
     private async Task<string> RunAndCaptureBodyAsync(UserPickScored msg)
@@ -145,4 +150,63 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
         body.Should().Contain("Your pick won.");
         body.Should().NotContain("you picked");
     }
+
+    [Fact]
+    public async Task Consume_PersistsTypedRow_WithPickMetadata()
+    {
+        // The whole point of the typed table: the audit row carries the
+        // notification's subject (PickId/ContestId/LeagueId) as real columns.
+        var userId = Guid.NewGuid();
+        var pickId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var leagueId = Guid.NewGuid();
+
+        await RunAndCaptureBodyAsync(
+            Msg(userId, "BOS", "NYY", awayScore: 3, homeScore: 2,
+                isCorrect: true, pickedIsHome: false, pickedSpread: null,
+                pickId: pickId, contestId: contestId, leagueId: leagueId));
+
+        var row = await DataContext.NotificationUserPicks.SingleAsync();
+        row.UserId.Should().Be(userId);
+        row.PickId.Should().Be(pickId);
+        row.ContestId.Should().Be(contestId);
+        row.LeagueId.Should().Be(leagueId);
+        row.Channel.Should().Be("Fcm");
+        row.Result.Should().Be("Sent");
+        row.Title.Should().Be("Nice pick!");
+        row.Body.Should().Be("Sluggers: BOS 3, NYY 2 — you picked BOS ✓");
+    }
+
+    [Fact]
+    public async Task Consume_SameUserAndContest_DistinctPicks_EachNotifies()
+    {
+        // A user in three leagues who picked the same game has three distinct
+        // PickIds. The old (CorrelationId, UserId, Channel) key collapsed these
+        // to one push; (UserId, PickId) preserves all three. One device, three
+        // picks → three rows and three sends.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+
+        foreach (var _ in Enumerable.Range(0, 3))
+        {
+            var msg = Msg(userId, "BOS", "NYY", awayScore: 3, homeScore: 2,
+                isCorrect: true, pickedIsHome: false, pickedSpread: null,
+                pickId: Guid.NewGuid(), contestId: contestId, leagueId: Guid.NewGuid());
+            var sut = Mocker.CreateInstance<UserPickScoredConsumer>();
+            await sut.Consume(ContextFor(msg));
+        }
+
+        (await DataContext.NotificationUserPicks.CountAsync()).Should().Be(3);
+        _pushSender.Verify(
+            x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    // Note: the duplicate-suppression path (a re-scored pick / redelivery on a
+    // different CorrelationId colliding on the (UserId, PickId) unique index and
+    // hitting the "already claimed" branch) relies on Postgres raising 23505.
+    // The InMemory provider does not enforce unique indexes, so that branch is
+    // validated against the local migration DB rather than here.
 }


### PR DESCRIPTION
## Summary

First step of the **table-per-notification-type** split (design doc included:
`docs/architecture/notification-log-table-per-type.md`). Moves the **pick-result**
push off the catch-all `NotificationLog` onto a typed `NotificationUserPick`
table that carries the notification's subject — `PickId`, `ContestId`, `LeagueId`
— as first-class, queryable columns.

**Motivation is visibility first** (the catch-all row can't answer "did we notify
this user about this pick?"), with a real duplicate fix as the side benefit.

## The dedup fix

Dedup key moves from the transport `(CorrelationId, UserId, Channel)` to the
semantic `(UserId, PickId)`. A pick is scored exactly once, so this:

- **Stops the duplicate** — the same pick result arriving from two correlation
  chains (`ContestFinalized` event *and* the cron finalization backstop) no
  longer produces two pushes; both collide on `PickId`.
- **Preserves per-league notifications the old key wrongly dropped** — a user in
  N leagues who picked one game emits N events sharing one run `CorrelationId`;
  the old index collapsed them to a single push. N distinct `PickId`s now each
  notify.

## Changes

- `UserPickScored`: add `PickId` (the publisher already has `pick.Id` in the loop).
- New `NotificationUserPick` entity + migration + `UNIQUE (UserId, PickId)`.
- `UserPickScoredConsumer` claims/finalizes against the typed table; `CorrelationId`
  demoted to a tracing column.
- Tests: metadata persistence + three-distinct-picks-each-notify. The
  unique-constraint suppression path (Postgres 23505) is verified against the
  **local migration DB** — the InMemory provider doesn't enforce indexes.

## Scope / deferred

- `NotificationLog` is **untouched** and stays until it's retired in a later PR.
- The **fan-out policy** (send N per-league pushes vs. one rolled-up "your picks
  resolved") is deliberately deferred — the table stores all three ids so it
  stays a send-side change, not a re-model.
- Remaining categories (LeagueInvite, Membership, OddsChanged, PickDeadline,
  ContestStart) migrate in follow-up PRs per the doc's rollout order.

## Validation

- Build clean (Core, Notification, API).
- Notification unit 38 pass (+2 new); API scoring 55 pass.
- Migration applied locally; table + unique index confirmed; duplicate
  `(UserId, PickId)` insert rejected with 23505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pick-specific notification tracking with per-pick deduplication, including contest/league context and dispatch outcomes.
  * Updated scored pick events to carry the scored pick identifier for accurate notification handling.
  * Documented the approved notification audit-table architecture and rollout approach.
* **Bug Fixes**
  * Improved duplicate suppression to prevent under- and over-suppression across pick scoring scenarios.
* **Tests**
  * Added unit tests validating persistence of pick-level notification records and correct duplicate handling across multiple picks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->