### PR TITLE
feat(mobile): My Leagues screen with cloning, collapsible overview, and filters

### DIFF
--- a/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
+++ b/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
@@ -113,21 +113,21 @@ describe('leaguesApi.getUserLeagues', () => {
     (apiClient.get as jest.Mock).mockResolvedValue({ data: [] });
   });
 
-  it('GETs /ui/leagues', async () => {
+  // Default omits the param entirely rather than sending includeDeactivated=false,
+  // so the request matches the BE's default contract.
+  it('GETs /ui/leagues without the param by default', async () => {
     await leaguesApi.getUserLeagues();
 
     expect(apiClient.get).toHaveBeenCalledTimes(1);
-    expect(apiClient.get).toHaveBeenCalledWith('/ui/leagues');
+    expect(apiClient.get).toHaveBeenCalledWith('/ui/leagues', { params: undefined });
   });
 
-  // No includeDeactivated param: mobile has no past-leagues surface, so it
-  // relies on the BE default excluding them. If this ever sends the flag,
-  // LeaguesScreen has to start hiding Duplicate on deactivated rows.
-  it('does not opt into deactivated leagues', async () => {
-    await leaguesApi.getUserLeagues();
+  it('opts into deactivated leagues when asked', async () => {
+    await leaguesApi.getUserLeagues({ includeDeactivated: true });
 
-    const [, config] = (apiClient.get as jest.Mock).mock.calls[0];
-    expect(config).toBeUndefined();
+    expect(apiClient.get).toHaveBeenCalledWith('/ui/leagues', {
+      params: { includeDeactivated: true },
+    });
   });
 
   it('returns the server response body', async () => {

--- a/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
+++ b/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
@@ -4,12 +4,14 @@ import {
   type CreateFootballNcaaLeagueRequest,
   type CreateFootballNflLeagueRequest,
   type CreateLeagueResponse,
+  type LeagueSummary,
 } from '@/src/services/api/leaguesApi';
 
 // Mock the shared axios instance — we only care that the right URL + body go out.
 jest.mock('@/src/services/api/client', () => ({
   apiClient: {
     post: jest.fn(),
+    get: jest.fn(),
   },
 }));
 
@@ -104,3 +106,70 @@ testCreateLeague(
   leaguesApi.createBaseballMlbLeague,
   mlbPayload,
 );
+
+describe('leaguesApi.getUserLeagues', () => {
+  beforeEach(() => {
+    (apiClient.get as jest.Mock).mockReset();
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: [] });
+  });
+
+  it('GETs /ui/leagues', async () => {
+    await leaguesApi.getUserLeagues();
+
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+    expect(apiClient.get).toHaveBeenCalledWith('/ui/leagues');
+  });
+
+  // No includeDeactivated param: mobile has no past-leagues surface, so it
+  // relies on the BE default excluding them. If this ever sends the flag,
+  // LeaguesScreen has to start hiding Duplicate on deactivated rows.
+  it('does not opt into deactivated leagues', async () => {
+    await leaguesApi.getUserLeagues();
+
+    const [, config] = (apiClient.get as jest.Mock).mock.calls[0];
+    expect(config).toBeUndefined();
+  });
+
+  it('returns the server response body', async () => {
+    const league: LeagueSummary = {
+      id: 'league-1',
+      name: 'MLB Test',
+      sport: 'BaseballMlb',
+      league: 'MLB',
+      leagueType: 'StraightUp',
+      useConfidencePoints: false,
+      memberCount: 4,
+      avatarUrl: null,
+      deactivatedUtc: null,
+    };
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: [league] });
+
+    const response = await leaguesApi.getUserLeagues();
+    expect(response.data).toEqual([league]);
+  });
+});
+
+describe('leaguesApi.cloneLeague', () => {
+  beforeEach(() => {
+    (apiClient.post as jest.Mock).mockReset();
+    (apiClient.post as jest.Mock).mockResolvedValue({ data: { id: 'clone-1' } });
+  });
+
+  it('POSTs to /ui/leagues/{id}/clone with the name and inviteMembers', async () => {
+    await leaguesApi.cloneLeague('source-1', { name: 'MLB Test (Copy)', inviteMembers: true });
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    expect(apiClient.post).toHaveBeenCalledWith('/ui/leagues/source-1/clone', {
+      name: 'MLB Test (Copy)',
+      inviteMembers: true,
+    });
+  });
+
+  it('returns the new league id', async () => {
+    const response = await leaguesApi.cloneLeague('source-1', {
+      name: 'Copy',
+      inviteMembers: false,
+    });
+    expect(response.data).toEqual({ id: 'clone-1' });
+  });
+});

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -380,6 +380,7 @@ function RootLayoutNav() {
       <Stack>
         <Stack.Screen name="(auth)" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="leagues" options={{ title: 'My Leagues' }} />
         <Stack.Screen name="create-league" options={{ presentation: 'modal' }} />
         <Stack.Screen name="league-invite/[leagueId]" options={{ presentation: 'modal' }} />
         <Stack.Screen name="admin/push-token" options={{ title: 'Push Token' }} />

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import { View, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
+
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { CloneLeagueModal } from '@/src/components/features/leagues/CloneLeagueModal';
+import { leaguesApi, type LeagueSummary } from '@/src/services/api/leaguesApi';
+import { standingsKeys } from '@/src/hooks/useStandings';
+
+export const leaguesKeys = {
+  mine: ['leagues', 'mine'] as const,
+};
+
+// Mirrors YourLeaguesCard's SPORT_ICON map.
+const SPORT_ICON: Record<LeagueSummary['sport'], string> = {
+  FootballNcaa: '🏈',
+  FootballNfl: '🏈',
+  BaseballMlb: '⚾',
+};
+
+const PICK_TYPE_LABEL: Record<LeagueSummary['leagueType'], string> = {
+  StraightUp: 'Straight Up',
+  AgainstTheSpread: 'Against The Spread',
+  OverUnder: 'Over / Under',
+};
+
+/**
+ * "My Leagues" — mobile's league management surface, mirroring sd-ui's
+ * /app/leagues. One card per league with Picks + Duplicate.
+ *
+ * No Settings action yet: mobile has no league-settings screen (only
+ * create-league and league-invite exist), so the card stops at what mobile can
+ * actually route to. Add it here when that screen lands.
+ *
+ * Past-season leagues aren't shown — the BE excludes them unless the caller
+ * opts in via includeDeactivated, and mobile has no past-leagues toggle yet
+ * (web grew one in #519). That's also why no card needs to hide Duplicate: every
+ * league reaching this screen is active and therefore cloneable.
+ */
+export default function LeaguesScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [cloneTarget, setCloneTarget] = useState<LeagueSummary | null>(null);
+
+  const { data: leagues = [], isLoading } = useQuery({
+    queryKey: leaguesKeys.mine,
+    queryFn: () => leaguesApi.getUserLeagues().then((r) => r.data),
+  });
+
+  const cloneMutation = useMutation({
+    mutationFn: ({ name, inviteMembers }: { name: string; inviteMembers: boolean }) => {
+      if (!cloneTarget) throw new Error('No league selected to duplicate.');
+      return leaguesApi.cloneLeague(cloneTarget.id, { name, inviteMembers }).then((r) => r.data);
+    },
+    onSuccess: async () => {
+      setCloneTarget(null);
+      Toast.show({ type: 'success', text1: 'League duplicated!' });
+      // Refresh both surfaces that list leagues: this screen and the home
+      // YourLeaguesCard (which reads leagues off /user/me).
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: leaguesKeys.mine }),
+        queryClient.invalidateQueries({ queryKey: standingsKeys.me }),
+      ]);
+    },
+    onError: (err: unknown) => {
+      const serverMessage = (
+        err as { response?: { data?: { errors?: { errorMessage?: string }[] } } }
+      )?.response?.data?.errors?.[0]?.errorMessage;
+      Toast.show({
+        type: 'error',
+        text1: 'Could not duplicate league',
+        text2: serverMessage || 'Something went wrong. Please try again.',
+      });
+    },
+  });
+
+  const openPicks = (leagueId: string) =>
+    router.push({ pathname: '/(tabs)/picks', params: { leagueId } } as never);
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: 'My Leagues',
+          headerStyle: { backgroundColor: theme.card },
+          headerTintColor: theme.text,
+        }}
+      />
+
+      <ScrollView
+        style={{ backgroundColor: theme.background }}
+        contentContainerStyle={styles.content}
+      >
+        {isLoading ? (
+          <ActivityIndicator style={styles.loading} color={theme.tint} />
+        ) : leagues.length === 0 ? (
+          <View style={styles.empty}>
+            <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+              You&rsquo;re not part of any leagues yet.
+            </Text>
+            <TouchableOpacity
+              style={[styles.createButton, { backgroundColor: theme.tint }]}
+              onPress={() => router.push('/create-league' as never)}
+            >
+              <Text style={[styles.createButtonText, { color: theme.textOnAccent }]}>
+                Create League
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          leagues.map((league) => (
+            <View
+              key={league.id}
+              style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
+            >
+              <View style={styles.cardHeader}>
+                <Text
+                  style={styles.cardIcon}
+                  accessibilityElementsHidden
+                  importantForAccessibility="no-hide-descendants"
+                >
+                  {SPORT_ICON[league.sport]}
+                </Text>
+                <Text style={[styles.cardName, { color: theme.text }]} numberOfLines={1}>
+                  {league.name}
+                </Text>
+              </View>
+
+              <Text style={[styles.cardMeta, { color: theme.textMuted }]}>
+                {PICK_TYPE_LABEL[league.leagueType] ?? league.leagueType}
+                {league.useConfidencePoints ? ' · Confidence' : ''}
+                {' · '}
+                {league.memberCount} member{league.memberCount === 1 ? '' : 's'}
+              </Text>
+
+              <View style={styles.cardActions}>
+                <TouchableOpacity
+                  style={[styles.action, { backgroundColor: theme.tint }]}
+                  onPress={() => openPicks(league.id)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open picks for ${league.name}`}
+                >
+                  <Text style={[styles.actionText, { color: theme.textOnAccent }]}>Picks</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.action, styles.actionSecondary, { borderColor: theme.border }]}
+                  onPress={() => setCloneTarget(league)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Duplicate ${league.name}`}
+                >
+                  <Text style={[styles.actionText, { color: theme.text }]}>Duplicate</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          ))
+        )}
+      </ScrollView>
+
+      <CloneLeagueModal
+        visible={!!cloneTarget}
+        league={cloneTarget}
+        submitting={cloneMutation.isPending}
+        onClose={() => {
+          if (!cloneMutation.isPending) setCloneTarget(null);
+        }}
+        onConfirm={(name, inviteMembers) => cloneMutation.mutate({ name, inviteMembers })}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: { padding: 16, gap: 12 },
+  loading: { marginTop: 32 },
+  empty: { alignItems: 'center', gap: 16, marginTop: 48 },
+  emptyText: { fontSize: 15 },
+  createButton: { paddingHorizontal: 20, paddingVertical: 12, borderRadius: 10 },
+  createButtonText: { fontSize: 15, fontWeight: '700' },
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    gap: 8,
+  },
+  cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  cardIcon: { fontSize: 18 },
+  cardName: { fontSize: 17, fontWeight: '700', flexShrink: 1 },
+  cardMeta: { fontSize: 13 },
+  cardActions: { flexDirection: 'row', gap: 10, paddingTop: 6 },
+  action: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  actionSecondary: { borderWidth: 1 },
+  actionText: { fontSize: 14, fontWeight: '700' },
+});

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -42,7 +42,12 @@ export default function LeaguesScreen() {
   // Always fetch past leagues so the toggle is instant rather than a refetch.
   // A user's league count is small, and every row is needed the moment they
   // flip "Past" on.
-  const { data: leagues = [], isLoading } = useQuery({
+  const {
+    data: leagues = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
     queryKey: leaguesKeys.mine,
     queryFn: () => leaguesApi.getUserLeagues({ includeDeactivated: true }).then((r) => r.data),
   });
@@ -153,6 +158,25 @@ export default function LeaguesScreen() {
 
         {isLoading ? (
           <ActivityIndicator style={styles.loading} color={theme.tint} />
+        ) : isError ? (
+          // Must precede the empty branch: on failure `leagues` falls back to []
+          // and would otherwise render "you're not part of any leagues yet",
+          // making a network blip look like data loss.
+          <View style={styles.empty}>
+            <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+              Couldn&rsquo;t load your leagues.
+            </Text>
+            <TouchableOpacity
+              style={[styles.createButton, { backgroundColor: theme.tint }]}
+              onPress={() => refetch()}
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading your leagues"
+            >
+              <Text style={[styles.createButtonText, { color: theme.textOnAccent }]}>
+                Try again
+              </Text>
+            </TouchableOpacity>
+          </View>
         ) : leagues.length === 0 ? (
           <View style={styles.empty}>
             <Text style={[styles.emptyText, { color: theme.textMuted }]}>

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
 import { View, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
 
 import { Text } from '@/src/components/ui/AppText';
+import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { CloneLeagueModal } from '@/src/components/features/leagues/CloneLeagueModal';
+import { LeagueCard } from '@/src/components/features/leagues/LeagueCard';
 import { leaguesApi, type LeagueSummary } from '@/src/services/api/leaguesApi';
 import { standingsKeys } from '@/src/hooks/useStandings';
 
@@ -15,31 +18,15 @@ export const leaguesKeys = {
   mine: ['leagues', 'mine'] as const,
 };
 
-// Mirrors YourLeaguesCard's SPORT_ICON map.
-const SPORT_ICON: Record<LeagueSummary['sport'], string> = {
-  FootballNcaa: '🏈',
-  FootballNfl: '🏈',
-  BaseballMlb: '⚾',
-};
-
-const PICK_TYPE_LABEL: Record<LeagueSummary['leagueType'], string> = {
-  StraightUp: 'Straight Up',
-  AgainstTheSpread: 'Against The Spread',
-  OverUnder: 'Over / Under',
-};
+const ALL_LEAGUES = 'All';
 
 /**
  * "My Leagues" — mobile's league management surface, mirroring sd-ui's
- * /app/leagues. One card per league with Picks + Duplicate.
+ * /app/leagues. One card per league with a collapsible overview (standing in for
+ * web's dedicated /app/league/{id} page), plus Picks + Duplicate.
  *
- * No Settings action yet: mobile has no league-settings screen (only
- * create-league and league-invite exist), so the card stops at what mobile can
- * actually route to. Add it here when that screen lands.
- *
- * Past-season leagues aren't shown — the BE excludes them unless the caller
- * opts in via includeDeactivated, and mobile has no past-leagues toggle yet
- * (web grew one in #519). That's also why no card needs to hide Duplicate: every
- * league reaching this screen is active and therefore cloneable.
+ * Filters mirror the web's: a sport-league filter and a past-leagues toggle. A
+ * season-year filter is expected on both platforms later.
  */
 export default function LeaguesScreen() {
   const scheme = useColorScheme();
@@ -48,10 +35,16 @@ export default function LeaguesScreen() {
   const queryClient = useQueryClient();
 
   const [cloneTarget, setCloneTarget] = useState<LeagueSummary | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showPast, setShowPast] = useState(false);
+  const [leagueFilter, setLeagueFilter] = useState<string>(ALL_LEAGUES);
 
+  // Always fetch past leagues so the toggle is instant rather than a refetch.
+  // A user's league count is small, and every row is needed the moment they
+  // flip "Past" on.
   const { data: leagues = [], isLoading } = useQuery({
     queryKey: leaguesKeys.mine,
-    queryFn: () => leaguesApi.getUserLeagues().then((r) => r.data),
+    queryFn: () => leaguesApi.getUserLeagues({ includeDeactivated: true }).then((r) => r.data),
   });
 
   const cloneMutation = useMutation({
@@ -81,6 +74,26 @@ export default function LeaguesScreen() {
     },
   });
 
+  // Everything below is derived from `leagues` rather than mirrored into state,
+  // so the filters can't drift out of sync with a refetch.
+  const hasPast = leagues.some((l) => l.deactivatedUtc);
+  const scoped = showPast ? leagues : leagues.filter((l) => !l.deactivatedUtc);
+
+  const availableLeagues = [...new Set(scoped.map((l) => l.league).filter(Boolean))].sort();
+
+  // Self-healing: if the selected league leaves scope (e.g. it only existed
+  // among past leagues and "Past" was switched off), fall back to All instead
+  // of stranding the user on an empty list.
+  const activeFilter = availableLeagues.includes(leagueFilter as LeagueSummary['league'])
+    ? leagueFilter
+    : ALL_LEAGUES;
+
+  const visibleLeagues =
+    activeFilter === ALL_LEAGUES ? scoped : scoped.filter((l) => l.league === activeFilter);
+
+  const showFilterBar = leagues.length > 0 && (hasPast || availableLeagues.length > 1);
+  const filterOptions = [ALL_LEAGUES, ...availableLeagues].map((v) => ({ value: v, label: v }));
+
   const openPicks = (leagueId: string) =>
     router.push({ pathname: '/(tabs)/picks', params: { leagueId } } as never);
 
@@ -98,6 +111,46 @@ export default function LeaguesScreen() {
         style={{ backgroundColor: theme.background }}
         contentContainerStyle={styles.content}
       >
+        {showFilterBar && (
+          <View style={styles.filterBar}>
+            {availableLeagues.length > 1 && (
+              <SegmentedControl
+                value={activeFilter}
+                options={filterOptions}
+                onChange={setLeagueFilter}
+                accessibilityLabel="Filter by league"
+              />
+            )}
+            {hasPast && (
+              <TouchableOpacity
+                style={[
+                  styles.pastToggle,
+                  { borderColor: showPast ? theme.tint : theme.border },
+                  showPast && { backgroundColor: theme.tint },
+                ]}
+                onPress={() => setShowPast(!showPast)}
+                accessibilityRole="button"
+                accessibilityLabel={showPast ? 'Hide past leagues' : 'Show past leagues'}
+                accessibilityState={{ selected: showPast }}
+              >
+                <Ionicons
+                  name={showPast ? 'eye-outline' : 'eye-off-outline'}
+                  size={14}
+                  color={showPast ? theme.textOnAccent : theme.textMuted}
+                />
+                <Text
+                  style={[
+                    styles.pastToggleText,
+                    { color: showPast ? theme.textOnAccent : theme.textMuted },
+                  ]}
+                >
+                  Past
+                </Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        )}
+
         {isLoading ? (
           <ActivityIndicator style={styles.loading} color={theme.tint} />
         ) : leagues.length === 0 ? (
@@ -114,51 +167,22 @@ export default function LeaguesScreen() {
               </Text>
             </TouchableOpacity>
           </View>
+        ) : visibleLeagues.length === 0 ? (
+          <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+            No leagues match this filter.
+          </Text>
         ) : (
-          leagues.map((league) => (
-            <View
+          visibleLeagues.map((league) => (
+            <LeagueCard
               key={league.id}
-              style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
-            >
-              <View style={styles.cardHeader}>
-                <Text
-                  style={styles.cardIcon}
-                  accessibilityElementsHidden
-                  importantForAccessibility="no-hide-descendants"
-                >
-                  {SPORT_ICON[league.sport]}
-                </Text>
-                <Text style={[styles.cardName, { color: theme.text }]} numberOfLines={1}>
-                  {league.name}
-                </Text>
-              </View>
-
-              <Text style={[styles.cardMeta, { color: theme.textMuted }]}>
-                {PICK_TYPE_LABEL[league.leagueType] ?? league.leagueType}
-                {league.useConfidencePoints ? ' · Confidence' : ''}
-                {' · '}
-                {league.memberCount} member{league.memberCount === 1 ? '' : 's'}
-              </Text>
-
-              <View style={styles.cardActions}>
-                <TouchableOpacity
-                  style={[styles.action, { backgroundColor: theme.tint }]}
-                  onPress={() => openPicks(league.id)}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Open picks for ${league.name}`}
-                >
-                  <Text style={[styles.actionText, { color: theme.textOnAccent }]}>Picks</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.action, styles.actionSecondary, { borderColor: theme.border }]}
-                  onPress={() => setCloneTarget(league)}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Duplicate ${league.name}`}
-                >
-                  <Text style={[styles.actionText, { color: theme.text }]}>Duplicate</Text>
-                </TouchableOpacity>
-              </View>
-            </View>
+              league={league}
+              expanded={expandedId === league.id}
+              onToggleExpanded={() =>
+                setExpandedId((prev) => (prev === league.id ? null : league.id))
+              }
+              onOpenPicks={() => openPicks(league.id)}
+              onDuplicate={() => setCloneTarget(league)}
+            />
           ))
         )}
       </ScrollView>
@@ -178,28 +202,21 @@ export default function LeaguesScreen() {
 
 const styles = StyleSheet.create({
   content: { padding: 16, gap: 12 },
+  filterBar: { gap: 10 },
+  pastToggle: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  pastToggleText: { fontSize: 12, fontWeight: '700' },
   loading: { marginTop: 32 },
   empty: { alignItems: 'center', gap: 16, marginTop: 48 },
-  emptyText: { fontSize: 15 },
+  emptyText: { fontSize: 15, textAlign: 'center' },
   createButton: { paddingHorizontal: 20, paddingVertical: 12, borderRadius: 10 },
   createButtonText: { fontSize: 15, fontWeight: '700' },
-  card: {
-    borderRadius: 14,
-    borderWidth: StyleSheet.hairlineWidth,
-    padding: 16,
-    gap: 8,
-  },
-  cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  cardIcon: { fontSize: 18 },
-  cardName: { fontSize: 17, fontWeight: '700', flexShrink: 1 },
-  cardMeta: { fontSize: 13 },
-  cardActions: { flexDirection: 'row', gap: 10, paddingTop: 6 },
-  action: {
-    flex: 1,
-    paddingVertical: 10,
-    borderRadius: 10,
-    alignItems: 'center',
-  },
-  actionSecondary: { borderWidth: 1 },
-  actionText: { fontSize: 14, fontWeight: '700' },
 });

--- a/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
@@ -50,7 +50,17 @@ export function YourLeaguesCard({ leagues }: Props) {
         { backgroundColor: theme.card, borderColor: theme.border },
       ]}
     >
-      <Text style={[styles.eyebrow, { color: theme.tint }]}>YOUR LEAGUES</Text>
+      <View style={styles.headerRow}>
+        <Text style={[styles.eyebrow, { color: theme.tint }]}>YOUR LEAGUES</Text>
+        <TouchableOpacity
+          onPress={() => router.push('/leagues' as never)}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Manage your leagues"
+        >
+          <Text style={[styles.manage, { color: theme.tint }]}>Manage ›</Text>
+        </TouchableOpacity>
+      </View>
 
       <View style={styles.pillGrid}>
         {leagues.map((league) => {
@@ -96,11 +106,20 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
     padding: 16,
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
   eyebrow: {
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
-    marginBottom: 10,
+  },
+  manage: {
+    fontSize: 12,
+    fontWeight: '700',
   },
   pillGrid: {
     flexDirection: 'row',

--- a/src/UI/sd-mobile/src/components/features/leagues/CloneLeagueModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/CloneLeagueModal.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Modal,
+  View,
+  TextInput,
+  Switch,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import type { LeagueSummary } from '@/src/services/api/leaguesApi';
+
+interface Props {
+  visible: boolean;
+  league: LeagueSummary | null;
+  submitting: boolean;
+  onClose: () => void;
+  onConfirm: (name: string, inviteMembers: boolean) => void;
+}
+
+/**
+ * Duplicate-league sheet. Mirrors sd-ui's CloneLeagueDialog: name (pre-filled
+ * "<Original> (Copy)") plus an option to invite the source league's members.
+ * Config and the slate are copied server-side; picks are not.
+ */
+export function CloneLeagueModal({ visible, league, submitting, onClose, onConfirm }: Props) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const [name, setName] = useState('');
+  const [inviteMembers, setInviteMembers] = useState(false);
+
+  // The sheet stays mounted so it can animate, so initial state goes stale —
+  // `league` is null on first mount and changes as the user picks a different
+  // card. Re-seed each time it opens. Keyed on visible + league id only, so a
+  // background leagues refetch can't wipe a half-typed name.
+  useEffect(() => {
+    if (!visible || !league) return;
+    setName(`${league.name} (Copy)`);
+    setInviteMembers(false);
+  }, [visible, league?.id]); // eslint-disable-line react-hooks/exhaustive-deps -- seed only on open
+
+  const trimmed = name.trim();
+  const canSubmit = !submitting && trimmed.length > 0;
+
+  return (
+    <Modal
+      visible={visible && !!league}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={submitting ? undefined : onClose}
+    >
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={[styles.header, { borderBottomColor: theme.border }]}>
+          <Text style={[styles.headerTitle, { color: theme.text }]}>Duplicate league</Text>
+          <TouchableOpacity onPress={onClose} disabled={submitting} hitSlop={12}>
+            <Text style={[styles.closeText, { color: theme.textMuted }]}>✕</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.body}>
+          <Text style={[styles.hint, { color: theme.textMuted }]}>
+            Create a copy of {league?.name} with the same settings and games.
+            Picks aren&rsquo;t copied.
+          </Text>
+
+          <Text style={[styles.label, { color: theme.text }]}>Name</Text>
+          <TextInput
+            value={name}
+            onChangeText={setName}
+            editable={!submitting}
+            autoFocus
+            selectTextOnFocus
+            placeholder="League name"
+            placeholderTextColor={theme.textMuted}
+            style={[
+              styles.input,
+              { color: theme.text, borderColor: theme.border, backgroundColor: theme.card },
+            ]}
+            accessibilityLabel="Name for the duplicated league"
+          />
+
+          <View style={styles.toggleRow}>
+            <Text style={[styles.toggleLabel, { color: theme.text }]} numberOfLines={2}>
+              Invite members from {league?.name}
+            </Text>
+            <Switch
+              value={inviteMembers}
+              onValueChange={setInviteMembers}
+              disabled={submitting}
+              accessibilityLabel="Invite members from the source league"
+            />
+          </View>
+        </View>
+
+        <View style={[styles.footer, { borderTopColor: theme.border }]}>
+          <TouchableOpacity
+            style={[styles.button, styles.cancel, { borderColor: theme.border }]}
+            onPress={onClose}
+            disabled={submitting}
+          >
+            <Text style={[styles.buttonText, { color: theme.text }]}>Cancel</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.confirm,
+              { backgroundColor: theme.tint },
+              !canSubmit && styles.disabled,
+            ]}
+            onPress={() => onConfirm(trimmed, inviteMembers)}
+            disabled={!canSubmit}
+          >
+            <Text style={[styles.buttonText, { color: theme.textOnAccent }]}>
+              {submitting ? 'Creating…' : 'Create copy'}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {submitting && (
+          <View style={styles.savingOverlay}>
+            <ActivityIndicator size="small" color={theme.tint} />
+          </View>
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerTitle: { fontSize: 18, fontWeight: '700' },
+  closeText: { fontSize: 20, fontWeight: '600' },
+  body: { flex: 1, paddingHorizontal: 16, paddingTop: 16, gap: 8 },
+  hint: { fontSize: 14, lineHeight: 20, marginBottom: 8 },
+  label: { fontSize: 13, fontWeight: '600' },
+  input: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingTop: 12,
+  },
+  toggleLabel: { fontSize: 14, fontWeight: '600', flexShrink: 1 },
+  footer: {
+    flexDirection: 'row',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  cancel: { borderWidth: 1 },
+  confirm: {},
+  disabled: { opacity: 0.5 },
+  buttonText: { fontSize: 15, fontWeight: '700' },
+  savingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/UI/sd-mobile/src/components/features/leagues/LeagueCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/LeagueCard.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useQuery } from '@tanstack/react-query';
+
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { leaguesApi, type LeagueSummary } from '@/src/services/api/leaguesApi';
+
+// Mirrors YourLeaguesCard's SPORT_ICON map.
+const SPORT_ICON: Record<LeagueSummary['sport'], string> = {
+  FootballNcaa: '🏈',
+  FootballNfl: '🏈',
+  BaseballMlb: '⚾',
+};
+
+const PICK_TYPE_LABEL: Record<string, string> = {
+  StraightUp: 'Straight Up',
+  AgainstTheSpread: 'Against The Spread',
+  OverUnder: 'Over / Under',
+};
+
+const TIEBREAKER_LABEL: Record<string, string> = {
+  TotalPoints: 'Total Points',
+  HomeAndAwayScores: 'Home & Away Scores',
+  EarliestSubmission: 'Earliest Pick',
+};
+
+export const leagueDetailKeys = {
+  byId: (id: string) => ['leagues', 'detail', id] as const,
+};
+
+/**
+ * Formats the league window the same way sd-ui's LeagueDetail does: both bounds
+ * null means full season, otherwise an open-ended side reads as "—".
+ */
+function formatWindow(startsOn: string | null, endsOn: string | null): string {
+  if (!startsOn && !endsOn) return 'Full season';
+  const fmt = (iso: string | null) =>
+    iso ? new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : '—';
+  return `${fmt(startsOn)} – ${fmt(endsOn)}`;
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  const theme = getTheme(useColorScheme());
+  return (
+    <View style={styles.detailRow}>
+      <Text style={[styles.detailLabel, { color: theme.textMuted }]}>{label}</Text>
+      <Text style={[styles.detailValue, { color: theme.text }]}>{value}</Text>
+    </View>
+  );
+}
+
+interface Props {
+  league: LeagueSummary;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onOpenPicks: () => void;
+  onDuplicate: () => void;
+}
+
+/**
+ * One league on My Leagues: summary header always visible, with a collapsible
+ * overview standing in for web's dedicated /app/league/{id} page. The detail
+ * fetch is lazy (enabled only while expanded), so opening the screen costs one
+ * request rather than one per league.
+ *
+ * Past-season leagues render muted and drop Duplicate — the BE rejects cloning
+ * a deactivated league regardless, so this is presentation only.
+ */
+export function LeagueCard({
+  league,
+  expanded,
+  onToggleExpanded,
+  onOpenPicks,
+  onDuplicate,
+}: Props) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const isPast = !!league.deactivatedUtc;
+
+  const { data: detail, isLoading: detailLoading } = useQuery({
+    queryKey: leagueDetailKeys.byId(league.id),
+    queryFn: () => leaguesApi.getLeagueById(league.id).then((r) => r.data),
+    enabled: expanded,
+  });
+
+  return (
+    <View
+      style={[
+        styles.card,
+        { backgroundColor: theme.card, borderColor: theme.border },
+        isPast && styles.cardPast,
+      ]}
+    >
+      <View style={styles.cardHeader}>
+        <Text
+          style={styles.cardIcon}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
+          {SPORT_ICON[league.sport]}
+        </Text>
+        <Text style={[styles.cardName, { color: theme.text }]} numberOfLines={1}>
+          {league.name}
+        </Text>
+        {isPast && (
+          <View style={[styles.pastBadge, { borderColor: theme.border }]}>
+            <Text style={[styles.pastBadgeText, { color: theme.textMuted }]}>Past</Text>
+          </View>
+        )}
+      </View>
+
+      <Text style={[styles.cardMeta, { color: theme.textMuted }]}>
+        {PICK_TYPE_LABEL[league.leagueType] ?? league.leagueType}
+        {league.useConfidencePoints ? ' · Confidence' : ''}
+        {' · '}
+        {league.memberCount} member{league.memberCount === 1 ? '' : 's'}
+      </Text>
+
+      <TouchableOpacity
+        style={styles.disclosure}
+        onPress={onToggleExpanded}
+        accessibilityRole="button"
+        accessibilityLabel={`${expanded ? 'Hide' : 'Show'} details for ${league.name}`}
+        accessibilityState={{ expanded }}
+      >
+        <Text style={[styles.disclosureText, { color: theme.tint }]}>
+          {expanded ? 'Hide details' : 'Details'}
+        </Text>
+        <Ionicons
+          name={expanded ? 'chevron-up' : 'chevron-down'}
+          size={14}
+          color={theme.tint}
+        />
+      </TouchableOpacity>
+
+      {expanded && (
+        <View style={[styles.details, { borderTopColor: theme.border }]}>
+          {detailLoading || !detail ? (
+            <ActivityIndicator size="small" color={theme.tint} style={styles.detailLoading} />
+          ) : (
+            <>
+              {detail.description ? (
+                <Text style={[styles.description, { color: theme.textMuted }]}>
+                  {detail.description}
+                </Text>
+              ) : null}
+
+              <Row
+                label="Tiebreaker"
+                value={TIEBREAKER_LABEL[detail.tiebreakerType] ?? detail.tiebreakerType}
+              />
+              <Row label="Window" value={formatWindow(detail.startsOn, detail.endsOn)} />
+              <Row label="Visibility" value={detail.isPublic ? 'Public' : 'Private'} />
+              {detail.rankingFilter ? (
+                <Row label="Ranking filter" value={detail.rankingFilter.replace(/_/g, ' ')} />
+              ) : null}
+              <Row
+                label={league.sport === 'FootballNcaa' ? 'Conferences' : 'Divisions'}
+                value={
+                  detail.conferenceSlugs.length > 0 ? detail.conferenceSlugs.join(', ') : 'All'
+                }
+              />
+
+              <Text style={[styles.membersHeading, { color: theme.text }]}>
+                Members ({detail.members.length})
+              </Text>
+              {detail.members.map((m) => (
+                <View key={m.userId} style={styles.memberRow}>
+                  <Text style={[styles.memberName, { color: theme.text }]} numberOfLines={1}>
+                    {m.username}
+                  </Text>
+                  <Text style={[styles.memberRole, { color: theme.textMuted }]}>{m.role}</Text>
+                </View>
+              ))}
+            </>
+          )}
+        </View>
+      )}
+
+      <View style={styles.cardActions}>
+        <TouchableOpacity
+          style={[styles.action, { backgroundColor: theme.tint }]}
+          onPress={onOpenPicks}
+          accessibilityRole="button"
+          accessibilityLabel={`Open picks for ${league.name}`}
+        >
+          <Text style={[styles.actionText, { color: theme.textOnAccent }]}>Picks</Text>
+        </TouchableOpacity>
+        {!isPast && (
+          <TouchableOpacity
+            style={[styles.action, styles.actionSecondary, { borderColor: theme.border }]}
+            onPress={onDuplicate}
+            accessibilityRole="button"
+            accessibilityLabel={`Duplicate ${league.name}`}
+          >
+            <Text style={[styles.actionText, { color: theme.text }]}>Duplicate</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    gap: 8,
+  },
+  cardPast: { opacity: 0.75 },
+  cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  cardIcon: { fontSize: 18 },
+  cardName: { fontSize: 17, fontWeight: '700', flexShrink: 1 },
+  pastBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  pastBadgeText: { fontSize: 10, fontWeight: '700' },
+  cardMeta: { fontSize: 13 },
+  disclosure: { flexDirection: 'row', alignItems: 'center', gap: 4, paddingVertical: 2 },
+  disclosureText: { fontSize: 13, fontWeight: '700' },
+  details: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingTop: 10,
+    gap: 6,
+  },
+  detailLoading: { paddingVertical: 12 },
+  description: { fontSize: 13, lineHeight: 18, marginBottom: 4 },
+  detailRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
+  detailLabel: { fontSize: 13 },
+  detailValue: { fontSize: 13, fontWeight: '600', flexShrink: 1, textAlign: 'right' },
+  membersHeading: { fontSize: 13, fontWeight: '700', marginTop: 8 },
+  memberRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
+  memberName: { fontSize: 13, flexShrink: 1 },
+  memberRole: { fontSize: 12, textTransform: 'lowercase' },
+  cardActions: { flexDirection: 'row', gap: 10, paddingTop: 6 },
+  action: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  actionSecondary: { borderWidth: 1 },
+  actionText: { fontSize: 14, fontWeight: '700' },
+});

--- a/src/UI/sd-mobile/src/components/features/leagues/LeagueCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/LeagueCard.tsx
@@ -81,7 +81,12 @@ export function LeagueCard({
 
   const isPast = !!league.deactivatedUtc;
 
-  const { data: detail, isLoading: detailLoading } = useQuery({
+  const {
+    data: detail,
+    isLoading: detailLoading,
+    isError: detailError,
+    refetch: refetchDetail,
+  } = useQuery({
     queryKey: leagueDetailKeys.byId(league.id),
     queryFn: () => leaguesApi.getLeagueById(league.id).then((r) => r.data),
     enabled: expanded,
@@ -139,8 +144,25 @@ export function LeagueCard({
 
       {expanded && (
         <View style={[styles.details, { borderTopColor: theme.border }]}>
-          {detailLoading || !detail ? (
+          {detailLoading ? (
             <ActivityIndicator size="small" color={theme.tint} style={styles.detailLoading} />
+          ) : detailError || !detail ? (
+            // Split from the loading branch deliberately: a failed fetch leaves
+            // isLoading false with detail undefined, so folding the two together
+            // spins forever with no way out.
+            <View style={styles.detailError}>
+              <Text style={[styles.detailErrorText, { color: theme.textMuted }]}>
+                Couldn&rsquo;t load details.
+              </Text>
+              <TouchableOpacity
+                onPress={() => refetchDetail()}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel={`Retry loading details for ${league.name}`}
+              >
+                <Text style={[styles.detailRetry, { color: theme.tint }]}>Try again</Text>
+              </TouchableOpacity>
+            </View>
           ) : (
             <>
               {detail.description ? (
@@ -232,6 +254,15 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   detailLoading: { paddingVertical: 12 },
+  detailError: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 8,
+  },
+  detailErrorText: { fontSize: 13, flexShrink: 1 },
+  detailRetry: { fontSize: 13, fontWeight: '700' },
   description: { fontSize: 13, lineHeight: 18, marginBottom: 4 },
   detailRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
   detailLabel: { fontSize: 13 },

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -56,13 +56,25 @@ export interface LeagueMember {
   role: string;
 }
 
-// Subset of the BE LeagueDetailDto the invite preview needs.
+// Subset of the BE LeagueDetailDto used by the invite preview and the
+// expandable league overview on My Leagues. Mirrors what sd-ui's LeagueDetail
+// page renders, minus its Danger Zone (mobile has no delete affordance).
 export interface LeagueDetail {
   id: string;
   name: string;
   description: string | null;
   pickType: PickType;
+  useConfidencePoints: boolean;
+  tiebreakerType: TiebreakerType;
+  tiebreakerTiePolicy: TiebreakerTiePolicy;
+  /** NCAA-only AP-poll filter; null for every other sport. */
+  rankingFilter: NcaaRankingFilter | null;
+  /** Conferences (NCAA) or divisions (NFL/MLB) — see the BE's naming note. */
+  conferenceSlugs: string[];
   isPublic: boolean;
+  /** League window. Null on either side = open-ended; both null = full season. */
+  startsOn: string | null;
+  endsOn: string | null;
   members: LeagueMember[];
 }
 
@@ -113,11 +125,14 @@ export const leaguesApi = {
   joinLeague: (id: string) =>
     apiClient.post<void>(`/ui/leagues/${id}/join`),
 
-  // GET /ui/leagues — the current user's leagues. Deactivated (past-season)
-  // leagues are excluded by the BE unless includeDeactivated is passed, which
-  // mobile doesn't do: there's no past-leagues surface here yet.
-  getUserLeagues: () =>
-    apiClient.get<LeagueSummary[]>('/ui/leagues'),
+  // GET /ui/leagues — the current user's leagues. The BE excludes deactivated
+  // (past-season) leagues unless includeDeactivated is passed; those rows come
+  // back carrying a non-null deactivatedUtc so the caller can mark them
+  // read-only.
+  getUserLeagues: ({ includeDeactivated = false }: { includeDeactivated?: boolean } = {}) =>
+    apiClient.get<LeagueSummary[]>('/ui/leagues', {
+      params: includeDeactivated ? { includeDeactivated: true } : undefined,
+    }),
 
   // POST /ui/leagues/{id}/clone — duplicate a league the user belongs to.
   // Copies config and regenerates the slate server-side; picks are NOT copied.

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -66,6 +66,32 @@ export interface LeagueDetail {
   members: LeagueMember[];
 }
 
+// Matches SportsData.Api.Application.UI.Leagues.Dtos.LeagueSummaryDto.
+export interface LeagueSummary {
+  id: string;
+  name: string;
+  sport: 'FootballNcaa' | 'FootballNfl' | 'BaseballMlb';
+  /** Sport-league the group plays. */
+  league: 'NCAAF' | 'NFL' | 'MLB' | 'NBA';
+  /** PickType by name — the BE projects `PickType.ToString()` into this field. */
+  leagueType: PickType;
+  useConfidencePoints: boolean;
+  memberCount: number;
+  avatarUrl: string | null;
+  /**
+   * Non-null once the league's season has passed: read-only, and not cloneable.
+   * Only populated when the caller opts in via `includeDeactivated`; the default
+   * list omits those rows entirely, so this is null for every league mobile
+   * currently fetches.
+   */
+  deactivatedUtc: string | null;
+}
+
+export interface CloneLeagueRequest {
+  name: string;
+  inviteMembers: boolean;
+}
+
 export const leaguesApi = {
   // POST /ui/leagues/football/ncaa
   createFootballNcaaLeague: (payload: CreateFootballNcaaLeagueRequest) =>
@@ -86,4 +112,16 @@ export const leaguesApi = {
   // POST /ui/leagues/{id}/join — join a league by id.
   joinLeague: (id: string) =>
     apiClient.post<void>(`/ui/leagues/${id}/join`),
+
+  // GET /ui/leagues — the current user's leagues. Deactivated (past-season)
+  // leagues are excluded by the BE unless includeDeactivated is passed, which
+  // mobile doesn't do: there's no past-leagues surface here yet.
+  getUserLeagues: () =>
+    apiClient.get<LeagueSummary[]>('/ui/leagues'),
+
+  // POST /ui/leagues/{id}/clone — duplicate a league the user belongs to.
+  // Copies config and regenerates the slate server-side; picks are NOT copied.
+  // Returns the new league's id.
+  cloneLeague: (id: string, payload: CloneLeagueRequest) =>
+    apiClient.post<{ id: string }>(`/ui/leagues/${id}/clone`, payload),
 };


### PR DESCRIPTION
## What

Mobile parity for league cloning (web shipped in #519). Mobile-only — no BE changes; every endpoint used here already exists.

Cloning needed a home, and mobile had none. The only leagues surface was the home `YourLeaguesCard` pill grid, which is a *navigation shortcut* into Picks rather than a management surface. So this adds the screen web has had all along.

### My Leagues (`app/leagues.tsx`)

One card per league: sport icon, pick type, confidence flag, member count, plus **Picks** and **Duplicate**. Entry point is a **"Manage ›"** affordance on the home `YourLeaguesCard` header.

### Cloning

`CloneLeagueModal` mirrors sd-ui's `CloneLeagueDialog` — name pre-filled `<Original> (Copy)` plus an invite-source-members toggle. Follows `ImportPicksModal`'s `pageSheet` shape and its **re-seed-on-open** effect, since the sheet stays mounted and its initial state would otherwise go stale (the bug caught during #517).

On success it invalidates **both** surfaces that list leagues — this screen and `standingsKeys.me`, which backs the home card — then toasts.

### Collapsible overview, in place of a details page

Rather than port web's dedicated `/app/league/{id}`, each card gets a **Details** disclosure with a concise version of it: description, tiebreaker, window, visibility, ranking filter (NCAA only), conferences/divisions, and the member list with roles.

- **Lazy fetch** — the detail query is `enabled: expanded`, so opening the screen costs one request rather than one per league. Accordion behaviour (opening one closes the other) keeps a long list navigable and bounds the fetches.
- **No Danger Zone** — web's detail page has delete; mobile has no delete affordance, so this doesn't introduce a destructive action in passing.
- The conferences row reads **"Divisions"** for NFL/MLB, matching the BE's own naming note that `PickemGroup.Conferences` holds divisions for those sports.

### Filters (parity with #519)

Sport-league filter (`SegmentedControl` — the mobile idiom, already used for source league in `ImportPicksModal`) and a past-leagues toggle.

- `getUserLeagues` now takes `includeDeactivated`; the screen always passes `true` and filters client-side, so the toggle is instant rather than a refetch.
- **Filters are derived from fetched data, not mirrored into state**, so they can't drift on refetch; a selected league that leaves scope self-heals to `All` instead of stranding an empty list.
- Past leagues render muted with a **Past** badge and drop Duplicate — presentation only, since the BE rejects cloning a deactivated league regardless.

## Testing

- `npx tsc --noEmit` clean.
- **73 tests pass**, 9 suites (`--forceExit`, per the existing convention).
- New coverage for `getUserLeagues` (param omitted by default; opt-in when asked) and `cloneLeague` (URL + body, response).

Note: sd-mobile has **no ESLint setup** — `npx expo lint` errors with `Cannot find module 'eslint'`. Typecheck + Jest are the gates here. Worth adding a linter deliberately sometime, but not in this PR.

## Reviewer notes

The first commit added a test asserting mobile *never* opts into `includeDeactivated`, specifically so it would fail loudly if that changed. The second commit changes it, so that test is flipped to assert the opt-in in both directions. The guard worked as intended.

**Not included:** a season-year filter, expected on both platforms later. It's a bigger lift than it looks — `PickemGroup` has no `SeasonYear` column (the clone handler derives season from the league's matchups), so it needs a BE decision about where that value comes from before either UI can surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “My Leagues” mobile screen with league listings, filtering, past-league visibility, expandable details, and navigation to picks.
  - Added league duplication with customizable name and member invitations.
  - Added league detail displays, including season, visibility, ranking, tiebreaker, and member information.
  - Added a “Manage” shortcut from the home screen’s leagues card.
  - Added support for fetching and duplicating leagues through the mobile experience.

- **Tests**
  - Added coverage for league retrieval and duplication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->