### PR TITLE
fix(web): hide Logos tab from non-admins on team overview

### DIFF
--- a/src/UI/sd-ui/src/components/teams/TeamCard.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamCard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTheme } from "../../contexts/ThemeContext";
+import { useUserDto } from "../../contexts/UserContext";
 import apiWrapper from "../../api/apiWrapper";
 import "./TeamCard.css";
 import TeamSchedule from "./TeamSchedule";
@@ -14,6 +15,10 @@ function TeamCard() {
   const { sport = 'football', league = 'ncaa', slug, seasonYear } = useParams();
   const navigate = useNavigate();
   const { theme } = useTheme();
+  // Logos is an admin-only diagnostic tab (drives dark-bg logo selection);
+  // non-admins have no use for it, so hide the tab entirely.
+  const { userDto } = useUserDto();
+  const isAdmin = userDto?.isAdmin;
   const [team, setTeam] = useState(null);
   const [loading, setLoading] = useState(true);
   const [selectedTab, setSelectedTab] = useState("schedule");
@@ -135,12 +140,14 @@ function TeamCard() {
         >
           Statistics
         </button>
-        <button
-          className={selectedTab === "logos" ? "active" : ""}
-          onClick={() => setSelectedTab("logos")}
-        >
-          Logos
-        </button>
+        {isAdmin && (
+          <button
+            className={selectedTab === "logos" ? "active" : ""}
+            onClick={() => setSelectedTab("logos")}
+          >
+            Logos
+          </button>
+        )}
       </div>
 
       <div className="team-card-content">
@@ -159,7 +166,7 @@ function TeamCard() {
             <TeamStatistics team={team} seasonYear={resolvedSeason} stats={teamStats} />
           )
         )}
-        {selectedTab === "logos" && (
+        {isAdmin && selectedTab === "logos" && (
           <TeamLogos slug={slug} seasonYear={resolvedSeason} sport={sport} league={league} />
         )}
       </div>


### PR DESCRIPTION
## Summary

On the team overview page (e.g. `/app/sport/baseball/mlb/team/los-angeles-dodgers/2026`)
non-admin users could see the **Logos** tab. It's an admin-only diagnostic
surface (it drives dark-background logo selection) — non-admins have no use for
it, so hide the tab entirely rather than disable the selectors.

## Change

`TeamCard.jsx` — gate both the Logos tab **button** and its **content** behind
`userDto?.isAdmin` (via `useUserDto`), matching the app's existing admin-gate
pattern (`ContestOverview`, `InsightDialog`, `LeagueCreatePage`). Admins are
unaffected.

## Validation

- ESLint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)