### PR TITLE
fix(contest-overview): remove licensed headshots, restyle leaders/header, reorg columns

### DIFF
--- a/src/UI/sd-ui/src/components/contests/ContestOverview.css
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.css
@@ -82,15 +82,15 @@
   min-width: 120px;
   max-width: 160px;
 .contest-team-logo-wrap {
-  width: 48px;
-  height: 48px;
+  width: 60px;
+  height: 60px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--text-inverse); /* white background looks best for most logos */
+  /* No background box: generated roundels are transparent, self-contained,
+     team-colored marks — a bg/border rendered as a black square in dark mode.
+     Show the mark bare, matching mobile. */
   border-radius: 8px;
-  padding: 4px;
-  border: 1px solid var(--border-strong);
 }
   font-size: 1.1rem;
   font-weight: 600;
@@ -140,10 +140,18 @@
   margin-bottom: 8px;
 }
 
-.contest-leaders-stacked {
+/* Two columns: away | home. */
+.contest-leaders-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.contest-leaders-column {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  min-width: 0;
 }
 
 .contest-leader-item {
@@ -154,22 +162,26 @@
   padding: 4px 0;
 }
 
+/* Player name on top (prominent), stat line smaller on the line below. */
 .contest-leader-player {
-  font-weight: 600;
+  font-size: 1.02rem;
+  font-weight: 700;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 160px;
 }
 
 .contest-leader-statline {
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .contest-leader-team-logo {
-  width: 18px;
-  height: 18px;
+  width: 32px;
+  height: 32px;
   object-fit: contain;
   flex-shrink: 0;
 }
@@ -194,17 +206,16 @@
 }
 
 .contest-scoring-summary-logo-wrap {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--text-inverse); /* white background looks best for most logos */
+  /* No background box: transparent roundel, matches the header/mobile. A
+     bg/border rendered as a black square in dark mode. */
   border-radius: 6px;
-  padding: 3px;
   margin-right: 8px;
   flex: 0 0 auto;
-  border: 1px solid var(--border-strong);
 }
 
 .contest-scoring-summary-logo {
@@ -213,7 +224,7 @@
 
 .contest-scoring-summary-quarter {
   font-weight: 700;
-  color: var(--warning);
+  color: var(--accent);
 }
 
 .contest-scoring-summary-team {
@@ -423,7 +434,7 @@
   color: var(--info);
 }
 .contest-analysis-actual strong {
-  color: var(--warning);
+  color: var(--accent);
 }
 .contest-analysis-notes strong {
   color: var(--text-secondary);
@@ -451,7 +462,7 @@
 .contest-section-title {
   font-size: 1.25rem;
   font-weight: 700;
-  color: var(--warning);
+  color: var(--accent);
   margin-bottom: 14px;
   letter-spacing: 1px;
   border-bottom: 1px solid var(--bg-input);
@@ -496,7 +507,7 @@
 .contest-boxscore-section th {
   font-weight: 700;
   background: var(--badge-bg);
-  color: var(--warning);
+  color: var(--accent);
 }
 .contest-boxscore-section tr:last-child td {
   border-bottom: none;
@@ -560,22 +571,20 @@
   text-align: center;
 }
 .contest-team-logo {
-  width: 40px;
-  height: 40px;
+  width: 60px;
+  height: 60px;
   object-fit: contain;
   margin-bottom: 0;
 }
 
 .contest-team-logo-wrap {
-  width: 48px;
-  height: 48px;
+  width: 60px;
+  height: 60px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--text-inverse);
+  /* No background box — see note above (transparent roundel, matches mobile). */
   border-radius: 8px;
-  padding: 4px;
-  border: 1px solid var(--border-strong);
 }
 @media (max-width: 900px) {
   .contest-header-flex {

--- a/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverview.jsx
@@ -57,15 +57,15 @@ export default function ContestOverview() {
           {/* Win probability moved up until TeamStats is available */}
           <ContestOverviewWinProb winProbability={winProbability} homeTeam={homeTeam} awayTeam={awayTeam} sport={sport} />
           <ContestOverviewMetrics homeMetrics={homeMetrics} awayMetrics={awayMetrics} homeName={homeTeam?.displayName} awayName={awayTeam?.displayName} />
-          {/* Admin section slots into the second column immediately after
-              Metrics. Hidden from non-admins via the isAdmin gate. */}
-          {isAdmin && (
-            <ContestOverviewAdmin contestId={contestId} sport={sport} league={league} />
-          )}
-          <ContestOverviewInfo info={info} />
         </div>
         <div className="contest-overview-col">
           <ContestOverviewPlaylog playLog={playLog} sport={sport} contestId={contestId} league={league} />
+          <ContestOverviewInfo info={info} />
+          {/* Admin section sits in the third column below Play Log and Info.
+              Hidden from non-admins via the isAdmin gate. */}
+          {isAdmin && (
+            <ContestOverviewAdmin contestId={contestId} sport={sport} league={league} />
+          )}
         </div>
       </div>
     </div>

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewAdmin.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewAdmin.jsx
@@ -100,6 +100,7 @@ export default function ContestOverviewAdmin({ contestId, sport, league }) {
   // invisible against the .contest-section background. Use --accent for
   // a high-contrast call-to-action treatment that works in both themes.
   const buttonStyle = {
+    width: "100%",
     padding: "10px 24px",
     fontSize: 16,
     fontWeight: 600,
@@ -113,7 +114,7 @@ export default function ContestOverviewAdmin({ contestId, sport, league }) {
   return (
     <div className="contest-section">
       <div className="contest-section-title">Admin</div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "stretch" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, alignItems: "start" }}>
         <div>
           <button onClick={handleRefresh} disabled={refreshing} style={buttonStyle}>
             {refreshing ? "Refreshing..." : "Refresh Contest"}

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewLeaders.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewLeaders.jsx
@@ -17,17 +17,13 @@ export default function ContestOverviewLeaders({ homeTeam, awayTeam, leaders }) 
             className="contest-leader-team-logo"
           />
         )}
-        {l.playerHeadshotUrl && (
-          <img
-            src={l.playerHeadshotUrl}
-            alt={l.playerName}
-            style={{ width: '36px', height: '36px', borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
-          />
-        )}
+        {/* Player headshot removed: ESPN-sourced player headshots are licensed
+            and can't ship (same constraint as team logos). NCAAFB still surfaced
+            them here. Team logo + name/stat line remain. */}
         <div style={{ minWidth: 0 }}>
-          <span className="contest-leader-player">{l.playerName}</span>
+          <div className="contest-leader-player">{l.playerName}</div>
           {l.statLine && (
-            <span className="contest-leader-statline"> - {l.statLine}</span>
+            <div className="contest-leader-statline">{l.statLine}</div>
           )}
         </div>
       </div>
@@ -57,11 +53,19 @@ export default function ContestOverviewLeaders({ homeTeam, awayTeam, leaders }) 
               <div className="contest-leader-category-header">
                 {cat.categoryName}
               </div>
-              <div className="contest-leaders-stacked">
-                {cat.away?.leaders?.length > 0 &&
-                  cat.away.leaders.map((l, i) => <React.Fragment key={`a${i}`}>{renderPlayer(l, awayTeam)}</React.Fragment>)}
-                {cat.home?.leaders?.length > 0 &&
-                  cat.home.leaders.map((l, i) => <React.Fragment key={`h${i}`}>{renderPlayer(l, homeTeam)}</React.Fragment>)}
+              {/* Two columns: away | home. Leaders aren't sequential like the
+                  play log, so side-by-side reads more intuitively than a stack. */}
+              <div className="contest-leaders-columns">
+                <div className="contest-leaders-column">
+                  {cat.away?.leaders?.map((l, i) => (
+                    <React.Fragment key={`a${i}`}>{renderPlayer(l, awayTeam)}</React.Fragment>
+                  ))}
+                </div>
+                <div className="contest-leaders-column">
+                  {cat.home?.leaders?.map((l, i) => (
+                    <React.Fragment key={`h${i}`}>{renderPlayer(l, homeTeam)}</React.Fragment>
+                  ))}
+                </div>
               </div>
             </div>
           ))

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewPlaylog.jsx
@@ -116,7 +116,7 @@ export default function ContestOverviewPlaylog({ playLog, sport, contestId, leag
                 padding: "14px 18px"
               }}
             >
-              <div style={{ fontWeight: 700, color: 'var(--warning)', marginBottom: 8 }}>{periodPrefix}{quarter}</div>
+              <div style={{ fontWeight: 700, color: 'var(--accent)', marginBottom: 8 }}>{periodPrefix}{quarter}</div>
               <div className="contest-scoring-summary-list">
                 {playsByQuarter[quarter].map((play, idx) => {
                   const logoUrl = getLogoUrl(play.team);
@@ -128,7 +128,7 @@ export default function ContestOverviewPlaylog({ playLog, sport, contestId, leag
                             src={logoUrl}
                             alt={play.team}
                             className="contest-scoring-summary-logo"
-                            style={{ width: 20, height: 20, objectFit: 'contain', verticalAlign: 'middle' }}
+                            style={{ width: 32, height: 32, objectFit: 'contain', verticalAlign: 'middle' }}
                           />
                         </div>
                       )}

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewThemed.css
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewThemed.css
@@ -24,8 +24,8 @@
 }
 
 .contest-team-logo {
-  width: 48px;
-  height: 48px;
+  width: 60px;
+  height: 60px;
   object-fit: contain;
   margin-bottom: 4px;
 }
@@ -119,7 +119,7 @@
 }
 
 .contest-leader-statline {
-  font-size: 0.95rem;
+  font-size: 0.8rem;
   color: var(--text-secondary);
 }
 

--- a/src/UI/sd-ui/src/components/shared/BoxScoreTable.css
+++ b/src/UI/sd-ui/src/components/shared/BoxScoreTable.css
@@ -82,13 +82,20 @@
   background: var(--bg-input) !important;
 }
 
+/* Header cell that carries the status pill; spans the period columns so the
+   pill centers over them. Spacing below separates it from the period row. */
+.boxscore-status-cell {
+  padding-bottom: 6px;
+}
+
 .boxscore-status {
-  color: var(--warning);
+  display: inline-block;
+  color: var(--accent);
   font-weight: 700;
   background: var(--badge-bg);
   border-radius: 6px;
   padding: 4px 10px;
-  margin-bottom: 6px;
+  white-space: nowrap;
 }
 
 @media (max-width: 900px) {

--- a/src/UI/sd-ui/src/components/shared/BoxScoreTable.jsx
+++ b/src/UI/sd-ui/src/components/shared/BoxScoreTable.jsx
@@ -40,9 +40,18 @@ export default function BoxScoreTable({
 
   return (
     <div className={`boxscore-table-wrapper compact${wideClass}`}>
-      <div className="boxscore-status">{statusLabel}</div>
       <table className={`boxscore-table compact${wideClass}`}>
         <thead>
+          {/* Status ("Final" / "Live · B5") spans only the period columns so it
+              centers over them regardless of period count (football 4, MLB 9+) —
+              the empty cells hold the team-label and Total columns. */}
+          <tr>
+            <th aria-hidden="true"></th>
+            <th colSpan={periodScores.length} className="boxscore-status-cell">
+              <span className="boxscore-status">{statusLabel}</span>
+            </th>
+            <th aria-hidden="true"></th>
+          </tr>
           <tr>
             <th></th>
             {periodScores.map((p) => (


### PR DESCRIPTION
## Summary

Polish pass on the web **Contest Overview** page. No API/contract changes — all UI.

### Compliance
- Remove ESPN-sourced player **headshots** from the Leaders section. Like team logos, headshots are licensed and can't ship; NCAAFB was still surfacing them. Team logo + name/stat line remain.

### Leaders
- Switch each category from a vertical stack to a **two-column away | home** layout, player name on top with a smaller stat line below. Reads more intuitively (leaders aren't sequential like the play log) and consumes less vertical space.
- Leader team logo `18px → 32px`.

### Header & logos
- Drop the black background box behind header team logos (matching mobile) and grow `48px → 60px`.
- Scoring-summary / play-log logos: drop the background box, `20px → 32px`.

### BoxScoreTable
- Center the status label (`Final` / `Live · B5`) over the **period columns** via a `colSpan` header cell, so it stays centered regardless of period count — football 4, MLB 9+. Shared widget, so the picks-page/Command-Center reuse benefits too.

### Color & layout
- Recolor the page's amber `var(--warning)` text to `var(--accent)` (section titles, quarter chips, status badge) for a consistent accent treatment.
- Move **Info** and **Admin** into the third column below **Play Log**; lay the Admin action buttons out in a **two-column grid**.

## Notes
- `ContestOverviewThemed.css` is not imported anywhere (dead file); its logo-size/statline edits are included only to keep it aligned with the live stylesheet.

## Testing
- `CI=true npx react-scripts build` — compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Box score status labels now appear directly in the table header.
  * Contest leaders are displayed in separate home and away columns.
  * Admin actions are arranged in a compact two-column layout.

* **Style**
  * Updated contest logos, player details, spacing, and typography for improved visibility.
  * Enlarged team and play logos throughout contest views.
  * Refreshed accent colors and improved status-label alignment and readability.
  * Removed player headshots from leader entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->