### PR TITLE
feat(leagues-web): My Leagues + League Detail polish, season filter, read-only past leagues

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueDetailDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueDetailDto.cs
@@ -30,6 +30,12 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
 
         public DateTime? EndsOn { get; set; }
 
+        /// <summary>
+        /// Non-null once the league's season has passed: it's read-only. The UI
+        /// hides mutating affordances (invite members, delete) when this is set.
+        /// </summary>
+        public DateTime? DeactivatedUtc { get; set; }
+
         public List<LeagueMemberDto> Members { get; set; } = [];
 
         public class LeagueMemberDto

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
@@ -6,6 +6,12 @@
 
         public string Name { get; set; } = null!;
 
+        /// <summary>
+        /// Optional commissioner-set blurb, shown under the league name on the
+        /// My Leagues cards. Null when the commissioner didn't set one.
+        /// </summary>
+        public string? Description { get; set; }
+
         public string Sport { get; set; } = null!;
 
         /// <summary>

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueById/GetLeagueByIdQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueById/GetLeagueByIdQueryHandler.cs
@@ -56,6 +56,7 @@ public class GetLeagueByIdQueryHandler : IGetLeagueByIdQueryHandler
             IsPublic = league.IsPublic,
             StartsOn = league.StartsOn,
             EndsOn = league.EndsOn,
+            DeactivatedUtc = league.DeactivatedUtc,
             Members = league.Members.Select(m => new LeagueDetailDto.LeagueMemberDto
             {
                 UserId = m.UserId,

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
@@ -39,6 +39,7 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
             {
                 Id = m.Group.Id,
                 Name = m.Group.Name,
+                Description = m.Group.Description,
                 Sport = m.Group.Sport.ToString(),
                 League = m.Group.League.ToString(),
                 LeagueType = m.Group.PickType.ToString(),

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.css
@@ -47,15 +47,29 @@
   background-color: var(--bg-modal);
   border: 2px solid var(--accent);
   border-radius: 12px;
-  padding: 2rem;
+  padding: 1rem 1.75rem 1.75rem;
 }
 
-.league-info-card h2 {
+/* Both card titles (league name + Members) share one style so the two columns
+   read as peers. */
+.league-info-card h2,
+.members-section h2 {
   color: var(--accent);
   font-size: 2rem;
-  margin-bottom: 1.5rem;
+  margin: 0 0 1rem 0;
   font-weight: 600;
   text-align: center;
+}
+
+/* Commissioner blurb as a subtitle directly under the league name. The negative
+   top margin tucks it up against the name (whose margin-bottom is 1.5rem). */
+.league-detail-byline {
+  margin: -0.75rem 0 1.25rem 0;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  font-style: italic;
+  line-height: 1.4;
 }
 
 .make-picks-button {
@@ -105,31 +119,28 @@
   background-color: var(--bg-modal);
   border: 2px solid var(--accent);
   border-radius: 12px;
-  padding: 2rem;
+  padding: 1rem 1.75rem 1.75rem;
 }
 
-.members-section h2 {
-  color: var(--accent);
-  font-size: 1.5rem;
-  margin-bottom: 1.5rem;
-  font-weight: 600;
-}
-
+/* Two responsive columns — one when the sidebar is narrow, two when there's
+   room — so the members list stops wasting horizontal space. */
 .members-list {
   list-style-type: none;
   padding: 0;
   margin: 0;
   display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 0.5rem;
 }
 
 .members-list li {
   background-color: var(--bg-card-hover);
-  padding: 1rem;
+  padding: 0.75rem 1rem;
   border-radius: 8px;
+  border-left: 4px solid var(--accent);
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 0.5rem;
   transition: background-color 0.3s ease;
 }
 
@@ -142,19 +153,11 @@
   color: var(--text-primary);
 }
 
-.member-role {
-  background-color: var(--accent);
-  color: var(--bg-modal);
-  padding: 0.25rem 0.75rem;
-  border-radius: 20px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  text-transform: capitalize;
-}
-
-.member-role.commissioner {
-  background-color: var(--warning);
-  color: var(--bg-modal);
+/* Only the commissioner is marked, with a crown — normal members carry no
+   badge. */
+.member-crown {
+  font-size: 0.95rem;
+  line-height: 1;
 }
 
 .no-members-message {
@@ -261,18 +264,9 @@
     padding: 1.5rem;
   }
 
-  .league-info-card h2 {
+  .league-info-card h2,
+  .members-section h2 {
     font-size: 1.5rem;
-  }
-
-  .members-list li {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .member-role {
-    align-self: flex-end;
   }
 
   .confirm-delete-button {

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -78,6 +78,10 @@ const LeagueDetail = () => {
   const commissionerId = commissioner?.userId;
   const isCommissioner = userDto?.id === commissionerId;
 
+  // A deactivated league is a finished season: read-only. Hide the mutating
+  // affordances (invite members, delete) entirely.
+  const isPast = !!league.deactivatedUtc;
+
   const startLabel = formatWindowBound(league.startsOn);
   const endLabel = formatWindowBound(league.endsOn);
   let windowLabel;
@@ -95,11 +99,13 @@ const LeagueDetail = () => {
       <div className="league-detail-primary">
         <div className="league-info-card">
           <h2>{league.name}</h2>
+          {league.description && (
+            <p className="league-detail-byline">{league.description}</p>
+          )}
           <Link to={`/app/picks/${league.id}`} className="make-picks-button">
             Make Your Picks
           </Link>
           <ul className="league-details-list">
-            <li><strong>Description:</strong> {league.description}</li>
             <li><strong>Pick Type:</strong> {league.pickType}</li>
             <li><strong>Tiebreaker:</strong> {league.tiebreakerType}</li>
             <li><strong>Tie Policy:</strong> {league.tiebreakerTiePolicy}</li>
@@ -125,8 +131,16 @@ const LeagueDetail = () => {
             <ul className="members-list">
               {league.members.map((member) => (
                 <li key={member.userId}>
+                  {member.role === "commissioner" && (
+                    <span
+                      className="member-crown"
+                      title="Commissioner"
+                      aria-label="Commissioner"
+                    >
+                      👑
+                    </span>
+                  )}
                   <span className="member-username">{member.username}</span>
-                  <span className={`member-role ${member.role}`}>{member.role}</span>
                 </li>
               ))}
             </ul>
@@ -135,9 +149,11 @@ const LeagueDetail = () => {
           )}
         </div>
 
-        <LeagueInvitation leagueId={league.id} leagueName={league.name} />
+        {!isPast && (
+          <LeagueInvitation leagueId={league.id} leagueName={league.name} />
+        )}
 
-        {isCommissioner && (
+        {isCommissioner && !isPast && (
           <div className="danger-zone">
           <h2>Danger Zone</h2>
           {confirmingDelete ? (

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.css
@@ -1,3 +1,47 @@
+/* The league name is the primary CTA — a link into that league's picks page. */
+.league-card-name-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.league-card-name-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* Commissioner blurb as a byline under the name. Rendered as a block span
+   INSIDE the h2 so it sits above the shared .card h2 border-bottom without
+   touching that global rule. Overrides the h2's bold/large/accent styling on
+   just this element. */
+.league-card-description {
+  display: block;
+  margin: 0.25rem 0 0 0;
+  font-size: 0.85rem;
+  font-weight: 400;
+  font-style: italic;
+  color: var(--text-secondary);
+  line-height: 1.3;
+}
+
+/* Action buttons sit in a single row (Settings [/ Duplicate]) rather than a
+   full-width vertical stack, to tighten each league card. flex:1 lets them
+   share the width evenly whether there are one or two. */
+.league-card-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+/* Gap owns the spacing here; higher specificity beats the stacked-layout margin
+   rules below (including their mobile-media variants). */
+.card .league-card-actions .submit-button {
+  flex: 1;
+  margin: 0;
+  padding: 0.6rem 0.5rem;
+  font-size: 0.85rem;
+}
+
 .submit-button {
   display: block;
   box-sizing: border-box;

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.css
@@ -1,3 +1,20 @@
+/* Header wrapper carries the underline (relocated off the h2) so the name stays
+   a pure heading and the description byline sits above the rule. Mirrors the
+   shared .card h2 border from HomePage.css. */
+.league-card-header {
+  border-bottom: 1.5px solid var(--accent);
+  padding-bottom: 0.4rem;
+  margin-bottom: 1.2rem;
+}
+
+/* The title no longer owns the shared .card h2 underline — the wrapper does.
+   Scoped tighter than .card h2 so the override wins. */
+.card .league-card-title {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin: 0;
+}
+
 /* The league name is the primary CTA — a link into that league's picks page. */
 .league-card-name-link {
   color: inherit;
@@ -10,12 +27,9 @@
   text-decoration: underline;
 }
 
-/* Commissioner blurb as a byline under the name. Rendered as a block span
-   INSIDE the h2 so it sits above the shared .card h2 border-bottom without
-   touching that global rule. Overrides the h2's bold/large/accent styling on
-   just this element. */
-.league-card-description {
-  display: block;
+/* Commissioner blurb as a byline under the name. Scoped tighter than the global
+   .card p so its subtitle styling wins. */
+.card .league-card-description {
   margin: 0.25rem 0 0 0;
   font-size: 0.85rem;
   font-weight: 400;

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
@@ -16,9 +16,14 @@ const LeagueOverviewCard = ({ league, onDuplicate }) => {
           className="league-avatar"
         />
       )}
-      <h2>
-        {league.name}
+      <h2 className="league-card-title">
+        <Link to={`/app/picks/${league.id}`} className="league-card-name-link">
+          {league.name}
+        </Link>
         {isPast && <span className="past-league-badge">Past</span>}
+        {league.description && (
+          <span className="league-card-description">{league.description}</span>
+        )}
       </h2>
       <p>
         <strong>Type:</strong> {league.leagueType}
@@ -29,21 +34,20 @@ const LeagueOverviewCard = ({ league, onDuplicate }) => {
       <p>
         <strong>Members:</strong> {league.memberCount}
       </p>
-      <Link to={`/app/league/${league.id}`} className="submit-button">
-        League Settings
-      </Link>
-      <Link to={`/app/picks/${league.id}`} className="submit-button">
-        Picks
-      </Link>
-      {onDuplicate && !isPast && (
-        <button
-          type="button"
-          className="submit-button"
-          onClick={() => onDuplicate(league)}
-        >
-          Duplicate
-        </button>
-      )}
+      <div className="league-card-actions">
+        <Link to={`/app/league/${league.id}`} className="submit-button">
+          Settings
+        </Link>
+        {onDuplicate && !isPast && (
+          <button
+            type="button"
+            className="submit-button"
+            onClick={() => onDuplicate(league)}
+          >
+            Duplicate
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
@@ -16,15 +16,17 @@ const LeagueOverviewCard = ({ league, onDuplicate }) => {
           className="league-avatar"
         />
       )}
-      <h2 className="league-card-title">
-        <Link to={`/app/picks/${league.id}`} className="league-card-name-link">
-          {league.name}
-        </Link>
-        {isPast && <span className="past-league-badge">Past</span>}
+      <div className="league-card-header">
+        <h2 className="league-card-title">
+          <Link to={`/app/picks/${league.id}`} className="league-card-name-link">
+            {league.name}
+          </Link>
+          {isPast && <span className="past-league-badge">Past</span>}
+        </h2>
         {league.description && (
-          <span className="league-card-description">{league.description}</span>
+          <p className="league-card-description">{league.description}</p>
         )}
-      </h2>
+      </div>
       <p>
         <strong>Type:</strong> {league.leagueType}
       </p>

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -9,13 +9,28 @@ import CloneLeagueDialog from "./CloneLeagueDialog";
 import "./Leagues.css"; // for grid styling
 
 const ALL_LEAGUES = "All";
+const ALL_SEASONS = "All";
+
+// Persist the My Leagues filter state so navigating into a league detail and
+// back (or returning in a later visit) restores the same view instead of
+// resetting to defaults. Stale values are absorbed by the self-healing below.
+const FILTERS_STORAGE_KEY = "leagues.filters";
+
+function loadPersistedFilters() {
+  try {
+    return JSON.parse(localStorage.getItem(FILTERS_STORAGE_KEY)) || {};
+  } catch {
+    return {};
+  }
+}
 
 const Leagues = () => {
   const [leagues, setLeagues] = useState([]);
   const [cloneTarget, setCloneTarget] = useState(null);
   const [cloning, setCloning] = useState(false);
-  const [showPast, setShowPast] = useState(false);
-  const [leagueFilter, setLeagueFilter] = useState(ALL_LEAGUES);
+  const [showPast, setShowPast] = useState(() => loadPersistedFilters().showPast ?? false);
+  const [leagueFilter, setLeagueFilter] = useState(() => loadPersistedFilters().leagueFilter ?? ALL_LEAGUES);
+  const [seasonFilter, setSeasonFilter] = useState(() => loadPersistedFilters().seasonFilter ?? ALL_SEASONS);
 
   // Always fetch past leagues so the toggle is instant rather than a refetch.
   // The user's league count is small, and every row is needed the moment they
@@ -28,6 +43,19 @@ const Leagues = () => {
   useEffect(() => {
     fetchLeagues();
   }, [fetchLeagues]);
+
+  // Persist filters so a round-trip to a league detail (or a later visit)
+  // restores the same view.
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        FILTERS_STORAGE_KEY,
+        JSON.stringify({ showPast, leagueFilter, seasonFilter })
+      );
+    } catch {
+      /* ignore storage failures (private mode, quota) */
+    }
+  }, [showPast, leagueFilter, seasonFilter]);
 
   const handleClone = async (name, inviteMembers) => {
     if (!cloneTarget) return;
@@ -61,12 +89,25 @@ const Leagues = () => {
     ? leagueFilter
     : ALL_LEAGUES;
 
-  const visibleLeagues =
-    activeFilter === ALL_LEAGUES
-      ? scoped
-      : scoped.filter((l) => l.league === activeFilter);
+  // Season years present in the current scope, newest-first. Derived from
+  // `scoped` (post-"Past" toggle) so picking a season can't strand the user on a
+  // year that isn't currently shown; the self-heal falls back to All otherwise.
+  const availableSeasons = [
+    ...new Set(scoped.map((l) => l.seasonYear).filter(Boolean)),
+  ].sort((a, b) => b - a);
 
-  const showFilterBar = hasPast || availableLeagues.length > 1;
+  const activeSeasonFilter = availableSeasons.includes(seasonFilter)
+    ? seasonFilter
+    : ALL_SEASONS;
+
+  const visibleLeagues = scoped.filter(
+    (l) =>
+      (activeFilter === ALL_LEAGUES || l.league === activeFilter) &&
+      (activeSeasonFilter === ALL_SEASONS || l.seasonYear === activeSeasonFilter)
+  );
+
+  const showFilterBar =
+    hasPast || availableLeagues.length > 1 || availableSeasons.length > 1;
 
   return (
     <div className="page-container">
@@ -79,6 +120,23 @@ const Leagues = () => {
 
       {leagues.length > 0 && showFilterBar && (
         <div className="leagues-filter-bar">
+          {availableSeasons.length > 1 && (
+            <div className="league-filter-chips" role="group" aria-label="Filter by season">
+              {[ALL_SEASONS, ...availableSeasons].map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={`league-filter-chip${
+                    activeSeasonFilter === option ? " active" : ""
+                  }`}
+                  onClick={() => setSeasonFilter(option)}
+                  aria-pressed={activeSeasonFilter === option}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          )}
           {availableLeagues.length > 1 && (
             <div className="league-filter-chips" role="group" aria-label="Filter by league">
               {[ALL_LEAGUES, ...availableLeagues].map((option) => (

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -96,21 +96,26 @@ const Leagues = () => {
     ? leagueFilter
     : ALL_LEAGUES;
 
-  // Season years present in the current scope, newest-first. Derived from
-  // `scoped` (post-"Past" toggle) so picking a season can't strand the user on a
-  // year that isn't currently shown; the self-heal falls back to All otherwise.
+  // League (sport) is the primary filter; season options derive from the
+  // league-filtered set so the two can't combine into an empty result.
+  const leaguesInLeagueFilter =
+    activeFilter === ALL_LEAGUES
+      ? scoped
+      : scoped.filter((l) => l.league === activeFilter);
+
+  // Season years available *for the active league*, newest-first. Because they
+  // come from the league-filtered set, any (league, season) pair has leagues;
+  // switching to a league that lacks the chosen season self-heals season to All.
   const availableSeasons = [
-    ...new Set(scoped.map((l) => l.seasonYear).filter(Boolean)),
+    ...new Set(leaguesInLeagueFilter.map((l) => l.seasonYear).filter(Boolean)),
   ].sort((a, b) => b - a);
 
   const activeSeasonFilter = availableSeasons.includes(seasonFilter)
     ? seasonFilter
     : ALL_SEASONS;
 
-  const visibleLeagues = scoped.filter(
-    (l) =>
-      (activeFilter === ALL_LEAGUES || l.league === activeFilter) &&
-      (activeSeasonFilter === ALL_SEASONS || l.seasonYear === activeSeasonFilter)
+  const visibleLeagues = leaguesInLeagueFilter.filter(
+    (l) => activeSeasonFilter === ALL_SEASONS || l.seasonYear === activeSeasonFilter
   );
 
   const showFilterBar =

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -17,18 +17,25 @@ const ALL_SEASONS = "All";
 const FILTERS_STORAGE_KEY = "leagues.filters";
 
 function loadPersistedFilters() {
+  let parsed;
   try {
-    return JSON.parse(localStorage.getItem(FILTERS_STORAGE_KEY)) || {};
+    parsed = JSON.parse(localStorage.getItem(FILTERS_STORAGE_KEY)) || {};
   } catch {
-    return {};
+    parsed = {};
   }
+  return {
+    ...parsed,
+    // Coerce to a strict boolean: a stale/legacy non-boolean (e.g. the string
+    // "false", which is truthy) must not accidentally enable the toggle.
+    showPast: parsed.showPast === true,
+  };
 }
 
 const Leagues = () => {
   const [leagues, setLeagues] = useState([]);
   const [cloneTarget, setCloneTarget] = useState(null);
   const [cloning, setCloning] = useState(false);
-  const [showPast, setShowPast] = useState(() => loadPersistedFilters().showPast ?? false);
+  const [showPast, setShowPast] = useState(() => loadPersistedFilters().showPast);
   const [leagueFilter, setLeagueFilter] = useState(() => loadPersistedFilters().leagueFilter ?? ALL_LEAGUES);
   const [seasonFilter, setSeasonFilter] = useState(() => loadPersistedFilters().seasonFilter ?? ALL_SEASONS);
 


### PR DESCRIPTION
## Summary

A pass of UI/UX polish on the **web** league surfaces (weekday research posture), plus the small server-side DTO additions that drive it. No mobile changes.

## My Leagues (`/app/leagues`)
- League card actions collapse to a single row (**Settings** [/ Duplicate]) instead of a full-width vertical stack; "League Settings" → "Settings"; **Picks button removed** — the **league name is now the CTA link** into that league's picks page.
- Commissioner **description as a byline** under the name (rendered inside the `h2` so it sits above the shared `.card h2` border, not below it — no change to the shared rule).
- **Season-year filter** chip row, shown only when 2+ seasons are in scope; self-heals to All if the selected season leaves scope.
- **Filter persistence** — show-past / league / season saved to `localStorage`, so navigating into a league detail and back restores the same view.

## League Detail (`/app/league/{id}`)
- Description moved out of the settings list to a **byline** under the name.
- **Deactivated (past) leagues are read-only** — invite-members and the delete Danger Zone are hidden.
- Layout polish: trimmed card top padding (the culprit was the `h2`'s un-reset default top margin), **unified the league-name and Members titles**, added the accent **left-border to member rows**, **two-column responsive members grid**, and replaced the per-member role badge with a **crown on the commissioner only**.

## Server metadata
- `LeagueSummaryDto` gains `Description` (projected in `GetUserLeagues`).
- `LeagueDetailDto` gains `DeactivatedUtc` (projected in `GetLeagueById`) so the UI can gate mutating affordances.

## Testing
- `dotnet build src/SportsData.Api` — clean.
- `CI=true react-scripts build` (sd-ui) — compiles clean, no lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added season filtering for leagues, with filter selections preserved between visits.
  - Added optional league descriptions to league cards and detail views.
  - Added deactivation (“Past”) status across league views, with commissioner-only crown indicators.

- **Bug Fixes**
  - Past leagues are now treated as finished/readonly: invitations and destructive actions are hidden, with delete restricted to commissioners.

- **Style**
  - Refined league overview and detail layouts: updated action areas, responsive member lists, and improved typography/badge styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->