### PR TITLE
feat(picks): web UI for cross-league pick import + picks-status restyle

### DIFF
--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommand.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommand.cs
@@ -8,6 +8,10 @@ public sealed class ImportPicksCommand
 
     public required Guid TargetLeagueId { get; init; }
 
-    /// <summary>Contest ids for collisions the user chose to replace with the source pick.</summary>
-    public IReadOnlyCollection<Guid> ReplaceContestIds { get; init; } = [];
+    /// <summary>
+    /// The contests the user selected to import (checked in the dialog). Only these
+    /// are imported/replaced; every other contest is left untouched. Contest ids
+    /// that aren't importable per the server-side plan are ignored.
+    /// </summary>
+    public IReadOnlyCollection<Guid> ContestIds { get; init; } = [];
 }

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
@@ -54,7 +54,10 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
         var context = success.Value;
 
         var plan = context.Plan;
-        var selected = command.ContestIds.ToHashSet();
+        // Null-safe: an absent/null selection (e.g. "contestIds": null in the
+        // payload, which overrides the DTO default) means nothing was chosen —
+        // import nothing rather than NRE.
+        var selected = (command.ContestIds ?? Array.Empty<Guid>()).ToHashSet();
 
         // Confidence targets don't commit directly: the pick sheet is save-gated on
         // a confidence value per pick, so return the selected team selections as a

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Commands/ImportPicks/ImportPicksCommandHandler.cs
@@ -15,11 +15,12 @@ public interface IImportPicksCommandHandler
 
 /// <summary>
 /// Commits a cross-league pick import into a non-confidence target: re-plans
-/// server-side (never trusts the client's classification), then upserts the
-/// import set plus the collisions the user approved for replacement, each via
-/// <see cref="ISubmitPickCommandHandler"/> so imported picks are validated and
-/// published identically to hand-made ones. See
-/// docs/features/pick-import-across-leagues.md.
+/// server-side (never trusts the client's classification), then upserts exactly
+/// the contests the user selected (<see cref="ImportPicksCommand.ContestIds"/>)
+/// that the plan says are importable — a fresh import or a collision replace —
+/// each via <see cref="ISubmitPickCommandHandler"/> so imported picks are
+/// validated and published identically to hand-made ones. Unselected contests
+/// are left untouched. See docs/features/pick-import-across-leagues.md.
 /// </summary>
 public class ImportPicksCommandHandler : IImportPicksCommandHandler
 {
@@ -53,15 +54,16 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
         var context = success.Value;
 
         var plan = context.Plan;
-        var replaceSet = command.ReplaceContestIds.ToHashSet();
+        var selected = command.ContestIds.ToHashSet();
 
         // Confidence targets don't commit directly: the pick sheet is save-gated on
-        // a confidence value per pick, so return the selections the user wants
-        // (import set + approved replaces) as a draft to pre-fill that sheet. No
-        // writes. See docs/features/pick-import-across-leagues.md.
+        // a confidence value per pick, so return the selected team selections as a
+        // draft to pre-fill that sheet. No writes. See
+        // docs/features/pick-import-across-leagues.md.
         if (context.TargetUsesConfidencePoints)
         {
             var draft = plan.ToImport
+                .Where(i => selected.Contains(i.ContestId))
                 .Select(i => new PickImportDraftItemDto
                 {
                     ContestId = i.ContestId,
@@ -70,7 +72,7 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
                     Headline = i.Headline
                 })
                 .Concat(plan.Collisions
-                    .Where(c => replaceSet.Contains(c.ContestId))
+                    .Where(c => selected.Contains(c.ContestId))
                     .Select(c => new PickImportDraftItemDto
                     {
                         ContestId = c.ContestId,
@@ -91,7 +93,7 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
         var replaced = 0;
         var failed = 0;
 
-        foreach (var item in plan.ToImport)
+        foreach (var item in plan.ToImport.Where(i => selected.Contains(i.ContestId)))
         {
             if (await TrySubmitAsync(command, context.TargetPickType, item.ContestId, item.Week,
                     item.FranchiseSeasonId, item.SourcePickId, cancellationToken))
@@ -100,7 +102,7 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
                 failed++;
         }
 
-        foreach (var collision in plan.Collisions.Where(c => replaceSet.Contains(c.ContestId)))
+        foreach (var collision in plan.Collisions.Where(c => selected.Contains(c.ContestId)))
         {
             if (await TrySubmitAsync(command, context.TargetPickType, collision.ContestId, collision.Week,
                     collision.SourceFranchiseSeasonId, collision.SourcePickId, cancellationToken))
@@ -109,14 +111,16 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
                 failed++;
         }
 
-        var keptCount = plan.Collisions.Count(c => !replaceSet.Contains(c.ContestId));
+        // Importable contests the user left unchecked — left untouched, reported for transparency.
+        var notSelected = plan.ToImport.Count(i => !selected.Contains(i.ContestId))
+                          + plan.Collisions.Count(c => !selected.Contains(c.ContestId));
 
         var skippedByReason = plan.Skipped
             .GroupBy(s => s.Reason.ToString())
             .ToDictionary(g => g.Key, g => g.Count());
 
-        if (keptCount > 0)
-            skippedByReason["KeptExisting"] = keptCount;
+        if (notSelected > 0)
+            skippedByReason["NotSelected"] = notSelected;
         if (failed > 0)
             skippedByReason["Failed"] = failed;
 
@@ -124,7 +128,7 @@ public class ImportPicksCommandHandler : IImportPicksCommandHandler
         {
             Imported = imported,
             Replaced = replaced,
-            Skipped = plan.Skipped.Count + keptCount + failed,
+            Skipped = plan.Skipped.Count + notSelected + failed,
             SkippedByReason = skippedByReason
         };
 

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportRequest.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/Dtos/PickImportRequest.cs
@@ -2,13 +2,13 @@ namespace SportsData.Api.Application.UI.Picks.PickImport.Dtos;
 
 /// <summary>
 /// Body for POST /ui/leagues/{targetId}/picks/import. The target league is the
-/// route id; this names the source league and the collisions the user chose to
-/// replace (by contest id). Contests not listed here keep their existing target
-/// pick.
+/// route id; this names the source league and the contests the user selected to
+/// import (the checked boxes). Only those are imported; every other contest is
+/// left untouched.
 /// </summary>
 public sealed class PickImportRequest
 {
     public Guid SourceLeagueId { get; set; }
 
-    public List<Guid> ReplaceContestIds { get; set; } = [];
+    public List<Guid> ContestIds { get; set; } = [];
 }

--- a/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PickImport/PickImportController.cs
@@ -83,7 +83,7 @@ public class PickImportController : ApiControllerBase
             UserId = HttpContext.GetCurrentUserId(),
             SourceLeagueId = request.SourceLeagueId,
             TargetLeagueId = targetId,
-            ReplaceContestIds = request.ReplaceContestIds
+            ContestIds = request.ContestIds
         };
 
         var result = await handler.ExecuteAsync(command, cancellationToken);

--- a/src/UI/sd-ui/src/api/apiWrapper.js
+++ b/src/UI/sd-ui/src/api/apiWrapper.js
@@ -15,6 +15,7 @@ import Maps from "./mapsApi";
 import Articles from "./articlesApi";
 import Season from "./seasonApi";
 import LogoAdmin from "./logoAdminApi";
+import Imports from "./importsApi";
 
 const apiWrapper = {
   Matchups,
@@ -33,7 +34,8 @@ const apiWrapper = {
   Maps,
   Articles,
   Season,
-  LogoAdmin
+  LogoAdmin,
+  Imports
 };
 
 export default apiWrapper;

--- a/src/UI/sd-ui/src/api/importsApi.js
+++ b/src/UI/sd-ui/src/api/importsApi.js
@@ -1,0 +1,26 @@
+import apiClient from "./apiClient";
+
+// Cross-league pick import. Routes are league-scoped on the target league.
+const ImportsApi = {
+  // Candidate same-type source leagues that share >=1 contest with the target.
+  getSources: (leagueId) =>
+    apiClient.get(
+      `/ui/leagues/${encodeURIComponent(leagueId)}/picks/import/sources`
+    ),
+
+  // Dry-run plan: { toImport[], collisions[], skipped[], targetUsesConfidencePoints }.
+  getPreview: (leagueId, sourceLeagueId) =>
+    apiClient.post(
+      `/ui/leagues/${encodeURIComponent(leagueId)}/picks/import/preview`,
+      { sourceLeagueId }
+    ),
+
+  // Commit: imports exactly the selected contestIds. Returns the summary.
+  execute: (leagueId, sourceLeagueId, contestIds) =>
+    apiClient.post(
+      `/ui/leagues/${encodeURIComponent(leagueId)}/picks/import`,
+      { sourceLeagueId, contestIds }
+    ),
+};
+
+export default ImportsApi;

--- a/src/UI/sd-ui/src/components/picks/ImportPicksDialog.css
+++ b/src/UI/sd-ui/src/components/picks/ImportPicksDialog.css
@@ -1,0 +1,165 @@
+/* The page-level "Import N picks" button (lives in the picks status row). */
+.import-picks-button {
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.import-picks-button:hover {
+  background-color: var(--accent-hover);
+}
+
+/* Dialog — mirrors ConfirmationDialog with a scrollable checkbox list. */
+.import-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--bg-overlay);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.import-dialog {
+  background-color: var(--bg-modal);
+  border: 2px solid var(--accent);
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 480px;
+  width: 90%;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.import-dialog-title {
+  color: var(--accent);
+  margin: 0 0 12px 0;
+  font-size: 1.5rem;
+}
+
+.import-dialog-message {
+  color: var(--text-primary);
+  margin: 0 0 16px 0;
+  line-height: 1.5;
+}
+
+.import-dialog-source {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.import-dialog-source label {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.import-dialog-source select {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border-strong);
+  background-color: var(--bg-modal);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.import-dialog-selectall {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  cursor: pointer;
+  margin-bottom: 8px;
+  font-size: 0.9rem;
+}
+
+.import-dialog-list {
+  max-height: 45vh;
+  overflow-y: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.import-dialog-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.import-dialog-row:last-child {
+  border-bottom: none;
+}
+
+.import-dialog-row:hover {
+  background-color: var(--active-bg);
+}
+
+.import-dialog-row input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.import-dialog-row-matchup {
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.import-dialog-row-team {
+  color: var(--accent);
+  font-weight: bold;
+  white-space: nowrap;
+}
+
+.import-dialog-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.import-dialog-button {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.import-dialog-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.import-dialog-button.cancel {
+  background-color: var(--border-strong);
+  color: var(--text-primary);
+  border: 1px solid var(--text-muted);
+}
+
+.import-dialog-button.cancel:hover:not(:disabled) {
+  background-color: var(--active-bg);
+}
+
+.import-dialog-button.confirm {
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+  border: none;
+}
+
+.import-dialog-button.confirm:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+}

--- a/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
+++ b/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from "react";
+import "./ImportPicksDialog.css";
+
+/**
+ * Import-picks dialog. A single import always draws from ONE source league:
+ * with multiple candidates the user picks one from the dropdown, then the
+ * checkbox list shows that league's importable picks (all checked by default).
+ * `sources` is [{ leagueId, name, items: [{ contestId, franchiseSeasonId, team,
+ * matchupLabel }] }], already enriched and filtered to useful sources by the parent.
+ */
+function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
+  const [selectedSourceId, setSelectedSourceId] = useState(sources[0]?.leagueId ?? null);
+
+  const currentSource =
+    sources.find((s) => s.leagueId === selectedSourceId) ?? sources[0] ?? null;
+  const items = currentSource?.items ?? [];
+
+  const [selected, setSelected] = useState(() => new Set(items.map((i) => i.contestId)));
+
+  // Reset checkboxes to all-checked whenever the chosen source changes.
+  useEffect(() => {
+    const src = sources.find((s) => s.leagueId === selectedSourceId) ?? sources[0] ?? null;
+    setSelected(new Set((src?.items ?? []).map((i) => i.contestId)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedSourceId]);
+
+  if (!isOpen || !currentSource) return null;
+
+  const toggle = (contestId) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(contestId)) next.delete(contestId);
+      else next.add(contestId);
+      return next;
+    });
+  };
+
+  const allSelected = items.length > 0 && items.every((i) => selected.has(i.contestId));
+  const toggleAll = () =>
+    setSelected(allSelected ? new Set() : new Set(items.map((i) => i.contestId)));
+
+  const count = selected.size;
+
+  return (
+    <div className="import-dialog-overlay" onClick={importing ? undefined : onClose}>
+      <div className="import-dialog" onClick={(e) => e.stopPropagation()}>
+        <h3 className="import-dialog-title">Import picks</h3>
+
+        {sources.length > 1 ? (
+          <div className="import-dialog-source">
+            <label htmlFor="import-source">Import from</label>
+            <select
+              id="import-source"
+              value={selectedSourceId}
+              onChange={(e) => setSelectedSourceId(e.target.value)}
+              disabled={importing}
+            >
+              {sources.map((s) => (
+                <option key={s.leagueId} value={s.leagueId}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <p className="import-dialog-message">
+            Copy your picks from <strong>{currentSource.name}</strong>. Uncheck any you
+            don&rsquo;t want.
+          </p>
+        )}
+
+        <label className="import-dialog-selectall">
+          <input type="checkbox" checked={allSelected} onChange={toggleAll} />
+          Select all
+        </label>
+
+        <div className="import-dialog-list">
+          {items.map((item) => (
+            <label key={item.contestId} className="import-dialog-row">
+              <input
+                type="checkbox"
+                checked={selected.has(item.contestId)}
+                onChange={() => toggle(item.contestId)}
+              />
+              <span className="import-dialog-row-matchup">{item.matchupLabel}</span>
+              <span className="import-dialog-row-team">{item.team}</span>
+            </label>
+          ))}
+        </div>
+
+        <div className="import-dialog-buttons">
+          <button
+            className="import-dialog-button cancel"
+            onClick={onClose}
+            disabled={importing}
+          >
+            Cancel
+          </button>
+          <button
+            className="import-dialog-button confirm"
+            onClick={() => onImport(currentSource.leagueId, [...selected])}
+            disabled={importing || count === 0}
+          >
+            {importing ? "Importing…" : `Import ${count} pick${count === 1 ? "" : "s"}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ImportPicksDialog;

--- a/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
+++ b/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import "./ImportPicksDialog.css";
 
 /**
@@ -17,6 +17,8 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
 
   const [selected, setSelected] = useState(() => new Set(items.map((i) => i.contestId)));
 
+  const dialogRef = useRef(null);
+
   // Close on Escape (unless mid-import), matching the app's Gallery modal.
   useEffect(() => {
     const onKey = (e) => {
@@ -26,7 +28,35 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [importing, onClose]);
 
+  // Move focus into the dialog on open; restore it to the trigger on close.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement;
+    dialogRef.current?.focus();
+    return () => {
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+    };
+  }, []);
+
   if (!isOpen || !currentSource) return null;
+
+  // Trap Tab / Shift+Tab within the dialog so keyboard focus can't escape to the
+  // page behind the modal.
+  const handleTabTrap = (e) => {
+    if (e.key !== "Tab") return;
+    const focusables = dialogRef.current?.querySelectorAll(
+      'button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+    );
+    if (!focusables || focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   // Switch source and re-seed the checkboxes to all of that source's picks.
   // Done here (on the user's action) rather than in an effect so a background
@@ -50,7 +80,12 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
   const toggleAll = () =>
     setSelected(allSelected ? new Set() : new Set(items.map((i) => i.contestId)));
 
-  const count = selected.size;
+  // Submit only contests still present in the source being imported from — prunes
+  // any stale ids if a background refresh changed/dropped the selected source, so
+  // source and contestIds can never mismatch. No-op in the normal case.
+  const currentItemIds = new Set(items.map((i) => i.contestId));
+  const chosenContestIds = [...selected].filter((id) => currentItemIds.has(id));
+  const count = chosenContestIds.length;
 
   return (
     <div className="import-dialog-overlay" onClick={importing ? undefined : onClose}>
@@ -59,6 +94,9 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="import-dialog-title"
+        ref={dialogRef}
+        tabIndex={-1}
+        onKeyDown={handleTabTrap}
         onClick={(e) => e.stopPropagation()}
       >
         <h3 id="import-dialog-title" className="import-dialog-title">
@@ -70,7 +108,7 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
             <label htmlFor="import-source">Import from</label>
             <select
               id="import-source"
-              value={selectedSourceId}
+              value={currentSource.leagueId}
               onChange={(e) => changeSource(e.target.value)}
               disabled={importing}
             >
@@ -117,7 +155,7 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
           </button>
           <button
             className="import-dialog-button confirm"
-            onClick={() => onImport(currentSource.leagueId, [...selected])}
+            onClick={() => onImport(currentSource.leagueId, chosenContestIds)}
             disabled={importing || count === 0}
           >
             {importing ? "Importing…" : `Import ${count} pick${count === 1 ? "" : "s"}`}

--- a/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
+++ b/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
@@ -49,7 +49,11 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
     if (!focusables || focusables.length === 0) return;
     const first = focusables[0];
     const last = focusables[focusables.length - 1];
-    if (e.shiftKey && document.activeElement === first) {
+    // Right after open, focus sits on the container (tabIndex -1) — treat it as
+    // before the first control so Shift+Tab wraps to the last instead of escaping.
+    const atStart =
+      document.activeElement === first || document.activeElement === dialogRef.current;
+    if (e.shiftKey && atStart) {
       e.preventDefault();
       last.focus();
     } else if (!e.shiftKey && document.activeElement === last) {

--- a/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
+++ b/src/UI/sd-ui/src/components/picks/ImportPicksDialog.jsx
@@ -17,14 +17,25 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
 
   const [selected, setSelected] = useState(() => new Set(items.map((i) => i.contestId)));
 
-  // Reset checkboxes to all-checked whenever the chosen source changes.
+  // Close on Escape (unless mid-import), matching the app's Gallery modal.
   useEffect(() => {
-    const src = sources.find((s) => s.leagueId === selectedSourceId) ?? sources[0] ?? null;
-    setSelected(new Set((src?.items ?? []).map((i) => i.contestId)));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedSourceId]);
+    const onKey = (e) => {
+      if (e.key === "Escape" && !importing) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [importing, onClose]);
 
   if (!isOpen || !currentSource) return null;
+
+  // Switch source and re-seed the checkboxes to all of that source's picks.
+  // Done here (on the user's action) rather than in an effect so a background
+  // data refresh can never wipe in-progress checkbox edits.
+  const changeSource = (leagueId) => {
+    setSelectedSourceId(leagueId);
+    const src = sources.find((s) => s.leagueId === leagueId);
+    setSelected(new Set((src?.items ?? []).map((i) => i.contestId)));
+  };
 
   const toggle = (contestId) => {
     setSelected((prev) => {
@@ -43,8 +54,16 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
 
   return (
     <div className="import-dialog-overlay" onClick={importing ? undefined : onClose}>
-      <div className="import-dialog" onClick={(e) => e.stopPropagation()}>
-        <h3 className="import-dialog-title">Import picks</h3>
+      <div
+        className="import-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="import-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="import-dialog-title" className="import-dialog-title">
+          Import picks
+        </h3>
 
         {sources.length > 1 ? (
           <div className="import-dialog-source">
@@ -52,7 +71,7 @@ function ImportPicksDialog({ isOpen, sources, importing, onClose, onImport }) {
             <select
               id="import-source"
               value={selectedSourceId}
-              onChange={(e) => setSelectedSourceId(e.target.value)}
+              onChange={(e) => changeSource(e.target.value)}
               disabled={importing}
             >
               {sources.map((s) => (

--- a/src/UI/sd-ui/src/components/picks/PicksPage.css
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.css
@@ -82,9 +82,26 @@
   grid-column: 3; /* Position in the third column */
 }
 
-.pick-status {
-  font-size: 1rem;
+/* Picks-made count, styled as a pill to match .pick-mode-badge. Muted while
+   picks remain, accent (with a check) once every game is picked. */
+.pick-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background-color: var(--active-bg);
   color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.4;
+}
+
+.pick-status-badge.complete {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .pick-mode-badge {
@@ -102,12 +119,29 @@
   line-height: 1.4;
 }
 
+/* Show/hide-picked-games toggle: a compact icon button matching the pill row.
+   Accent-highlighted while picked games are hidden. */
 .hide-picked-toggle {
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  padding: 5px 9px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background-color: var(--active-bg);
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.hide-picked-toggle:hover {
+  color: var(--text-primary);
+}
+
+.hide-picked-toggle.active {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 @media (max-width: 600px) {

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -319,6 +319,12 @@ function PicksPage() {
       if (!routeLeagueId || selectedWeek === null) return;
       if (!seasonWeeks.includes(selectedWeek)) return;
 
+      // Invalidate the loaded key while this request is in flight; only a
+      // successful response re-validates it. A failure (e.g. the post-import
+      // refetch) thus leaves imports gated rather than evaluating against a
+      // stale pick set.
+      setPicksLoadedKey(null);
+
       try {
         const response = await apiWrapper.Picks.getUserPicksByWeek(
           routeLeagueId,

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -6,6 +6,8 @@ import { useUserDto } from "../../contexts/UserContext";
 import { useLeagueContext } from "../../contexts/LeagueContext";
 import { useContestUpdates } from "../../contexts/ContestUpdatesContext";
 import InsightDialog from "../insights/InsightDialog.jsx";
+import ImportPicksDialog from "./ImportPicksDialog.jsx";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 import toast from "react-hot-toast";
 import apiWrapper from "../../api/apiWrapper.js";
 import LeagueWeekSelector from "./LeagueWeekSelector.jsx";
@@ -61,6 +63,14 @@ function PicksPage() {
   const [hidePicked, setHidePicked] = useState(false);
   const [fadingOut, setFadingOut] = useState([]);
   const [now, setNow] = useState(new Date());
+
+  // Cross-league pick import. importState is set by an off-critical-path
+  // availability check when the user can fill unpicked games from another league.
+  const [importState, setImportState] = useState(null); // { sources: [{ leagueId, name, toImport }] }
+  const [isImportOpen, setIsImportOpen] = useState(false);
+  const [importing, setImporting] = useState(false);
+  // Bumped to force a picks refetch after an import commits.
+  const [picksReload, setPicksReload] = useState(0);
 
   // Update 'now' every 15 seconds to keep lock status in sync with MatchupCard
   useEffect(() => {
@@ -328,7 +338,123 @@ function PicksPage() {
     return () => {
       cancelled = true;
     };
-  }, [routeLeagueId, selectedWeek, seasonWeeks]);
+  }, [routeLeagueId, selectedWeek, seasonWeeks, picksReload]);
+
+  // Off-critical-path: can the user import picks into this league from another
+  // (same-type) league? Drives the "Import N picks" button. The whole-league
+  // preview is fetched; the dialog scopes display to the current week's matchups.
+  // Runs after matchups/picks load so it never delays time-to-first-pick.
+  useEffect(() => {
+    let cancelled = false;
+    async function checkImportAvailability() {
+      if (!routeLeagueId || matchups.length === 0) {
+        setImportState(null);
+        return;
+      }
+      // Nothing to fill → don't even ask.
+      if (!matchups.some((m) => !userPicks[m.contestId])) {
+        setImportState(null);
+        return;
+      }
+
+      try {
+        const sourcesRes = await apiWrapper.Imports.getSources(routeLeagueId);
+        if (cancelled) return;
+        const sources = sourcesRes.data || [];
+        if (sources.length === 0) {
+          setImportState(null);
+          return;
+        }
+
+        // Preview every candidate source in parallel; keep only those that
+        // actually have picks to import. A single import always draws from one
+        // source, so this just populates the dialog's source picker.
+        const previews = await Promise.all(
+          sources.map((s) =>
+            apiWrapper.Imports.getPreview(routeLeagueId, s.leagueId)
+              .then((res) => ({
+                leagueId: s.leagueId,
+                name: s.name,
+                toImport: res.data?.toImport || [],
+              }))
+              .catch(() => ({ leagueId: s.leagueId, name: s.name, toImport: [] }))
+          )
+        );
+        if (cancelled) return;
+
+        const withPicks = previews.filter((p) => p.toImport.length > 0);
+        setImportState(withPicks.length > 0 ? { sources: withPicks } : null);
+      } catch (error) {
+        if (cancelled) return;
+        console.error("Import availability check failed:", error);
+        setImportState(null);
+      }
+    }
+
+    checkImportAvailability();
+    return () => {
+      cancelled = true;
+    };
+  }, [routeLeagueId, selectedWeek, matchups, userPicks]);
+
+  // Per-source importable rows for the dialog: each candidate source's picks,
+  // scoped to this week's still-unpicked matchups and enriched for display from
+  // data already loaded. Sources with nothing to offer are dropped, so the
+  // dialog's picker only lists useful ones. Built off raw `matchups` (stable)
+  // rather than enrichedMatchups so live score ticks don't churn it.
+  // Kept with the other hooks (before any early return) per rules-of-hooks.
+  const importSources = useMemo(() => {
+    if (!importState) return [];
+    const byContest = new Map(matchups.map((m) => [m.contestId, m]));
+    return importState.sources
+      .map((src) => ({
+        leagueId: src.leagueId,
+        name: src.name,
+        items: src.toImport
+          .filter((i) => byContest.has(i.contestId) && !userPicks[i.contestId])
+          .map((i) => {
+            const m = byContest.get(i.contestId);
+            const isHome = i.franchiseSeasonId === m.homeFranchiseSeasonId;
+            return {
+              contestId: i.contestId,
+              franchiseSeasonId: i.franchiseSeasonId,
+              team: isHome ? m.home : m.away,
+              matchupLabel: `${m.away} @ ${m.home}`,
+            };
+          }),
+      }))
+      .filter((src) => src.items.length > 0);
+  }, [importState, matchups, userPicks]);
+
+  async function handleImport(sourceLeagueId, contestIds) {
+    if (!sourceLeagueId || contestIds.length === 0) return;
+    setImporting(true);
+    try {
+      const res = await apiWrapper.Imports.execute(
+        routeLeagueId,
+        sourceLeagueId,
+        contestIds
+      );
+
+      if (res.data?.requiresConfidence) {
+        // Confidence-league target: import returns a draft, not a commit. That
+        // pick-sheet flow isn't wired up yet.
+        toast("This league uses confidence points — import isn’t available here yet.", {
+          icon: "⚠️",
+        });
+      } else {
+        const imported = res.data?.imported ?? contestIds.length;
+        toast.success(`Imported ${imported} pick${imported === 1 ? "" : "s"}!`);
+        setPicksReload((k) => k + 1); // refetch picks → UI + button update
+      }
+      setIsImportOpen(false);
+    } catch (error) {
+      console.error("Failed to import picks:", error);
+      toast.error("Failed to import picks. Please try again.");
+    } finally {
+      setImporting(false);
+    }
+  }
 
   async function handlePick(matchup, selectedFranchiseSeasonId, confidencePoints) {
     try {
@@ -569,20 +695,37 @@ function PicksPage() {
                 </span>
               );
             })()}
-            <span className="pick-status">
-              {allPicked
-                ? "All Picks Made"
-                : `${picksMade} / ${totalGames} Picks Made`}
+            <span
+              className={`pick-status-badge${allPicked ? " complete" : ""}`}
+              title="Picks made"
+            >
+              {allPicked && "✓ "}
+              {picksMade}/{totalGames}
             </span>
             {!allPicked && (
-              <label className="hide-picked-toggle">
-                <input
-                  type="checkbox"
-                  checked={hidePicked}
-                  onChange={() => setHidePicked(!hidePicked)}
-                />
-                Hide Picked Games
-              </label>
+              <button
+                type="button"
+                className={`hide-picked-toggle${hidePicked ? " active" : ""}`}
+                onClick={() => setHidePicked(!hidePicked)}
+                title={hidePicked ? "Show all games" : "Hide picked games"}
+                aria-label={hidePicked ? "Show all games" : "Hide picked games"}
+                aria-pressed={hidePicked}
+              >
+                {hidePicked ? <FaEyeSlash /> : <FaEye />}
+              </button>
+            )}
+            {importSources.length > 0 && (
+              <button
+                type="button"
+                className="import-picks-button"
+                onClick={() => setIsImportOpen(true)}
+              >
+                {importSources.length === 1
+                  ? `Import ${importSources[0].items.length} pick${
+                      importSources[0].items.length === 1 ? "" : "s"
+                    }`
+                  : "Import picks"}
+              </button>
             )}
           </div>
         </div>
@@ -631,6 +774,16 @@ function PicksPage() {
             loading={loadingInsight}
             onRejectPreview={handleRejectPreview}
             onApprovePreview={handleApprovePreview}
+          />
+        )}
+
+        {isImportOpen && (
+          <ImportPicksDialog
+            isOpen={isImportOpen}
+            sources={importSources}
+            importing={importing}
+            onClose={() => setIsImportOpen(false)}
+            onImport={handleImport}
           />
         )}
       </div>

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -71,6 +71,10 @@ function PicksPage() {
   const [importing, setImporting] = useState(false);
   // Bumped to force a picks refetch after an import commits.
   const [picksReload, setPicksReload] = useState(0);
+  // "leagueId:week" that the current userPicks belong to. Gates the import
+  // availability check so a stale pick set — e.g. the previous league, which
+  // shares contest ids on same-day games — can't mis-drive the button.
+  const [picksLoadedKey, setPicksLoadedKey] = useState(null);
 
   // Update 'now' every 15 seconds to keep lock status in sync with MatchupCard
   useEffect(() => {
@@ -328,6 +332,7 @@ function PicksPage() {
         }
 
         setUserPicks(picksByContest);
+        setPicksLoadedKey(`${routeLeagueId}:${selectedWeek}`);
       } catch (error) {
         if (cancelled) return;
         console.error("Failed to fetch user picks:", error);
@@ -347,6 +352,13 @@ function PicksPage() {
   useEffect(() => {
     let cancelled = false;
     async function checkImportAvailability() {
+      // Only evaluate once the CURRENT league/week's picks have loaded — a stale
+      // pick set could otherwise mis-drive the button (shared contest ids across
+      // leagues). Stays unset while loading or after a picks-fetch failure.
+      if (picksLoadedKey !== `${routeLeagueId}:${selectedWeek}`) {
+        setImportState(null);
+        return;
+      }
       if (!routeLeagueId || matchups.length === 0) {
         setImportState(null);
         return;
@@ -395,7 +407,7 @@ function PicksPage() {
     return () => {
       cancelled = true;
     };
-  }, [routeLeagueId, selectedWeek, matchups, userPicks]);
+  }, [routeLeagueId, selectedWeek, matchups, userPicks, picksLoadedKey]);
 
   // Per-source importable rows for the dialog: each candidate source's picks,
   // scoped to this week's still-unpicked matchups and enriched for display from

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
@@ -175,6 +175,34 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
     }
 
     [Fact]
+    public async Task NullContestIds_ImportsNothing_WithoutThrowing()
+    {
+        // A "contestIds": null payload overrides the DTO default; treat it as an
+        // empty selection (no-op) rather than throwing.
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var contest = Guid.NewGuid();
+        var team = Guid.NewGuid();
+        SeedMatchup(targetId, contest, NowUtc.AddDays(1));
+        SeedPick(sourceId, userId, contest, team);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId,
+            ContestIds = null!
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Imported.Should().Be(0);
+        TargetPick(targetId, userId, contest).Should().BeNull();
+    }
+
+    [Fact]
     public async Task ReplacesOnlySelectedCollisions_AndLeavesUnselected()
     {
         var userId = Guid.NewGuid();

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
@@ -123,7 +123,8 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         {
             UserId = userId,
             SourceLeagueId = sourceId,
-            TargetLeagueId = targetId
+            TargetLeagueId = targetId,
+            ContestIds = [contestA, contestB]
         });
 
         result.IsSuccess.Should().BeTrue();
@@ -139,7 +140,42 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
     }
 
     [Fact]
-    public async Task ReplacesOnlyApprovedCollisions_AndKeepsTheRest()
+    public async Task ImportsOnlySelectedContests_LeavesUnselectedUntouched()
+    {
+        // The user unchecks one of two importable contests — only the checked one is written.
+        var userId = Guid.NewGuid();
+        var sourceId = SeedLeague(userId, PickType.StraightUp);
+        var targetId = SeedLeague(userId, PickType.StraightUp);
+
+        var selected = Guid.NewGuid();
+        var unselected = Guid.NewGuid();
+        var team = Guid.NewGuid();
+        var future = NowUtc.AddDays(1);
+
+        SeedMatchup(targetId, selected, future);
+        SeedMatchup(targetId, unselected, future);
+        SeedPick(sourceId, userId, selected, team);
+        SeedPick(sourceId, userId, unselected, team);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new ImportPicksCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            TargetLeagueId = targetId,
+            ContestIds = [selected]
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Imported.Should().Be(1);
+        result.Value.SkippedByReason.Should().ContainKey("NotSelected").WhoseValue.Should().Be(1);
+
+        TargetPick(targetId, userId, selected).Should().NotBeNull();
+        TargetPick(targetId, userId, unselected).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReplacesOnlySelectedCollisions_AndLeavesUnselected()
     {
         var userId = Guid.NewGuid();
         var sourceId = SeedLeague(userId, PickType.StraightUp);
@@ -165,13 +201,13 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
             UserId = userId,
             SourceLeagueId = sourceId,
             TargetLeagueId = targetId,
-            ReplaceContestIds = [approved]
+            ContestIds = [approved]
         });
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Imported.Should().Be(0);
         result.Value.Replaced.Should().Be(1);
-        result.Value.SkippedByReason.Should().ContainKey("KeptExisting").WhoseValue.Should().Be(1);
+        result.Value.SkippedByReason.Should().ContainKey("NotSelected").WhoseValue.Should().Be(1);
 
         // Approved collision was overwritten with the source team + traceability.
         var approvedPick = TargetPick(targetId, userId, approved)!;
@@ -208,7 +244,8 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         {
             UserId = userId,
             SourceLeagueId = sourceId,
-            TargetLeagueId = targetId
+            TargetLeagueId = targetId,
+            ContestIds = [locked, matches, notShared]
         });
 
         result.IsSuccess.Should().BeTrue();
@@ -238,7 +275,8 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         {
             UserId = userId,
             SourceLeagueId = sourceId,
-            TargetLeagueId = targetId
+            TargetLeagueId = targetId,
+            ContestIds = [contest]
         });
 
         result.IsSuccess.Should().BeTrue();
@@ -270,7 +308,7 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
             UserId = userId,
             SourceLeagueId = sourceId,
             TargetLeagueId = targetId,
-            ReplaceContestIds = [collision]
+            ContestIds = [collision]
         });
 
         result.Value.RequiresConfidence.Should().BeTrue();
@@ -338,7 +376,8 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         {
             UserId = userId,
             SourceLeagueId = sourceId,
-            TargetLeagueId = targetId
+            TargetLeagueId = targetId,
+            ContestIds = [okContest, failContest]
         });
 
         result.IsSuccess.Should().BeTrue();
@@ -370,7 +409,8 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         {
             UserId = userId,
             SourceLeagueId = sourceId,
-            TargetLeagueId = targetId
+            TargetLeagueId = targetId,
+            ContestIds = [contest]
         };
 
         var first = await CreateHandler().ExecuteAsync(command);


### PR DESCRIPTION
## What

The **web front-end** for import-picks-across-leagues (backend shipped in #513–#515), plus two small picks-page styling tweaks. Validated end-to-end locally (2- and 3-league same-day MLB).

## Backend — selection contract

The commit endpoint now takes an **explicit selection** so unchecking a box actually excludes it:

```
POST /ui/leagues/{targetId}/picks/import  { sourceLeagueId, contestIds }
```

Imports exactly the checked `contestIds` (that the server-side plan says are importable) and leaves everything else untouched — replacing the previous "import-all `toImport` + `replaceContestIds`" model. A single import always draws from **one** source league, so there is no cross-source merging or conflict resolution to worry about. No consumer existed yet, so this is a free revision. Covered by updated `ImportPicksCommandHandler` tests (including a new "imports only selected, leaves the rest untouched").

## Web (`sd-ui`)

- **"Import N picks" / "Import picks" button** in the picks status row, shown only when the user can actually fill unpicked games from another same-type league. Driven by an **off-critical-path** availability check (runs after the page renders) that previews each candidate source and keeps the ones with importable picks.
- **`ImportPicksDialog`** — a checkbox list of the shared contests, **all checked by default** (never forced), with **Select all**. When more than one source qualifies, a **"Import from" dropdown** lets the user choose the single source league; switching sources re-checks all. Commits the selected set and toasts the summary, then refetches picks so the sheet and button update.
- Confidence-league targets are guarded with a "not available here yet" toast (that draft flow is deferred).

## Styling tweaks (same PR, per request)

- **Picks-made count**: `X / Y Picks Made` → a compact pill matching the pick-type badge — muted `3/10`, flips to accent `✓ 10/10` when complete.
- **Hide-picked toggle**: the `☐ Hide Picked Games` checkbox → an **eye / eye-slash icon button** (`react-icons`, already a project dep), accent-highlighted while hiding, with `aria-pressed` / tooltip.

## Verification

- Full `SportsData.Api.Tests.Unit` suite green (522).
- `sd-ui` production build clean (`CI=true`).
- Manually exercised: single-source import, multi-source dropdown, uncheck-to-exclude, button/count refresh after import.

## Deferred (future)

Collision resolution (differing existing target picks), the confidence-league draft pick-sheet flow, and **mobile parity** (next up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-league pick importing from the Picks page, including source selection, preview, and an import confirmation dialog.
  * Users can choose which contests to import (including “Select all”) and confirm, with in-progress, success, and error feedback.
  * Updated UI presentation with badge-style pick status and a compact hide-picked control.

* **Bug Fixes**
  * Import operations now apply only to explicitly selected contests; other contests are left unchanged.
  * Updated skipped/failed counts and skip reasons to accurately reflect selection (e.g., “Not selected” for unchosen contests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->