### PR TITLE
fix: stop guessing week 1 when a league's slate hasn't landed yet

### DIFF
--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -57,7 +57,15 @@ namespace SportsData.Api.Application.Processors
 
             if (groupWeek is null)
             {
-                _logger.LogError("GroupWeek was null.{GroupId} {SeasonWeekId}", command.GroupId, command.SeasonWeekId);
+                // Expected on every league's first pass (create or clone) — the
+                // shell is created right here and processing continues. Logged at
+                // Debug because at Error it was the loudest line in a healthy
+                // bootstrap trail and read as the cause of failures it had nothing
+                // to do with.
+                _logger.LogDebug(
+                    "No PickemGroupWeek for group {GroupId} week {SeasonWeekId} yet; creating it.",
+                    command.GroupId,
+                    command.SeasonWeekId);
 
                 groupWeek = new PickemGroupWeek()
                 {

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import {
   View,
   FlatList,
+  ScrollView,
   StyleSheet,
   RefreshControl,
   Pressable,
@@ -34,7 +35,12 @@ export default function PicksScreen() {
   const router = useRouter();
   const navigation = useNavigation();
 
-  const { data: me, isLoading: meLoading, refetch: refetchMe } = useCurrentUser();
+  const {
+    data: me,
+    isLoading: meLoading,
+    refetch: refetchMe,
+    isRefetching: meRefetching,
+  } = useCurrentUser();
   const leagues = useMemo(() => getLeagues(me), [me]);
 
   // Optional deep-link param: home "Your Leagues" card pushes
@@ -341,13 +347,28 @@ export default function PicksScreen() {
   // stale and the heal-refetch above is in flight. Previously this fell back to
   // week 1 — a week that doesn't exist for every sport (MLB's start at 17) — and
   // rendered an empty slate that read as "the league failed to build".
+  //
+  // Scrollable so pull-to-refresh actually works: the heal fires only once per
+  // league, so this is the user's only way out if it didn't resolve.
   if (selectedWeek === null) {
     return (
-      <EmptyState
-        icon="🗓️"
-        title="Setting up your league"
-        subtitle="Your games are being scheduled. This usually takes a moment — pull to refresh if they don't appear."
-      />
+      <ScrollView
+        style={[styles.container, { backgroundColor: theme.background }]}
+        contentContainerStyle={styles.setupContent}
+        refreshControl={
+          <RefreshControl
+            refreshing={meRefetching}
+            onRefresh={refetchMe}
+            tintColor={theme.tint}
+          />
+        }
+      >
+        <EmptyState
+          icon="🗓️"
+          title="Setting up your league"
+          subtitle="Your games are being scheduled. This usually takes a moment — pull down to refresh if they don't appear."
+        />
+      </ScrollView>
     );
   }
 
@@ -506,6 +527,9 @@ export default function PicksScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
+  // flexGrow so EmptyState's own flex:1 can center in a short ScrollView, while
+  // still leaving the content pullable.
+  setupContent: { flexGrow: 1 },
   // gap = vertical spacing between rows (replaces the old ItemSeparator).
   list: { padding: 14, paddingBottom: 24, gap: 10 },
   // Horizontal spacing between columns in a multi-column row.

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   View,
   FlatList,
@@ -34,7 +34,7 @@ export default function PicksScreen() {
   const router = useRouter();
   const navigation = useNavigation();
 
-  const { data: me, isLoading: meLoading } = useCurrentUser();
+  const { data: me, isLoading: meLoading, refetch: refetchMe } = useCurrentUser();
   const leagues = useMemo(() => getLeagues(me), [me]);
 
   // Optional deep-link param: home "Your Leagues" card pushes
@@ -62,25 +62,48 @@ export default function PicksScreen() {
       : null;
     if (targeted) {
       setLeagueId(targeted.id);
-      setSelectedWeek(latestWeek(targeted) ?? 1);
+      setSelectedWeek(latestWeek(targeted));
       return;
     }
 
     // Otherwise initialize once to the first league in the list.
     if (!leagueId) {
       setLeagueId(leagues[0].id);
-      setSelectedWeek(latestWeek(leagues[0]) ?? 1);
+      setSelectedWeek(latestWeek(leagues[0]));
     }
   }, [leagues, leagueIdParam]);
 
   const selectedLeague = leagues.find((l) => l.id === leagueId) ?? null;
   const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
 
+  // A league with no weeks means this /user/me snapshot predates its slate
+  // build. Create/clone return before the slate exists (~700ms), and anything
+  // invalidating /user/me on that response caches the one empty frame — which
+  // useCurrentUser's 5-minute staleTime then serves for the next five minutes.
+  // Refetch to heal, once per league so a genuinely week-less league (e.g. a
+  // future-season league whose SeasonWeeks aren't sourced yet) can't loop.
+  const healedLeagueRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedLeague || seasonWeeks.length > 0) return;
+    if (healedLeagueRef.current === selectedLeague.id) return;
+    healedLeagueRef.current = selectedLeague.id;
+    refetchMe();
+  }, [selectedLeague, seasonWeeks.length, refetchMe]);
+
+  // Snap to the latest week once the weeks actually arrive. The init effect
+  // above only runs on league/param change, so without this a heal-refetch
+  // would land the data and still leave no week selected.
+  useEffect(() => {
+    if (selectedWeek !== null) return;
+    const week = latestWeek(selectedLeague);
+    if (week !== null) setSelectedWeek(week);
+  }, [selectedLeague, selectedWeek]);
+
   const handleLeagueChange = useCallback(
     (id: string) => {
       setLeagueId(id);
       const league = leagues.find((l) => l.id === id);
-      setSelectedWeek(latestWeek(league) ?? 1);
+      setSelectedWeek(latestWeek(league));
     },
     [leagues],
   );
@@ -308,6 +331,20 @@ export default function PicksScreen() {
         icon="🗓️"
         title="No active league"
         subtitle="You haven't joined a pick'em group yet."
+      />
+    );
+  }
+
+  // No week to show: either the slate is still being built, or this snapshot is
+  // stale and the heal-refetch above is in flight. Previously this fell back to
+  // week 1 — a week that doesn't exist for every sport (MLB's start at 17) — and
+  // rendered an empty slate that read as "the league failed to build".
+  if (selectedWeek === null) {
+    return (
+      <EmptyState
+        icon="🗓️"
+        title="Setting up your league"
+        subtitle="Your games are being scheduled. This usually takes a moment — pull to refresh if they don't appear."
       />
     );
   }

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -82,11 +82,13 @@ export default function PicksScreen() {
   // useCurrentUser's 5-minute staleTime then serves for the next five minutes.
   // Refetch to heal, once per league so a genuinely week-less league (e.g. a
   // future-season league whose SeasonWeeks aren't sourced yet) can't loop.
-  const healedLeagueRef = useRef<string | null>(null);
+  // A Set, not a single id: with one slot, switching between two week-less
+  // leagues evicts the guard and each switch back refetches again.
+  const healedLeaguesRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     if (!selectedLeague || seasonWeeks.length > 0) return;
-    if (healedLeagueRef.current === selectedLeague.id) return;
-    healedLeagueRef.current = selectedLeague.id;
+    if (healedLeaguesRef.current.has(selectedLeague.id)) return;
+    healedLeaguesRef.current.add(selectedLeague.id);
     refetchMe();
   }, [selectedLeague, seasonWeeks.length, refetchMe]);
 


### PR DESCRIPTION
## What

A freshly created or cloned league could render an empty slate that reads as *"the league failed to build."* It hadn't — the games existed within ~700ms. **The UI was asking for a week that never existed.**

Found while investigating a prod clone (`MLB0717v3`) reported as failed. It hadn't failed:

```
12:45:35.736  Cloned league 3d5f4aab… into b2a096f6…
12:45:35.914  Bootstrap resolved 1 SeasonWeek(s)
12:45:36.340  League window filtered 75 -> 14
12:45:36.340  Inclusion filter kept 14/14      ← every matchup survived
12:45:36.43   14x PickemGroupMatchup projections inserted
12:45:38.820  GET .../matchups/1 → 0 matchups  ← 2.4s AFTER they existed
12:47:16.417  GET .../matchups/17 → 14 matchups ✓
```

## Root cause: a poisoned cache, not slow async

Create/clone return **before** the slate is built, and both invalidate `/user/me` on that response — the one instant guaranteed to read zero matchups. The refetch snapshots `seasonWeeks: []`, and `useCurrentUser`'s **`staleTime: 5 minutes`** then serves that empty frame for the next five minutes. Nothing re-reads it.

`picks.tsx` did `latestWeek(league) ?? 1`, and **week 1 doesn't exist for every sport** — MLB's weeks start at 17. So it requested a week with no games and rendered nothing.

This is why polling or "waiting for eventual consistency" would be the wrong fix: the data was already there.

## Changes

**`picks.tsx`** — no more week-1 fallback (removed from all three call sites).
- A league with no weeks refetches `/user/me` to heal the stale snapshot, **guarded to once per league** so a genuinely week-less league (future season whose SeasonWeeks aren't sourced yet) can't refetch-loop.
- Renders **"Setting up your league"** until weeks arrive, instead of an empty slate that implies failure.
- A second effect snaps to the latest week once they land — the init effect only runs on league/param change, so without it a heal-refetch would fetch the data and still leave no week selected.
- `useMatchups` is already gated on `!!week`, so the wasted week-1 request disappears for free.

**`MatchupScheduleProcessor`** — `GroupWeek was null` drops **Error → Debug** and is reworded. It fires on every league's first pass immediately before the code creates the shell and continues. At Error it was the loudest line in a *healthy* bootstrap trail, and it got blamed for failures it had nothing to do with — including this one.

## What I deliberately did NOT do

**Dropping the `/user/me` invalidation on clone success**, even though it's the thing that poisons the cache.

`picks.tsx` resolves its deep-linked league out of `/user/me`, and on a miss it falls through to `leagues[0]` *silently*. So removing the invalidation trades "empty week" for "opens a completely different league" — strictly worse, and far harder to notice. Healing the snapshot where it's **read** fixes both entry points and makes the invalidation harmless.

## Scope

Not a cloning bug. `create-league` has the same invalidate-then-`router.back()` shape, so this has been reachable since MLB onboarding — cloning just made it trivial to hit, because you go from "duplicate" to "look at the picks" in two seconds.

## Testing

- `dotnet build` clean; 34 affected API tests pass (`MatchupSchedule` + `CloneLeague`).
- `npx tsc --noEmit` clean; **73 mobile tests pass**, 9 suites.

## Reviewer notes

The two new effects in `picks.tsx` are the load-bearing part: `healedLeagueRef` is what prevents the refetch loop, and the snap effect is what makes the heal actually select a week. Worth a look at both.

Follow-up worth considering separately: `useCurrentUser`'s 5-minute `staleTime` is what turned a 700ms race into a five-minute outage. Without it, the next mount would have quietly fixed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when league schedules are still being prepared.
  * Automatically refreshes missing schedule data and selects the latest available week once loaded.
  * Prevented repeated refresh attempts when no weeks are available.

* **User Experience**
  * Added a clear empty state while league scheduling is in progress instead of displaying an incorrect default week.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->