### PR TITLE
fix(mobile): add Android OAuth client to google-services.json (Google Sign-In)

### DIFF
--- a/src/UI/sd-mobile/google-services.json
+++ b/src/UI/sd-mobile/google-services.json
@@ -14,6 +14,14 @@
       },
       "oauth_client": [
         {
+          "client_id": "812654295319-jsh0nbhh23mj3ndp5gmui7r9roa9tpiv.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.sportdeets.mobile",
+            "certificate_hash": "235aa78ffea9205980512517662751c10e24eb10"
+          }
+        },
+        {
           "client_id": "812654295319-dgb618dhnl9oflea534fjgdlipkgoi5f.apps.googleusercontent.com",
           "client_type": 3
         }


### PR DESCRIPTION
## Problem

Google Sign-In on Android failed with `DEVELOPER_ERROR` on installed builds. Email login and iOS Google auth worked; nothing appeared in Sentry/Seq because this is a native config rejection from Google Play Services *before* any JS runs.

## Cause

`src/UI/sd-mobile/google-services.json` had **no Android OAuth client** — its `oauth_client` list contained only the web client (`client_type: 3`) and (in appinvite) the iOS client (`client_type: 2`). The `client_type: 1` Android entry — which ties the app's package name to the signing certificate's SHA-1 — was missing, so Play Services couldn't authorize the calling app.

## Fix

- Registered the EAS **default keystore**'s SHA-1 and SHA-256 fingerprints in the Firebase Android app (`com.sportdeets.mobile`).
- Re-downloaded `google-services.json`, which now includes the Android OAuth client with `certificate_hash` matching the signing keystore (`235aa78f…24eb10` == keystore SHA-1 `23:5A:A7:…:24:EB:10`).
- The `webClientId` in code was already correct — no code change.

## Follow-ups

- **Requires a fresh EAS build** to take effect (Expo bakes `google-services.json` at build time via `app.json` `googleServicesFile`); the currently-installed APK won't pick it up.
- **At Play Store launch:** Google Play App Signing re-signs with a different key, so also add the **Play App Signing SHA-1** (Play Console → App integrity) to Firebase and re-download `google-services.json` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added Android authentication configuration for an additional app signing certificate.
  * Enables supported Google services to recognize the updated Android app credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->