### PR TITLE
feat(standings): season filter + active/ended toggle on web leaderboard and mobile

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
@@ -21,6 +21,22 @@
         public int MemberCount { get; set; }
 
         /// <summary>
+        /// The season the league belongs to (e.g. 2026). Drives the leaderboard's
+        /// season filter so the client can group leagues by season without
+        /// inferring it. Server-authoritative — read straight off
+        /// <c>PickemGroup.SeasonYear</c>.
+        /// </summary>
+        public int SeasonYear { get; set; }
+
+        /// <summary>
+        /// Distinct week numbers the league has, ascending. Lets the leaderboard
+        /// source its week selector from this one call (including past-season /
+        /// deactivated leagues that <c>/user/me</c> omits). Empty for leagues with
+        /// no weeks generated yet.
+        /// </summary>
+        public List<int> SeasonWeeks { get; set; } = [];
+
+        /// <summary>
         /// Set once the group's season has passed. Non-null means the league is
         /// read-only: it cannot be cloned (the clone handler rejects it) and the
         /// UI hides its Duplicate action. Only populated when the caller opts in

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
@@ -44,6 +44,16 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
                 LeagueType = m.Group.PickType.ToString(),
                 UseConfidencePoints = m.Group.UseConfidencePoints,
                 MemberCount = m.Group.Members.Count,
+                SeasonYear = m.Group.SeasonYear,
+                // Distinct week numbers, ascending. Some leagues have multiple
+                // PickemGroupWeek rows with the same SeasonWeek (e.g. preseason +
+                // regular-season Week 1); the UI wants the unique set. Mirrors the
+                // projection on /user/me.
+                SeasonWeeks = m.Group.Weeks
+                    .Select(w => w.SeasonWeek)
+                    .Distinct()
+                    .OrderBy(w => w)
+                    .ToList(),
                 DeactivatedUtc = m.Group.DeactivatedUtc
             })
             .ToListAsync(cancellationToken);

--- a/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
@@ -58,6 +58,20 @@ describe('useSeasonLeagueSelection', () => {
     expect(result.current.seasonLeagues.map((l) => l.id).sort()).toEqual(['active', 'ended']);
   });
 
+  it('sorts leagues by name so ordering and the snap target are deterministic', () => {
+    const leagues = [
+      league({ id: 'z', name: 'Zeta', seasonYear: 2026 }),
+      league({ id: 'a', name: 'Alpha', seasonYear: 2026 }),
+      league({ id: 'm', name: 'Mu', seasonYear: 2026 }),
+    ];
+
+    const { result } = renderHook(() => useSeasonLeagueSelection(leagues));
+
+    expect(result.current.seasonLeagues.map((l) => l.name)).toEqual(['Alpha', 'Mu', 'Zeta']);
+    // Snap target is the first in sorted order, not the input order.
+    expect(result.current.selectedLeagueId).toBe('a');
+  });
+
   it('treats a prior season as all-ended: no ended filter, every league shown', () => {
     const leagues = [
       league({ id: 'current', seasonYear: 2026 }),

--- a/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useSeasonLeagueSelection } from '@/src/hooks/useSeasonLeagueSelection';
+import type { LeagueSummary } from '@/src/services/api/leaguesApi';
+
+function league(
+  partial: Partial<LeagueSummary> & { id: string; seasonYear: number },
+): LeagueSummary {
+  return {
+    name: partial.id,
+    sport: 'BaseballMlb',
+    league: 'MLB',
+    leagueType: 'StraightUp',
+    useConfidencePoints: false,
+    memberCount: 1,
+    avatarUrl: null,
+    seasonWeeks: [],
+    deactivatedUtc: null,
+    ...partial,
+  };
+}
+
+describe('useSeasonLeagueSelection', () => {
+  it('returns empty derivations when the user has no leagues', () => {
+    const { result } = renderHook(() => useSeasonLeagueSelection([]));
+
+    expect(result.current.seasons).toEqual([]);
+    expect(result.current.selectedSeason).toBeNull();
+    expect(result.current.seasonLeagues).toEqual([]);
+    expect(result.current.selectedLeagueId).toBeNull();
+  });
+
+  it('defaults to the newest season, active-only, and selects the first league', () => {
+    const leagues = [
+      league({ id: 'active', seasonYear: 2026 }),
+      league({ id: 'ended', seasonYear: 2026, deactivatedUtc: '2026-01-01T00:00:00Z' }),
+    ];
+
+    const { result } = renderHook(() => useSeasonLeagueSelection(leagues));
+
+    expect(result.current.seasons).toEqual([2026]);
+    expect(result.current.selectedSeason).toBe(2026);
+    expect(result.current.canFilterEnded).toBe(true);
+    // Active-only by default: the deactivated league is excluded.
+    expect(result.current.seasonLeagues.map((l) => l.id)).toEqual(['active']);
+    expect(result.current.selectedLeagueId).toBe('active');
+  });
+
+  it('reveals ended leagues when showEnded is toggled on', () => {
+    const leagues = [
+      league({ id: 'active', seasonYear: 2026 }),
+      league({ id: 'ended', seasonYear: 2026, deactivatedUtc: '2026-01-01T00:00:00Z' }),
+    ];
+
+    const { result } = renderHook(() => useSeasonLeagueSelection(leagues));
+
+    act(() => result.current.setShowEnded(true));
+
+    expect(result.current.seasonLeagues.map((l) => l.id).sort()).toEqual(['active', 'ended']);
+  });
+
+  it('treats a prior season as all-ended: no ended filter, every league shown', () => {
+    const leagues = [
+      league({ id: 'current', seasonYear: 2026 }),
+      league({ id: 'past', seasonYear: 2025, deactivatedUtc: '2025-12-01T00:00:00Z' }),
+    ];
+
+    const { result } = renderHook(() => useSeasonLeagueSelection(leagues));
+
+    // Newest season is the default.
+    expect(result.current.seasons).toEqual([2026, 2025]);
+    expect(result.current.selectedSeason).toBe(2026);
+
+    // Switching to the past season disables the ended filter and shows all its
+    // leagues; the selected league snaps into the new season.
+    act(() => result.current.setSelectedSeason(2025));
+
+    expect(result.current.canFilterEnded).toBe(false);
+    expect(result.current.seasonLeagues.map((l) => l.id)).toEqual(['past']);
+    expect(result.current.selectedLeagueId).toBe('past');
+  });
+});

--- a/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
+++ b/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
@@ -140,6 +140,8 @@ describe('leaguesApi.getUserLeagues', () => {
       useConfidencePoints: false,
       memberCount: 4,
       avatarUrl: null,
+      seasonYear: 2026,
+      seasonWeeks: [1, 2, 3],
       deactivatedUtc: null,
     };
     (apiClient.get as jest.Mock).mockResolvedValue({ data: [league] });

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   View,
   FlatList,
@@ -12,6 +12,7 @@ import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
 import { EmptyState } from '@/src/components/ui/EmptyState';
 import { StandingsControls } from '@/src/components/features/selectors/StandingsControls';
 import { useStandings, useUserLeagues } from '@/src/hooks/useStandings';
+import { useSeasonLeagueSelection } from '@/src/hooks/useSeasonLeagueSelection';
 import { useAuthStore } from '@/src/stores/authStore';
 import type { Standing } from '@/src/types/models';
 
@@ -80,62 +81,20 @@ export default function StandingsScreen() {
   // season and recently-ended leagues are reachable — /user/me is active-only.
   const { data: allLeagues = [], isLoading: leaguesLoading } = useUserLeagues();
 
-  const [selectedLeagueId, setSelectedLeagueId] = useState<string | null>(null);
-  const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
-  // Active-only by default to keep the league row short; the pill reveals ended.
-  const [showEnded, setShowEnded] = useState(false);
+  // Season/league selection state machine (derivation + reconciliation).
+  const {
+    seasons,
+    selectedSeason,
+    setSelectedSeason,
+    seasonLeagues,
+    selectedLeagueId,
+    setSelectedLeagueId,
+    canFilterEnded,
+    showEnded,
+    setShowEnded,
+  } = useSeasonLeagueSelection(allLeagues);
+
   const [showBots, setShowBots] = useState(true);
-
-  // Season options, newest-first, from all the user's leagues (server-
-  // authoritative seasonYear). Shown only when there's cross-season history.
-  const seasons = useMemo(
-    () => [...new Set(allLeagues.map((l) => l.seasonYear))].sort((a, b) => b - a),
-    [allLeagues],
-  );
-
-  const seasonAllLeagues = useMemo(
-    () =>
-      selectedSeason == null
-        ? []
-        : allLeagues.filter((l) => l.seasonYear === selectedSeason),
-    [allLeagues, selectedSeason],
-  );
-
-  // The "Show ended" pill applies only to the current (newest) season; a prior
-  // season is browsed as history and shows all its leagues. seasonHasActive also
-  // hides it when even the current season has no active leagues (no empty row).
-  const isCurrentSeason = selectedSeason != null && selectedSeason === seasons[0];
-  const seasonHasActive = useMemo(
-    () => seasonAllLeagues.some((l) => !l.deactivatedUtc),
-    [seasonAllLeagues],
-  );
-  const canFilterEnded = isCurrentSeason && seasonHasActive;
-
-  const seasonLeagues = useMemo(
-    () =>
-      canFilterEnded && !showEnded
-        ? seasonAllLeagues.filter((l) => !l.deactivatedUtc)
-        : seasonAllLeagues,
-    [seasonAllLeagues, canFilterEnded, showEnded],
-  );
-
-  // Keep selectedSeason valid: unset or no-longer-present snaps to the saved
-  // league's season if it's one of theirs, otherwise the newest season.
-  useEffect(() => {
-    if (seasons.length === 0) return;
-    if (selectedSeason != null && seasons.includes(selectedSeason)) return;
-    const saved = allLeagues.find((l) => l.id === selectedLeagueId);
-    setSelectedSeason(saved ? saved.seasonYear : seasons[0]);
-  }, [seasons, selectedSeason, allLeagues, selectedLeagueId]);
-
-  // Keep the selected league within the visible set (snap after switching season
-  // or toggling the pill).
-  useEffect(() => {
-    if (selectedSeason == null || seasonLeagues.length === 0) return;
-    if (!seasonLeagues.some((l) => l.id === selectedLeagueId)) {
-      setSelectedLeagueId(seasonLeagues[0].id);
-    }
-  }, [selectedSeason, seasonLeagues, selectedLeagueId]);
 
   const {
     data: standings = [],

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import {
   View,
   FlatList,
+  ScrollView,
   StyleSheet,
   RefreshControl,
 } from 'react-native';
@@ -10,6 +11,7 @@ import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
 import { EmptyState } from '@/src/components/ui/EmptyState';
+import { Button } from '@/src/components/ui/Button';
 import { StandingsControls } from '@/src/components/features/selectors/StandingsControls';
 import { useStandings, useUserLeagues } from '@/src/hooks/useStandings';
 import { useSeasonLeagueSelection } from '@/src/hooks/useSeasonLeagueSelection';
@@ -144,11 +146,28 @@ export default function StandingsScreen() {
       {standingsLoading ? (
         <LoadingSpinner message="Loading standings…" />
       ) : isError ? (
-        <EmptyState
-          icon="🏆"
-          title="No standings yet"
-          subtitle="Standings appear once the season begins."
-        />
+        // Genuine fetch failure (distinct from the not-started empty state,
+        // which the FlatList's ListEmptyComponent handles). Scrollable so
+        // pull-to-refresh works, plus an explicit Retry.
+        <ScrollView
+          contentContainerStyle={styles.errorContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={refetch}
+              tintColor={theme.tint}
+            />
+          }
+        >
+          <Text style={styles.errorIcon}>⚠️</Text>
+          <Text style={[styles.errorTitle, { color: theme.text }]}>
+            Couldn't load standings
+          </Text>
+          <Text style={[styles.errorSubtitle, { color: theme.textMuted }]}>
+            Something went wrong. Pull to refresh or tap retry.
+          </Text>
+          <Button title="Retry" variant="secondary" size="sm" onPress={() => refetch()} />
+        </ScrollView>
       ) : (
         <FlatList
           data={visibleStandings}
@@ -190,6 +209,11 @@ export default function StandingsScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   list: { padding: 14, paddingBottom: 24 },
+  // flexGrow fills the viewport so the error centers and pull-to-refresh works.
+  errorContent: { flexGrow: 1, alignItems: 'center', justifyContent: 'center', padding: 40, gap: 10 },
+  errorIcon: { fontSize: 48, marginBottom: 4 },
+  errorTitle: { fontSize: 18, fontWeight: '700', textAlign: 'center' },
+  errorSubtitle: { fontSize: 14, textAlign: 'center', lineHeight: 20, marginBottom: 6 },
   listHeader: {
     flexDirection: 'row',
     paddingHorizontal: 16,

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   View,
   FlatList,
@@ -10,7 +10,8 @@ import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
 import { EmptyState } from '@/src/components/ui/EmptyState';
-import { useStandings, useCurrentUser } from '@/src/hooks/useStandings';
+import { StandingsControls } from '@/src/components/features/selectors/StandingsControls';
+import { useStandings, useUserLeagues } from '@/src/hooks/useStandings';
 import { useAuthStore } from '@/src/stores/authStore';
 import type { Standing } from '@/src/types/models';
 
@@ -74,8 +75,67 @@ export default function StandingsScreen() {
   const theme = getTheme(scheme);
 
   const { user } = useAuthStore();
-  const { data: me } = useCurrentUser();
-  const firstLeagueId = me?.leagues?.[0]?.id;
+
+  // Source the league list from getUserLeagues (includes deactivated) so past-
+  // season and recently-ended leagues are reachable — /user/me is active-only.
+  const { data: allLeagues = [], isLoading: leaguesLoading } = useUserLeagues();
+
+  const [selectedLeagueId, setSelectedLeagueId] = useState<string | null>(null);
+  const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
+  // Active-only by default to keep the league row short; the pill reveals ended.
+  const [showEnded, setShowEnded] = useState(false);
+  const [showBots, setShowBots] = useState(true);
+
+  // Season options, newest-first, from all the user's leagues (server-
+  // authoritative seasonYear). Shown only when there's cross-season history.
+  const seasons = useMemo(
+    () => [...new Set(allLeagues.map((l) => l.seasonYear))].sort((a, b) => b - a),
+    [allLeagues],
+  );
+
+  const seasonAllLeagues = useMemo(
+    () =>
+      selectedSeason == null
+        ? []
+        : allLeagues.filter((l) => l.seasonYear === selectedSeason),
+    [allLeagues, selectedSeason],
+  );
+
+  // The "Show ended" pill applies only to the current (newest) season; a prior
+  // season is browsed as history and shows all its leagues. seasonHasActive also
+  // hides it when even the current season has no active leagues (no empty row).
+  const isCurrentSeason = selectedSeason != null && selectedSeason === seasons[0];
+  const seasonHasActive = useMemo(
+    () => seasonAllLeagues.some((l) => !l.deactivatedUtc),
+    [seasonAllLeagues],
+  );
+  const canFilterEnded = isCurrentSeason && seasonHasActive;
+
+  const seasonLeagues = useMemo(
+    () =>
+      canFilterEnded && !showEnded
+        ? seasonAllLeagues.filter((l) => !l.deactivatedUtc)
+        : seasonAllLeagues,
+    [seasonAllLeagues, canFilterEnded, showEnded],
+  );
+
+  // Keep selectedSeason valid: unset or no-longer-present snaps to the saved
+  // league's season if it's one of theirs, otherwise the newest season.
+  useEffect(() => {
+    if (seasons.length === 0) return;
+    if (selectedSeason != null && seasons.includes(selectedSeason)) return;
+    const saved = allLeagues.find((l) => l.id === selectedLeagueId);
+    setSelectedSeason(saved ? saved.seasonYear : seasons[0]);
+  }, [seasons, selectedSeason, allLeagues, selectedLeagueId]);
+
+  // Keep the selected league within the visible set (snap after switching season
+  // or toggling the pill).
+  useEffect(() => {
+    if (selectedSeason == null || seasonLeagues.length === 0) return;
+    if (!seasonLeagues.some((l) => l.id === selectedLeagueId)) {
+      setSelectedLeagueId(seasonLeagues[0].id);
+    }
+  }, [selectedSeason, seasonLeagues, selectedLeagueId]);
 
   const {
     data: standings = [],
@@ -83,54 +143,85 @@ export default function StandingsScreen() {
     refetch,
     isRefetching,
     isError,
-  } = useStandings(firstLeagueId);
+  } = useStandings(selectedLeagueId);
 
-  if (isLoading) {
+  const visibleStandings = useMemo(
+    () => (showBots ? standings : standings.filter((s) => !s.isSynthetic)),
+    [standings, showBots],
+  );
+
+  if (leaguesLoading) {
     return <LoadingSpinner message="Loading standings…" fullScreen />;
   }
 
-  if (isError || !firstLeagueId) {
+  if (allLeagues.length === 0) {
     return (
       <EmptyState
         icon="🏆"
-        title="No standings yet"
-        subtitle="Standings appear once the season begins."
+        title="No leagues yet"
+        subtitle="Join or create a league to see standings."
       />
     );
   }
 
+  const standingsLoading = isLoading || !selectedLeagueId;
+
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <FlatList
-        data={standings}
-        keyExtractor={(item) => item.userId}
-        renderItem={({ item }) => (
-          <StandingRow
-            standing={item}
-            isMe={item.userId === user?.uid}
-          />
-        )}
-        contentContainerStyle={styles.list}
-        showsVerticalScrollIndicator={false}
-        refreshControl={
-          <RefreshControl
-            refreshing={isRefetching}
-            onRefresh={refetch}
-            tintColor={theme.tint}
-          />
-        }
-        ListHeaderComponent={
-          <View style={styles.listHeader}>
-            <Text style={[styles.listHeaderText, { color: theme.textMuted }]}>Rank</Text>
-            <Text style={[styles.listHeaderText, { color: theme.textMuted, flex: 1, marginLeft: 48 }]}>Player</Text>
-            <Text style={[styles.listHeaderText, { color: theme.textMuted }]}>Points</Text>
-          </View>
-        }
-        ItemSeparatorComponent={() => <View style={{ height: 6 }} />}
-        ListEmptyComponent={
-          <EmptyState title="No standings yet" subtitle="Be the first to make your picks!" />
-        }
+      <StandingsControls
+        seasons={seasons}
+        selectedSeason={selectedSeason}
+        onSeasonChange={setSelectedSeason}
+        leagues={seasonLeagues}
+        selectedLeagueId={selectedLeagueId}
+        onLeagueChange={setSelectedLeagueId}
+        canFilterEnded={canFilterEnded}
+        showEnded={showEnded}
+        onToggleEnded={() => setShowEnded((v) => !v)}
+        showBots={showBots}
+        onToggleBots={() => setShowBots((v) => !v)}
       />
+
+      {standingsLoading ? (
+        <LoadingSpinner message="Loading standings…" />
+      ) : isError ? (
+        <EmptyState
+          icon="🏆"
+          title="No standings yet"
+          subtitle="Standings appear once the season begins."
+        />
+      ) : (
+        <FlatList
+          data={visibleStandings}
+          keyExtractor={(item) => item.userId}
+          renderItem={({ item }) => (
+            <StandingRow
+              standing={item}
+              isMe={item.userId === user?.uid}
+            />
+          )}
+          contentContainerStyle={styles.list}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={refetch}
+              tintColor={theme.tint}
+            />
+          }
+          ListHeaderComponent={
+            <View style={styles.listHeader}>
+              <Text style={[styles.listHeaderText, { color: theme.textMuted }]}>Rank</Text>
+              <Text style={[styles.listHeaderText, { color: theme.textMuted, flex: 1, marginLeft: 48 }]}>Player</Text>
+              <Text style={[styles.listHeaderText, { color: theme.textMuted }]}>Points</Text>
+            </View>
+          }
+          ItemSeparatorComponent={() => <View style={{ height: 6 }} />}
+          ListEmptyComponent={
+            <EmptyState title="No standings yet" subtitle="Be the first to make your picks!" />
+          }
+        />
+      )}
     </View>
   );
 }

--- a/src/UI/sd-mobile/src/components/features/selectors/LeagueWeekSelector.tsx
+++ b/src/UI/sd-mobile/src/components/features/selectors/LeagueWeekSelector.tsx
@@ -125,6 +125,12 @@ export function LeagueWeekSelector({
             </View>
           )}
 
+          {/* Hairline rule separating the league and week groups (only present
+              when the league row renders). */}
+          {leagues.length > 1 && (
+            <View style={[styles.divider, { backgroundColor: theme.border }]} />
+          )}
+
           {/* Week selector */}
           <View style={styles.chipRow}>
             {weeks.map((w) => {
@@ -183,6 +189,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 8,
     gap: 8,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginHorizontal: 14,
   },
   chip: {
     paddingHorizontal: 14,

--- a/src/UI/sd-mobile/src/components/features/selectors/StandingsControls.tsx
+++ b/src/UI/sd-mobile/src/components/features/selectors/StandingsControls.tsx
@@ -1,0 +1,192 @@
+import React, { useState } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  StyleSheet,
+  LayoutAnimation,
+  Platform,
+  UIManager,
+} from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import type { LeagueSummary } from '@/src/services/api/leaguesApi';
+
+// Required for LayoutAnimation on Android.
+if (Platform.OS === 'android') {
+  UIManager.setLayoutAnimationEnabledExperimental?.(true);
+}
+
+interface StandingsControlsProps {
+  /** All seasons the user has leagues in, newest-first. */
+  seasons: number[];
+  selectedSeason: number | null;
+  onSeasonChange: (year: number) => void;
+  /** Leagues within the selected season (already filtered by active/ended). */
+  leagues: LeagueSummary[];
+  selectedLeagueId: string | null;
+  onLeagueChange: (id: string) => void;
+  /** Whether the "Show ended" pill applies (current season with active leagues). */
+  canFilterEnded: boolean;
+  showEnded: boolean;
+  onToggleEnded: () => void;
+  showBots: boolean;
+  onToggleBots: () => void;
+}
+
+/**
+ * Standings header: a collapsible summary bar (matching the picks tab's
+ * LeagueWeekSelector) that expands to compact season chips (multi-season only),
+ * a wrapping row of league chips, and the Show ended / Show Bots pills — with
+ * hairline rules between the groups. Purely presentational; selection state
+ * lives in the screen.
+ */
+export function StandingsControls({
+  seasons,
+  selectedSeason,
+  onSeasonChange,
+  leagues,
+  selectedLeagueId,
+  onLeagueChange,
+  canFilterEnded,
+  showEnded,
+  onToggleEnded,
+  showBots,
+  onToggleBots,
+}: StandingsControlsProps) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  // Start collapsed if a league is already selected (e.g. returning to the tab);
+  // otherwise open so the user can pick.
+  const [collapsed, setCollapsed] = useState(() => selectedLeagueId != null);
+
+  const toggle = () => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setCollapsed((c) => !c);
+  };
+
+  const selectedLeagueName =
+    leagues.find((l) => l.id === selectedLeagueId)?.name ?? leagues[0]?.name ?? 'League';
+  const summaryLabel =
+    seasons.length > 1 && selectedSeason != null
+      ? `${selectedSeason} · ${selectedLeagueName}`
+      : selectedLeagueName;
+
+  const chip = (
+    key: string,
+    label: string,
+    active: boolean,
+    onPress: () => void,
+    extraStyle?: object,
+  ) => (
+    <TouchableOpacity
+      key={key}
+      style={[
+        styles.chip,
+        active
+          ? { backgroundColor: theme.tint, borderColor: theme.tint }
+          : { borderColor: theme.border },
+        extraStyle,
+      ]}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+    >
+      <Text
+        style={[styles.chipText, { color: active ? theme.textOnAccent : theme.textMuted }]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  // Only the sections that actually render, with a hairline rule between them.
+  const sections = [
+    seasons.length > 1 ? (
+      <View style={styles.wrapRow}>
+        {seasons.map((y) =>
+          chip(String(y), String(y), y === selectedSeason, () => onSeasonChange(y)),
+        )}
+      </View>
+    ) : null,
+    leagues.length > 1 ? (
+      <View style={styles.wrapRow}>
+        {leagues.map((l) =>
+          chip(l.id, l.name, l.id === selectedLeagueId, () => onLeagueChange(l.id), styles.leagueChip),
+        )}
+      </View>
+    ) : null,
+    <View style={styles.wrapRow}>
+      {canFilterEnded && chip('__ended', 'Show ended', showEnded, onToggleEnded)}
+      {chip('__bots', 'Show Bots', showBots, onToggleBots)}
+    </View>,
+  ].filter(Boolean);
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.card, borderBottomColor: theme.border }]}>
+      {/* Always-visible summary — tap to expand/collapse. */}
+      <TouchableOpacity style={styles.summaryBar} onPress={toggle} activeOpacity={0.7}>
+        <Text style={[styles.summaryText, { color: theme.text }]} numberOfLines={1}>
+          {summaryLabel}
+        </Text>
+        <Text style={[styles.chevron, { color: theme.textMuted }]}>{collapsed ? '▾' : '▴'}</Text>
+      </TouchableOpacity>
+
+      {!collapsed && (
+        <View style={styles.panel}>
+          {sections.map((section, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && <View style={[styles.divider, { backgroundColor: theme.border }]} />}
+              {section}
+            </React.Fragment>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  summaryBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  summaryText: {
+    fontSize: 14,
+    fontWeight: '600',
+    flexShrink: 1,
+    marginRight: 8,
+  },
+  chevron: { fontSize: 14 },
+  panel: {
+    paddingBottom: 8,
+    gap: 8,
+  },
+  wrapRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingHorizontal: 14,
+    gap: 8,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginHorizontal: 14,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 16,
+    borderWidth: 1,
+  },
+  leagueChip: { maxWidth: '100%' },
+  chipText: { fontSize: 13, fontWeight: '600' },
+});

--- a/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
+++ b/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
@@ -1,0 +1,100 @@
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
+import type { LeagueSummary } from '@/src/services/api/leaguesApi';
+
+export interface SeasonLeagueSelection {
+  /** All seasons the user has leagues in, newest-first. */
+  seasons: number[];
+  selectedSeason: number | null;
+  setSelectedSeason: (year: number) => void;
+  /** Leagues within the selected season, filtered by the active/ended toggle. */
+  seasonLeagues: LeagueSummary[];
+  selectedLeagueId: string | null;
+  setSelectedLeagueId: (id: string) => void;
+  /** Whether the "Show ended" toggle applies (current season with active leagues). */
+  canFilterEnded: boolean;
+  showEnded: boolean;
+  setShowEnded: Dispatch<SetStateAction<boolean>>;
+}
+
+/**
+ * Season/league selection state machine for the Standings screen. Pure aside
+ * from its own local state: derives the season list from allLeagues (server-
+ * authoritative seasonYear), applies the active/ended filter, and reconciles the
+ * selected season + league so they stay valid as inputs change. Extracted from
+ * the screen so this logic is independently unit-testable.
+ *
+ * Behavior preserved from the inline version:
+ *  - Season list is newest-first, distinct across all leagues.
+ *  - "Show ended" applies only to the current (newest) season that has active
+ *    leagues; a prior season is all-ended so every league shows there, and the
+ *    seasonHasActive guard avoids an empty row when even the current season has
+ *    no active leagues.
+ *  - selectedSeason falls back to the saved league's season (if it's one of
+ *    theirs) else the newest.
+ *  - selectedLeagueId snaps to the first visible league whenever it drops out of
+ *    the current season/filter.
+ */
+export function useSeasonLeagueSelection(allLeagues: LeagueSummary[]): SeasonLeagueSelection {
+  const [selectedLeagueId, setSelectedLeagueId] = useState<string | null>(null);
+  const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
+  // Active-only by default to keep the league row short; the pill reveals ended.
+  const [showEnded, setShowEnded] = useState(false);
+
+  const seasons = useMemo(
+    () => [...new Set(allLeagues.map((l) => l.seasonYear))].sort((a, b) => b - a),
+    [allLeagues],
+  );
+
+  const seasonAllLeagues = useMemo(
+    () =>
+      selectedSeason == null
+        ? []
+        : allLeagues.filter((l) => l.seasonYear === selectedSeason),
+    [allLeagues, selectedSeason],
+  );
+
+  const isCurrentSeason = selectedSeason != null && selectedSeason === seasons[0];
+  const seasonHasActive = useMemo(
+    () => seasonAllLeagues.some((l) => !l.deactivatedUtc),
+    [seasonAllLeagues],
+  );
+  const canFilterEnded = isCurrentSeason && seasonHasActive;
+
+  const seasonLeagues = useMemo(
+    () =>
+      canFilterEnded && !showEnded
+        ? seasonAllLeagues.filter((l) => !l.deactivatedUtc)
+        : seasonAllLeagues,
+    [seasonAllLeagues, canFilterEnded, showEnded],
+  );
+
+  // Keep selectedSeason valid: unset or no-longer-present snaps to the saved
+  // league's season if it's one of theirs, otherwise the newest season.
+  useEffect(() => {
+    if (seasons.length === 0) return;
+    if (selectedSeason != null && seasons.includes(selectedSeason)) return;
+    const saved = allLeagues.find((l) => l.id === selectedLeagueId);
+    setSelectedSeason(saved ? saved.seasonYear : seasons[0]);
+  }, [seasons, selectedSeason, allLeagues, selectedLeagueId]);
+
+  // Keep the selected league within the visible set (snap after switching season
+  // or toggling the pill).
+  useEffect(() => {
+    if (selectedSeason == null || seasonLeagues.length === 0) return;
+    if (!seasonLeagues.some((l) => l.id === selectedLeagueId)) {
+      setSelectedLeagueId(seasonLeagues[0].id);
+    }
+  }, [selectedSeason, seasonLeagues, selectedLeagueId]);
+
+  return {
+    seasons,
+    selectedSeason,
+    setSelectedSeason,
+    seasonLeagues,
+    selectedLeagueId,
+    setSelectedLeagueId,
+    canFilterEnded,
+    showEnded,
+    setShowEnded,
+  };
+}

--- a/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
+++ b/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
@@ -45,11 +45,16 @@ export function useSeasonLeagueSelection(allLeagues: LeagueSummary[]): SeasonLea
     [allLeagues],
   );
 
+  // Sorted by name (id tie-breaker) so the league list order and the
+  // reconciliation snap target (seasonLeagues[0]) are deterministic —
+  // getUserLeagues returns no guaranteed order.
   const seasonAllLeagues = useMemo(
     () =>
       selectedSeason == null
         ? []
-        : allLeagues.filter((l) => l.seasonYear === selectedSeason),
+        : allLeagues
+            .filter((l) => l.seasonYear === selectedSeason)
+            .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)),
     [allLeagues, selectedSeason],
   );
 

--- a/src/UI/sd-mobile/src/hooks/useStandings.ts
+++ b/src/UI/sd-mobile/src/hooks/useStandings.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { standingsApi } from '@/src/services/api/standingsApi';
+import { leaguesApi, type LeagueSummary } from '@/src/services/api/leaguesApi';
 import { useAuthStore } from '@/src/stores/authStore';
 import type { Standing, UserDto } from '@/src/types/models';
 
@@ -7,6 +8,7 @@ import type { Standing, UserDto } from '@/src/types/models';
 export const standingsKeys = {
   byLeague: (leagueId: string) => ['standings', leagueId] as const,
   me: ['user', 'me'] as const,
+  userLeagues: ['leagues', 'all'] as const,
 };
 
 // ─── Hooks ────────────────────────────────────────────────────────────────────
@@ -32,6 +34,23 @@ export function useCurrentUser() {
   return useQuery<UserDto>({
     queryKey: standingsKeys.me,
     queryFn: () => standingsApi.getMe().then((r) => r.data),
+    staleTime: 1000 * 60 * 5,
+    enabled: isInitialized && user !== null,
+  });
+}
+
+/**
+ * Every league the user belongs to, including deactivated (past-season) ones.
+ * Unlike /user/me (active-only), this drives the Standings season/league filter,
+ * carrying seasonYear + seasonWeeks + deactivatedUtc per league.
+ */
+export function useUserLeagues() {
+  const { user, isInitialized } = useAuthStore();
+
+  return useQuery<LeagueSummary[]>({
+    queryKey: standingsKeys.userLeagues,
+    queryFn: () =>
+      leaguesApi.getUserLeagues({ includeDeactivated: true }).then((r) => r.data),
     staleTime: 1000 * 60 * 5,
     enabled: isInitialized && user !== null,
   });

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -91,6 +91,18 @@ export interface LeagueSummary {
   memberCount: number;
   avatarUrl: string | null;
   /**
+   * The season the league belongs to (e.g. 2026). Server-authoritative; drives
+   * the Standings season filter so the client groups leagues by season without
+   * inferring it.
+   */
+  seasonYear: number;
+  /**
+   * Distinct week numbers the league has, ascending. Lets Standings source its
+   * week list from this one call (including past-season / deactivated leagues
+   * that /user/me omits). Empty for leagues with no weeks yet.
+   */
+  seasonWeeks: number[];
+  /**
    * Non-null once the league's season has passed: read-only, and not cloneable.
    * Only populated when the caller opts in via `includeDeactivated`; the default
    * list omits those rows entirely, so this is null for every league mobile

--- a/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.css
+++ b/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.css
@@ -61,6 +61,33 @@
   font-weight: 500;
 }
 
+/* Pill toggle (e.g. "Show ended"): outlined when off, filled accent when on. */
+.pill-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border-primary, var(--accent));
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.pill-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.pill-toggle.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
 .leaderboard-table {
   width: 100%;
   margin-top: 20px;

--- a/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
+++ b/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useUserDto } from "../../contexts/UserContext";
 import { useLeagueContext } from "../../contexts/LeagueContext";
 import LeagueSelector from "../shared/LeagueSelector";
@@ -11,8 +11,17 @@ import "./LeaderboardPage.css";
 
 function LeaderboardPage() {
   const { userDto, loading: userLoading } = useUserDto();
-  const { selectedLeagueId, setSelectedLeagueId, initializeLeagueSelection } = useLeagueContext();
-  const leagues = Object.values(userDto?.leagues || []);
+  const { selectedLeagueId, setSelectedLeagueId } = useLeagueContext();
+
+  // Source the league list from getUserLeagues (includeDeactivated) rather than
+  // userDto.leagues: the latter is active-only, so past-season / recently-ended
+  // leagues never appear. This call carries seasonYear + seasonWeeks per league,
+  // so the season filter and week selector work for every season.
+  const [allLeagues, setAllLeagues] = useState([]);
+  const [selectedSeason, setSelectedSeason] = useState(null);
+  // Active-only by default to keep the League selector short (important on
+  // mobile). The pill reveals ended/deactivated leagues on demand.
+  const [showEnded, setShowEnded] = useState(false);
 
   const [leaderboard, setLeaderboard] = useState([]);
   const [sortBy, setSortBy] = useState("totalPoints");
@@ -26,11 +35,78 @@ function LeaderboardPage() {
 
   const currentUserId = userDto?.id ?? null;
 
+  // Fetch every league the user belongs to, including deactivated ones.
   useEffect(() => {
-    if (!userLoading && leagues.length > 0) {
-      initializeLeagueSelection(leagues);
-    }
-  }, [userLoading, leagues, initializeLeagueSelection]);
+    let cancelled = false;
+    LeaguesApi.getUserLeagues({ includeDeactivated: true })
+      .then((list) => {
+        if (!cancelled) setAllLeagues(Array.isArray(list) ? list : []);
+      })
+      .catch((err) => {
+        console.error("Failed to load leagues", err);
+        if (!cancelled) setAllLeagues([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Season options, newest-first, from ALL the user's leagues (server-
+  // authoritative seasonYear). This is a primary control shown whenever there's
+  // cross-season history — independent of the "Show ended" pill.
+  const seasons = useMemo(
+    () => [...new Set(allLeagues.map((l) => l.seasonYear))].sort((a, b) => b - a),
+    [allLeagues]
+  );
+
+  // Every league in the selected season (active + ended).
+  const seasonAllLeagues = useMemo(
+    () =>
+      selectedSeason == null
+        ? []
+        : allLeagues.filter((l) => l.seasonYear === selectedSeason),
+    [allLeagues, selectedSeason]
+  );
+
+  // The "Show ended" pill applies only to the current (newest) season: a prior
+  // season is browsed as history, so its toggle is never shown regardless of
+  // whether some league there is still marked active. The extra seasonHasActive
+  // check also hides the pill (and shows everything) when the current season has
+  // no active leagues, avoiding an empty selector.
+  const isCurrentSeason = selectedSeason != null && selectedSeason === seasons[0];
+  const seasonHasActive = useMemo(
+    () => seasonAllLeagues.some((l) => !l.deactivatedUtc),
+    [seasonAllLeagues]
+  );
+  const canFilterEnded = isCurrentSeason && seasonHasActive;
+
+  // League selector options: active-only in the current season unless the pill
+  // is on; otherwise (past season, or pill on) show everything.
+  const seasonLeagues = useMemo(
+    () =>
+      canFilterEnded && !showEnded
+        ? seasonAllLeagues.filter((l) => !l.deactivatedUtc)
+        : seasonAllLeagues,
+    [seasonAllLeagues, canFilterEnded, showEnded]
+  );
+
+  // Keep selectedSeason valid: unset or no-longer-present snaps to the saved
+  // league's season if it's one of theirs, otherwise the newest season.
+  useEffect(() => {
+    if (seasons.length === 0) return;
+    if (selectedSeason != null && seasons.includes(selectedSeason)) return;
+    const saved = allLeagues.find((l) => l.id === selectedLeagueId);
+    setSelectedSeason(saved ? saved.seasonYear : seasons[0]);
+  }, [seasons, selectedSeason, allLeagues, selectedLeagueId]);
+
+  // Keep the selected league consistent with the visible set: if the current
+  // selection isn't in it (e.g. after switching seasons or toggling the pill),
+  // snap to the first league shown.
+  useEffect(() => {
+    if (selectedSeason == null || seasonLeagues.length === 0) return;
+    const inSeason = seasonLeagues.some((l) => l.id === selectedLeagueId);
+    if (!inSeason) setSelectedLeagueId(seasonLeagues[0].id);
+  }, [selectedSeason, seasonLeagues, selectedLeagueId, setSelectedLeagueId]);
 
   useEffect(() => {
     const fetchLeaderboard = async () => {
@@ -53,8 +129,10 @@ function LeaderboardPage() {
     fetchLeaderboard();
   }, [selectedLeagueId]);
 
-  // Find the selected league and its ascending week list
-  const selectedLeague = leagues.find(l => l.id === selectedLeagueId);
+  // Find the selected league and its ascending week list. Search across all
+  // leagues (not just the season subset) so seasonWeeks still resolves during
+  // the brief window before a season switch reconciles the selection.
+  const selectedLeague = allLeagues.find(l => l.id === selectedLeagueId);
   const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
   const latestSeasonWeek = seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
 
@@ -152,21 +230,50 @@ function LeaderboardPage() {
   return (
     <div className="leaderboard-container">
       <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
+        {/* Season filter — only when the user has leagues across multiple
+            seasons. Scopes the League selector below it. */}
+        {seasons.length > 1 && (
+          <div className="league-selector">
+            <label htmlFor="seasonSelect">Season:</label>
+            <select
+              id="seasonSelect"
+              value={selectedSeason ?? ""}
+              onChange={(e) => setSelectedSeason(Number(e.target.value))}
+            >
+              {seasons.map((year) => (
+                <option key={year} value={year}>{year}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
         <LeagueSelector
-          leagues={leagues}
+          leagues={seasonLeagues}
           selectedLeagueId={selectedLeagueId}
           setSelectedLeagueId={setSelectedLeagueId}
         />
-        
-        {/* Show Bots Filter */}
-        <label className="checkbox-label">
-          <input
-            type="checkbox"
-            checked={showBots}
-            onChange={(e) => setShowBots(e.target.checked)}
-          />
-          <span>Show Bots</span>
-        </label>
+
+        {/* Reveal ended/deactivated leagues. Current season only — a past
+            season is browsed as history and shows all its leagues. */}
+        {canFilterEnded && (
+          <button
+            type="button"
+            className={`pill-toggle ${showEnded ? "active" : ""}`}
+            aria-pressed={showEnded}
+            onClick={() => setShowEnded((v) => !v)}
+          >
+            Show ended
+          </button>
+        )}
+
+        <button
+          type="button"
+          className={`pill-toggle ${showBots ? "active" : ""}`}
+          aria-pressed={showBots}
+          onClick={() => setShowBots((v) => !v)}
+        >
+          Show Bots
+        </button>
       </div>
 
       {/* Tab Navigation */}

--- a/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
+++ b/src/UI/sd-ui/src/components/leaderboard/LeaderboardPage.jsx
@@ -60,11 +60,16 @@ function LeaderboardPage() {
   );
 
   // Every league in the selected season (active + ended).
+  // Sorted by name (id tie-breaker) so the League dropdown order and the
+  // reconciliation effect's seasonLeagues[0] snap target are deterministic —
+  // getUserLeagues returns no guaranteed order.
   const seasonAllLeagues = useMemo(
     () =>
       selectedSeason == null
         ? []
-        : allLeagues.filter((l) => l.seasonYear === selectedSeason),
+        : allLeagues
+            .filter((l) => l.seasonYear === selectedSeason)
+            .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)),
     [allLeagues, selectedSeason]
   );
 


### PR DESCRIPTION
## Summary

Follow-up to the `PickemGroup.SeasonYear` work (#530). Adds a **season filter** and an **active/ended toggle** to the standings/leaderboard on both web and mobile, so users can reach past-season and recently-ended (deactivated) leagues.

**Why:** the standings/leaderboard filtered active-only, so any league more than 7 days past its `EndsOn` (once the deactivation job stamps it) vanished from the page. This surfaces them behind a deliberate toggle without cluttering the default view.

## Server metadata (filtering is server-authoritative)

- `LeagueSummaryDto` gains **`SeasonYear`** (off `PickemGroup.SeasonYear`) and **`SeasonWeeks`** (distinct week numbers); `GetUserLeagues` projects both.
- The web leaderboard and mobile standings now source their league list from `getUserLeagues({ includeDeactivated: true })` instead of active-only `/user/me`, so deactivated leagues are reachable and each carries its season + weeks. The client does no season inference — it just renders `distinct(seasonYear)`.

## Web (`LeaderboardPage`)

- **Season selector** — shown only when the user has leagues across 2+ seasons.
- **"Show ended" / "Show Bots" pills** (unified styling). Active-only by default; the ended pill reveals deactivated leagues and applies to the **current season only** — a prior season is entirely ended, so the pill is hidden there and all its leagues show.
- Selection snaps to stay valid when switching season or toggling the pill.

## Mobile (`Standings`)

Went from a hardcoded `leagues[0]` (no selector at all) to a real selector:

- **`StandingsControls`** — a collapsible summary bar matching the picks tab's `LeagueWeekSelector`, expanding to compact season chips (multi-season only), wrapping league chips (no edge clipping), and Show ended / Show Bots pills, with hairline rules between the groups. Same season/ended semantics as web.
- Adds a `useUserLeagues` hook and `seasonYear` / `seasonWeeks` on the `LeagueSummary` type.
- **`LeagueWeekSelector`** (picks tab) — same hairline rule between the league and week groups, for visual consistency.

## Notes

- Deactivated prior-season leagues count toward "spanning >1 season" (so the season control shows for them) — intentional.
- Naming: web calls this surface "leaderboard", mobile calls it "standings". Left as-is here; a dedicated follow-up PR will standardize on "Standings" (matches the BE `PickemGroupUserStanding` domain).

## Testing

- API: `dotnet build src/SportsData.Api` — clean.
- Web: `CI=true react-scripts build` — compiles clean, no lint warnings.
- Mobile: `tsc --noEmit` clean; full `jest` suite 75/75 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added season-aware standings and leaderboard browsing, including selection of leagues and weeks.
  * Users can toggle viewing ended leagues (where available) and optionally show bot entries.
  * Added expandable standings controls and improved season/year context in league details.

* **UI Improvements**
  * Updated league/week selection flow and loading/error handling for standings.
  * Added pill-style toggle UI with clearer styling and separators.

* **Tests**
  * Added unit tests for season/league selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->