### PR TITLE
feat(picks): mobile UI for cross-league pick import

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -20,8 +20,11 @@ import { EmptyState } from '@/src/components/ui/EmptyState';
 import { usePicks, useSubmitPick } from '@/src/hooks/useContest';
 import { useMatchups } from '@/src/hooks/useMatchups';
 import { useCurrentUser } from '@/src/hooks/useStandings';
+import { useImportAvailability, useImportPicks } from '@/src/hooks/useImportPicks';
+import { ImportPicksModal } from '@/src/components/features/picks/ImportPicksModal';
 import { getLeagues } from '@/src/lib/leagues';
 import { resolveSportLeague } from '@/src/utils/sportLinks';
+import Toast from 'react-native-toast-message';
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
@@ -41,6 +44,7 @@ export default function PicksScreen() {
   const [leagueId, setLeagueId] = useState<string | null>(null);
   const [selectedWeek, setSelectedWeek] = useState<number | null>(null);
   const [hidePicked, setHidePicked] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
   // Latest week = last element of the ascending seasonWeeks list.
   const latestWeek = (l: { seasonWeeks?: number[] } | null | undefined) =>
@@ -123,6 +127,76 @@ export default function PicksScreen() {
   // on screen.
   const made = entries.filter((e) => e.pick !== null).length;
   const allPicked = total > 0 && made >= total;
+
+  // ── Cross-league pick import ────────────────────────────────────────────────
+  // Only check availability once picks + matchups have loaded and there are
+  // unpicked games to fill (React Query's enabled replaces the web's manual
+  // picks-loaded gating).
+  const importEnabled =
+    !picksLoading && !matchupsLoading && total > 0 && made < total;
+  const { data: availabilityData } = useImportAvailability(
+    leagueId,
+    selectedWeek,
+    importEnabled,
+  );
+  const importPicks = useImportPicks();
+
+  // Enrich the previewed sources for display, scoped to this week's still-unpicked
+  // matchups; drop sources with nothing left to offer.
+  const importSources = useMemo(() => {
+    const avail = availabilityData ?? [];
+    const byContest = new Map(matchups.map((m) => [m.contestId, m]));
+    return avail
+      .map((src) => ({
+        leagueId: src.leagueId,
+        name: src.name,
+        items: src.toImport
+          .filter((i) => byContest.has(i.contestId) && !pickMap.has(i.contestId))
+          .map((i) => {
+            const m = byContest.get(i.contestId)!;
+            const isHome = i.franchiseSeasonId === m.homeFranchiseSeasonId;
+            return {
+              contestId: i.contestId,
+              franchiseSeasonId: i.franchiseSeasonId,
+              team: isHome ? m.home : m.away,
+              matchupLabel: `${m.away} @ ${m.home}`,
+            };
+          }),
+      }))
+      .filter((src) => src.items.length > 0);
+  }, [availabilityData, matchups, pickMap]);
+
+  const handleImport = useCallback(
+    (sourceLeagueId: string, contestIds: string[]) => {
+      if (!leagueId || selectedWeek == null) return;
+      importPicks.mutate(
+        { leagueId, week: selectedWeek, sourceLeagueId, contestIds },
+        {
+          onSuccess: (res) => {
+            setImportOpen(false);
+            if (res?.requiresConfidence) {
+              Toast.show({
+                type: 'info',
+                text1: 'Not available here yet',
+                text2: 'This league uses confidence points.',
+              });
+            } else {
+              const n = res?.imported ?? contestIds.length;
+              Toast.show({ type: 'success', text1: `Imported ${n} pick${n === 1 ? '' : 's'}!` });
+            }
+          },
+          onError: () => {
+            Toast.show({
+              type: 'error',
+              text1: 'Failed to import picks',
+              text2: 'Please try again.',
+            });
+          },
+        },
+      );
+    },
+    [leagueId, selectedWeek, importPicks],
+  );
 
   // Hide Picked is a no-op once allPicked flips true — the toggle is also
   // hidden in that branch of the header, so respecting it would strand the
@@ -251,6 +325,23 @@ export default function PicksScreen() {
         />
       )}
 
+      {importSources.length > 0 && !allPicked && (
+        <Pressable
+          onPress={() => setImportOpen(true)}
+          style={[styles.importBanner, { backgroundColor: theme.tint }]}
+          accessibilityRole="button"
+        >
+          <Ionicons name="download-outline" size={18} color={theme.textOnAccent} />
+          <Text style={[styles.importBannerText, { color: theme.textOnAccent }]}>
+            {importSources.length === 1
+              ? `Import ${importSources[0].items.length} pick${
+                  importSources[0].items.length === 1 ? '' : 's'
+                } from ${importSources[0].name}`
+              : 'Import picks from another league'}
+          </Text>
+        </Pressable>
+      )}
+
       {isLoading ? (
         <LoadingSpinner message="Loading picks…" />
       ) : (
@@ -360,6 +451,14 @@ export default function PicksScreen() {
           }
         />
       )}
+
+      <ImportPicksModal
+        visible={importOpen}
+        sources={importSources}
+        importing={importPicks.isPending}
+        onClose={() => setImportOpen(false)}
+        onImport={handleImport}
+      />
     </View>
   );
 }
@@ -374,6 +473,18 @@ const styles = StyleSheet.create({
   columnWrapper: { gap: 10 },
   // Each card fills its share of the row so columns stay equal width.
   cardSlot: { flex: 1 },
+  // "Import picks" banner shown above the slate when picks can be pulled in.
+  importBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginHorizontal: 14,
+    marginTop: 10,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  importBannerText: { fontSize: 15, fontWeight: '700' },
 });
 
 const headerStyles = StyleSheet.create({

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -32,6 +32,7 @@ import { useRegisterPushDevice } from '@/src/hooks/useRegisterPushDevice';
 import { ThemeProvider, useThemeMode } from '@/src/lib/theme/ThemeContext';
 import { TextSizeProvider, useTextSize } from '@/src/lib/textSize/TextSizeContext';
 import { SignalRGate } from '@/src/components/signalR/SignalRGate';
+import Toast from 'react-native-toast-message';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -153,6 +154,8 @@ function RootLayout() {
           <RootLayoutNav />
         </TextSizeProvider>
       </ThemeProvider>
+      {/* Root-level toast host — renders above the nav tree. */}
+      <Toast />
     </QueryClientProvider>
   );
 }

--- a/src/UI/sd-mobile/package-lock.json
+++ b/src/UI/sd-mobile/package-lock.json
@@ -45,6 +45,7 @@
         "react-native-reanimated": "4.2.1",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
+        "react-native-toast-message": "^2.4.0",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.7.4",
         "zod": "^4.3.6",
@@ -11404,6 +11405,15 @@
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-toast-message": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.4.0.tgz",
+      "integrity": "sha512-Ip4sPpf9707Qmn06Jp1aGJrYLx2mwTYBRjXzP7ebPvmjABA6OCT9bEh62E0L6s5zc/KPZ3rix+OnBKW/pOJZ4g==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/src/UI/sd-mobile/package.json
+++ b/src/UI/sd-mobile/package.json
@@ -75,6 +75,7 @@
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
+    "react-native-toast-message": "^2.4.0",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.7.4",
     "zod": "^4.3.6",

--- a/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Modal,
+  View,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Text } from '@/src/components/ui/AppText';
+import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+
+export interface ImportItemRow {
+  contestId: string;
+  franchiseSeasonId: string;
+  team: string;
+  matchupLabel: string;
+}
+
+export interface ImportSourceForModal {
+  leagueId: string;
+  name: string;
+  items: ImportItemRow[];
+}
+
+interface Props {
+  visible: boolean;
+  sources: ImportSourceForModal[];
+  importing: boolean;
+  onClose: () => void;
+  onImport: (sourceLeagueId: string, contestIds: string[]) => void;
+}
+
+/**
+ * Import-picks sheet. A single import always draws from ONE source league; with
+ * multiple candidates the user picks one (segmented control), then toggles the
+ * checkbox list of that league's importable games (all checked by default).
+ */
+export function ImportPicksModal({ visible, sources, importing, onClose, onImport }: Props) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const [selectedSourceId, setSelectedSourceId] = useState<string | null>(
+    sources[0]?.leagueId ?? null,
+  );
+  const currentSource =
+    sources.find((s) => s.leagueId === selectedSourceId) ?? sources[0] ?? null;
+  const items = currentSource?.items ?? [];
+
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(items.map((i) => i.contestId)),
+  );
+
+  // The modal stays mounted (so the sheet can animate in/out), so its initial
+  // state can be stale — sources is often empty on first mount, before the
+  // availability query resolves. Re-seed to the first source, all-checked, each
+  // time the sheet opens. Keyed on `visible` only so a background sources refresh
+  // while open can't wipe in-progress edits.
+  useEffect(() => {
+    if (!visible) return;
+    const first = sources[0] ?? null;
+    setSelectedSourceId(first?.leagueId ?? null);
+    setSelected(new Set((first?.items ?? []).map((i) => i.contestId)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed only on open
+  }, [visible]);
+
+  // Switch source and re-seed the checkboxes to all of that source's picks. Done
+  // on the user's action (not an effect) so a background refresh can't wipe edits.
+  const changeSource = (leagueId: string) => {
+    setSelectedSourceId(leagueId);
+    const src = sources.find((s) => s.leagueId === leagueId);
+    setSelected(new Set((src?.items ?? []).map((i) => i.contestId)));
+  };
+
+  const toggle = (contestId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(contestId)) next.delete(contestId);
+      else next.add(contestId);
+      return next;
+    });
+  };
+
+  const allSelected = items.length > 0 && items.every((i) => selected.has(i.contestId));
+  const toggleAll = () =>
+    setSelected(allSelected ? new Set() : new Set(items.map((i) => i.contestId)));
+
+  // Submit only contests still present in the chosen source, so source and
+  // contestIds can never mismatch.
+  const chosenContestIds = useMemo(() => {
+    const ids = new Set(items.map((i) => i.contestId));
+    return [...selected].filter((id) => ids.has(id));
+  }, [items, selected]);
+  const count = chosenContestIds.length;
+
+  const sourceOptions = sources.map((s) => ({ value: s.leagueId, label: s.name }));
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={importing ? undefined : onClose}
+    >
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={[styles.header, { borderBottomColor: theme.border }]}>
+          <Text style={[styles.headerTitle, { color: theme.text }]}>Import picks</Text>
+          <TouchableOpacity onPress={onClose} disabled={importing} hitSlop={12}>
+            <Text style={[styles.closeText, { color: theme.textMuted }]}>✕</Text>
+          </TouchableOpacity>
+        </View>
+
+        {sources.length > 1 && currentSource ? (
+          <View style={styles.sourceRow}>
+            <Text style={[styles.sourceLabel, { color: theme.textMuted }]}>Import from</Text>
+            <SegmentedControl
+              value={currentSource.leagueId}
+              options={sourceOptions}
+              onChange={changeSource}
+              accessibilityLabel="Source league"
+            />
+          </View>
+        ) : currentSource ? (
+          <Text style={[styles.sourceHint, { color: theme.textMuted }]}>
+            Copy your picks from {currentSource.name}. Uncheck any you don&rsquo;t want.
+          </Text>
+        ) : null}
+
+        <TouchableOpacity
+          style={styles.selectAll}
+          onPress={toggleAll}
+          disabled={importing || items.length === 0}
+        >
+          <Ionicons
+            name={allSelected ? 'checkbox' : 'square-outline'}
+            size={20}
+            color={theme.tint}
+          />
+          <Text style={[styles.selectAllText, { color: theme.textMuted }]}>Select all</Text>
+        </TouchableOpacity>
+
+        <FlatList
+          data={items}
+          keyExtractor={(item) => item.contestId}
+          renderItem={({ item }) => {
+            const checked = selected.has(item.contestId);
+            return (
+              <TouchableOpacity
+                style={[styles.row, { borderBottomColor: theme.border }]}
+                onPress={() => toggle(item.contestId)}
+                disabled={importing}
+              >
+                <Ionicons
+                  name={checked ? 'checkbox' : 'square-outline'}
+                  size={22}
+                  color={checked ? theme.tint : theme.textMuted}
+                />
+                <View style={styles.rowText}>
+                  <Text style={[styles.rowMatchup, { color: theme.text }]}>
+                    {item.matchupLabel}
+                  </Text>
+                </View>
+                <Text style={[styles.rowTeam, { color: theme.tint }]} numberOfLines={1}>
+                  {item.team}
+                </Text>
+              </TouchableOpacity>
+            );
+          }}
+          contentContainerStyle={styles.list}
+        />
+
+        <View style={[styles.footer, { borderTopColor: theme.border }]}>
+          <TouchableOpacity
+            style={[styles.button, styles.cancel, { borderColor: theme.border }]}
+            onPress={onClose}
+            disabled={importing}
+          >
+            <Text style={[styles.buttonText, { color: theme.text }]}>Cancel</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.confirm,
+              { backgroundColor: theme.tint },
+              (importing || count === 0) && styles.disabled,
+            ]}
+            onPress={() => currentSource && onImport(currentSource.leagueId, chosenContestIds)}
+            disabled={importing || count === 0}
+          >
+            <Text style={[styles.buttonText, { color: theme.textOnAccent }]}>
+              {importing ? 'Importing…' : `Import ${count} pick${count === 1 ? '' : 's'}`}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {importing && (
+          <View style={styles.savingOverlay}>
+            <ActivityIndicator size="small" color={theme.tint} />
+          </View>
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerTitle: { fontSize: 18, fontWeight: '700' },
+  closeText: { fontSize: 20, fontWeight: '600' },
+  sourceRow: { paddingHorizontal: 16, paddingTop: 14, gap: 8 },
+  sourceLabel: { fontSize: 13, fontWeight: '600' },
+  sourceHint: { paddingHorizontal: 16, paddingTop: 14, fontSize: 14, lineHeight: 20 },
+  selectAll: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  selectAllText: { fontSize: 13, fontWeight: '600' },
+  list: { paddingHorizontal: 16, paddingBottom: 16 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  rowText: { flex: 1 },
+  rowMatchup: { fontSize: 15 },
+  rowTeam: { fontSize: 15, fontWeight: '700', maxWidth: 120 },
+  footer: {
+    flexDirection: 'row',
+    gap: 12,
+    padding: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 13,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancel: { borderWidth: 1 },
+  confirm: {},
+  disabled: { opacity: 0.5 },
+  buttonText: { fontSize: 15, fontWeight: '700' },
+  savingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.15)',
+  },
+});

--- a/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
@@ -133,6 +133,9 @@ export function ImportPicksModal({ visible, sources, importing, onClose, onImpor
           style={styles.selectAll}
           onPress={toggleAll}
           disabled={importing || items.length === 0}
+          accessibilityRole="checkbox"
+          accessibilityLabel="Select all"
+          accessibilityState={{ checked: allSelected, disabled: importing || items.length === 0 }}
         >
           <Ionicons
             name={allSelected ? 'checkbox' : 'square-outline'}
@@ -152,6 +155,9 @@ export function ImportPicksModal({ visible, sources, importing, onClose, onImpor
                 style={[styles.row, { borderBottomColor: theme.border }]}
                 onPress={() => toggle(item.contestId)}
                 disabled={importing}
+                accessibilityRole="checkbox"
+                accessibilityLabel={`${item.matchupLabel}, pick ${item.team}`}
+                accessibilityState={{ checked, disabled: importing }}
               >
                 <Ionicons
                   name={checked ? 'checkbox' : 'square-outline'}

--- a/src/UI/sd-mobile/src/hooks/useImportPicks.ts
+++ b/src/UI/sd-mobile/src/hooks/useImportPicks.ts
@@ -46,7 +46,13 @@ export function useImportAvailability(
               name: s.name,
               toImport: r.data?.toImport ?? [],
             }))
-            .catch(() => ({ leagueId: s.leagueId, name: s.name, toImport: [] })),
+            .catch((err) => {
+              // Degrade gracefully — one flaky source shouldn't hide the whole
+              // import feature — but surface the failure (feeds a Sentry
+              // breadcrumb) rather than swallowing it silently.
+              console.warn('[import] preview failed for source', s.leagueId, err);
+              return { leagueId: s.leagueId, name: s.name, toImport: [] };
+            }),
         ),
       );
       return previews.filter((p) => p.toImport.length > 0);

--- a/src/UI/sd-mobile/src/hooks/useImportPicks.ts
+++ b/src/UI/sd-mobile/src/hooks/useImportPicks.ts
@@ -1,0 +1,77 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { picksApi } from '@/src/services/api/picksApi';
+import type { PickImportItem } from '@/src/services/api/picksApi';
+import { pickKeys } from './useContest';
+import { useAuthStore } from '@/src/stores/authStore';
+
+export interface ImportSourceWithPicks {
+  leagueId: string;
+  name: string;
+  toImport: PickImportItem[];
+}
+
+export const importKeys = {
+  availability: (leagueId: string, week: number) =>
+    ['import', 'availability', leagueId, week] as const,
+};
+
+/**
+ * Which other (same-type) leagues the user can import picks into this one from.
+ * Previews every candidate source and keeps only those with something to import.
+ * A single import always draws from ONE source; this just populates the picker.
+ *
+ * Gate `enabled` on the picks + matchups queries having loaded so availability is
+ * evaluated against confirmed current picks — React Query's enabled/queryKey give
+ * us the staleness handling the web had to do manually.
+ */
+export function useImportAvailability(
+  leagueId: string | null | undefined,
+  week: number | null | undefined,
+  enabled: boolean,
+) {
+  const { user, isInitialized } = useAuthStore();
+  return useQuery<ImportSourceWithPicks[]>({
+    queryKey: importKeys.availability(leagueId ?? '', week ?? 0),
+    queryFn: async () => {
+      const sourcesRes = await picksApi.getImportSources(leagueId!);
+      const sources = sourcesRes.data ?? [];
+      if (sources.length === 0) return [];
+
+      const previews = await Promise.all(
+        sources.map((s) =>
+          picksApi
+            .getImportPreview(leagueId!, s.leagueId)
+            .then((r) => ({
+              leagueId: s.leagueId,
+              name: s.name,
+              toImport: r.data?.toImport ?? [],
+            }))
+            .catch(() => ({ leagueId: s.leagueId, name: s.name, toImport: [] })),
+        ),
+      );
+      return previews.filter((p) => p.toImport.length > 0);
+    },
+    enabled: isInitialized && !!user && !!leagueId && !!week && enabled,
+    staleTime: 1000 * 30,
+  });
+}
+
+/** Commits an import from one source league; refreshes picks + availability. */
+export function useImportPicks() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: {
+      leagueId: string;
+      week: number;
+      sourceLeagueId: string;
+      contestIds: string[];
+    }) =>
+      picksApi
+        .executeImport(vars.leagueId, vars.sourceLeagueId, vars.contestIds)
+        .then((r) => r.data),
+    onSuccess: (_res, vars) => {
+      qc.invalidateQueries({ queryKey: pickKeys.byLeagueWeek(vars.leagueId, vars.week) });
+      qc.invalidateQueries({ queryKey: importKeys.availability(vars.leagueId, vars.week) });
+    },
+  });
+}

--- a/src/UI/sd-mobile/src/services/api/picksApi.ts
+++ b/src/UI/sd-mobile/src/services/api/picksApi.ts
@@ -10,6 +10,46 @@ export interface SubmitPickPayload {
   confidencePoints?: number;
 }
 
+// ─── Cross-league pick import ───────────────────────────────────────────────
+
+/** A candidate league to import picks from (same type, shares >=1 contest). */
+export interface PickImportSource {
+  leagueId: string;
+  name: string;
+  sport?: string;
+  pickType?: PickType;
+  useConfidencePoints?: boolean;
+  sharedContestCount?: number;
+  memberCount?: number;
+}
+
+/** A single importable pick in a preview (an unpicked target contest). */
+export interface PickImportItem {
+  contestId: string;
+  week: number;
+  franchiseSeasonId: string;
+  headline?: string | null;
+  targetHomeSpread?: number | null;
+}
+
+export interface PickImportPreview {
+  sourceLeagueId: string;
+  targetLeagueId: string;
+  targetUsesConfidencePoints: boolean;
+  toImport: PickImportItem[];
+  collisions: unknown[];
+  skipped: unknown[];
+}
+
+export interface PickImportResult {
+  imported: number;
+  replaced: number;
+  skipped: number;
+  skippedByReason: Record<string, number>;
+  requiresConfidence: boolean;
+  draft: PickImportItem[];
+}
+
 export const picksApi = {
   // GET /ui/picks/{leagueId}/week/{week}
   getByLeagueAndWeek: (leagueId: string, week: number) =>
@@ -22,4 +62,24 @@ export const picksApi = {
   // GET /ui/picks/{year}/widget  — season-to-date pick record for the current user
   getWidget: (year = 2025) =>
     apiClient.get<PickWidgetResponse>(`/ui/picks/${year}/widget`),
+
+  // GET /ui/leagues/{targetId}/picks/import/sources
+  getImportSources: (leagueId: string) =>
+    apiClient.get<PickImportSource[]>(
+      `/ui/leagues/${leagueId}/picks/import/sources`,
+    ),
+
+  // POST /ui/leagues/{targetId}/picks/import/preview
+  getImportPreview: (leagueId: string, sourceLeagueId: string) =>
+    apiClient.post<PickImportPreview>(
+      `/ui/leagues/${leagueId}/picks/import/preview`,
+      { sourceLeagueId },
+    ),
+
+  // POST /ui/leagues/{targetId}/picks/import
+  executeImport: (leagueId: string, sourceLeagueId: string, contestIds: string[]) =>
+    apiClient.post<PickImportResult>(
+      `/ui/leagues/${leagueId}/picks/import`,
+      { sourceLeagueId, contestIds },
+    ),
 };


### PR DESCRIPTION
## What

React Native (sd-mobile) parity for the cross-league pick import feature — the backend (#513–#515) and web UI (#516) already merged. **No backend change**: reuses the `sources` / `preview` / `import` endpoints and the `{ sourceLeagueId, contestIds }` selection contract. Tested locally on device.

## Pieces

- **`picksApi.ts`** — `getImportSources` / `getImportPreview` / `executeImport` + TS types.
- **`useImportPicks.ts`** — `useImportAvailability` (React Query query; `enabled` gates on picks + matchups loaded — the clean RN replacement for the web's manual `picksLoadedKey` dance) and `useImportPicks` mutation (invalidates picks + availability on success).
- **`ImportPicksModal.tsx`** — RN `Modal` (`pageSheet`): `SegmentedControl` source picker when >1 candidate, `FlatList` of checkbox rows (all checked by default), Select-all, submit pruned to the chosen source, importing overlay. Seeds the selection on open (the modal stays mounted, so its mount-time state was stale before availability resolved).
- **`picks.tsx`** — an **"Import N picks from <league>"** banner above the slate (phone-friendlier than the already-busy header row), wired to the modal + toasts.
- **Toast** — added `react-native-toast-message` (pure-JS, no native autolinking → Expo SDK 55 safe) and mounted `<Toast/>` at the root layout.

## Behavior parity with web

Single-source import; all games checked by default (never forced); uncheck-to-exclude; source picker appears only with 3+ leagues; confidence-league target guarded with an info toast; success/error toasts; slate + banner auto-refresh via query invalidation.

## Mobile-specific adaptations (not a 1:1 port)

- Sheet instead of an overlay box (RN `Modal` pageSheet), `FlatList` checkbox rows, `SegmentedControl` instead of a `<select>`, banner button instead of a header button. Focus-trap/aria are web-only and N/A here.

## Verification

- `tsc --noEmit` — exit 0.
- `jest` — 68/68 (9 suites).
- Manual device test: single-source import, multi-source picker, uncheck-to-exclude, first-open Select-all fix, toast + list refresh.

## Deferred (same as web)

Collision resolution, the confidence-league draft pick-sheet flow, cross-type SU↔ATS mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to import picks from other leagues during the current week.
  * Preview available picks, choose individual games or select all, and switch between eligible source leagues.
  * Added progress indicators and confirmation feedback, including the number of imported picks.

* **Bug Fixes**
  * Prevented importing picks that are already selected or unavailable for the current matchups.
  * Refreshes picks and import availability after an import completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->