### PR TITLE
feat(leagues): clone a league, past-league toggle + league filter

### DIFF
--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -158,6 +158,24 @@ namespace SportsData.Api.Application.Processors
                     .ToList();
             }
 
+            // Inclusion filter is the last place a slate can silently go empty:
+            // a matchup survives only on a rank hit (topX) or a conference/division
+            // slug hit. Sports without ranks (MLB) lean entirely on the slugs, so a
+            // group carrying zero slugs yields zero matchups with no other signal.
+            // Log the inputs alongside the result so an empty slate is attributable
+            // without a repro.
+            _logger.LogInformation(
+                "Inclusion filter kept {After}/{Before} matchups for group {GroupId} week {Week} " +
+                "(topX={TopX}, conferences={ConferenceCount} [{ConferenceSlugs}], nonStandardWeek={IsNonStandardWeek})",
+                groupMatchups.Count,
+                allMatchups.Count,
+                group.Id,
+                command.SeasonWeek,
+                topX,
+                conferenceSlugs.Count,
+                string.Join(",", conferenceSlugs),
+                groupWeek.IsNonStandardWeek);
+
             // Upsert-by-ContestId. The shape supports both first-pass and
             // refresh calls:
             //   • Filter passes a contest already in groupWeek.Matchups →

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommand.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommand.cs
@@ -1,0 +1,14 @@
+namespace SportsData.Api.Application.UI.Leagues.Commands.CloneLeague;
+
+public sealed class CloneLeagueCommand
+{
+    public required Guid UserId { get; init; }
+
+    public required Guid SourceLeagueId { get; init; }
+
+    /// <summary>Name for the clone (FE pre-fills "&lt;Original&gt; (Copy)").</summary>
+    public required string Name { get; init; }
+
+    /// <summary>When true, invite the source league's members to the clone.</summary>
+    public bool InviteMembers { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandler.cs
@@ -1,0 +1,239 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
+
+namespace SportsData.Api.Application.UI.Leagues.Commands.CloneLeague;
+
+public interface ICloneLeagueCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        CloneLeagueCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Duplicates one of the user's leagues into a new one they own: copies the
+/// source league's config and re-publishes <see cref="PickemGroupCreated"/> so the
+/// bootstrap consumer regenerates the same slate (matchups aren't copied by hand),
+/// and — if requested — invites the source league's members. Members and picks are
+/// NOT copied; the clone starts fresh (picks are what the import feature is for).
+/// A deactivated (wound-down) league can't be cloned.
+/// </summary>
+public class CloneLeagueCommandHandler : ICloneLeagueCommandHandler
+{
+    private readonly ILogger<CloneLeagueCommandHandler> _logger;
+    private readonly AppDataContext _dbContext;
+    private readonly IEventBus _eventBus;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public CloneLeagueCommandHandler(
+        ILogger<CloneLeagueCommandHandler> logger,
+        AppDataContext dbContext,
+        IEventBus eventBus,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+        _eventBus = eventBus;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        CloneLeagueCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var name = command.Name?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.Name), "A name is required.")]);
+        }
+
+        var source = await _dbContext.PickemGroups
+            .AsNoTracking()
+            .Include(g => g.Conferences)
+            .FirstOrDefaultAsync(g => g.Id == command.SourceLeagueId, cancellationToken);
+
+        if (source is null)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(command.SourceLeagueId), "League not found.")]);
+        }
+
+        // Ownership: the caller must belong to the source league.
+        var isMember = await _dbContext.PickemGroupMembers
+            .AsNoTracking()
+            .AnyAsync(m => m.PickemGroupId == source.Id && m.UserId == command.UserId, cancellationToken);
+
+        if (!isMember)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.Forbid,
+                [new ValidationFailure(nameof(command.SourceLeagueId), "You can only clone a league you belong to.")]);
+        }
+
+        // Honor DeactivatedUtc: a wound-down league (e.g. all contests completed)
+        // can't be cloned.
+        if (source.DeactivatedUtc is not null)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.SourceLeagueId), "This league has ended and can't be cloned.")]);
+        }
+
+        // PickemGroup has no SeasonYear column; the slate regenerates from config +
+        // season, so derive the season from the source's matchups.
+        var seasonYear = await _dbContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => m.GroupId == source.Id)
+            .Select(m => m.SeasonYear)
+            .OrderByDescending(y => y)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (seasonYear == 0)
+            seasonYear = _dateTimeProvider.UtcNow().Year;
+
+        var clone = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            CommissionerUserId = command.UserId,
+            CreatedBy = command.UserId,
+            Name = name,
+            Description = source.Description,
+            Sport = source.Sport,
+            League = source.League,
+            PickType = source.PickType,
+            TiebreakerType = source.TiebreakerType,
+            TiebreakerTiePolicy = source.TiebreakerTiePolicy,
+            UseConfidencePoints = source.UseConfidencePoints,
+            IsPublic = source.IsPublic,
+            MaxUsers = source.MaxUsers,
+            DropLowWeeksCount = source.DropLowWeeksCount,
+            StartsOn = source.StartsOn,
+            EndsOn = source.EndsOn,
+            RankingFilter = source.RankingFilter,
+            NonStandardWeekGroupSeasonMapFilter = source.NonStandardWeekGroupSeasonMapFilter,
+        };
+
+        foreach (var c in source.Conferences)
+        {
+            clone.Conferences.Add(new PickemGroupConference
+            {
+                ConferenceSlug = c.ConferenceSlug,
+                ConferenceId = c.ConferenceId,
+                PickemGroupId = clone.Id,
+            });
+        }
+
+        clone.Members.Add(new PickemGroupMember
+        {
+            CreatedBy = command.UserId,
+            PickemGroupId = clone.Id,
+            Role = LeagueRole.Commissioner,
+            UserId = command.UserId,
+        });
+
+        var synthetic = await _dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.IsSynthetic == true)
+            .Select(u => (Guid?)u.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (synthetic is not null)
+        {
+            clone.Members.Add(new PickemGroupMember
+            {
+                CreatedBy = command.UserId,
+                PickemGroupId = clone.Id,
+                Role = LeagueRole.Member,
+                UserId = synthetic.Value,
+            });
+        }
+
+        await _dbContext.PickemGroups.AddAsync(clone, cancellationToken);
+
+        // Optionally invite the source league's members — same push-deep-link path
+        // as invite-by-username. Exclude the cloner and the synthetic user (both
+        // already added). These ride the outbox atomically with the writes above.
+        if (command.InviteMembers)
+        {
+            var invitees = await _dbContext.PickemGroupMembers
+                .AsNoTracking()
+                .Where(m => m.PickemGroupId == source.Id
+                            && m.UserId != command.UserId
+                            && (synthetic == null || m.UserId != synthetic.Value))
+                .Select(m => m.UserId)
+                .ToListAsync(cancellationToken);
+
+            foreach (var inviteeId in invitees)
+            {
+                await _eventBus.Publish(
+                    new UserInvitedToPickemGroup(
+                        InviteeUserId: inviteeId,
+                        GroupId: clone.Id,
+                        LeagueName: clone.Name,
+                        InvitedByUserId: command.UserId,
+                        Sport: clone.Sport,
+                        SeasonYear: null,
+                        CorrelationId: Guid.NewGuid(),
+                        CausationId: Guid.NewGuid()),
+                    cancellationToken);
+            }
+        }
+
+        // Regenerate the slate: the bootstrap consumer builds matchups from the
+        // clone's config + season, producing the same games as the source.
+        // Published BEFORE the commit so it persists atomically via the outbox.
+        await _eventBus.Publish(
+            new PickemGroupCreated(
+                clone.Id,
+                clone.Name,
+                clone.CommissionerUserId,
+                clone.PickType.ToString(),
+                null,
+                clone.Sport,
+                seasonYear,
+                Guid.NewGuid(),
+                Guid.NewGuid()),
+            cancellationToken);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        // Log every field the bootstrap pipeline actually reads off the clone
+        // (Sport, StartsOn, EndsOn, Conferences, RankingFilter) — the event
+        // payload's SeasonYear is NOT one of them, since
+        // BootstrapLeagueMatchupsProcessor re-reads the group. When a clone
+        // bootstraps to an empty slate, this line plus the processor's
+        // "resolved N SeasonWeek(s)" / "League window .. filtered X -> Y" tells
+        // you which of the copied values was responsible.
+        _logger.LogInformation(
+            "Cloned league {SourceId} into {CloneId} by user {UserId}; inviteMembers={InviteMembers}, " +
+            "seasonYear={SeasonYear}, sport={Sport}, window={StartsOn}..{EndsOn}, " +
+            "rankingFilter={RankingFilter}, conferences={ConferenceCount} [{ConferenceSlugs}]",
+            source.Id,
+            clone.Id,
+            command.UserId,
+            command.InviteMembers,
+            seasonYear,
+            clone.Sport,
+            clone.StartsOn,
+            clone.EndsOn,
+            clone.RankingFilter,
+            clone.Conferences.Count,
+            string.Join(",", clone.Conferences.Select(c => c.ConferenceSlug)));
+
+        return new Success<Guid>(clone.Id);
+    }
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueRequest.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueRequest.cs
@@ -1,0 +1,11 @@
+namespace SportsData.Api.Application.UI.Leagues.Commands.CloneLeague;
+
+/// <summary>
+/// Body for POST /ui/leagues/{id}/clone. The source league is the route id.
+/// </summary>
+public sealed class CloneLeagueRequest
+{
+    public string Name { get; set; } = string.Empty;
+
+    public bool InviteMembers { get; set; }
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
@@ -8,11 +8,25 @@
 
         public string Sport { get; set; } = null!;
 
+        /// <summary>
+        /// The sport-league the group plays (NCAAF / NFL / MLB / NBA).
+        /// Drives the league filter on the My Leagues page.
+        /// </summary>
+        public string League { get; set; } = null!;
+
         public string LeagueType { get; set; } = null!;
 
         public bool UseConfidencePoints { get; set; } = false;
 
         public int MemberCount { get; set; }
+
+        /// <summary>
+        /// Set once the group's season has passed. Non-null means the league is
+        /// read-only: it cannot be cloned (the clone handler rejects it) and the
+        /// UI hides its Duplicate action. Only populated when the caller opts in
+        /// via <c>includeDeactivated</c>; otherwise these rows aren't returned.
+        /// </summary>
+        public DateTime? DeactivatedUtc { get; set; }
 
         public string? AvatarUrl { get; set; } // optional for visuals
     }

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Api.Application.UI.Leagues.Commands.AddMatchup;
+using SportsData.Api.Application.UI.Leagues.Commands.CloneLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague.Dtos;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague;
@@ -114,6 +115,35 @@ public class LeagueController : ApiControllerBase
         return result.ToActionResult();
     }
 
+    /// <summary>
+    /// Clones one of the user's leagues into a new one they own: copies the config
+    /// and regenerates the same slate, optionally inviting the source's members.
+    /// Deactivated leagues can't be cloned.
+    /// </summary>
+    [HttpPost("{id}/clone")]
+    [Authorize]
+    public async Task<ActionResult<Guid>> CloneLeague(
+        [FromRoute] Guid id,
+        [FromBody] CloneLeagueRequest request,
+        [FromServices] ICloneLeagueCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new CloneLeagueCommand
+        {
+            UserId = HttpContext.GetCurrentUserId(),
+            SourceLeagueId = id,
+            Name = request.Name,
+            InviteMembers = request.InviteMembers
+        };
+
+        var result = await handler.ExecuteAsync(command, cancellationToken);
+
+        if (result.IsSuccess)
+            return CreatedAtAction(nameof(GetById), new { id = result.Value }, new { id = result.Value });
+
+        return result.ToActionResult();
+    }
+
     [HttpGet("{id}")]
     [Authorize]
     public async Task<ActionResult<LeagueDetailDto>> GetById(
@@ -131,11 +161,16 @@ public class LeagueController : ApiControllerBase
     [Authorize]
     public async Task<ActionResult<List<LeagueSummaryDto>>> GetLeagues(
         [FromServices] IGetUserLeaguesQueryHandler handler,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        [FromQuery] bool includeDeactivated = false)
     {
         var userId = HttpContext.GetCurrentUserId();
 
-        var query = new GetUserLeaguesQuery { UserId = userId };
+        var query = new GetUserLeaguesQuery
+        {
+            UserId = userId,
+            IncludeDeactivated = includeDeactivated
+        };
         var result = await handler.ExecuteAsync(query, cancellationToken);
 
         return result.ToActionResult();

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQuery.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQuery.cs
@@ -3,4 +3,12 @@ namespace SportsData.Api.Application.UI.Leagues.Queries.GetUserLeagues;
 public class GetUserLeaguesQuery
 {
     public required Guid UserId { get; init; }
+
+    /// <summary>
+    /// When true, deactivated (past-season) leagues are returned alongside
+    /// active ones, carrying a non-null DeactivatedUtc so the caller can tell
+    /// them apart. Defaults to false to keep the historical contract: callers
+    /// that just want the user's live leagues need no change.
+    /// </summary>
+    public bool IncludeDeactivated { get; init; }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
@@ -29,18 +29,22 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
         var leagues = await _dbContext.PickemGroupMembers
             .AsNoTracking()
             .Where(m => m.UserId == query.UserId)
-            // Hide deactivated leagues — matches the filter on /user/me. A future
-            // "Past Seasons" endpoint will surface the excluded rows explicitly.
-            .Where(m => m.Group.DeactivatedUtc == null)
+            // Hide deactivated leagues unless the caller opts in — matches the
+            // filter on /user/me. Opting in is how the My Leagues page powers its
+            // "show past leagues" toggle; the rows carry DeactivatedUtc so the UI
+            // can mark them read-only.
+            .Where(m => query.IncludeDeactivated || m.Group.DeactivatedUtc == null)
             .Include(m => m.Group)
             .Select(m => new LeagueSummaryDto
             {
                 Id = m.Group.Id,
                 Name = m.Group.Name,
                 Sport = m.Group.Sport.ToString(),
+                League = m.Group.League.ToString(),
                 LeagueType = m.Group.PickType.ToString(),
                 UseConfidencePoints = m.Group.UseConfidencePoints,
-                MemberCount = m.Group.Members.Count
+                MemberCount = m.Group.Members.Count,
+                DeactivatedUtc = m.Group.DeactivatedUtc
             })
             .ToListAsync(cancellationToken);
 

--- a/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandler.cs
@@ -25,15 +25,18 @@ public class SubmitPickCommandHandler : ISubmitPickCommandHandler
     private readonly ILogger<SubmitPickCommandHandler> _logger;
     private readonly AppDataContext _dataContext;
     private readonly IEventBus _eventBus;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     public SubmitPickCommandHandler(
         ILogger<SubmitPickCommandHandler> logger,
         AppDataContext dataContext,
-        IEventBus eventBus)
+        IEventBus eventBus,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
         _eventBus = eventBus;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
@@ -64,7 +67,7 @@ public class SubmitPickCommandHandler : ISubmitPickCommandHandler
                 [new ValidationFailure(nameof(command.ContestId), "Matchup not found for the specified contest")]);
         }
 
-        if (matchup.IsLocked())
+        if (matchup.IsLocked(_dateTimeProvider.UtcNow()))
         {
             return new Failure<Guid>(
                 default,

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -109,6 +109,9 @@ namespace SportsData.Api.DependencyInjection
 
             // League Commands
             services.AddScoped<IAddMatchupCommandHandler, AddMatchupCommandHandler>();
+            services.AddScoped<
+                Application.UI.Leagues.Commands.CloneLeague.ICloneLeagueCommandHandler,
+                Application.UI.Leagues.Commands.CloneLeague.CloneLeagueCommandHandler>();
             services.AddScoped<ICreateFootballNcaaLeagueCommandHandler, CreateFootballNcaaLeagueCommandHandler>();
             services.AddScoped<ICreateFootballNflLeagueCommandHandler, CreateFootballNflLeagueCommandHandler>();
             services.AddScoped<ICreateBaseballMlbLeagueCommandHandler, CreateBaseballMlbLeagueCommandHandler>();

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -190,6 +190,8 @@ function MainApp() {
             <Route path="/league/create" element={<LeagueCreatePage />} />
             <Route path="/league/:id" element={<LeagueDetail />} />
             <Route path="/league" element={<Leagues />} />
+            {/* Alias: honor the plural /leagues too. */}
+            <Route path="/leagues" element={<Leagues />} />
             <Route path="/join/:leagueId" element={<AutoJoinRedirect />} />
             <Route
               path="/:sport/:seasonYear"

--- a/src/UI/sd-ui/src/api/leagues/leaguesApi.js
+++ b/src/UI/sd-ui/src/api/leagues/leaguesApi.js
@@ -32,6 +32,17 @@ const createBaseballMlbLeague = async (request) => {
 };
 
 /**
+ * Clones an existing league the user belongs to into a new one they own.
+ * @param {string} leagueId - Source league GUID
+ * @param {{ name: string, inviteMembers: boolean }} body
+ * @returns {Promise<{ id: string }>} The new league's ID
+ */
+const cloneLeague = async (leagueId, body) => {
+  const response = await apiClient.post(`${BASE_PATH}/${leagueId}/clone`, body);
+  return response.data;
+};
+
+/**
  * Fetches a league by ID.
  * @param {string} id - League GUID
  * @returns {Promise<LeagueDetailDto>} League details
@@ -43,10 +54,15 @@ const getLeagueById = async (id) => {
 
 /**
  * Fetches all leagues the current user belongs to.
+ * @param {Object} [options]
+ * @param {boolean} [options.includeDeactivated=false] - Also return past-season
+ *   leagues. Those carry a non-null deactivatedUtc and are read-only.
  * @returns {Promise<LeagueSummaryDto[]>} Array of leagues
  */
-const getUserLeagues = async () => {
-  const response = await apiClient.get(BASE_PATH);
+const getUserLeagues = async ({ includeDeactivated = false } = {}) => {
+  const response = await apiClient.get(BASE_PATH, {
+    params: includeDeactivated ? { includeDeactivated: true } : undefined,
+  });
   return response.data;
 };
 
@@ -141,6 +157,7 @@ const LeaguesApi = {
   createFootballNcaaLeague,
   createFootballNflLeague,
   createBaseballMlbLeague,
+  cloneLeague,
   getLeagueById,
   getUserLeagues,
   joinLeague,

--- a/src/UI/sd-ui/src/components/leagues/CloneLeagueDialog.css
+++ b/src/UI/sd-ui/src/components/leagues/CloneLeagueDialog.css
@@ -1,0 +1,108 @@
+/* Mirrors ConfirmationDialog for a consistent modal look. */
+.clone-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: var(--bg-overlay);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.clone-dialog {
+  background-color: var(--bg-modal);
+  border: 2px solid var(--accent);
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.clone-dialog-title {
+  color: var(--accent);
+  margin: 0 0 12px 0;
+  font-size: 1.5rem;
+}
+
+.clone-dialog-message {
+  color: var(--text-primary);
+  margin: 0 0 18px 0;
+  line-height: 1.5;
+}
+
+.clone-dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+
+.clone-dialog-field span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.clone-dialog-field input[type="text"] {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-strong);
+  background-color: var(--bg-modal);
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.clone-dialog-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  cursor: pointer;
+  margin-bottom: 22px;
+}
+
+.clone-dialog-toggle input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.clone-dialog-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.clone-dialog-button {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.clone-dialog-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.clone-dialog-button.cancel {
+  background-color: var(--border-strong);
+  color: var(--text-primary);
+  border: 1px solid var(--text-muted);
+}
+
+.clone-dialog-button.cancel:hover:not(:disabled) {
+  background-color: var(--active-bg);
+}
+
+.clone-dialog-button.confirm {
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+  border: none;
+}
+
+.clone-dialog-button.confirm:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+}

--- a/src/UI/sd-ui/src/components/leagues/CloneLeagueDialog.jsx
+++ b/src/UI/sd-ui/src/components/leagues/CloneLeagueDialog.jsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import "./CloneLeagueDialog.css";
+
+/**
+ * Duplicate-league dialog: name (pre-filled "<Original> (Copy)") + an option to
+ * invite the source league's members. Config and the slate are copied server-side;
+ * picks are not.
+ */
+function CloneLeagueDialog({ league, submitting, onClose, onConfirm }) {
+  const [name, setName] = useState(`${league.name} (Copy)`);
+  const [inviteMembers, setInviteMembers] = useState(false);
+
+  const trimmed = name.trim();
+
+  return (
+    <div className="clone-dialog-overlay" onClick={submitting ? undefined : onClose}>
+      <div className="clone-dialog" onClick={(e) => e.stopPropagation()}>
+        <h3 className="clone-dialog-title">Duplicate league</h3>
+        <p className="clone-dialog-message">
+          Create a copy of <strong>{league.name}</strong> with the same settings and
+          games. Picks aren&rsquo;t copied.
+        </p>
+
+        <label className="clone-dialog-field">
+          <span>Name</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={submitting}
+            autoFocus
+          />
+        </label>
+
+        <label className="clone-dialog-toggle">
+          <input
+            type="checkbox"
+            checked={inviteMembers}
+            onChange={(e) => setInviteMembers(e.target.checked)}
+            disabled={submitting}
+          />
+          Invite members from {league.name}
+        </label>
+
+        <div className="clone-dialog-buttons">
+          <button
+            className="clone-dialog-button cancel"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            className="clone-dialog-button confirm"
+            onClick={() => onConfirm(trimmed, inviteMembers)}
+            disabled={submitting || trimmed.length === 0}
+          >
+            {submitting ? "Creating…" : "Create copy"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CloneLeagueDialog;

--- a/src/UI/sd-ui/src/components/leagues/CloneLeagueDialog.jsx
+++ b/src/UI/sd-ui/src/components/leagues/CloneLeagueDialog.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import "./CloneLeagueDialog.css";
 
 /**
@@ -10,12 +10,67 @@ function CloneLeagueDialog({ league, submitting, onClose, onConfirm }) {
   const [name, setName] = useState(`${league.name} (Copy)`);
   const [inviteMembers, setInviteMembers] = useState(false);
 
+  const dialogRef = useRef(null);
+
   const trimmed = name.trim();
+
+  // Close on Escape (unless mid-submit), matching ImportPicksDialog.
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape" && !submitting) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [submitting, onClose]);
+
+  // Restore focus to the trigger on close. Focus doesn't need moving IN on open —
+  // the name input autoFocuses, which is both inside the dialog and the field the
+  // user came here to edit.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement;
+    return () => {
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+    };
+  }, []);
+
+  // Trap Tab / Shift+Tab within the dialog so keyboard focus can't escape to the
+  // page behind the modal.
+  const handleTabTrap = (e) => {
+    if (e.key !== "Tab") return;
+    const focusables = dialogRef.current?.querySelectorAll(
+      'button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+    );
+    if (!focusables || focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    // The container (tabIndex -1) can hold focus if the input is disabled mid-submit;
+    // treat it as before the first control so Shift+Tab wraps instead of escaping.
+    const atStart =
+      document.activeElement === first || document.activeElement === dialogRef.current;
+    if (e.shiftKey && atStart) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   return (
     <div className="clone-dialog-overlay" onClick={submitting ? undefined : onClose}>
-      <div className="clone-dialog" onClick={(e) => e.stopPropagation()}>
-        <h3 className="clone-dialog-title">Duplicate league</h3>
+      <div
+        className="clone-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="clone-dialog-title"
+        ref={dialogRef}
+        tabIndex={-1}
+        onKeyDown={handleTabTrap}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="clone-dialog-title" className="clone-dialog-title">
+          Duplicate league
+        </h3>
         <p className="clone-dialog-message">
           Create a copy of <strong>{league.name}</strong> with the same settings and
           games. Picks aren&rsquo;t copied.

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
@@ -2,9 +2,13 @@
 import { Link } from "react-router-dom";
 import "./LeagueOverviewCard.css"; // Assuming you have styles for the card
 
-const LeagueOverviewCard = ({ league }) => {
+const LeagueOverviewCard = ({ league, onDuplicate }) => {
+  // A deactivated league is a finished season: read-only, and not cloneable
+  // (CloneLeagueCommandHandler rejects it server-side regardless).
+  const isPast = !!league.deactivatedUtc;
+
   return (
-    <div className="card">
+    <div className={`card${isPast ? " card-past" : ""}`}>
       {league.avatarUrl && (
         <img
           src={league.avatarUrl}
@@ -12,7 +16,10 @@ const LeagueOverviewCard = ({ league }) => {
           className="league-avatar"
         />
       )}
-      <h2>{league.name}</h2>
+      <h2>
+        {league.name}
+        {isPast && <span className="past-league-badge">Past</span>}
+      </h2>
       <p>
         <strong>Type:</strong> {league.leagueType}
       </p>
@@ -28,6 +35,15 @@ const LeagueOverviewCard = ({ league }) => {
       <Link to={`/app/picks/${league.id}`} className="submit-button">
         Picks
       </Link>
+      {onDuplicate && !isPast && (
+        <button
+          type="button"
+          className="submit-button"
+          onClick={() => onDuplicate(league)}
+        >
+          Duplicate
+        </button>
+      )}
     </div>
   );
 };

--- a/src/UI/sd-ui/src/components/leagues/Leagues.css
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.css
@@ -43,6 +43,60 @@
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.25);
 }
 
+.leagues-filter-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+
+.league-filter-chips {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.league-filter-chip,
+.past-leagues-toggle {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.past-leagues-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.league-filter-chip:hover,
+.past-leagues-toggle:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.league-filter-chip.active,
+.past-leagues-toggle.active {
+  background-color: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.league-filter-chip:focus-visible,
+.past-leagues-toggle:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+}
+
 .league-grid {
   display: flex;
   flex-direction: column;
@@ -138,6 +192,28 @@
 .card:hover {
   transform: translateY(-4px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+/* Past seasons read as archived: muted border, de-emphasized until hovered. */
+.card-past {
+  border-color: var(--border-strong);
+  opacity: 0.75;
+}
+
+.card-past:hover {
+  opacity: 1;
+}
+
+.past-league-badge {
+  margin-left: 0.5rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  font-weight: 600;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .league-avatar {

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -1,20 +1,72 @@
 // src/components/leagues/Leagues.jsx
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
+import toast from "react-hot-toast";
 import LeaguesApi from "api/leagues/leaguesApi";
 import LeagueOverviewCard from "./LeagueOverviewCard";
+import CloneLeagueDialog from "./CloneLeagueDialog";
 import "./Leagues.css"; // for grid styling
+
+const ALL_LEAGUES = "All";
 
 const Leagues = () => {
   const [leagues, setLeagues] = useState([]);
+  const [cloneTarget, setCloneTarget] = useState(null);
+  const [cloning, setCloning] = useState(false);
+  const [showPast, setShowPast] = useState(false);
+  const [leagueFilter, setLeagueFilter] = useState(ALL_LEAGUES);
+
+  // Always fetch past leagues so the toggle is instant rather than a refetch.
+  // The user's league count is small, and every row is needed the moment they
+  // flip "Past" on.
+  const fetchLeagues = useCallback(async () => {
+    const result = await LeaguesApi.getUserLeagues({ includeDeactivated: true });
+    setLeagues(result);
+  }, []);
 
   useEffect(() => {
-    const fetchLeagues = async () => {
-      const result = await LeaguesApi.getUserLeagues();
-      setLeagues(result);
-    };
     fetchLeagues();
-  }, []);
+  }, [fetchLeagues]);
+
+  const handleClone = async (name, inviteMembers) => {
+    if (!cloneTarget) return;
+    setCloning(true);
+    try {
+      await LeaguesApi.cloneLeague(cloneTarget.id, { name, inviteMembers });
+      toast.success("League duplicated!");
+      setCloneTarget(null);
+      await fetchLeagues();
+    } catch (err) {
+      console.error("Failed to clone league:", err);
+      toast.error("Failed to duplicate league. Please try again.");
+    } finally {
+      setCloning(false);
+    }
+  };
+
+  // Everything below is derived from `leagues` rather than mirrored into state,
+  // so the filters can't drift out of sync with a refetch.
+  const hasPast = leagues.some((l) => l.deactivatedUtc);
+  const scoped = showPast ? leagues : leagues.filter((l) => !l.deactivatedUtc);
+
+  const availableLeagues = [
+    ...new Set(scoped.map((l) => l.league).filter(Boolean)),
+  ].sort();
+
+  // Self-healing: if the selected league leaves scope (e.g. it only existed
+  // among past leagues and "Past" was switched off), fall back to All instead
+  // of stranding the user on an empty grid.
+  const activeFilter = availableLeagues.includes(leagueFilter)
+    ? leagueFilter
+    : ALL_LEAGUES;
+
+  const visibleLeagues =
+    activeFilter === ALL_LEAGUES
+      ? scoped
+      : scoped.filter((l) => l.league === activeFilter);
+
+  const showFilterBar = hasPast || availableLeagues.length > 1;
 
   return (
     <div className="page-container">
@@ -24,17 +76,68 @@ const Leagues = () => {
           + Create League
         </Link>
       </div>
+
+      {leagues.length > 0 && showFilterBar && (
+        <div className="leagues-filter-bar">
+          {availableLeagues.length > 1 && (
+            <div className="league-filter-chips" role="group" aria-label="Filter by league">
+              {[ALL_LEAGUES, ...availableLeagues].map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={`league-filter-chip${
+                    activeFilter === option ? " active" : ""
+                  }`}
+                  onClick={() => setLeagueFilter(option)}
+                  aria-pressed={activeFilter === option}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          )}
+          {hasPast && (
+            <button
+              type="button"
+              className={`past-leagues-toggle${showPast ? " active" : ""}`}
+              onClick={() => setShowPast(!showPast)}
+              title={showPast ? "Hide past leagues" : "Show past leagues"}
+              aria-pressed={showPast}
+            >
+              {showPast ? <FaEye /> : <FaEyeSlash />} Past
+            </button>
+          )}
+        </div>
+      )}
+
       {leagues.length === 0 ? (
         <p>
           You’re not part of any leagues yet.{" "}
           <Link to="/app/league/create">Create one</Link>.
         </p>
+      ) : visibleLeagues.length === 0 ? (
+        <p>No leagues match this filter.</p>
       ) : (
         <div className="league-grid">
-          {leagues.map((league) => (
-            <LeagueOverviewCard key={league.id} league={league} />
+          {visibleLeagues.map((league) => (
+            <LeagueOverviewCard
+              key={league.id}
+              league={league}
+              onDuplicate={setCloneTarget}
+            />
           ))}
         </div>
+      )}
+
+      {cloneTarget && (
+        <CloneLeagueDialog
+          league={cloneTarget}
+          submitting={cloning}
+          onClose={() => {
+            if (!cloning) setCloneTarget(null);
+          }}
+          onConfirm={handleClone}
+        />
       )}
     </div>
   );

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandlerTests.cs
@@ -1,0 +1,230 @@
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Leagues.Commands.CloneLeague;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Commands.CloneLeague;
+
+public class CloneLeagueCommandHandlerTests : ApiTestBase<CloneLeagueCommandHandler>
+{
+    private static readonly DateTime NowUtc = new(2026, 7, 16, 0, 0, 0, DateTimeKind.Utc);
+
+    private CloneLeagueCommandHandler CreateHandler(Mock<IEventBus> eventBus)
+    {
+        var dt = new Mock<IDateTimeProvider>();
+        dt.Setup(x => x.UtcNow()).Returns(NowUtc);
+        return new CloneLeagueCommandHandler(
+            NullLogger<CloneLeagueCommandHandler>.Instance, DataContext, eventBus.Object, dt.Object);
+    }
+
+    private Guid SeedSource(Guid ownerId, bool deactivated = false)
+    {
+        var id = Guid.NewGuid();
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = id,
+            Name = "Source League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            PickType = PickType.AgainstTheSpread,
+            UseConfidencePoints = true,
+            IsPublic = true,
+            CommissionerUserId = ownerId,
+            DeactivatedUtc = deactivated ? NowUtc : null,
+        });
+        return id;
+    }
+
+    private void SeedMember(Guid groupId, Guid userId, LeagueRole role = LeagueRole.Member) =>
+        DataContext.PickemGroupMembers.Add(new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = groupId,
+            UserId = userId,
+            Role = role,
+        });
+
+    private Guid SeedSyntheticUser()
+    {
+        var id = Guid.NewGuid();
+        DataContext.Users.Add(new UserEntity
+        {
+            Id = id,
+            Username = "synthetic",
+            FirebaseUid = Guid.NewGuid().ToString(),
+            Email = "syn@test.com",
+            DisplayName = "Synthetic",
+            SignInProvider = "test",
+            LastLoginUtc = NowUtc,
+            IsSynthetic = true,
+        });
+        return id;
+    }
+
+    [Fact]
+    public async Task Clones_CopiesConfig_AddsOwner_AndPublishesCreated()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedSource(userId);
+        SeedMember(sourceId, userId, LeagueRole.Commissioner);
+        await DataContext.SaveChangesAsync();
+
+        var eventBus = new Mock<IEventBus>();
+        var result = await CreateHandler(eventBus).ExecuteAsync(new CloneLeagueCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            Name = "My Clone",
+        });
+
+        result.IsSuccess.Should().BeTrue();
+
+        var clone = DataContext.PickemGroups.AsNoTracking().Single(g => g.Id == result.Value);
+        clone.Name.Should().Be("My Clone");
+        clone.CommissionerUserId.Should().Be(userId);
+        clone.PickType.Should().Be(PickType.AgainstTheSpread);
+        clone.UseConfidencePoints.Should().BeTrue();
+        clone.IsPublic.Should().BeTrue();
+        clone.DeactivatedUtc.Should().BeNull();
+
+        DataContext.PickemGroupMembers.AsNoTracking()
+            .Should().Contain(m => m.PickemGroupId == clone.Id
+                                   && m.UserId == userId
+                                   && m.Role == LeagueRole.Commissioner);
+
+        // Slate regenerates via the event, not a matchup copy.
+        eventBus.Verify(x => x.Publish(
+            It.Is<PickemGroupCreated>(e => e.GroupId == clone.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RejectsDeactivatedSource()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedSource(userId, deactivated: true);
+        SeedMember(sourceId, userId, LeagueRole.Commissioner);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler(new Mock<IEventBus>()).ExecuteAsync(new CloneLeagueCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            Name = "My Clone",
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task RejectsNonMember()
+    {
+        var ownerId = Guid.NewGuid();
+        var strangerId = Guid.NewGuid();
+        var sourceId = SeedSource(ownerId);
+        SeedMember(sourceId, ownerId, LeagueRole.Commissioner);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler(new Mock<IEventBus>()).ExecuteAsync(new CloneLeagueCommand
+        {
+            UserId = strangerId, // not a member
+            SourceLeagueId = sourceId,
+            Name = "My Clone",
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Forbid);
+    }
+
+    [Fact]
+    public async Task RejectsMissingName()
+    {
+        var userId = Guid.NewGuid();
+        var sourceId = SeedSource(userId);
+        SeedMember(sourceId, userId, LeagueRole.Commissioner);
+        await DataContext.SaveChangesAsync();
+
+        var result = await CreateHandler(new Mock<IEventBus>()).ExecuteAsync(new CloneLeagueCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            Name = "   ",
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task InvitesSourceMembers_ExceptSelfAndSynthetic_WhenRequested()
+    {
+        var userId = Guid.NewGuid();
+        var friendId = Guid.NewGuid();
+        var syntheticId = SeedSyntheticUser();
+        var sourceId = SeedSource(userId);
+        SeedMember(sourceId, userId, LeagueRole.Commissioner);
+        SeedMember(sourceId, friendId);
+        SeedMember(sourceId, syntheticId);
+        await DataContext.SaveChangesAsync();
+
+        var eventBus = new Mock<IEventBus>();
+        var result = await CreateHandler(eventBus).ExecuteAsync(new CloneLeagueCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            Name = "My Clone",
+            InviteMembers = true,
+        });
+
+        result.IsSuccess.Should().BeTrue();
+
+        // Friend invited; self and synthetic are not.
+        eventBus.Verify(x => x.Publish(
+            It.Is<UserInvitedToPickemGroup>(e => e.InviteeUserId == friendId && e.GroupId == result.Value),
+            It.IsAny<CancellationToken>()), Times.Once);
+        eventBus.Verify(x => x.Publish(
+            It.Is<UserInvitedToPickemGroup>(e => e.InviteeUserId == userId),
+            It.IsAny<CancellationToken>()), Times.Never);
+        eventBus.Verify(x => x.Publish(
+            It.Is<UserInvitedToPickemGroup>(e => e.InviteeUserId == syntheticId),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DoesNotInvite_WhenNotRequested()
+    {
+        var userId = Guid.NewGuid();
+        var friendId = Guid.NewGuid();
+        var sourceId = SeedSource(userId);
+        SeedMember(sourceId, userId, LeagueRole.Commissioner);
+        SeedMember(sourceId, friendId);
+        await DataContext.SaveChangesAsync();
+
+        var eventBus = new Mock<IEventBus>();
+        var result = await CreateHandler(eventBus).ExecuteAsync(new CloneLeagueCommand
+        {
+            UserId = userId,
+            SourceLeagueId = sourceId,
+            Name = "My Clone",
+            InviteMembers = false,
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        eventBus.Verify(x => x.Publish(
+            It.IsAny<UserInvitedToPickemGroup>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandlerTests.cs
@@ -14,6 +14,90 @@ namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Queries.GetUserLeague
 public class GetUserLeaguesQueryHandlerTests : ApiTestBase<GetUserLeaguesQueryHandler>
 {
     [Fact]
+    public async Task ExecuteAsync_WhenIncludeDeactivated_ShouldReturnPastLeaguesMarkedDeactivated()
+    {
+        // Arrange — same two memberships as the exclusion test, but the caller
+        // opts in. Past leagues must come back AND carry DeactivatedUtc, since
+        // that non-null value is what tells the UI to hide Duplicate.
+        var userId = Guid.NewGuid();
+        var deactivatedOn = DateTime.UtcNow.AddDays(-7);
+
+        var user = new UserEntity
+        {
+            Username = "test_user_7",
+            Id = userId,
+            FirebaseUid = "firebase-past-leagues",
+            Email = "past@example.com",
+            DisplayName = "P",
+            SignInProvider = "password",
+            EmailVerified = true,
+            CreatedUtc = DateTime.UtcNow.AddDays(-30),
+            LastLoginUtc = DateTime.UtcNow
+        };
+
+        var activeGroup = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Active League",
+            Sport = Sport.BaseballMlb,
+            League = League.MLB
+        };
+
+        var deactivatedGroup = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Last Season",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            DeactivatedUtc = deactivatedOn
+        };
+
+        var activeMembership = new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = activeGroup.Id,
+            User = user,
+            Group = activeGroup
+        };
+
+        var deactivatedMembership = new PickemGroupMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = deactivatedGroup.Id,
+            User = user,
+            Group = deactivatedGroup
+        };
+
+        user.GroupMemberships.Add(activeMembership);
+        user.GroupMemberships.Add(deactivatedMembership);
+
+        await DataContext.Users.AddAsync(user);
+        await DataContext.PickemGroups.AddRangeAsync(activeGroup, deactivatedGroup);
+        await DataContext.PickemGroupMembers.AddRangeAsync(activeMembership, deactivatedMembership);
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetUserLeaguesQueryHandler>();
+        var query = new GetUserLeaguesQuery { UserId = userId, IncludeDeactivated = true };
+
+        // Act
+        var result = await handler.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+
+        var active = result.Value.Single(l => l.Id == activeGroup.Id);
+        active.DeactivatedUtc.Should().BeNull();
+        active.League.Should().Be(nameof(League.MLB));
+
+        var past = result.Value.Single(l => l.Id == deactivatedGroup.Id);
+        past.DeactivatedUtc.Should().Be(deactivatedOn);
+        past.League.Should().Be(nameof(League.NCAAF));
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ShouldExcludeDeactivatedLeagues()
     {
         // Arrange — one active and one deactivated membership for the same user.

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Commands/SubmitPick/SubmitPickCommandHandlerTests.cs
@@ -8,12 +8,24 @@ using SportsData.Api.Application.UI.Picks.Commands.SubmitPick;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 
+using Moq;
+
 using Xunit;
 
 namespace SportsData.Api.Tests.Unit.Application.UI.Picks.Commands.SubmitPick;
 
 public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandler>
 {
+    // Fixed "now" so matchup lock state is deterministic — the handler now checks
+    // lock via the injected IDateTimeProvider (configured below) rather than the
+    // real wall clock.
+    private static readonly DateTime Now = new(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+
+    public SubmitPickCommandHandlerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+    }
+
     [Fact]
     public async Task ExecuteAsync_ShouldReturnNotFound_WhenGroupDoesNotExist()
     {
@@ -88,7 +100,7 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
             Id = Guid.NewGuid(),
             GroupId = groupId,
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddMinutes(2) // Within lock window (5 min)
+            StartDateUtc = Now.AddMinutes(2) // Within lock window (5 min)
         };
 
         await DataContext.PickemGroups.AddAsync(group);
@@ -132,7 +144,7 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
             Id = Guid.NewGuid(),
             GroupId = groupId,
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddHours(1)
+            StartDateUtc = Now.AddHours(1)
         };
 
         await DataContext.PickemGroups.AddAsync(group);
@@ -179,7 +191,7 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
             Id = Guid.NewGuid(),
             GroupId = groupId,
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddHours(1)
+            StartDateUtc = Now.AddHours(1)
         };
 
         await DataContext.PickemGroups.AddAsync(group);
@@ -242,7 +254,7 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
             Id = Guid.NewGuid(),
             GroupId = groupId,
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddHours(1)
+            StartDateUtc = Now.AddHours(1)
         };
         var existingPick = new PickemGroupUserPick
         {
@@ -313,7 +325,7 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
             Id = Guid.NewGuid(),
             GroupId = groupId,
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddHours(1)
+            StartDateUtc = Now.AddHours(1)
         };
 
         await DataContext.PickemGroups.AddAsync(group);
@@ -363,7 +375,7 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
             Id = Guid.NewGuid(),
             GroupId = groupId,
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddHours(1)
+            StartDateUtc = Now.AddHours(1)
         };
         await DataContext.PickemGroups.AddAsync(group);
         await DataContext.PickemGroupMatchups.AddAsync(matchup);
@@ -411,7 +423,7 @@ public class SubmitPickCommandHandlerTests : ApiTestBase<SubmitPickCommandHandle
             Id = Guid.NewGuid(),
             GroupId = groupId,
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddHours(1)
+            StartDateUtc = Now.AddHours(1)
         };
         await DataContext.PickemGroups.AddAsync(group);
         await DataContext.PickemGroupMatchups.AddAsync(matchup);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/PickImport/ImportPicksCommandHandlerTests.cs
@@ -19,6 +19,9 @@ namespace SportsData.Api.Tests.Unit.Application.UI.Picks.PickImport;
 
 public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHandler>
 {
+    // Both the plan service and the (real) SubmitPickCommandHandler are driven by
+    // this mocked clock, so lock state is fully deterministic regardless of the
+    // calendar.
     private static readonly DateTime NowUtc = new(2026, 7, 15, 12, 0, 0, DateTimeKind.Utc);
 
     // Real plan service + real submit handler so the whole write path is exercised.
@@ -33,7 +36,8 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         var submitHandler = submitOverride ?? new SubmitPickCommandHandler(
             NullLogger<SubmitPickCommandHandler>.Instance,
             DataContext,
-            new Mock<IEventBus>().Object);
+            new Mock<IEventBus>().Object,
+            dateTime.Object);
 
         return new ImportPicksCommandHandler(
             NullLogger<ImportPicksCommandHandler>.Instance,
@@ -386,10 +390,13 @@ public class ImportPicksCommandHandlerTests : ApiTestBase<ImportPicksCommandHand
         SeedPick(sourceId, userId, failContest, team);
         await DataContext.SaveChangesAsync();
 
+        var realSubmitClock = new Mock<IDateTimeProvider>();
+        realSubmitClock.Setup(x => x.UtcNow()).Returns(NowUtc);
         var realSubmit = new SubmitPickCommandHandler(
             NullLogger<SubmitPickCommandHandler>.Instance,
             DataContext,
-            new Mock<IEventBus>().Object);
+            new Mock<IEventBus>().Object,
+            realSubmitClock.Object);
 
         var submit = new Mock<ISubmitPickCommandHandler>();
         submit.Setup(x => x.ExecuteAsync(


### PR DESCRIPTION
## What

Adds **league cloning**, plus the surfaces needed to make it usable, and folds in two adjacent fixes. All validated locally.

### League cloning (API + web)

`POST /api/league/{id}/clone` duplicates a league you belong to: copies config (pick type, tiebreakers, confidence, window, conferences, filters), makes you commissioner, and re-publishes `PickemGroupCreated` so the bootstrap consumer regenerates the slate.

- **Matchups and picks are not copied.** The slate regenerates from config; importing picks is a separate existing feature.
- Deactivated leagues can't be cloned; non-members get `Forbid`.
- Optionally invites the source league's members (excluding you and the synthetic user). Invites + `PickemGroupCreated` ride the outbox atomically with the writes.
- Web: **Duplicate** on the league card opens a dialog to name the copy and choose whether to invite members.

**No blackout-date guard here, deliberately.** The clone copies the source's window verbatim, and the source was verified against that same window at create time. The guard is a pure function of `(sport, window)`, so re-running it re-derives a known answer. Note the coupling: this holds *only* because we copy the window — if clone ever re-windows to a new date, the guard becomes mandatory.

### Past leagues + league filter

`GetUserLeagues` filtered deactivated leagues out unconditionally, so the UI couldn't show or reason about them.

- Opt-in `IncludeDeactivated` (**default false**, so the existing contract is unchanged — no other consumer is affected). Projects `League` + `DeactivatedUtc` onto `LeagueSummaryDto`.
- My Leagues fetches with `includeDeactivated=true` once and filters client-side, so both controls are instant. **Filters are derived from the fetched data rather than mirrored into state**, so they can't drift on refetch; a selected league that leaves scope falls back to `All` instead of stranding an empty grid.
- Past leagues render muted, badged, no Duplicate button — cosmetic only, since the handler rejects a deactivated source regardless.

### Adjacent fixes

- **`SubmitPickCommandHandler` now injects `IDateTimeProvider`** instead of reading `DateTime.UtcNow` directly (CLAUDE.md violation + a deferred CodeRabbit finding from #511). Lock checks are deterministic under test, which also removes a calendar time bomb that turned the ImportPicks suite red once the date rolled past its seeded matchups.
- Route alias so `/app/leagues` resolves alongside `/app/league`.

### Observability

- `MatchupScheduleProcessor` logs the inclusion-filter inputs and result. That filter is the last place a slate can silently go empty, and sports without ranks (MLB) lean entirely on conference/division slugs — a group with zero slugs yielded zero matchups with no signal at all.
- `CloneLeagueCommandHandler` logs every field bootstrap actually reads off the clone, so an empty cloned slate is attributable without a repro.

## Testing

- `dotnet build` clean; **529 tests pass**.
- The one failure, `DisplayNameGeneratorTests.Should_Generate_Unique_DisplayNames`, is a **pre-existing randomness flake** (25 generated names, occasional collision) — passes in isolation, unrelated to this branch.
- Web build clean under `CI=true`.
- Clone verified end-to-end locally.

## Reviewer notes

New `CloneLeague` handler tests cover: clones config/owner + publishes `PickemGroupCreated`, rejects deactivated (`Validation`), rejects non-member (`Forbid`), rejects missing name, invites source members except self/synthetic, and doesn't invite when not requested. New `GetUserLeagues` test asserts opt-in returns past leagues carrying `DeactivatedUtc`; the original exclusion guard is untouched and still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added league duplication with optional member invitations.
  * Added filtering for active and past leagues, including past-league labels.
  * Added support for viewing deactivated leagues and their status.
  * Added `/leagues` navigation support.

* **Bug Fixes**
  * Improved pick submission lock timing consistency.
  * Added clearer feedback when league duplication succeeds or fails.

* **Tests**
  * Added coverage for league duplication, filtering, invitations, authorization, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->