### PR TITLE
feat(picks): confidence-target import draft + confidence-required-at-save (v1)

### DIFF
--- a/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
@@ -80,6 +80,19 @@ public class SubmitPickCommandHandler : ISubmitPickCommandHandler
                 [new ValidationFailure(nameof(command.OverUnder), "PickType is OverUnder, but selection not provided")]);
         }
 
+        // Confidence leagues score each pick by its assigned confidence; a pick
+        // saved without one would score 0 (unranked). Gate the save so no
+        // incomplete picks persist. This is what makes the confidence pick sheet
+        // "save-gated" for imported selections. See
+        // docs/features/pick-import-across-leagues.md.
+        if (group.UseConfidencePoints && command.ConfidencePoints is null)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.ConfidencePoints), "This league uses confidence points; assign a confidence value to the pick.")]);
+        }
+
         var existing = await _dataContext.UserPicks
             .FirstOrDefaultAsync(p =>
                     p.UserId == command.UserId &&

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
@@ -1,5 +1,3 @@
-using FluentValidation.Results;
-
 using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Picks.Commands.SubmitPick;
 using SportsData.Api.Application.UI.Picks.PickImport.Dtos;
@@ -54,21 +52,40 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
 
         var context = success.Value;
 
-        // Confidence-points targets take a different (pick-sheet, save-gated) path
-        // that isn't built yet. Reject explicitly rather than committing unranked
-        // picks that would score 0. Deferred to a follow-up PR.
-        if (context.TargetUsesConfidencePoints)
-        {
-            return new Failure<PickImportResultDto>(
-                default!,
-                ResultStatus.Validation,
-                [new ValidationFailure(
-                    nameof(command.TargetLeagueId),
-                    "Importing into a confidence-points league is not yet supported.")]);
-        }
-
         var plan = context.Plan;
         var replaceSet = command.ReplaceContestIds.ToHashSet();
+
+        // Confidence targets don't commit directly: the pick sheet is save-gated on
+        // a confidence value per pick, so return the selections the user wants
+        // (import set + approved replaces) as a draft to pre-fill that sheet. No
+        // writes. See docs/features/pick-import-across-leagues.md.
+        if (context.TargetUsesConfidencePoints)
+        {
+            var draft = plan.ToImport
+                .Select(i => new PickImportDraftItemDto
+                {
+                    ContestId = i.ContestId,
+                    Week = i.Week,
+                    FranchiseSeasonId = i.FranchiseSeasonId,
+                    Headline = i.Headline
+                })
+                .Concat(plan.Collisions
+                    .Where(c => replaceSet.Contains(c.ContestId))
+                    .Select(c => new PickImportDraftItemDto
+                    {
+                        ContestId = c.ContestId,
+                        Week = c.Week,
+                        FranchiseSeasonId = c.SourceFranchiseSeasonId,
+                        Headline = c.Headline
+                    }))
+                .ToList();
+
+            return new Success<PickImportResultDto>(new PickImportResultDto
+            {
+                RequiresConfidence = true,
+                Draft = draft
+            });
+        }
 
         var imported = 0;
         var replaced = 0;

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportResultDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportResultDto.cs
@@ -20,4 +20,30 @@ public sealed class PickImportResultDto
 
     /// <summary>Skipped counts keyed by reason (e.g. Locked, AlreadyMatches, NotShared, KeptExisting, Failed).</summary>
     public Dictionary<string, int> SkippedByReason { get; init; } = new();
+
+    /// <summary>
+    /// True when the target uses confidence points: nothing was written. The
+    /// selections in <see cref="Draft"/> pre-fill the pick sheet, and the user
+    /// assigns a confidence value to each before saving via the normal
+    /// (confidence-required) path.
+    /// </summary>
+    public bool RequiresConfidence { get; init; }
+
+    /// <summary>
+    /// Draft selections for a confidence target (import set plus approved replaces).
+    /// Empty for a direct (non-confidence) commit.
+    /// </summary>
+    public List<PickImportDraftItemDto> Draft { get; init; } = [];
+}
+
+/// <summary>A team selection to pre-fill into a confidence-league pick sheet.</summary>
+public sealed class PickImportDraftItemDto
+{
+    public Guid ContestId { get; init; }
+
+    public int Week { get; init; }
+
+    public Guid FranchiseSeasonId { get; init; }
+
+    public string? Headline { get; init; }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandlerTests.cs
@@ -342,4 +342,100 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
         var pick = await DataContext.UserPicks.FirstOrDefaultAsync();
         pick!.ImportedFromPickId.Should().Be(sourcePickId);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnValidation_WhenConfidenceLeagueAndConfidenceMissing()
+    {
+        // Arrange
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        var group = new PickemGroup
+        {
+            Id = groupId,
+            Name = "Confidence League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            UseConfidencePoints = true
+        };
+        var matchup = new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            ContestId = contestId,
+            StartDateUtc = DateTime.UtcNow.AddHours(1)
+        };
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<SubmitPickCommandHandler>();
+
+        var command = new SubmitPickCommand
+        {
+            UserId = Guid.NewGuid(),
+            PickemGroupId = groupId,
+            ContestId = contestId,
+            Week = 5,
+            PickType = PickType.StraightUp,
+            FranchiseSeasonId = Guid.NewGuid(),
+            ConfidencePoints = null // unranked — must be rejected in a confidence league
+        };
+
+        // Act
+        var result = await handler.ExecuteAsync(command);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+        (await DataContext.UserPicks.FirstOrDefaultAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldSucceed_WhenConfidenceLeagueAndConfidenceProvided()
+    {
+        // Arrange
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        var group = new PickemGroup
+        {
+            Id = groupId,
+            Name = "Confidence League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            UseConfidencePoints = true
+        };
+        var matchup = new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            ContestId = contestId,
+            StartDateUtc = DateTime.UtcNow.AddHours(1)
+        };
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.PickemGroupMatchups.AddAsync(matchup);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<SubmitPickCommandHandler>();
+
+        var command = new SubmitPickCommand
+        {
+            UserId = Guid.NewGuid(),
+            PickemGroupId = groupId,
+            ContestId = contestId,
+            Week = 5,
+            PickType = PickType.StraightUp,
+            FranchiseSeasonId = Guid.NewGuid(),
+            ConfidencePoints = 5
+        };
+
+        // Act
+        var result = await handler.ExecuteAsync(command);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var pick = await DataContext.UserPicks.FirstOrDefaultAsync();
+        pick!.ConfidencePoints.Should().Be(5);
+    }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
@@ -222,11 +222,16 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
     }
 
     [Fact]
-    public async Task RejectsConfidencePointsTarget()
+    public async Task ReturnsDraftForConfidenceTarget_WithoutWriting()
     {
         var userId = Guid.NewGuid();
         var sourceId = SeedLeague(userId, PickType.StraightUp);
         var targetId = SeedLeague(userId, PickType.StraightUp, useConfidence: true);
+
+        var contest = Guid.NewGuid();
+        var team = Guid.NewGuid();
+        SeedMatchup(targetId, contest, NowUtc.AddDays(1));
+        SeedPick(sourceId, userId, contest, team);
         await DataContext.SaveChangesAsync();
 
         var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
@@ -236,8 +241,43 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
             TargetLeagueId = targetId
         });
 
-        result.IsSuccess.Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.Validation);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RequiresConfidence.Should().BeTrue();
+        result.Value.Imported.Should().Be(0);
+        result.Value.Draft.Should().ContainSingle(d => d.ContestId == contest && d.FranchiseSeasonId == team);
+
+        // Confidence targets never write from the import; the pick sheet persists later.
+        TargetPick(targetId, userId, contest).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ConfidenceDraft_IncludesApprovedReplaceSelections_ButKeepsExistingPicks()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp, useConfidence: true);
+
+        var collision = Guid.NewGuid();
+        var sourceTeam = Guid.NewGuid();
+        var existingTeam = Guid.NewGuid();
+        SeedMatchup(targetId, collision, NowUtc.AddDays(1));
+        SeedPick(sourceId, userId, collision, sourceTeam);
+        SeedPick(targetId, userId, collision, existingTeam);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId,
+            ReplaceContestIds = [collision]
+        });
+
+        result.Value.RequiresConfidence.Should().BeTrue();
+        result.Value.Draft.Should().ContainSingle(d => d.ContestId == collision && d.FranchiseSeasonId == sourceTeam);
+
+        // Draft mode writes nothing — the existing target pick is untouched.
+        TargetPick(targetId, userId, collision)!.FranchiseSeasonId.Should().Be(existingTeam);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Final v1 slice of **import picks from one league into another** (`docs/features/pick-import-across-leagues.md`) — confidence-league handling. Builds on the read path (#513) and the commit path (#514). **No migration.**

## Changes

1. **`SubmitPickCommandHandler` — confidence save-gate.** A pick saved to a confidence league (`UseConfidencePoints`) with a null `ConfidencePoints` is now rejected (Validation). A confidence league scores each pick by its assigned value, so a null one would score 0 (unranked) — gating the save means no incomplete picks persist. This is what makes the confidence pick sheet "save-gated," and it's the prerequisite the design doc called out as not previously enforced.

2. **`ImportPicksCommandHandler` — draft path.** Confidence targets are no longer rejected (they were in #514, deferred to here). The handler now returns the mapped selections (import set + user-approved replaces) as a **draft** with `RequiresConfidence = true` and **writes nothing**. The FE pre-fills the pick sheet with the draft, the user assigns a confidence value per pick, and saves via the now-gated `POST /ui/picks`.

3. **`PickImportResultDto`** gains `RequiresConfidence` + `Draft` (new `PickImportDraftItemDto`).

## Blast radius

Change #1 alters the **existing** `POST /ui/picks` behavior for confidence leagues. Confirmed safe:
- `SyntheticPickService` writes `UserPicks` directly, bypassing this handler.
- No existing `SubmitPickCommandHandler` test uses a confidence league (they default `UseConfidencePoints = false`).
- The web/mobile confidence picker already sends points.
- No live users other than the author at this time.

## Tests

+4:
- `SubmitPickCommandHandler`: reject when confidence league + null confidence; succeed (and persist the value) when provided.
- `ImportPicksCommandHandler`: confidence target returns a draft (`RequiresConfidence`, populated `Draft`) and writes nothing; approved-replace selections appear in the draft while the existing target pick stays untouched.

Full `SportsData.Api.Tests.Unit` suite green (520 passing; the one failure is a pre-existing unrelated `DisplayNameGenerator` randomness flake that passes in isolation). API builds clean.

## v1 status

With this, backend v1 is complete: sources + preview (#513), commit (#514), confidence handling (this). Still deferred per the doc: cross-type SU↔ATS mapping, tiebreaker-guess copy, confidence-league UX refinement, and the web/mobile UI (a separate track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Importing picks into confidence-points leagues now provides a draft prefill for the pick sheet instead of failing.
  * Drafts include imported selections and approved replacements while leaving existing picks unchanged until submission.
  * Import results identify when confidence points are required and provide contest details for the draft.

* **Bug Fixes**
  * Submitting a pick in a confidence-points league now requires confidence points before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->