### PR TITLE
fix(producer): capture dropped record-level fields on CompetitionCompetitorRecord

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessor.cs
@@ -220,6 +220,10 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
             CompetitionCompetitorId = competitorId,
             Type = dto.Type,
             Name = dto.Name,
+            Abbreviation = dto.Abbreviation,
+            DisplayName = dto.DisplayName,
+            ShortDisplayName = dto.ShortDisplayName,
+            Description = dto.Description,
             Summary = dto.Summary,
             DisplayValue = dto.DisplayValue,
             Value = dto.Value,
@@ -251,6 +255,10 @@ public class EventCompetitionCompetitorRecordDocumentProcessor<TDataContext> : D
 
         // Update record properties
         existingRecord.Name = dto.Name;
+        existingRecord.Abbreviation = dto.Abbreviation;
+        existingRecord.DisplayName = dto.DisplayName;
+        existingRecord.ShortDisplayName = dto.ShortDisplayName;
+        existingRecord.Description = dto.Description;
         existingRecord.Summary = dto.Summary;
         existingRecord.DisplayValue = dto.DisplayValue;
         existingRecord.Value = dto.Value;

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorRecord.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorRecord.cs
@@ -2,8 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 using SportsData.Core.Infrastructure.Data.Entities;
-using SportsData.Producer.Infrastructure.Data.Common;
-using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Infrastructure.Data.Entities;
 
@@ -16,6 +14,17 @@ public class CompetitionCompetitorRecord : CanonicalEntityBase<Guid>
     public required string Type { get; set; }
 
     public string? Name { get; set; }
+
+    // Record-level display fields ESPN ships on every record — previously
+    // dropped at the entity-mapping step (the DTO captured them, the entity
+    // never persisted them). See docs/features/competition-competitor-record-canonical.md.
+    public string? Abbreviation { get; set; }
+
+    public string? DisplayName { get; set; }
+
+    public string? ShortDisplayName { get; set; }
+
+    public string? Description { get; set; }
 
     public string? Summary { get; set; }
 
@@ -35,6 +44,10 @@ public class CompetitionCompetitorRecord : CanonicalEntityBase<Guid>
             builder.Property(x => x.CompetitionCompetitorId).IsRequired();
             builder.Property(x => x.Type).IsRequired().HasMaxLength(50);
             builder.Property(x => x.Name).HasMaxLength(100);
+            builder.Property(x => x.Abbreviation).HasMaxLength(50);
+            builder.Property(x => x.DisplayName).HasMaxLength(100);
+            builder.Property(x => x.ShortDisplayName).HasMaxLength(50);
+            builder.Property(x => x.Description).HasMaxLength(200);
             builder.Property(x => x.Summary).HasMaxLength(50);
             builder.Property(x => x.DisplayValue).HasMaxLength(50);
             builder.Property(x => x.Value);

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorRecordStat.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionCompetitorRecordStat.cs
@@ -2,8 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 using SportsData.Core.Infrastructure.Data.Entities;
-using SportsData.Producer.Infrastructure.Data.Common;
-using SportsData.Producer.Infrastructure.Data.Entities;
 
 namespace SportsData.Producer.Infrastructure.Data.Entities;
 

--- a/src/SportsData.Producer/Migrations/Baseball/20260721134341_21JulV1_CompetitionCompetitorRecordFields.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260721134341_21JulV1_CompetitionCompetitorRecordFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260721134341_21JulV1_CompetitionCompetitorRecordFields")]
+    partial class _21JulV1_CompetitionCompetitorRecordFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260721134341_21JulV1_CompetitionCompetitorRecordFields.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260721134341_21JulV1_CompetitionCompetitorRecordFields.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class _21JulV1_CompetitionCompetitorRecordFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Abbreviation",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Abbreviation",
+                table: "CompetitionCompetitorRecord");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "CompetitionCompetitorRecord");
+
+            migrationBuilder.DropColumn(
+                name: "DisplayName",
+                table: "CompetitionCompetitorRecord");
+
+            migrationBuilder.DropColumn(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorRecord");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/20260721134334_21JulV1_CompetitionCompetitorRecordFields.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260721134334_21JulV1_CompetitionCompetitorRecordFields.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Baseball;
+using SportsData.Producer.Infrastructure.Data.Football;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Baseball
+namespace SportsData.Producer.Migrations.Football
 {
-    [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(FootballDataContext))]
+    [Migration("20260721134334_21JulV1_CompetitionCompetitorRecordFields")]
+    partial class _21JulV1_CompetitionCompetitorRecordFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,233 +415,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<bool>("Active")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("ConfigurationId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int>("Season")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SeasonType")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SplitTypeId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
-
-                    b.ToTable("AthleteSeasonHotZone", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("AtBats")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("AthleteSeasonHotZoneId")
-                        .HasColumnType("uuid");
-
-                    b.Property<double?>("BattingAvg")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("BattingAvgScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int?>("Hits")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<double?>("Slugging")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("SluggingScore")
-                        .HasPrecision(7, 4)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("XMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMax")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double>("YMin")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("ZoneId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonHotZoneId");
-
-                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("AthleteRef")
-                        .HasColumnType("text");
-
-                    b.Property<Guid>("CompetitionStatusId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("PlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasColumnType("text");
-
-                    b.Property<string>("TeamRef")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionStatusId");
-
-                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Abbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<Guid>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionCompetitorId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("DisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int>("EspnPlayerId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("ShortDisplayName")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId");
-
-                    b.HasIndex("CompetitionCompetitorId", "Name")
-                        .IsUnique();
-
-                    b.ToTable("CompetitionCompetitorProbable", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3264,6 +3040,206 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("CompetitionCompetitorStatisticStats");
                 });
 
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
+                    b.Property<string>("DisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("EndClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("EndClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("EndDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("EndPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EndShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("EndText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("EndYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsScore")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("OffensivePlays")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Result")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SequenceNumber")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("ShortDisplayResult")
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<string>("SourceDescription")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SourceId")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("StartClockDisplayValue")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("StartClockValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<Guid?>("StartFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("StartPeriodNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StartPeriodType")
+                        .HasColumnType("text");
+
+                    b.Property<string>("StartShortDownDistanceText")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StartText")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeElapsedDisplay")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<double?>("TimeElapsedValue")
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("Yards")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionId");
+
+                    b.ToTable("CompetitionDrive", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DriveId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Provider")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SourceUrl")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("SourceUrlHash")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DriveId");
+
+                    b.ToTable("CompetitionDriveExternalId", (string)null);
+                });
+
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
                 {
                     b.Property<Guid>("Id")
@@ -4085,65 +4061,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasIndex("CompetitionPlayId");
 
                     b.ToTable("CompetitionPlayExternalId", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("AthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionPlayId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Discriminator")
-                        .IsRequired()
-                        .HasMaxLength(34)
-                        .HasColumnType("character varying(34)");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Order")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid?>("PositionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("StatisticsRef")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<string>("Type")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AthleteSeasonId");
-
-                    b.HasIndex("PositionId");
-
-                    b.HasIndex("CompetitionPlayId", "Type");
-
-                    b.ToTable("CompetitionPlayParticipant", (string)null);
-
-                    b.HasDiscriminator<string>("Discriminator").HasValue("CompetitionPlayParticipantBase");
-
-                    b.UseTphMappingStrategy();
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPowerIndex", b =>
@@ -8009,17 +7926,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -8030,247 +7939,99 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("ThrowsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("ThrowsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("BaseballAthlete");
+                    b.HasDiscriminator().HasValue("FootballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
+                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.Property<int?>("CurrentSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("CurrentSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("CurrentSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("CurrentSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("CurrentSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("CurrentSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EspnSeriesId")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesAwayTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesAwayWins")
-                        .HasColumnType("integer");
-
-                    b.Property<bool?>("SeasonSeriesCompleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("SeasonSeriesHomeTies")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("SeasonSeriesHomeWins")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SeasonSeriesSummary")
-                        .HasColumnType("text");
-
-                    b.Property<int?>("SeasonSeriesTotalCompetitions")
-                        .HasColumnType("integer");
-
-                    b.HasIndex("EspnSeriesId");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetition");
+                    b.HasDiscriminator().HasValue("FootballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
+                    b.Property<int?>("CuratedRankCurrent")
+                        .HasColumnType("integer");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<Guid?>("AtBatAthleteSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("AtBatId")
+                    b.Property<string>("ClockDisplayValue")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<int?>("AtBatPitchNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AwayHits")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("BatOrder")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("BatsAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("BatsType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("HalfInning")
-                        .HasMaxLength(8)
-                        .HasColumnType("character varying(8)");
-
-                    b.Property<double?>("HitCoordinateX")
-                        .HasPrecision(7, 2)
+                    b.Property<double>("ClockValue")
                         .HasColumnType("double precision");
 
-                    b.Property<double?>("HitCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("HomeErrors")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("HomeHits")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsDoublePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsTriplePlay")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsValid")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("Outs")
-                        .HasColumnType("integer");
-
-                    b.Property<double?>("PitchCoordinateX")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<double?>("PitchCoordinateY")
-                        .HasPrecision(7, 2)
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("PitchCountBalls")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("PitchCountStrikes")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PitchTypeAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeId")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("PitchTypeText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<int?>("PitchVelocity")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PitchesAbbreviation")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
-
-                    b.Property<string>("PitchesType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<Guid?>("PitchingAthleteSeasonId")
+                    b.Property<Guid?>("DriveId")
                         .HasColumnType("uuid");
 
-                    b.Property<int>("RbiCount")
+                    b.Property<int?>("EndDistance")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountBalls")
+                    b.Property<int?>("EndDown")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ResultCountStrikes")
+                    b.Property<Guid?>("EndFranchiseSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("EndYardLine")
                         .HasColumnType("integer");
 
-                    b.Property<string>("StrikeType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                    b.Property<int?>("EndYardsToEndzone")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("SummaryType")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.Property<int?>("StartDistance")
+                        .HasColumnType("integer");
 
-                    b.Property<string>("Trajectory")
-                        .HasMaxLength(5)
-                        .HasColumnType("character varying(5)");
+                    b.Property<int?>("StartDown")
+                        .HasColumnType("integer");
 
-                    b.Property<DateTime?>("Wallclock")
-                        .HasColumnType("timestamp with time zone");
+                    b.Property<int?>("StartYardLine")
+                        .HasColumnType("integer");
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
+                    b.Property<int?>("StartYardsToEndzone")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("StatYardage")
+                        .HasColumnType("integer");
+
+                    b.HasIndex("DriveId");
+
+                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
-                {
-                    b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase");
-
-                    b.HasDiscriminator().HasValue("BaseballCompetitionPlayParticipant");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
-
-                    b.Property<int?>("HalfInning")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("PeriodPrefix")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("BaseballContest");
+                    b.HasDiscriminator().HasValue("FootballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8303,47 +8064,6 @@ namespace SportsData.Producer.Migrations.Baseball
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
-                        .WithMany("Entries")
-                        .HasForeignKey("AthleteSeasonHotZoneId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("HotZone");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
-                        .WithMany("FeaturedAthletes")
-                        .HasForeignKey("CompetitionStatusId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionStatus");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "AthleteSeason")
-                        .WithMany()
-                        .HasForeignKey("AthleteSeasonId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", "CompetitionCompetitor")
-                        .WithMany("Probables")
-                        .HasForeignKey("CompetitionCompetitorId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("AthleteSeason");
-
-                    b.Navigation("CompetitionCompetitor");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8928,6 +8648,34 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
+                        .WithMany()
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                        .WithMany("Drives")
+                        .HasForeignKey("CompetitionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Competition");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("ExternalIds")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9840,7 +9588,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9849,40 +9597,36 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
+                        .WithMany("Plays")
+                        .HasForeignKey("DriveId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", "CompetitionPlay")
-                        .WithMany("Participants")
-                        .HasForeignKey("CompetitionPlayId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CompetitionPlay");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9894,11 +9638,6 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
-                {
-                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -10052,6 +9791,13 @@ namespace SportsData.Producer.Migrations.Baseball
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
+                {
+                    b.Navigation("ExternalIds");
+
+                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10244,29 +9990,16 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
                 {
+                    b.Navigation("Drives");
+
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
-                {
-                    b.Navigation("Probables");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
-                {
-                    b.Navigation("Participants");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
-                {
-                    b.Navigation("FeaturedAthletes");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Football/20260721134334_21JulV1_CompetitionCompetitorRecordFields.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260721134334_21JulV1_CompetitionCompetitorRecordFields.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class _21JulV1_CompetitionCompetitorRecordFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Abbreviation",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DisplayName",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorRecord",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Abbreviation",
+                table: "CompetitionCompetitorRecord");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "CompetitionCompetitorRecord");
+
+            migrationBuilder.DropColumn(
+                name: "DisplayName",
+                table: "CompetitionCompetitorRecord");
+
+            migrationBuilder.DropColumn(
+                name: "ShortDisplayName",
+                table: "CompetitionCompetitorRecord");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Football/FootballDataContextModelSnapshot.cs
@@ -2671,6 +2671,10 @@ namespace SportsData.Producer.Migrations.Football
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
                     b.Property<Guid>("CompetitionCompetitorId")
                         .HasColumnType("uuid");
 
@@ -2679,6 +2683,14 @@ namespace SportsData.Producer.Migrations.Football
 
                     b.Property<DateTime>("CreatedUtc")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("DisplayValue")
                         .HasMaxLength(50)
@@ -2693,6 +2705,10 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<string>("Name")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
 
                     b.Property<string>("Summary")
                         .HasMaxLength(50)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorRecordDocumentProcessorTests.cs
@@ -235,6 +235,50 @@ public class EventCompetitionCompetitorRecordDocumentProcessorTests
         stats.Should().NotContain(s => s.Name == "ties");
     }
 
+    // Extract one items[] entry from the real captured collection. In production
+    // Provider fans the records collection out into one DocumentPublished<T> per
+    // item, so this processor receives a single record — mirror that here.
+    private static string ExtractItem(string collectionJson, int index)
+    {
+        using var doc = JsonDocument.Parse(collectionJson);
+        return doc.RootElement.GetProperty("items")[index].GetRawText();
+    }
+
+    [Fact]
+    public async Task RealJson_TotalRecord_CapturesRecordLevelFields_AndAllStats()
+    {
+        var competitorId = await SeedCompetitorAsync();
+        var collection = await LoadJsonTestData(
+            "EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitorRecord.json");
+        var totalJson = ExtractItem(collection, 0); // items[0] = "total"
+
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorRecordDocumentProcessor<TeamSportDataContext>>();
+        await sut.ProcessAsync(BuildCommand(competitorId.ToString(), totalJson));
+
+        var record = await FootballDataContext.CompetitionCompetitorRecords
+            .AsNoTracking()
+            .Include(r => r.Stats)
+            .FirstOrDefaultAsync(r => r.CompetitionCompetitorId == competitorId);
+
+        record.Should().NotBeNull();
+        record!.Type.Should().Be("total");
+        record.Summary.Should().Be("6-4");
+
+        // Record-level fields that were previously dropped at the mapping step
+        // (these are NOT in the stats array — the actual capture gap).
+        record.Abbreviation.Should().Be("Game");
+        record.DisplayName.Should().Be("Record Year To Date");
+        record.ShortDisplayName.Should().Be("YTD");
+        record.Description.Should().Be("Overall Record");
+
+        // The granular values (wins/losses/points/streak/…) live in the Stats
+        // collection — not flattened onto the record. All 23 captured.
+        record.Stats.Count.Should().BeGreaterThan(20);
+        record.Stats.Should().Contain(s => s.Name == "wins" && s.Value == 6);
+        record.Stats.Should().Contain(s => s.Name == "losses" && s.Value == 4);
+        record.Stats.Should().Contain(s => s.Name == "streak" && s.DisplayValue == "W1");
+    }
+
     [Fact]
     public async Task WhenCompetitorMissing_ReturnsWithoutCreatingRecord()
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Data/EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitorRecord.json
+++ b/test/unit/SportsData.Producer.Tests.Unit/Data/EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitorRecord.json
@@ -1,0 +1,445 @@
+{
+  "count": 4,
+  "pageIndex": 1,
+  "pageSize": 25,
+  "pageCount": 1,
+  "items": [
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401752768/competitions/401752768/competitors/99/records/1?lang=en&region=us",
+      "id": "1",
+      "name": "overall",
+      "abbreviation": "Game",
+      "displayName": "Record Year To Date",
+      "shortDisplayName": "YTD",
+      "description": "Overall Record",
+      "type": "total",
+      "summary": "6-4",
+      "displayValue": "6-4",
+      "value": 0.6,
+      "stats": [
+        {
+          "name": "OTLosses",
+          "displayName": "Overtime Losses",
+          "shortDisplayName": "OTL",
+          "description": "Number of Overtime Losses",
+          "abbreviation": "OTL",
+          "type": "otlosses",
+          "value": 0.0,
+          "displayValue": "0"
+        },
+        {
+          "name": "OTWins",
+          "displayName": "Overtime Wins",
+          "shortDisplayName": "OT Wins",
+          "description": "Number of Overtime Wins",
+          "abbreviation": "OTW",
+          "type": "otwins",
+          "value": 0.0,
+          "displayValue": "0"
+        },
+        {
+          "name": "avgPointsAgainst",
+          "displayName": "Opponent Points Per Game",
+          "shortDisplayName": "OPTS/G",
+          "description": "Opponent Points Per Game",
+          "abbreviation": "OPTS/G",
+          "type": "avgpointsagainst",
+          "value": 2.2,
+          "displayValue": "2.2"
+        },
+        {
+          "name": "avgPointsFor",
+          "displayName": "Points Per Game",
+          "shortDisplayName": "PTS/G",
+          "description": "Points Per Game",
+          "abbreviation": "PTS/G",
+          "type": "avgpointsfor",
+          "value": 2.3,
+          "displayValue": "2.3"
+        },
+        {
+          "name": "differential",
+          "displayName": "Point Differential",
+          "shortDisplayName": "DIFF",
+          "description": "Point Differential",
+          "abbreviation": "DIFF",
+          "type": "differential",
+          "value": 1.0,
+          "displayValue": "+1"
+        },
+        {
+          "name": "divisionWinPercent",
+          "displayName": "Division Win Percentage",
+          "shortDisplayName": "DPCT",
+          "description": "Division Winning Percentage",
+          "abbreviation": "DPCT",
+          "type": "divisionwinpercent",
+          "value": 0.0,
+          "displayValue": "0.000"
+        },
+        {
+          "name": "gamesBehind",
+          "displayName": "Games Back",
+          "shortDisplayName": "GB",
+          "description": "Games Back",
+          "abbreviation": "GB",
+          "type": "gamesbehind",
+          "value": 0.0,
+          "displayValue": "-"
+        },
+        {
+          "name": "gamesPlayed",
+          "displayName": "Games Played",
+          "shortDisplayName": "GP",
+          "description": "Games Played",
+          "abbreviation": "GP",
+          "type": "gamesplayed",
+          "value": 10.0,
+          "displayValue": "10"
+        },
+        {
+          "name": "leagueWinPercent",
+          "displayName": "League Win Percentage",
+          "shortDisplayName": "LPCT",
+          "description": "League Winning Percentage",
+          "abbreviation": "LPCT",
+          "type": "leaguewinpercent",
+          "value": 0.42857143,
+          "displayValue": "0.429"
+        },
+        {
+          "name": "losses",
+          "displayName": "Losses",
+          "shortDisplayName": "L",
+          "description": "Losses",
+          "abbreviation": "L",
+          "type": "losses",
+          "value": 4.0,
+          "displayValue": "4"
+        },
+        {
+          "name": "playoffSeed",
+          "displayName": "Position",
+          "shortDisplayName": "POS",
+          "description": "Playoff Seed",
+          "abbreviation": "SEED",
+          "type": "playoffseed",
+          "value": 9.0,
+          "displayValue": "9"
+        },
+        {
+          "name": "pointDifferential",
+          "displayName": "Point Differential",
+          "shortDisplayName": "DIFF",
+          "description": "Point Differential",
+          "abbreviation": "DIFF",
+          "type": "pointdifferential",
+          "value": 1.0,
+          "displayValue": "+1"
+        },
+        {
+          "name": "points",
+          "displayName": "Points",
+          "shortDisplayName": "PTS",
+          "description": "Total Points",
+          "abbreviation": "PTS",
+          "type": "points",
+          "value": 1.0,
+          "displayValue": "1.0"
+        },
+        {
+          "name": "pointsAgainst",
+          "displayName": "Points Against",
+          "shortDisplayName": "PA",
+          "description": "Total Points Against",
+          "abbreviation": "PA",
+          "type": "pointsagainst",
+          "value": 22.0,
+          "displayValue": "22"
+        },
+        {
+          "name": "pointsFor",
+          "displayName": "Points For",
+          "shortDisplayName": "PF",
+          "description": "Total Points For",
+          "abbreviation": "PF",
+          "type": "pointsfor",
+          "value": 23.0,
+          "displayValue": "23"
+        },
+        {
+          "name": "streak",
+          "displayName": "Streak",
+          "shortDisplayName": "STRK",
+          "description": "Current Streak",
+          "abbreviation": "STRK",
+          "type": "streak",
+          "value": 1.0,
+          "displayValue": "W1"
+        },
+        {
+          "name": "ties",
+          "displayName": "Ties",
+          "shortDisplayName": "T",
+          "description": "Ties",
+          "abbreviation": "T",
+          "type": "ties",
+          "value": 0.0,
+          "displayValue": "0"
+        },
+        {
+          "name": "winPercent",
+          "displayName": "Win Percentage",
+          "shortDisplayName": "PCT",
+          "description": "Winning Percentage",
+          "abbreviation": "PCT",
+          "type": "winpercent",
+          "value": 0.6,
+          "displayValue": ".600"
+        },
+        {
+          "name": "wins",
+          "displayName": "Wins",
+          "shortDisplayName": "W",
+          "description": "Wins",
+          "abbreviation": "W",
+          "type": "wins",
+          "value": 6.0,
+          "displayValue": "6"
+        },
+        {
+          "name": "divisionLosses",
+          "displayName": "Division Losses",
+          "shortDisplayName": "DL",
+          "description": "Division Losses",
+          "abbreviation": "DL",
+          "type": "divisionlosses",
+          "value": 0.0,
+          "displayValue": "0"
+        },
+        {
+          "name": "divisionRecord",
+          "displayName": "Division record",
+          "shortDisplayName": "DIV",
+          "description": "Division Record",
+          "abbreviation": "DIV",
+          "type": "divisionrecord",
+          "value": 0.0,
+          "displayValue": "0-0"
+        },
+        {
+          "name": "divisionTies",
+          "displayName": "Division Tie ",
+          "shortDisplayName": "DT",
+          "description": "Division Tie ",
+          "abbreviation": "DT",
+          "type": "divisionties",
+          "value": 0.0,
+          "displayValue": "0.000"
+        },
+        {
+          "name": "divisionWins",
+          "displayName": "Division Wins ",
+          "shortDisplayName": "DW",
+          "description": "Division Winning ",
+          "abbreviation": "DW",
+          "type": "divisionwins",
+          "value": 0.0,
+          "displayValue": "0.000"
+        }
+      ]
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401752768/competitions/401752768/competitors/99/records/9002?lang=en&region=us",
+      "id": "9002",
+      "name": "Home",
+      "displayName": "Home",
+      "shortDisplayName": "HOME",
+      "description": "Home Record",
+      "type": "home",
+      "summary": "5-1",
+      "displayValue": "5-1",
+      "value": 0.8333333333333334,
+      "stats": [
+        {
+          "name": "wins",
+          "displayName": "Wins",
+          "shortDisplayName": "W",
+          "description": "Wins",
+          "abbreviation": "W",
+          "type": "wins",
+          "value": 5.0,
+          "displayValue": "5"
+        },
+        {
+          "name": "losses",
+          "displayName": "Losses",
+          "shortDisplayName": "L",
+          "description": "Losses",
+          "abbreviation": "L",
+          "type": "losses",
+          "value": 1.0,
+          "displayValue": "1"
+        },
+        {
+          "name": "ties",
+          "displayName": "Ties",
+          "shortDisplayName": "T",
+          "description": "Ties",
+          "abbreviation": "T",
+          "type": "ties",
+          "value": 0.0,
+          "displayValue": "0"
+        },
+        {
+          "name": "winPercent",
+          "displayName": "Win Percentage",
+          "shortDisplayName": "PCT",
+          "description": "Winning Percentage",
+          "abbreviation": "PCT",
+          "type": "winpercent",
+          "value": 0.8333333134651184,
+          "displayValue": ".833"
+        },
+        {
+          "name": "OTLosses",
+          "displayName": "Overtime Losses",
+          "shortDisplayName": "OTL",
+          "description": "Number of Overtime Losses",
+          "abbreviation": "OTL",
+          "type": "otlosses",
+          "value": 0.0,
+          "displayValue": "0"
+        }
+      ]
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401752768/competitions/401752768/competitors/99/records/9003?lang=en&region=us",
+      "id": "9003",
+      "name": "Road",
+      "displayName": "Road",
+      "shortDisplayName": "AWAY",
+      "description": "Away Record",
+      "type": "road",
+      "summary": "1-3",
+      "displayValue": "1-3",
+      "value": 0.25,
+      "stats": [
+        {
+          "name": "wins",
+          "displayName": "Wins",
+          "shortDisplayName": "W",
+          "description": "Wins",
+          "abbreviation": "W",
+          "type": "wins",
+          "value": 1.0,
+          "displayValue": "1"
+        },
+        {
+          "name": "losses",
+          "displayName": "Losses",
+          "shortDisplayName": "L",
+          "description": "Losses",
+          "abbreviation": "L",
+          "type": "losses",
+          "value": 3.0,
+          "displayValue": "3"
+        },
+        {
+          "name": "ties",
+          "displayName": "Ties",
+          "shortDisplayName": "T",
+          "description": "Ties",
+          "abbreviation": "T",
+          "type": "ties",
+          "value": 0.0,
+          "displayValue": "0"
+        },
+        {
+          "name": "winPercent",
+          "displayName": "Win Percentage",
+          "shortDisplayName": "PCT",
+          "description": "Winning Percentage",
+          "abbreviation": "PCT",
+          "type": "winpercent",
+          "value": 0.25,
+          "displayValue": ".250"
+        },
+        {
+          "name": "OTLosses",
+          "displayName": "Overtime Losses",
+          "shortDisplayName": "OTL",
+          "description": "Number of Overtime Losses",
+          "abbreviation": "OTL",
+          "type": "otlosses",
+          "value": 0.0,
+          "displayValue": "0"
+        }
+      ]
+    },
+    {
+      "$ref": "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401752768/competitions/401752768/competitors/99/records/9009?lang=en&region=us",
+      "id": "9009",
+      "name": "vs. Conf.",
+      "displayName": "CONF",
+      "shortDisplayName": "CONF",
+      "description": "Conference Record",
+      "type": "vsconf",
+      "summary": "3-4",
+      "displayValue": "3-4",
+      "value": 0.42857142857142855,
+      "stats": [
+        {
+          "name": "wins",
+          "displayName": "Wins",
+          "shortDisplayName": "W",
+          "description": "Wins",
+          "abbreviation": "W",
+          "type": "wins",
+          "value": 3.0,
+          "displayValue": "3"
+        },
+        {
+          "name": "losses",
+          "displayName": "Losses",
+          "shortDisplayName": "L",
+          "description": "Losses",
+          "abbreviation": "L",
+          "type": "losses",
+          "value": 4.0,
+          "displayValue": "4"
+        },
+        {
+          "name": "ties",
+          "displayName": "Ties",
+          "shortDisplayName": "T",
+          "description": "Ties",
+          "abbreviation": "T",
+          "type": "ties",
+          "value": 0.0,
+          "displayValue": "0"
+        },
+        {
+          "name": "leagueWinPercent",
+          "displayName": "League Win Percentage",
+          "shortDisplayName": "LPCT",
+          "description": "League Winning Percentage",
+          "abbreviation": "LPCT",
+          "type": "leaguewinpercent",
+          "value": 0.4285714328289032,
+          "displayValue": "0.429"
+        },
+        {
+          "name": "OTLosses",
+          "displayName": "Overtime Losses",
+          "shortDisplayName": "OTL",
+          "description": "Number of Overtime Losses",
+          "abbreviation": "OTL",
+          "type": "otlosses",
+          "value": 0.0,
+          "displayValue": "0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Pilot for the ESPN processor data-capture work. `EventCompetitionCompetitorRecordDocumentProcessor` deserialized the 4 record-level display fields but the entity mapping **never persisted them** — silent data loss the hand-built unit tests couldn't catch.

These fields live at the **record level, not in the `stats` array**, so they were genuinely lost. The granular values (wins/losses/points/streak/…) were already captured in the `Stats` collection — so this deliberately does **not** flatten anything onto the record.

## Changes

- Add `Abbreviation`, `DisplayName`, `ShortDisplayName`, `Description` to `CompetitionCompetitorRecord` (+ max-length config).
- Map them in the processor's **create + update** paths.
- **Convert the test to real captured single-item ESPN JSON** — extracts one `items[]` entry (as Provider fans out in production), asserts the recovered fields AND that granular values stay in `Stats` (not flattened). This is the durable prevention for the whole capture-drop class.
- Migrations for **Football + Baseball** contexts (additive nullable columns).
- Dropped unused usings in the touched entity files.

## Testing

- `dotnet build src/SportsData.Producer` — clean.
- Record processor tests — 6/6 pass.

## Context

Pilot for `docs/features/competition-competitor-record-canonical.md`; first of the fixes catalogued in `docs/features/espn-processor-data-capture-audit.md` (14 processors drop fields the same way). Proves the loop: capture fix + real-JSON test + migration. Phase 2 will replay historical docs from Mongo (no ESPN crawl) once the capture fixes land.

Note: Producer entity/migration change — needs a Producer deploy + migration to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Competition records now store abbreviations, display names, short display names, and descriptions, and they’re available in exported/served record data.
* **Bug Fixes**
  * When ESPN updates an existing competition record, these display fields are refreshed to match the latest incoming data.
* **Tests**
  * Added unit coverage using new ESPN “captured” fixtures to validate record-level display fields and detailed statistics extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->