### PR TITLE
feat(picks): cross-league pick import — commit endpoint (v1 writes)

### DIFF
--- a/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommand.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommand.cs
@@ -27,4 +27,12 @@ public class SubmitPickCommand
     public int? TiebreakerGuessHome { get; set; }
 
     public int? TiebreakerGuessAway { get; set; }
+
+    /// <summary>
+    /// When this pick was created/updated by importing from another league, the
+    /// id of the source <see cref="Infrastructure.Data.Entities.PickemGroupUserPick"/>
+    /// it was copied from. Null for hand-made picks. Enables import traceability
+    /// and idempotent re-runs. See docs/features/pick-import-across-leagues.md.
+    /// </summary>
+    public Guid? ImportedFromPickId { get; set; }
 }

--- a/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
@@ -96,6 +96,7 @@ public class SubmitPickCommandHandler : ISubmitPickCommandHandler
             existing.TiebreakerGuessTotal = command.TiebreakerGuessTotal;
             existing.TiebreakerGuessHome = command.TiebreakerGuessHome;
             existing.TiebreakerGuessAway = command.TiebreakerGuessAway;
+            existing.ImportedFromPickId = command.ImportedFromPickId;
         }
         else
         {
@@ -115,6 +116,8 @@ public class SubmitPickCommandHandler : ISubmitPickCommandHandler
                 TiebreakerGuessTotal = command.TiebreakerGuessTotal,
                 TiebreakerGuessHome = command.TiebreakerGuessHome,
                 TiebreakerGuessAway = command.TiebreakerGuessAway,
+
+                ImportedFromPickId = command.ImportedFromPickId,
 
                 TiebreakerType = TiebreakerType.TotalPoints
             };

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommand.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommand.cs
@@ -1,0 +1,13 @@
+namespace SportsData.Api.Application.UI.Picks.PickImport.Commands.ImportPicks;
+
+public sealed class ImportPicksCommand
+{
+    public required Guid UserId { get; init; }
+
+    public required Guid SourceLeagueId { get; init; }
+
+    public required Guid TargetLeagueId { get; init; }
+
+    /// <summary>Contest ids for collisions the user chose to replace with the source pick.</summary>
+    public IReadOnlyCollection<Guid> ReplaceContestIds { get; init; } = [];
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
@@ -1,0 +1,152 @@
+using FluentValidation.Results;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Picks.Commands.SubmitPick;
+using SportsData.Api.Application.UI.Picks.PickImport.Dtos;
+using SportsData.Api.Application.UI.Picks.PickImport.Planner;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.UI.Picks.PickImport.Commands.ImportPicks;
+
+public interface IImportPicksCommandHandler
+{
+    Task<Result<PickImportResultDto>> ExecuteAsync(
+        ImportPicksCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Commits a cross-league pick import into a non-confidence target: re-plans
+/// server-side (never trusts the client's classification), then upserts the
+/// import set plus the collisions the user approved for replacement, each via
+/// <see cref="ISubmitPickCommandHandler"/> so imported picks are validated and
+/// published identically to hand-made ones. See
+/// docs/features/pick-import-across-leagues.md.
+/// </summary>
+public class ImportPicksCommandHandler : IImportPicksCommandHandler
+{
+    private readonly ILogger<ImportPicksCommandHandler> _logger;
+    private readonly IPickImportPlanService _planService;
+    private readonly ISubmitPickCommandHandler _submitPick;
+
+    public ImportPicksCommandHandler(
+        ILogger<ImportPicksCommandHandler> logger,
+        IPickImportPlanService planService,
+        ISubmitPickCommandHandler submitPick)
+    {
+        _logger = logger;
+        _planService = planService;
+        _submitPick = submitPick;
+    }
+
+    public async Task<Result<PickImportResultDto>> ExecuteAsync(
+        ImportPicksCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var planResult = await _planService.BuildAsync(
+            command.UserId, command.SourceLeagueId, command.TargetLeagueId, cancellationToken);
+
+        if (planResult is not Success<PickImportPlanContext> success)
+        {
+            var failure = (Failure<PickImportPlanContext>)planResult;
+            return new Failure<PickImportResultDto>(default!, failure.Status, failure.Errors);
+        }
+
+        var context = success.Value;
+
+        // Confidence-points targets take a different (pick-sheet, save-gated) path
+        // that isn't built yet. Reject explicitly rather than committing unranked
+        // picks that would score 0. Deferred to a follow-up PR.
+        if (context.TargetUsesConfidencePoints)
+        {
+            return new Failure<PickImportResultDto>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(
+                    nameof(command.TargetLeagueId),
+                    "Importing into a confidence-points league is not yet supported.")]);
+        }
+
+        var plan = context.Plan;
+        var replaceSet = command.ReplaceContestIds.ToHashSet();
+
+        var imported = 0;
+        var replaced = 0;
+        var failed = 0;
+
+        foreach (var item in plan.ToImport)
+        {
+            if (await TrySubmitAsync(command, context.TargetPickType, item.ContestId, item.Week,
+                    item.FranchiseSeasonId, item.SourcePickId, cancellationToken))
+                imported++;
+            else
+                failed++;
+        }
+
+        foreach (var collision in plan.Collisions.Where(c => replaceSet.Contains(c.ContestId)))
+        {
+            if (await TrySubmitAsync(command, context.TargetPickType, collision.ContestId, collision.Week,
+                    collision.SourceFranchiseSeasonId, collision.SourcePickId, cancellationToken))
+                replaced++;
+            else
+                failed++;
+        }
+
+        var keptCount = plan.Collisions.Count(c => !replaceSet.Contains(c.ContestId));
+
+        var skippedByReason = plan.Skipped
+            .GroupBy(s => s.Reason.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        if (keptCount > 0)
+            skippedByReason["KeptExisting"] = keptCount;
+        if (failed > 0)
+            skippedByReason["Failed"] = failed;
+
+        var result = new PickImportResultDto
+        {
+            Imported = imported,
+            Replaced = replaced,
+            Skipped = plan.Skipped.Count + keptCount + failed,
+            SkippedByReason = skippedByReason
+        };
+
+        _logger.LogInformation(
+            "Pick import committed. UserId={UserId}, Source={Source}, Target={Target}, Imported={Imported}, Replaced={Replaced}, Skipped={Skipped}",
+            command.UserId, command.SourceLeagueId, command.TargetLeagueId, imported, replaced, result.Skipped);
+
+        return new Success<PickImportResultDto>(result);
+    }
+
+    private async Task<bool> TrySubmitAsync(
+        ImportPicksCommand command,
+        PickType targetPickType,
+        Guid contestId,
+        int week,
+        Guid franchiseSeasonId,
+        Guid sourcePickId,
+        CancellationToken cancellationToken)
+    {
+        var submit = new SubmitPickCommand
+        {
+            UserId = command.UserId,
+            PickemGroupId = command.TargetLeagueId,
+            ContestId = contestId,
+            Week = week,
+            PickType = targetPickType,
+            FranchiseSeasonId = franchiseSeasonId,
+            ImportedFromPickId = sourcePickId
+        };
+
+        var result = await _submitPick.ExecuteAsync(submit, cancellationToken);
+        if (result.IsSuccess)
+            return true;
+
+        // A contest can lock between plan and commit; treat as skip, not a hard
+        // failure — re-running the import is idempotent and picks up the rest.
+        _logger.LogWarning(
+            "Pick import skipped a contest that failed to submit. UserId={UserId}, Target={Target}, ContestId={ContestId}, Status={Status}",
+            command.UserId, command.TargetLeagueId, contestId, result.Status);
+        return false;
+    }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportRequest.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportRequest.cs
@@ -1,0 +1,14 @@
+namespace SportsData.Api.Application.UI.Picks.PickImport.Dtos;
+
+/// <summary>
+/// Body for POST /ui/leagues/{targetId}/picks/import. The target league is the
+/// route id; this names the source league and the collisions the user chose to
+/// replace (by contest id). Contests not listed here keep their existing target
+/// pick.
+/// </summary>
+public sealed class PickImportRequest
+{
+    public Guid SourceLeagueId { get; set; }
+
+    public List<Guid> ReplaceContestIds { get; set; } = [];
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportResultDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportResultDto.cs
@@ -1,0 +1,23 @@
+namespace SportsData.Api.Application.UI.Picks.PickImport.Dtos;
+
+/// <summary>
+/// Outcome of committing a cross-league pick import (non-confidence target).
+/// Returned by POST /ui/leagues/{targetId}/picks/import.
+/// </summary>
+public sealed class PickImportResultDto
+{
+    /// <summary>New target picks created from source selections.</summary>
+    public int Imported { get; init; }
+
+    /// <summary>Existing target picks overwritten because the user chose to replace them.</summary>
+    public int Replaced { get; init; }
+
+    /// <summary>
+    /// Contests not imported — plan skips (locked / already-matches / not-shared),
+    /// collisions the user kept, and any per-contest submit failures.
+    /// </summary>
+    public int Skipped { get; init; }
+
+    /// <summary>Skipped counts keyed by reason (e.g. Locked, AlreadyMatches, NotShared, KeptExisting, Failed).</summary>
+    public Dictionary<string, int> SkippedByReason { get; init; } = new();
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Api.Application.UI.Picks.PickImport.Commands.ImportPicks;
 using SportsData.Api.Application.UI.Picks.PickImport.Dtos;
 using SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportPreview;
 using SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportSources;
@@ -60,6 +61,32 @@ public class PickImportController : ApiControllerBase
         };
 
         var result = await handler.ExecuteAsync(query, cancellationToken);
+
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Commits the import: creates the import set plus the collisions the user
+    /// chose to replace. Returns a summary. Confidence-points targets are not yet
+    /// supported and are rejected.
+    /// </summary>
+    [HttpPost]
+    [Authorize]
+    public async Task<ActionResult<PickImportResultDto>> Import(
+        [FromRoute] Guid targetId,
+        [FromBody] PickImportRequest request,
+        [FromServices] IImportPicksCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new ImportPicksCommand
+        {
+            UserId = HttpContext.GetCurrentUserId(),
+            SourceLeagueId = request.SourceLeagueId,
+            TargetLeagueId = targetId,
+            ReplaceContestIds = request.ReplaceContestIds
+        };
+
+        var result = await handler.ExecuteAsync(command, cancellationToken);
 
         return result.ToActionResult();
     }

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Planner/PickImportPlanService.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Planner/PickImportPlanService.cs
@@ -1,0 +1,160 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Extensions;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.UI.Picks.PickImport.Planner;
+
+/// <summary>
+/// Loads and classifies a cross-league pick import for a user: validates
+/// membership / pick-type, reads the target's matchups plus the user's source
+/// and existing-target selections, and runs <see cref="IPickImportPlanner"/>.
+/// Both the preview (dry-run) and the commit path go through here so they can
+/// never classify the same request differently.
+/// See docs/features/pick-import-across-leagues.md.
+/// </summary>
+public interface IPickImportPlanService
+{
+    Task<Result<PickImportPlanContext>> BuildAsync(
+        Guid userId,
+        Guid sourceLeagueId,
+        Guid targetLeagueId,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record PickImportPlanContext(
+    Guid SourceLeagueId,
+    Guid TargetLeagueId,
+    PickType TargetPickType,
+    bool TargetUsesConfidencePoints,
+    PickImportPlan Plan);
+
+public class PickImportPlanService : IPickImportPlanService
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IPickImportPlanner _planner;
+    private readonly IDateTimeProvider _dateTime;
+
+    public PickImportPlanService(
+        AppDataContext dataContext,
+        IPickImportPlanner planner,
+        IDateTimeProvider dateTime)
+    {
+        _dataContext = dataContext;
+        _planner = planner;
+        _dateTime = dateTime;
+    }
+
+    public async Task<Result<PickImportPlanContext>> BuildAsync(
+        Guid userId,
+        Guid sourceLeagueId,
+        Guid targetLeagueId,
+        CancellationToken cancellationToken = default)
+    {
+        if (sourceLeagueId == targetLeagueId)
+        {
+            return Fail(ResultStatus.Validation, nameof(sourceLeagueId), "Source and target leagues must be different.");
+        }
+
+        // Membership-gate both leagues in one round-trip; also carries the group
+        // fields we need (pick type / confidence flag). Deactivated leagues are
+        // excluded so a wound-down league can't be a source or target.
+        var memberships = await _dataContext.PickemGroupMembers
+            .AsNoTracking()
+            .Where(m => m.UserId == userId
+                        && m.Group.DeactivatedUtc == null
+                        && (m.PickemGroupId == sourceLeagueId || m.PickemGroupId == targetLeagueId))
+            .Select(m => new
+            {
+                m.PickemGroupId,
+                m.Group.PickType,
+                m.Group.UseConfidencePoints
+            })
+            .ToListAsync(cancellationToken);
+
+        var target = memberships.FirstOrDefault(m => m.PickemGroupId == targetLeagueId);
+        if (target is null)
+        {
+            return Fail(ResultStatus.NotFound, nameof(targetLeagueId), "Target league not found or you are not a member.");
+        }
+
+        var source = memberships.FirstOrDefault(m => m.PickemGroupId == sourceLeagueId);
+        if (source is null)
+        {
+            return Fail(ResultStatus.NotFound, nameof(sourceLeagueId), "Source league not found or you are not a member.");
+        }
+
+        if (source.PickType != target.PickType)
+        {
+            return Fail(ResultStatus.Validation, nameof(sourceLeagueId), "Source and target leagues must be the same pick type.");
+        }
+
+        var nowUtc = _dateTime.UtcNow();
+
+        // The target league's matchups define the universe. Project only the
+        // fields the plan needs (lock state derives from StartDateUtc) rather
+        // than materializing the full ~30-column entity.
+        var targetMatchups = await _dataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => m.GroupId == targetLeagueId)
+            .Select(m => new
+            {
+                m.ContestId,
+                m.SeasonWeek,
+                m.StartDateUtc,
+                m.Headline,
+                m.HomeSpread
+            })
+            .ToListAsync(cancellationToken);
+
+        var contestIds = targetMatchups.Select(m => m.ContestId).ToList();
+
+        // The user's source-league selections for those shared contests (team picks only).
+        var sourceSelections = await _dataContext.UserPicks
+            .AsNoTracking()
+            .Where(p => p.UserId == userId
+                        && p.PickemGroupId == sourceLeagueId
+                        && p.FranchiseSeasonId != null
+                        && contestIds.Contains(p.ContestId))
+            .Select(p => new { p.ContestId, FranchiseSeasonId = p.FranchiseSeasonId!.Value, PickId = p.Id })
+            .ToListAsync(cancellationToken);
+
+        // The user's existing target-league selections for those contests (team picks only).
+        var existingTargetSelections = await _dataContext.UserPicks
+            .AsNoTracking()
+            .Where(p => p.UserId == userId
+                        && p.PickemGroupId == targetLeagueId
+                        && p.FranchiseSeasonId != null
+                        && contestIds.Contains(p.ContestId))
+            .Select(p => new { p.ContestId, FranchiseSeasonId = p.FranchiseSeasonId!.Value })
+            .ToListAsync(cancellationToken);
+
+        var input = new PickImportPlanInput(
+            targetMatchups
+                .Select(m => new PickImportTargetMatchup(
+                    m.ContestId,
+                    m.SeasonWeek,
+                    PickemGroupMatchupExtensions.IsStartLocked(m.StartDateUtc, nowUtc),
+                    m.Headline,
+                    m.HomeSpread))
+                .ToList(),
+            sourceSelections
+                .GroupBy(s => s.ContestId)
+                .ToDictionary(g => g.Key, g => new PickImportSourceSelection(g.First().FranchiseSeasonId, g.First().PickId)),
+            existingTargetSelections
+                .GroupBy(s => s.ContestId)
+                .ToDictionary(g => g.Key, g => g.First().FranchiseSeasonId));
+
+        var plan = _planner.BuildPlan(input);
+
+        return new Success<PickImportPlanContext>(
+            new PickImportPlanContext(sourceLeagueId, targetLeagueId, target.PickType, target.UseConfidencePoints, plan));
+    }
+
+    private static Failure<PickImportPlanContext> Fail(ResultStatus status, string field, string message) =>
+        new(default!, status, [new ValidationFailure(field, message)]);
+}

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Queries/GetPickImportPreview/GetPickImportPreviewQueryHandler.cs
@@ -1,11 +1,5 @@
-using FluentValidation.Results;
-
-using Microsoft.EntityFrameworkCore;
-
 using SportsData.Api.Application.UI.Picks.PickImport.Dtos;
 using SportsData.Api.Application.UI.Picks.PickImport.Planner;
-using SportsData.Api.Extensions;
-using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.UI.Picks.PickImport.Queries.GetPickImportPreview;
@@ -24,137 +18,34 @@ public interface IGetPickImportPreviewQueryHandler
 /// </summary>
 public class GetPickImportPreviewQueryHandler : IGetPickImportPreviewQueryHandler
 {
-    private readonly AppDataContext _dataContext;
-    private readonly IPickImportPlanner _planner;
-    private readonly IDateTimeProvider _dateTime;
+    private readonly IPickImportPlanService _planService;
 
-    public GetPickImportPreviewQueryHandler(
-        AppDataContext dataContext,
-        IPickImportPlanner planner,
-        IDateTimeProvider dateTime)
+    public GetPickImportPreviewQueryHandler(IPickImportPlanService planService)
     {
-        _dataContext = dataContext;
-        _planner = planner;
-        _dateTime = dateTime;
+        _planService = planService;
     }
 
     public async Task<Result<PickImportPreviewDto>> ExecuteAsync(
         GetPickImportPreviewQuery query,
         CancellationToken cancellationToken = default)
     {
-        if (query.SourceLeagueId == query.TargetLeagueId)
+        var planResult = await _planService.BuildAsync(
+            query.UserId, query.SourceLeagueId, query.TargetLeagueId, cancellationToken);
+
+        if (planResult is not Success<PickImportPlanContext> success)
         {
-            return new Failure<PickImportPreviewDto>(
-                default!,
-                ResultStatus.Validation,
-                [new ValidationFailure(nameof(query.SourceLeagueId), "Source and target leagues must be different.")]);
+            var failure = (Failure<PickImportPlanContext>)planResult;
+            return new Failure<PickImportPreviewDto>(default!, failure.Status, failure.Errors);
         }
 
-        // Membership-gate both leagues in one round-trip; also carries the group
-        // fields we need (pick type / confidence flag). Deactivated leagues are
-        // excluded so a wound-down league can't be a source or target.
-        var memberships = await _dataContext.PickemGroupMembers
-            .AsNoTracking()
-            .Where(m => m.UserId == query.UserId
-                        && m.Group.DeactivatedUtc == null
-                        && (m.PickemGroupId == query.SourceLeagueId || m.PickemGroupId == query.TargetLeagueId))
-            .Select(m => new
-            {
-                m.PickemGroupId,
-                m.Group.PickType,
-                m.Group.UseConfidencePoints
-            })
-            .ToListAsync(cancellationToken);
-
-        var target = memberships.FirstOrDefault(m => m.PickemGroupId == query.TargetLeagueId);
-        if (target is null)
-        {
-            return new Failure<PickImportPreviewDto>(
-                default!,
-                ResultStatus.NotFound,
-                [new ValidationFailure(nameof(query.TargetLeagueId), "Target league not found or you are not a member.")]);
-        }
-
-        var source = memberships.FirstOrDefault(m => m.PickemGroupId == query.SourceLeagueId);
-        if (source is null)
-        {
-            return new Failure<PickImportPreviewDto>(
-                default!,
-                ResultStatus.NotFound,
-                [new ValidationFailure(nameof(query.SourceLeagueId), "Source league not found or you are not a member.")]);
-        }
-
-        if (source.PickType != target.PickType)
-        {
-            return new Failure<PickImportPreviewDto>(
-                default!,
-                ResultStatus.Validation,
-                [new ValidationFailure(nameof(query.SourceLeagueId), "Source and target leagues must be the same pick type.")]);
-        }
-
-        var nowUtc = _dateTime.UtcNow();
-
-        // The target league's matchups define the universe. Project only the
-        // fields the plan needs (lock state derives from StartDateUtc) rather
-        // than materializing the full ~30-column entity.
-        var targetMatchups = await _dataContext.PickemGroupMatchups
-            .AsNoTracking()
-            .Where(m => m.GroupId == query.TargetLeagueId)
-            .Select(m => new
-            {
-                m.ContestId,
-                m.SeasonWeek,
-                m.StartDateUtc,
-                m.Headline,
-                m.HomeSpread
-            })
-            .ToListAsync(cancellationToken);
-
-        var contestIds = targetMatchups.Select(m => m.ContestId).ToList();
-
-        // The user's source-league selections for those shared contests (team picks only).
-        var sourceSelections = await _dataContext.UserPicks
-            .AsNoTracking()
-            .Where(p => p.UserId == query.UserId
-                        && p.PickemGroupId == query.SourceLeagueId
-                        && p.FranchiseSeasonId != null
-                        && contestIds.Contains(p.ContestId))
-            .Select(p => new { p.ContestId, FranchiseSeasonId = p.FranchiseSeasonId!.Value, PickId = p.Id })
-            .ToListAsync(cancellationToken);
-
-        // The user's existing target-league selections for those contests (team picks only).
-        var existingTargetSelections = await _dataContext.UserPicks
-            .AsNoTracking()
-            .Where(p => p.UserId == query.UserId
-                        && p.PickemGroupId == query.TargetLeagueId
-                        && p.FranchiseSeasonId != null
-                        && contestIds.Contains(p.ContestId))
-            .Select(p => new { p.ContestId, FranchiseSeasonId = p.FranchiseSeasonId!.Value })
-            .ToListAsync(cancellationToken);
-
-        var input = new PickImportPlanInput(
-            targetMatchups
-                .Select(m => new PickImportTargetMatchup(
-                    m.ContestId,
-                    m.SeasonWeek,
-                    PickemGroupMatchupExtensions.IsStartLocked(m.StartDateUtc, nowUtc),
-                    m.Headline,
-                    m.HomeSpread))
-                .ToList(),
-            sourceSelections
-                .GroupBy(s => s.ContestId)
-                .ToDictionary(g => g.Key, g => new PickImportSourceSelection(g.First().FranchiseSeasonId, g.First().PickId)),
-            existingTargetSelections
-                .GroupBy(s => s.ContestId)
-                .ToDictionary(g => g.Key, g => g.First().FranchiseSeasonId));
-
-        var plan = _planner.BuildPlan(input);
+        var context = success.Value;
+        var plan = context.Plan;
 
         var dto = new PickImportPreviewDto
         {
-            SourceLeagueId = query.SourceLeagueId,
-            TargetLeagueId = query.TargetLeagueId,
-            TargetUsesConfidencePoints = target.UseConfidencePoints,
+            SourceLeagueId = context.SourceLeagueId,
+            TargetLeagueId = context.TargetLeagueId,
+            TargetUsesConfidencePoints = context.TargetUsesConfidencePoints,
             ToImport = plan.ToImport
                 .Select(i => new PickImportPreviewItemDto
                 {

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -135,11 +135,17 @@ namespace SportsData.Api.DependencyInjection
                 Application.UI.Picks.PickImport.Planner.IPickImportPlanner,
                 Application.UI.Picks.PickImport.Planner.PickImportPlanner>();
             services.AddScoped<
+                Application.UI.Picks.PickImport.Planner.IPickImportPlanService,
+                Application.UI.Picks.PickImport.Planner.PickImportPlanService>();
+            services.AddScoped<
                 Application.UI.Picks.PickImport.Queries.GetPickImportPreview.IGetPickImportPreviewQueryHandler,
                 Application.UI.Picks.PickImport.Queries.GetPickImportPreview.GetPickImportPreviewQueryHandler>();
             services.AddScoped<
                 Application.UI.Picks.PickImport.Queries.GetPickImportSources.IGetPickImportSourcesQueryHandler,
                 Application.UI.Picks.PickImport.Queries.GetPickImportSources.GetPickImportSourcesQueryHandler>();
+            services.AddScoped<
+                Application.UI.Picks.PickImport.Commands.ImportPicks.IImportPicksCommandHandler,
+                Application.UI.Picks.PickImport.Commands.ImportPicks.ImportPicksCommandHandler>();
 
             // Public Results Queries
             services.AddScoped<

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandlerTests.cs
@@ -292,4 +292,54 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
         updated.TiebreakerGuessHome.Should().Be(21);
         updated.TiebreakerGuessAway.Should().Be(24);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldPersistImportedFromPickId_WhenProvided()
+    {
+        // Arrange
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var sourcePickId = Guid.NewGuid();
+
+        var group = new PickemGroup
+        {
+            Id = groupId,
+            Name = "Test League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF
+        };
+        var matchup = new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            ContestId = contestId,
+            StartDateUtc = DateTime.UtcNow.AddHours(1)
+        };
+
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<SubmitPickCommandHandler>();
+
+        var command = new SubmitPickCommand
+        {
+            UserId = Guid.NewGuid(),
+            PickemGroupId = groupId,
+            ContestId = contestId,
+            Week = 5,
+            PickType = PickType.StraightUp,
+            FranchiseSeasonId = Guid.NewGuid(),
+            ImportedFromPickId = sourcePickId
+        };
+
+        // Act
+        var result = await handler.ExecuteAsync(command);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var pick = await DataContext.UserPicks.FirstOrDefaultAsync();
+        pick!.ImportedFromPickId.Should().Be(sourcePickId);
+    }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/GetPickImportPreviewQueryHandlerTests.cs
@@ -20,7 +20,8 @@ public class GetPickImportPreviewQueryHandlerTests : ApiTestBase<GetPickImportPr
     {
         var dateTime = new Mock<IDateTimeProvider>();
         dateTime.Setup(x => x.UtcNow()).Returns(NowUtc);
-        return new GetPickImportPreviewQueryHandler(DataContext, new PickImportPlanner(), dateTime.Object);
+        var planService = new PickImportPlanService(DataContext, new PickImportPlanner(), dateTime.Object);
+        return new GetPickImportPreviewQueryHandler(planService);
     }
 
     private Guid SeedLeague(Guid userId, PickType pickType, bool useConfidence = false, bool deactivated = false)

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
@@ -262,8 +262,9 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
     public async Task CountsSubmitFailureUnderFailed_AndImportsTheRest()
     {
         // A contest can lock (or otherwise fail to submit) between plan and commit.
-        // Stub the submit handler to fail one of two planned imports; the other
-        // still imports and the failure is counted, not fatal.
+        // Force a failure on one of two planned imports; the other goes through the
+        // real submit handler and actually persists, and the failure is counted,
+        // not fatal.
         var userId = Guid.NewGuid();
         var sourceId = SeedLeague(userId, PickType.StraightUp);
         var targetId = SeedLeague(userId, PickType.StraightUp);
@@ -279,13 +280,19 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         SeedPick(sourceId, userId, failContest, team);
         await DataContext.SaveChangesAsync();
 
+        var realSubmit = new SubmitPickCommandHandler(
+            NullLogger<SubmitPickCommandHandler>.Instance,
+            DataContext,
+            new Mock<IEventBus>().Object);
+
         var submit = new Mock<ISubmitPickCommandHandler>();
         submit.Setup(x => x.ExecuteAsync(
                 It.Is<SubmitPickCommand>(c => c.ContestId == failContest), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Failure<Guid>(Guid.Empty, ResultStatus.Validation, []));
+        // okContest delegates to the real handler so it genuinely persists.
         submit.Setup(x => x.ExecuteAsync(
                 It.Is<SubmitPickCommand>(c => c.ContestId == okContest), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<Guid>(okContest));
+            .Returns((SubmitPickCommand c, CancellationToken ct) => realSubmit.ExecuteAsync(c, ct));
 
         var result = await CreateHandler(submit.Object).ExecuteAsync(new ImportPicksCommand
         {
@@ -298,6 +305,12 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         result.Value.Imported.Should().Be(1);
         result.Value.SkippedByReason.Should().ContainKey("Failed").WhoseValue.Should().Be(1);
         result.Value.Skipped.Should().Be(1);
+
+        // The successful import actually persisted; the failed one did not.
+        var okPick = TargetPick(targetId, userId, okContest);
+        okPick.Should().NotBeNull();
+        okPick!.FranchiseSeasonId.Should().Be(team);
+        TargetPick(targetId, userId, failContest).Should().BeNull();
     }
 
     [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
@@ -1,0 +1,292 @@
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Picks.Commands.SubmitPick;
+using SportsData.Api.Application.UI.Picks.PickImport.Commands.ImportPicks;
+using SportsData.Api.Application.UI.Picks.PickImport.Planner;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Picks.PickImport;
+
+public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHandler>
+{
+    private static readonly DateTime NowUtc = new(2026, 7, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    // Real plan service + real submit handler so the whole write path is exercised.
+    private ImportPicksCommandHandler CreateHandler()
+    {
+        var dateTime = new Mock<IDateTimeProvider>();
+        dateTime.Setup(x => x.UtcNow()).Returns(NowUtc);
+
+        var planService = new PickImportPlanService(DataContext, new PickImportPlanner(), dateTime.Object);
+
+        var submitHandler = new SubmitPickCommandHandler(
+            NullLogger<SubmitPickCommandHandler>.Instance,
+            DataContext,
+            new Mock<IEventBus>().Object);
+
+        return new ImportPicksCommandHandler(
+            NullLogger<ImportPicksCommandHandler>.Instance,
+            planService,
+            submitHandler);
+    }
+
+    private Guid SeedLeague(Guid userId, PickType pickType, bool useConfidence = false)
+    {
+        var groupId = Guid.NewGuid();
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = groupId,
+            Name = "League " + groupId.ToString()[..4],
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            PickType = pickType,
+            UseConfidencePoints = useConfidence,
+            CommissionerUserId = userId
+        });
+        DataContext.PickemGroupMembers.Add(new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = groupId,
+            UserId = userId,
+            Role = LeagueRole.Member
+        });
+        return groupId;
+    }
+
+    private void SeedMatchup(Guid groupId, Guid contestId, DateTime startUtc, int week = 3)
+    {
+        DataContext.PickemGroupMatchups.Add(new PickemGroupMatchup
+        {
+            GroupId = groupId,
+            SeasonWeekId = Guid.NewGuid(),
+            ContestId = contestId,
+            StartDateUtc = startUtc,
+            SeasonYear = 2026,
+            SeasonWeek = week,
+            Headline = "Away @ Home",
+            HomeSpread = -3.5
+        });
+    }
+
+    private Guid SeedPick(Guid groupId, Guid userId, Guid contestId, Guid franchiseSeasonId)
+    {
+        var id = Guid.NewGuid();
+        DataContext.UserPicks.Add(new PickemGroupUserPick
+        {
+            Id = id,
+            PickemGroupId = groupId,
+            UserId = userId,
+            ContestId = contestId,
+            Week = 3,
+            PickType = PickType.StraightUp,
+            FranchiseSeasonId = franchiseSeasonId,
+            TiebreakerType = TiebreakerType.TotalPoints
+        });
+        return id;
+    }
+
+    private PickemGroupUserPick? TargetPick(Guid targetId, Guid userId, Guid contestId) =>
+        DataContext.UserPicks.AsNoTracking().SingleOrDefault(p =>
+            p.PickemGroupId == targetId && p.UserId == userId && p.ContestId == contestId);
+
+    [Fact]
+    public async Task ImportsNewSelections_AndStampsImportedFromPickId()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var contestA = Guid.NewGuid();
+        var contestB = Guid.NewGuid();
+        var teamA = Guid.NewGuid();
+        var teamB = Guid.NewGuid();
+        var future = NowUtc.AddDays(1);
+
+        SeedMatchup(targetId, contestA, future);
+        SeedMatchup(targetId, contestB, future);
+        var sourcePickA = SeedPick(sourceId, userId, contestA, teamA);
+        var sourcePickB = SeedPick(sourceId, userId, contestB, teamB);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Imported.Should().Be(2);
+        result.Value.Replaced.Should().Be(0);
+
+        var pickA = TargetPick(targetId, userId, contestA)!;
+        pickA.FranchiseSeasonId.Should().Be(teamA);
+        pickA.ImportedFromPickId.Should().Be(sourcePickA);
+        pickA.Week.Should().Be(3);
+
+        TargetPick(targetId, userId, contestB)!.ImportedFromPickId.Should().Be(sourcePickB);
+    }
+
+    [Fact]
+    public async Task ReplacesOnlyApprovedCollisions_AndKeepsTheRest()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var approved = Guid.NewGuid();
+        var kept = Guid.NewGuid();
+        var sourceTeam = Guid.NewGuid();
+        var existingApproved = Guid.NewGuid();
+        var existingKept = Guid.NewGuid();
+        var future = NowUtc.AddDays(1);
+
+        SeedMatchup(targetId, approved, future);
+        SeedMatchup(targetId, kept, future);
+        var sourcePickApproved = SeedPick(sourceId, userId, approved, sourceTeam);
+        SeedPick(sourceId, userId, kept, sourceTeam);
+        SeedPick(targetId, userId, approved, existingApproved);
+        SeedPick(targetId, userId, kept, existingKept);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId,
+            ReplaceContestIds = [approved]
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Imported.Should().Be(0);
+        result.Value.Replaced.Should().Be(1);
+        result.Value.SkippedByReason.Should().ContainKey("KeptExisting").WhoseValue.Should().Be(1);
+
+        // Approved collision was overwritten with the source team + traceability.
+        var approvedPick = TargetPick(targetId, userId, approved)!;
+        approvedPick.FranchiseSeasonId.Should().Be(sourceTeam);
+        approvedPick.ImportedFromPickId.Should().Be(sourcePickApproved);
+
+        // Kept collision is untouched.
+        var keptPick = TargetPick(targetId, userId, kept)!;
+        keptPick.FranchiseSeasonId.Should().Be(existingKept);
+        keptPick.ImportedFromPickId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SkipsLockedMatchesAndNotShared_WithReasons()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var locked = Guid.NewGuid();
+        var matches = Guid.NewGuid();
+        var notShared = Guid.NewGuid();
+        var team = Guid.NewGuid();
+
+        SeedMatchup(targetId, locked, NowUtc.AddDays(-1));
+        SeedMatchup(targetId, matches, NowUtc.AddDays(1));
+        SeedMatchup(targetId, notShared, NowUtc.AddDays(1));
+        SeedPick(sourceId, userId, locked, team);
+        SeedPick(sourceId, userId, matches, team);
+        SeedPick(targetId, userId, matches, team); // already matches
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Imported.Should().Be(0);
+        result.Value.SkippedByReason.Should().ContainKey(nameof(PickImportSkipReason.Locked));
+        result.Value.SkippedByReason.Should().ContainKey(nameof(PickImportSkipReason.AlreadyMatches));
+        result.Value.SkippedByReason.Should().ContainKey(nameof(PickImportSkipReason.NotShared));
+
+        // Locked contest was never written.
+        TargetPick(targetId, userId, locked).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RejectsConfidencePointsTarget()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp, useConfidence: true);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task PropagatesPlanFailure_WhenNotMemberOfSource()
+    {
+        var userId = Guid.NewGuid();
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = Guid.NewGuid(), // not a member
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task IsIdempotent_WhenReRun()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var contest = Guid.NewGuid();
+        var team = Guid.NewGuid();
+        SeedMatchup(targetId, contest, NowUtc.AddDays(1));
+        SeedPick(sourceId, userId, contest, team);
+        await DataContext.SaveChangesAsync();
+
+        var command = new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        };
+
+        var first = await CreateHandler().ExecuteAsync(command);
+        first.Value.Imported.Should().Be(1);
+
+        // Second run: the target now matches the source, so it's a no-op skip.
+        var second = await CreateHandler().ExecuteAsync(command);
+        second.Value.Imported.Should().Be(0);
+        second.Value.SkippedByReason.Should().ContainKey(nameof(PickImportSkipReason.AlreadyMatches));
+
+        DataContext.UserPicks.AsNoTracking()
+            .Count(p => p.PickemGroupId == targetId && p.ContestId == contest)
+            .Should().Be(1);
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
@@ -22,14 +22,15 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
     private static readonly DateTime NowUtc = new(2026, 7, 15, 12, 0, 0, DateTimeKind.Utc);
 
     // Real plan service + real submit handler so the whole write path is exercised.
-    private ImportPicksCommandHandler CreateHandler()
+    // Pass submitOverride to force per-contest submit outcomes (failure-path coverage).
+    private ImportPicksCommandHandler CreateHandler(ISubmitPickCommandHandler? submitOverride = null)
     {
         var dateTime = new Mock<IDateTimeProvider>();
         dateTime.Setup(x => x.UtcNow()).Returns(NowUtc);
 
         var planService = new PickImportPlanService(DataContext, new PickImportPlanner(), dateTime.Object);
 
-        var submitHandler = new SubmitPickCommandHandler(
+        var submitHandler = submitOverride ?? new SubmitPickCommandHandler(
             NullLogger<SubmitPickCommandHandler>.Instance,
             DataContext,
             new Mock<IEventBus>().Object);
@@ -255,6 +256,48 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
 
         result.IsSuccess.Should().BeFalse();
         result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task CountsSubmitFailureUnderFailed_AndImportsTheRest()
+    {
+        // A contest can lock (or otherwise fail to submit) between plan and commit.
+        // Stub the submit handler to fail one of two planned imports; the other
+        // still imports and the failure is counted, not fatal.
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var okContest = Guid.NewGuid();
+        var failContest = Guid.NewGuid();
+        var team = Guid.NewGuid();
+        var future = NowUtc.AddDays(1);
+
+        SeedMatchup(targetId, okContest, future);
+        SeedMatchup(targetId, failContest, future);
+        SeedPick(sourceId, userId, okContest, team);
+        SeedPick(sourceId, userId, failContest, team);
+        await DataContext.SaveChangesAsync();
+
+        var submit = new Mock<ISubmitPickCommandHandler>();
+        submit.Setup(x => x.ExecuteAsync(
+                It.Is<SubmitPickCommand>(c => c.ContestId == failContest), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<Guid>(Guid.Empty, ResultStatus.Validation, []));
+        submit.Setup(x => x.ExecuteAsync(
+                It.Is<SubmitPickCommand>(c => c.ContestId == okContest), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<Guid>(okContest));
+
+        var result = await CreateHandler(submit.Object).ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Imported.Should().Be(1);
+        result.Value.SkippedByReason.Should().ContainKey("Failed").WhoseValue.Should().Be(1);
+        result.Value.Skipped.Should().Be(1);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Second slice of **import picks from one league into another** (`docs/features/pick-import-across-leagues.md`) — the **write path**, building on the read-only preview shipped in #513. **No migration** (`ImportedFromPickId` already exists on the entity).

## Endpoint

`POST /ui/leagues/{targetId}/picks/import` — body `{ sourceLeagueId, replaceContestIds[] }`

Re-plans **server-side** (never trusts the client's classification), then upserts the `toImport` set plus the collisions the user approved for replacement, each via `SubmitPickCommandHandler` so imported picks are validated and publish `UserPickMade` **identically to hand-made ones**. Returns a summary:

```
{ imported, replaced, skipped, skippedByReason: { Locked, AlreadyMatches, NotShared, KeptExisting, Failed } }
```

A per-contest submit failure (e.g. a matchup that race-locked between plan and commit) is counted under `Failed` and skipped — not fatal. Re-running is idempotent (the now-matching target picks classify as `AlreadyMatches`).

## Design

- **`PickImportPlanService`** — extracted the load + validate + classify out of the preview handler into a shared service, so **preview and commit can never classify the same request differently** (a real correctness risk). The preview handler (from #513) now just maps the shared plan to its DTO — hence the −123 lines there.
- **`SubmitPickCommand.ImportedFromPickId (Guid?)`** — persisted on create/update for import traceability + idempotency (guardrail 8).

## Scope / deferred

Per the agreed phasing, **confidence-points targets are deferred to a follow-up PR** (their save-gated pick-sheet path + the `POST /ui/picks` confidence-required-at-save enforcement). This endpoint **rejects a confidence-points target explicitly** with a clear validation message; the FE already knows from the preview's `TargetUsesConfidencePoints`. Also still deferred: cross-type SU↔ATS mapping, tiebreaker-guess copy.

## Tests

+8, full write-path integration (real plan service + real submit handler):
- imports stamp `ImportedFromPickId`; only user-approved collisions replaced (kept ones untouched); locked / already-matches / not-shared skipped with reasons; confidence target rejected; plan-failure (non-member) propagation; idempotent re-run.
- plus a focused `SubmitPickCommandHandler` `ImportedFromPickId` round-trip.

Full `SportsData.Api.Tests.Unit` suite green (**517**); API builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-league pick importing via a new import endpoint that returns import, replacement, and skip totals.
  * Importing supports contest collision replacement (with explicit approval) and safe re-runs without duplicates.
  * Validation ensures compatible leagues and skips locked, non-shared, or already-matching contests; confidence-points targets are rejected.
* **Bug Fixes**
  * Imported picks are now stamped with their originating pick ID for improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->