### PR TITLE
fix(logos): fail-closed logo selection — never render a licensed logo

### DIFF
--- a/docs/logo-license-audit.md
+++ b/docs/logo-license-audit.md
@@ -238,14 +238,14 @@ WHERE NOT EXISTS (
         WHERE fl."FranchiseId" = f."Id" AND 'sportdeets-mark' = ANY(fl."Rel"));
 ```
 
-## Decisions pending
+## Decisions (resolved 2026-07-18)
 
-- **Fail closed?** — recommended yes (see fix plan). Confirms the guarantee
-  regardless of backfill completeness.
+- **Fail closed?** — YES. The only hard guarantee no licensed logo can render;
+  implemented in A + B.
 - **Placeholder design** — team-color circle + abbreviation (client-side, fully
-  license-free) vs. a static neutral asset.
-- **Backfill scope** — run Q6/Q7 to size it; decide whether to block launch on
-  full coverage or ship fail-closed + placeholder now and backfill after.
+  license-free); implemented in C.
+- **Backfill scope** — generate one mark per franchise for ALL franchises
+  (Option 2, franchise-level), run in prod for all three sports.
 
 ---
 
@@ -313,18 +313,23 @@ placeholder) is the remaining safety net for teams with no mark.
 
 - Data backfill: **DONE** — franchise-level marks generated + inserted for all
   three sports in prod (6 script runs, zero errors).
-- A (`LogoSelectionService` fail-closed): **DRAFTED** — + 9 unit tests; full
-  Producer suite green (502 passed).
-- B (`GetMatchupsByContestIds.sql` marks-only): **DRAFTED**.
-- C (frontend placeholders): pending.
+- A (`LogoSelectionService` fail-closed): **DONE** — + 9 unit tests; full Producer
+  suite green (502 passed).
+- B (`GetMatchupsByContestIds.sql` marks-only): **DONE**.
+- C (frontend placeholders): **DONE** — reusable web `TeamLogo` wired into the
+  matchup cards + TeamCard team-header; mobile `MatchupCard` placeholder upgraded
+  to team-color.
 
-### Sequencing
+All of A + B + C ship together in one PR (fix/logo-compliance-fail-closed).
 
-Backfill (below) → **A + B** (fail-closed selection) → **C** (placeholders) ship
-together. After the backfill + A + B, every team with a mark renders it; C is the
-safety net for any gap. **Compliance is not achieved until A + B ship** — the
-data backfill alone leaves the fail-open code serving licensed logos for any team
-that still has a season ESPN row (which is most of them).
+### Sequencing (as shipped)
+
+The prod backfill ran first (marks now exist), then A + B + C shipped together in
+one PR. With the backfill done, A + B guarantee no licensed logo can render and
+every team with a mark shows it; C is the safety net for any team still lacking a
+mark. Note the data backfill alone would NOT have been enough — the fail-open
+code kept serving licensed logos for any team with a season ESPN row (most of
+them), which is exactly what A + B fixes.
 
 ---
 
@@ -389,5 +394,6 @@ WHERE NOT EXISTS (
 - `run.ps1 -Environment <dev|prod>` writes blob + DB **together** for that env;
   they must match (a prod DB row can't point at a dev blob URL).
 - `-Grain FranchiseSeason` still runs the legacy per-season pass if ever needed.
-- The selector change (fail-closed, franchise-only) comes AFTER this backfill so
-  the app reads these marks instead of the licensed mirrors.
+- The selector change (fail-closed; season mark preferred, then franchise mark,
+  else null) comes AFTER this backfill so the app reads these marks instead of
+  the licensed mirrors.

--- a/docs/logo-license-audit.md
+++ b/docs/logo-license-audit.md
@@ -1,0 +1,393 @@
+# Logo license audit — ensuring only generated marks render
+
+**Context (2026-07-18):** licensed team logos are still appearing in the UI (e.g.
+the `team-header` on `/app/sport/football/ncaa/team/washington-huskies/2024` and
+`/2026`). Goal for app-store submission: the UI must render only
+sportDeets-generated marks (rows whose `Rel` array contains `sportdeets-mark`),
+never ESPN-sourced licensed logos.
+
+## How selection works today
+
+`TeamCard.jsx` → TeamCard API → Producer `GetTeamCardQueryHandler` →
+`LogoSelectionService.SelectWithFallback(franchiseSeason.Logos, franchise.Logos)`.
+
+Two problems, possibly both in play:
+
+1. **Logic bug — fail-open shadowing** (`LogoSelectionService.cs`, `SelectWithFallback`):
+   `selector(seasonLogos) ?? selector(franchiseLogos)`. `selector` returns
+   non-null whenever the list is non-empty (its last resort just returns the
+   first logo). So if a FranchiseSeason has *any* logos but no mark, its ESPN
+   logo is returned and the **franchise-level logos are never consulted** — a
+   franchise-level mark can't rescue a mark-less season. Correct precedence
+   should be: season-mark → franchise-mark → season-ESPN → franchise-ESPN.
+
+2. **Data gap** — marks were inserted per-FranchiseSeason (`FranchiseSeasonLogo`);
+   `src/marks/batch/insert.js` notes franchise-level rows were deferred to "a
+   later batch pass." Seasons the batch didn't cover fall straight through to
+   ESPN.
+
+3. **Fail-open policy** — even after fixing (1) and backfilling (2), a team with
+   no mark *anywhere* still returns an ESPN logo. A hard guarantee requires
+   failing **closed**: return null / a neutral placeholder when no
+   `sportdeets-mark` exists, never an ESPN row.
+
+`Rel` is a Postgres `text[]`, so membership is tested with
+`'sportdeets-mark' = ANY("Rel")`.
+
+---
+
+## Diagnostic queries
+
+> Run against the **football / NCAA canonical (Producer) database**. Adjust the
+> DB per sport if auditing others.
+
+### 1. Washington Huskies — season-level marks (the two linked seasons)
+
+```sql
+SELECT fs."SeasonYear",
+       fsl."Rel",
+       fsl."Uri",
+       fsl."IsForDarkBg"
+FROM "Franchise" f
+JOIN "FranchiseSeason" fs ON fs."FranchiseId" = f."Id"
+LEFT JOIN "FranchiseSeasonLogo" fsl ON fsl."FranchiseSeasonId" = fs."Id"
+WHERE f."Slug" = 'washington-huskies'
+  AND fs."SeasonYear" IN (2024, 2026)
+ORDER BY fs."SeasonYear";
+```
+SeasonYear	Rel	Uri	IsForDarkBg
+2024	NULL	NULL	NULL
+2026	NULL	NULL	NULL
+
+### 2. Washington Huskies — franchise-level marks (the "later pass")
+
+```sql
+SELECT fl."Rel",
+       fl."Uri",
+       fl."IsForDarkBg"
+FROM "Franchise" f
+JOIN "FranchiseLogo" fl ON fl."FranchiseId" = f."Id"
+WHERE f."Slug" = 'washington-huskies';
+```
+Rel	Uri	IsForDarkBg
+{}	https://sportdeetssa.blob.core.windows.net/franchise-logo-football-ncaa/6c4cfbb006cb82aa4f1e14a203c4d510f88ff9f93a498a246ffc9c0da315cd79.png	NULL
+{}	https://sportdeetssa.blob.core.windows.net/franchise-logo-football-ncaa/ecca50fb72d549b9ae57fdc674609a3db2bfc2f13a8b2bc30aa063c62d67f0be.png	NULL
+
+**What to look for:** does any returned row's `Rel` contain `sportdeets-mark`,
+and at which level (season vs franchise)?
+- No mark at either level → **data gap** (backfill the mark).
+- Mark at franchise but not season 2024/2026 → **logic bug** is what's hiding it
+  (the fail-open shadow), fix the selector.
+- Mark present at the season level → selection isn't picking it; dig into the
+  `Rel` direction tags (`roundel` / `shield` / `hex`).
+
+---
+
+## Fleet-wide audit (the app-store sweep)
+
+### 3. FranchiseSeasons that have logos but NO mark (the fail-open risk set)
+
+These are the season rows that will render an ESPN logo today.
+
+```sql
+SELECT f."Slug",
+       fs."SeasonYear",
+       COUNT(fsl."Id") AS total_logos,
+       COUNT(*) FILTER (WHERE 'sportdeets-mark' = ANY(fsl."Rel")) AS mark_logos
+FROM "Franchise" f
+JOIN "FranchiseSeason" fs ON fs."FranchiseId" = f."Id"
+LEFT JOIN "FranchiseSeasonLogo" fsl ON fsl."FranchiseSeasonId" = fs."Id"
+GROUP BY f."Slug", fs."SeasonYear"
+HAVING COUNT(fsl."Id") > 0
+   AND COUNT(*) FILTER (WHERE 'sportdeets-mark' = ANY(fsl."Rel")) = 0
+ORDER BY f."Slug", fs."SeasonYear";
+```
+
+### 4. Franchise-level mark coverage (did the "later pass" ever run?)
+
+```sql
+SELECT f."Slug",
+       COUNT(fl."Id") AS total_logos,
+       COUNT(*) FILTER (WHERE 'sportdeets-mark' = ANY(fl."Rel")) AS mark_logos
+FROM "Franchise" f
+LEFT JOIN "FranchiseLogo" fl ON fl."FranchiseId" = f."Id"
+GROUP BY f."Slug"
+ORDER BY mark_logos ASC, f."Slug";
+```
+Result: Not a sinlge one of the 893 teams have a value > 0 in mark_logos column.
+
+Rows with `mark_logos = 0` are franchises whose only logos are ESPN — the
+franchise-level fallback would serve a licensed logo for them.
+
+### 5. Count of at-risk season rows (one-number severity)
+
+```sql
+SELECT COUNT(*) AS at_risk_franchise_seasons
+FROM (
+  SELECT fs."Id"
+  FROM "FranchiseSeason" fs
+  JOIN "FranchiseSeasonLogo" fsl ON fsl."FranchiseSeasonId" = fs."Id"
+  GROUP BY fs."Id"
+  HAVING COUNT(*) FILTER (WHERE 'sportdeets-mark' = ANY(fsl."Rel")) = 0
+) x;
+```
+Result: 791 rows
+---
+
+## Findings (2026-07-18, from queries 1–2)
+
+**Washington Huskies = pure data gap. No generated mark exists at any level.**
+
+- Season (Q1): zero `FranchiseSeasonLogo` rows for 2024/2026 (all NULL).
+- Franchise (Q2): two rows, both `Rel = {}` (empty — NOT `{sportdeets-mark,...}`),
+  on `sportdeetssa.blob.../franchise-logo-football-ncaa/...`.
+
+**The blob URL is a red herring.** Those franchise rows are the **original ESPN
+logos re-hosted to our own blob** (Producer mirrors ESPN art to avoid hotlinking).
+Re-hosting doesn't change licensing — still the copyrighted logo. Generated marks
+are the rows tagged `Rel = {sportdeets-mark, <direction>}`; empty `Rel` ⇒ NOT a
+mark ⇒ ESPN mirror. So selection correctly finds no mark, falls through the ESPN
+cascade (Priority 5 returns the first untagged franchise logo), and **renders the
+licensed mirror — fail-open**. The logic bug (season shadows franchise) is real
+but is NOT the cause here (season was empty, so franchise *was* consulted).
+
+## Severity (from Q4/Q5, 2026-07-18)
+
+- **Q4: zero of 893 franchises have a franchise-level mark.** The franchise-level
+  fallback can therefore ONLY ever serve a licensed mirror — the "later pass" for
+  franchise marks never ran.
+- **Q5: 791 franchise-seasons** have season logos but no season-level mark.
+
+This is broad, not isolated. Consequence: with a fail-closed selector, a
+significant number of teams will show the **placeholder** until backfill — so the
+placeholder is a high-visibility surface (must look good), and the backfill is a
+prioritized track, not an afterthought. Fail-closed remains mandatory: a
+placeholder is compliant, a licensed logo is not.
+
+## Fix plan
+
+1. **Fail-closed selector** — `LogoSelectionService` returns a `sportdeets-mark`
+   or `null`; never an untagged / ESPN-mirror row. This is the only *hard*
+   guarantee no licensed logo can render, and it fixes the fail-open shadowing
+   bug for free (no ESPN cascade to shadow anything).
+2. **Frontend placeholder** — when the logo URL is empty, `TeamCard` renders a
+   license-free fallback (team-color circle + abbreviation), not a broken `<img>`.
+3. **Data backfill (Option 2 — franchise-level single source) — DECIDED
+   (2026-07-18).** Generate a FranchiseLogo mark for EVERY franchise (fresh, all
+   893 — uniform, zero holes), select from it, and let go of FranchiseSeasonLogo
+   for display. Generated marks are year-invariant, so their home is
+   `FranchiseLogo` (one per franchise), NOT per-season. The full generation pipeline still exists in `src/marks/`
+   (`marks.js` renderer; `generate.js` → `upload.js` → `insert.js`) and the color
+   dumps are present (`franchise-colors-{ncaafb,nfl,mlb}.txt`, which already carry
+   `FranchiseId`). Backfill steps:
+   - **Broaden the color query** — `franchise-colors.sql` filters
+     `SeasonYear = 2026 AND IsActive`, yielding 651 of 893 NCAA franchises. Take
+     each franchise's *latest-season* colors instead so all 893 are covered
+     (the ~242 inactive/historical ones otherwise stay holes).
+   - **Generate + upload** — existing scripts, unchanged.
+   - **Add a franchise-level insert path** — `insert.js` only writes
+     `FranchiseSeasonLogo` ("Franchise-level rows will land in a later batch
+     pass" — never built). Add the sibling that writes `FranchiseLogo` keyed on
+     `FranchiseId`, tagged `Rel = {sportdeets-mark, <direction>}`.
+   - Going forward: stop writing per-season marks; franchise marks are
+     year-invariant and cover every season, so no new holes accrue.
+   Once every franchise has a franchise-level mark, (1) fail-closed never renders
+   a licensed logo AND the placeholder effectively never fires.
+
+## Corrected fleet sweep
+
+Query 3 above misses the Washington pattern (it requires `total_logos > 0` at the
+**season** level; Washington has zero season logos). The franchises actually at
+risk are those with **no `sportdeets-mark` at either level** — these render a
+licensed mirror today.
+
+### 6. Franchises with NO mark anywhere (season or franchise) — the true risk set
+
+```sql
+SELECT f."Slug",
+       (SELECT COUNT(*) FROM "FranchiseSeasonLogo" fsl
+          JOIN "FranchiseSeason" fs ON fs."Id" = fsl."FranchiseSeasonId"
+         WHERE fs."FranchiseId" = f."Id"
+           AND 'sportdeets-mark' = ANY(fsl."Rel"))
+       + (SELECT COUNT(*) FROM "FranchiseLogo" fl
+           WHERE fl."FranchiseId" = f."Id"
+             AND 'sportdeets-mark' = ANY(fl."Rel")) AS mark_rows
+FROM "Franchise" f
+GROUP BY f."Id", f."Slug"
+HAVING (SELECT COUNT(*) FROM "FranchiseSeasonLogo" fsl
+          JOIN "FranchiseSeason" fs ON fs."Id" = fsl."FranchiseSeasonId"
+         WHERE fs."FranchiseId" = f."Id"
+           AND 'sportdeets-mark' = ANY(fsl."Rel"))
+     + (SELECT COUNT(*) FROM "FranchiseLogo" fl
+         WHERE fl."FranchiseId" = f."Id"
+           AND 'sportdeets-mark' = ANY(fl."Rel")) = 0
+ORDER BY f."Slug";
+```
+
+### 7. One-number severity: how many franchises have no mark anywhere
+
+```sql
+SELECT COUNT(*) AS franchises_without_any_mark
+FROM "Franchise" f
+WHERE NOT EXISTS (
+        SELECT 1 FROM "FranchiseSeasonLogo" fsl
+        JOIN "FranchiseSeason" fs ON fs."Id" = fsl."FranchiseSeasonId"
+        WHERE fs."FranchiseId" = f."Id" AND 'sportdeets-mark' = ANY(fsl."Rel"))
+  AND NOT EXISTS (
+        SELECT 1 FROM "FranchiseLogo" fl
+        WHERE fl."FranchiseId" = f."Id" AND 'sportdeets-mark' = ANY(fl."Rel"));
+```
+
+## Decisions pending
+
+- **Fail closed?** — recommended yes (see fix plan). Confirms the guarantee
+  regardless of backfill completeness.
+- **Placeholder design** — team-color circle + abbreviation (client-side, fully
+  license-free) vs. a static neutral asset.
+- **Backfill scope** — run Q6/Q7 to size it; decide whether to block launch on
+  full coverage or ship fail-closed + placeholder now and backfill after.
+
+---
+
+## Wiring — the code changes required (the "use it" side)
+
+There are **two separate logo-selection engines**, and both currently fail OPEN
+(fall through to the ESPN/untagged row when no mark exists). Backfilling data
+alone does not fix either — the selection code must change too.
+
+### A. C# `LogoSelectionService` (4 callers, one file)
+
+Callers, all routed through the service — so one change covers all four:
+`GetTeamCardQueryHandler`, `GetContestOverviewQueryHandler`,
+`GetContestPlayLogQueryHandler`, `GetCurrentPollsQueryHandler`.
+
+**Change:** make it **fail-closed** — return a `sportdeets-mark` (season, then
+franchise) or `null`; never an untagged / ESPN row. This simultaneously:
+- guarantees no licensed logo can render, and
+- fixes the fail-open shadowing bug in `SelectWithFallback`
+  (`selector(season) ?? selector(franchise)` — the ESPN cascade is gone, so a
+  season ESPN logo can no longer shadow a franchise mark).
+
+Simplest shape: a `SelectMark(logos, direction)` that returns only a
+`sportdeets-mark` Uri or null, then `SelectMark(season) ?? SelectMark(franchise)`.
+The whole ESPN priority cascade (curated/dark/white/default/first) is deleted.
+
+### B. Raw SQL `GetMatchupsByContestIds.sql` (picks page / live tiles / matchup cards)
+
+This is the **highest-traffic** logo surface and it does NOT use the C# service —
+it selects logos in SQL via LATERAL subqueries and
+`COALESCE(fslAway."Uri", flAway."Uri")` (season preferred, franchise fallback).
+The **light-background laterals still fail open** (`ORDER BY CASE ... ELSE 2`,
+i.e. fall to the ESPN row when no mark exists); the dark laterals already filter
+marks-only.
+
+**Change:** make every logo lateral **marks-only** — add
+`WHERE fl."Rel" @> ARRAY['sportdeets-mark']` (as the dark laterals already do) and
+drop the `ELSE 2` ESPN fallback. Then each lateral returns a mark or nothing, and
+`COALESCE(season-mark, franchise-mark)` fail-closes AND stops a season ESPN logo
+from shadowing the franchise mark. One SQL file.
+(`GetRankingsByPollByWeek.sql` already uses the marks-only pattern — no change.)
+
+### C. Frontend placeholders (web + mobile)
+
+Fail-closed means the logo Uri can be **null** for any team without a mark (rare
+after backfill, but must be safe). Every `<img src={logoUri}>` needs a null-guard
+that renders a license-free fallback (team-color circle + abbreviation — colors
+are already on the DTOs). Surfaces: TeamCard `team-header`, matchup cards
+(picks + live tiles, web + mobile), results, contest overview, standings.
+
+### D. Other paths — verified (2026-07-18)
+
+- **Results page** (`GetSeasonResults`) calls the SAME `GetMatchupsByContestIds`
+  query as the picks page → **covered by B**, no separate change.
+- **`GetRankingsByPollByWeek.sql`** — already marks-only, fail-closed. No change.
+- **`GetTeamCard.sql`** selects an unfiltered `FranchiseLogo."Uri"` (fail-open),
+  BUT nothing invokes `ProducerSqlQueryProvider.GetTeamCard()` — it's **dead
+  code**. The live TeamCard handler uses EF + the C# service (covered by A).
+  Cleanup candidate, not a compliance risk.
+
+**Net:** A + B together cover every *live* licensed-logo path found. C (frontend
+placeholder) is the remaining safety net for teams with no mark.
+
+### Status (2026-07-18)
+
+- Data backfill: **DONE** — franchise-level marks generated + inserted for all
+  three sports in prod (6 script runs, zero errors).
+- A (`LogoSelectionService` fail-closed): **DRAFTED** — + 9 unit tests; full
+  Producer suite green (502 passed).
+- B (`GetMatchupsByContestIds.sql` marks-only): **DRAFTED**.
+- C (frontend placeholders): pending.
+
+### Sequencing
+
+Backfill (below) → **A + B** (fail-closed selection) → **C** (placeholders) ship
+together. After the backfill + A + B, every team with a mark renders it; C is the
+safety net for any gap. **Compliance is not achieved until A + B ship** — the
+data backfill alone leaves the fail-open code serving licensed logos for any team
+that still has a season ESPN row (which is most of them).
+
+---
+
+## Running the franchise-level backfill
+
+Generates one year-invariant mark per franchise and writes it to `FranchiseLogo`
+(`Rel = {sportdeets-mark, <direction>}`). Idempotent — re-runnable.
+
+**Prereqs**
+- Franchise-grain color dumps in `src/marks/batch/data/`
+  (`franchise-colors-{ncaafb,nfl,mlb}.txt`), tab-separated, header row intact.
+- `SPORTDEETS_SECRETS_PATH` set (run.ps1 dot-sources it for blob + PG creds).
+
+**The scripts you run:** `run.ps1` only (it invokes `upload.js` then `insert.js`).
+`-Grain Franchise` is the default, so it's implicit. Run the two phases as a pair
+per sport (insert consumes the newest manifest), then move to the next sport.
+
+Start with **NFL on `dev`** (small + confirmed data) to verify the whole chain,
+then repeat for Ncaafb and Mlb, then flip `-Environment prod` when satisfied.
+
+```powershell
+cd C:\Projects\sports-data\src\marks\batch
+
+# ── NFL (dev / local first) ─────────────────────────────────────────────
+./run.ps1 -Phase upload -Environment dev -Sport Nfl     # render + upload + manifest
+./run.ps1 -Phase insert -Environment dev -Sport Nfl     # write FranchiseLogo rows
+
+# ── then NCAAFB, then MLB (same pair each) ──────────────────────────────
+./run.ps1 -Phase upload -Environment dev -Sport Ncaafb
+./run.ps1 -Phase insert -Environment dev -Sport Ncaafb
+./run.ps1 -Phase upload -Environment dev -Sport Mlb
+./run.ps1 -Phase insert -Environment dev -Sport Mlb
+
+# ── when verified on dev, repeat with -Environment prod ─────────────────
+# ./run.ps1 -Phase upload -Environment prod -Sport Nfl
+# ./run.ps1 -Phase insert -Environment prod -Sport Nfl
+#   ...Ncaafb, Mlb
+```
+
+**Verify after each insert** (against that sport's Producer DB):
+
+```sql
+-- franchise-level marks written. Expect (franchises × 3 directions):
+--   NFL ~31×3=93, NCAAFB 893×3=2679, MLB ~30×3=90
+SELECT COUNT(*) AS franchise_mark_rows
+FROM "FranchiseLogo"
+WHERE 'sportdeets-mark' = ANY("Rel");
+
+-- franchises still with NO mark anywhere should now be 0 (re-run Q7):
+SELECT COUNT(*) AS franchises_without_any_mark
+FROM "Franchise" f
+WHERE NOT EXISTS (
+        SELECT 1 FROM "FranchiseSeasonLogo" fsl
+        JOIN "FranchiseSeason" fs ON fs."Id" = fsl."FranchiseSeasonId"
+        WHERE fs."FranchiseId" = f."Id" AND 'sportdeets-mark' = ANY(fsl."Rel"))
+  AND NOT EXISTS (
+        SELECT 1 FROM "FranchiseLogo" fl
+        WHERE fl."FranchiseId" = f."Id" AND 'sportdeets-mark' = ANY(fl."Rel"));
+```
+
+**Notes**
+- `run.ps1 -Environment <dev|prod>` writes blob + DB **together** for that env;
+  they must match (a prod DB row can't point at a dev blob URL).
+- `-Grain FranchiseSeason` still runs the legacy per-season pass if ever needed.
+- The selector change (fail-closed, franchise-only) comes AFTER this backfill so
+  the app reads these marks instead of the licensed mirrors.

--- a/src/SportsData.Producer/Application/Services/LogoSelectionService.cs
+++ b/src/SportsData.Producer/Application/Services/LogoSelectionService.cs
@@ -4,188 +4,93 @@ using SportsData.Producer.Infrastructure.Data.Entities.Contracts;
 namespace SportsData.Producer.Application.Services;
 
 /// <summary>
-/// Service for intelligently selecting logos optimized for different display contexts.
+/// Selects team logos for display. FAIL-CLOSED (2026-07-18): only ever returns a
+/// sportDeets-generated mark (a row whose <c>Rel</c> contains
+/// <c>"sportdeets-mark"</c>), or <c>null</c>. It NEVER returns an ESPN-sourced /
+/// untagged logo — those are licensed and must not render (app-store constraint;
+/// see docs/logo-license-audit.md). A null result means the caller renders a
+/// license-free placeholder.
 ///
-/// As of the team-mark rollout (2026-06), the selection cascade prefers sportDeets-generated
-/// marks (Rel = "sportdeets-mark") over ESPN-sourced rows when present. The optional
-/// <see cref="MarkDirection"/> parameter on each selection method picks the matching
-/// direction (Roundel / Shield / Hex) when multiple sportdeets-mark rows exist for a team.
-/// Direction defaults to <see cref="MarkDirection.Roundel"/> until the user-preference UI ships;
-/// see docs/team-mark-user-preference-design.md for the larger plan.
+/// <para>
+/// The marks are theme-agnostic, so the dark/light methods select identically;
+/// the <c>darkBackground</c> parameter is retained only for interface stability
+/// and no longer affects the result. The optional <see cref="MarkDirection"/>
+/// picks the matching direction (Roundel / Shield / Hex) when a team has multiple
+/// marks; it defaults to <see cref="MarkDirection.Roundel"/>.
+/// </para>
 /// </summary>
 public interface ILogoSelectionService
 {
-    /// <summary>
-    /// Selects the best logo for display on a dark background by prioritizing manually curated logos,
-    /// then falling back to Rel-based heuristics and avoiding white background variants.
-    /// </summary>
+    /// <summary>Fail-closed: the team's mark for the given direction, or null.</summary>
     Uri? SelectLogoForDarkBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel);
 
-    /// <summary>
-    /// Selects the best logo for display on a light/default background by prioritizing manually curated logos,
-    /// then falling back to Rel-based heuristics and preferring white background variants.
-    /// </summary>
+    /// <summary>Fail-closed: the team's mark for the given direction, or null.</summary>
     Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel);
 
     /// <summary>
-    /// Selects the best logo with fallback from season logos to franchise logos.
-    /// Uses dark background selection by default.
+    /// Fail-closed mark with season → franchise fallback: the season mark if one
+    /// exists, else the franchise mark, else null. Uses dark selection by default
+    /// (immaterial — marks are theme-agnostic).
     /// </summary>
     Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, MarkDirection direction = MarkDirection.Roundel);
 
     /// <summary>
-    /// Selects the best logo with fallback, for the specified background type.
+    /// Fail-closed mark with season → franchise fallback. <paramref name="darkBackground"/>
+    /// is retained for interface stability and no longer affects the result.
     /// </summary>
     Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground, MarkDirection direction = MarkDirection.Roundel);
 }
 
-/// <summary>
-/// Implementation of logo selection service that uses manual curation flags and
-/// metadata-based heuristics to select appropriate logos for different display contexts.
-/// </summary>
+/// <inheritdoc />
 public class LogoSelectionService : ILogoSelectionService
 {
-    // Rel-tag constants for sportDeets-generated marks. The marks batch script
-    // writes rows with Rel = ["sportdeets-mark", "{direction}"]; see
-    // src/marks/batch/upload.js and the team-mark design docs.
+    // The marks batch (src/marks/batch/upload.js) writes rows with
+    // Rel = ["sportdeets-mark", "{direction}"]. An untagged / ESPN-sourced row
+    // has no such tag and is therefore never selected.
     private const string SportdeetsMarkRel = "sportdeets-mark";
 
     private static string DirectionRel(MarkDirection direction) =>
         direction.ToString().ToLowerInvariant();
 
     /// <summary>
-    /// Picks a sportdeets-mark row. Prefers the row tagged with the requested
-    /// direction; falls back to any sportdeets-mark row if the requested
-    /// direction hasn't been generated for that team yet. Returns null when
-    /// no sportdeets-mark rows exist — caller falls through to ESPN cascade.
+    /// The single selection primitive: returns ONLY a sportdeets-mark Uri —
+    /// preferring the requested direction, falling back to any mark — or null
+    /// when the team has no mark at all. This is what makes the service
+    /// fail-closed: an ESPN / untagged row can never be returned.
     /// </summary>
-    private static Uri? SelectSportdeetsMark(IReadOnlyList<ILogo> logos, MarkDirection direction)
+    private static Uri? SelectMark(IEnumerable<ILogo>? logos, MarkDirection direction)
     {
+        if (logos == null)
+            return null;
+
+        var list = logos as IReadOnlyList<ILogo> ?? logos.ToList();
+        if (list.Count == 0)
+            return null;
+
         var dirTag = DirectionRel(direction);
-        var preferred = logos.FirstOrDefault(l =>
+        var preferred = list.FirstOrDefault(l =>
             l.Rel != null && l.Rel.Contains(SportdeetsMarkRel) && l.Rel.Contains(dirTag));
         if (preferred != null)
             return preferred.Uri;
 
-        var anyMark = logos.FirstOrDefault(l =>
+        var anyMark = list.FirstOrDefault(l =>
             l.Rel != null && l.Rel.Contains(SportdeetsMarkRel));
         return anyMark?.Uri;
     }
 
     public Uri? SelectLogoForDarkBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel)
-    {
-        if (logos == null)
-            return null;
-
-        var logoList = logos.ToList();
-        if (logoList.Count == 0)
-            return null;
-
-        // Priority -1: sportdeets-generated mark for the requested direction
-        // (or any sportdeets mark as fallback). When present, this wins over
-        // all ESPN-sourced rows below. The marks are theme-agnostic, so the
-        // same selection serves dark and light contexts.
-        var sportdeetsMark = SelectSportdeetsMark(logoList, direction);
-        if (sportdeetsMark != null)
-            return sportdeetsMark;
-
-        // Priority 0: Manually curated logos marked as safe for dark backgrounds
-        var curatedDarkLogo = logoList.FirstOrDefault(l => l.IsForDarkBg == true);
-        if (curatedDarkLogo != null)
-            return curatedDarkLogo.Uri;
-
-        // Priority 1: Logos explicitly designed for black backgrounds
-        var blackLogo = logoList.FirstOrDefault(l =>
-            l.Rel != null && l.Rel.Contains("primary_logo_on_black_color"));
-        if (blackLogo != null)
-            return blackLogo.Uri;
-
-        // Priority 2: Logos marked as "dark"
-        var darkLogo = logoList.FirstOrDefault(l =>
-            l.Rel != null && l.Rel.Contains("dark"));
-        if (darkLogo != null)
-            return darkLogo.Uri;
-
-        // Priority 3: Logos on team primary/secondary colors (usually safe on dark)
-        var teamColorLogo = logoList.FirstOrDefault(l =>
-            l.Rel != null && (l.Rel.Contains("on_primary_color") || l.Rel.Contains("on_secondary_color")));
-        if (teamColorLogo != null)
-            return teamColorLogo.Uri;
-
-        // Priority 4: Default logo
-        var defaultLogo = logoList.FirstOrDefault(l =>
-            l.Rel != null && l.Rel.Contains("default"));
-        if (defaultLogo != null)
-            return defaultLogo.Uri;
-
-        // Priority 5: First logo that's NOT designed for white background
-        var anyNonWhiteLogo = logoList.FirstOrDefault(l =>
-            l.Rel == null || !l.Rel.Contains("on_white_color"));
-        if (anyNonWhiteLogo != null)
-            return anyNonWhiteLogo.Uri;
-
-        // Absolute fallback
-        return logoList.FirstOrDefault()?.Uri;
-    }
+        => SelectMark(logos, direction);
 
     public Uri? SelectLogoForLightBackground(IEnumerable<ILogo>? logos, MarkDirection direction = MarkDirection.Roundel)
-    {
-        if (logos == null)
-            return null;
-
-        var logoList = logos.ToList();
-        if (logoList.Count == 0)
-            return null;
-
-        // Priority -1: sportdeets-generated mark (see SelectLogoForDarkBackground
-        // for the rationale; the same Rel selection wins here because the
-        // marks are theme-agnostic).
-        var sportdeetsMark = SelectSportdeetsMark(logoList, direction);
-        if (sportdeetsMark != null)
-            return sportdeetsMark;
-
-        // Priority 0: Manually curated — IsForDarkBg == false means curated for light
-        var curatedLightLogo = logoList.FirstOrDefault(l => l.IsForDarkBg == false);
-        if (curatedLightLogo != null)
-            return curatedLightLogo.Uri;
-
-        // Priority 1: Logos explicitly designed for white backgrounds
-        var whiteLogo = logoList.FirstOrDefault(l =>
-            l.Rel != null && l.Rel.Contains("on_white_color"));
-        if (whiteLogo != null)
-            return whiteLogo.Uri;
-
-        // Priority 2: Default logo
-        var defaultLogo = logoList.FirstOrDefault(l =>
-            l.Rel != null && l.Rel.Contains("default"));
-        if (defaultLogo != null)
-            return defaultLogo.Uri;
-
-        // Priority 3: Logos on team colors (generally safe)
-        var teamColorLogo = logoList.FirstOrDefault(l =>
-            l.Rel != null && (l.Rel.Contains("on_primary_color") || l.Rel.Contains("on_secondary_color")));
-        if (teamColorLogo != null)
-            return teamColorLogo.Uri;
-
-        // Priority 4: First logo that's NOT designed for black background
-        var anyNonDarkLogo = logoList.FirstOrDefault(l =>
-            l.Rel == null || !l.Rel.Contains("primary_logo_on_black_color"));
-        if (anyNonDarkLogo != null)
-            return anyNonDarkLogo.Uri;
-
-        // Absolute fallback
-        return logoList.FirstOrDefault()?.Uri;
-    }
+        => SelectMark(logos, direction);
 
     public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, MarkDirection direction = MarkDirection.Roundel)
         => SelectWithFallback(seasonLogos, franchiseLogos, darkBackground: true, direction);
 
     public Uri? SelectWithFallback(IEnumerable<ILogo>? seasonLogos, IEnumerable<ILogo>? franchiseLogos, bool darkBackground, MarkDirection direction = MarkDirection.Roundel)
-    {
-        var selector = darkBackground
-            ? (Func<IEnumerable<ILogo>?, MarkDirection, Uri?>)SelectLogoForDarkBackground
-            : SelectLogoForLightBackground;
-
-        return selector(seasonLogos, direction) ?? selector(franchiseLogos, direction);
-    }
+        // Season mark preferred, franchise mark fallback, else null. Because
+        // SelectMark returns null for a mark-less (ESPN-only) season, the franchise
+        // mark is now correctly reached — the prior fail-open shadowing bug
+        // (a season ESPN logo hiding a franchise mark) is gone.
+        => SelectMark(seasonLogos, direction) ?? SelectMark(franchiseLogos, direction);
 }

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -50,74 +50,48 @@ LEFT JOIN LATERAL (
 LEFT JOIN public."CompetitionTeamOdds" cto ON cto."CompetitionOddsId" = co."Id" AND cto."Side" = 'Home'
 INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
 INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
--- Logo selection order (applies to all eight lateral subqueries below):
---   1. sportdeets-mark row tagged with the requested direction (@Direction)
---   2. any sportdeets-mark row (fallback when requested direction not yet
---      generated for this team — e.g. shields not backfilled)
---   3. anything else (preserves ESPN-sourced behavior for unbackfilled teams)
--- Tie-breaker stays CreatedUtc ASC to match prior behavior on ties.
+-- Logo selection: FAIL-CLOSED (2026-07-18). Every lateral filters to
+-- sportdeets-mark rows only (`Rel @> ARRAY['sportdeets-mark']`) and NEVER falls
+-- through to an ESPN / untagged row — a null result renders a placeholder, never
+-- a licensed logo. See docs/logo-license-audit.md. Order among marks: the
+-- requested @Direction first, then any mark; CreatedUtc ASC breaks ties.
+-- COALESCE(season, franchise) prefers a season mark, else the franchise mark;
+-- because a mark-less season now yields NULL, the franchise mark is correctly
+-- reached (the prior fail-open shadowing is gone). Dark laterals are identical —
+-- marks are theme-agnostic, so the same mark serves both backgrounds.
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
   WHERE fl."FranchiseId" = fAway."Id"
+    AND fl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
-      ELSE                                                               2
-    END,
+    CASE WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fl."CreatedUtc" ASC
   LIMIT 1
 ) flAway ON TRUE
--- FranchiseSeason-level logo is preferred; Franchise-level acts as fallback
--- (matches LogoSelectionService.SelectWithFallback convention: season -> franchise).
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
   WHERE fsl."FranchiseSeasonId" = fsAway."Id"
+    AND fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
-      ELSE                                                                2
-    END,
+    CASE WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fsl."CreatedUtc" ASC
   LIMIT 1
 ) fslAway ON TRUE
--- Dark-bg variants for theme-aware UI rendering. Same season -> franchise
--- fallback as the default lateral above. Note sportdeets-marks are
--- theme-agnostic (single render serves both backgrounds), so a team with
--- sportdeets-mark rows will surface the same Uri here as in the light lateral
--- above — that is the intended behavior until/unless dedicated dark variants
--- are generated. The IsForDarkBg = TRUE filter only matters for ESPN-sourced
--- rows in the ELSE branch.
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
   WHERE fl."FranchiseId" = fAway."Id"
-    AND (
-      fl."Rel" @> ARRAY['sportdeets-mark']::text[]
-      OR fl."IsForDarkBg" = TRUE
-    )
+    AND fl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
-      ELSE                                                               2
-    END,
+    CASE WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fl."CreatedUtc" ASC
   LIMIT 1
 ) flDarkAway ON TRUE
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
   WHERE fsl."FranchiseSeasonId" = fsAway."Id"
-    AND (
-      fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
-      OR fsl."IsForDarkBg" = TRUE
-    )
+    AND fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
-      ELSE                                                                2
-    END,
+    CASE WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fsl."CreatedUtc" ASC
   LIMIT 1
 ) fslDarkAway ON TRUE
@@ -136,58 +110,36 @@ INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
   WHERE fl."FranchiseId" = fHome."Id"
+    AND fl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
-      ELSE                                                               2
-    END,
+    CASE WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fl."CreatedUtc" ASC
   LIMIT 1
 ) flHome ON TRUE
--- FranchiseSeason-level preferred, Franchise fallback — see Away comment above.
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
   WHERE fsl."FranchiseSeasonId" = fsHome."Id"
+    AND fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
-      ELSE                                                                2
-    END,
+    CASE WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fsl."CreatedUtc" ASC
   LIMIT 1
 ) fslHome ON TRUE
--- Dark-bg variants — see Away comment above.
 LEFT JOIN LATERAL (
   SELECT fl.* FROM public."FranchiseLogo" fl
   WHERE fl."FranchiseId" = fHome."Id"
-    AND (
-      fl."Rel" @> ARRAY['sportdeets-mark']::text[]
-      OR fl."IsForDarkBg" = TRUE
-    )
+    AND fl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fl."Rel")                        THEN 1
-      ELSE                                                               2
-    END,
+    CASE WHEN fl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fl."CreatedUtc" ASC
   LIMIT 1
 ) flDarkHome ON TRUE
 LEFT JOIN LATERAL (
   SELECT fsl.* FROM public."FranchiseSeasonLogo" fsl
   WHERE fsl."FranchiseSeasonId" = fsHome."Id"
-    AND (
-      fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
-      OR fsl."IsForDarkBg" = TRUE
-    )
+    AND fsl."Rel" @> ARRAY['sportdeets-mark']::text[]
   ORDER BY
-    CASE
-      WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0
-      WHEN 'sportdeets-mark' = ANY(fsl."Rel")                        THEN 1
-      ELSE                                                                2
-    END,
+    CASE WHEN fsl."Rel" @> ARRAY['sportdeets-mark', @Direction]::text[] THEN 0 ELSE 1 END,
     fsl."CreatedUtc" ASC
   LIMIT 1
 ) fslDarkHome ON TRUE

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -158,8 +158,24 @@ function TeamRow({
         {logoUrl ? (
           <Image source={{ uri: logoUrl }} style={styles.logo} resizeMode="contain" />
         ) : (
-          <View style={[styles.logoPlaceholder, { backgroundColor: teamColor ?? theme.border }]}>
-            <Text style={{ color: teamColor ? '#fff' : theme.textMuted, fontSize: 11, fontWeight: '700' }}>
+          <View
+            style={[styles.logoPlaceholder, { backgroundColor: teamColor ?? theme.border }]}
+            accessible
+            accessibilityRole="image"
+            accessibilityLabel={`${name} logo`}
+          >
+            <Text
+              style={{
+                color: teamColor ? '#fff' : theme.textMuted,
+                fontSize: 11,
+                fontWeight: '700',
+                // Matches web TeamLogo: keeps the label legible against arbitrary
+                // team colors, including very light ones.
+                textShadowColor: 'rgba(0, 0, 0, 0.45)',
+                textShadowOffset: { width: 0, height: 1 },
+                textShadowRadius: 2,
+              }}
+            >
               {abbr.slice(0, 3)}
             </Text>
           </View>

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -105,6 +105,12 @@ function TeamRow({
   const isHome = side === 'home';
   const name = isHome ? matchup.home : matchup.away;
   const abbr = isHome ? matchup.homeShort : matchup.awayShort;
+  // Team color for the license-free logo placeholder (shown when a team has no
+  // generated mark — logos are fail-closed, so no licensed logo is ever served).
+  const rawColor = isHome ? matchup.homeColor : matchup.awayColor;
+  const teamColor = rawColor
+    ? (rawColor.startsWith('#') ? rawColor : `#${rawColor}`)
+    : null;
   // Dark-mode logo swap: some teams have a *Dark variant for use against
   // a dark surface (e.g. dark-on-white wordmarks that disappear against
   // theme.card in dark mode). Falls back to the default variant when no
@@ -152,8 +158,8 @@ function TeamRow({
         {logoUrl ? (
           <Image source={{ uri: logoUrl }} style={styles.logo} resizeMode="contain" />
         ) : (
-          <View style={[styles.logoPlaceholder, { backgroundColor: theme.border }]}>
-            <Text style={{ color: theme.textMuted, fontSize: 11, fontWeight: '700' }}>
+          <View style={[styles.logoPlaceholder, { backgroundColor: teamColor ?? theme.border }]}>
+            <Text style={{ color: teamColor ? '#fff' : theme.textMuted, fontSize: 11, fontWeight: '700' }}>
               {abbr.slice(0, 3)}
             </Text>
           </View>

--- a/src/UI/sd-ui/src/components/common/TeamLogo.css
+++ b/src/UI/sd-ui/src/components/common/TeamLogo.css
@@ -1,0 +1,27 @@
+/* License-free logo fallback: a team-color circle with the abbreviation. Takes
+   its width/height from the sizing class passed alongside (matchup-logo /
+   team-logo), and centers bold white text. Font sizes per known size class so
+   the label fits; a generic default covers anything else. */
+.team-logo-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  overflow: hidden;
+  /* Legible against arbitrary team colors, incl. very light ones. */
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  font-size: 0.7rem; /* default; overridden per size class below */
+}
+
+.matchup-logo.team-logo-fallback {
+  font-size: 0.72rem;
+}
+
+.team-logo.team-logo-fallback {
+  font-size: 1.6rem;
+}

--- a/src/UI/sd-ui/src/components/common/TeamLogo.jsx
+++ b/src/UI/sd-ui/src/components/common/TeamLogo.jsx
@@ -1,0 +1,35 @@
+import "./TeamLogo.css";
+
+/**
+ * Renders a team's generated mark when available; otherwise a license-free
+ * fallback — a team-color circle with the abbreviation. Never renders a broken
+ * <img>. Logos can now be null: selection is fail-closed (a licensed ESPN logo
+ * is never served), so any team without a generated mark returns no URL. See
+ * docs/logo-license-audit.md.
+ *
+ * `className` should carry the sizing (e.g. "matchup-logo", "team-logo"); it's
+ * applied to both the img and the fallback so they occupy the same box.
+ */
+function TeamLogo({ src, abbr, color, alt, className = "" }) {
+  if (src) {
+    return <img src={src} alt={alt} className={className} />;
+  }
+
+  const bg = color
+    ? (color.startsWith("#") ? color : `#${color}`)
+    : "#4b5563"; // neutral slate when a team has no color either
+  const label = (abbr || "").slice(0, 4).toUpperCase();
+
+  return (
+    <span
+      className={`team-logo-fallback ${className}`}
+      style={{ backgroundColor: bg }}
+      role="img"
+      aria-label={alt}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default TeamLogo;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -170,6 +170,8 @@ function MatchupCard({
         {/* Away Team Row */}
         <TeamRow
           teamName={matchup.away}
+          teamShort={matchup.awayShort}
+          teamColor={matchup.awayColor}
           teamSlug={matchup.awaySlug}
           logoUri={awayLogoSrc}
           rank={matchup.awayRank}
@@ -191,6 +193,8 @@ function MatchupCard({
         {/* Home Team Row */}
         <TeamRow
           teamName={matchup.home}
+          teamShort={matchup.homeShort}
+          teamColor={matchup.homeColor}
           teamSlug={matchup.homeSlug}
           logoUri={homeLogoSrc}
           rank={matchup.homeRank}

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { FaSearchPlus, FaSearchMinus } from "react-icons/fa";
 import { teamLink, resolveSportLeague } from '../../utils/sportLinks';
 import MiniSchedule from "./MiniSchedule";
+import TeamLogo from "../common/TeamLogo";
 
 /**
  * TeamRow component - displays team information, record, and optional schedule
@@ -24,6 +25,8 @@ import MiniSchedule from "./MiniSchedule";
  */
 function TeamRow({
   teamName,
+  teamShort,
+  teamColor,
   teamSlug,
   rank,
   logoUri,
@@ -49,13 +52,13 @@ function TeamRow({
     <>
       <div className="team-row">
         <div className="team-info">
-          {logoUri && (
-            <img
-              src={logoUri}
-              alt={`${teamName} logo`}
-              className="matchup-logo"
-            />
-          )}
+          <TeamLogo
+            src={logoUri}
+            abbr={teamShort}
+            color={teamColor}
+            alt={`${teamName} logo`}
+            className="matchup-logo"
+          />
           <div className="team-details">
             <div className="team-name-row">
               {rank && (

--- a/src/UI/sd-ui/src/components/teams/TeamCard.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamCard.jsx
@@ -10,6 +10,7 @@ import TeamNews from "./TeamNews";
 import TeamStatistics from "./TeamStatistics";
 import TeamRoster from "./TeamRoster";
 import TeamLogos from "./TeamLogos";
+import TeamLogo from "../common/TeamLogo";
 
 function TeamCard() {
   const { sport = 'football', league = 'ncaa', slug, seasonYear } = useParams();
@@ -72,8 +73,10 @@ function TeamCard() {
       }}
     >
       <div className="team-header">
-        <img
+        <TeamLogo
           src={theme === 'dark' ? (team.logoUrlDark || team.logoUrl) : (team.logoUrlLight || team.logoUrl)}
+          abbr={team.shortName}
+          color={team.colorPrimary}
           alt={`${team.name} logo`}
           className="team-logo"
         />

--- a/src/marks/batch/insert.js
+++ b/src/marks/batch/insert.js
@@ -1,12 +1,23 @@
-// Phase 5: read a manifest produced by upload.js and write FranchiseSeasonLogo
-// rows into Postgres. Idempotent — re-runnable against the same manifest.
+// Phase 5: read a manifest produced by upload.js and write logo rows into
+// Postgres. Idempotent — re-runnable against the same manifest.
+//
+// Handles both manifest grains by entry.kind:
+//   'franchise-season' -> FranchiseSeasonLogo (keyed by FranchiseSeasonId)
+//   'franchise'        -> FranchiseLogo       (keyed by FranchiseId)
 //
 // Usage:
 //   node insert.js                # uses the newest manifest in output/manifests/
 //   node insert.js path/to/manifest.json
 //
-// Idempotency: SELECT by (FranchiseSeasonId, OriginalUrlHash); UPDATE if a
-// row already exists, INSERT otherwise. No schema change required.
+// Idempotency: SELECT by (<fkColumn>, OriginalUrlHash); UPDATE if a row already
+// exists, INSERT otherwise. No schema change required.
+
+// Maps a manifest entry.kind to its target table + foreign-key column. Values
+// are fixed constants (never user input), so interpolating them into SQL is safe.
+const LOGO_TARGETS = {
+  'franchise-season': { table: 'FranchiseSeasonLogo', fkColumn: 'FranchiseSeasonId' },
+  'franchise': { table: 'FranchiseLogo', fkColumn: 'FranchiseId' },
+};
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -36,6 +47,57 @@ function requireEnv(name) {
   return v;
 }
 
+// Idempotent upsert of one mark row into the given logo table. Returns
+// 'inserted' or 'updated'. `table`/`fkColumn` come from LOGO_TARGETS (fixed
+// constants), so string-interpolating them is safe.
+async function upsertLogo(client, table, fkColumn, fkValue, e) {
+  const existing = await client.query(
+    `SELECT "Id" FROM "${table}"
+     WHERE "${fkColumn}" = $1 AND "OriginalUrlHash" = $2
+     LIMIT 1`,
+    [fkValue, e.originalUrlHash]
+  );
+
+  if (existing.rowCount > 0) {
+    await client.query(
+      `UPDATE "${table}"
+       SET "Uri" = $1,
+           "Width" = $2,
+           "Height" = $3,
+           "Rel" = $4,
+           "IsForDarkBg" = $5,
+           "ModifiedUtc" = (NOW() AT TIME ZONE 'UTC'),
+           "ModifiedBy" = $6
+       WHERE "Id" = $7`,
+      [e.blobUrl, e.width, e.height, e.rel, false, CREATED_BY, existing.rows[0].Id]
+    );
+    return 'updated';
+  }
+
+  await client.query(
+    `INSERT INTO "${table}"
+       ("Id", "${fkColumn}", "Uri", "OriginalUrlHash",
+        "Width", "Height", "Rel", "IsForDarkBg",
+        "CreatedUtc", "CreatedBy", "ModifiedUtc", "ModifiedBy")
+     VALUES
+       ($1, $2, $3, $4,
+        $5, $6, $7, $8,
+        (NOW() AT TIME ZONE 'UTC'), $9, NULL, NULL)`,
+    [
+      crypto.randomUUID(),
+      fkValue,
+      e.blobUrl,
+      e.originalUrlHash,
+      e.width,
+      e.height,
+      e.rel,
+      false,
+      CREATED_BY
+    ]
+  );
+  return 'inserted';
+}
+
 async function main() {
   const manifestArg = process.argv[2];
   const manifestPath = manifestArg
@@ -61,61 +123,20 @@ async function main() {
   await client.connect();
   console.log(`Connected to ${process.env.PG_DATABASE} @ ${process.env.PG_HOST}\n`);
 
-  let inserted = 0, updated = 0, failed = 0;
+  let inserted = 0, updated = 0, failed = 0, skipped = 0;
 
   for (const e of manifest.entries) {
-    if (e.kind !== 'franchise-season') {
-      // Franchise-level rows will land in a later batch pass.
+    const target = LOGO_TARGETS[e.kind];
+    if (!target) {
+      // Unknown grain — count it rather than silently dropping.
+      skipped++;
+      process.stdout.write('s');
       continue;
     }
     try {
-      const existing = await client.query(
-        `SELECT "Id" FROM "FranchiseSeasonLogo"
-         WHERE "FranchiseSeasonId" = $1 AND "OriginalUrlHash" = $2
-         LIMIT 1`,
-        [e.entityId, e.originalUrlHash]
-      );
-
-      if (existing.rowCount > 0) {
-        await client.query(
-          `UPDATE "FranchiseSeasonLogo"
-           SET "Uri" = $1,
-               "Width" = $2,
-               "Height" = $3,
-               "Rel" = $4,
-               "IsForDarkBg" = $5,
-               "ModifiedUtc" = (NOW() AT TIME ZONE 'UTC'),
-               "ModifiedBy" = $6
-           WHERE "Id" = $7`,
-          [e.blobUrl, e.width, e.height, e.rel, false, CREATED_BY, existing.rows[0].Id]
-        );
-        updated++;
-        process.stdout.write('u');
-      } else {
-        await client.query(
-          `INSERT INTO "FranchiseSeasonLogo"
-             ("Id", "FranchiseSeasonId", "Uri", "OriginalUrlHash",
-              "Width", "Height", "Rel", "IsForDarkBg",
-              "CreatedUtc", "CreatedBy", "ModifiedUtc", "ModifiedBy")
-           VALUES
-             ($1, $2, $3, $4,
-              $5, $6, $7, $8,
-              (NOW() AT TIME ZONE 'UTC'), $9, NULL, NULL)`,
-          [
-            crypto.randomUUID(),
-            e.entityId,
-            e.blobUrl,
-            e.originalUrlHash,
-            e.width,
-            e.height,
-            e.rel,
-            false,
-            CREATED_BY
-          ]
-        );
-        inserted++;
-        process.stdout.write('i');
-      }
+      const result = await upsertLogo(client, target.table, target.fkColumn, e.entityId, e);
+      if (result === 'inserted') { inserted++; process.stdout.write('i'); }
+      else { updated++; process.stdout.write('u'); }
     } catch (err) {
       failed++;
       process.stdout.write('x');
@@ -126,7 +147,7 @@ async function main() {
 
   await client.end();
 
-  console.log(`Inserted: ${inserted}  Updated: ${updated}  Failed: ${failed}`);
+  console.log(`Inserted: ${inserted}  Updated: ${updated}  Skipped: ${skipped}  Failed: ${failed}`);
   if (failed > 0) process.exitCode = 1;
 }
 

--- a/src/marks/batch/run.ps1
+++ b/src/marks/batch/run.ps1
@@ -35,11 +35,17 @@ param(
   [ValidateSet('Mlb','Ncaafb','Nfl')]
   [string]$Sport = 'Mlb',
 
-  # 'Teams' (default) runs upload.js / insert.js against franchise-colors data
-  # and writes FranchiseSeasonLogo rows. 'Athletes' runs upload-athletes.js /
-  # insert-athletes.js against athletes-{sport} data and writes AthleteImage.
+  # 'Teams' (default) runs upload.js / insert.js against franchise-colors data.
+  # 'Athletes' runs upload-athletes.js / insert-athletes.js against
+  # athletes-{sport} data and writes AthleteImage.
   [ValidateSet('Teams','Athletes')]
   [string]$Target = 'Teams',
+
+  # Teams grain. 'Franchise' (default, go-forward) writes one year-invariant mark
+  # per franchise into FranchiseLogo. 'FranchiseSeason' is the legacy per-season
+  # pass (FranchiseSeasonLogo). Ignored for -Target Athletes.
+  [ValidateSet('Franchise','FranchiseSeason')]
+  [string]$Grain = 'Franchise',
 
   [string]$Scope,
 
@@ -107,7 +113,13 @@ switch ($Sport) {
 
 if ($Target -eq 'Teams') {
   $env:SD_DATA_FILE = "franchise-colors-$sportLower.txt"
-  if (-not $Scope) { $Scope = 'franchise-season:2026' }
+  if ($Grain -eq 'Franchise') {
+    $env:SD_KIND = 'franchise'
+    if (-not $Scope) { $Scope = 'franchise' }
+  } else {
+    $env:SD_KIND = 'franchise-season'
+    if (-not $Scope) { $Scope = 'franchise-season:2026' }
+  }
 } else {
   # Athletes
   $env:SD_DATA_FILE = "athletes-$sportLower.txt"
@@ -117,9 +129,9 @@ $env:SD_SCOPE = $Scope
 
 $env:SD_TARGET_ENV = $Environment
 
-Write-Host "Phase: $Phase  Environment: $Environment  Sport: $Sport  Target: $Target" -ForegroundColor Cyan
+Write-Host "Phase: $Phase  Environment: $Environment  Sport: $Sport  Target: $Target  Grain: $Grain" -ForegroundColor Cyan
 Write-Host "PG: $env:PG_DATABASE @ $env:PG_HOST" -ForegroundColor Cyan
-Write-Host "Data file: $env:SD_DATA_FILE  Scope: $env:SD_SCOPE" -ForegroundColor Cyan
+Write-Host "Data file: $env:SD_DATA_FILE  Kind: $env:SD_KIND  Scope: $env:SD_SCOPE" -ForegroundColor Cyan
 
 # Script picker: target × phase → which Node script runs.
 $scriptName = if ($Target -eq 'Teams') {

--- a/src/marks/batch/upload.js
+++ b/src/marks/batch/upload.js
@@ -17,14 +17,21 @@ const SDMarks = require('../marks.js');
 // with MLB defaults so the first-pass developer experience still works
 // without the wrapper.
 const SPORT = process.env.SD_SPORT || 'MLB';
+// Data files live in batch/data/. SD_DATA_FILE is a bare filename resolved
+// there (run.ps1 sets it per sport, e.g. franchise-colors-ncaafb.txt).
 const DATA_FILE = path.resolve(
   __dirname,
-  '..',
+  'data',
   process.env.SD_DATA_FILE || 'franchise-colors-mlb.txt'
 );
 // Default matches the year currently in franchise-colors.sql; run.ps1 sets
 // SD_SCOPE explicitly so this default only matters for direct node invocation.
 const SCOPE = process.env.SD_SCOPE || 'franchise-season:2026';
+// Entity grain this run targets. 'franchise-season' (default, legacy) keys marks
+// by FranchiseSeasonId; 'franchise' (the go-forward backfill) keys them by
+// FranchiseId — one year-invariant mark per franchise. The franchise-grain data
+// file (franchise-colors.sql) carries FranchiseId but no FranchiseSeasonId.
+const KIND = process.env.SD_KIND || 'franchise-season';
 const OUTPUT_DIR = path.resolve(__dirname, 'output');
 const MANIFEST_DIR = path.join(OUTPUT_DIR, 'manifests');
 const CONTAINER = 'sportdeets-marks';
@@ -102,8 +109,13 @@ async function main() {
       secondary: (altHex && altHex !== 'NULL') ? '#' + altHex : null
     };
 
+    // The entity a mark is keyed to depends on the run grain: FranchiseId for a
+    // franchise-level run, FranchiseSeasonId for a season-level one. The blob
+    // path and idempotency hash both key off it, so re-runs are stable per grain.
+    const entityId = KIND === 'franchise' ? row.FranchiseId : row.FranchiseSeasonId;
+
     for (const direction of DIRECTIONS) {
-      const blobPath = `franchise-season/${direction}/${row.FranchiseSeasonId}.png`;
+      const blobPath = `${KIND}/${direction}/${entityId}.png`;
       try {
         const png = renderPng(direction, team);
         const blob = container.getBlockBlobClient(blobPath);
@@ -111,15 +123,15 @@ async function main() {
           blobHTTPHeaders: { blobContentType: 'image/png' }
         });
         entries.push({
-          kind: 'franchise-season',
+          kind: KIND,
           direction,
-          entityId: row.FranchiseSeasonId,
+          entityId,
           franchiseId: row.FranchiseId,
           slug: row.Slug,
           sport: SPORT,
           blobPath,
           blobUrl: blob.url,
-          originalUrlHash: syntheticHash(direction, row.FranchiseSeasonId),
+          originalUrlHash: syntheticHash(direction, entityId),
           width: SIZE,
           height: SIZE,
           rel: ['sportdeets-mark', direction]

--- a/src/marks/batch/upload.js
+++ b/src/marks/batch/upload.js
@@ -24,14 +24,16 @@ const DATA_FILE = path.resolve(
   'data',
   process.env.SD_DATA_FILE || 'franchise-colors-mlb.txt'
 );
-// Default matches the year currently in franchise-colors.sql; run.ps1 sets
-// SD_SCOPE explicitly so this default only matters for direct node invocation.
-const SCOPE = process.env.SD_SCOPE || 'franchise-season:2026';
-// Entity grain this run targets. 'franchise-season' (default, legacy) keys marks
-// by FranchiseSeasonId; 'franchise' (the go-forward backfill) keys them by
-// FranchiseId — one year-invariant mark per franchise. The franchise-grain data
-// file (franchise-colors.sql) carries FranchiseId but no FranchiseSeasonId.
-const KIND = process.env.SD_KIND || 'franchise-season';
+// Entity grain this run targets. Defaults to 'franchise' so a bare
+// `node upload.js` (no wrapper) is internally consistent with the franchise-grain
+// default data file above — the previous 'franchise-season' default paired with
+// a franchise-grain file yields undefined entity IDs. run.ps1 sets SD_KIND
+// explicitly for either grain. 'franchise' keys marks by FranchiseId (one
+// year-invariant mark per franchise); 'franchise-season' keys by
+// FranchiseSeasonId (legacy per-season pass).
+const KIND = process.env.SD_KIND || 'franchise';
+// Manifest label only. Defaults to the grain; run.ps1 sets SD_SCOPE explicitly.
+const SCOPE = process.env.SD_SCOPE || KIND;
 const OUTPUT_DIR = path.resolve(__dirname, 'output');
 const MANIFEST_DIR = path.join(OUTPUT_DIR, 'manifests');
 const CONTAINER = 'sportdeets-marks';
@@ -89,8 +91,24 @@ async function main() {
   await container.createIfNotExists({ access: 'blob' });
 
   const rows = readTeams(DATA_FILE);
+
+  // Pre-flight: every row must carry the entity ID that KIND keys on, BEFORE any
+  // blob is written. A grain/data-file mismatch (e.g. franchise-season KIND
+  // against a franchise-grain file) would otherwise yield undefined IDs and
+  // stamp every mark onto one shared blob key. Fail clearly instead.
+  const idField = KIND === 'franchise' ? 'FranchiseId' : 'FranchiseSeasonId';
+  const missingIdCount = rows.filter((r) => !r[idField]).length;
+  if (missingIdCount > 0) {
+    console.error(
+      `SD_KIND='${KIND}' keys on "${idField}", but ${missingIdCount} of ${rows.length} ` +
+      `rows in ${path.basename(DATA_FILE)} lack it — the data file's grain does not ` +
+      `match SD_KIND. Aborting before upload.`
+    );
+    process.exit(1);
+  }
+
   console.log(`Loaded ${rows.length} teams from ${path.basename(DATA_FILE)}`);
-  console.log(`Target: ${targetEnv} / container "${CONTAINER}" / scope ${SCOPE}`);
+  console.log(`Target: ${targetEnv} / container "${CONTAINER}" / scope ${SCOPE} / kind ${KIND}`);
   console.log(`Uploading ${rows.length * DIRECTIONS.length} blobs...\n`);
 
   const entries = [];

--- a/src/marks/franchise-colors.sql
+++ b/src/marks/franchise-colors.sql
@@ -1,5 +1,33 @@
-select fr."Id" as "FranchiseId", f."Id" as "FranchiseSeasonId", f."Slug", f."Abbreviation", f."ColorCodeHex", f."ColorCodeAltHex"
-from public."FranchiseSeason" f
-inner join public."Franchise" fr on fr."Id" = f."FranchiseId"
-where f."SeasonYear" = 2026 and f."IsActive" = true
-order by f."Slug";
+-- ============================================================================
+-- Franchise-LEVEL color dump (go-forward). One row per franchise, colors from
+-- its most-recent season. Feeds the franchise-level mark backfill: generate a
+-- FranchiseLogo mark per franchise (year-invariant), which the selector uses
+-- fail-closed. See docs/logo-license-audit.md.
+--
+-- No SeasonYear / IsActive filter, so ALL franchises are covered (not just the
+-- 2026-active 651) — that's what makes the backfill hole-free.
+--
+-- Export tab-separated with the header row intact; the header MUST start with
+-- "FranchiseId\t" (upload.js / generate.js detect the header by that prefix).
+-- Save per sport to franchise-colors-{ncaafb,nfl,mlb}.txt.
+-- ============================================================================
+SELECT DISTINCT ON (fr."Id")
+       fr."Id"            AS "FranchiseId",
+       f."Slug",
+       f."Abbreviation",
+       f."ColorCodeHex",
+       f."ColorCodeAltHex"
+FROM public."FranchiseSeason" f
+INNER JOIN public."Franchise" fr ON fr."Id" = f."FranchiseId"
+ORDER BY fr."Id", f."SeasonYear" DESC;
+
+-- ----------------------------------------------------------------------------
+-- Prior season-level query (2026-active only) — kept for reference. This is the
+-- grain the ORIGINAL franchise-SEASON mark pass used; no longer the go-forward.
+-- ----------------------------------------------------------------------------
+-- SELECT fr."Id" AS "FranchiseId", f."Id" AS "FranchiseSeasonId", f."Slug",
+--        f."Abbreviation", f."ColorCodeHex", f."ColorCodeAltHex"
+-- FROM public."FranchiseSeason" f
+-- INNER JOIN public."Franchise" fr ON fr."Id" = f."FranchiseId"
+-- WHERE f."SeasonYear" = 2026 AND f."IsActive" = true
+-- ORDER BY f."Slug";

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Services/LogoSelectionServiceTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Services/LogoSelectionServiceTests.cs
@@ -1,0 +1,137 @@
+#nullable enable
+using FluentAssertions;
+
+using SportsData.Core.Common;
+using SportsData.Producer.Application.Services;
+using SportsData.Producer.Infrastructure.Data.Entities.Contracts;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Services;
+
+/// <summary>
+/// Pins the FAIL-CLOSED contract of the logo selector: it returns ONLY a
+/// sportDeets-generated mark, or null — never an ESPN / untagged (licensed)
+/// logo. Also guards the fail-open shadowing regression (a season ESPN logo
+/// hiding a franchise mark). See docs/logo-license-audit.md.
+/// </summary>
+public class LogoSelectionServiceTests
+{
+    private readonly LogoSelectionService _sut = new();
+
+    private sealed class TestLogo : ILogo
+    {
+        public string OriginalUrlHash { get; set; } = string.Empty;
+        public Uri Uri { get; set; } = null!;
+        public long? Height { get; set; }
+        public long? Width { get; set; }
+        public List<string>? Rel { get; set; }
+        public bool? IsForDarkBg { get; set; }
+    }
+
+    private static TestLogo Mark(string uri, params string[] rel) =>
+        new() { Uri = new Uri(uri), Rel = rel.ToList() };
+
+    // An ESPN-sourced / untagged logo — a real Rel that does NOT contain
+    // "sportdeets-mark" (or none at all).
+    private static TestLogo Espn(string uri, params string[] rel) =>
+        new() { Uri = new Uri(uri), Rel = rel.Length == 0 ? null : rel.ToList() };
+
+    [Fact]
+    public void SelectLogoForDarkBackground_ReturnsMark_WhenMarkPresent()
+    {
+        var logos = new[]
+        {
+            Espn("https://espn/logo.png", "default"),
+            Mark("https://sd/roundel.png", "sportdeets-mark", "roundel"),
+        };
+
+        _sut.SelectLogoForDarkBackground(logos)!.OriginalString
+            .Should().Be("https://sd/roundel.png");
+    }
+
+    [Fact]
+    public void SelectLogoForDarkBackground_ReturnsNull_WhenOnlyEspnLogos()
+    {
+        // The core guarantee: a licensed logo is never returned.
+        var logos = new[]
+        {
+            Espn("https://espn/logo.png", "default"),
+            Espn("https://espn/dark.png", "dark"),
+            Espn("https://espn/plain.png"),
+        };
+
+        _sut.SelectLogoForDarkBackground(logos).Should().BeNull();
+    }
+
+    [Fact]
+    public void SelectLogoForLightBackground_MatchesDark_MarksAreThemeAgnostic()
+    {
+        var logos = new[] { Mark("https://sd/roundel.png", "sportdeets-mark", "roundel") };
+
+        _sut.SelectLogoForLightBackground(logos)!.OriginalString
+            .Should().Be(_sut.SelectLogoForDarkBackground(logos)!.OriginalString);
+    }
+
+    [Fact]
+    public void Select_PrefersRequestedDirection()
+    {
+        var logos = new[]
+        {
+            Mark("https://sd/hex.png", "sportdeets-mark", "hex"),
+            Mark("https://sd/roundel.png", "sportdeets-mark", "roundel"),
+        };
+
+        _sut.SelectLogoForDarkBackground(logos, MarkDirection.Hex)!.OriginalString
+            .Should().Be("https://sd/hex.png");
+        _sut.SelectLogoForDarkBackground(logos, MarkDirection.Roundel)!.OriginalString
+            .Should().Be("https://sd/roundel.png");
+    }
+
+    [Fact]
+    public void Select_FallsBackToAnyMark_WhenRequestedDirectionMissing()
+    {
+        var logos = new[] { Mark("https://sd/hex.png", "sportdeets-mark", "hex") };
+
+        _sut.SelectLogoForDarkBackground(logos, MarkDirection.Roundel)!.OriginalString
+            .Should().Be("https://sd/hex.png");
+    }
+
+    [Fact]
+    public void SelectWithFallback_PrefersSeasonMark_OverFranchiseMark()
+    {
+        var season = new[] { Mark("https://sd/season.png", "sportdeets-mark", "roundel") };
+        var franchise = new[] { Mark("https://sd/franchise.png", "sportdeets-mark", "roundel") };
+
+        _sut.SelectWithFallback(season, franchise)!.OriginalString
+            .Should().Be("https://sd/season.png");
+    }
+
+    [Fact]
+    public void SelectWithFallback_UsesFranchiseMark_WhenSeasonHasOnlyEspn()
+    {
+        // Regression guard for the fail-open shadowing bug: a season that has
+        // only an ESPN logo (no mark) must NOT shadow the franchise mark.
+        var season = new[] { Espn("https://espn/season.png", "default") };
+        var franchise = new[] { Mark("https://sd/franchise.png", "sportdeets-mark", "roundel") };
+
+        _sut.SelectWithFallback(season, franchise)!.OriginalString
+            .Should().Be("https://sd/franchise.png");
+    }
+
+    [Fact]
+    public void SelectWithFallback_ReturnsNull_WhenNoMarksAnywhere()
+    {
+        var season = new[] { Espn("https://espn/season.png", "default") };
+        var franchise = new[] { Espn("https://espn/franchise.png", "default") };
+
+        _sut.SelectWithFallback(season, franchise).Should().BeNull();
+    }
+
+    [Fact]
+    public void SelectWithFallback_ReturnsNull_WhenBothEmptyOrNull()
+    {
+        _sut.SelectWithFallback(null, null).Should().BeNull();
+        _sut.SelectWithFallback(Array.Empty<ILogo>(), Array.Empty<ILogo>()).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## What

Licensed ESPN team logos were still rendering in the UI (the reported case: the `team-header` on `/app/.../team/washington-huskies/2024` and `/2026`). This makes logo selection **fail-closed**: only a sportDeets-generated mark (a row whose `Rel` contains `sportdeets-mark`) can ever render — never a licensed ESPN row. App-store constraint.

Full investigation, audit queries, and plan: **`docs/logo-license-audit.md`** (in this PR).

## Root cause

Selection failed **open** — when no mark existed it fell through to the ESPN-sourced (licensed) logo. Two things compounded it:
- **Two independent selection engines** both fail-open: the C# `LogoSelectionService` (4 handlers) and the raw SQL `GetMatchupsByContestIds.sql` (picks page / live tiles / results).
- **A data gap**: zero franchise-level marks existed (the "later pass" never ran), and 791 franchise-seasons had logos but no mark. Backfilled separately (see below).

## Changes

### A — `LogoSelectionService` fail-closed
Returns a mark (season → franchise) or `null`; the entire ESPN priority cascade is deleted. This also fixes the **fail-open shadowing bug** — a mark-less season now yields `null`, so the franchise mark is reached instead of being hidden behind a season ESPN logo. Covers TeamCard, ContestOverview, ContestPlayLog, CurrentPolls. **+9 unit tests** pin the guarantee and the shadowing regression.

### B — `GetMatchupsByContestIds.sql` marks-only
All 8 logo laterals now filter to `Rel @> ARRAY['sportdeets-mark']` and drop the `ELSE → ESPN` fallback, so `COALESCE(season-mark, franchise-mark)` fail-closes and no longer lets a season ESPN logo shadow a franchise mark. Covers the picks page, live tiles, and the results page (which reuses this query).

### C — Frontend placeholders
A null logo must render a license-free fallback, not a broken `<img>`.
- **Web:** new reusable `TeamLogo` (mark, else a team-color circle + abbreviation), wired into the matchup cards (`TeamRow`) and the `TeamCard` team-header.
- **Mobile:** `MatchupCard` already had a null placeholder — upgraded from neutral gray to team-color for parity.

### Batch tooling — franchise-level backfill support
`upload.js` / `insert.js` / `run.ps1` / `franchise-colors.sql` gain an `SD_KIND=franchise` grain that writes one **year-invariant** mark per franchise to `FranchiseLogo`. **The prod backfill has already been run** for all three sports (zero errors), so the marks exist — this PR is the code that *reads* them.

## Testing

- Producer suite **502 passed** (incl. the 9 new selector tests).
- Web build clean; mobile `tsc` clean + **75 tests** green.
- **Not covered by unit tests:** the raw SQL (B). Verify the picks page against a DB (local or post-deploy) to confirm marks render and there's no SQL error.

## Reviewer notes

- The `darkBackground` param on the service is now a no-op (marks are theme-agnostic); kept for interface stability.
- Coverage sweep confirmed A + B hit every *live* logo path. `GetRankingsByPollByWeek.sql` was already marks-only; `GetTeamCard.sql` is fail-open but **dead code** (never invoked) — flagged as a cleanup candidate, not fixed here.
- The `franchise-colors-*.txt` regeneration dumps are intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent team logo rendering across matchup and team views.
  * Added accessible, license-free fallback graphics using team colors and abbreviations when logos are unavailable.

* **Bug Fixes**
  * Prevented unapproved or unavailable logos from appearing through fallback selection.
  * Improved logo selection consistency across light and dark backgrounds.
  * Added safer handling for missing logo data, including placeholders in matchup cards.

* **Documentation**
  * Added guidance for auditing logo licensing, addressing missing marks, and verifying logo coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->