### PR TITLE
fix(picks): rename UserPickDto.FranchiseId → FranchiseSeasonId at the API boundary

### DIFF
--- a/src/SportsData.Api/Application/UI/Picks/Dtos/UserPickDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Dtos/UserPickDto.cs
@@ -14,7 +14,7 @@ public record UserPickDto
 
     public Guid ContestId { get; init; }
 
-    public Guid FranchiseId { get; init; }
+    public Guid FranchiseSeasonId { get; init; }
 
     public PickType PickType { get; init; }
 

--- a/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
@@ -45,7 +45,7 @@ public class GetUserPicksByGroupAndWeekQueryHandler : IGetUserPicksByGroupAndWee
                 User = p.User.DisplayName,
                 ConfidencePoints = p.ConfidencePoints,
                 ContestId = p.ContestId,
-                FranchiseId = p.FranchiseSeasonId ?? Guid.Empty,
+                FranchiseSeasonId = p.FranchiseSeasonId ?? Guid.Empty,
                 IsCorrect = p.IsCorrect,
                 PickType = p.PickType,
                 TiebreakerGuessTotal = p.TiebreakerGuessTotal,

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -314,7 +314,7 @@ function PickSelector({
   awayTeamName,
   homeFranchiseSeasonId,
   awayFranchiseSeasonId,
-  existingPickFranchiseId,
+  existingPickFranchiseSeasonId,
   isLocked,
   submitPending,
   onPick,
@@ -323,7 +323,7 @@ function PickSelector({
   awayTeamName: string;
   homeFranchiseSeasonId: string;
   awayFranchiseSeasonId: string;
-  existingPickFranchiseId: string | null;
+  existingPickFranchiseSeasonId: string | null;
   isLocked: boolean;
   submitPending: boolean;
   onPick: (choice: PickChoice, franchiseSeasonId: string) => void;
@@ -331,8 +331,8 @@ function PickSelector({
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
 
-  const pickedHome = existingPickFranchiseId === homeFranchiseSeasonId;
-  const pickedAway = existingPickFranchiseId === awayFranchiseSeasonId;
+  const pickedHome = existingPickFranchiseSeasonId === homeFranchiseSeasonId;
+  const pickedAway = existingPickFranchiseSeasonId === awayFranchiseSeasonId;
   const hasPick = pickedHome || pickedAway;
   const locked = isLocked || submitPending;
 
@@ -503,7 +503,7 @@ export default function GameDetailScreen() {
             awayTeamName={matchup.away}
             homeFranchiseSeasonId={matchup.homeFranchiseSeasonId}
             awayFranchiseSeasonId={matchup.awayFranchiseSeasonId}
-            existingPickFranchiseId={existingPick?.franchiseId ?? null}
+            existingPickFranchiseSeasonId={existingPick?.franchiseSeasonId ?? null}
             isLocked={isLocked}
             submitPending={submitPick.isPending}
             onPick={handlePick}

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -695,7 +695,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
     enrichedMatchup.awayScore > enrichedMatchup.homeScore;
 
   // Use server pick if available, otherwise optimistic
-  const effectiveFranchiseId = pick?.franchiseId ?? optimisticFranchiseId;
+  const effectiveFranchiseId = pick?.franchiseSeasonId ?? optimisticFranchiseId;
 
   const pickedHome = effectiveFranchiseId === matchup.homeFranchiseSeasonId;
   const pickedAway = effectiveFranchiseId === matchup.awayFranchiseSeasonId;

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -192,7 +192,7 @@ export interface UserPick {
   id: string;
   userId: string;
   contestId: string;
-  franchiseId: string;
+  franchiseSeasonId: string;
   pickType: PickType;
   confidencePoints?: number | null;
   tiebreakerGuessTotal?: number | null;

--- a/src/UI/sd-ui/src/components/leaderboard/LeagueWeekOverviewTable.jsx
+++ b/src/UI/sd-ui/src/components/leaderboard/LeagueWeekOverviewTable.jsx
@@ -98,12 +98,12 @@ function LeagueWeekOverviewTable({ overview }) {
                   const pick = pickMap[user.userId]?.[contest.contestId];
                   let teamShort = '';
                   if (pick) {
-                    if (pick.franchiseId === contest.awayFranchiseSeasonId) {
+                    if (pick.franchiseSeasonId === contest.awayFranchiseSeasonId) {
                       teamShort = contest.awayShort;
-                    } else if (pick.franchiseId === contest.homeFranchiseSeasonId) {
+                    } else if (pick.franchiseSeasonId === contest.homeFranchiseSeasonId) {
                       teamShort = contest.homeShort;
                     } else {
-                      teamShort = pick.franchiseId; // fallback
+                      teamShort = pick.franchiseSeasonId; // fallback
                     }
                   }
                   return (

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -22,7 +22,7 @@ function MatchupCard({
   matchup,
   pickType,
   userPickFranchiseSeasonId,
-  userPickResult, // New: DTO containing isCorrect, franchiseId, etc.
+  userPickResult, // New: DTO containing isCorrect, franchiseSeasonId, etc.
   onPick,
   onViewInsight,
   isInsightUnlocked,
@@ -113,11 +113,11 @@ function MatchupCard({
   // Reset local pick if matchup or user pick changes (e.g., after refresh or parent update)
   useEffect(() => {
     setLocalPickFranchiseId(null);
-  }, [matchup.matchupId, userPickFranchiseSeasonId, userPickResult?.franchiseId]);
+  }, [matchup.matchupId, userPickFranchiseSeasonId, userPickResult?.franchiseSeasonId]);
 
   // Determine selected team: prefer local pick, then userPickResult, then userPickFranchiseSeasonId
   const selectedFranchiseId =
-    localPickFranchiseId ?? userPickResult?.franchiseId ?? userPickFranchiseSeasonId;
+    localPickFranchiseId ?? userPickResult?.franchiseSeasonId ?? userPickFranchiseSeasonId;
 
   const isAwaySelected = selectedFranchiseId === matchup.awayFranchiseSeasonId;
   const isHomeSelected = selectedFranchiseId === matchup.homeFranchiseSeasonId;

--- a/src/UI/sd-ui/src/components/matchups/MatchupList.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupList.jsx
@@ -36,7 +36,7 @@ function MatchupList({
           key={matchup.contestId}
           matchup={matchup}
           pickType={pickType}
-          userPickFranchiseSeasonId={userPicks[matchup.contestId]?.franchiseId}
+          userPickFranchiseSeasonId={userPicks[matchup.contestId]?.franchiseSeasonId}
           userPickResult={userPicks[matchup.contestId]}
           onPick={onPick}
           onViewInsight={onViewInsight}

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -349,7 +349,7 @@ function PicksPage() {
       const updatedPick = {
         ...userPicks[matchup.contestId],
         contestId: matchup.contestId,
-        franchiseId: selectedFranchiseSeasonId,
+        franchiseSeasonId: selectedFranchiseSeasonId,
         confidencePoints: confidencePoints !== undefined ? confidencePoints : userPicks[matchup.contestId]?.confidencePoints
       };
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
@@ -88,9 +88,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         result.Value.Should().HaveCount(1);
         result.Value[0].UserId.Should().Be(userId);
         result.Value[0].ContestId.Should().Be(contestId);
-        // The DTO exposes the pick's FranchiseSeasonId under the API-compatible
-        // `FranchiseId` field name (kept for the web/mobile contract).
-        result.Value[0].FranchiseId.Should().Be(franchiseSeasonId);
+        result.Value[0].FranchiseSeasonId.Should().Be(franchiseSeasonId);
         result.Value[0].PickType.Should().Be(PickType.StraightUp);
         result.Value[0].ConfidencePoints.Should().Be(7);
         result.Value[0].IsCorrect.Should().BeTrue();


### PR DESCRIPTION
## What

Completes the FE-coordinated boundary rename that was explicitly deferred from #511:

> _Scope call: the response-DTO field (GetUserPicksByGroupAndWeek) keeps the name `FranchiseId` so the web/mobile API contract doesn't break — that boundary rename is a separate FE-coordinated follow-up._

The `UserPick` entity field was already renamed to `FranchiseSeasonId` in #511. This harmonizes the **read-side** response DTO and every web/mobile consumer to match. The write side (`SubmitUserPickRequest.FranchiseSeasonId`) was already consistent, so this closes the last `FranchiseId` in the picks domain.

## Scope

`UserPickDto.FranchiseId → FranchiseSeasonId`. Because `LeagueWeekOverviewDto` embeds `List<UserPickDto>` (its handler delegates to the picks query handler), this touches **two** response contracts — no separate mapping change was needed there.

**BE — `SportsData.Api`**
- `UserPickDto` field + `GetUserPicksByGroupAndWeekQueryHandler` mapping
- Unit test assertion (removed the now-stale "kept for contract" comment)

**Web — `sd-ui`**
- `PicksPage.jsx` (optimistic-cache mirror), `MatchupList.jsx`, `MatchupCard.jsx`, `LeagueWeekOverviewTable.jsx`

**Mobile — `sd-mobile`**
- `UserPick` model, `MatchupCard.tsx`, game screen (incl. cosmetic `existingPickFranchiseSeasonId` props)

Purely-local variable names (e.g. `handleTeamPick(franchiseId)`, `localPickFranchiseId`) were left untouched — they aren't the wire contract.

## Why now / no shim

Atomic hard rename across BE + web + mobile in one PR. The app isn't in the stores yet, so there are no field-deployed clients that read the old field name — no dual-emit / back-compat shim required.

## Verification

- `dotnet build` on `SportsData.Api` — clean (0 warnings, 0 errors)
- Affected unit tests (`GetUserPicksByGroupAndWeek`, `GetLeagueWeekOverview`) — 10/10 pass
- Grep sweep across `src/` confirms no remaining `franchiseId`/`FranchiseId` reads off the pick DTO (remaining `.FranchiseId` hits are unrelated `Franchise`/`FranchiseSeason` entity FKs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pick tracking to use season-specific team identifiers.
  * Corrected selected-team highlighting across game details, matchup cards, pick buttons, and leaderboard views.
  * Improved consistency when displaying existing picks and confidence points.
* **Tests**
  * Updated pick retrieval coverage to validate season-specific identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->