### PR TITLE
feat(matchups): point-in-time (as-of-week) team records via prior-game lag

### DIFF
--- a/docs/features/point-in-time-team-records.md
+++ b/docs/features/point-in-time-team-records.md
@@ -20,7 +20,7 @@ Today it shows the final-season record.
 team records from the **mutable, season-level `FranchiseSeason` row** (aliases
 `fsAway` / `fsHome`):
 
-```
+```sql
 fsAway."Wins", fsAway."Losses", fsAway."ConferenceWins", fsAway."ConferenceLosses"
 fsHome."Wins", fsHome."Losses", fsHome."ConferenceWins", fsHome."ConferenceLosses"
 ```

--- a/docs/features/point-in-time-team-records.md
+++ b/docs/features/point-in-time-team-records.md
@@ -1,0 +1,155 @@
+# Point-in-Time (As-Of-Week) Team Records
+
+Status: **Design / discussion** (not yet scheduled)
+Last updated: 2026-07-20
+
+## Problem
+
+On the picks / matchup surfaces, each team shows a win-loss record (e.g. "3-0",
+"6-2 (3-1)"). When viewing a **historical week** — now reachable via the
+read-only past-league picks view (PR #533) — the records render as
+**end-of-season** values instead of the record the team carried **into** that
+week.
+
+Example: LSU 2024, Week 10 vs Alabama should show LSU entering at **6-2 (3-1)**.
+Today it shows the final-season record.
+
+## Root cause
+
+`src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql` sources
+team records from the **mutable, season-level `FranchiseSeason` row** (aliases
+`fsAway` / `fsHome`):
+
+```
+fsAway."Wins", fsAway."Losses", fsAway."ConferenceWins", fsAway."ConferenceLosses"
+fsHome."Wins", fsHome."Losses", fsHome."ConferenceWins", fsHome."ConferenceLosses"
+```
+
+That row is overwritten as the season progresses, so every past week renders the
+same (latest) numbers. A point-in-time record must be **frozen in the game's
+context**, not derived from a season-level row that moves.
+
+## Key finding: ESPN's per-game record is POST-game
+
+ESPN embeds each competitor's record inside every competition document
+(`EspnEventCompetitionCompetitorRecordDto`: a `Type` — `total` / `vsconf` /
+`home` / `road` — a `Summary` like "3-0", and `Stats` for wins/losses/ties). We
+already model this as **`CompetitionCompetitorRecord` + `CompetitionCompetitorRecordStat`**
+(Producer), fed by `EventCompetitionCompetitorRecordDocumentProcessor`, keyed on
+`CompetitionCompetitorId`.
+
+**These records are post-game — they include that game's result.** Verified for
+LSU 2024 vs Alabama (`Competition` `55505ccc-…`):
+
+| Team | ESPN `total` | ESPN `vsconf` | Meaning |
+|------|-------------|---------------|---------|
+| LSU (home)   | 6-3 | 3-2 | **includes** the Alabama loss |
+| Alabama (away) | 7-2 | 4-2 | **includes** the LSU win |
+
+Cross-checked against ESPN's LSU 2024 schedule page: the Nov 9 (Alabama) row
+reads `6-3 (3-2)`; the record LSU *carried in* is the prior row (Oct 26, Texas
+A&M): `6-2 (3-1)`. So the DB and ESPN agree — the stored record is the record
+**through** the game, not entering it.
+
+Implication: we cannot display ESPN's per-game record directly; we need the
+**entering** record.
+
+## Deriving the entering record
+
+**Approach B (recommended): entering(game N) = the same team's *previous* game's
+ESPN post-game record.**
+- LSU-Alabama entering = LSU's Texas A&M record = 6-2 (3-1). Exact, no arithmetic.
+- The prior game's record already carries the correct conf / non-conf split, so
+  it can't drift from what users see on ESPN.
+- Implementation: a lag over each `FranchiseSeason`'s competitions ordered by
+  date. Season opener → 0-0 (0-0) seed.
+
+**Approach A (alternative): entering = this game's post-game record minus this
+game's result.**
+- Self-contained per row: `Winner` flag is on the competitor, conference slugs
+  decide whether the game counts toward `vsconf`.
+- More surface to get wrong (independents, FCS opponents, neutral-site
+  conference games), because we do the conference-classification + arithmetic
+  ourselves.
+- Naturally fits the live pipeline (a finalizing game has everything), but B
+  also works live (game N-1 is already final).
+
+## Approach: read N-1's existing record (no new storage)
+
+Decided 2026-07-20: **persist nothing new.** The record a team carried INTO
+game N is its record THROUGH its prior game (N-1), and that already exists in
+`CompetitionCompetitorRecord`. So no new columns, no migration, no backfill, no
+processor change — the matchup query derives the entering record on the fly by
+lagging to the team's prior competition's record. This is the leanest fix: zero
+duplication, and the existing `EventCompetitionCompetitorRecordDocumentProcessor`
+already keeps the source current (it lands each game's `total`/`vsconf`
+post-game), so "keeping it current" isn't a design concern — reads always reflect
+the latest prior record and ESPN corrections flow through automatically.
+
+Tradeoff: the read is heavier — a lateral lag per competitor plus parsing the EAV
+`Summary` string (`"6-2"`, or `"8-7-1"` for an NFL tie, split on `-`). Acceptable
+for a per-page-load query. If it ever proves too slow, flattening the post-game
+record into columns on `FootballCompetitionCompetitor` is the fallback
+optimization — not the starting point.
+
+## Read-path change (the whole implementation)
+
+`GetMatchupsByContestIds.sql`: replace the `fsAway`/`fsHome` record columns
+(mutable `FranchiseSeason`) with an entering record derived per competitor:
+
+- Lag to the team's **most-recent prior competition that has a record** (same
+  `FranchiseSeason`, same season, game date `<` this game's) and read that
+  competitor's `CompetitionCompetitorRecord` — `total` (overall W-L[-T]) and
+  `vsconf` (conference W-L[-T]).
+- Parse the `Summary` on `-`; non-conference = overall − conference if ever
+  needed (the current card shows overall + conference).
+- `COALESCE` to 0 when there's no prior record — the season opener, or (rarely) a
+  gap where the immediately-prior record isn't sourced.
+
+The API matchup DTO field names (`AwayConferenceWins`, etc.) stay; only the
+source moves. No other layer changes.
+
+## Sourcing (the only "backfill")
+
+Nothing to backfill in the schema sense — the data already lives in
+`CompetitionCompetitorRecord`. The only gap is **sourcing coverage** (below):
+2024 is ~98% there; 2025's record refs are largely un-sourced and need an
+ingestion pass. Per the happy-path decision, ship the read path first and use the
+UI itself to spot which real (FBS/NFL) games are missing data, rather than
+auditing every un-sourced row up front.
+
+The inherent latency gap — entering(N) can't show until N-1 is played *and* its
+record has landed — is short (quick-turnaround games) and shared by any approach.
+
+## Outstanding questions
+
+1. **Coverage — measured 2026-07-20** (`sql/pgsql/_debug_point_in_time_coverage.sql`).
+   2024: 3737/3802 competitions fully covered (98.3%), **0 missing competitors**,
+   65 missing records. 2025: 5/3833 records, again **0 missing competitors**. So
+   the model/processor is proven (2024) and the competitor layer is complete both
+   years — remaining work is **sourcing the record refs** (all of 2025, a
+   finished + fully-sourceable season, plus the 65 in 2024), not a design change.
+   Follow-ups: (a) characterize the 65 (2024) gaps — likely lower-division / FCS
+   games outside pick'em slates; scope the coverage query to FBS + NFL for the
+   number that actually matters; (b) source 2025 and re-run.
+1a. **Lag robustness for residual gaps.** entering(N) = the prior game's record,
+   so a missing record at game G blanks the *next* game's record for that team
+   (gaps propagate one hop). Lag to the **most-recent prior game that has a
+   record**, not strictly the immediately-prior competition, so a rare gap leaves
+   the record stale by one result rather than blank.
+2. **Read-lag cost.** The matchup query gains a lateral lag per competitor over
+   `CompetitionCompetitorRecord` (indexed by `CompetitionCompetitorId`; the lag
+   ordered by `FranchiseSeason` + game date). Confirm it stays cheap in
+   `GetMatchupsByContestIds.sql`; flattening into competitor columns is the
+   fallback only if it isn't.
+3. **`Summary` parsing.** Read the entering W/L(/T) by splitting the `Summary`
+   string (`"6-2"` / `"8-7-1"`) on `-`, or by joining the `CompetitionCompetitorRecordStat`
+   children for typed int values? Confirm which is reliably populated.
+4. **Non-football sports.** MLB is divisions, not conferences; some sports have
+   neither; ties apply to few. Football reads `total`/`vsconf`; what are the
+   equivalent record `Type`s per sport, and does the same lag pattern apply?
+5. **Edge cases.** Season opener → 0-0 (coalesce); bye weeks (chronologically-
+   prior game is fine); postseason/bowl games (entering = end of regular season);
+   quick-turnaround games where N-1's record lands close to kickoff.
+6. **ATS / other record types.** There is `FranchiseSeasonRecordAts`. Do ATS
+   leagues want a point-in-time ATS record too, or is that out of scope for v1?

--- a/sql/pgsql/_debug_franchiseSeason_record.sql
+++ b/sql/pgsql/_debug_franchiseSeason_record.sql
@@ -1,0 +1,31 @@
+select * from public."Franchise" where "Slug" = 'lsu-tigers';
+select * from public."FranchiseSeason" where "FranchiseId" = 'd2ca25ce-337e-1913-b405-69a16329efe7'; -- 8f90c51b-d906-2c02-e8e8-2ac0ac6340ae 2024
+
+select * from public."FranchiseSeasonRecord" where "FranchiseSeasonId" = '8f90c51b-d906-2c02-e8e8-2ac0ac6340ae'; -- LSU 2024
+select * from public."FranchiseSeasonRecord" where "FranchiseId" = 'd2ca25ce-337e-1913-b405-69a16329efe7';
+
+select * from public."Contest" where "SeasonYear" = 2024 and "HomeTeamFranchiseSeasonId" = '8f90c51b-d906-2c02-e8e8-2ac0ac6340ae';
+
+select * from public."Competition" where "ContestId" = '5272e3d1-cb53-a569-9435-79c3cf1581b2'; -- BAMA @ LSU 2024
+
+select * from public."CompetitionCompetitor" where "CompetitionId" = '55505ccc-c57b-222e-9d6b-120deced9bc9'; -- BAMA @ LSU 2024
+
+-- Id	CompetitionId	FranchiseSeasonId	Type	Order	HomeAway	Winner	CuratedRankCurrent	CreatedUtc	ModifiedUtc	CreatedBy	ModifiedBy	Points	Discriminator
+-- dbdbf477-edae-dc06-996c-edbcb264efc8	55505ccc-c57b-222e-9d6b-120deced9bc9	8f90c51b-d906-2c02-e8e8-2ac0ac6340ae	team	0	home	False	15	2026-02-26 02:21:39.150639-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL	NULL	FootballCompetitionCompetitor
+-- 80e3500e-63a8-701a-8471-0109bf78a6db	55505ccc-c57b-222e-9d6b-120deced9bc9	bb43b2d9-68de-5a60-6f7d-9389962e0eaf	team	1	away	True	11	2026-02-26 02:21:39.278214-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL	NULL	FootballCompetitionCompetitor
+
+select * from public."CompetitionCompetitorRecord" where "CompetitionCompetitorId" = '80e3500e-63a8-701a-8471-0109bf78a6db'; -- BAMA 2024
+
+-- Id	CompetitionCompetitorId	Type	Name	Summary	DisplayValue	Value	CreatedUtc	ModifiedUtc	CreatedBy	ModifiedBy
+-- 31809a70-1449-4ddf-be60-2d5b5b4f8dfe	80e3500e-63a8-701a-8471-0109bf78a6db	road	Road	2-2	2-2	0.5	2026-02-27 00:19:31.502895-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL
+-- f389e483-6e3a-4a75-b8ae-94b2565e1396	80e3500e-63a8-701a-8471-0109bf78a6db	home	Home	5-0	5-0	1	2026-02-27 00:19:31.46071-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL
+-- 6b056419-83f4-40f7-9a12-64dcc5bf066f	80e3500e-63a8-701a-8471-0109bf78a6db	total	overall	7-2	7-2	0.7777777777777778	2026-02-27 00:19:31.455239-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL
+-- e893f7eb-e2e4-49e8-a70c-a0c64bd7dabc	80e3500e-63a8-701a-8471-0109bf78a6db	vsconf	vs. Conf.	4-2	4-2	0.6666666666666666	2026-02-27 00:19:31.495909-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL
+
+select * from public."CompetitionCompetitorRecord" where "CompetitionCompetitorId" = 'dbdbf477-edae-dc06-996c-edbcb264efc8'; -- LSU 2024
+
+-- Id	CompetitionCompetitorId	Type	Name	Summary	DisplayValue	Value	CreatedUtc	ModifiedUtc	CreatedBy	ModifiedBy
+-- ffdd007a-b972-4cdb-bb0b-e74b0486ccfd	dbdbf477-edae-dc06-996c-edbcb264efc8	road	Road	2-1	2-1	0.6666666666666666	2026-02-27 00:19:31.339797-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL
+-- 6e0836c6-b72b-454d-bd4d-c3cf54d5263a	dbdbf477-edae-dc06-996c-edbcb264efc8	home	Home	4-1	4-1	0.8	2026-02-27 00:19:31.322044-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL
+-- 030e841a-b70b-401d-95ca-92a87cf3c4cb	dbdbf477-edae-dc06-996c-edbcb264efc8	total	overall	6-3	6-3	0.6666666666666666	2026-02-27 00:19:31.248249-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL
+-- e0c33385-dc58-41f0-ad3a-42abf46a7238	dbdbf477-edae-dc06-996c-edbcb264efc8	vsconf	vs. Conf.	3-2	3-2	0.6	2026-02-27 00:19:31.382692-05	NULL	c5b1fb0b-1350-429c-851a-4e8d30f603de	NULL

--- a/sql/pgsql/_debug_point_in_time_coverage.sql
+++ b/sql/pgsql/_debug_point_in_time_coverage.sql
@@ -1,0 +1,67 @@
+-- Point-in-time records coverage check, by season (football).
+-- See docs/features/point-in-time-team-records.md.
+--
+-- For a COMPLETED season (e.g. 2025) every team competition should have exactly
+-- 2 CompetitionCompetitor rows, each with a 'total' AND a 'vsconf'
+-- CompetitionCompetitorRecord. Any row returned by the DETAIL query is a gap.
+--
+-- For the CURRENT season, un-played games legitimately have no records yet
+-- (ESPN's competitor record is post-game), so restrict to finalized contests
+-- before trusting the numbers (see the commented FinalizedUtc filter).
+
+-- ── change the season here ──────────────────────────────────────────────────
+-- (psql) \set season 2025
+
+WITH football_comp AS (
+    SELECT co."Id" AS competition_id,
+           ct."Id" AS contest_id
+    FROM public."Contest" ct
+    JOIN public."Competition" co ON co."ContestId" = ct."Id"
+    WHERE ct."SeasonYear" = 2025
+    -- current-season only: AND ct."FinalizedUtc" IS NOT NULL
+),
+cc AS (
+    SELECT c."Id",
+           c."CompetitionId",
+           EXISTS (SELECT 1 FROM public."CompetitionCompetitorRecord" r
+                   WHERE r."CompetitionCompetitorId" = c."Id" AND r."Type" = 'total')  AS has_total,
+           EXISTS (SELECT 1 FROM public."CompetitionCompetitorRecord" r
+                   WHERE r."CompetitionCompetitorId" = c."Id" AND r."Type" = 'vsconf') AS has_vsconf
+    FROM public."CompetitionCompetitor" c
+    WHERE c."Discriminator" = 'FootballCompetitionCompetitor'
+      AND c."CompetitionId" IN (SELECT competition_id FROM football_comp)
+),
+per_comp AS (
+    SELECT fc.competition_id,
+           fc.contest_id,
+           COUNT(cc."Id")                                 AS competitor_count,
+           COUNT(cc."Id") FILTER (WHERE cc.has_total)     AS with_total,
+           COUNT(cc."Id") FILTER (WHERE cc.has_vsconf)    AS with_vsconf
+    FROM football_comp fc
+    LEFT JOIN cc ON cc."CompetitionId" = fc.competition_id
+    GROUP BY fc.competition_id, fc.contest_id
+)
+
+-- ── SUMMARY ─────────────────────────────────────────────────────────────────
+SELECT
+    COUNT(*)                                                                              AS competitions,
+    COUNT(*) FILTER (WHERE competitor_count = 2 AND with_total = 2 AND with_vsconf = 2)    AS fully_covered,
+    COUNT(*) FILTER (WHERE competitor_count <> 2)                                          AS missing_competitors,
+    COUNT(*) FILTER (WHERE competitor_count = 2 AND (with_total <> 2 OR with_vsconf <> 2)) AS missing_records
+FROM per_comp;
+
+-- ── DETAIL (uncomment to list the gaps) ─────────────────────────────────────
+-- SELECT contest_id, competition_id, competitor_count, with_total, with_vsconf
+-- FROM per_comp
+-- WHERE competitor_count <> 2 OR with_total <> 2 OR with_vsconf <> 2
+-- ORDER BY contest_id;
+
+-- ========= RESULTS ==================
+---------------------------------------
+-- 2024
+-- competitions	fully_covered	missing_competitors	missing_records
+-- 3802	3737	0	65
+---------------------------------------
+-- 2025
+-- competitions	fully_covered	missing_competitors	missing_records
+-- 3833	5	0	3828

--- a/sql/pgsql/_debug_point_in_time_validate.sql
+++ b/sql/pgsql/_debug_point_in_time_validate.sql
@@ -1,0 +1,58 @@
+-- Validate the entering-record lag used in GetMatchupsByContestIds.sql.
+-- For each of LSU 2024's games (by date), show this game's POST-game record and
+-- the ENTERING record derived by lagging to the most-recent prior game with a
+-- 'total' record. Expected: entering(row N) == post-game(row N-1), and the
+-- schedule column (e.g. Alabama Nov 9: entering 6-2 (3-1), post 6-3 (3-2)); the
+-- opener has a NULL entering (→ 0 via COALESCE in the real query).
+-- LSU 2024 FranchiseSeason = 8f90c51b-d906-2c02-e8e8-2ac0ac6340ae
+
+WITH games AS (
+    SELECT cc."Id" AS cc_id, ct."StartDateUtc"
+    FROM public."CompetitionCompetitor" cc
+    JOIN public."Competition" comp ON comp."Id" = cc."CompetitionId"
+    JOIN public."Contest" ct ON ct."Id" = comp."ContestId"
+    WHERE cc."FranchiseSeasonId" = '8f90c51b-d906-2c02-e8e8-2ac0ac6340ae'
+)
+SELECT
+    g."StartDateUtc",
+    (SELECT r."Summary" FROM public."CompetitionCompetitorRecord" r
+     WHERE r."CompetitionCompetitorId" = g.cc_id AND r."Type" = 'total')  AS post_total,
+    (SELECT r."Summary" FROM public."CompetitionCompetitorRecord" r
+     WHERE r."CompetitionCompetitorId" = g.cc_id AND r."Type" = 'vsconf') AS post_conf,
+    enter."Wins" || '-' || enter."Losses"                       AS entering_total,
+    enter."ConferenceWins" || '-' || enter."ConferenceLosses"   AS entering_conf
+FROM games g
+LEFT JOIN LATERAL (
+    SELECT
+        split_part(tot."Summary", '-', 1)::int  AS "Wins",
+        split_part(tot."Summary", '-', 2)::int  AS "Losses",
+        split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
+        split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
+    FROM public."CompetitionCompetitor" prev_cc
+    JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
+    JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+    JOIN public."CompetitionCompetitorRecord" tot
+        ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+    LEFT JOIN public."CompetitionCompetitorRecord" conf
+        ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
+    WHERE prev_cc."FranchiseSeasonId" = '8f90c51b-d906-2c02-e8e8-2ac0ac6340ae'
+      AND prev_ct."StartDateUtc" < g."StartDateUtc"
+    ORDER BY prev_ct."StartDateUtc" DESC
+    LIMIT 1
+) enter ON TRUE
+ORDER BY g."StartDateUtc";
+
+-- StartDateUtc	post_total	post_conf	entering_total	entering_conf
+-- 2024-09-01 23:30:00+00	0-1	0-0	NULL	NULL
+-- 2024-09-07 23:30:00+00	1-1	0-0	0-1	0-0
+-- 2024-09-14 16:00:00+00	2-1	1-0	1-1	0-0
+-- 2024-09-21 19:30:00+00	3-1	1-0	2-1	1-0
+-- 2024-09-28 23:45:00+00	4-1	1-0	3-1	1-0
+-- 2024-10-12 23:30:00+00	5-1	2-0	4-1	1-0
+-- 2024-10-19 23:00:00+00	6-1	3-0	5-1	2-0
+-- 2024-10-26 23:30:00+00	6-2	3-1	6-1	3-0
+-- 2024-11-10 00:30:00+00	6-3	3-2	6-2	3-1
+-- 2024-11-16 20:30:00+00	6-4	3-3	6-3	3-2
+-- 2024-11-24 00:45:00+00	7-4	4-3	6-4	3-3
+-- 2024-12-01 00:00:00+00	8-4	5-3	7-4	4-3
+-- 2024-12-31 20:30:00+00	9-4	5-3	8-4	5-3

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -122,6 +122,10 @@ LEFT JOIN LATERAL (
   INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
   INNER JOIN public."CompetitionCompetitorRecord" tot
     ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+  -- LEFT (not INNER) on purpose: an FBS independent (Notre Dame, UConn, …) has
+  -- no conference and carries no 'vsconf' record, so INNER would exclude ALL
+  -- their games and blank the overall record. 'total' (the INNER join above) is
+  -- the authoritative driver; a missing 'vsconf' correctly yields 0-0 conference.
   LEFT JOIN public."CompetitionCompetitorRecord" conf
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
   WHERE prev_cc."FranchiseSeasonId" = fsAway."Id"

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -14,16 +14,16 @@ SELECT
   COALESCE(fslDarkAway."Uri", flDarkAway."Uri") AS "AwayLogoUriDark",
   fAway."Slug" AS "AwaySlug", fAway."ColorCodeHex" AS "AwayColor",
   fsrdAway."Current" AS "AwayRank", gsAway."Slug" AS "AwayConferenceSlug",
-  fsAway."Wins" AS "AwayWins", fsAway."Losses" AS "AwayLosses",
-  fsAway."ConferenceWins" AS "AwayConferenceWins", fsAway."ConferenceLosses" AS "AwayConferenceLosses",
+  COALESCE(enterAway."Wins", 0) AS "AwayWins", COALESCE(enterAway."Losses", 0) AS "AwayLosses",
+  COALESCE(enterAway."ConferenceWins", 0) AS "AwayConferenceWins", COALESCE(enterAway."ConferenceLosses", 0) AS "AwayConferenceLosses",
   fHome."DisplayName" AS "Home", fHome."Abbreviation" AS "HomeShort",
   fsHome."Id" AS "HomeFranchiseSeasonId",
   COALESCE(fslHome."Uri", flHome."Uri") AS "HomeLogoUri",
   COALESCE(fslDarkHome."Uri", flDarkHome."Uri") AS "HomeLogoUriDark",
   fHome."Slug" AS "HomeSlug", fHome."ColorCodeHex" AS "HomeColor",
   fsrdHome."Current" AS "HomeRank", gsHome."Slug" AS "HomeConferenceSlug",
-  fsHome."Wins" AS "HomeWins", fsHome."Losses" AS "HomeLosses",
-  fsHome."ConferenceWins" AS "HomeConferenceWins", fsHome."ConferenceLosses" AS "HomeConferenceLosses",
+  COALESCE(enterHome."Wins", 0) AS "HomeWins", COALESCE(enterHome."Losses", 0) AS "HomeLosses",
+  COALESCE(enterHome."ConferenceWins", 0) AS "HomeConferenceWins", COALESCE(enterHome."ConferenceLosses", 0) AS "HomeConferenceLosses",
   co."Details" AS "SpreadCurrentDetails", co."Spread" AS "SpreadCurrent",
   cto."SpreadPointsOpen" AS "SpreadOpen",
   co."OverUnder" AS "OverUnderCurrent", co."TotalPointsOpen" AS "OverUnderOpen",
@@ -105,6 +105,30 @@ LEFT JOIN LATERAL (
   ORDER BY sw."StartDate" DESC LIMIT 1
 ) fsrAway ON TRUE
 LEFT JOIN public."FranchiseSeasonRankingDetail" fsrdAway ON fsrdAway."FranchiseSeasonRankingId" = fsrAway."Id"
+-- Entering record: the record the away team carried INTO this game = its record
+-- THROUGH its most-recent prior competition that has a 'total' record (same
+-- FranchiseSeason, earlier StartDate). Point-in-time, unlike the mutable
+-- FranchiseSeason W/L. Parsed from ESPN's CompetitionCompetitorRecord Summary
+-- ("6-2"). Null (→ 0 via COALESCE) at the season opener or an un-sourced gap.
+-- See docs/features/point-in-time-team-records.md.
+LEFT JOIN LATERAL (
+  SELECT
+    split_part(tot."Summary", '-', 1)::int  AS "Wins",
+    split_part(tot."Summary", '-', 2)::int  AS "Losses",
+    split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
+    split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
+  FROM public."CompetitionCompetitor" prev_cc
+  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
+  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionCompetitorRecord" tot
+    ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+  LEFT JOIN public."CompetitionCompetitorRecord" conf
+    ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
+  WHERE prev_cc."FranchiseSeasonId" = fsAway."Id"
+    AND prev_ct."StartDateUtc" < c."StartDateUtc"
+  ORDER BY prev_ct."StartDateUtc" DESC
+  LIMIT 1
+) enterAway ON TRUE
 INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
 INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
 LEFT JOIN LATERAL (
@@ -153,6 +177,25 @@ LEFT JOIN LATERAL (
   ORDER BY sw."StartDate" DESC LIMIT 1
 ) fsrHome ON TRUE
 LEFT JOIN public."FranchiseSeasonRankingDetail" fsrdHome ON fsrdHome."FranchiseSeasonRankingId" = fsrHome."Id"
+-- Entering record for the home team — same lag as enterAway above.
+LEFT JOIN LATERAL (
+  SELECT
+    split_part(tot."Summary", '-', 1)::int  AS "Wins",
+    split_part(tot."Summary", '-', 2)::int  AS "Losses",
+    split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
+    split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
+  FROM public."CompetitionCompetitor" prev_cc
+  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
+  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionCompetitorRecord" tot
+    ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+  LEFT JOIN public."CompetitionCompetitorRecord" conf
+    ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
+  WHERE prev_cc."FranchiseSeasonId" = fsHome."Id"
+    AND prev_ct."StartDateUtc" < c."StartDateUtc"
+  ORDER BY prev_ct."StartDateUtc" DESC
+  LIMIT 1
+) enterHome ON TRUE
 WHERE c."Id" = ANY(@ContestIds)
 GROUP BY
   c."SeasonWeekId", sw_contest."EndDate", c."Id", c."StartDateUtc", cn."Headline", cs."StatusTypeName", cs."StatusDescription",
@@ -160,13 +203,13 @@ GROUP BY
   fAway."DisplayName", fAway."DisplayNameShort", fsAway."Id",
   flAway."Uri", fslAway."Uri", flDarkAway."Uri", fslDarkAway."Uri", fAway."Slug",
   fsrdAway."Current", gsAway."Slug",
-  fsAway."Wins", fsAway."Losses", fsAway."ConferenceWins", fsAway."ConferenceLosses",
+  enterAway."Wins", enterAway."Losses", enterAway."ConferenceWins", enterAway."ConferenceLosses",
   fAway."Abbreviation", fAway."ColorCodeHex",
   fHome."Abbreviation", fHome."ColorCodeHex",
   fHome."DisplayName", fHome."DisplayNameShort", fsHome."Id",
   flHome."Uri", fslHome."Uri", flDarkHome."Uri", fslDarkHome."Uri", fHome."Slug",
   fsrdHome."Current", gsHome."Slug",
-  fsHome."Wins", fsHome."Losses", fsHome."ConferenceWins", fsHome."ConferenceLosses",
+  enterHome."Wins", enterHome."Losses", enterHome."ConferenceWins", enterHome."ConferenceLosses",
   co."Details", co."Spread", co."OverUnder", co."OverOdds", co."UnderOdds",
   co."ProviderName",
   cto."SpreadPointsOpen", co."TotalPointsOpen",


### PR DESCRIPTION
## Summary

Matchup / pick cards showed **end-of-season** records when viewing a historical week (now reachable via the read-only past-league picks view, #533) because `GetMatchupsByContestIds.sql` sourced W/L from the **mutable `FranchiseSeason`** row, which is overwritten as the season advances.

ESPN's per-game competitor record (`CompetitionCompetitorRecord`) is **post-game** — it includes that game's result — so the record a team carried *into* a game is its record *through its prior game*. This derives the **entering** record at read time by lagging to the prior game.

## Change — read-path only

**No schema, migration, backfill, or processor change.** The point-in-time data already lives in `CompetitionCompetitorRecord`; we just read it.

- Added `enterAway` / `enterHome` lateral joins that lag to each team's **most-recent prior competition with a `total` record** (same `FranchiseSeason`, earlier `StartDateUtc`), parsing `total` + `vsconf` `Summary` into ints. `COALESCE` to 0 at the season opener or an un-sourced gap.
- Swapped the four record columns per side (SELECT + GROUP BY) from `fsAway`/`fsHome` to `enterAway`/`enterHome`. Matchup DTO field names (`AwayWins`, `AwayConferenceWins`, …) and every other layer are unchanged.
- Bonus consistency: the ranking lateral was *already* point-in-time, so records now match — the whole card is as-of-week.

## Validation

`sql/pgsql/_debug_point_in_time_validate.sql` (LSU 2024): each game's entering record equals the prior game's post-game record, including the Alabama game (**entering 6-2 (3-1)**, post 6-3 (3-2)), byes, and the bowl. Opener is NULL → 0.

## Docs / follow-up

- Design + decisions: `docs/features/point-in-time-team-records.md`.
- Coverage: `sql/pgsql/_debug_point_in_time_coverage.sql` — 2024 is ~98% covered; **2025's competitor records are largely un-sourced**. Per the happy-path plan, this ships first and the UI itself surfaces which real (FBS/NFL) games lack data. **Immediate follow-up: a one-time sourcing pass for 2025** competitor records.

Note: this is a Producer read query; it needs a Producer deploy to take effect. No API/UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Matchups now show each team’s win-loss and conference records as they stood before the game (point-in-time “entering” records) rather than updated season totals.
  * Opening games correctly display 0–0 records when there is no prior record available.
  * Improved behavior when historical record data is incomplete, reducing incorrect or inconsistent matchup record displays.
* **Documentation**
  * Added guidance on point-in-time team records, coverage expectations, and known edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->