### PR TITLE
feat(notifications): typed reminder tables (PickDeadline + ContestStart) (PR3)

### DIFF
--- a/docs/architecture/notification-log-table-per-type.md
+++ b/docs/architecture/notification-log-table-per-type.md
@@ -1,9 +1,10 @@
 # Notification logging: table-per-type
 
-**Status:** Approved, in progress. **PR1 (PickResult → `NotificationUserPick`)
-and PR2 (LeagueInvite → `NotificationLeagueInvitation`, Membership →
-`NotificationMembership`) implemented.** PRs 3–5 (see "Migration & rollout") are
-planned and not yet started.
+**Status:** Approved, in progress. **PR1 (PickResult → `NotificationUserPick`),
+PR2 (LeagueInvite → `NotificationLeagueInvitation`, Membership →
+`NotificationMembership`), and PR3 (PickDeadline → `NotificationPickDeadline`,
+ContestStart → `NotificationContestStart`) implemented.** PR4 (OddsChange) and
+PR5 (retire `NotificationLog`) are planned and not yet started.
 **Owner:** Randall.
 **Scope:** `SportsData.Notification` service (+ one additive field on a `SportsData.Core` event).
 

--- a/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
+++ b/src/SportsData.Notification/Application/Dispatching/NotificationDispatcher.cs
@@ -16,14 +16,14 @@ namespace SportsData.Notification.Application.Dispatching
     /// (<see cref="Consumers.UserPickScoredConsumer"/> etc.).
     ///
     /// <para>
-    /// Deterministic CorrelationId: each method derives a stable Guid from
-    /// its parameters via MD5(input bytes). Hangfire retrying the same call
-    /// produces the same CorrelationId and collides on the
-    /// <c>NotificationLog (CorrelationId, UserId, Channel)</c> unique
-    /// constraint — Postgres rejects the second insert, the consumer falls
-    /// through to the "already claimed" branch, and no duplicate push goes
-    /// out. MD5 is fine here: this is a dedupe key, not a cryptographic
-    /// signature.
+    /// Idempotency now rides on each reminder's typed table and its natural
+    /// key — <c>NotificationPickDeadline (UserId, LeagueId, SeasonWeek,
+    /// FireTimeUtc)</c> and <c>NotificationContestStart (UserId, ContestId,
+    /// FireTimeUtc)</c>. The <c>FireTimeUtc</c> component is the version anchor:
+    /// a Hangfire retry of the same fire collides and is suppressed, while a
+    /// reschedule (new fire-time) is a new row and re-fires. The deterministic
+    /// CorrelationId (stable MD5 over the parameters) is retained as a trace id
+    /// for log correlation but no longer participates in dedup.
     /// </para>
     /// </summary>
     public class NotificationDispatcher : INotificationDispatcher
@@ -71,18 +71,23 @@ namespace SportsData.Notification.Application.Dispatching
 
             _logger.LogInformation("SendPickDeadlineReminderAsync invoked.");
 
-            // Atomic claim — see UserPickScoredConsumer for the full
-            // rationale (TOCTOU race, crash-vs-duplicate trade-off).
-            var claim = new NotificationLog
+            // Atomic claim on (UserId, LeagueId, SeasonWeek, FireTimeUtc) — the
+            // natural key now does what the deterministic CorrelationId did
+            // against NotificationLog: a Hangfire retry of the same fire collides
+            // (suppressed) while a reschedule (new FireTimeUtc) re-fires.
+            // See UserPickScoredConsumer for the claim-first rationale.
+            var claim = new NotificationPickDeadline
             {
                 UserId = userId,
+                LeagueId = pickemGroupId,
+                SeasonWeek = seasonWeek,
+                FireTimeUtc = fireTimeUtc,
                 CorrelationId = correlationId,
-                Category = "PickDeadline",
                 Channel = "Fcm",
                 Result = "Dispatching",
                 AttemptedUtc = _dateTimeProvider.UtcNow()
             };
-            _dataContext.NotificationLog.Add(claim);
+            _dataContext.NotificationPickDeadlines.Add(claim);
 
             try
             {
@@ -212,16 +217,19 @@ namespace SportsData.Notification.Application.Dispatching
 
             _logger.LogInformation("SendContestStartReminderAsync invoked.");
 
-            var claim = new NotificationLog
+            // Atomic claim on (UserId, ContestId, FireTimeUtc) — natural-key dedup
+            // with fire-time versioning, same as PickDeadline.
+            var claim = new NotificationContestStart
             {
                 UserId = userId,
+                ContestId = contestId,
+                FireTimeUtc = fireTimeUtc,
                 CorrelationId = correlationId,
-                Category = "ContestStart",
                 Channel = "Fcm",
                 Result = "Dispatching",
                 AttemptedUtc = _dateTimeProvider.UtcNow()
             };
-            _dataContext.NotificationLog.Add(claim);
+            _dataContext.NotificationContestStarts.Add(claim);
 
             try
             {
@@ -318,7 +326,17 @@ namespace SportsData.Notification.Application.Dispatching
             await _dataContext.SaveChangesAsync();
         }
 
-        private async Task FinalizeAsync(NotificationLog claim, string result)
+        // Terminal-state writes. Two overloads because the reminder tables are
+        // independent (no shared base) — each dispatch method finalizes its own
+        // typed claim.
+        private async Task FinalizeAsync(NotificationPickDeadline claim, string result)
+        {
+            claim.Result = result;
+            claim.ModifiedUtc = _dateTimeProvider.UtcNow();
+            await _dataContext.SaveChangesAsync();
+        }
+
+        private async Task FinalizeAsync(NotificationContestStart claim, string result)
         {
             claim.Result = result;
             claim.ModifiedUtc = _dateTimeProvider.UtcNow();
@@ -388,10 +406,11 @@ namespace SportsData.Notification.Application.Dispatching
         }
 
         /// <summary>
-        /// MD5 over a canonical parameter encoding. Used only as a dedupe key —
-        /// not cryptographic. Two calls with the same inputs produce the same
-        /// Guid, which makes the NotificationLog unique constraint catch
-        /// Hangfire retries.
+        /// MD5 over a canonical parameter encoding — a stable trace id, not
+        /// cryptographic. Two calls with the same inputs produce the same Guid,
+        /// giving a deterministic CorrelationId for log correlation across a
+        /// reminder's retries. Dedup itself is handled by the typed table's
+        /// natural key, not this value.
         /// </summary>
         private static Guid DeterministicCorrelationId(string category, Guid userId, Guid scopeId, long qualifier)
         {

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -48,6 +48,10 @@ namespace SportsData.Notification.Infrastructure.Data
 
         public DbSet<NotificationMembership> NotificationMemberships => Set<NotificationMembership>();
 
+        public DbSet<NotificationPickDeadline> NotificationPickDeadlines => Set<NotificationPickDeadline>();
+
+        public DbSet<NotificationContestStart> NotificationContestStarts => Set<NotificationContestStart>();
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -146,6 +150,22 @@ namespace SportsData.Notification.Infrastructure.Data
             // Replaces the NotificationLog claim for the Membership path.
             modelBuilder.Entity<NotificationMembership>()
                 .HasIndex(l => new { l.UserId, l.LeagueId })
+                .IsUnique();
+
+            // Typed pick-deadline reminder idempotency key. FireTimeUtc is the
+            // version anchor: a Hangfire retry of the same fire collides
+            // (suppressed) while a reschedule (new fire-time) re-fires. Replaces
+            // the deterministic-CorrelationId trick against NotificationLog.
+            // SeasonWeek is non-null here (PickDeadline always scopes a week), so
+            // no nulls-distinct concern like the shared PendingScheduledJob index.
+            modelBuilder.Entity<NotificationPickDeadline>()
+                .HasIndex(l => new { l.UserId, l.LeagueId, l.SeasonWeek, l.FireTimeUtc })
+                .IsUnique();
+
+            // Typed contest-start reminder idempotency key. Same fire-time
+            // versioning as PickDeadline. Replaces the NotificationLog claim.
+            modelBuilder.Entity<NotificationContestStart>()
+                .HasIndex(l => new { l.UserId, l.ContestId, l.FireTimeUtc })
                 .IsUnique();
 
             // League-wide fan-out is the dominant query against this join

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationContestStart.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationContestStart.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Audit + idempotency row for a <b>contest-start reminder</b> push. Typed
+    /// notification table replacing the catch-all <see cref="NotificationLog"/>
+    /// for the ContestStart category (see
+    /// <c>docs/architecture/notification-log-table-per-type.md</c>).
+    ///
+    /// <para>
+    /// Dedup key is <c>(UserId, ContestId, FireTimeUtc)</c>. The
+    /// <see cref="FireTimeUtc"/> component preserves the scheduler's fire-time
+    /// versioning: a Hangfire retry of the same fire collides and is suppressed,
+    /// but a reschedule (new fire-time) is a new row and re-fires. This replaces
+    /// the deterministic-CorrelationId trick the dispatcher used against
+    /// NotificationLog; <see cref="CorrelationId"/> is now a stable trace id only,
+    /// not part of the key.
+    /// </para>
+    ///
+    /// <para>Never read by the user-facing app — audit / debugging / idempotency only.</para>
+    /// </summary>
+    public class NotificationContestStart : CanonicalEntityBase<Guid>
+    {
+        /// <summary>Recipient.</summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>Contest that is about to start.</summary>
+        public Guid ContestId { get; set; }
+
+        /// <summary>
+        /// The scheduler's intended fire time — the version anchor. Part of the
+        /// dedup key so a reschedule re-fires while a retry of the same fire does not.
+        /// </summary>
+        public DateTime FireTimeUtc { get; set; }
+
+        /// <summary>
+        /// Deterministic trace id derived from the reminder's parameters. Stable
+        /// across retries for log correlation; NOT part of the dedup key.
+        /// </summary>
+        public Guid CorrelationId { get; set; }
+
+        /// <summary>Channel used. Today "Fcm" only; reserved for future "Email", "Sms".</summary>
+        [Required]
+        [MaxLength(16)]
+        public string Channel { get; set; }
+
+        [MaxLength(256)]
+        public string Title { get; set; }
+
+        [MaxLength(1024)]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Outcome. e.g. "Dispatching", "Sent", "Suppressed_StaleFire",
+        /// "Suppressed_UserOptedOut", "Suppressed_NoDevice", "Failed_FcmError".
+        /// </summary>
+        [Required]
+        [MaxLength(64)]
+        public string Result { get; set; }
+
+        [MaxLength(512)]
+        public string FailureReason { get; set; }
+
+        public DateTime AttemptedUtc { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationPickDeadline.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/NotificationPickDeadline.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel.DataAnnotations;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Audit + idempotency row for a <b>pick-deadline reminder</b> push. Typed
+    /// notification table replacing the catch-all <see cref="NotificationLog"/>
+    /// for the PickDeadline category (see
+    /// <c>docs/architecture/notification-log-table-per-type.md</c>).
+    ///
+    /// <para>
+    /// Dedup key is <c>(UserId, LeagueId, SeasonWeek, FireTimeUtc)</c>. The
+    /// <see cref="FireTimeUtc"/> component preserves the scheduler's fire-time
+    /// versioning: a Hangfire retry of the same fire collides and is suppressed,
+    /// but a reschedule (new fire-time) is a new row and re-fires. This replaces
+    /// the deterministic-CorrelationId trick the dispatcher used against
+    /// NotificationLog; <see cref="CorrelationId"/> is now a stable trace id only,
+    /// not part of the key.
+    /// </para>
+    ///
+    /// <para>Never read by the user-facing app — audit / debugging / idempotency only.</para>
+    /// </summary>
+    public class NotificationPickDeadline : CanonicalEntityBase<Guid>
+    {
+        /// <summary>Recipient.</summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>League (PickemGroup) whose pick deadline is approaching.</summary>
+        public Guid LeagueId { get; set; }
+
+        /// <summary>Season week the deadline is for. Part of the dedup key.</summary>
+        public int SeasonWeek { get; set; }
+
+        /// <summary>
+        /// The scheduler's intended fire time — the version anchor. Part of the
+        /// dedup key so a reschedule re-fires while a retry of the same fire does not.
+        /// </summary>
+        public DateTime FireTimeUtc { get; set; }
+
+        /// <summary>
+        /// Deterministic trace id derived from the reminder's parameters. Stable
+        /// across retries for log correlation; NOT part of the dedup key.
+        /// </summary>
+        public Guid CorrelationId { get; set; }
+
+        /// <summary>Channel used. Today "Fcm" only; reserved for future "Email", "Sms".</summary>
+        [Required]
+        [MaxLength(16)]
+        public string Channel { get; set; }
+
+        [MaxLength(256)]
+        public string Title { get; set; }
+
+        [MaxLength(1024)]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Outcome. e.g. "Dispatching", "Sent", "Suppressed_StaleFire",
+        /// "Suppressed_UserOptedOut", "Suppressed_NoDevice", "Failed_FcmError".
+        /// </summary>
+        [Required]
+        [MaxLength(64)]
+        public string Result { get; set; }
+
+        [MaxLength(512)]
+        public string FailureReason { get; set; }
+
+        public DateTime AttemptedUtc { get; set; }
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/PendingScheduledJob.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/PendingScheduledJob.cs
@@ -15,7 +15,9 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
     /// Same crash-safe pattern as Producer's CompetitionStream: persist the
     /// new Hangfire job id, save, then delete the old job. If delete fails
     /// the orphan job becomes a benign duplicate — the FCM send path is
-    /// idempotent via the NotificationLog dedupe key.
+    /// idempotent via the reminder tables' natural keys
+    /// (NotificationPickDeadline / NotificationContestStart), whose FireTimeUtc
+    /// component also lets a reschedule re-fire while a retry does not.
     /// </summary>
     public class PendingScheduledJob : CanonicalEntityBase<Guid>
     {

--- a/src/SportsData.Notification/Migrations/20260713150543_AddNotificationReminderTables.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260713150543_AddNotificationReminderTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260713150543_AddNotificationReminderTables")]
+    partial class AddNotificationReminderTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260713150543_AddNotificationReminderTables.cs
+++ b/src/SportsData.Notification/Migrations/20260713150543_AddNotificationReminderTables.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotificationReminderTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NotificationContestStarts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContestId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FireTimeUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Channel = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Body = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    Result = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    FailureReason = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    AttemptedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationContestStarts", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NotificationPickDeadlines",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LeagueId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SeasonWeek = table.Column<int>(type: "integer", nullable: false),
+                    FireTimeUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Channel = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Title = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Body = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    Result = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    FailureReason = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    AttemptedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationPickDeadlines", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationContestStarts_UserId_ContestId_FireTimeUtc",
+                table: "NotificationContestStarts",
+                columns: new[] { "UserId", "ContestId", "FireTimeUtc" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationPickDeadlines_UserId_LeagueId_SeasonWeek_FireTi~",
+                table: "NotificationPickDeadlines",
+                columns: new[] { "UserId", "LeagueId", "SeasonWeek", "FireTimeUtc" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NotificationContestStarts");
+
+            migrationBuilder.DropTable(
+                name: "NotificationPickDeadlines");
+        }
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/NotificationDispatcherTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/NotificationDispatcherTests.cs
@@ -109,6 +109,31 @@ public class NotificationDispatcherTests : NotificationTestBase<NotificationDisp
     }
 
     [Fact]
+    public async Task PickDeadline_OptedOut_SuppressedAndDoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        var leagueId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+        await SeedScheduleAsync(userId, "PickDeadline", leagueId, seasonWeek: 3, FireTime);
+        DataContext.UserNotificationPreferences.Add(new UserNotificationPreferences
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickDeadlineReminderEnabled = false,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<NotificationDispatcher>();
+        await sut.SendPickDeadlineReminderAsync(userId, leagueId, 3, FireTime);
+
+        VerifySendCount(Times.Never());
+        var row = await DataContext.NotificationPickDeadlines.SingleAsync();
+        row.Result.Should().Be("Suppressed_UserOptedOut");
+    }
+
+    [Fact]
     public async Task ContestStart_MatchingScheduleAndDevice_NotifiesAndPersistsRow()
     {
         var userId = Guid.NewGuid();
@@ -151,5 +176,21 @@ public class NotificationDispatcherTests : NotificationTestBase<NotificationDisp
         VerifySendCount(Times.Never());
         var row = await DataContext.NotificationContestStarts.SingleAsync();
         row.Result.Should().Be("Suppressed_UserOptedOut");
+    }
+
+    [Fact]
+    public async Task ContestStart_NoScheduleRow_SuppressedStaleFire()
+    {
+        // No PendingScheduledJob → the fire is an orphan; suppress before sending.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<NotificationDispatcher>();
+        await sut.SendContestStartReminderAsync(userId, contestId, FireTime);
+
+        VerifySendCount(Times.Never());
+        var row = await DataContext.NotificationContestStarts.SingleAsync();
+        row.Result.Should().Be("Suppressed_StaleFire");
     }
 }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/NotificationDispatcherTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/NotificationDispatcherTests.cs
@@ -1,0 +1,155 @@
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Notification.Application.Dispatching;
+using SportsData.Notification.Infrastructure.Data.Entities;
+using SportsData.Notification.Infrastructure.Notifications;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Dispatching;
+
+// Covers the two scheduled-reminder paths claiming/dispatching into the typed
+// NotificationPickDeadline / NotificationContestStart tables. The stale-fire
+// check reads PendingScheduledJobs, so the happy paths seed a matching row.
+public class NotificationDispatcherTests : NotificationTestBase<NotificationDispatcher>
+{
+    private static readonly DateTime FixedNow = new(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime FireTime = new(2026, 9, 5, 16, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IPushNotificationSender> _pushSender;
+
+    public NotificationDispatcherTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+
+        _pushSender = Mocker.GetMock<IPushNotificationSender>();
+        _pushSender
+            .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<string>("msg-id"));
+    }
+
+    private void VerifySendCount(Times times) =>
+        _pushSender.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), times);
+
+    private async Task SeedDeviceAsync(Guid userId, bool enabled = true)
+    {
+        DataContext.UserDevices.Add(new UserDevice
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            InstallationId = Guid.NewGuid().ToString(),
+            FcmToken = "tok",
+            Platform = "ios",
+            NotificationsEnabled = enabled,
+            LastSeenUtc = FixedNow,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    private async Task SeedScheduleAsync(Guid userId, string jobKind, Guid targetId, int? seasonWeek, DateTime fireTimeUtc)
+    {
+        DataContext.PendingScheduledJobs.Add(new PendingScheduledJob
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            JobKind = jobKind,
+            TargetId = targetId,
+            SeasonWeek = seasonWeek,
+            HangfireJobId = "job-1",
+            ScheduledFireUtc = fireTimeUtc,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task PickDeadline_MatchingScheduleAndDevice_NotifiesAndPersistsRow()
+    {
+        var userId = Guid.NewGuid();
+        var leagueId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+        await SeedScheduleAsync(userId, "PickDeadline", leagueId, seasonWeek: 3, FireTime);
+
+        var sut = Mocker.CreateInstance<NotificationDispatcher>();
+        await sut.SendPickDeadlineReminderAsync(userId, leagueId, 3, FireTime);
+
+        VerifySendCount(Times.Once());
+        var row = await DataContext.NotificationPickDeadlines.SingleAsync();
+        row.UserId.Should().Be(userId);
+        row.LeagueId.Should().Be(leagueId);
+        row.SeasonWeek.Should().Be(3);
+        row.FireTimeUtc.Should().Be(FireTime);
+        row.CorrelationId.Should().NotBeEmpty();
+        row.Result.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task PickDeadline_NoScheduleRow_SuppressedStaleFire()
+    {
+        // No PendingScheduledJob → the fire is an orphan; suppress before sending.
+        var userId = Guid.NewGuid();
+        var leagueId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+
+        var sut = Mocker.CreateInstance<NotificationDispatcher>();
+        await sut.SendPickDeadlineReminderAsync(userId, leagueId, 3, FireTime);
+
+        VerifySendCount(Times.Never());
+        var row = await DataContext.NotificationPickDeadlines.SingleAsync();
+        row.Result.Should().Be("Suppressed_StaleFire");
+    }
+
+    [Fact]
+    public async Task ContestStart_MatchingScheduleAndDevice_NotifiesAndPersistsRow()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+        await SeedScheduleAsync(userId, "ContestStart", contestId, seasonWeek: null, FireTime);
+
+        var sut = Mocker.CreateInstance<NotificationDispatcher>();
+        await sut.SendContestStartReminderAsync(userId, contestId, FireTime);
+
+        VerifySendCount(Times.Once());
+        var row = await DataContext.NotificationContestStarts.SingleAsync();
+        row.UserId.Should().Be(userId);
+        row.ContestId.Should().Be(contestId);
+        row.FireTimeUtc.Should().Be(FireTime);
+        row.CorrelationId.Should().NotBeEmpty();
+        row.Result.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task ContestStart_OptedOut_SuppressedAndDoesNotNotify()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+        await SeedScheduleAsync(userId, "ContestStart", contestId, seasonWeek: null, FireTime);
+        DataContext.UserNotificationPreferences.Add(new UserNotificationPreferences
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ContestStartReminderEnabled = false,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<NotificationDispatcher>();
+        await sut.SendContestStartReminderAsync(userId, contestId, FireTime);
+
+        VerifySendCount(Times.Never());
+        var row = await DataContext.NotificationContestStarts.SingleAsync();
+        row.Result.Should().Be("Suppressed_UserOptedOut");
+    }
+}


### PR DESCRIPTION
## Summary

Third step of the **table-per-notification-type** split (design doc:
`docs/architecture/notification-log-table-per-type.md`). Moves the two
**scheduled reminders** off the catch-all `NotificationLog` onto typed tables.

Follows PR1 (#503) and PR2 (#504).

## Tables

- **`NotificationPickDeadline`** — `UserId`, `LeagueId`, `SeasonWeek`,
  `FireTimeUtc`. Dedup `UNIQUE (UserId, LeagueId, SeasonWeek, FireTimeUtc)`.
- **`NotificationContestStart`** — `UserId`, `ContestId`, `FireTimeUtc`.
  Dedup `UNIQUE (UserId, ContestId, FireTimeUtc)`.

## Fire-time versioning

`FireTimeUtc` is the version anchor: a Hangfire **retry of the same fire**
collides and is suppressed, while a **reschedule (new fire-time)** is a new row
and re-fires. This replaces the deterministic-CorrelationId trick these paths
used against `NotificationLog`. `CorrelationId` is retained as a stable **trace
id** (log correlation) but no longer participates in dedup. `SeasonWeek` is
non-null on PickDeadline, so there's no nulls-distinct concern like the shared
`PendingScheduledJob` index.

## Notes

- `NotificationDispatcher` claims/finalizes against the typed tables (two typed
  `FinalizeAsync` overloads, since the tables are independent — no shared base).
  Stale-fire check and the deterministic trace-id helper are unchanged.
- **No Core/event changes.**
- `NotificationLog` untouched (retired in PR5).

## Remaining rollout

- **PR4** — OddsChange (carries the open movement-grain decision).
- **PR5** — retire `NotificationLog`.

## Validation

- Build clean; Notification unit **47** pass (+4: new `NotificationDispatcher`
  suite — send + typed-row persistence, stale-fire suppression, opt-out).
- Migration additive (two tables + unique indexes), applied locally and
  **constraint-verified**: same-fire retry rejected, reschedule accepted, for
  both tables (23505).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable reminders for pick deadlines and contest starts.
  * Implemented idempotent dispatch using the scheduled fire time so retries won’t duplicate, while reschedules can re-send.
  * Added delivery outcome tracking plus suppression and failure details.
* **Bug Fixes**
  * Improved handling of stale scheduled reminders and opted-out notification preferences.
* **Documentation**
  * Updated the notification architecture plan/status to reflect PR1–PR3 implemented and PR4–PR5 planned.
* **Tests**
  * Added unit coverage for pick-deadline and contest-start reminder dispatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->