### PR TITLE
fix(mobile): tablet home 2-column layout, countdown CTA columns, leagues back label

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/index.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { ScrollView, StyleSheet, RefreshControl } from 'react-native';
+import { ScrollView, View, StyleSheet, RefreshControl, useWindowDimensions } from 'react-native';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
@@ -35,6 +35,12 @@ export default function HomeScreen() {
   } = useCurrentUser();
   const leagues = useMemo(() => getLeagues(me), [me]);
 
+  // On tablet-width screens, place the countdown and leagues side by side so the
+  // countdown stops stretching awkwardly across the full width. Same width-driven
+  // breakpoint as the leagues grid.
+  const { width } = useWindowDimensions();
+  const twoColumn = width >= 680;
+
   if (meLoading) {
     return <LoadingSpinner message="Loading…" fullScreen />;
   }
@@ -55,10 +61,21 @@ export default function HomeScreen() {
       }
     >
       {hasLeagues ? (
-        <>
-          <PrimarySlotOffSeasonCountdown />
-          <YourLeaguesCard leagues={leagues} />
-        </>
+        twoColumn ? (
+          <View style={styles.twoCol}>
+            <View style={styles.col}>
+              <PrimarySlotOffSeasonCountdown />
+            </View>
+            <View style={styles.col}>
+              <YourLeaguesCard leagues={leagues} />
+            </View>
+          </View>
+        ) : (
+          <>
+            <PrimarySlotOffSeasonCountdown />
+            <YourLeaguesCard leagues={leagues} />
+          </>
+        )
       ) : (
         <PrimarySlotNewUser />
       )}
@@ -72,4 +89,8 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     gap: 16,
   },
+  // Countdown | leagues side by side; top-aligned so the leagues list can grow
+  // without stretching the countdown column.
+  twoCol: { flexDirection: 'row', gap: 16, alignItems: 'flex-start' },
+  col: { flex: 1 },
 });

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -128,6 +128,9 @@ export default function LeaguesScreen() {
           title: 'My Leagues',
           headerStyle: { backgroundColor: theme.card },
           headerTintColor: theme.text,
+          // The parent (tabs) group has no title, so iOS would otherwise render
+          // the raw route name ("(tabs)") as the back label. Show just the chevron.
+          headerBackButtonDisplayMode: 'minimal',
         }}
       />
 

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -139,7 +139,7 @@ export function PrimarySlotOffSeasonCountdown() {
             title="Go to picks"
             onPress={() => router.push('/(tabs)/picks' as never)}
             size="md"
-            fullWidth
+            style={styles.actionButton}
           />
         ) : (
           phrases.map((s) => {
@@ -159,7 +159,7 @@ export function PrimarySlotOffSeasonCountdown() {
                       )
                 }
                 size="md"
-                fullWidth
+                style={styles.actionButton}
               />
             );
           })
@@ -202,6 +202,12 @@ const styles = StyleSheet.create({
   },
   actions: {
     width: '100%',
+    flexDirection: 'row',
     gap: 8,
+  },
+  // Each CTA shares the row equally → two sports read as two columns; the lone
+  // all-live "Go to picks" button fills the row on its own.
+  actionButton: {
+    flex: 1,
   },
 });


### PR DESCRIPTION
## Summary

Mobile polish found while testing on device/emulator (iPhone + iPad). All tablet/form-factor + one iOS nav fix.

## Changes

- **Home (`app/(tabs)/index.tsx`)** — on tablet-width screens (`≥680`, same breakpoint as the leagues grid) the off-season **countdown and YourLeaguesCard sit side by side** (50/50, top-aligned) instead of the countdown stretching across the full width. Phones keep the single column.
- **Off-season countdown (`PrimarySlotOffSeasonCountdown`)** — the CTA buttons now sit in a **two-column row** (`flex: 1` each): the two sport buttons ("Create NCAAFB league" / "Create NFL league") read as columns; the lone all-live "Go to picks" button fills the row on its own.
- **My Leagues (`app/leagues.tsx`)** — `headerBackButtonDisplayMode: 'minimal'` so the iOS back button shows just the chevron instead of the leaked **`(tabs)`** route-group name (the parent group has `headerShown: false`, so iOS fell back to the raw route name).

Groundwork note: the home 2-column layout also leaves room for future league-standings widgets in the second column — a later conversation.

## Testing

- `tsc --noEmit` clean; full `jest` suite 80/80 passing.
- Previewed the tablet home 2-column + countdown CTA columns in the emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tablet layouts now display the off-season countdown and leagues card side by side for easier viewing.
  - Countdown actions are arranged in an adaptive horizontal layout, with buttons sharing available space.

- **Bug Fixes**
  - Improved the iOS “My Leagues” back button to show only the navigation chevron instead of route text.

- **Style**
  - Updated responsive spacing and button presentation for clearer, more consistent mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->