### PR TITLE
feat(leagues): nightly LeagueDeactivationJob to soft-close finished leagues

### DIFF
--- a/src/SportsData.Api/Application/Jobs/LeagueDeactivationJob.cs
+++ b/src/SportsData.Api/Application/Jobs/LeagueDeactivationJob.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Common.Jobs;
+
+namespace SportsData.Api.Application.Jobs
+{
+    /// <summary>
+    /// Nightly job that soft-closes finished leagues by stamping
+    /// <see cref="Infrastructure.Data.Entities.PickemGroup.DeactivatedUtc"/>.
+    /// Deactivation is not deletion: ~8 read sites (e.g. <c>/user/me</c>,
+    /// GetUserLeagues, pick-import, MatchupScheduler) filter active-only on this
+    /// field, so a stamped league drops out of the active surface but remains
+    /// viewable via the "show past leagues" (<c>IncludeDeactivated</c>) toggle.
+    ///
+    /// Rule 1 (only rule today): a league whose window has an explicit
+    /// <see cref="Infrastructure.Data.Entities.PickemGroup.EndsOn"/> is
+    /// deactivated once at least <see cref="DeactivationGraceDays"/> days have
+    /// elapsed since that end datetime. Leagues with a null <c>EndsOn</c>
+    /// (season-long) are out of scope here and left for a future rule.
+    ///
+    /// The job only ever stamps null → value; it never reactivates. Extending a
+    /// league's <c>EndsOn</c> after deactivation isn't exposed today, so there's
+    /// nothing to un-stamp.
+    /// </summary>
+    public class LeagueDeactivationJob : IAmARecurringJob
+    {
+        /// <summary>
+        /// Days that must elapse after a league's <c>EndsOn</c> before it is
+        /// deactivated. Gives just-finished leagues a grace window before they
+        /// slide into history.
+        /// </summary>
+        private const int DeactivationGraceDays = 7;
+
+        private readonly ILogger<LeagueDeactivationJob> _logger;
+        private readonly AppDataContext _dataContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public LeagueDeactivationJob(
+            ILogger<LeagueDeactivationJob> logger,
+            AppDataContext dataContext,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task ExecuteAsync()
+        {
+            _logger.LogInformation("Starting {JobName}", nameof(LeagueDeactivationJob));
+
+            try
+            {
+                var now = _dateTimeProvider.UtcNow();
+
+                // now - EndsOn >= grace  ⟺  EndsOn <= now - grace. Expressed as a
+                // cutoff so the comparison translates cleanly at the DB layer.
+                var cutoff = now.AddDays(-DeactivationGraceDays);
+
+                // Tracked (not AsNoTracking): these rows are being updated.
+                var toDeactivate = await _dataContext.PickemGroups
+                    .Where(g => g.DeactivatedUtc == null
+                                && g.EndsOn != null
+                                && g.EndsOn <= cutoff)
+                    .ToListAsync();
+
+                _logger.LogInformation(
+                    "Found {Count} league(s) past the {GraceDays}-day post-EndsOn window to deactivate.",
+                    toDeactivate.Count, DeactivationGraceDays);
+
+                foreach (var group in toDeactivate)
+                {
+                    group.DeactivatedUtc = now;
+                    _logger.LogInformation(
+                        "Deactivating league {LeagueId} ({LeagueName}); EndsOn={EndsOn:o}",
+                        group.Id, group.Name, group.EndsOn);
+                }
+
+                if (toDeactivate.Count > 0)
+                {
+                    await _dataContext.SaveChangesAsync();
+                }
+
+                _logger.LogInformation(
+                    "Completed {JobName}: {Count} league(s) deactivated.",
+                    nameof(LeagueDeactivationJob), toDeactivate.Count);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in {JobName}", nameof(LeagueDeactivationJob));
+                throw;
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -300,6 +300,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddSingleton<GameRecapPromptProvider>();
             services.AddScoped<PickScoringJob>();
             services.AddScoped<LeagueWeekScoringJob>();
+            services.AddScoped<LeagueDeactivationJob>();
 
             // TODO: Restore after Contest processing is refactored
             // services.AddScoped<ContestRecapJob>();
@@ -358,6 +359,14 @@ namespace SportsData.Api.DependencyInjection
                 nameof(LeagueWeekScoringJob),
                 job => job.ExecuteAsync(),
                 Cron.Daily(9, 15));
+
+            // Nightly soft-close of finished leagues. Stamps DeactivatedUtc on
+            // leagues whose EndsOn is more than 7 days past, dropping them from
+            // active surfaces. 4am UTC keeps it clear of the 2/6/9am job cluster.
+            recurringJobManager.AddOrUpdate<LeagueDeactivationJob>(
+                nameof(LeagueDeactivationJob),
+                job => job.ExecuteAsync(),
+                Cron.Daily(4));
 
             recurringJobManager.AddOrUpdate<MatchupPreviewGenerator>(
                 nameof(MatchupPreviewGenerator),

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueDeactivationJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueDeactivationJobTests.cs
@@ -1,9 +1,11 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 using Moq;
 
 using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.Jobs;
+using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
 
@@ -134,6 +136,50 @@ public class LeagueDeactivationJobTests : ApiTestBase<LeagueDeactivationJob>
         Assert.False(await DataContext.PickemGroups.AnyAsync());
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WhenSaveChangesThrows_RethrowsException()
+    {
+        // Covers the job's catch-log-rethrow path. Seed an eligible league via a
+        // normal context, then run the job through one whose SaveChangesAsync
+        // always throws (both share the same InMemory store), and assert the
+        // exact exception propagates.
+        var options = new DbContextOptionsBuilder<AppDataContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        await using (var seed = new AppDataContext(options))
+        {
+            seed.PickemGroups.Add(new PickemGroup
+            {
+                Id = Guid.NewGuid(),
+                Name = "Eligible League",
+                Sport = Sport.BaseballMlb,
+                League = League.MLB,
+                PickType = PickType.StraightUp,
+                TiebreakerType = TiebreakerType.None,
+                TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
+                CommissionerUserId = Guid.NewGuid(),
+                EndsOn = FixedNow.AddDays(-10),
+                CreatedUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                CreatedBy = Guid.Empty,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var expected = new InvalidOperationException("save failed");
+
+        // Swap the job's DbContext for the throwing one (overrides ApiTestBase's
+        // registration), pointed at the same store the seed wrote to.
+        await using var throwingContext = new ThrowOnSaveDataContext(options, expected);
+        Mocker.Use<AppDataContext>(throwingContext);
+
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.ExecuteAsync());
+        Assert.Same(expected, actual);
+    }
+
     private async Task SeedLeagueAsync(
         Guid leagueId,
         DateTime? endsOn,
@@ -157,5 +203,24 @@ public class LeagueDeactivationJobTests : ApiTestBase<LeagueDeactivationJob>
 
         await DataContext.PickemGroups.AddAsync(group);
         await DataContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// AppDataContext whose <see cref="SaveChangesAsync"/> always throws the
+    /// supplied exception, so the job's catch-log-rethrow path can be exercised.
+    /// Queries delegate to the base InMemory store.
+    /// </summary>
+    private sealed class ThrowOnSaveDataContext : AppDataContext
+    {
+        private readonly Exception _toThrow;
+
+        public ThrowOnSaveDataContext(DbContextOptions<AppDataContext> options, Exception toThrow)
+            : base(options)
+        {
+            _toThrow = toThrow;
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+            => throw _toThrow;
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueDeactivationJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueDeactivationJobTests.cs
@@ -220,7 +220,10 @@ public class LeagueDeactivationJobTests : ApiTestBase<LeagueDeactivationJob>
             _toThrow = toThrow;
         }
 
+        // Return a faulted task (not a synchronous throw) so the exception
+        // surfaces at the job's await, matching how a real async SaveChangesAsync
+        // fails.
         public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-            => throw _toThrow;
+            => Task.FromException<int>(_toThrow);
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueDeactivationJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Jobs/LeagueDeactivationJobTests.cs
@@ -1,0 +1,161 @@
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.Jobs;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Jobs;
+
+/// <summary>
+/// Tests for <see cref="LeagueDeactivationJob"/>. Rule 1: deactivate leagues
+/// whose EndsOn is more than 7 days past. Validates the grace boundary, the
+/// null-EndsOn (season-long) exclusion, and idempotency against already-
+/// deactivated leagues.
+/// </summary>
+public class LeagueDeactivationJobTests : ApiTestBase<LeagueDeactivationJob>
+{
+    // Anchor "now". Grace window is 7 days, so the cutoff is 2026-07-12 12:00Z:
+    // a league is deactivated iff EndsOn <= cutoff.
+    private static readonly DateTime FixedNow = new(2026, 7, 19, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Cutoff = FixedNow.AddDays(-7);
+
+    public LeagueDeactivationJobTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeactivatesLeague_PastGraceWindow()
+    {
+        var leagueId = Guid.NewGuid();
+        await SeedLeagueAsync(leagueId, endsOn: FixedNow.AddDays(-9));
+
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+        await sut.ExecuteAsync();
+
+        var group = await DataContext.PickemGroups.AsNoTracking().SingleAsync(g => g.Id == leagueId);
+        Assert.Equal(FixedNow, group.DeactivatedUtc);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeactivatesLeague_ExactlyAtGraceBoundary()
+    {
+        // EndsOn == cutoff (exactly 7 days past). Predicate is EndsOn <= cutoff,
+        // so the boundary deactivates.
+        var leagueId = Guid.NewGuid();
+        await SeedLeagueAsync(leagueId, endsOn: Cutoff);
+
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+        await sut.ExecuteAsync();
+
+        var group = await DataContext.PickemGroups.AsNoTracking().SingleAsync(g => g.Id == leagueId);
+        Assert.Equal(FixedNow, group.DeactivatedUtc);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotDeactivate_WithinGraceWindow()
+    {
+        // Ended 4 days ago — still inside the 7-day grace window.
+        var leagueId = Guid.NewGuid();
+        await SeedLeagueAsync(leagueId, endsOn: FixedNow.AddDays(-4));
+
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+        await sut.ExecuteAsync();
+
+        var group = await DataContext.PickemGroups.AsNoTracking().SingleAsync(g => g.Id == leagueId);
+        Assert.Null(group.DeactivatedUtc);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotDeactivate_NullEndsOn()
+    {
+        // Season-long league (no explicit end) is out of scope for rule 1.
+        var leagueId = Guid.NewGuid();
+        await SeedLeagueAsync(leagueId, endsOn: null);
+
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+        await sut.ExecuteAsync();
+
+        var group = await DataContext.PickemGroups.AsNoTracking().SingleAsync(g => g.Id == leagueId);
+        Assert.Null(group.DeactivatedUtc);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotRestamp_AlreadyDeactivatedLeague()
+    {
+        // Already closed (manually or a prior run). EndsOn is well past, but the
+        // job must not overwrite the original DeactivatedUtc.
+        var leagueId = Guid.NewGuid();
+        var originalDeactivatedUtc = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc);
+        await SeedLeagueAsync(leagueId, endsOn: FixedNow.AddDays(-30), deactivatedUtc: originalDeactivatedUtc);
+
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+        await sut.ExecuteAsync();
+
+        var group = await DataContext.PickemGroups.AsNoTracking().SingleAsync(g => g.Id == leagueId);
+        Assert.Equal(originalDeactivatedUtc, group.DeactivatedUtc);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OnlyDeactivatesEligibleLeagues_InMixedSet()
+    {
+        var eligibleId = Guid.NewGuid();
+        var withinWindowId = Guid.NewGuid();
+        var nullEndsOnId = Guid.NewGuid();
+
+        await SeedLeagueAsync(eligibleId, endsOn: FixedNow.AddDays(-10));
+        await SeedLeagueAsync(withinWindowId, endsOn: FixedNow.AddDays(-2));
+        await SeedLeagueAsync(nullEndsOnId, endsOn: null);
+
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+        await sut.ExecuteAsync();
+
+        var groups = await DataContext.PickemGroups.AsNoTracking().ToDictionaryAsync(g => g.Id);
+        Assert.Equal(FixedNow, groups[eligibleId].DeactivatedUtc);
+        Assert.Null(groups[withinWindowId].DeactivatedUtc);
+        Assert.Null(groups[nullEndsOnId].DeactivatedUtc);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoLeagues_CompletesWithoutError()
+    {
+        var sut = Mocker.CreateInstance<LeagueDeactivationJob>();
+
+        // Should not throw with an empty table.
+        await sut.ExecuteAsync();
+
+        Assert.False(await DataContext.PickemGroups.AnyAsync());
+    }
+
+    private async Task SeedLeagueAsync(
+        Guid leagueId,
+        DateTime? endsOn,
+        DateTime? deactivatedUtc = null)
+    {
+        var group = new PickemGroup
+        {
+            Id = leagueId,
+            Name = $"Test League {leagueId:N}",
+            Sport = Sport.BaseballMlb,
+            League = League.MLB,
+            PickType = PickType.StraightUp,
+            TiebreakerType = TiebreakerType.None,
+            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
+            CommissionerUserId = Guid.NewGuid(),
+            EndsOn = endsOn,
+            DeactivatedUtc = deactivatedUtc,
+            CreatedUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CreatedBy = Guid.Empty,
+        };
+
+        await DataContext.PickemGroups.AddAsync(group);
+        await DataContext.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a nightly Hangfire recurring job that **soft-closes finished leagues** by stamping `PickemGroup.DeactivatedUtc`. Deactivation is not deletion — ~8 read sites (`/user/me`, `GetUserLeagues`, pick-import, `MatchupScheduler`, clone) already filter active-only on this field, so a stamped league drops out of active surfaces but stays viewable via the existing `IncludeDeactivated` "show past leagues" toggle.

Motivation: the UI accumulates finished/test leagues (e.g. many single-day MLB leagues) with no automated way to retire them.

## Rule 1 (only rule today)

A league with an explicit `EndsOn` is deactivated once **at least 7 days** have elapsed since that end datetime (`now - EndsOn >= 7d`). Leagues with a null `EndsOn` (season-long) are out of scope and left for a future ground rule. The job only ever stamps `null -> value`; it never reactivates.

## Changes

- **`LeagueDeactivationJob`** — `IAmARecurringJob`; injects `IDateTimeProvider`, loads tracked `PickemGroup` rows where `DeactivatedUtc == null && EndsOn != null && EndsOn <= now-7d`, stamps `DeactivatedUtc = now`, saves once. Logs the count and each deactivated league id/EndsOn.
- **DI** — `AddScoped<LeagueDeactivationJob>()` + `recurringJobManager.AddOrUpdate<LeagueDeactivationJob>(..., Cron.Daily(4))` (4am UTC, clear of the existing 2/6/9am job cluster).
- **7 unit tests** — past-window, exact 7-day boundary, within-window skip, null-`EndsOn` skip, already-deactivated not re-stamped, mixed set, empty-table no-op.

No migration required; `EndsOn` and `DeactivatedUtc` already exist on `PickemGroup`.

## Testing

- `dotnet build src/SportsData.Api` — clean, 0 warnings.
- `dotnet test --filter LeagueDeactivationJobTests` — 7/7 passing.

## Notes

First prod run will be triggered manually from the Hangfire dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Finished leagues are automatically soft-deactivated after the configured grace period.
  - A nightly job runs at 4:00 AM UTC to close eligible leagues.

- **Bug Fixes**
  - Avoids restamping leagues that are already deactivated or not yet past the grace window.
  - Handles cases with missing end dates without updating records.

- **Tests**
  - Added unit coverage for cutoff/boundary behavior, null end dates, mixed eligible/ineligible records, empty datasets, idempotency, and exception propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->