### PR TITLE
feat(leagues): add SeasonYear to PickemGroup, populate on create + clone

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandler.cs
@@ -94,8 +94,9 @@ public class CloneLeagueCommandHandler : ICloneLeagueCommandHandler
                 [new ValidationFailure(nameof(command.SourceLeagueId), "This league has ended and can't be cloned.")]);
         }
 
-        // PickemGroup has no SeasonYear column; the slate regenerates from config +
-        // season, so derive the season from the source's matchups.
+        // Derive the clone's season from the source's matchups — the authoritative
+        // record of which season the slate ran in. (The source's own SeasonYear may
+        // still be a pre-backfill default for older leagues, so matchups are safer.)
         var seasonYear = await _dbContext.PickemGroupMatchups
             .AsNoTracking()
             .Where(m => m.GroupId == source.Id)
@@ -113,6 +114,7 @@ public class CloneLeagueCommandHandler : ICloneLeagueCommandHandler
             Name = name,
             Description = source.Description,
             Sport = source.Sport,
+            SeasonYear = seasonYear,
             League = source.League,
             PickType = source.PickType,
             TiebreakerType = source.TiebreakerType,

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -184,6 +184,7 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
             Name = request.Name.Trim(),
             PickType = pickType,
             Sport = SportMode,
+            SeasonYear = seasonYear,
             TiebreakerTiePolicy = tiebreakerTiePolicy,
             TiebreakerType = tiebreakerType,
             UseConfidencePoints = request.UseConfidencePoints,

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
@@ -39,6 +39,16 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         public int? DropLowWeeksCount { get; set; }
 
         /// <summary>
+        /// The season the league belongs to (e.g. 2026). Populated at creation from
+        /// the request (falling back to the current year) and by the clone handler.
+        /// Lets active-only surfaces (e.g. the leaderboard) offer a season filter so
+        /// users can still reach deactivated leagues from prior seasons without
+        /// widening the active filter. Existing rows were backfilled to 2026 via a DB
+        /// default; earlier seasons are corrected by hand.
+        /// </summary>
+        public int SeasonYear { get; set; }
+
+        /// <summary>
         /// Inclusive start of the league window. Null = from the start of the season.
         /// Contests with StartTime &gt;= StartsOn are in-window.
         /// </summary>
@@ -86,6 +96,11 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.Property(x => x.Name).HasMaxLength(100);
 
                 builder.Property(x => x.NonStandardWeekGroupSeasonMapFilter).HasMaxLength(100);
+
+                // DB default backfills pre-existing rows to 2026 (avoids a
+                // nullable→backfill→non-nullable migration dance) and serves as a
+                // safety net; creation paths set it explicitly to the real season.
+                builder.Property(x => x.SeasonYear).HasDefaultValue(2026);
 
                 builder.Property(l => l.PickType)
                     .HasConversion<int>() // Store bitflag as int

--- a/src/SportsData.Api/Migrations/20260719093601_19JulV1_PickemGroupSeasonYear.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260719093601_19JulV1_PickemGroupSeasonYear.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260719093601_19JulV1_PickemGroupSeasonYear")]
+    partial class _19JulV1_PickemGroupSeasonYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260719093601_19JulV1_PickemGroupSeasonYear.cs
+++ b/src/SportsData.Api/Migrations/20260719093601_19JulV1_PickemGroupSeasonYear.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class _19JulV1_PickemGroupSeasonYear : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SeasonYear",
+                table: "PickemGroup",
+                type: "integer",
+                nullable: false,
+                defaultValue: 2026);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SeasonYear",
+                table: "PickemGroup");
+        }
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CloneLeague/CloneLeagueCommandHandlerTests.cs
@@ -99,6 +99,8 @@ public class CloneLeagueCommandHandlerTests : ApiTestBase<CloneLeagueCommandHand
         clone.UseConfidencePoints.Should().BeTrue();
         clone.IsPublic.Should().BeTrue();
         clone.DeactivatedUtc.Should().BeNull();
+        // No source matchups seeded, so the season falls back to the clock year.
+        clone.SeasonYear.Should().Be(NowUtc.Year);
 
         DataContext.PickemGroupMembers.AsNoTracking()
             .Should().Contain(m => m.PickemGroupId == clone.Id

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
@@ -167,6 +167,7 @@ public class CreateFootballNcaaLeagueCommandHandlerTests : ApiTestBase<CreateFoo
         saved.RankingFilter.Should().BeNull();
         saved.CommissionerUserId.Should().Be(currentUserId);
         saved.CreatedBy.Should().Be(currentUserId);
+        saved.SeasonYear.Should().Be(SeasonYear);
 
         saved.Conferences.Should().ContainSingle()
             .Which.Should().Match<PickemGroupConference>(c =>


### PR DESCRIPTION
## Summary

Follow-up to the LeagueDeactivationJob work (#529). Adds a non-nullable `SeasonYear` column to `PickemGroup`.

**Why:** the leaderboard (and pick page) filter out deactivated leagues, which means a user can't see a league that ended more than 7 days ago. That's unacceptable. A `SeasonYear` on the league lets active-only surfaces offer a **season filter** (alongside Sport / Active toggles), so a user can still reach a deactivated league from a prior season without widening the active filter.

## Changes

- **Entity** — `int SeasonYear` with a **DB default of 2026**. The default backfills pre-existing rows (avoids the `nullable → backfill script → non-nullable` migration dance) and serves as a safety net; the handful of prior-season leagues get corrected by hand.
- **`CreateLeagueCommandHandlerBase`** — persist the already-computed `seasonYear` (`request.SeasonYear ?? now.Year`) on the entity. It previously only rode the `PickemGroupCreated` event; the column was never set.
- **`CloneLeagueCommandHandler`** — persist the season derived from the source's matchups (authoritative record of which season the slate ran; safer than `source.SeasonYear` during the backfill transition). Refreshed the now-stale "PickemGroup has no SeasonYear column" comment.
- **Migration** `19JulV1_PickemGroupSeasonYear` — `AddColumn nullable:false, defaultValue:2026`.
- **Tests** — extended the create + clone happy-path unit tests with a `SeasonYear` assertion (the InMemory provider ignores the DB default, so these genuinely verify the handlers set the value).

Not included (future): the leaderboard/pick-page UI toggles that consume this column, and surfacing `SeasonYear` in league DTOs.

## Testing

- `dotnet build src/SportsData.Api` — clean, 0 warnings.
- Full `SportsData.Api.Tests.Unit` — 540 pass + 2 new assertions; one unrelated randomized test (`DisplayNameGeneratorTests`) is flaky and passes in isolation.
- Migration applied against a throwaway Postgres: column verified `integer NOT NULL DEFAULT 2026`.

## Notes

Pre-existing prior-season leagues will be corrected manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)