### PR TITLE
chore(sd-ui): inject app version into the footer at build time

### DIFF
--- a/src/UI/sd-ui/Dockerfile
+++ b/src/UI/sd-ui/Dockerfile
@@ -20,6 +20,11 @@ ARG REACT_APP_API_BASE_URL
 ARG REACT_APP_ENVIRONMENT
 ARG REACT_APP_PROD_URL
 ARG REACT_APP_GOOGLE_MAPS_API_KEY
+# Optional explicit version — e.g. pass --build-arg REACT_APP_VERSION=<image-tag>
+# from whatever builds this image. Left unset it falls back to a UTC build
+# timestamp (resolved in the build RUN below). Surfaced in the footer via
+# process.env.REACT_APP_VERSION (LandingFooter.jsx).
+ARG REACT_APP_VERSION
 
 # Set as environment variables for the build
 ENV REACT_APP_API_BASE_URL=${REACT_APP_API_BASE_URL}
@@ -27,8 +32,12 @@ ENV REACT_APP_ENVIRONMENT=${REACT_APP_ENVIRONMENT}
 ENV REACT_APP_PROD_URL=${REACT_APP_PROD_URL}
 ENV REACT_APP_GOOGLE_MAPS_API_KEY=${REACT_APP_GOOGLE_MAPS_API_KEY}
 
-# Build the app directly with react-scripts (env vars already set above)
-RUN npx react-scripts build
+# Build the app. Resolve the version in-shell (not via ENV) so an explicit
+# REACT_APP_VERSION wins, but an unset one defaults to a UTC build timestamp
+# (YYYY.MM.DD.HHMM) — so the footer always shows something meaningful with no
+# change required to whatever builds this image.
+RUN export REACT_APP_VERSION="${REACT_APP_VERSION:-$(date -u +%Y.%m.%d.%H%M)}" && \
+    npx react-scripts build
 
 # Production stage
 FROM nginx:1.28-alpine

--- a/src/UI/sd-ui/azure-pipelines.yml
+++ b/src/UI/sd-ui/azure-pipelines.yml
@@ -1,3 +1,8 @@
+# Build number doubles as the app version shown in the footer (injected as the
+# REACT_APP_VERSION build-arg below). $(Rev:.r) is the per-day build counter,
+# starting at .1 — e.g. 2026.07.18.1, 2026.07.18.2.
+name: $(Date:yyyy.MM.dd)$(Rev:.r)
+
 trigger:
   branches:
     include:
@@ -121,7 +126,7 @@ stages:
               dockerfile: $(dockerfilePath)
               containerRegistry: $(dockerRegistryServiceConnection)
               buildContext: '$(Build.SourcesDirectory)/src/UI/sd-ui'
-              arguments: '--build-arg REACT_APP_API_BASE_URL=https://api.sportdeets.com --build-arg REACT_APP_ENVIRONMENT=production --build-arg REACT_APP_PROD_URL=https://sportdeets.com --build-arg REACT_APP_GOOGLE_MAPS_API_KEY=$(REACT_APP_GOOGLE_MAPS_API_KEY)'
+              arguments: '--build-arg REACT_APP_API_BASE_URL=https://api.sportdeets.com --build-arg REACT_APP_ENVIRONMENT=production --build-arg REACT_APP_PROD_URL=https://sportdeets.com --build-arg REACT_APP_GOOGLE_MAPS_API_KEY=$(REACT_APP_GOOGLE_MAPS_API_KEY) --build-arg REACT_APP_VERSION=$(Build.BuildNumber)'
               tags: |
                 $(tag)
                 latest


### PR DESCRIPTION
## What

The footer's version placeholder stopped populating ~a year ago when the web app moved from an Azure Static Web App to a **container** build. `LandingFooter.jsx` already reads `process.env.REACT_APP_VERSION` — the container build just never set it, so it fell back to `v0.0.0`.

Two complementary changes, no app-code touched:

### `azure-pipelines.yml` — the fix for the deployed app
- `name: $(Date:yyyy.MM.dd)$(Rev:.r)` sets the build number to a date version: `2026.07.18.1`, `2026.07.18.2`, … (`.r` is the per-day counter, starts at `.1`).
- Passes it into the image build: `--build-arg REACT_APP_VERSION=$(Build.BuildNumber)`, alongside the existing `REACT_APP_*` args.

So the next merge to `main` rebuilds the image and the footer shows the version.

### `Dockerfile` — belt-and-suspenders
- Accepts the `REACT_APP_VERSION` build-arg (the pipeline supplies it).
- If it's ever built **without** one — a local `docker build`, another path — it defaults to a UTC `YYYY.MM.DD.HHMM` timestamp (resolved in-shell in the build `RUN`) instead of `v0.0.0`.

## Deliberate scope note

The image **tag** stays `$(Build.BuildId)` — I did **not** change it to match the footer string. Making them identical would change what the cluster/Flux pulls, a riskier change than this warranted. So the footer version (`Build.BuildNumber`, date-formatted) and the ACR tag (`Build.BuildId`, integer) are different strings by design. If you'd prefer the footer show the literal image tag, it's a one-word swap (`$(Build.BuildNumber)` → `$(Build.BuildId)`).

## Testing

- YAML parses clean.
- Version-resolution shell logic verified both ways: unset → date fallback; explicit → wins.
- Can't fully exercise the Docker/pipeline build locally; the change follows the file's existing build-arg pattern exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI builds now support displaying a release version.
  * Release versions can be supplied during the build or generated automatically from the UTC build timestamp.

* **Enhancements**
  * Pipeline run names now include the build date and a daily revision number.
  * UI builds receive the pipeline’s build number as the application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->