### PR TITLE
feat(picks): view past leagues read-only (web + mobile) + iPad leagues grid

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -209,7 +209,7 @@ export default function PicksScreen() {
   // unpicked games to fill (React Query's enabled replaces the web's manual
   // picks-loaded gating).
   const importEnabled =
-    !picksLoading && !matchupsLoading && total > 0 && made < total;
+    !isReadOnly && !picksLoading && !matchupsLoading && total > 0 && made < total;
   const { data: availabilityData } = useImportAvailability(
     leagueId,
     selectedWeek,
@@ -244,6 +244,7 @@ export default function PicksScreen() {
 
   const handleImport = useCallback(
     (sourceLeagueId: string, contestIds: string[]) => {
+      if (isReadOnly) return; // deactivated leagues are view-only
       if (!leagueId || selectedWeek == null) return;
       importPicks.mutate(
         { leagueId, week: selectedWeek, sourceLeagueId, contestIds },
@@ -271,7 +272,7 @@ export default function PicksScreen() {
         },
       );
     },
-    [leagueId, selectedWeek, importPicks],
+    [isReadOnly, leagueId, selectedWeek, importPicks],
   );
 
   // Hide Picked is a no-op once allPicked flips true — the toggle is also

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -25,6 +25,10 @@ import { useImportAvailability, useImportPicks } from '@/src/hooks/useImportPick
 import { ImportPicksModal } from '@/src/components/features/picks/ImportPicksModal';
 import { getLeagues } from '@/src/lib/leagues';
 import { resolveSportLeague } from '@/src/utils/sportLinks';
+import { useQuery } from '@tanstack/react-query';
+import { leaguesApi } from '@/src/services/api/leaguesApi';
+import { leaguesKeys } from '../leagues';
+import type { League } from '@/src/types/models';
 import Toast from 'react-native-toast-message';
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
@@ -47,6 +51,37 @@ export default function PicksScreen() {
   // /(tabs)/picks?leagueId=<id> so the screen opens on that league directly.
   const { leagueId: leagueIdParam } = useLocalSearchParams<{ leagueId?: string }>();
 
+  // Viewing a PAST (deactivated) league: /user/me is active-only, so a deep-link
+  // param that isn't in the active set is fetched on demand (getUserLeagues
+  // includes deactivated) and rendered read-only. Reuses the My Leagues query
+  // key so arriving from that screen costs no extra request.
+  const candidatePastId = useMemo(
+    () =>
+      leagueIdParam && !leagues.some((l) => l.id === leagueIdParam)
+        ? leagueIdParam
+        : null,
+    [leagueIdParam, leagues],
+  );
+  const { data: allLeagues, isFetched: allLeaguesFetched } = useQuery({
+    queryKey: leaguesKeys.mine,
+    queryFn: () =>
+      leaguesApi.getUserLeagues({ includeDeactivated: true }).then((r) => r.data),
+    enabled: !!candidatePastId,
+  });
+  const pastLeagueAsLeague = useMemo<League | null>(() => {
+    if (!candidatePastId || !allLeagues) return null;
+    const found = allLeagues.find((l) => l.id === candidatePastId);
+    return found
+      ? { id: found.id, name: found.name, sport: found.sport, seasonWeeks: found.seasonWeeks }
+      : null;
+  }, [candidatePastId, allLeagues]);
+
+  // Active leagues plus the viewed past league — used for resolution + selector.
+  const selectableLeagues = useMemo(
+    () => (pastLeagueAsLeague ? [...leagues, pastLeagueAsLeague] : leagues),
+    [leagues, pastLeagueAsLeague],
+  );
+
   const [leagueId, setLeagueId] = useState<string | null>(null);
   const [selectedWeek, setSelectedWeek] = useState<number | null>(null);
   const [hidePicked, setHidePicked] = useState(false);
@@ -56,31 +91,39 @@ export default function PicksScreen() {
   const latestWeek = (l: { seasonWeeks?: number[] } | null | undefined) =>
     l?.seasonWeeks?.length ? l.seasonWeeks[l.seasonWeeks.length - 1] : null;
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize once and avoid rerunning on user selection
+  // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize/target, not rerun on user selection
   useEffect(() => {
-    if (leagues.length === 0) return;
-
-    // If a deep-link param targets a league the user actually belongs to,
-    // force-select it (overrides any prior in-session selection so tapping
-    // a different league from the home card always lands on that league).
-    const targeted = leagueIdParam
-      ? leagues.find((l) => l.id === leagueIdParam)
-      : null;
-    if (targeted) {
-      setLeagueId(targeted.id);
-      setSelectedWeek(latestWeek(targeted));
-      return;
+    // Deep-link param wins: an active league, or the on-demand past league.
+    if (leagueIdParam) {
+      const active = leagues.find((l) => l.id === leagueIdParam);
+      if (active) {
+        setLeagueId(active.id);
+        setSelectedWeek(latestWeek(active));
+        return;
+      }
+      if (pastLeagueAsLeague && pastLeagueAsLeague.id === leagueIdParam) {
+        setLeagueId(pastLeagueAsLeague.id);
+        setSelectedWeek(latestWeek(pastLeagueAsLeague));
+        return;
+      }
+      // Param is a past league still being fetched → wait rather than default to
+      // the first active league (that was the bug).
+      if (candidatePastId === leagueIdParam && !allLeaguesFetched) return;
+      // Otherwise it's not one of the user's leagues → fall through to default.
     }
 
-    // Otherwise initialize once to the first league in the list.
-    if (!leagueId) {
+    // Initialize once to the first active league.
+    if (!leagueId && leagues.length > 0) {
       setLeagueId(leagues[0].id);
       setSelectedWeek(latestWeek(leagues[0]));
     }
-  }, [leagues, leagueIdParam]);
+  }, [leagues, leagueIdParam, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
 
-  const selectedLeague = leagues.find((l) => l.id === leagueId) ?? null;
+  const selectedLeague = selectableLeagues.find((l) => l.id === leagueId) ?? null;
   const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
+
+  // Read-only when viewing a deactivated league — no pick submission.
+  const isReadOnly = !!pastLeagueAsLeague && leagueId === pastLeagueAsLeague.id;
 
   // A league with no weeks means this /user/me snapshot predates its slate
   // build. Create/clone return before the slate exists (~700ms), and anything
@@ -289,6 +332,13 @@ export default function PicksScreen() {
     navigation.setOptions({
       headerRight: () => (
         <View style={headerStyles.pill}>
+          {isReadOnly && (
+            <View style={[headerStyles.modeBadge, { borderColor: theme.textMuted }]}>
+              <Text style={[headerStyles.modeBadgeText, { color: theme.textMuted }]}>
+                🔒 ENDED
+              </Text>
+            </View>
+          )}
           {pickModeLabel ? (
             <View style={[headerStyles.modeBadge, { borderColor: theme.tint }]}>
               <Text style={[headerStyles.modeBadgeText, { color: theme.tint }]}>
@@ -327,7 +377,7 @@ export default function PicksScreen() {
         </View>
       ),
     });
-  }, [made, total, allPicked, hidePicked, theme, pickModeLabel]);
+  }, [made, total, allPicked, hidePicked, theme, pickModeLabel, isReadOnly]);
 
   if (meLoading) {
     return <LoadingSpinner message="Loading picks…" fullScreen />;
@@ -376,7 +426,7 @@ export default function PicksScreen() {
     <View style={[styles.container, { backgroundColor: theme.background }]}>
       {selectedWeek !== null && (
         <LeagueWeekSelector
-          leagues={leagues}
+          leagues={selectableLeagues}
           selectedLeagueId={leagueId}
           onLeagueChange={handleLeagueChange}
           selectedWeek={selectedWeek}
@@ -481,6 +531,15 @@ export default function PicksScreen() {
                 );
               }}
               onPick={(m, _choice, franchiseSeasonId) => {
+                // Past (deactivated) leagues are view-only — the season is over.
+                if (isReadOnly) {
+                  Toast.show({
+                    type: 'info',
+                    text1: 'League has ended',
+                    text2: 'Picks are read-only.',
+                  });
+                  return;
+                }
                 if (!leagueId || !selectedWeek) return;
                 submitPick.mutate({
                   pickemGroupId: leagueId,

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -153,10 +153,12 @@ export default function PicksScreen() {
   const handleLeagueChange = useCallback(
     (id: string) => {
       setLeagueId(id);
-      const league = leagues.find((l) => l.id === id);
+      // Search selectableLeagues (active + viewed past) so switching to the past
+      // league resolves its weeks instead of transiently clearing selectedWeek.
+      const league = selectableLeagues.find((l) => l.id === id);
       setSelectedWeek(latestWeek(league));
     },
-    [leagues],
+    [selectableLeagues],
   );
 
   const {

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -222,6 +222,10 @@ export default function PicksScreen() {
   // Enrich the previewed sources for display, scoped to this week's still-unpicked
   // matchups; drop sources with nothing left to offer.
   const importSources = useMemo(() => {
+    // Never offer imports for a read-only past league. Guards the race where
+    // availabilityData was cached before isReadOnly resolved (the query disables
+    // but keeps its last data).
+    if (isReadOnly) return [];
     const avail = availabilityData ?? [];
     const byContest = new Map(matchups.map((m) => [m.contestId, m]));
     return avail
@@ -242,7 +246,7 @@ export default function PicksScreen() {
           }),
       }))
       .filter((src) => src.items.length > 0);
-  }, [availabilityData, matchups, pickMap]);
+  }, [isReadOnly, availabilityData, matchups, pickMap]);
 
   const handleImport = useCallback(
     (sourceLeagueId: string, contestIds: string[]) => {
@@ -577,7 +581,7 @@ export default function PicksScreen() {
       )}
 
       <ImportPicksModal
-        visible={importOpen}
+        visible={!isReadOnly && importOpen}
         sources={importSources}
         importing={importPicks.isPending}
         onClose={() => setImportOpen(false)}

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -70,7 +70,9 @@ export default function PicksScreen() {
   });
   const pastLeagueAsLeague = useMemo<League | null>(() => {
     if (!candidatePastId || !allLeagues) return null;
-    const found = allLeagues.find((l) => l.id === candidatePastId);
+    // Only a genuinely deactivated league becomes a read-only past view — an
+    // active league merely missing from a stale /user/me snapshot must not be.
+    const found = allLeagues.find((l) => l.id === candidatePastId && l.deactivatedUtc);
     return found
       ? { id: found.id, name: found.name, sport: found.sport, seasonWeeks: found.seasonWeeks }
       : null;

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -1,5 +1,12 @@
 import React, { useState } from 'react';
-import { View, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import {
+  View,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  useWindowDimensions,
+} from 'react-native';
 import { Stack, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -19,6 +26,8 @@ export const leaguesKeys = {
 };
 
 const ALL_LEAGUES = 'All';
+const CONTENT_PADDING = 16; // matches styles.content horizontal padding
+const GRID_GAP = 12; // matches styles.grid gap
 
 /**
  * "My Leagues" — mobile's league management surface, mirroring sd-ui's
@@ -101,6 +110,16 @@ export default function LeaguesScreen() {
 
   const openPicks = (leagueId: string) =>
     router.push({ pathname: '/(tabs)/picks', params: { leagueId } } as never);
+
+  // Responsive columns: phones stay single-column; tablets flow into 2 (portrait)
+  // or 3 (wide/landscape) so the cards stop wasting horizontal space. Width-driven
+  // (not device type) so it also tracks orientation and split-screen.
+  const { width } = useWindowDimensions();
+  const columns = width >= 1000 ? 3 : width >= 680 ? 2 : 1;
+  const cardWidth =
+    columns === 1
+      ? undefined
+      : (width - CONTENT_PADDING * 2 - GRID_GAP * (columns - 1)) / columns;
 
   return (
     <>
@@ -196,18 +215,24 @@ export default function LeaguesScreen() {
             No leagues match this filter.
           </Text>
         ) : (
-          visibleLeagues.map((league) => (
-            <LeagueCard
-              key={league.id}
-              league={league}
-              expanded={expandedId === league.id}
-              onToggleExpanded={() =>
-                setExpandedId((prev) => (prev === league.id ? null : league.id))
-              }
-              onOpenPicks={() => openPicks(league.id)}
-              onDuplicate={() => setCloneTarget(league)}
-            />
-          ))
+          <View style={styles.grid}>
+            {visibleLeagues.map((league) => (
+              <View
+                key={league.id}
+                style={cardWidth != null ? { width: cardWidth } : styles.cardFull}
+              >
+                <LeagueCard
+                  league={league}
+                  expanded={expandedId === league.id}
+                  onToggleExpanded={() =>
+                    setExpandedId((prev) => (prev === league.id ? null : league.id))
+                  }
+                  onOpenPicks={() => openPicks(league.id)}
+                  onDuplicate={() => setCloneTarget(league)}
+                />
+              </View>
+            ))}
+          </View>
         )}
       </ScrollView>
 
@@ -226,6 +251,10 @@ export default function LeaguesScreen() {
 
 const styles = StyleSheet.create({
   content: { padding: 16, gap: 12 },
+  // Wrapping grid; cards top-align (flex-start) so an expanded card grows down
+  // without stretching its shorter row-mates. Item widths are set inline.
+  grid: { flexDirection: 'row', flexWrap: 'wrap', gap: 12, alignItems: 'flex-start' },
+  cardFull: { width: '100%' },
   filterBar: { gap: 10 },
   pastToggle: {
     alignSelf: 'flex-start',

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -119,7 +119,7 @@ export default function LeaguesScreen() {
   const cardWidth =
     columns === 1
       ? undefined
-      : (width - CONTENT_PADDING * 2 - GRID_GAP * (columns - 1)) / columns;
+      : Math.floor((width - CONTENT_PADDING * 2 - GRID_GAP * (columns - 1)) / columns);
 
   return (
     <>

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -102,8 +102,10 @@ const LeagueDetail = () => {
           {league.description && (
             <p className="league-detail-byline">{league.description}</p>
           )}
+          {/* Past leagues open the picks page read-only ("View Picks"); active
+              leagues go there to make picks. */}
           <Link to={`/app/picks/${league.id}`} className="make-picks-button">
-            Make Your Picks
+            {isPast ? "View Picks" : "Make Your Picks"}
           </Link>
           <ul className="league-details-list">
             <li><strong>Pick Type:</strong> {league.pickType}</li>

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -10,6 +10,7 @@ import ImportPicksDialog from "./ImportPicksDialog.jsx";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import toast from "react-hot-toast";
 import apiWrapper from "../../api/apiWrapper.js";
+import LeaguesApi from "../../api/leagues/leaguesApi";
 import LeagueWeekSelector from "./LeagueWeekSelector.jsx";
 import MatchupList from "../matchups/MatchupList.jsx";
 import MatchupGrid from "../matchups/MatchupGrid.jsx";
@@ -85,9 +86,62 @@ function PicksPage() {
   // Memoized so the init effect's dep check doesn't fire on every render
   // (a fresh `Object.values` ref every render previously triggered re-init
   // and stomped the user's dropdown selection).
-  const leagues = useMemo(
+  const activeLeagues = useMemo(
     () => Object.values(userDto?.leagues || {}),
     [userDto]
+  );
+
+  // Viewing a PAST (deactivated) league: /user/me is active-only, so when the
+  // route points at a league that isn't in the active set, fetch it on demand
+  // (getUserLeagues includes deactivated) and render it read-only. This keeps
+  // the shared chrome active-only while still allowing a historical picks view.
+  const [pastLeague, setPastLeague] = useState(null);
+  const [pastLeagueResolvedFor, setPastLeagueResolvedFor] = useState(null);
+  const pastFetchAttemptedFor = useRef(null);
+
+  useEffect(() => {
+    if (userLoading || !routeLeagueId) return;
+    // Route is an active league → no past fetch; clear any stale past state.
+    if (activeLeagues.some((l) => l.id === routeLeagueId)) {
+      pastFetchAttemptedFor.current = null;
+      setPastLeague(null);
+      setPastLeagueResolvedFor(null);
+      return;
+    }
+    // Fetch once per routeLeagueId; the ref guards against a refetch loop.
+    if (pastFetchAttemptedFor.current === routeLeagueId) return;
+    pastFetchAttemptedFor.current = routeLeagueId;
+    let cancelled = false;
+    LeaguesApi.getUserLeagues({ includeDeactivated: true })
+      .then((list) => {
+        if (cancelled) return;
+        const found = (list || []).find((l) => l.id === routeLeagueId) ?? null;
+        setPastLeague(found);
+        setPastLeagueResolvedFor(routeLeagueId);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPastLeague(null);
+        setPastLeagueResolvedFor(routeLeagueId);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userLoading, routeLeagueId, activeLeagues]);
+
+  // The fetched past league only counts when it matches the current route.
+  const viewedPastLeague = useMemo(
+    () => (pastLeague && pastLeague.id === routeLeagueId ? pastLeague : null),
+    [pastLeague, routeLeagueId]
+  );
+
+  // Read-only when viewing a deactivated league — no pick submission.
+  const isReadOnly = !!viewedPastLeague;
+
+  // Resolution + selector set: active leagues plus the viewed past league.
+  const leagues = useMemo(
+    () => (viewedPastLeague ? [...activeLeagues, viewedPastLeague] : activeLeagues),
+    [activeLeagues, viewedPastLeague]
   );
 
   // Derive the selected league from the route param. With `leagues`
@@ -226,30 +280,39 @@ function PicksPage() {
   // available. Once the URL has a valid league id, subsequent league
   // switches happen through `handleLeagueChange` (selector → navigate).
   useEffect(() => {
-    if (userLoading || leagues.length === 0) return;
+    if (userLoading || activeLeagues.length === 0) return;
 
-    initializeLeagueSelection(leagues);
+    initializeLeagueSelection(activeLeagues);
 
-    const isRouteValid =
-      routeLeagueId && leagues.some((l) => l.id === routeLeagueId);
-    if (isRouteValid) {
-      // Keep cross-page memory current with the URL-driven selection so
-      // Leaderboard/Messageboard remember the user's league after a tab
-      // switch.
+    // Active league in the URL → keep cross-page memory current so
+    // Leaderboard/Messageboard remember the user's league after a tab switch.
+    if (routeLeagueId && activeLeagues.some((l) => l.id === routeLeagueId)) {
       setGlobalLeagueId(routeLeagueId);
       return;
     }
 
+    // A loaded past (deactivated) league → valid read-only view. Don't redirect,
+    // and don't write a deactivated id into the shared chrome selection.
+    if (viewedPastLeague) return;
+
+    // A past-league URL whose on-demand fetch hasn't resolved yet → wait rather
+    // than bounce to an active league (that was the original bug).
+    if (routeLeagueId && pastLeagueResolvedFor !== routeLeagueId) return;
+
+    // Genuinely not one of the user's leagues → fall back to a remembered/first
+    // active league.
     const fallback =
-      globalLeagueId && leagues.some((l) => l.id === globalLeagueId)
+      globalLeagueId && activeLeagues.some((l) => l.id === globalLeagueId)
         ? globalLeagueId
-        : leagues[0].id;
+        : activeLeagues[0].id;
     setGlobalLeagueId(fallback);
     navigate(`/app/picks/${fallback}`, { replace: true });
   }, [
     userLoading,
-    leagues,
+    activeLeagues,
     routeLeagueId,
+    viewedPastLeague,
+    pastLeagueResolvedFor,
     globalLeagueId,
     setGlobalLeagueId,
     initializeLeagueSelection,
@@ -475,6 +538,11 @@ function PicksPage() {
   }
 
   async function handlePick(matchup, selectedFranchiseSeasonId, confidencePoints) {
+    // Past (deactivated) leagues are view-only — the season is over.
+    if (isReadOnly) {
+      toast("This league has ended — picks are read-only.", { icon: "🔒" });
+      return;
+    }
     try {
       const pickPayload = {
         pickemGroupId: routeLeagueId,
@@ -696,6 +764,14 @@ function PicksPage() {
             seasonWeeks={seasonWeeks}
           />
           <div className="pick-status-toggle-row">
+            {isReadOnly && (
+              <span
+                className="pick-mode-badge"
+                title="This league has ended — read-only"
+              >
+                🔒 Ended
+              </span>
+            )}
             {(() => {
               // Pick-mode badge. PickType enum on the wire serializes as a
               // string ("StraightUp" / "AgainstTheSpread" / "OverUnder").

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -115,7 +115,11 @@ function PicksPage() {
     LeaguesApi.getUserLeagues({ includeDeactivated: true })
       .then((list) => {
         if (cancelled) return;
-        const found = (list || []).find((l) => l.id === routeLeagueId) ?? null;
+        // Only a genuinely deactivated league becomes a read-only past view. An
+        // active league merely missing from a stale /user/me snapshot must not be
+        // caught here, or normal pick submission would be blocked.
+        const found =
+          (list || []).find((l) => l.id === routeLeagueId && l.deactivatedUtc) ?? null;
         setPastLeague(found);
         setPastLeagueResolvedFor(routeLeagueId);
       })
@@ -129,9 +133,13 @@ function PicksPage() {
     };
   }, [userLoading, routeLeagueId, activeLeagues]);
 
-  // The fetched past league only counts when it matches the current route.
+  // The fetched past league only counts when it matches the current route AND is
+  // actually deactivated (guards against an active league treated as read-only).
   const viewedPastLeague = useMemo(
-    () => (pastLeague && pastLeague.id === routeLeagueId ? pastLeague : null),
+    () =>
+      pastLeague && pastLeague.deactivatedUtc && pastLeague.id === routeLeagueId
+        ? pastLeague
+        : null,
     [pastLeague, routeLeagueId]
   );
 


### PR DESCRIPTION
## Summary

Opening a **past (deactivated) league's picks** used to bounce to the first active league — the picks page sourced its league list from active-only `/user/me` and treated any other route id as invalid. This makes a past league's picks viewable **read-only** on both platforms, and gives the mobile My Leagues screen a responsive multi-column layout on tablets.

## Past-league picks (web + mobile)

Kept `/user/me` active-only (the clean chrome contract). When the routed/param league isn't in the active set, the picks page **fetches it on demand** via `getUserLeagues({includeDeactivated:true})`, merges it for resolution + the selector, and renders it **read-only**. The init/redirect logic now **waits** for that fetch instead of defaulting to the first active league.

- **Web `PicksPage`:** `activeLeagues` + on-demand `viewedPastLeague` → combined `leagues`. `isReadOnly` gates `handlePick` (toast) and shows a **🔒 Ended** badge.
- **Mobile `picks.tsx`:** same pattern, **reusing the My Leagues query-key cache** so arriving from that screen costs no extra request. Read-only toast + **🔒 ENDED** header badge.
- **`LeagueDetail`:** a past league's button reads **"View Picks"** (→ picks read-only) instead of "Make Your Picks".

Security note: `getUserLeagues` only returns leagues the caller belongs to, so a past-league URL for a league you're not in still can't be viewed.

## iPad leagues grid (mobile)

`app/leagues.tsx` rendered `LeagueCard`s in a single column. Now a responsive flex-wrap grid via `useWindowDimensions`: **1 column** on phones, **2** on tablet portrait (≥680), **3** on wide/landscape (≥1000). Width-driven (not device type), so it tracks orientation + split-screen. Cards top-align so an expanded card grows down without stretching its row-mates.

## Notes
- Backend `DeactivatedUtc` on `LeagueDetailDto` already shipped in #532.
- Still open (tracked separately): the as-of-week point-in-time bug (records/rankings show end-of-season) that this read-only view now makes visible.

## Testing
- Web: `CI=true react-scripts build` — clean.
- Mobile: `tsc --noEmit` clean; full `jest` suite 80/80 passing.
- Verified locally (past-league picks flow + iPad grid on emulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deep-link support for past/deactivated leagues and a dedicated read-only experience.
  * Past/deactivated leagues now show an **“Ended”** badge and **“View Picks”** (instead of pick submission actions).
* **Bug Fixes**
  * Corrected initialization/redirect logic so valid past-league routes stay in place.
  * Improved league/week selection to prioritize the deep-linked past/deactivated context.
* **UI Improvements**
  * Enhanced responsive league card grid layout for mobile, tablet, and desktop.
* **Behavior Changes**
  * Disabled pick submissions and importing for ended leagues, with an informational notification instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->