### PR TITLE
fix(mobile): resilient + observable push-device registration

### DIFF
--- a/docs/mobile/device-registration-resilience.md
+++ b/docs/mobile/device-registration-resilience.md
@@ -1,0 +1,105 @@
+# Push device registration: resilience + observability
+
+**Status:** Approved — implementing.
+**Owner:** Randall.
+**Scope:** `src/UI/sd-mobile` (native push-device registration). No backend change.
+Ships via **TestFlight/EAS**, which is a separate deploy track from the k8s
+notification-service deploy hold — so this is **not blocked** by that hold.
+
+## Problem
+
+A signed-in, notification-permitted device can end up with **no `UserDevice` row**
+in the Notification service, so every push is `Suppressed_NoDevice`.
+
+Observed: iPhone (account "sportDeets") has its row and works; iPad (signed in as
+`jrandallsexton@gmail.com`, permission granted via TestFlight) has a `User` row
+but **no `UserDevice` row at all** (confirmed: exactly one device row exists, and
+it's the iPhone's). So the iPad **never registered** — this is not an ownership
+race.
+
+## Root cause
+
+`useRegisterPushDevice` fetches the FCM token and POSTs **exactly once per
+sign-in**, and only re-runs on **auth change** or **FCM token rotation** — never
+on app foreground or a permission-state change. `getFcmTokenIfGranted()` returns
+a token **only if permission is already granted at that instant**, and it
+**swallows every error** (`catch { return null }`). The hook likewise swallows
+POST failures (`console.log` only, "Never surface to the user").
+
+So if, on the iPad, at the one moment the hook ran:
+- permission wasn't granted **yet** (granted later via prompt or iOS Settings), **or**
+- the APNs token wasn't ready **yet** (`getToken()` returned null/threw — common on
+  a TestFlight first run), **or**
+- the POST failed (network/JWT/API),
+
+…registration silently no-ops and **nothing ever re-triggers it**. Permission
+being on *now* doesn't help — the hook won't look again. And because all three
+failure points are silent, the failure left **zero trace** (nothing in Seq, no
+Sentry event) — which is itself the core defect: this was un-diagnosable.
+
+We don't need to distinguish the three timings to fix it — they share one defect
+(**one-shot + silent + no re-trigger**) and one fix.
+
+## Fix
+
+### 1. Re-attempt on foreground (the automatic fix)
+Add an `AppState` listener: when the app becomes `active` while authenticated and
+registration hasn't yet succeeded this session, re-attempt. A cheap permission
+check short-circuits when permission isn't granted (no POST spam); once a
+registration succeeds, foreground retries stop (a session flag). This covers
+permission-granted-late, APNs-not-ready, and transient POST failures — the iPad
+gets its next chance the moment it's foregrounded.
+
+### 2. Stop swallowing — surface failures to Sentry
+- `getFcmTokenIfGranted()` returns the **rich** `FcmTokenResult`
+  (`{ token, permissionStatus, error }`), mirroring its prompting sibling
+  `getFcmToken()`, instead of a bare `string | null` that discards the error.
+- A new composing helper `registerThisDevice({ prompt })` reports failures to
+  **Sentry** (`area: push-registration`): a *warning* when permission is granted
+  but the token is still unavailable, and a captured *exception* when the POST
+  throws. TestFlight builds report under the `preview` environment, so the next
+  occurrence is diagnosable.
+
+### 3. Manual "register this device" escape hatch
+On the notification-settings screen, a **"This device"** action that runs
+`registerThisDevice({ prompt: true })` (prompting for permission if needed) and
+shows the outcome via `Alert` — so a user who somehow ends up unregistered can
+fix it themselves and *see* the result (the exact affordance whose absence made
+this hard to diagnose).
+
+### 4. (Deferred) backend "enabled but no device" signal
+A user whose prefs are enabled but who has no `UserDevice` row is a detectable
+"wants notifications, can't receive them" state. Worth surfacing later (a
+dispatcher log/metric on `Suppressed_NoDevice` for opted-in users); **out of
+scope** for this pass.
+
+## Files
+
+- `src/lib/notifications/pushNotifications.ts` — `getFcmTokenIfGranted()` returns
+  `FcmTokenResult` (never prompts); no longer swallows the error.
+- **New** `src/lib/notifications/registerPushDevice.ts` — `registerThisDevice({
+  prompt })`: token → installationId → POST, with Sentry reporting on failure.
+  The single place registration happens; web/undetermined no-ops cleanly.
+- `src/hooks/useRegisterPushDevice.ts` — delegates to `registerThisDevice`,
+  adds the `AppState` foreground re-attempt + session success flag, keeps the
+  auth-change and token-rotation triggers.
+- `app/settings/notifications.tsx` — "This device" section with the manual
+  re-register action + `Alert` feedback.
+
+## Tests
+
+`registerThisDevice` is the testable core (mock `getFcmToken`/
+`getFcmTokenIfGranted`, `devicesApi`, `getOrCreateInstallationId`, Sentry):
+- token + POST ok → `{ ok: true }`.
+- permission granted, no token → `{ ok: false }` + a Sentry warning.
+- permission not granted → `{ ok: false }`, **no** Sentry noise.
+- POST throws → `{ ok: false }` + a captured Sentry exception.
+
+`tsc --noEmit` clean; Jest 29 suite green.
+
+## How this resolves the reported iPad case
+
+Once shipped: the iPad, already permitted, re-attempts on the very next
+foreground and registers — the `UserDevice` row appears and pushes flow. If it
+*still* fails, the Sentry event (with `permissionStatus` + the underlying error)
+tells us exactly which of the three timings it was — the observability we lacked.

--- a/docs/mobile/device-registration-resilience.md
+++ b/docs/mobile/device-registration-resilience.md
@@ -43,6 +43,7 @@ We don't need to distinguish the three timings to fix it — they share one defe
 ## Fix
 
 ### 1. Re-attempt on foreground (the automatic fix)
+
 Add an `AppState` listener: when the app becomes `active` while authenticated and
 registration hasn't yet succeeded this session, re-attempt. A cheap permission
 check short-circuits when permission isn't granted (no POST spam); once a
@@ -51,6 +52,7 @@ permission-granted-late, APNs-not-ready, and transient POST failures — the iPa
 gets its next chance the moment it's foregrounded.
 
 ### 2. Stop swallowing — surface failures to Sentry
+
 - `getFcmTokenIfGranted()` returns the **rich** `FcmTokenResult`
   (`{ token, permissionStatus, error }`), mirroring its prompting sibling
   `getFcmToken()`, instead of a bare `string | null` that discards the error.
@@ -61,6 +63,7 @@ gets its next chance the moment it's foregrounded.
   occurrence is diagnosable.
 
 ### 3. Manual "register this device" escape hatch
+
 On the notification-settings screen, a **"This device"** action that runs
 `registerThisDevice({ prompt: true })` (prompting for permission if needed) and
 shows the outcome via `Alert` — so a user who somehow ends up unregistered can
@@ -68,6 +71,7 @@ fix it themselves and *see* the result (the exact affordance whose absence made
 this hard to diagnose).
 
 ### 4. (Deferred) backend "enabled but no device" signal
+
 A user whose prefs are enabled but who has no `UserDevice` row is a detectable
 "wants notifications, can't receive them" state. Worth surfacing later (a
 dispatcher log/metric on `Suppressed_NoDevice` for opted-in users); **out of

--- a/src/UI/sd-mobile/__tests__/lib/notifications/registerPushDevice.test.ts
+++ b/src/UI/sd-mobile/__tests__/lib/notifications/registerPushDevice.test.ts
@@ -1,0 +1,92 @@
+import * as Sentry from '@sentry/react-native';
+
+import { registerThisDevice } from '@/src/lib/notifications/registerPushDevice';
+import { getFcmToken, getFcmTokenIfGranted } from '@/src/lib/notifications/pushNotifications';
+import { getOrCreateInstallationId } from '@/src/lib/device/installationId';
+import { devicesApi } from '@/src/services/api/devicesApi';
+
+jest.mock('@/src/lib/notifications/pushNotifications', () => ({
+  getFcmToken: jest.fn(),
+  getFcmTokenIfGranted: jest.fn(),
+}));
+jest.mock('@/src/lib/device/installationId', () => ({
+  getOrCreateInstallationId: jest.fn(),
+}));
+jest.mock('@/src/services/api/devicesApi', () => ({
+  devicesApi: { registerDevice: jest.fn(), unregisterDevice: jest.fn() },
+}));
+
+const mockGranted = getFcmTokenIfGranted as jest.Mock;
+const mockPrompt = getFcmToken as jest.Mock;
+const mockInstallId = getOrCreateInstallationId as jest.Mock;
+const mockRegister = devicesApi.registerDevice as jest.Mock;
+const mockCaptureMessage = Sentry.captureMessage as jest.Mock;
+const mockCaptureException = Sentry.captureException as jest.Mock;
+
+describe('registerThisDevice', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInstallId.mockResolvedValue('install-123');
+  });
+
+  it('registers when a token is available (silent path)', async () => {
+    mockGranted.mockResolvedValue({ token: 'fcm-abc', permissionStatus: 'granted', error: null });
+    mockRegister.mockResolvedValue(undefined);
+
+    const outcome = await registerThisDevice();
+
+    expect(outcome.ok).toBe(true);
+    expect(mockRegister).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: 'install-123', fcmToken: 'fcm-abc' })
+    );
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('warns to Sentry when permission is granted but no token was obtained', async () => {
+    mockGranted.mockResolvedValue({
+      token: null,
+      permissionStatus: 'granted',
+      error: 'FCM returned empty token',
+    });
+
+    const outcome = await registerThisDevice();
+
+    expect(outcome.ok).toBe(false);
+    expect(mockRegister).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a silent no-op (no Sentry) when permission is not granted', async () => {
+    mockGranted.mockResolvedValue({ token: null, permissionStatus: 'undetermined', error: null });
+
+    const outcome = await registerThisDevice();
+
+    expect(outcome.ok).toBe(false);
+    expect(mockRegister).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('captures a Sentry exception when the POST throws', async () => {
+    mockGranted.mockResolvedValue({ token: 'fcm-abc', permissionStatus: 'granted', error: null });
+    mockRegister.mockRejectedValue(new Error('network down'));
+
+    const outcome = await registerThisDevice();
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toBe('network down');
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the prompting token fn when prompt=true', async () => {
+    mockPrompt.mockResolvedValue({ token: 'fcm-xyz', permissionStatus: 'granted', error: null });
+    mockRegister.mockResolvedValue(undefined);
+
+    const outcome = await registerThisDevice({ prompt: true });
+
+    expect(outcome.ok).toBe(true);
+    expect(mockPrompt).toHaveBeenCalled();
+    expect(mockGranted).not.toHaveBeenCalled();
+  });
+});

--- a/src/UI/sd-mobile/__tests__/lib/notifications/registerPushDevice.test.ts
+++ b/src/UI/sd-mobile/__tests__/lib/notifications/registerPushDevice.test.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import * as Sentry from '@sentry/react-native';
 
 import { registerThisDevice } from '@/src/lib/notifications/registerPushDevice';
@@ -77,6 +78,20 @@ describe('registerThisDevice', () => {
     expect(outcome.ok).toBe(false);
     expect(outcome.error).toBe('network down');
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op on web (never touches permission/token/API)', async () => {
+    const replaced = jest.replaceProperty(Platform, 'OS', 'web');
+    try {
+      const outcome = await registerThisDevice();
+
+      expect(outcome).toEqual({ ok: false, permissionStatus: 'undetermined' });
+      expect(mockGranted).not.toHaveBeenCalled();
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(mockRegister).not.toHaveBeenCalled();
+    } finally {
+      replaced.restore();
+    }
   });
 
   it('uses the prompting token fn when prompt=true', async () => {

--- a/src/UI/sd-mobile/app/settings/notifications.tsx
+++ b/src/UI/sd-mobile/app/settings/notifications.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { View, StyleSheet, ScrollView, Switch, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, ScrollView, Switch, ActivityIndicator, Alert, Pressable } from 'react-native';
 import { Stack } from 'expo-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { usersApi } from '@/src/services/api/usersApi';
+import { registerThisDevice } from '@/src/lib/notifications/registerPushDevice';
 import type { NotificationPreferences } from '@/src/types/models';
 
 // Per-category push-notification opt-out screen. The API owns these flags
@@ -161,6 +162,37 @@ export default function NotificationSettingsScreen() {
 
   const effective = prefs ?? ALL_ENABLED;
 
+  // Manual "register this device" escape hatch. The auto-register hook is
+  // silent and only fires at sign-in / foreground; this lets a user whose
+  // device somehow never registered fix it and SEE the result. Prompts for
+  // permission if needed.
+  const [registeringDevice, setRegisteringDevice] = useState(false);
+  const handleRegisterDevice = async () => {
+    if (registeringDevice) return;
+    setRegisteringDevice(true);
+    try {
+      const outcome = await registerThisDevice({ prompt: true });
+      if (outcome.ok) {
+        Alert.alert(
+          'Device registered',
+          'This device is set up to receive push notifications.'
+        );
+      } else if (outcome.permissionStatus !== 'granted') {
+        Alert.alert(
+          'Notifications are off',
+          'Turn on notifications for sportDeets in your device Settings, then try again.'
+        );
+      } else {
+        Alert.alert(
+          "Couldn't register this device",
+          outcome.error ?? 'Please try again in a moment.'
+        );
+      }
+    } finally {
+      setRegisteringDevice(false);
+    }
+  };
+
   return (
     <>
       <Stack.Screen options={{ title: 'Notifications', headerBackTitle: 'Back' }} />
@@ -239,6 +271,47 @@ export default function NotificationSettingsScreen() {
                 </View>
               </View>
             ))}
+
+            <View style={styles.section}>
+              <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>
+                This device
+              </Text>
+              <View
+                style={[
+                  styles.card,
+                  { backgroundColor: theme.card, borderColor: theme.border },
+                ]}
+              >
+                <View style={styles.row}>
+                  <View style={styles.rowText}>
+                    <Text style={[styles.rowLabel, { color: theme.text }]}>
+                      Register this device
+                    </Text>
+                    <Text style={[styles.rowDesc, { color: theme.textMuted }]}>
+                      Not getting notifications on this device? Tap to set it up.
+                    </Text>
+                  </View>
+                  <Pressable
+                    onPress={handleRegisterDevice}
+                    disabled={registeringDevice}
+                    accessibilityRole="button"
+                    accessibilityLabel="Register this device for push notifications"
+                    style={[
+                      styles.registerButton,
+                      { borderColor: theme.tint, opacity: registeringDevice ? 0.5 : 1 },
+                    ]}
+                  >
+                    {registeringDevice ? (
+                      <ActivityIndicator color={theme.tint} size="small" />
+                    ) : (
+                      <Text style={[styles.registerButtonText, { color: theme.tint }]}>
+                        Register
+                      </Text>
+                    )}
+                  </Pressable>
+                </View>
+              </View>
+            </View>
           </>
         )}
       </ScrollView>
@@ -277,4 +350,14 @@ const styles = StyleSheet.create({
   rowText: { flex: 1, gap: 2 },
   rowLabel: { fontSize: 15, fontWeight: '600' },
   rowDesc: { fontSize: 12, lineHeight: 16 },
+  registerButton: {
+    minWidth: 88,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  registerButtonText: { fontSize: 14, fontWeight: '700' },
 });

--- a/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
+++ b/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
@@ -1,87 +1,83 @@
 import { useEffect, useRef } from 'react';
-import { Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import messaging from '@react-native-firebase/messaging';
 
 import { useAuth } from './useAuth';
-import { getFcmTokenIfGranted } from '@/src/lib/notifications/pushNotifications';
-import { getOrCreateInstallationId } from '@/src/lib/device/installationId';
-import { devicesApi } from '@/src/services/api/devicesApi';
+import { registerThisDevice } from '@/src/lib/notifications/registerPushDevice';
 
 /**
  * Silently registers this device's FCM token with the API once the user is
- * authenticated and notification permission has already been granted. Replaces
- * the manual copy-paste step on the admin push-token screen.
+ * authenticated and notification permission has already been granted.
  *
  * Design choices:
- * - NO permission prompt. We use {@link getFcmTokenIfGranted}, which only
- *   returns a token when permission is already granted, so sign-in never fires
- *   an unsolicited iOS prompt. Requesting permission (with context) is a
- *   separate product flow.
- * - Native-only. expo-notifications / RN-Firebase messaging have no web
- *   equivalent; the hook no-ops on web.
- * - Idempotent + cheap. The backend upserts on (UserId, FcmToken), so repeat
- *   calls are harmless; the per-session token set just avoids needless POSTs.
- * - Token rotation. Subscribes to onTokenRefresh so a mid-session FCM token
- *   rotation re-registers without waiting for the next launch.
+ * - NO permission prompt. Registration goes through
+ *   {@link registerThisDevice} with prompt=false, which only returns a token
+ *   when permission is already granted — sign-in never fires an unsolicited
+ *   iOS prompt. (The manual settings action uses prompt=true.)
+ * - Native-only. RN-Firebase messaging has no web equivalent; the hook no-ops
+ *   on web.
+ * - Resilient. The one-shot sign-in attempt used to be the ONLY automatic
+ *   trigger, so a device whose permission or APNs token wasn't ready at that
+ *   instant (or whose POST failed) silently never registered. We now re-attempt
+ *   on every foreground until a registration succeeds this session, and on FCM
+ *   token rotation. See docs/mobile/device-registration-resilience.md.
  *
  * Call once from the root layout (native-only).
  */
 export function useRegisterPushDevice(): void {
   const { isAuthenticated, user } = useAuth();
 
-  // Tokens already registered this app session. Backend idempotency makes this
-  // a chattiness guard, not a correctness one.
-  const registeredTokensRef = useRef<Set<string>>(new Set());
+  // Whether registration has already succeeded this session. Reset on sign-out
+  // / account switch. Gates the foreground retry loop so we stop once done.
+  const registeredRef = useRef(false);
 
   useEffect(() => {
     if (Platform.OS === 'web') return;
 
     if (!isAuthenticated) {
-      // Signed out — forget what we registered so the next user's device
-      // re-registers cleanly.
-      registeredTokensRef.current.clear();
+      // Signed out — forget success so the next user's device re-registers.
+      registeredRef.current = false;
       return;
     }
 
-    // Fresh start for this sign-in. The effect also re-runs on a direct
-    // account switch (user?.uid A -> B with no intermediate sign-out); since
-    // the device's FCM token is the same across accounts, a stale cached token
-    // would otherwise suppress the new user's registration POST.
-    registeredTokensRef.current.clear();
+    // Fresh start for this sign-in. The effect also re-runs on a direct account
+    // switch (user?.uid A -> B with no intermediate sign-out).
+    registeredRef.current = false;
 
     let cancelled = false;
-    const platform = Platform.OS === 'ios' ? 'ios' : 'android';
 
-    const register = async (token: string | null) => {
-      if (cancelled || !token) return;
-      if (registeredTokensRef.current.has(token)) return;
-
-      try {
-        const installationId = await getOrCreateInstallationId();
-        await devicesApi.registerDevice({ installationId, fcmToken: token, platform });
-        registeredTokensRef.current.add(token);
-      } catch (err) {
-        // Non-fatal: reminders just won't reach this device until a later
-        // retry (next launch / token refresh). Never surface to the user.
-        const message = err instanceof Error ? err.message : String(err);
-        console.log('[push] device registration failed', { message });
-      }
+    // Silent attempt, gated on not-yet-succeeded. A cheap permission check
+    // short-circuits inside registerThisDevice when permission isn't granted,
+    // so foreground retries don't POST-spam while denied.
+    const attempt = async () => {
+      if (cancelled || registeredRef.current) return;
+      const outcome = await registerThisDevice();
+      if (!cancelled && outcome.ok) registeredRef.current = true;
     };
 
-    // Initial registration for this sign-in.
-    void (async () => {
-      const token = await getFcmTokenIfGranted();
-      await register(token);
-    })();
+    // Initial attempt for this sign-in.
+    void attempt();
 
-    // Re-register if FCM rotates the token while signed in.
-    const unsubscribe = messaging().onTokenRefresh((token) => {
-      void register(token);
+    // Re-attempt on foreground until we've succeeded once. Covers permission
+    // granted after launch, an APNs token that wasn't ready at sign-in, and
+    // transient POST failures — none of which the one-shot attempt recovered.
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void attempt();
+    });
+
+    // Token rotation must reach the backend even after a prior success, so this
+    // re-registers unconditionally (not gated by registeredRef).
+    const unsubscribeTokenRefresh = messaging().onTokenRefresh(() => {
+      void (async () => {
+        const outcome = await registerThisDevice();
+        if (!cancelled && outcome.ok) registeredRef.current = true;
+      })();
     });
 
     return () => {
       cancelled = true;
-      unsubscribe();
+      appStateSub.remove();
+      unsubscribeTokenRefresh();
     };
   }, [isAuthenticated, user?.uid]);
 }

--- a/src/UI/sd-mobile/src/lib/notifications/pushNotifications.ts
+++ b/src/UI/sd-mobile/src/lib/notifications/pushNotifications.ts
@@ -94,27 +94,40 @@ export async function getFcmToken(): Promise<FcmTokenResult> {
 
 /**
  * Like {@link getFcmToken}, but NEVER prompts. Returns the FCM token only
- * when notification permission has ALREADY been granted; returns null
+ * when notification permission has ALREADY been granted; the token is null
  * otherwise (denied / undetermined / web / error).
  *
  * Used for silent automatic device registration at sign-in so we don't fire
- * an unsolicited iOS permission prompt on launch. Permission is requested
- * explicitly elsewhere (the admin push-token screen today; a priming flow in
- * the future), and once granted this picks the token up on the next sign-in.
+ * an unsolicited iOS permission prompt on launch. Returns the full
+ * {@link FcmTokenResult} — crucially, the <c>error</c> is surfaced rather than
+ * swallowed, so a granted-but-tokenless failure (e.g. the APNs token not being
+ * ready yet) is diagnosable instead of a silent no-op.
  */
-export async function getFcmTokenIfGranted(): Promise<string | null> {
-  if (Platform.OS === 'web') return null;
+export async function getFcmTokenIfGranted(): Promise<FcmTokenResult> {
+  if (Platform.OS === 'web') {
+    return { token: null, permissionStatus: 'undetermined', error: null };
+  }
+
+  let permissionStatus: PermissionStatus = 'undetermined';
   try {
     const { status } = await Notifications.getPermissionsAsync();
-    if (status !== 'granted') return null;
+    permissionStatus = status as PermissionStatus;
+    if (permissionStatus !== 'granted') {
+      return { token: null, permissionStatus, error: null };
+    }
 
     if (Platform.OS === 'ios') {
       await messaging().registerDeviceForRemoteMessages();
     }
 
     const token = await messaging().getToken();
-    return token || null;
-  } catch {
-    return null;
+    return {
+      token: token || null,
+      permissionStatus,
+      error: token ? null : 'FCM returned empty token',
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { token: null, permissionStatus, error: message };
   }
 }

--- a/src/UI/sd-mobile/src/lib/notifications/registerPushDevice.ts
+++ b/src/UI/sd-mobile/src/lib/notifications/registerPushDevice.ts
@@ -1,0 +1,67 @@
+import { Platform } from 'react-native';
+import * as Sentry from '@sentry/react-native';
+
+import { getFcmToken, getFcmTokenIfGranted, type PermissionStatus } from './pushNotifications';
+import { getOrCreateInstallationId } from '@/src/lib/device/installationId';
+import { devicesApi } from '@/src/services/api/devicesApi';
+
+export interface RegistrationOutcome {
+  ok: boolean;
+  permissionStatus: PermissionStatus;
+  error?: string;
+}
+
+/**
+ * Registers this device's FCM token with the API — the single place device
+ * registration happens (used by both the auto-register hook and the manual
+ * "register this device" settings action).
+ *
+ * - <c>prompt=false</c> (default): silent. Only registers when permission is
+ *   already granted, so it never fires an unsolicited iOS prompt.
+ * - <c>prompt=true</c>: may request permission first, so the manual action can
+ *   grant + register in one tap.
+ *
+ * Failures are reported to Sentry (<c>area: push-registration</c>) so a device
+ * that won't register is diagnosable — the observability gap that made the
+ * missing-iPad-row case invisible. See
+ * docs/mobile/device-registration-resilience.md.
+ */
+export async function registerThisDevice(
+  { prompt = false }: { prompt?: boolean } = {}
+): Promise<RegistrationOutcome> {
+  if (Platform.OS === 'web') {
+    return { ok: false, permissionStatus: 'undetermined' };
+  }
+
+  const { token, permissionStatus, error } = prompt
+    ? await getFcmToken()
+    : await getFcmTokenIfGranted();
+
+  if (!token) {
+    // Permission simply not granted is a normal silent no-op. But permission
+    // granted with no token (e.g. APNs not ready, RN-Firebase error) is a real
+    // failure worth surfacing.
+    if (permissionStatus === 'granted') {
+      Sentry.captureMessage('Push registration: no FCM token despite granted permission', {
+        level: 'warning',
+        tags: { area: 'push-registration', prompt: String(prompt) },
+        extra: { error, permissionStatus },
+      });
+    }
+    return { ok: false, permissionStatus, error: error ?? undefined };
+  }
+
+  try {
+    const installationId = await getOrCreateInstallationId();
+    const platform = Platform.OS === 'ios' ? 'ios' : 'android';
+    await devicesApi.registerDevice({ installationId, fcmToken: token, platform });
+    return { ok: true, permissionStatus };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    Sentry.captureException(err, {
+      tags: { area: 'push-registration', prompt: String(prompt) },
+      extra: { stage: 'post', permissionStatus },
+    });
+    return { ok: false, permissionStatus, error: message };
+  }
+}


### PR DESCRIPTION
## Problem

A signed-in, notification-permitted device could end up with **no `UserDevice`
row** in the Notification service, so every push is `Suppressed_NoDevice`.
Observed: iPad (signed in as gmail, permission granted via TestFlight) had a
`User` row but **no `UserDevice` row at all** — it never registered.

## Root cause

`useRegisterPushDevice` fetched the FCM token and POSTed **exactly once per
sign-in**, re-running only on auth change / token rotation — never on foreground
or a permission-state change. `getFcmTokenIfGranted()` returns a token only if
permission is already granted **at that instant**, and **swallowed every error**
(`catch { return null }`); the hook swallowed POST failures too (`console.log`).
So if permission or the APNs token wasn't ready at that one moment (TestFlight
first-run timing), or the POST failed, registration silently no-oped **forever**
and left **zero trace**.

## Fix

Design doc: `docs/mobile/device-registration-resilience.md`.

1. **Foreground re-attempt** — an `AppState` listener re-tries registration on
   every foreground until one succeeds this session (reset on sign-out / account
   switch); token rotation still re-registers separately. Recovers
   permission-granted-late, APNs-not-ready, and transient POST failures. *This is
   the automatic fix.*
2. **Stop swallowing** — `getFcmTokenIfGranted()` returns the rich
   `FcmTokenResult`; a new `registerThisDevice()` helper (the single registration
   path) reports failures to **Sentry** (`area: push-registration`): a *warning*
   when permission is granted but no token, a captured *exception* on POST
   failure. TestFlight reports under the `preview` env, so the next occurrence is
   diagnosable.
3. **Manual "Register this device"** action on the notification-settings screen
   (prompts if needed, shows the result via `Alert`) — the user-facing escape
   hatch whose absence made this hard to diagnose.
4. Backend "enabled-but-no-device" signal — deferred (noted in the doc).

## Notes

- **JS-only** — no native modules, native config, or permission changes. Ships as
  an **EAS OTA update** to the existing TestFlight build; no new native build
  needed. **Not blocked** by the notification-service deploy hold (separate track).

## Validation

- `tsc --noEmit` clean.
- New `registerThisDevice` unit test **5/5** (token+POST ok; granted-but-no-token
  → Sentry warning; not-granted → silent no-op; POST throws → Sentry exception;
  prompt=true uses the prompting token fn).
- Full mobile Jest suite **67/67**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual “This device” push registration action in notification settings, including progress feedback and clear success/failure alerts.
  * Introduced more structured reporting for permission/token availability and registration outcomes.
* **Bug Fixes**
  * Improved push-device registration resilience by retrying on app foreground until successful per sign-in session and re-attempting after token rotation.
  * Enhanced observability for missing tokens and backend registration failures.
* **Tests**
  * Added coverage for success, permission granted/denied, token unavailability, web no-op behavior, and backend error handling.
* **Documentation**
  * Added a new mobile device-registration resilience and observability documentation page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->