### PR TITLE
feat(leagues): prefill a suggested description at create time (web + mobile)

### DIFF
--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -442,7 +442,9 @@ export default function CreateLeagueScreen() {
     const s = formatDateShort(startsOn);
     const e = formatDateShort(endsOn);
     if (!s && !e) return null;
-    if (s && e) return s === e ? s : `${s}–${e}`;
+    // Single-day is decided by the raw ISO values, not the formatted labels —
+    // the label drops the year, so dates a year apart would format identically.
+    if (s && e) return startsOn === endsOn ? s : `${s}–${e}`;
     return s || e;
   })();
 

--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -132,6 +132,50 @@ const chunkInto = <T,>(arr: T[], size: number): T[][] => {
 const DURATION_FULL = 'full';
 const DURATION_DATES = 'dates';
 
+// Suggested-description building blocks — mirrors sd-ui's LeagueCreatePage. A
+// compact, glanceable tag prefilled into the (optional) description field so a
+// commissioner doesn't leave it blank; it's what makes leagues legible on the
+// home YourLeaguesCard for members in several leagues. Terse by design:
+// "NCAAFB ATS w/Confidence", "MLB SU · Aug 29".
+const SPORT_DESC_PHRASE: Record<SportKey, string> = {
+  FootballNcaa: 'NCAAFB',
+  FootballNfl: 'NFL',
+  BaseballMlb: 'MLB',
+};
+
+const PICK_TYPE_DESC_PHRASE: Record<string, string> = {
+  StraightUp: 'SU',
+  AgainstTheSpread: 'ATS',
+  OverUnder: 'O/U',
+};
+
+// "Aug 29" from a YYYY-MM-DD value. Parsed at local midnight so the calendar day
+// isn't shifted back by a UTC parse. null for empty input.
+function formatDateShort(iso: string): string | null {
+  if (!iso) return null;
+  const d = new Date(`${iso}T00:00:00`);
+  return Number.isNaN(d.getTime())
+    ? null
+    : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+// The suggested tag, enriched by whatever's chosen so far. Gated on sport alone
+// (always set) so it's robust; pick type / confidence / window refine it.
+// `windowLabel` is a pre-formatted day/range string, or null for full season.
+function buildSuggestedDescription(
+  sport: SportKey,
+  pickType: string,
+  useConfidencePoints: boolean,
+  windowLabel: string | null,
+): string {
+  const sportPhrase = SPORT_DESC_PHRASE[sport];
+  const pickPhrase = PICK_TYPE_DESC_PHRASE[pickType];
+  let tag = pickPhrase ? `${sportPhrase} ${pickPhrase}` : sportPhrase;
+  if (useConfidencePoints) tag += ' w/Confidence';
+  if (windowLabel) tag += ` · ${windowLabel}`;
+  return tag;
+}
+
 const schema = z
   .object({
     sport: z.enum(['FootballNcaa', 'FootballNfl', 'BaseballMlb']),
@@ -374,6 +418,8 @@ export default function CreateLeagueScreen() {
   const sport = watch('sport');
   const divisionSlugs = watch('divisionSlugs');
   const durationMode = watch('durationMode');
+  const pickType = watch('pickType');
+  const useConfidencePoints = watch('useConfidencePoints');
   // Watched for two reasons: (1) the end-date picker clamps its
   // minimumDate to startsOn so the user can't pick an end earlier than
   // the start, and (2) if the user moves startsOn *past* an already-set
@@ -389,6 +435,32 @@ export default function CreateLeagueScreen() {
       setValue('endsOn', startsOn, { shouldDirty: true, shouldValidate: true });
     }
   }, [durationMode, startsOn, endsOn, setValue]);
+
+  // Suggested description window: single day, a date range, or null (full season).
+  const descriptionWindowLabel = (() => {
+    if (durationMode !== DURATION_DATES) return null;
+    const s = formatDateShort(startsOn);
+    const e = formatDateShort(endsOn);
+    if (!s && !e) return null;
+    if (s && e) return s === e ? s : `${s}–${e}`;
+    return s || e;
+  })();
+
+  const suggestedDescription = buildSuggestedDescription(
+    sport,
+    pickType,
+    useConfidencePoints,
+    descriptionWindowLabel,
+  );
+
+  // Prefill the description with the suggested tag until the user edits it, so
+  // the field is populated without ever clobbering deliberate input. RHF holds
+  // the value, so the submit payload picks it up automatically.
+  const descriptionEditedRef = useRef(false);
+  useEffect(() => {
+    if (descriptionEditedRef.current) return;
+    setValue('description', suggestedDescription);
+  }, [suggestedDescription, setValue]);
 
   // Today as 'YYYY-MM-DD' for the date-picker floors. Memoized so re-renders
   // during the form session don't create a new Date object per render, but
@@ -593,41 +665,6 @@ export default function CreateLeagueScreen() {
             />
             {errors.name && (
               <Text style={[styles.fieldError, { color: theme.error }]}>{errors.name.message}</Text>
-            )}
-          </View>
-
-          {/* Description */}
-          <View style={styles.field}>
-            <Text style={[styles.label, { color: theme.textMuted }]}>Description (optional)</Text>
-            <Controller
-              control={control}
-              name="description"
-              render={({ field: { onChange, value, onBlur } }) => (
-                <TextInput
-                  style={[
-                    styles.input,
-                    styles.multiline,
-                    {
-                      backgroundColor: theme.card,
-                      borderColor: errors.description ? theme.error : theme.border,
-                      color: theme.text,
-                    },
-                  ]}
-                  placeholder={copy.descPlaceholder}
-                  placeholderTextColor={theme.textMuted}
-                  onChangeText={onChange}
-                  onBlur={onBlur}
-                  value={value ?? ''}
-                  maxLength={500}
-                  multiline
-                  textAlignVertical="top"
-                />
-              )}
-            />
-            {errors.description && (
-              <Text style={[styles.fieldError, { color: theme.error }]}>
-                {errors.description.message}
-              </Text>
             )}
           </View>
 
@@ -886,6 +923,47 @@ export default function CreateLeagueScreen() {
               </View>
             )}
           />
+
+          {/* Description last: optional flavor, and its suggested tag derives
+              from the parameters chosen above — so by the time the user reaches
+              it, the field is prefilled with a fully informed suggestion they
+              can accept, edit, or clear. */}
+          <View style={styles.field}>
+            <Text style={[styles.label, { color: theme.textMuted }]}>Description (optional)</Text>
+            <Controller
+              control={control}
+              name="description"
+              render={({ field: { onChange, value, onBlur } }) => (
+                <TextInput
+                  style={[
+                    styles.input,
+                    styles.multiline,
+                    {
+                      backgroundColor: theme.card,
+                      borderColor: errors.description ? theme.error : theme.border,
+                      color: theme.text,
+                    },
+                  ]}
+                  placeholder={copy.descPlaceholder}
+                  placeholderTextColor={theme.textMuted}
+                  onChangeText={(text) => {
+                    descriptionEditedRef.current = true;
+                    onChange(text);
+                  }}
+                  onBlur={onBlur}
+                  value={value ?? ''}
+                  maxLength={500}
+                  multiline
+                  textAlignVertical="top"
+                />
+              )}
+            />
+            {errors.description && (
+              <Text style={[styles.fieldError, { color: theme.error }]}>
+                {errors.description.message}
+              </Text>
+            )}
+          </View>
 
           <Button
             title="Create League"

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -185,7 +185,9 @@ const LeagueCreatePage = () => {
       const s = formatDateShort(startsOn);
       const e = formatDateShort(endsOn);
       if (!s && !e) return null;
-      if (s && e) return s === e ? s : `${s}–${e}`; // single day vs range
+      // Single-day is decided by the raw ISO values, not the formatted labels —
+      // the label drops the year, so dates a year apart would format identically.
+      if (s && e) return startsOn === endsOn ? s : `${s}–${e}`;
       return s || e;
     }
     return null; // full season

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -67,6 +67,52 @@ const SPORT_COPY = {
   },
 };
 
+// Suggested-description building blocks. A description is trivially skipped at
+// create time but is what makes a league legible on YourLeaguesCard for members
+// in several leagues — so we offer a one-tap, non-destructive suggestion derived
+// from the sport + pick type the commissioner already chose. Friendlier sport
+// phrasing than SPORT_COPY.label ("College football" vs "NCAA").
+const SPORT_DESC_PHRASE = {
+  [SPORT_NCAA]: "NCAAFB",
+  [SPORT_NFL]: "NFL",
+  [SPORT_MLB]: "MLB",
+};
+
+const PICK_TYPE_DESC_PHRASE = {
+  StraightUp: "SU",
+  AgainstTheSpread: "ATS",
+  OverUnder: "O/U",
+};
+
+// "Aug 29" from a YYYY-MM-DD date-input value. Parsed at local midnight (append
+// T00:00:00) so the date input's calendar day isn't shifted back a day by
+// UTC-parsing. Returns null for empty input.
+function formatDateShort(iso) {
+  if (!iso) return null;
+  const d = new Date(`${iso}T00:00:00`);
+  return Number.isNaN(d.getTime())
+    ? null
+    : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// Returns the suggested description as a compact tag, enriched by whatever's
+// chosen so far. Gated on sport alone (always set) so it's robust; pick type /
+// confidence / window refine it. Terse by design — it's a glanceable
+// distinguisher on the home card, not a sentence: e.g. "NCAAFB ATS w/Confidence",
+// "MLB SU · Aug 29". The Description field lives at the BOTTOM of the form, so by
+// the time the user reaches it every input is set and the tag is complete; that
+// placement also primes the writer. `windowLabel` is a pre-formatted
+// span/day/week string, or null for full season.
+function buildSuggestedDescription(sport, pickType, useConfidencePoints, windowLabel) {
+  const sportPhrase = SPORT_DESC_PHRASE[sport];
+  if (!sportPhrase) return null;
+  const pickPhrase = PICK_TYPE_DESC_PHRASE[pickType]; // may be undefined pre-selection
+  let tag = pickPhrase ? `${sportPhrase} ${pickPhrase}` : sportPhrase;
+  if (useConfidencePoints) tag += " w/Confidence";
+  if (windowLabel) tag += ` · ${windowLabel}`;
+  return tag;
+}
+
 const DURATION_FULL = "full";
 const DURATION_WEEKS = "weeks";
 const DURATION_DATES = "dates";
@@ -90,6 +136,9 @@ const LeagueCreatePage = () => {
   const [sport, setSport] = useState(initialSport);
   const [leagueName, setLeagueName] = useState("");
   const [description, setDescription] = useState("");
+  // True once the user types in the description field, which freezes the
+  // auto-suggestion so their input is never overwritten. See effectiveDescription.
+  const [descriptionEdited, setDescriptionEdited] = useState(false);
   const [pickType, setPickType] = useState("");
   const [tiebreaker, setTiebreaker] = useState("");
   const [useConfidencePoints, setUseConfidencePoints] = useState(false);
@@ -123,6 +172,41 @@ const LeagueCreatePage = () => {
   const isNcaa = sport === SPORT_NCAA;
   const isMlbAvailable = userDto?.isAdmin === true;
   const copy = SPORT_COPY[sport];
+
+  // Human-readable window for the suggested description: a single day, a date
+  // range, a single week, or a week range. null for a full-season league.
+  const descriptionWindowLabel = (() => {
+    if (durationMode === DURATION_WEEKS) {
+      return startWeek === endWeek
+        ? `Week ${startWeek}`
+        : `Weeks ${startWeek}–${endWeek}`;
+    }
+    if (durationMode === DURATION_DATES) {
+      const s = formatDateShort(startsOn);
+      const e = formatDateShort(endsOn);
+      if (!s && !e) return null;
+      if (s && e) return s === e ? s : `${s}–${e}`; // single day vs range
+      return s || e;
+    }
+    return null; // full season
+  })();
+
+  // The suggested description, recomputed each render from every parameter
+  // chosen so far (sport/pickType/confidence/window).
+  const suggestedDescription = buildSuggestedDescription(
+    sport,
+    pickType,
+    useConfidencePoints,
+    descriptionWindowLabel
+  );
+
+  // Prefill the description field with the suggestion by default, but stop
+  // tracking once the user edits it — so the field is populated (readily
+  // visible) without ever clobbering what someone deliberately types. The
+  // effective value is what both the field shows and the submit payload sends.
+  const effectiveDescription = descriptionEdited
+    ? description
+    : suggestedDescription ?? "";
 
   useEffect(() => {
     if (!isNcaa) return;
@@ -207,7 +291,7 @@ const LeagueCreatePage = () => {
 
     const formState = {
       leagueName,
-      description,
+      description: effectiveDescription,
       pickType,
       tiebreaker,
       useConfidencePoints,
@@ -319,17 +403,6 @@ const LeagueCreatePage = () => {
               onChange={(e) => setLeagueName(e.target.value)}
               placeholder={copy.namePlaceholder}
               required
-            />
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="description">Description (optional)</label>
-            <textarea
-              id="description"
-              name="description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder={copy.descPlaceholder}
             />
           </div>
 
@@ -569,6 +642,24 @@ const LeagueCreatePage = () => {
             </div>
           </div>
 
+          {/* Description is intentionally last: it's optional flavor, and its
+              suggested value derives from the parameters chosen above — so by the
+              time the user reaches it, the field is pre-filled with a fully
+              informed suggestion the user can accept, edit, or clear. */}
+          <div className="form-group">
+            <label htmlFor="description">Description (optional)</label>
+            <textarea
+              id="description"
+              name="description"
+              value={effectiveDescription}
+              onChange={(e) => {
+                setDescriptionEdited(true);
+                setDescription(e.target.value);
+              }}
+              placeholder={copy.descPlaceholder}
+            />
+          </div>
+
           <button type="submit" className="submit-button">
             Create League
           </button>
@@ -599,7 +690,7 @@ const LeagueCreatePage = () => {
                 {useConfidencePoints ? "Yes" : "No"}
               </li>
               <li>
-                <strong>Description:</strong> {description || "None"}
+                <strong>Description:</strong> {effectiveDescription || "None"}
               </li>
               <li>
                 <strong>Pick Deadline:</strong> 5 minutes before kickoff


### PR DESCRIPTION
## What

A league description is trivially skipped at create time, but it's what makes leagues legible on the home **YourLeaguesCard** for members in several leagues (descriptions started showing there in #524). This helps the commissioner fall into the pit of success: **prefill a compact, glanceable tag** they can accept, edit, or clear.

## Behavior

The suggestion is a terse tag derived from the parameters already chosen:

| League setup | Prefilled description |
|---|---|
| NCAAFB · ATS · confidence | `NCAAFB ATS w/Confidence` |
| MLB · straight-up · single day | `MLB SU · Aug 29` |
| NFL · ATS · confidence · date range | `NFL ATS w/Confidence · Aug 29–Sep 1` |
| NCAAFB · full season | `NCAAFB` |

- **Prefilled into the field, not a hidden button** — readily visible. It **freezes the moment the user types**, so deliberate input is never clobbered; whatever's in the field is what submits.
- **Description field moved to the BOTTOM of the form** on both platforms. It's optional flavor and its suggestion derives from the parameters above — so by the time the user reaches it, the tag is fully informed. Placing it last also *primes the writer*: walking the options first spurs the intent to describe.
- Dates parsed at **local midnight** so a single-day league shows the day actually picked, not shifted back a day by a UTC parse.

## Implementation

- **Web** (`LeagueCreatePage.jsx`): derived `effectiveDescription` = `edited ? typed : suggestion`, used for the field value, the submit payload, and the confirm dialog. Window supports single day / date range / **week range** (web has week mode).
- **Mobile** (`create-league.tsx`): react-hook-form `setValue('description', suggestion)` guarded by an `edited` ref; field value/submit come from RHF automatically. Window supports single day / date range (mobile has no week mode).
- **No backend change** — description already flows through the existing create payload.

## Testing

- Web build clean.
- Mobile `tsc --noEmit` clean; **75 tests pass**.
- The suggestion-styling CSS I briefly added for a button approach was removed when it became a prefill, so there's no CSS change in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic league description suggestions based on sport, pick type, confidence settings, and league dates.
  * Suggestions update as selections change and include compact date or date-range labels when applicable.
  * Users can edit the suggested description; manual edits are preserved and submitted.
  * Confirmation details now display the final description that will be submitted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->