### PR TITLE
feat(seasons): data-driven off-season countdown via current-season resource

### DIFF
--- a/docs/features/data-driven-season-countdown.md
+++ b/docs/features/data-driven-season-countdown.md
@@ -1,0 +1,147 @@
+# Data-driven off-season countdown
+
+## Problem
+
+`PrimarySlotOffSeasonCountdown` (the Tier-1 home slot shown to logged-in users
+when no followed sport is in-season) counts down to each sport's kickoff. Both
+platforms currently get the kickoff date wrong:
+
+- **Web** (`sd-ui/.../home/PrimarySlotOffSeasonCountdown.jsx`) hardcodes
+  `Date.UTC(2026, 8, 5)` / `Date.UTC(2026, 8, 10)` constants. Stale by
+  construction — they were right when written and rot silently each season. A
+  manual test edit also left them inconsistent.
+- **Mobile** (`sd-mobile/.../home/PrimarySlotOffSeasonCountdown.tsx`) *computes*
+  kickoff from rules: NCAAFB = "first Saturday of September", NFL = "Thursday
+  after Labor Day". Both rules are wrong for 2026:
+
+  | Sport  | Rule computes | Actual (sourced) | Error |
+  |--------|---------------|------------------|-------|
+  | NCAAFB | Sep 5         | **Aug 29**       | 7 days early |
+  | NFL    | Sep 10        | **Sep 9** (Wed)  | 1 day late |
+
+  NCAAFB has no fixed rule at all; NFL's is a convention the league doesn't
+  actually honor. A derived date is a guess wearing an algorithm's clothing — it
+  produces a plausible-but-wrong date every year with no symptom, which is worse
+  than web's loud staleness.
+
+The two platforms also disagree with each other, with no shared source.
+
+## Source of truth
+
+Producer's `SeasonPhase` entity already carries the answer:
+
+```
+SeasonPhase { TypeCode, Name, Abbreviation, Slug, Year, StartDate, EndDate, ... }
+```
+
+`TypeCode`: 1 = Preseason, 2 = Regular Season, 3 = Postseason, 4 = Off Season.
+
+The countdown target = `StartDate` of the **Regular Season** phase (`TypeCode = 2`)
+for the sport's current season. Confirmed present in both sport DBs for 2026 with
+correct dates (NCAAFB Aug 29, NFL Sep 9), so the primary path needs no fallback
+to ship — see "Absent-data behavior" for graceful degradation.
+
+## Design
+
+Thin pass-through at each layer; no new persistence. Modelled as a **general
+per-sport season resource**, not a countdown-shaped endpoint.
+
+**BFF vs. standard-endpoint test:** if the endpoint returned the *countdown*
+(e.g. `{ label: "NCAAFB in 43 days" }` — the answer pre-computed for one UI), it
+would be a BFF concern and belong under `Application/UI/*`. Because it returns
+*raw* season/phase data (`{ TypeCode, StartDate, ... }`) for the client to
+interpret, it's a standard endpoint. It therefore lives as a normal vertical
+slice under `Application/Seasons/`, on the same `api/{sport}/{league}/{resource}`
+convention as the existing Contests / Franchises / Venues slices.
+
+Consequently the API does **not** fan out both sports and knows nothing about
+"kickoffs". "Which sports the countdown shows" is a presentation decision that
+stays in the countdown component; "kickoff" is that component's interpretation of
+"regular-season start" and stays in the UI. The API speaks seasons and phases.
+
+### 1. Producer — current-or-upcoming season with phases
+
+`GET seasons/current` → `CurrentSeasonDto`
+
+```
+record SeasonPhaseDto {
+  int TypeCode; string Name; DateTime StartDate; DateTime EndDate;
+}
+record CurrentSeasonDto {
+  int SeasonYear; string Name;
+  DateTime StartDate; DateTime EndDate;
+  List<SeasonPhaseDto> Phases;
+}
+```
+
+New query handler (`GetCurrentSeason`) resolves the **current-or-upcoming**
+`Season` directly from the data — `EndDate >= now`, earliest `StartDate` — with
+its `Phases` included, `.AsNoTracking()`, projected to the DTO. This is
+data-driven and avoids a calendar heuristic: during a season it returns the
+in-progress one (its `EndDate` is still in the future, which also covers the
+Jan–Feb playoff window that broke naive `UtcNow().Year`); during the off-season
+the prior season's `EndDate` is past, so the next upcoming season wins. No season
+row matching (brand-new sport, or a gap before next season is sourced) →
+`NotFound`, a legitimate not-yet-sourced case.
+
+Deliberately *not* reusing `GET {year}/overview`: overview drags every week + poll
+across the wire and exposes `SeasonPhaseName` (string) rather than `TypeCode`.
+
+### 2. Core — SeasonClient method
+
+`Task<Result<CurrentSeasonDto>> GetCurrentSeason(CancellationToken)`
+
+Added to `IProvideSeasons`. `SeasonClientFactory.Resolve(mode)` already builds
+sport-keyed base addresses (`CommonConfig:SeasonClientConfig:{mode}:ApiUrl`,
+default fallback), so per-sport routing is free — the resolved client hits that
+sport's Producer DB, so "current season" is naturally sport-scoped.
+
+### 3. API — current-season resource (per sport)
+
+`GET api/{sport}/{league}/seasons/current` → `CurrentSeasonDto`
+
+New `Application/Seasons/` slice: controller + `GetCurrentSeason` query handler.
+Maps the route's `{sport}/{league}` to a `Sport` mode via `ModeMapper.ResolveMode`
+(as Venues/Contests do), resolves `ISeasonClientFactory` for it, and passes the
+`CurrentSeasonDto` straight through. One sport per call — the client calls it
+once per sport it cares about. General and reusable; no countdown vocabulary and
+no season-year guessing (Producer owns "current").
+
+### 4. Web + mobile — consume the resource
+
+Both `PrimarySlotOffSeasonCountdown` components drop their hardcoded constants /
+computed rules. Each keeps its own list of sports to surface (a presentation
+choice), fetches `seasons/current` per sport, and reads the `TypeCode == 2`
+(Regular Season) phase's `StartDate` as the countdown target:
+
+- Web: fetch per surfaced sport (or lift to the home data load).
+- Mobile: `useQuery` per sport; delete `ncaafbKickoff` / `nflKickoff` entirely.
+
+`daysUntil` / phrasing logic stays; only the date source changes. A sport whose
+current season has no Regular Season phase yet → "kickoff coming soon" / omitted,
+never a wrong countdown. Convert any remaining date construction to ISO strings
+(no `Date.UTC(y, m, d)`).
+
+## Absent-data behavior
+
+`KickoffUtc = null` for a sport → that sport shows "kickoff coming soon" (or is
+omitted) rather than a wrong countdown. Since both 2026 phases are already
+sourced this is not the primary path, but it's the correct behavior for a
+future season whose phases haven't landed, and it keeps the home page resilient
+to a Producer outage.
+
+## Out of scope / follow-ups
+
+- **Preseason pick'em leagues** ([[project_preseason_pickem_leagues]]) — the
+  countdown window is where preseason games would live; TypeCode 1 is available
+  from the same endpoint if/when that's built.
+- Season-year rollover edge cases beyond what's already handled.
+
+## Files touched
+
+- `SportsData.Producer`: new `GetSeasonPhases` query + handler; `SeasonController` action (`seasons/{year}/phases`); `SeasonPhaseDto` (Core.Dtos.Canonical).
+- `SportsData.Core`: `IProvideSeasons` / `SeasonClient.GetSeasonPhases`.
+- `SportsData.Api`: new `Application/Seasons/` slice — `SeasonsController` (`api/{sport}/{league}/seasons/current`) + `GetCurrentSeason` query handler + `CurrentSeasonDto` + DI registration.
+- `sd-ui`: `PrimarySlotOffSeasonCountdown.jsx` + season api client method.
+- `sd-mobile`: `PrimarySlotOffSeasonCountdown.tsx` + season api method.
+- Tests at each layer.

--- a/docs/features/data-driven-season-countdown.md
+++ b/docs/features/data-driven-season-countdown.md
@@ -139,9 +139,9 @@ to a Producer outage.
 
 ## Files touched
 
-- `SportsData.Producer`: new `GetSeasonPhases` query + handler; `SeasonController` action (`seasons/{year}/phases`); `SeasonPhaseDto` (Core.Dtos.Canonical).
-- `SportsData.Core`: `IProvideSeasons` / `SeasonClient.GetSeasonPhases`.
-- `SportsData.Api`: new `Application/Seasons/` slice — `SeasonsController` (`api/{sport}/{league}/seasons/current`) + `GetCurrentSeason` query handler + `CurrentSeasonDto` + DI registration.
+- `SportsData.Producer`: new `GetCurrentSeason` query + handler; `SeasonController` action (`seasons/current`); DI registration.
+- `SportsData.Core`: `IProvideSeasons` / `SeasonClient.GetCurrentSeason`; `CurrentSeasonDto` + `SeasonPhaseDto` (Core.Dtos.Canonical).
+- `SportsData.Api`: new `Application/Seasons/` slice — `SeasonsController` (`api/{sport}/{league}/seasons/current`) + `GetCurrentSeason` query handler + DI registration.
 - `sd-ui`: `PrimarySlotOffSeasonCountdown.jsx` + season api client method.
 - `sd-mobile`: `PrimarySlotOffSeasonCountdown.tsx` + season api method.
 - Tests at each layer.

--- a/docs/features/data-driven-season-countdown.md
+++ b/docs/features/data-driven-season-countdown.md
@@ -16,7 +16,7 @@ platforms currently get the kickoff date wrong:
 
   | Sport  | Rule computes | Actual (sourced) | Error |
   |--------|---------------|------------------|-------|
-  | NCAAFB | Sep 5         | **Aug 29**       | 7 days early |
+  | NCAAFB | Sep 5         | **Aug 29**       | 7 days late |
   | NFL    | Sep 10        | **Sep 9** (Wed)  | 1 day late |
 
   NCAAFB has no fixed rule at all; NFL's is a convention the league doesn't

--- a/src/SportsData.Api/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQuery.cs
+++ b/src/SportsData.Api/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQuery.cs
@@ -1,0 +1,8 @@
+namespace SportsData.Api.Application.Seasons.Queries.GetCurrentSeason;
+
+public class GetCurrentSeasonQuery
+{
+    public required string Sport { get; init; }
+
+    public required string League { get; init; }
+}

--- a/src/SportsData.Api/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandler.cs
+++ b/src/SportsData.Api/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandler.cs
@@ -1,0 +1,58 @@
+using SportsData.Core.Common;
+using SportsData.Core.Common.Mapping;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Season;
+
+namespace SportsData.Api.Application.Seasons.Queries.GetCurrentSeason;
+
+public interface IGetCurrentSeasonQueryHandler
+{
+    Task<Result<CurrentSeasonDto>> ExecuteAsync(
+        GetCurrentSeasonQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Per-sport pass-through to Producer's current-or-upcoming season. Maps the
+/// route's sport/league to a mode and resolves the sport-specific SeasonClient;
+/// returns raw phase data for the caller to interpret (e.g. the off-season
+/// kickoff countdown reading the Regular Season phase's StartDate).
+/// </summary>
+public class GetCurrentSeasonQueryHandler : IGetCurrentSeasonQueryHandler
+{
+    private readonly ISeasonClientFactory _seasonClientFactory;
+    private readonly ILogger<GetCurrentSeasonQueryHandler> _logger;
+
+    public GetCurrentSeasonQueryHandler(
+        ISeasonClientFactory seasonClientFactory,
+        ILogger<GetCurrentSeasonQueryHandler> logger)
+    {
+        _seasonClientFactory = seasonClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<Result<CurrentSeasonDto>> ExecuteAsync(
+        GetCurrentSeasonQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        Sport mode;
+        try
+        {
+            mode = ModeMapper.ResolveMode(query.Sport, query.League);
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogWarning(ex,
+                "Unsupported sport/league combination. Sport={Sport}, League={League}",
+                query.Sport.Sanitize(), query.League.Sanitize());
+            return new Failure<CurrentSeasonDto>(
+                default!,
+                ResultStatus.BadRequest,
+                [new FluentValidation.Results.ValidationFailure("Sport/League", ex.Message)]);
+        }
+
+        var client = _seasonClientFactory.Resolve(mode);
+        return await client.GetCurrentSeason(cancellationToken);
+    }
+}

--- a/src/SportsData.Api/Application/Seasons/SeasonsController.cs
+++ b/src/SportsData.Api/Application/Seasons/SeasonsController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Api.Application.Seasons.Queries.GetCurrentSeason;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
+
+namespace SportsData.Api.Application.Seasons;
+
+[ApiController]
+[Route("api/{sport}/{league}/seasons")]
+public class SeasonsController : ApiControllerBase
+{
+    /// <summary>
+    /// The current-or-upcoming season for the sport, with its phases. Standard
+    /// endpoint returning raw phase data (TypeCode + dates); clients interpret it
+    /// (e.g. the home off-season countdown derives kickoff from the Regular
+    /// Season phase's StartDate).
+    /// </summary>
+    [HttpGet("current", Name = "GetCurrentSeason")]
+    [ProducesResponseType(typeof(CurrentSeasonDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<CurrentSeasonDto>> GetCurrentSeason(
+        [FromServices] IGetCurrentSeasonQueryHandler handler,
+        [FromRoute] string sport,
+        [FromRoute] string league,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetCurrentSeasonQuery
+        {
+            Sport = sport,
+            League = league
+        };
+
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+
+        return result.ToActionResult();
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -210,6 +210,11 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetVenuesQueryHandler, GetVenuesQueryHandler>();
             services.AddScoped<IGetVenueByIdQueryHandler, GetVenueByIdQueryHandler>();
 
+            // Seasons Queries
+            services.AddScoped<
+                Application.Seasons.Queries.GetCurrentSeason.IGetCurrentSeasonQueryHandler,
+                Application.Seasons.Queries.GetCurrentSeason.GetCurrentSeasonQueryHandler>();
+
             // Conferences Queries
             services.AddScoped<IGetConferenceNamesAndSlugsQueryHandler, GetConferenceNamesAndSlugsQueryHandler>();
 

--- a/src/SportsData.Core/Dtos/Canonical/CurrentSeasonDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/CurrentSeasonDto.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Core.Dtos.Canonical;
+
+/// <summary>
+/// The current-or-upcoming season for a sport, with its phases. "Current" is
+/// resolved from the data (earliest season whose EndDate is still in the
+/// future), so during a season it returns the in-progress one and during the
+/// off-season it returns the next upcoming one — no calendar heuristic.
+/// </summary>
+public record CurrentSeasonDto
+{
+    public int SeasonYear { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public DateTime StartDate { get; init; }
+    public DateTime EndDate { get; init; }
+    public List<SeasonPhaseDto> Phases { get; init; } = [];
+}
+
+/// <summary>
+/// One phase of a season. <see cref="TypeCode"/>: 1 = Preseason,
+/// 2 = Regular Season, 3 = Postseason, 4 = Off Season.
+/// </summary>
+public record SeasonPhaseDto
+{
+    public int TypeCode { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public DateTime StartDate { get; init; }
+    public DateTime EndDate { get; init; }
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Season/SeasonClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Season/SeasonClient.cs
@@ -17,6 +17,7 @@ namespace SportsData.Core.Infrastructure.Clients.Season;
 public interface IProvideSeasons : IProvideHealthChecks
 {
     Task<Result<SeasonOverviewDto>> GetSeasonOverview(int seasonYear, CancellationToken ct = default);
+    Task<Result<CurrentSeasonDto>> GetCurrentSeason(CancellationToken ct = default);
     Task<Result<FranchiseSeasonPollDto>> GetPollBySeasonWeekId(Guid seasonWeekId, string pollSlug, CancellationToken ct = default);
     Task<Result<CanonicalSeasonWeekDto>> GetCurrentSeasonWeek(CancellationToken ct = default);
     Task<Result<List<CanonicalSeasonWeekDto>>> GetCurrentAndLastSeasonWeeks(CancellationToken ct = default);
@@ -49,6 +50,16 @@ public class SeasonClient : ClientBase, IProvideSeasons
             overview => overview,
             default!,
             "Season overview",
+            ResultStatus.NotFound,
+            ct);
+    }
+
+    public async Task<Result<CurrentSeasonDto>> GetCurrentSeason(CancellationToken ct = default)
+    {
+        return await GetAsync<CurrentSeasonDto>(
+            "seasons/current",
+            default!,
+            "Current season",
             ResultStatus.NotFound,
             ct);
     }

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQuery.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQuery.cs
@@ -1,0 +1,10 @@
+namespace SportsData.Producer.Application.Seasons.Queries.GetCurrentSeason;
+
+/// <summary>
+/// Returns the current-or-upcoming <see cref="SportsData.Core.Dtos.Canonical.CurrentSeasonDto"/>
+/// for this Producer's sport DB, with its phases. "Current" is resolved from the
+/// data (earliest season whose EndDate is still in the future), so it returns the
+/// in-progress season during play and the next upcoming season during the
+/// off-season — without a calendar heuristic.
+/// </summary>
+public record GetCurrentSeasonQuery();

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandler.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Seasons.Queries.GetCurrentSeason;
+
+public interface IGetCurrentSeasonQueryHandler
+{
+    Task<Result<CurrentSeasonDto>> ExecuteAsync(
+        GetCurrentSeasonQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Resolves the current-or-upcoming season with its phases. See
+/// <see cref="GetCurrentSeasonQuery"/> for the "current" definition.
+/// </summary>
+public class GetCurrentSeasonQueryHandler : IGetCurrentSeasonQueryHandler
+{
+    private readonly TeamSportDataContext _dbContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public GetCurrentSeasonQueryHandler(
+        TeamSportDataContext dbContext,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _dbContext = dbContext;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<CurrentSeasonDto>> ExecuteAsync(
+        GetCurrentSeasonQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _dateTimeProvider.UtcNow();
+
+        // Current-or-upcoming: earliest season not yet ended. In-season this is
+        // the in-progress season (its EndDate is still future, which also covers
+        // the Jan–Feb playoff window); off-season the prior season's EndDate has
+        // passed so the next upcoming season wins.
+        var season = await _dbContext.Seasons
+            .AsNoTracking()
+            .Where(s => s.EndDate >= now)
+            .OrderBy(s => s.StartDate)
+            .Select(s => new CurrentSeasonDto
+            {
+                SeasonYear = s.Year,
+                Name = s.Name,
+                StartDate = s.StartDate,
+                EndDate = s.EndDate,
+                Phases = s.Phases
+                    .OrderBy(p => p.StartDate)
+                    .Select(p => new SeasonPhaseDto
+                    {
+                        TypeCode = p.TypeCode,
+                        Name = p.Name,
+                        StartDate = p.StartDate,
+                        EndDate = p.EndDate
+                    })
+                    .ToList()
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (season is null)
+        {
+            return new Failure<CurrentSeasonDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new FluentValidation.Results.ValidationFailure(
+                    "Season", "No current or upcoming season found")]);
+        }
+
+        return new Success<CurrentSeasonDto>(season);
+    }
+}

--- a/src/SportsData.Producer/Application/Seasons/SeasonController.cs
+++ b/src/SportsData.Producer/Application/Seasons/SeasonController.cs
@@ -5,6 +5,7 @@ using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
 using SportsData.Producer.Application.Seasons.Queries.GetCompletedSeasonWeeks;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentAndLastSeasonWeeks;
+using SportsData.Producer.Application.Seasons.Queries.GetCurrentSeason;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentSeasonWeek;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonOverview;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
@@ -23,6 +24,21 @@ public class SeasonController : ControllerBase
     {
         var query = new GetSeasonOverviewQuery(seasonYear);
         var result = await handler.ExecuteAsync(query, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// The current-or-upcoming season with its phases, for this Producer's sport.
+    /// Backs the API's per-sport <c>seasons/current</c> resource (which the
+    /// off-season kickoff countdown consumes). Returns raw phase data — no
+    /// countdown computation here.
+    /// </summary>
+    [HttpGet("current")]
+    public async Task<ActionResult<CurrentSeasonDto>> GetCurrentSeason(
+        [FromServices] IGetCurrentSeasonQueryHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await handler.ExecuteAsync(new GetCurrentSeasonQuery(), cancellationToken);
         return result.ToActionResult();
     }
 

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -59,6 +59,7 @@ using SportsData.Producer.Application.GroupSeasons.Queries.GetConferenceIdsBySlu
 using SportsData.Producer.Application.Images;
 using SportsData.Producer.Application.Seasons.Queries.GetCompletedSeasonWeeks;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentAndLastSeasonWeeks;
+using SportsData.Producer.Application.Seasons.Queries.GetCurrentSeason;
 using SportsData.Producer.Application.Seasons.Queries.GetCurrentSeasonWeek;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonOverview;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
@@ -345,6 +346,7 @@ namespace SportsData.Producer.DependencyInjection
             }
 
             // Season Queries
+            services.AddScoped<IGetCurrentSeasonQueryHandler, GetCurrentSeasonQueryHandler>();
             services.AddScoped<IGetSeasonOverviewQueryHandler, GetSeasonOverviewQueryHandler>();
             services.AddScoped<IGetCurrentSeasonWeekQueryHandler, GetCurrentSeasonWeekQueryHandler>();
             services.AddScoped<IGetCurrentAndLastSeasonWeeksQueryHandler, GetCurrentAndLastSeasonWeeksQueryHandler>();

--- a/src/UI/sd-mobile/__tests__/services/api/seasonApi.test.ts
+++ b/src/UI/sd-mobile/__tests__/services/api/seasonApi.test.ts
@@ -1,0 +1,41 @@
+import { seasonApi, type CurrentSeason } from '@/src/services/api/seasonApi';
+
+// Mock the shared axios instance — we only care about the URL that goes out.
+jest.mock('@/src/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { apiClient } = require('@/src/services/api/client');
+
+describe('seasonApi.getCurrentSeason', () => {
+  beforeEach(() => {
+    (apiClient.get as jest.Mock).mockReset();
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: null });
+  });
+
+  it('GETs the per-sport current-season route', async () => {
+    await seasonApi.getCurrentSeason('football', 'ncaa');
+
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/football/ncaa/seasons/current');
+  });
+
+  it('returns the season with its phases', async () => {
+    const season: CurrentSeason = {
+      seasonYear: 2026,
+      name: '2026 Season',
+      startDate: '2026-08-29T00:00:00Z',
+      endDate: '2027-01-15T00:00:00Z',
+      phases: [
+        { typeCode: 2, name: 'Regular Season', startDate: '2026-08-29T00:00:00Z', endDate: '2026-12-07T00:00:00Z' },
+      ],
+    };
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: season });
+
+    const res = await seasonApi.getCurrentSeason('football', 'nfl');
+    expect(res.data).toEqual(season);
+  });
+});

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -1,80 +1,47 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useQueries } from '@tanstack/react-query';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { Button } from '@/src/components/ui/Button';
+import {
+  seasonApi,
+  REGULAR_SEASON_TYPE_CODE,
+  type CurrentSeason,
+} from '@/src/services/api/seasonApi';
 
-// ─── Kickoff helpers ──────────────────────────────────────────────────────────
+// ─── Sports ─────────────────────────────────────────────────────────────────
 //
-// NCAAFB: first Saturday of September. NFL: Thursday after Labor Day (Labor
-// Day = first Monday of September, kickoff = that Monday + 3 days). Computed
-// at render time so the card rolls over on its own each season — no yearly
-// constant maintenance.
+// `sportEnum` is what create-league reads from ?sport= to preselect the tab.
+// `sport`/`league` are the API route segments. Kickoff is data-driven — the
+// Regular Season phase's StartDate from seasons/current — not a computed rule.
+// The prior rules ("first Saturday of September" / "Thursday after Labor Day")
+// were both wrong for 2026. See docs/features/data-driven-season-countdown.md.
 
-/** First Saturday of September in the given year, 00:00 UTC. */
-function ncaafbKickoff(year: number): Date {
-  for (let day = 1; day <= 7; day++) {
-    const d = new Date(Date.UTC(year, 8, day)); // month 8 = September
-    if (d.getUTCDay() === 6) return d; // Saturday
-  }
-  return new Date(Date.UTC(year, 8, 7)); // unreachable fallback
+const SPORTS = [
+  { key: 'NCAAFB', label: 'NCAAFB', sportEnum: 'FootballNcaa', sport: 'football', league: 'ncaa' },
+  { key: 'NFL', label: 'NFL', sportEnum: 'FootballNfl', sport: 'football', league: 'nfl' },
+] as const;
+
+// Kickoff = the Regular Season phase's start, or null when not sourced yet.
+function regularSeasonStart(season: CurrentSeason | undefined): string | null {
+  return season?.phases?.find((p) => p.typeCode === REGULAR_SEASON_TYPE_CODE)?.startDate ?? null;
 }
 
-/** Thursday after Labor Day (first Monday of September) in the given year. */
-function nflKickoff(year: number): Date {
-  for (let day = 1; day <= 7; day++) {
-    const d = new Date(Date.UTC(year, 8, day));
-    if (d.getUTCDay() === 1) {
-      // Labor Day — kickoff is the following Thursday (+3 days).
-      return new Date(Date.UTC(year, 8, day + 3));
-    }
-  }
-  return new Date(Date.UTC(year, 8, 10)); // unreachable fallback
-}
-
-/**
- * Return the season year the countdown should track.
- *
- * Anchors on the *previous* calendar year's NFL kickoff so January/February
- * stays on the in-progress season (playoffs + Super Bowl) instead of
- * incorrectly advancing to the next year's off-season countdown. Rollover
- * happens ≈6 months after that kickoff — roughly March of the current
- * calendar year — which is the product-correct moment to start counting
- * down to the new season.
- *
- * Examples:
- *   - Nov 15, 2026 (regular season):       year=2026 ✓
- *   - Jan 15, 2027 (2026 playoffs):        year=2026 ✓ ("underway" still)
- *   - Apr 15, 2027 (off-season):           year=2027 ✓ (counting down)
- *   - Sep 11, 2027 (2027 NCAAFB started):  year=2027 ✓
- */
-function targetSeasonYear(nowMs: number): number {
-  const now = new Date(nowMs);
-  const year = now.getUTCFullYear();
-  const rollover = new Date(nflKickoff(year - 1));
-  rollover.setUTCMonth(rollover.getUTCMonth() + 6);
-  return nowMs >= rollover.getTime() ? year : year - 1;
-}
-
-function daysUntil(targetUtc: Date, nowMs: number): number {
+function daysUntil(kickoffIso: string, nowMs: number): number {
   const msPerDay = 1000 * 60 * 60 * 24;
-  return Math.ceil((targetUtc.getTime() - nowMs) / msPerDay);
+  return Math.ceil((new Date(kickoffIso).getTime() - nowMs) / msPerDay);
 }
 
-type SportPhrase = { status: 'live' | 'upcoming'; text: string };
+type SportPhrase = { status: 'live' | 'upcoming' | 'unknown'; text: string };
 
-function sportPhrase(
-  sport: { label: string; kickoff: Date },
-  nowMs: number,
-): SportPhrase {
-  const days = daysUntil(sport.kickoff, nowMs);
-  if (days <= 0) return { status: 'live', text: `${sport.label} is underway` };
-  return {
-    status: 'upcoming',
-    text: `${sport.label} in ${days} ${days === 1 ? 'day' : 'days'}`,
-  };
+function sportPhrase(label: string, kickoff: string | null, nowMs: number): SportPhrase {
+  if (!kickoff) return { status: 'unknown', text: `${label} kickoff coming soon` };
+  const days = daysUntil(kickoff, nowMs);
+  if (days <= 0) return { status: 'live', text: `${label} is underway` };
+  return { status: 'upcoming', text: `${label} in ${days} ${days === 1 ? 'day' : 'days'}` };
 }
 
 /**
@@ -84,9 +51,10 @@ function sportPhrase(
  *   - upcoming → create-league with ?sport= preselected
  *   - live     → picks tab (all leagues)
  *
- * `nowMs` ticks hourly so day-boundary transitions update without a remount —
- * an app left open across midnight still shows the correct "X days" count.
- * Hourly (vs daily) is cheap and covers DST / straggler tick drift for free.
+ * Kickoffs are fetched per sport from seasons/current (the Regular Season
+ * phase's StartDate). `nowMs` ticks hourly so day-boundary transitions update
+ * without a remount — an app left open across midnight still shows the correct
+ * "X days" count.
  */
 export function PrimarySlotOffSeasonCountdown() {
   const scheme = useColorScheme();
@@ -99,31 +67,44 @@ export function PrimarySlotOffSeasonCountdown() {
     return () => clearInterval(id);
   }, []);
 
-  const year = useMemo(() => targetSeasonYear(nowMs), [nowMs]);
-  const sports = useMemo(
-    () => [
-      {
-        key: 'NCAAFB',
-        label: 'NCAAFB',
-        kickoff: ncaafbKickoff(year),
-        sportEnum: 'FootballNcaa',
-      },
-      {
-        key: 'NFL',
-        label: 'NFL',
-        kickoff: nflKickoff(year),
-        sportEnum: 'FootballNfl',
-      },
-    ],
-    [year],
-  );
+  const results = useQueries({
+    queries: SPORTS.map((s) => ({
+      queryKey: ['season', 'current', s.sport, s.league],
+      queryFn: () => seasonApi.getCurrentSeason(s.sport, s.league).then((r) => r.data),
+      staleTime: 1000 * 60 * 60, // kickoff dates barely move; refetch hourly at most
+      // A sport with no sourced season is a valid "coming soon" state — don't
+      // retry it as though it were a transient error.
+      retry: false,
+    })),
+  });
 
-  const phrases = sports.map((s) => ({ ...s, phrase: sportPhrase(s, nowMs) }));
+  const loading = results.some((r) => r.isLoading);
+
+  // Cheap to recompute each render (and it must, to follow the hourly nowMs
+  // tick), so no memo — a memo here would just need fragile deps over the
+  // query results.
+  const phrases = SPORTS.map((s, i) => {
+    const kickoff = regularSeasonStart(results[i].data);
+    return { ...s, kickoff, phrase: sportPhrase(s.label, kickoff, nowMs) };
+  });
+
+  const seasonYear =
+    results.map((r) => r.data?.seasonYear).find((y) => y != null) ?? null;
+
   const allLive = phrases.every((s) => s.phrase.status === 'live');
+  const eyebrow = seasonYear ? `${seasonYear} SEASON` : 'UPCOMING SEASON';
 
   const body = allLive
     ? 'Jump into your leagues and lock in your picks before the next kickoff.'
-    : `Spin up your ${year} pick'em league now so you're ready for Week 1.`;
+    : `Spin up your ${seasonYear ?? ''} pick'em league now so you're ready for Week 1.`;
+
+  if (loading) {
+    return (
+      <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Text style={[styles.body, { color: theme.textMuted }]}>Loading the season schedule…</Text>
+      </View>
+    );
+  }
 
   return (
     <View
@@ -132,7 +113,7 @@ export function PrimarySlotOffSeasonCountdown() {
         { backgroundColor: theme.card, borderColor: theme.border },
       ]}
     >
-      <Text style={[styles.eyebrow, { color: theme.tint }]}>{year} SEASON</Text>
+      <Text style={[styles.eyebrow, { color: theme.tint }]}>{eyebrow}</Text>
 
       {allLive ? (
         <Text style={[styles.headline, { color: theme.text }]}>

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -96,7 +96,9 @@ export function PrimarySlotOffSeasonCountdown() {
 
   const body = allLive
     ? 'Jump into your leagues and lock in your picks before the next kickoff.'
-    : `Spin up your ${seasonYear ?? ''} pick'em league now so you're ready for Week 1.`;
+    : seasonYear
+      ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week 1.`
+      : "Spin up your pick'em league now so you're ready for Week 1.";
 
   if (loading) {
     return (

--- a/src/UI/sd-mobile/src/services/api/seasonApi.ts
+++ b/src/UI/sd-mobile/src/services/api/seasonApi.ts
@@ -1,0 +1,30 @@
+import { apiClient } from './client';
+
+// Matches SportsData.Core.Dtos.Canonical.SeasonPhaseDto.
+// TypeCode: 1 = Preseason, 2 = Regular Season, 3 = Postseason, 4 = Off Season.
+export interface SeasonPhase {
+  typeCode: number;
+  name: string;
+  startDate: string;
+  endDate: string;
+}
+
+// Matches SportsData.Core.Dtos.Canonical.CurrentSeasonDto.
+export interface CurrentSeason {
+  seasonYear: number;
+  name: string;
+  startDate: string;
+  endDate: string;
+  phases: SeasonPhase[];
+}
+
+export const REGULAR_SEASON_TYPE_CODE = 2;
+
+export const seasonApi = {
+  // GET /api/{sport}/{league}/seasons/current — current-or-upcoming season with
+  // its phases. Raw phase data; the caller interprets it (e.g. the off-season
+  // countdown reads the Regular Season phase's startDate). `sport`/`league` are
+  // route segments, e.g. ('football','ncaa').
+  getCurrentSeason: (sport: string, league: string) =>
+    apiClient.get<CurrentSeason>(`/api/${sport}/${league}/seasons/current`),
+};

--- a/src/UI/sd-ui/src/api/seasonApi.js
+++ b/src/UI/sd-ui/src/api/seasonApi.js
@@ -3,6 +3,13 @@ import apiClient from "./apiClient";
 const SeasonApi = {
   getSeasonOverview: (seasonYear) =>
     apiClient.get(`/ui/season/${seasonYear}/overview`),
+
+  // Current-or-upcoming season for a sport, with its phases. Standard endpoint
+  // returning raw phase data (TypeCode + dates); the caller interprets it —
+  // e.g. the off-season countdown reads the Regular Season (TypeCode 2) phase's
+  // startDate. `sport`/`league` are the route segments, e.g. ("football","ncaa").
+  getCurrentSeason: (sport, league) =>
+    apiClient.get(`/api/${sport}/${league}/seasons/current`),
 };
 
 export default SeasonApi;

--- a/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
+++ b/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import SeasonApi from "../../api/seasonApi";
 
 /**
  * Tier 1 primary slot — fallback shown when the user has at least one
@@ -6,66 +8,127 @@ import { Link } from "react-router-dom";
  * per-sport countdowns so users can see how close each product-focus
  * sport is to kickoff and spin up leagues ahead of time.
  *
- * Kickoff dates are hard-coded constants; revisit when ESPN publishes
- * each sport's official schedule if the dates shift.
+ * Kickoff dates are data-driven: each sport's kickoff is the StartDate of its
+ * current season's Regular Season phase (TypeCode 2), fetched from
+ * /api/{sport}/{league}/seasons/current. No hardcoded or rule-derived dates —
+ * those were wrong (NCAAFB has no fixed rule; NFL's "Thursday after Labor Day"
+ * isn't honored). See docs/features/data-driven-season-countdown.md.
  *
  * Seasonal calendar reference: docs/post-login-landing-design.md.
  */
 
+const REGULAR_SEASON_TYPE_CODE = 2;
+
 const SPORTS = [
-  // NCAAFB opens first weekend of September (always). `sportEnum` is the
-  // value LeagueCreatePage reads from ?sport= to preselect the sport tab.
-  {
-    key: "NCAAFB",
-    label: "NCAAFB",
-    kickoff: new Date(Date.UTC(2026, 8, 5)),
-    sportEnum: "FootballNcaa",
-  },
-  // NFL opens the Thursday after Labor Day (Kickoff Thursday).
-  {
-    key: "NFL",
-    label: "NFL",
-    kickoff: new Date(Date.UTC(2026, 8, 10)),
-    sportEnum: "FootballNfl",
-  },
+  // `sportEnum` is the value LeagueCreatePage reads from ?sport= to preselect
+  // the sport tab. `sport`/`league` are the API route segments.
+  { key: "NCAAFB", label: "NCAAFB", sportEnum: "FootballNcaa", sport: "football", league: "ncaa" },
+  { key: "NFL", label: "NFL", sportEnum: "FootballNfl", sport: "football", league: "nfl" },
 ];
 
-function daysUntil(targetUtc, nowMs = Date.now()) {
+function daysUntil(kickoffIso, nowMs) {
   const msPerDay = 1000 * 60 * 60 * 24;
-  return Math.ceil((targetUtc.getTime() - nowMs) / msPerDay);
+  return Math.ceil((new Date(kickoffIso).getTime() - nowMs) / msPerDay);
+}
+
+// Kickoff = the Regular Season phase's start. null when the season (or that
+// phase) isn't sourced yet — the caller renders "kickoff coming soon" rather
+// than a wrong countdown.
+function regularSeasonStart(currentSeason) {
+  const phase = currentSeason?.phases?.find(
+    (p) => p.typeCode === REGULAR_SEASON_TYPE_CODE
+  );
+  return phase?.startDate ?? null;
 }
 
 function sportPhrase(sport, nowMs) {
+  if (!sport.kickoff) {
+    return { status: "unknown", text: `${sport.label} kickoff coming soon` };
+  }
   const days = daysUntil(sport.kickoff, nowMs);
   if (days <= 0) return { status: "live", text: `${sport.label} is underway` };
-  return { status: "upcoming", text: `${sport.label} in ${days} ${days === 1 ? "day" : "days"}` };
+  return {
+    status: "upcoming",
+    text: `${sport.label} in ${days} ${days === 1 ? "day" : "days"}`,
+  };
 }
 
 function PrimarySlotOffSeasonCountdown() {
+  // { NCAAFB: { kickoff, seasonYear } | null, ... } once loaded.
+  const [seasons, setSeasons] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all(
+      SPORTS.map((s) =>
+        SeasonApi.getCurrentSeason(s.sport, s.league)
+          .then((res) => ({
+            key: s.key,
+            kickoff: regularSeasonStart(res.data),
+            seasonYear: res.data?.seasonYear ?? null,
+          }))
+          // A sport with no sourced season (404) is a valid state, not an error
+          // — surface it as "coming soon" rather than failing the whole slot.
+          .catch(() => ({ key: s.key, kickoff: null, seasonYear: null }))
+      )
+    ).then((results) => {
+      if (cancelled) return;
+      setSeasons(
+        Object.fromEntries(results.map((r) => [r.key, r]))
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (seasons === null) {
+    return (
+      <div className="home-primary home-primary--countdown">
+        <p className="home-primary__body">Loading the season schedule…</p>
+      </div>
+    );
+  }
+
   const nowMs = Date.now();
-  const sportsWithPhrases = SPORTS.map((s) => ({ ...s, phrase: sportPhrase(s, nowMs) }));
+  const sportsWithPhrases = SPORTS.map((s) => ({
+    ...s,
+    kickoff: seasons[s.key]?.kickoff ?? null,
+    seasonYear: seasons[s.key]?.seasonYear ?? null,
+    phrase: sportPhrase({ ...s, kickoff: seasons[s.key]?.kickoff ?? null }, nowMs),
+  }));
+
   const allLive = sportsWithPhrases.every((s) => s.phrase.status === "live");
+
+  // Eyebrow season year — first sport that reported one. Falls back to a
+  // generic label if no season is sourced yet.
+  const seasonYear =
+    sportsWithPhrases.find((s) => s.seasonYear)?.seasonYear ?? null;
 
   // Headline strategy:
   //   - All sports kicked off → "Picks are live" mode, drive users to picks.
-  //   - Any sport still upcoming → render each sport's phrase on its own
-  //     line so both countdowns carry equal visual weight and read like a
+  //   - Any sport still upcoming (or coming soon) → render each sport's phrase
+  //     on its own line so both carry equal visual weight and read like a
   //     scoreboard rather than a comma-run-on.
   const headline = allLive
     ? "NCAAFB and NFL are underway — pick your week"
     : sportsWithPhrases.map((s) => (
-        <span key={s.key} className="home-primary__headline-line">{s.phrase.text}</span>
+        <span key={s.key} className="home-primary__headline-line">
+          {s.phrase.text}
+        </span>
       ));
 
   const body = allLive
     ? "Jump into your leagues and lock in your picks before the next kickoff."
-    : "Spin up your 2026 pick'em league now so you're ready for Week 1.";
+    : `Spin up your ${seasonYear ?? ""} pick'em league now so you're ready for Week 1.`;
 
   // CTAs — per-sport when any sport is still upcoming, single collapsed
   // button when all sports are live. For a sport that's already live, the
   // CTA routes to unified picks (no need to dedup — the picks page shows
-  // all leagues the user belongs to). For an upcoming sport, link to league
-  // creation with ?sport= so LeagueCreatePage preselects the correct tab.
+  // all leagues the user belongs to). Otherwise link to league creation with
+  // ?sport= so LeagueCreatePage preselects the correct tab.
   const renderActions = () => {
     if (allLive) {
       return (
@@ -91,12 +154,10 @@ function PrimarySlotOffSeasonCountdown() {
 
   return (
     <div className="home-primary home-primary--countdown">
-      <div className="home-primary__eyebrow">2026 Season</div>
+      <div className="home-primary__eyebrow">{seasonYear ? `${seasonYear} Season` : "Upcoming Season"}</div>
       <h1 className="home-primary__headline">{headline}</h1>
       <p className="home-primary__body">{body}</p>
-      <div className="home-primary__actions">
-        {renderActions()}
-      </div>
+      <div className="home-primary__actions">{renderActions()}</div>
     </div>
   );
 }

--- a/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
+++ b/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
@@ -122,7 +122,9 @@ function PrimarySlotOffSeasonCountdown() {
 
   const body = allLive
     ? "Jump into your leagues and lock in your picks before the next kickoff."
-    : `Spin up your ${seasonYear ?? ""} pick'em league now so you're ready for Week 1.`;
+    : seasonYear
+    ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week 1.`
+    : "Spin up your pick'em league now so you're ready for Week 1.";
 
   // CTAs — per-sport when any sport is still upcoming, single collapsed
   // button when all sports are live. For a sport that's already live, the

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandlerTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.Seasons.Queries.GetCurrentSeason;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Season;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Seasons.Queries.GetCurrentSeason;
+
+public class GetCurrentSeasonQueryHandlerTests : ApiTestBase<GetCurrentSeasonQueryHandler>
+{
+    private readonly Mock<IProvideSeasons> _seasonClientMock;
+
+    public GetCurrentSeasonQueryHandlerTests()
+    {
+        _seasonClientMock = new Mock<IProvideSeasons>();
+        Mocker.GetMock<ISeasonClientFactory>()
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_seasonClientMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ResolvesSportAndPassesThroughCurrentSeason()
+    {
+        // Arrange
+        var expected = new CurrentSeasonDto
+        {
+            SeasonYear = 2026,
+            Name = "2026 Season",
+            Phases = [new SeasonPhaseDto { TypeCode = 2, Name = "Regular Season" }]
+        };
+        _seasonClientMock
+            .Setup(x => x.GetCurrentSeason(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<CurrentSeasonDto>(expected));
+
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+        var query = new GetCurrentSeasonQuery { Sport = "football", League = "ncaa" };
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert — the NCAA mode resolves and the DTO passes straight through.
+        Mocker.GetMock<ISeasonClientFactory>().Verify(x => x.Resolve(Sport.FootballNcaa), Times.Once);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(expected);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PropagatesNotFound()
+    {
+        // Arrange — season not sourced yet.
+        _seasonClientMock
+            .Setup(x => x.GetCurrentSeason(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<CurrentSeasonDto>(default!, ResultStatus.NotFound, []));
+
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+        var query = new GetCurrentSeasonQuery { Sport = "football", League = "nfl" };
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnsupportedSportLeague_ReturnsBadRequest_WithoutCallingClient()
+    {
+        // Arrange
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+        var query = new GetCurrentSeasonQuery { Sport = "quidditch", League = "hogwarts" };
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert — fails at mode resolution; never resolves a client.
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.BadRequest);
+        _seasonClientMock.Verify(x => x.GetCurrentSeason(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetCurrentSeason/GetCurrentSeasonQueryHandlerTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Application.Seasons.Queries.GetCurrentSeason;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Seasons.Queries.GetCurrentSeason;
+
+/// <summary>
+/// Pins the "current-or-upcoming" season resolution and phase projection that
+/// backs the API's per-sport seasons/current resource (which the off-season
+/// kickoff countdown consumes). "Current" = earliest season whose EndDate is
+/// still in the future, so it must return the in-progress season during play and
+/// the next upcoming season during the off-season.
+/// </summary>
+public class GetCurrentSeasonQueryHandlerTests : ProducerTestBase<GetCurrentSeasonQueryHandler>
+{
+    // Off-season "now": the 2025 season has ended, 2026 hasn't started.
+    private static readonly DateTime FixedUtcNow = new(2026, 7, 17, 0, 0, 0, DateTimeKind.Utc);
+
+    public GetCurrentSeasonQueryHandlerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedUtcNow);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OffSeason_ReturnsNextUpcomingSeasonWithPhases()
+    {
+        // Arrange — a finished 2025 season and an upcoming 2026 season.
+        await SeedSeasonAsync(
+            year: 2025,
+            start: new DateTime(2025, 8, 23, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+        await SeedSeasonWithPhasesAsync(
+            year: 2026,
+            start: new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2027, 1, 15, 0, 0, 0, DateTimeKind.Utc),
+            regularSeasonStart: new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+
+        // Act
+        var result = await sut.ExecuteAsync(new GetCurrentSeasonQuery());
+
+        // Assert — the finished 2025 season is skipped; 2026 wins.
+        result.IsSuccess.Should().BeTrue();
+        var season = ((Success<CurrentSeasonDto>)result).Value;
+        season.SeasonYear.Should().Be(2026);
+        season.Phases.Should().HaveCount(2);
+        var regular = season.Phases.Single(p => p.TypeCode == 2);
+        regular.StartDate.Should().Be(new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InSeason_ReturnsInProgressSeason()
+    {
+        // Arrange — "now" sits inside a 2026 season that started in August and
+        // runs into next January (covers the Jan–Feb playoff window that broke
+        // naive UtcNow().Year).
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(new DateTime(2027, 1, 20, 0, 0, 0, DateTimeKind.Utc));
+
+        await SeedSeasonWithPhasesAsync(
+            year: 2026,
+            start: new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2027, 2, 10, 0, 0, 0, DateTimeKind.Utc),
+            regularSeasonStart: new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+
+        // Act
+        var result = await sut.ExecuteAsync(new GetCurrentSeasonQuery());
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        ((Success<CurrentSeasonDto>)result).Value.SeasonYear.Should().Be(2026);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleUpcomingSeasons_ReturnsEarliestByStartDate()
+    {
+        // Arrange — two future seasons; the earliest-starting must win.
+        await SeedSeasonAsync(
+            year: 2027,
+            start: new DateTime(2027, 8, 28, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2028, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+        await SeedSeasonAsync(
+            year: 2026,
+            start: new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2027, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+
+        // Act
+        var result = await sut.ExecuteAsync(new GetCurrentSeasonQuery());
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        ((Success<CurrentSeasonDto>)result).Value.SeasonYear.Should().Be(2026);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoCurrentOrUpcomingSeason_ReturnsNotFound()
+    {
+        // Arrange — only a season that already ended.
+        await SeedSeasonAsync(
+            year: 2025,
+            start: new DateTime(2025, 8, 23, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+
+        // Act
+        var result = await sut.ExecuteAsync(new GetCurrentSeasonQuery());
+
+        // Assert — legitimate not-yet-sourced case, not an error.
+        result.IsSuccess.Should().BeFalse();
+        ((Failure<CurrentSeasonDto>)result).Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PhasesReturnedOrderedByStartDate()
+    {
+        // Arrange — insert phases out of order; projection must order by StartDate.
+        var seasonId = Guid.NewGuid();
+        await SeedSeasonAsync(
+            year: 2026,
+            start: new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2027, 1, 15, 0, 0, 0, DateTimeKind.Utc),
+            id: seasonId);
+        await SeedPhaseAsync(seasonId, typeCode: 2, name: "Regular Season",
+            start: new DateTime(2026, 8, 29, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2026, 12, 7, 0, 0, 0, DateTimeKind.Utc));
+        await SeedPhaseAsync(seasonId, typeCode: 1, name: "Preseason",
+            start: new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            end: new DateTime(2026, 8, 28, 0, 0, 0, DateTimeKind.Utc));
+
+        var sut = Mocker.CreateInstance<GetCurrentSeasonQueryHandler>();
+
+        // Act
+        var result = await sut.ExecuteAsync(new GetCurrentSeasonQuery());
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var phases = ((Success<CurrentSeasonDto>)result).Value.Phases;
+        phases.Select(p => p.TypeCode).Should().Equal(1, 2);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private async Task SeedSeasonAsync(int year, DateTime start, DateTime end, Guid? id = null)
+    {
+        await FootballDataContext.Seasons.AddAsync(new Season
+        {
+            Id = id ?? Guid.NewGuid(),
+            Year = year,
+            Name = $"{year} Season",
+            StartDate = start,
+            EndDate = end,
+            CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+    }
+
+    private async Task SeedSeasonWithPhasesAsync(
+        int year, DateTime start, DateTime end, DateTime regularSeasonStart)
+    {
+        var seasonId = Guid.NewGuid();
+        await SeedSeasonAsync(year, start, end, seasonId);
+        await SeedPhaseAsync(seasonId, typeCode: 1, name: "Preseason",
+            start: start, end: regularSeasonStart.AddDays(-1));
+        await SeedPhaseAsync(seasonId, typeCode: 2, name: "Regular Season",
+            start: regularSeasonStart, end: end);
+    }
+
+    private async Task SeedPhaseAsync(
+        Guid seasonId, int typeCode, string name, DateTime start, DateTime end)
+    {
+        await FootballDataContext.SeasonPhases.AddAsync(new SeasonPhase
+        {
+            Id = Guid.NewGuid(),
+            SeasonId = seasonId,
+            TypeCode = typeCode,
+            Name = name,
+            Abbreviation = name[..Math.Min(3, name.Length)].ToUpperInvariant(),
+            Slug = name.ToLowerInvariant().Replace(' ', '-'),
+            Year = 2026,
+            StartDate = start,
+            EndDate = end,
+            CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## What

The home off-season countdown showed **wrong kickoff dates on both platforms**. This replaces guessed dates with the sourced one.

- **Web** hardcoded constants that had gone stale — NCAAFB read *74 days* to a Sept 29 that should have been Aug 29.
- **Mobile** *computed* kickoff from rules — NCAAFB "first Saturday of September", NFL "Thursday after Labor Day" — both wrong for 2026:

  | Sport | Rule computed | Actual (sourced) |
  |---|---|---|
  | NCAAFB | Sep 5 | **Aug 29** |
  | NFL | Sep 10 | **Sep 9** |

  NCAAFB has no fixed rule, and NFL's isn't a convention the league honors. A derived date is a guess that's plausible-but-wrong every year with no symptom — worse than web's loud staleness.

## Source of truth

The Regular Season phase (`TypeCode = 2`) `StartDate` of the sport's current season. Producer already has this in `SeasonPhase`; both 2026 phases are sourced with correct dates (confirmed against the DB).

## Design

Thin pass-through, no new persistence. Modelled as a **general per-sport season resource**, not a countdown-shaped endpoint.

**BFF vs. standard-endpoint line:** if it returned the *countdown* (`{ label: "NCAAFB in 43 days" }`, pre-computed for one UI) it'd be a BFF concern under `Application/UI/*`. It returns *raw* phase data for the client to interpret, so it's a standard endpoint and lives as a normal vertical slice under `Application/Seasons/`.

- **Producer** — `GetCurrentSeason` query + `GET seasons/current`. Resolves the current-or-upcoming season **from data** (earliest season whose `EndDate` is still future) with its phases. No calendar heuristic, and it naturally covers the Jan–Feb playoff window that broke naive `UtcNow().Year`.
- **Core** — `SeasonClient.GetCurrentSeason` + `CurrentSeasonDto` / `SeasonPhaseDto`.
- **API** — new `Application/Seasons/` slice: `GET api/{sport}/{league}/seasons/current`, per-sport via `ModeMapper`. One sport per call; the client asks per sport it surfaces.
- **Web + mobile** — both `PrimarySlotOffSeasonCountdown` components fetch per sport and read the `TypeCode 2` phase's `StartDate`. Deleted all hardcoded constants and the `ncaafbKickoff` / `nflKickoff` rules. A sport with no sourced season → "kickoff coming soon", never a wrong count. ISO strings throughout (no 0-indexed `Date.UTC` month construction).

Design doc: `docs/features/data-driven-season-countdown.md`.

## Testing

- Producer 5, API 3, mobile 2 new tests (current-or-upcoming resolution, phase projection/ordering, `NotFound` when unsourced, per-sport routing, `NotFound`/`BadRequest` propagation).
- Producer & API season suites **49 / 44** green; mobile **75 / 75**; web + both backend projects build clean.

## Reviewer notes

- **The "current" definition is the load-bearing decision.** Data-driven (`EndDate >= now`, earliest `StartDate`) rather than a year heuristic — worth a look at `GetCurrentSeasonQueryHandler`. It's what makes the Jan–Feb window and the off-season→next-season rollover both correct without special-casing.
- **Ops:** the API (`mode=All`) resolves each sport's Season provider URI via `SeasonClientFactory`, which falls back to a default key if `SeasonClientConfig:{FootballNcaa,FootballNfl}:ApiUrl` aren't set in `Prod.All`. A sport that can't resolve, or isn't sourced, renders "coming soon" — so if a countdown reads "coming soon" in prod, check that config first.
- **Follow-up (out of scope):** preseason pick'em leagues — the countdown window is where preseason games live, and `TypeCode 1` is available from this same endpoint if that's ever built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API for retrieving current or upcoming season details and phases.
  * Off-season countdowns now use sourced Regular Season dates instead of fixed dates.
  * Countdown messaging dynamically reflects the season year and loading status.
  * Displays “kickoff coming soon” when season timing data is unavailable.
* **Bug Fixes**
  * Improved kickoff timing accuracy across web and mobile experiences.
* **Tests**
  * Added coverage for season selection, missing data, unsupported competitions, and API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->