### PR TITLE
feat(picks): cross-league pick import — preview + sources (v1, read-only)

### DIFF
--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewDto.cs
@@ -1,0 +1,75 @@
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+
+/// <summary>
+/// Dry-run plan for importing a user's picks from one league into another.
+/// Returned by POST /ui/leagues/{targetId}/picks/import/preview — no writes.
+/// </summary>
+public sealed class PickImportPreviewDto
+{
+    public Guid SourceLeagueId { get; init; }
+
+    public Guid TargetLeagueId { get; init; }
+
+    /// <summary>
+    /// When true, the FE must route the confirmed import through the
+    /// (confidence-required) pick sheet rather than a direct commit — the
+    /// imported team selections pre-fill the sheet and the user assigns
+    /// confidence before saving.
+    /// </summary>
+    public bool TargetUsesConfidencePoints { get; init; }
+
+    public List<PickImportPreviewItemDto> ToImport { get; init; } = [];
+
+    public List<PickImportPreviewCollisionDto> Collisions { get; init; } = [];
+
+    public List<PickImportPreviewSkippedDto> Skipped { get; init; } = [];
+}
+
+/// <summary>A contest whose source selection will be imported (no existing target pick).</summary>
+public sealed class PickImportPreviewItemDto
+{
+    public Guid ContestId { get; init; }
+
+    public int Week { get; init; }
+
+    /// <summary>The picked team, copied verbatim from the source pick.</summary>
+    public Guid FranchiseSeasonId { get; init; }
+
+    public string? Headline { get; init; }
+
+    /// <summary>
+    /// The target league's locked spread this pick will be judged against — may
+    /// differ from the source league's. Surfaced so the user understands the pick
+    /// copies the team, not the line.
+    /// </summary>
+    public double? TargetHomeSpread { get; init; }
+}
+
+/// <summary>A contest where the existing target pick differs from the source selection.</summary>
+public sealed class PickImportPreviewCollisionDto
+{
+    public Guid ContestId { get; init; }
+
+    public int Week { get; init; }
+
+    /// <summary>The team the source pick would import (replace with).</summary>
+    public Guid SourceFranchiseSeasonId { get; init; }
+
+    /// <summary>The team currently picked in the target league (keep).</summary>
+    public Guid ExistingFranchiseSeasonId { get; init; }
+
+    public string? Headline { get; init; }
+
+    public double? TargetHomeSpread { get; init; }
+}
+
+/// <summary>A contest that was not imported, with the reason.</summary>
+public sealed class PickImportPreviewSkippedDto
+{
+    public Guid ContestId { get; init; }
+
+    /// <summary>One of <see cref="Planner.PickImportSkipReason"/> as a string.</summary>
+    public string Reason { get; init; } = null!;
+
+    public string? Headline { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewDto.cs
@@ -1,4 +1,4 @@
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Dtos;
 
 /// <summary>
 /// Dry-run plan for importing a user's picks from one league into another.

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewRequest.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewRequest.cs
@@ -1,0 +1,10 @@
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+
+/// <summary>
+/// Body for POST /ui/leagues/{targetId}/picks/import/preview. The target league is
+/// the route id; this names the league to copy the user's picks from.
+/// </summary>
+public sealed class PickImportPreviewRequest
+{
+    public Guid SourceLeagueId { get; set; }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewRequest.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportPreviewRequest.cs
@@ -1,4 +1,4 @@
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Dtos;
 
 /// <summary>
 /// Body for POST /ui/leagues/{targetId}/picks/import/preview. The target league is

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportSourceDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportSourceDto.cs
@@ -1,4 +1,4 @@
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Dtos;
 
 /// <summary>
 /// A candidate source league for importing picks into a target: one of the user's

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportSourceDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportSourceDto.cs
@@ -1,0 +1,24 @@
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+
+/// <summary>
+/// A candidate source league for importing picks into a target: one of the user's
+/// other active same-type leagues that shares at least one contest with the target.
+/// Backs the source picker. Returned by GET /ui/leagues/{targetId}/picks/import/sources.
+/// </summary>
+public sealed class PickImportSourceDto
+{
+    public Guid LeagueId { get; init; }
+
+    public string Name { get; init; } = null!;
+
+    public string Sport { get; init; } = null!;
+
+    public string PickType { get; init; } = null!;
+
+    public bool UseConfidencePoints { get; init; }
+
+    /// <summary>Number of contests this source league shares with the target.</summary>
+    public int SharedContestCount { get; init; }
+
+    public int MemberCount { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
@@ -1,14 +1,14 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-using SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
-using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
-using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+using SportsData.Api.Application.UI.Picks.PickImport.Dtos;
+using SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportPreview;
+using SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportSources;
 using SportsData.Api.Extensions;
 using SportsData.Core.Common;
 using SportsData.Core.Extensions;
 
-namespace SportsData.Api.Application.UI.Leagues.PickImport;
+namespace SportsData.Api.Application.UI.Picks.PickImport;
 
 /// <summary>
 /// Cross-league pick import, scoped to the target league.

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
+using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+using SportsData.Api.Extensions;
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+
+namespace SportsData.Api.Application.UI.Leagues.PickImport;
+
+/// <summary>
+/// Cross-league pick import, scoped to the target league.
+/// See docs/features/pick-import-across-leagues.md.
+/// </summary>
+[ApiController]
+[Route("ui/leagues/{targetId:guid}/picks/import")]
+public class PickImportController : ApiControllerBase
+{
+    /// <summary>
+    /// Candidate source leagues for the picker: the user's other active same-type
+    /// leagues that share at least one contest with the target.
+    /// </summary>
+    [HttpGet("sources")]
+    [Authorize]
+    public async Task<ActionResult<List<PickImportSourceDto>>> GetSources(
+        [FromRoute] Guid targetId,
+        [FromServices] IGetPickImportSourcesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetPickImportSourcesQuery
+        {
+            UserId = HttpContext.GetCurrentUserId(),
+            TargetLeagueId = targetId
+        };
+
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Dry-run plan for importing the user's picks from the source league into this
+    /// target league. No writes.
+    /// </summary>
+    [HttpPost("preview")]
+    [Authorize]
+    public async Task<ActionResult<PickImportPreviewDto>> Preview(
+        [FromRoute] Guid targetId,
+        [FromBody] PickImportPreviewRequest request,
+        [FromServices] IGetPickImportPreviewQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetPickImportPreviewQuery
+        {
+            UserId = HttpContext.GetCurrentUserId(),
+            SourceLeagueId = request.SourceLeagueId,
+            TargetLeagueId = targetId
+        };
+
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+
+        return result.ToActionResult();
+    }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Planner/PickImportPlanner.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Planner/PickImportPlanner.cs
@@ -1,4 +1,4 @@
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Planner;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Planner;
 
 /// <summary>
 /// Pure, storage-agnostic classification core for cross-league pick import.

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Planner/PickImportPlanner.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Planner/PickImportPlanner.cs
@@ -1,0 +1,109 @@
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Planner;
+
+/// <summary>
+/// Pure, storage-agnostic classification core for cross-league pick import.
+/// Given the target league's matchups plus the user's source and existing-target
+/// selections, it classifies each target contest per the feature outcome table
+/// (import / no-op / collision / skip). Both the preview (dry-run) and the commit
+/// path build on this so their classification can never drift apart.
+/// See docs/features/pick-import-across-leagues.md.
+/// </summary>
+public interface IPickImportPlanner
+{
+    PickImportPlan BuildPlan(PickImportPlanInput input);
+}
+
+public class PickImportPlanner : IPickImportPlanner
+{
+    public PickImportPlan BuildPlan(PickImportPlanInput input)
+    {
+        var plan = new PickImportPlan();
+
+        foreach (var matchup in input.TargetMatchups)
+        {
+            // No source pick for this contest → nothing to copy.
+            if (!input.SourceSelectionsByContest.TryGetValue(matchup.ContestId, out var source))
+            {
+                plan.Skipped.Add(new PickImportPlannedSkip(
+                    matchup.ContestId, PickImportSkipReason.NotShared, matchup.Headline));
+                continue;
+            }
+
+            // Target matchup already locked/started → cannot pick it.
+            if (matchup.IsLocked)
+            {
+                plan.Skipped.Add(new PickImportPlannedSkip(
+                    matchup.ContestId, PickImportSkipReason.Locked, matchup.Headline));
+                continue;
+            }
+
+            if (input.ExistingTargetSelectionsByContest.TryGetValue(matchup.ContestId, out var existing))
+            {
+                if (existing == source.FranchiseSeasonId)
+                {
+                    // Already matches — silent no-op, surfaced only as informational.
+                    plan.Skipped.Add(new PickImportPlannedSkip(
+                        matchup.ContestId, PickImportSkipReason.AlreadyMatches, matchup.Headline));
+                }
+                else
+                {
+                    // Genuine conflict — user resolves keep/replace.
+                    plan.Collisions.Add(new PickImportPlannedCollision(
+                        matchup.ContestId, matchup.Week,
+                        source.FranchiseSeasonId, existing, source.SourcePickId,
+                        matchup.Headline, matchup.HomeSpread));
+                }
+            }
+            else
+            {
+                plan.ToImport.Add(new PickImportPlannedImport(
+                    matchup.ContestId, matchup.Week,
+                    source.FranchiseSeasonId, source.SourcePickId,
+                    matchup.Headline, matchup.HomeSpread));
+            }
+        }
+
+        return plan;
+    }
+}
+
+/// <summary>Inputs to <see cref="IPickImportPlanner.BuildPlan"/>, all in-memory.</summary>
+public sealed record PickImportPlanInput(
+    IReadOnlyCollection<PickImportTargetMatchup> TargetMatchups,
+    IReadOnlyDictionary<Guid, PickImportSourceSelection> SourceSelectionsByContest,
+    IReadOnlyDictionary<Guid, Guid> ExistingTargetSelectionsByContest);
+
+/// <summary>A target-league matchup that defines the import universe.</summary>
+public sealed record PickImportTargetMatchup(
+    Guid ContestId, int Week, bool IsLocked, string? Headline, double? HomeSpread);
+
+/// <summary>The user's source-league selection for a shared contest.</summary>
+public sealed record PickImportSourceSelection(Guid FranchiseSeasonId, Guid SourcePickId);
+
+public sealed class PickImportPlan
+{
+    public List<PickImportPlannedImport> ToImport { get; } = [];
+    public List<PickImportPlannedCollision> Collisions { get; } = [];
+    public List<PickImportPlannedSkip> Skipped { get; } = [];
+}
+
+public sealed record PickImportPlannedImport(
+    Guid ContestId, int Week, Guid FranchiseSeasonId, Guid SourcePickId, string? Headline, double? TargetHomeSpread);
+
+public sealed record PickImportPlannedCollision(
+    Guid ContestId, int Week, Guid SourceFranchiseSeasonId, Guid ExistingFranchiseSeasonId, Guid SourcePickId, string? Headline, double? TargetHomeSpread);
+
+public sealed record PickImportPlannedSkip(
+    Guid ContestId, PickImportSkipReason Reason, string? Headline);
+
+public enum PickImportSkipReason
+{
+    /// <summary>Target has no source pick for this contest (nothing to copy).</summary>
+    NotShared,
+
+    /// <summary>Target matchup has locked/started; cannot be picked.</summary>
+    Locked,
+
+    /// <summary>Existing target pick already equals the source selection.</summary>
+    AlreadyMatches
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQuery.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQuery.cs
@@ -1,4 +1,4 @@
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportPreview;
 
 public sealed class GetPickImportPreviewQuery
 {

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQuery.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQuery.cs
@@ -1,0 +1,10 @@
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
+
+public sealed class GetPickImportPreviewQuery
+{
+    public required Guid UserId { get; init; }
+
+    public required Guid SourceLeagueId { get; init; }
+
+    public required Guid TargetLeagueId { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
@@ -1,0 +1,181 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+using SportsData.Api.Application.UI.Leagues.PickImport.Planner;
+using SportsData.Api.Extensions;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
+
+public interface IGetPickImportPreviewQueryHandler
+{
+    Task<Result<PickImportPreviewDto>> ExecuteAsync(
+        GetPickImportPreviewQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Dry-run: classifies the target league's matchups against the user's source
+/// picks and existing target picks. No writes. See
+/// docs/features/pick-import-across-leagues.md.
+/// </summary>
+public class GetPickImportPreviewQueryHandler : IGetPickImportPreviewQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IPickImportPlanner _planner;
+    private readonly IDateTimeProvider _dateTime;
+
+    public GetPickImportPreviewQueryHandler(
+        AppDataContext dataContext,
+        IPickImportPlanner planner,
+        IDateTimeProvider dateTime)
+    {
+        _dataContext = dataContext;
+        _planner = planner;
+        _dateTime = dateTime;
+    }
+
+    public async Task<Result<PickImportPreviewDto>> ExecuteAsync(
+        GetPickImportPreviewQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        if (query.SourceLeagueId == query.TargetLeagueId)
+        {
+            return new Failure<PickImportPreviewDto>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(query.SourceLeagueId), "Source and target leagues must be different.")]);
+        }
+
+        // Membership-gate both leagues in one round-trip; also carries the group
+        // fields we need (pick type / confidence flag). Deactivated leagues are
+        // excluded so a wound-down league can't be a source or target.
+        var memberships = await _dataContext.PickemGroupMembers
+            .AsNoTracking()
+            .Where(m => m.UserId == query.UserId
+                        && m.Group.DeactivatedUtc == null
+                        && (m.PickemGroupId == query.SourceLeagueId || m.PickemGroupId == query.TargetLeagueId))
+            .Select(m => new
+            {
+                m.PickemGroupId,
+                m.Group.PickType,
+                m.Group.UseConfidencePoints
+            })
+            .ToListAsync(cancellationToken);
+
+        var target = memberships.FirstOrDefault(m => m.PickemGroupId == query.TargetLeagueId);
+        if (target is null)
+        {
+            return new Failure<PickImportPreviewDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(query.TargetLeagueId), "Target league not found or you are not a member.")]);
+        }
+
+        var source = memberships.FirstOrDefault(m => m.PickemGroupId == query.SourceLeagueId);
+        if (source is null)
+        {
+            return new Failure<PickImportPreviewDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(query.SourceLeagueId), "Source league not found or you are not a member.")]);
+        }
+
+        if (source.PickType != target.PickType)
+        {
+            return new Failure<PickImportPreviewDto>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(query.SourceLeagueId), "Source and target leagues must be the same pick type.")]);
+        }
+
+        var nowUtc = _dateTime.UtcNow();
+
+        // The target league's matchups define the universe.
+        var targetMatchups = await _dataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => m.GroupId == query.TargetLeagueId)
+            .ToListAsync(cancellationToken);
+
+        var contestIds = targetMatchups.Select(m => m.ContestId).ToList();
+
+        // The user's source-league selections for those shared contests (team picks only).
+        var sourceSelections = await _dataContext.UserPicks
+            .AsNoTracking()
+            .Where(p => p.UserId == query.UserId
+                        && p.PickemGroupId == query.SourceLeagueId
+                        && p.FranchiseSeasonId != null
+                        && contestIds.Contains(p.ContestId))
+            .Select(p => new { p.ContestId, FranchiseSeasonId = p.FranchiseSeasonId!.Value, PickId = p.Id })
+            .ToListAsync(cancellationToken);
+
+        // The user's existing target-league selections for those contests (team picks only).
+        var existingTargetSelections = await _dataContext.UserPicks
+            .AsNoTracking()
+            .Where(p => p.UserId == query.UserId
+                        && p.PickemGroupId == query.TargetLeagueId
+                        && p.FranchiseSeasonId != null
+                        && contestIds.Contains(p.ContestId))
+            .Select(p => new { p.ContestId, FranchiseSeasonId = p.FranchiseSeasonId!.Value })
+            .ToListAsync(cancellationToken);
+
+        var input = new PickImportPlanInput(
+            targetMatchups
+                .Select(m => new PickImportTargetMatchup(
+                    m.ContestId,
+                    m.SeasonWeek,
+                    m.IsLocked(nowUtc),
+                    m.Headline,
+                    m.HomeSpread))
+                .ToList(),
+            sourceSelections
+                .GroupBy(s => s.ContestId)
+                .ToDictionary(g => g.Key, g => new PickImportSourceSelection(g.First().FranchiseSeasonId, g.First().PickId)),
+            existingTargetSelections
+                .GroupBy(s => s.ContestId)
+                .ToDictionary(g => g.Key, g => g.First().FranchiseSeasonId));
+
+        var plan = _planner.BuildPlan(input);
+
+        var dto = new PickImportPreviewDto
+        {
+            SourceLeagueId = query.SourceLeagueId,
+            TargetLeagueId = query.TargetLeagueId,
+            TargetUsesConfidencePoints = target.UseConfidencePoints,
+            ToImport = plan.ToImport
+                .Select(i => new PickImportPreviewItemDto
+                {
+                    ContestId = i.ContestId,
+                    Week = i.Week,
+                    FranchiseSeasonId = i.FranchiseSeasonId,
+                    Headline = i.Headline,
+                    TargetHomeSpread = i.TargetHomeSpread
+                })
+                .ToList(),
+            Collisions = plan.Collisions
+                .Select(c => new PickImportPreviewCollisionDto
+                {
+                    ContestId = c.ContestId,
+                    Week = c.Week,
+                    SourceFranchiseSeasonId = c.SourceFranchiseSeasonId,
+                    ExistingFranchiseSeasonId = c.ExistingFranchiseSeasonId,
+                    Headline = c.Headline,
+                    TargetHomeSpread = c.TargetHomeSpread
+                })
+                .ToList(),
+            Skipped = plan.Skipped
+                .Select(s => new PickImportPreviewSkippedDto
+                {
+                    ContestId = s.ContestId,
+                    Reason = s.Reason.ToString(),
+                    Headline = s.Headline
+                })
+                .ToList()
+        };
+
+        return new Success<PickImportPreviewDto>(dto);
+    }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
@@ -94,10 +94,20 @@ public class GetPickImportPreviewQueryHandler : IGetPickImportPreviewQueryHandle
 
         var nowUtc = _dateTime.UtcNow();
 
-        // The target league's matchups define the universe.
+        // The target league's matchups define the universe. Project only the
+        // fields the plan needs (lock state derives from StartDateUtc) rather
+        // than materializing the full ~30-column entity.
         var targetMatchups = await _dataContext.PickemGroupMatchups
             .AsNoTracking()
             .Where(m => m.GroupId == query.TargetLeagueId)
+            .Select(m => new
+            {
+                m.ContestId,
+                m.SeasonWeek,
+                m.StartDateUtc,
+                m.Headline,
+                m.HomeSpread
+            })
             .ToListAsync(cancellationToken);
 
         var contestIds = targetMatchups.Select(m => m.ContestId).ToList();
@@ -127,7 +137,7 @@ public class GetPickImportPreviewQueryHandler : IGetPickImportPreviewQueryHandle
                 .Select(m => new PickImportTargetMatchup(
                     m.ContestId,
                     m.SeasonWeek,
-                    m.IsLocked(nowUtc),
+                    PickemGroupMatchupExtensions.IsStartLocked(m.StartDateUtc, nowUtc),
                     m.Headline,
                     m.HomeSpread))
                 .ToList(),

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
@@ -2,13 +2,13 @@ using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
 
-using SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
-using SportsData.Api.Application.UI.Leagues.PickImport.Planner;
+using SportsData.Api.Application.UI.Picks.PickImport.Dtos;
+using SportsData.Api.Application.UI.Picks.PickImport.Planner;
 using SportsData.Api.Extensions;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Common;
 
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportPreview;
 
 public interface IGetPickImportPreviewQueryHandler
 {

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQuery.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQuery.cs
@@ -1,0 +1,8 @@
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+
+public sealed class GetPickImportSourcesQuery
+{
+    public required Guid UserId { get; init; }
+
+    public required Guid TargetLeagueId { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQuery.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQuery.cs
@@ -1,4 +1,4 @@
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportSources;
 
 public sealed class GetPickImportSourcesQuery
 {

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQueryHandler.cs
@@ -2,11 +2,11 @@ using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
 
-using SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+using SportsData.Api.Application.UI.Picks.PickImport.Dtos;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Common;
 
-namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+namespace SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportSources;
 
 public interface IGetPickImportSourcesQueryHandler
 {

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportSources/GetPickImportSourcesQueryHandler.cs
@@ -1,0 +1,113 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.UI.Leagues.PickImport.Dtos;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+
+public interface IGetPickImportSourcesQueryHandler
+{
+    Task<Result<List<PickImportSourceDto>>> ExecuteAsync(
+        GetPickImportSourcesQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Lists the user's other active same-type leagues that share at least one contest
+/// with the target — the candidates for the import source picker.
+/// See docs/features/pick-import-across-leagues.md.
+/// </summary>
+public class GetPickImportSourcesQueryHandler : IGetPickImportSourcesQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+
+    public GetPickImportSourcesQueryHandler(AppDataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<List<PickImportSourceDto>>> ExecuteAsync(
+        GetPickImportSourcesQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        // The target must exist and the caller must be a member of it.
+        var target = await _dataContext.PickemGroupMembers
+            .AsNoTracking()
+            .Where(m => m.UserId == query.UserId
+                        && m.PickemGroupId == query.TargetLeagueId
+                        && m.Group.DeactivatedUtc == null)
+            .Select(m => new { m.Group.PickType })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (target is null)
+        {
+            return new Failure<List<PickImportSourceDto>>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(query.TargetLeagueId), "Target league not found or you are not a member.")]);
+        }
+
+        // Candidate sources: the user's other active leagues of the same pick type.
+        var candidates = await _dataContext.PickemGroupMembers
+            .AsNoTracking()
+            .Where(m => m.UserId == query.UserId
+                        && m.PickemGroupId != query.TargetLeagueId
+                        && m.Group.DeactivatedUtc == null
+                        && m.Group.PickType == target.PickType)
+            .Select(m => new
+            {
+                m.PickemGroupId,
+                m.Group.Name,
+                m.Group.Sport,
+                m.Group.PickType,
+                m.Group.UseConfidencePoints,
+                MemberCount = m.Group.Members.Count
+            })
+            .ToListAsync(cancellationToken);
+
+        if (candidates.Count == 0)
+        {
+            return new Success<List<PickImportSourceDto>>([]);
+        }
+
+        var candidateIds = candidates.Select(c => c.PickemGroupId).ToList();
+
+        var targetContestIds = await _dataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => m.GroupId == query.TargetLeagueId)
+            .Select(m => m.ContestId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        // Count shared contests per candidate against the target's contest set.
+        var sharedCounts = await _dataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => candidateIds.Contains(m.GroupId) && targetContestIds.Contains(m.ContestId))
+            .GroupBy(m => m.GroupId)
+            .Select(g => new { GroupId = g.Key, Count = g.Select(m => m.ContestId).Distinct().Count() })
+            .ToListAsync(cancellationToken);
+
+        var sharedByGroup = sharedCounts.ToDictionary(x => x.GroupId, x => x.Count);
+
+        var sources = candidates
+            .Where(c => sharedByGroup.ContainsKey(c.PickemGroupId))
+            .Select(c => new PickImportSourceDto
+            {
+                LeagueId = c.PickemGroupId,
+                Name = c.Name,
+                Sport = c.Sport.ToString(),
+                PickType = c.PickType.ToString(),
+                UseConfidencePoints = c.UseConfidencePoints,
+                SharedContestCount = sharedByGroup[c.PickemGroupId],
+                MemberCount = c.MemberCount
+            })
+            .OrderByDescending(s => s.SharedContestCount)
+            .ThenBy(s => s.Name)
+            .ToList();
+
+        return new Success<List<PickImportSourceDto>>(sources);
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -132,14 +132,14 @@ namespace SportsData.Api.DependencyInjection
 
             // Pick Import (cross-league)
             services.AddScoped<
-                Application.UI.Leagues.PickImport.Planner.IPickImportPlanner,
-                Application.UI.Leagues.PickImport.Planner.PickImportPlanner>();
+                Application.UI.Picks.PickImport.Planner.IPickImportPlanner,
+                Application.UI.Picks.PickImport.Planner.PickImportPlanner>();
             services.AddScoped<
-                Application.UI.Leagues.PickImport.Queries.GetPickImportPreview.IGetPickImportPreviewQueryHandler,
-                Application.UI.Leagues.PickImport.Queries.GetPickImportPreview.GetPickImportPreviewQueryHandler>();
+                Application.UI.Picks.PickImport.Queries.GetPickImportPreview.IGetPickImportPreviewQueryHandler,
+                Application.UI.Picks.PickImport.Queries.GetPickImportPreview.GetPickImportPreviewQueryHandler>();
             services.AddScoped<
-                Application.UI.Leagues.PickImport.Queries.GetPickImportSources.IGetPickImportSourcesQueryHandler,
-                Application.UI.Leagues.PickImport.Queries.GetPickImportSources.GetPickImportSourcesQueryHandler>();
+                Application.UI.Picks.PickImport.Queries.GetPickImportSources.IGetPickImportSourcesQueryHandler,
+                Application.UI.Picks.PickImport.Queries.GetPickImportSources.GetPickImportSourcesQueryHandler>();
 
             // Public Results Queries
             services.AddScoped<

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -130,6 +130,17 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetPublicLeaguesQueryHandler, GetPublicLeaguesQueryHandler>();
             services.AddScoped<IGetUserLeaguesQueryHandler, GetUserLeaguesQueryHandler>();
 
+            // Pick Import (cross-league)
+            services.AddScoped<
+                Application.UI.Leagues.PickImport.Planner.IPickImportPlanner,
+                Application.UI.Leagues.PickImport.Planner.PickImportPlanner>();
+            services.AddScoped<
+                Application.UI.Leagues.PickImport.Queries.GetPickImportPreview.IGetPickImportPreviewQueryHandler,
+                Application.UI.Leagues.PickImport.Queries.GetPickImportPreview.GetPickImportPreviewQueryHandler>();
+            services.AddScoped<
+                Application.UI.Leagues.PickImport.Queries.GetPickImportSources.IGetPickImportSourcesQueryHandler,
+                Application.UI.Leagues.PickImport.Queries.GetPickImportSources.GetPickImportSourcesQueryHandler>();
+
             // Public Results Queries
             services.AddScoped<
                 SportsData.Api.Application.UI.Results.Queries.GetSeasonResults.IGetSeasonResultsQueryHandler,

--- a/src/SportsData.Api/Extensions/PickemGroupMatchupExtensions.cs
+++ b/src/SportsData.Api/Extensions/PickemGroupMatchupExtensions.cs
@@ -5,11 +5,19 @@ namespace SportsData.Api.Extensions
     public static class PickemGroupMatchupExtensions
     {
         public static bool IsLocked(this PickemGroupMatchup matchup, DateTime? nowUtc = null)
+            => IsStartLocked(matchup.StartDateUtc, nowUtc);
+
+        /// <summary>
+        /// Core lock rule, expressed over a raw start time so read queries can
+        /// project just <c>StartDateUtc</c> instead of materializing the full
+        /// entity. <see cref="IsLocked(PickemGroupMatchup, DateTime?)"/> delegates here.
+        /// </summary>
+        public static bool IsStartLocked(DateTime startDateUtc, DateTime? nowUtc = null)
         {
             var referenceTime = nowUtc ?? DateTime.UtcNow;
 
             // Lock the matchup if it starts within 5 minutes or already started
-            return matchup.StartDateUtc <= referenceTime.AddMinutes(5);
+            return startDateUtc <= referenceTime.AddMinutes(5);
         }
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
@@ -252,4 +252,23 @@ public class GetPickImportPreviewQueryHandlerTests : ApiTestBase<GetPickImportPr
         result.IsSuccess.Should().BeFalse();
         result.Status.Should().Be(ResultStatus.NotFound);
     }
+
+    [Fact]
+    public async Task ExcludesDeactivatedSourceLeague()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp, deactivated: true);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportPreviewQuery
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
@@ -1,0 +1,255 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Leagues.PickImport.Planner;
+using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.PickImport;
+
+public class GetPickImportPreviewQueryHandlerTests : ApiTestBase<GetPickImportPreviewQueryHandler>
+{
+    private static readonly DateTime NowUtc = new(2026, 7, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    private GetPickImportPreviewQueryHandler CreateHandler()
+    {
+        var dateTime = new Mock<IDateTimeProvider>();
+        dateTime.Setup(x => x.UtcNow()).Returns(NowUtc);
+        return new GetPickImportPreviewQueryHandler(DataContext, new PickImportPlanner(), dateTime.Object);
+    }
+
+    private Guid SeedLeague(Guid userId, PickType pickType, bool useConfidence = false, bool deactivated = false)
+    {
+        var groupId = Guid.NewGuid();
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = groupId,
+            Name = "League " + groupId.ToString()[..4],
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            PickType = pickType,
+            UseConfidencePoints = useConfidence,
+            DeactivatedUtc = deactivated ? NowUtc : null,
+            CommissionerUserId = userId
+        });
+        DataContext.PickemGroupMembers.Add(new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = groupId,
+            UserId = userId,
+            Role = LeagueRole.Member
+        });
+        return groupId;
+    }
+
+    private void SeedMatchup(Guid groupId, Guid contestId, DateTime startUtc, int week = 1)
+    {
+        DataContext.PickemGroupMatchups.Add(new PickemGroupMatchup
+        {
+            GroupId = groupId,
+            SeasonWeekId = Guid.NewGuid(),
+            ContestId = contestId,
+            StartDateUtc = startUtc,
+            SeasonYear = 2026,
+            SeasonWeek = week,
+            Headline = "Away @ Home",
+            HomeSpread = -3.5
+        });
+    }
+
+    private void SeedPick(Guid groupId, Guid userId, Guid contestId, Guid? franchiseSeasonId, PickType pickType = PickType.StraightUp)
+    {
+        DataContext.UserPicks.Add(new PickemGroupUserPick
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = groupId,
+            UserId = userId,
+            ContestId = contestId,
+            Week = 1,
+            PickType = pickType,
+            FranchiseSeasonId = franchiseSeasonId,
+            TiebreakerType = TiebreakerType.TotalPoints
+        });
+    }
+
+    [Fact]
+    public async Task ReturnsValidation_WhenSourceEqualsTarget()
+    {
+        var leagueId = Guid.NewGuid();
+        var query = new GetPickImportPreviewQuery
+        {
+            UserId = Guid.NewGuid(),
+            SourceLeagueId = leagueId,
+            TargetLeagueId = leagueId
+        };
+
+        var result = await CreateHandler().ExecuteAsync(query);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenNotMemberOfTarget()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        await DataContext.SaveChangesAsync();
+
+        var query = new GetPickImportPreviewQuery
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = Guid.NewGuid() // not a member
+        };
+
+        var result = await CreateHandler().ExecuteAsync(query);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenNotMemberOfSource()
+    {
+        var userId = Guid.NewGuid();
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+        await DataContext.SaveChangesAsync();
+
+        var query = new GetPickImportPreviewQuery
+        {
+            UserId = userId,
+            SourceLeagueId = Guid.NewGuid(), // not a member
+            TargetLeagueId = targetId
+        };
+
+        var result = await CreateHandler().ExecuteAsync(query);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ReturnsValidation_WhenPickTypesDiffer()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.AgainstTheSpread);
+        await DataContext.SaveChangesAsync();
+
+        var query = new GetPickImportPreviewQuery
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        };
+
+        var result = await CreateHandler().ExecuteAsync(query);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task ClassifiesImportCollisionAndSkips_ForSharedContests()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var importContest = Guid.NewGuid();
+        var collisionContest = Guid.NewGuid();
+        var matchesContest = Guid.NewGuid();
+        var lockedContest = Guid.NewGuid();
+        var notSharedContest = Guid.NewGuid();
+
+        var teamA = Guid.NewGuid();
+        var teamB = Guid.NewGuid();
+
+        var future = NowUtc.AddDays(1);
+        var past = NowUtc.AddDays(-1);
+
+        // Target universe
+        SeedMatchup(targetId, importContest, future);
+        SeedMatchup(targetId, collisionContest, future);
+        SeedMatchup(targetId, matchesContest, future);
+        SeedMatchup(targetId, lockedContest, past);
+        SeedMatchup(targetId, notSharedContest, future);
+
+        // Source picks
+        SeedPick(sourceId, userId, importContest, teamA);
+        SeedPick(sourceId, userId, collisionContest, teamA);
+        SeedPick(sourceId, userId, matchesContest, teamA);
+        SeedPick(sourceId, userId, lockedContest, teamA);
+        // note: no source pick for notSharedContest
+
+        // Existing target picks
+        SeedPick(targetId, userId, collisionContest, teamB); // differs → collision
+        SeedPick(targetId, userId, matchesContest, teamA);   // matches → skip
+
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportPreviewQuery
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        var dto = result.Value;
+
+        dto.ToImport.Should().ContainSingle(i => i.ContestId == importContest && i.FranchiseSeasonId == teamA);
+        dto.Collisions.Should().ContainSingle(c =>
+            c.ContestId == collisionContest &&
+            c.SourceFranchiseSeasonId == teamA &&
+            c.ExistingFranchiseSeasonId == teamB);
+        dto.Skipped.Should().Contain(s => s.ContestId == matchesContest && s.Reason == nameof(PickImportSkipReason.AlreadyMatches));
+        dto.Skipped.Should().Contain(s => s.ContestId == lockedContest && s.Reason == nameof(PickImportSkipReason.Locked));
+        dto.Skipped.Should().Contain(s => s.ContestId == notSharedContest && s.Reason == nameof(PickImportSkipReason.NotShared));
+        dto.TargetUsesConfidencePoints.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetsTargetUsesConfidencePoints_WhenTargetIsConfidenceLeague()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp, useConfidence: true);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportPreviewQuery
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TargetUsesConfidencePoints.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExcludesDeactivatedTargetLeague()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp, deactivated: true);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportPreviewQuery
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
@@ -3,14 +3,14 @@ using FluentAssertions;
 using Moq;
 
 using SportsData.Api.Application.Common.Enums;
-using SportsData.Api.Application.UI.Leagues.PickImport.Planner;
-using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportPreview;
+using SportsData.Api.Application.UI.Picks.PickImport.Planner;
+using SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportPreview;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 
 using Xunit;
 
-namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.PickImport;
+namespace SportsData.Api.Tests.Unit.Application.UI.Picks.PickImport;
 
 public class GetPickImportPreviewQueryHandlerTests : ApiTestBase<GetPickImportPreviewQueryHandler>
 {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportSourcesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportSourcesQueryHandlerTests.cs
@@ -1,13 +1,13 @@
 using FluentAssertions;
 
 using SportsData.Api.Application.Common.Enums;
-using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+using SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportSources;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 
 using Xunit;
 
-namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.PickImport;
+namespace SportsData.Api.Tests.Unit.Application.UI.Picks.PickImport;
 
 public class GetPickImportSourcesQueryHandlerTests : ApiTestBase<GetPickImportSourcesQueryHandler>
 {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportSourcesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportSourcesQueryHandlerTests.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Leagues.PickImport.Queries.GetPickImportSources;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.PickImport;
+
+public class GetPickImportSourcesQueryHandlerTests : ApiTestBase<GetPickImportSourcesQueryHandler>
+{
+    private GetPickImportSourcesQueryHandler CreateHandler() => new(DataContext);
+
+    private Guid SeedLeague(Guid userId, PickType pickType, bool member = true, bool deactivated = false, string name = "League")
+    {
+        var groupId = Guid.NewGuid();
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = groupId,
+            Name = name,
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            PickType = pickType,
+            DeactivatedUtc = deactivated ? new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) : null,
+            CommissionerUserId = userId
+        });
+        if (member)
+        {
+            DataContext.PickemGroupMembers.Add(new PickemGroupMember
+            {
+                Id = Guid.NewGuid(),
+                PickemGroupId = groupId,
+                UserId = userId,
+                Role = LeagueRole.Member
+            });
+        }
+        return groupId;
+    }
+
+    private void SeedMatchup(Guid groupId, Guid contestId)
+    {
+        DataContext.PickemGroupMatchups.Add(new PickemGroupMatchup
+        {
+            GroupId = groupId,
+            SeasonWeekId = Guid.NewGuid(),
+            ContestId = contestId,
+            StartDateUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            SeasonYear = 2026,
+            SeasonWeek = 1,
+            Headline = "Away @ Home"
+        });
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenNotMemberOfTarget()
+    {
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportSourcesQuery
+        {
+            UserId = Guid.NewGuid(),
+            TargetLeagueId = Guid.NewGuid()
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ReturnsSameTypeSourcesSharingContests_WithSharedCount()
+    {
+        var userId = Guid.NewGuid();
+        var sharedA = Guid.NewGuid();
+        var sharedB = Guid.NewGuid();
+
+        var targetId = SeedLeague(userId, PickType.StraightUp, name: "Target");
+        SeedMatchup(targetId, sharedA);
+        SeedMatchup(targetId, sharedB);
+
+        // Same-type source sharing both contests.
+        var goodSource = SeedLeague(userId, PickType.StraightUp, name: "Good");
+        SeedMatchup(goodSource, sharedA);
+        SeedMatchup(goodSource, sharedB);
+        SeedMatchup(goodSource, Guid.NewGuid()); // extra, non-shared
+
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportSourcesQuery
+        {
+            UserId = userId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+        result.Value[0].LeagueId.Should().Be(goodSource);
+        result.Value[0].SharedContestCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ExcludesDifferentPickTypeSources()
+    {
+        var userId = Guid.NewGuid();
+        var shared = Guid.NewGuid();
+
+        var targetId = SeedLeague(userId, PickType.StraightUp, name: "Target");
+        SeedMatchup(targetId, shared);
+
+        var atsSource = SeedLeague(userId, PickType.AgainstTheSpread, name: "ATS");
+        SeedMatchup(atsSource, shared);
+
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportSourcesQuery
+        {
+            UserId = userId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExcludesSameTypeSourcesWithNoSharedContest()
+    {
+        var userId = Guid.NewGuid();
+
+        var targetId = SeedLeague(userId, PickType.StraightUp, name: "Target");
+        SeedMatchup(targetId, Guid.NewGuid());
+
+        var disjointSource = SeedLeague(userId, PickType.StraightUp, name: "Disjoint");
+        SeedMatchup(disjointSource, Guid.NewGuid()); // different contest
+
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportSourcesQuery
+        {
+            UserId = userId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExcludesLeaguesTheUserIsNotAMemberOf()
+    {
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var shared = Guid.NewGuid();
+
+        var targetId = SeedLeague(userId, PickType.StraightUp, name: "Target");
+        SeedMatchup(targetId, shared);
+
+        // Same-type league sharing a contest, but the user is NOT a member.
+        var foreignSource = SeedLeague(otherUserId, PickType.StraightUp, member: false, name: "Foreign");
+        DataContext.PickemGroupMembers.Add(new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = foreignSource,
+            UserId = otherUserId,
+            Role = LeagueRole.Member
+        });
+        SeedMatchup(foreignSource, shared);
+
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportSourcesQuery
+        {
+            UserId = userId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExcludesDeactivatedSourceLeagues()
+    {
+        var userId = Guid.NewGuid();
+        var shared = Guid.NewGuid();
+
+        var targetId = SeedLeague(userId, PickType.StraightUp, name: "Target");
+        SeedMatchup(targetId, shared);
+
+        var deadSource = SeedLeague(userId, PickType.StraightUp, deactivated: true, name: "Dead");
+        SeedMatchup(deadSource, shared);
+
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetPickImportSourcesQuery
+        {
+            UserId = userId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/PickImportPlannerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/PickImportPlannerTests.cs
@@ -1,10 +1,10 @@
 using FluentAssertions;
 
-using SportsData.Api.Application.UI.Leagues.PickImport.Planner;
+using SportsData.Api.Application.UI.Picks.PickImport.Planner;
 
 using Xunit;
 
-namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.PickImport;
+namespace SportsData.Api.Tests.Unit.Application.UI.Picks.PickImport;
 
 public class PickImportPlannerTests
 {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/PickImportPlannerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/PickImportPlannerTests.cs
@@ -1,0 +1,157 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.UI.Leagues.PickImport.Planner;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.PickImport;
+
+public class PickImportPlannerTests
+{
+    private readonly PickImportPlanner _planner = new();
+
+    private static PickImportTargetMatchup Matchup(Guid contestId, bool isLocked = false, int week = 1) =>
+        new(contestId, week, isLocked, Headline: "Away @ Home", HomeSpread: -3.5);
+
+    private static PickImportPlanInput Input(
+        IReadOnlyCollection<PickImportTargetMatchup> matchups,
+        IReadOnlyDictionary<Guid, PickImportSourceSelection> source,
+        IReadOnlyDictionary<Guid, Guid> existing) =>
+        new(matchups, source, existing);
+
+    [Fact]
+    public void BuildPlan_ImportsSourceSelection_WhenNoExistingTargetPick()
+    {
+        var contestId = Guid.NewGuid();
+        var team = Guid.NewGuid();
+        var sourcePickId = Guid.NewGuid();
+
+        var plan = _planner.BuildPlan(Input(
+            [Matchup(contestId)],
+            new Dictionary<Guid, PickImportSourceSelection> { [contestId] = new(team, sourcePickId) },
+            new Dictionary<Guid, Guid>()));
+
+        plan.ToImport.Should().ContainSingle();
+        plan.ToImport[0].ContestId.Should().Be(contestId);
+        plan.ToImport[0].FranchiseSeasonId.Should().Be(team);
+        plan.ToImport[0].SourcePickId.Should().Be(sourcePickId);
+        plan.Collisions.Should().BeEmpty();
+        plan.Skipped.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlan_SkipsAsAlreadyMatches_WhenExistingEqualsSource()
+    {
+        var contestId = Guid.NewGuid();
+        var team = Guid.NewGuid();
+
+        var plan = _planner.BuildPlan(Input(
+            [Matchup(contestId)],
+            new Dictionary<Guid, PickImportSourceSelection> { [contestId] = new(team, Guid.NewGuid()) },
+            new Dictionary<Guid, Guid> { [contestId] = team }));
+
+        plan.Skipped.Should().ContainSingle();
+        plan.Skipped[0].Reason.Should().Be(PickImportSkipReason.AlreadyMatches);
+        plan.ToImport.Should().BeEmpty();
+        plan.Collisions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlan_RecordsCollision_WhenExistingDiffersFromSource()
+    {
+        var contestId = Guid.NewGuid();
+        var sourceTeam = Guid.NewGuid();
+        var existingTeam = Guid.NewGuid();
+        var sourcePickId = Guid.NewGuid();
+
+        var plan = _planner.BuildPlan(Input(
+            [Matchup(contestId)],
+            new Dictionary<Guid, PickImportSourceSelection> { [contestId] = new(sourceTeam, sourcePickId) },
+            new Dictionary<Guid, Guid> { [contestId] = existingTeam }));
+
+        plan.Collisions.Should().ContainSingle();
+        plan.Collisions[0].SourceFranchiseSeasonId.Should().Be(sourceTeam);
+        plan.Collisions[0].ExistingFranchiseSeasonId.Should().Be(existingTeam);
+        plan.Collisions[0].SourcePickId.Should().Be(sourcePickId);
+        plan.ToImport.Should().BeEmpty();
+        plan.Skipped.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlan_SkipsAsNotShared_WhenNoSourcePick()
+    {
+        var contestId = Guid.NewGuid();
+
+        var plan = _planner.BuildPlan(Input(
+            [Matchup(contestId)],
+            new Dictionary<Guid, PickImportSourceSelection>(),
+            new Dictionary<Guid, Guid>()));
+
+        plan.Skipped.Should().ContainSingle();
+        plan.Skipped[0].Reason.Should().Be(PickImportSkipReason.NotShared);
+        plan.ToImport.Should().BeEmpty();
+        plan.Collisions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlan_SkipsAsLocked_WhenTargetMatchupLocked()
+    {
+        var contestId = Guid.NewGuid();
+        var team = Guid.NewGuid();
+
+        var plan = _planner.BuildPlan(Input(
+            [Matchup(contestId, isLocked: true)],
+            new Dictionary<Guid, PickImportSourceSelection> { [contestId] = new(team, Guid.NewGuid()) },
+            new Dictionary<Guid, Guid>()));
+
+        plan.Skipped.Should().ContainSingle();
+        plan.Skipped[0].Reason.Should().Be(PickImportSkipReason.Locked);
+        plan.ToImport.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlan_LockedTakesPrecedenceOverCollision()
+    {
+        // A locked target matchup is skipped even when the user has a differing
+        // existing pick — it can't be changed, so it's never a collision to resolve.
+        var contestId = Guid.NewGuid();
+
+        var plan = _planner.BuildPlan(Input(
+            [Matchup(contestId, isLocked: true)],
+            new Dictionary<Guid, PickImportSourceSelection> { [contestId] = new(Guid.NewGuid(), Guid.NewGuid()) },
+            new Dictionary<Guid, Guid> { [contestId] = Guid.NewGuid() }));
+
+        plan.Skipped.Should().ContainSingle();
+        plan.Skipped[0].Reason.Should().Be(PickImportSkipReason.Locked);
+        plan.Collisions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPlan_ClassifiesEachContestIndependently()
+    {
+        var toImport = Guid.NewGuid();
+        var matches = Guid.NewGuid();
+        var collides = Guid.NewGuid();
+        var notShared = Guid.NewGuid();
+        var team = Guid.NewGuid();
+
+        var plan = _planner.BuildPlan(Input(
+            [Matchup(toImport), Matchup(matches), Matchup(collides), Matchup(notShared)],
+            new Dictionary<Guid, PickImportSourceSelection>
+            {
+                [toImport] = new(team, Guid.NewGuid()),
+                [matches] = new(team, Guid.NewGuid()),
+                [collides] = new(team, Guid.NewGuid())
+            },
+            new Dictionary<Guid, Guid>
+            {
+                [matches] = team,
+                [collides] = Guid.NewGuid()
+            }));
+
+        plan.ToImport.Should().ContainSingle(i => i.ContestId == toImport);
+        plan.Collisions.Should().ContainSingle(c => c.ContestId == collides);
+        plan.Skipped.Should().Contain(s => s.ContestId == matches && s.Reason == PickImportSkipReason.AlreadyMatches);
+        plan.Skipped.Should().Contain(s => s.ContestId == notShared && s.Reason == PickImportSkipReason.NotShared);
+    }
+}


### PR DESCRIPTION
## What

First slice of **import picks from one league into another** (`docs/features/pick-import-across-leagues.md`). This PR is the **read-only** half of v1: the source picker and the dry-run preview. **No writes, no migration.**

## Endpoints

- `GET  /ui/leagues/{targetId}/picks/import/sources` — the user's other active **same-type** leagues that share ≥1 contest with the target, with a shared-contest count (backs the source picker).
- `POST /ui/leagues/{targetId}/picks/import/preview` — dry-run plan `{ toImport[], collisions[], skipped[] }` plus `TargetUsesConfidencePoints` so the FE knows to route a confidence target through the pick sheet.

Both are `[Authorize]`, membership-gated on **source and target**, reject `source == target`, require matching `PickType` (SU/ATS), and exclude deactivated leagues.

## Design

- **`PickImportPlanner`** — a pure, storage-agnostic classification core implementing the feature's outcome table (import / already-matches no-op / collision / skip+reason). Both the preview and the later commit path build on it so their classification can never drift apart.
- The target league's matchups define the universe; per contest we look up the user's source pick and existing target pick and classify. Lock state reuses `PickemGroupMatchupExtensions.IsLocked` with an injected `IDateTimeProvider` (deterministic tests).
- Code lives under `Application/UI/Picks/PickImport/`; the **routes stay league-scoped** per the design doc.

## Scope / deferred

Per the agreed two-PR split, the **writes** land next: the `POST …/picks/import` commit endpoint, `ImportedFromPickId` plumbing on `SubmitPickCommand`, and confidence-required-at-save enforcement. That PR branches off this one.

## Tests

20 added:
- `PickImportPlannerTests` — every outcome-table branch, locked-beats-collision precedence, independent per-contest classification.
- `GetPickImportPreviewQueryHandlerTests` — `source==target`, both membership gates, pick-type mismatch, deactivated exclusion, confidence flag, full mixed happy-path.
- `GetPickImportSourcesQueryHandlerTests` — same-type filter, shared-count, no-shared/non-member/deactivated exclusions.

Full `SportsData.Api.Tests.Unit` suite green (**509 passed**); API builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-league pick import UI with endpoints to list eligible source leagues and generate a dry-run preview.
  * Preview shows contests to import, potential collisions, and skipped contests with skip reasons.
  * Preview flags whether confidence-point handling applies for the target league.
* **Validation**
  * Added checks for matching source/target leagues, compatible pick types, membership and active league eligibility, and handling of locked contests.
* **Tests**
  * Added unit tests covering sources listing, preview planning (imports/collisions/skips), and validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->