### PR TITLE
fix(producer): capture competition feed-sources + baseball competition fields

### DIFF
--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetition.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/Entities/BaseballCompetition.cs
@@ -14,6 +14,16 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball.Entities
         // without an OfType cast.
         public BaseballCompetitionStatus? Status { get; set; }
 
+        // Baseball-specific competition fields ESPN ships but the mapper
+        // previously dropped. See docs/features/espn-processor-data-capture-audit.md.
+        public string? Duration { get; set; } // elapsed game time displayValue, e.g. "2:57"
+
+        public string? TimeOfDay { get; set; } // "day" / "night"
+
+        public bool? WasSuspended { get; set; }
+
+        public bool? Necessary { get; set; } // postseason "if necessary" game
+
         // Series snapshot, populated by BaseballEventCompetitionDocumentProcessor
         // from inline series data on the EventCompetition payload. The
         // snapshot reflects state at-game-start and is locked on first

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionBase.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/CompetitionBase.cs
@@ -81,13 +81,28 @@ namespace SportsData.Producer.Infrastructure.Data.Entities
 
         public string? TypeName { get; set; }
 
+        // ESPN feed-source state per data facet. FK to lkCompetitionSource
+        // (id 1 basic/manual, 2 feed, 4 official). Explicit FK ids so the mapper
+        // can populate them from ESPN's source objects — previously the nav
+        // existed only as a shadow FK and was never mapped, leaving all five
+        // permanently NULL. See docs/features/espn-processor-data-capture-audit.md.
+        public int? GameSourceId { get; set; }
+
         public CompetitionSource? GameSource { get; set; }
+
+        public int? BoxscoreSourceId { get; set; }
 
         public CompetitionSource? BoxscoreSource { get; set; }
 
+        public int? LinescoreSourceId { get; set; }
+
         public CompetitionSource? LinescoreSource { get; set; }
 
+        public int? PlayByPlaySourceId { get; set; }
+
         public CompetitionSource? PlayByPlaySource { get; set; }
+
+        public int? StatsSourceId { get; set; }
 
         public CompetitionSource? StatsSource { get; set; }
 

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionExtensions.cs
@@ -1,5 +1,6 @@
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Baseball;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Infrastructure.Data.Baseball.Entities;
@@ -38,6 +39,18 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
         {
             var entity = new BaseballCompetition();
             MapSharedProperties(dto, entity, externalRefIdentityGenerator, contestId, correlationId);
+
+            if (dto is not EspnBaseballEventCompetitionDto baseballDto)
+            {
+                throw new InvalidOperationException(
+                    $"Expected EspnBaseballEventCompetitionDto but got {dto.GetType().Name}");
+            }
+
+            entity.Duration = baseballDto.Duration?.DisplayValue;
+            entity.TimeOfDay = baseballDto.TimeOfDay;
+            entity.WasSuspended = baseballDto.WasSuspended;
+            entity.Necessary = baseballDto.Necessary;
+
             return entity;
         }
 
@@ -87,6 +100,14 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
             entity.IsTimeoutsAvailable = dto.TimeoutsAvailable;
             entity.IsWallClockAvailable = dto.WallclockAvailable;
             entity.TimeValid = dto.TimeValid;
+            // Feed-source state per facet. ESPN's source id ("2" = feed) maps to
+            // the lkCompetitionSource seed ids; TryParse so a novel/absent id
+            // leaves the FK null rather than throwing.
+            entity.GameSourceId = ParseSourceId(dto.GameSource?.Id);
+            entity.BoxscoreSourceId = ParseSourceId(dto.BoxscoreSource?.Id);
+            entity.LinescoreSourceId = ParseSourceId(dto.LinescoreSource?.Id);
+            entity.PlayByPlaySourceId = ParseSourceId(dto.PlayByPlaySource?.Id);
+            entity.StatsSourceId = ParseSourceId(dto.StatsSource?.Id);
             entity.TypeAbbreviation = dto.Type?.Abbreviation;
             entity.TypeId = dto.Type?.Id;
             entity.TypeName = dto.Type?.TypeName;
@@ -104,5 +125,8 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
                 }
             };
         }
+
+        private static int? ParseSourceId(string? espnSourceId) =>
+            int.TryParse(espnSourceId, out var id) ? id : null;
     }
 }

--- a/src/SportsData.Producer/Migrations/Baseball/20260721170949_21JulV2_CompetitionFeedSourceAndBaseballFields.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260721170949_21JulV2_CompetitionFeedSourceAndBaseballFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Baseball;
 namespace SportsData.Producer.Migrations.Baseball
 {
     [DbContext(typeof(BaseballDataContext))]
-    partial class BaseballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260721170949_21JulV2_CompetitionFeedSourceAndBaseballFields")]
+    partial class _21JulV2_CompetitionFeedSourceAndBaseballFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Baseball/20260721170949_21JulV2_CompetitionFeedSourceAndBaseballFields.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260721170949_21JulV2_CompetitionFeedSourceAndBaseballFields.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class _21JulV2_CompetitionFeedSourceAndBaseballFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Duration",
+                table: "Competition",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Necessary",
+                table: "Competition",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TimeOfDay",
+                table: "Competition",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "WasSuspended",
+                table: "Competition",
+                type: "boolean",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Duration",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "Necessary",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "TimeOfDay",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "WasSuspended",
+                table: "Competition");
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
@@ -138,6 +138,48 @@ public class BaseballEventCompetitionDocumentProcessorTests
     }
 
     [Fact]
+    public async Task FeedSourceIds_AreNull_WhenAbsentOrNonNumeric()
+    {
+        var (competitionId, _, cmd) = await SetupAndBuildCommand();
+
+        // Mutate the fixture: drop one source entirely (absent) and give the rest
+        // non-numeric ids. ParseSourceId must leave every FK null rather than
+        // throw or FK-violate.
+        var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
+        var dto = json.FromJson<EspnBaseballEventCompetitionDto>()!;
+        dto.GameSource = null!;          // absent → ParseSourceId(null)
+        dto.BoxscoreSource.Id = "abc";   // non-numeric
+        dto.LinescoreSource.Id = "";     // empty
+        dto.PlayByPlaySource.Id = "n/a";
+        dto.StatsSource.Id = "full";
+
+        var mutatedCmd = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.ParentId, cmd.ParentId)
+            .With(x => x.SeasonYear, cmd.SeasonYear)
+            .With(x => x.SourceDataProvider, cmd.SourceDataProvider)
+            .With(x => x.Sport, cmd.Sport)
+            .With(x => x.DocumentType, cmd.DocumentType)
+            .With(x => x.Document, dto.ToJson())
+            .With(x => x.UrlHash, cmd.UrlHash)
+            .With(x => x.IncludeLinkedDocumentTypes, cmd.IncludeLinkedDocumentTypes)
+            .OmitAutoProperties()
+            .Create();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>();
+        await sut.ProcessAsync(mutatedCmd);
+
+        var refreshed = await _baseballDataContext.Competitions
+            .OfType<BaseballCompetition>()
+            .FirstAsync(x => x.Id == competitionId);
+
+        refreshed.GameSourceId.Should().BeNull();
+        refreshed.BoxscoreSourceId.Should().BeNull();
+        refreshed.LinescoreSourceId.Should().BeNull();
+        refreshed.PlayByPlaySourceId.Should().BeNull();
+        refreshed.StatsSourceId.Should().BeNull();
+    }
+
+    [Fact]
     public async Task WhenReprocessed_SnapshotIsLocked_AndDoesNotOverwrite()
     {
         // arrange — process once with the real fixture.

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
@@ -111,6 +111,33 @@ public class BaseballEventCompetitionDocumentProcessorTests
     }
 
     [Fact]
+    public async Task CapturesFeedSourcesAndBaseballCompetitionFields()
+    {
+        var (competitionId, _, cmd) = await SetupAndBuildCommand();
+
+        var sut = Mocker.CreateInstance<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>();
+        await sut.ProcessAsync(cmd);
+
+        var refreshed = await _baseballDataContext.Competitions
+            .OfType<BaseballCompetition>()
+            .FirstAsync(x => x.Id == competitionId);
+
+        // Feed-source FKs — fixture ships id "2" (feed) for all five facets;
+        // previously left permanently NULL.
+        refreshed.GameSourceId.Should().Be(2);
+        refreshed.BoxscoreSourceId.Should().Be(2);
+        refreshed.LinescoreSourceId.Should().Be(2);
+        refreshed.PlayByPlaySourceId.Should().Be(2);
+        refreshed.StatsSourceId.Should().Be(2);
+
+        // Baseball-specific competition fields, previously dropped.
+        refreshed.Duration.Should().Be("2:42");
+        refreshed.TimeOfDay.Should().Be("DAY");
+        refreshed.WasSuspended.Should().BeFalse();
+        refreshed.Necessary.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task WhenReprocessed_SnapshotIsLocked_AndDoesNotOverwrite()
     {
         // arrange — process once with the real fixture.


### PR DESCRIPTION
## Summary

Step 2 of the ESPN capture-drop fixes (`docs/features/espn-processor-data-capture-audit.md`) — the highest-value batch. Two mapper drops on the competition entity.

## #1 — Feed-source FKs (both sports)

`CompetitionBase` declared 5 `CompetitionSource` navs (`GameSource`, `BoxscoreSource`, `LinescoreSource`, `PlayByPlaySource`, `StatsSource`) backed by shadow FK columns + indexes, but the mapper **never populated them** — all five were **permanently NULL for every competition**, so a fully-sourced game couldn't be distinguished from a delayed/partial one (`state:"full"` vs `"delay"`).

- Added explicit FK id props to `CompetitionBase` — this **materializes the existing shadow columns, so there's no schema change** (no football migration).
- Populate them in `MapSharedProperties` from ESPN's source `id` via a null-safe `ParseSourceId` (TryParse → null on a novel/absent id, so no FK-violation risk). ESPN ships `id:"2"` (feed) → `lkCompetitionSource` id 2.

## #10 / #11 — Baseball competition fields

`AsBaseballEntity` never cast the DTO to the baseball type (unlike the football path), so `duration` / `timeOfDay` / `wasSuspended` / `necessary` were dropped. Added those columns to `BaseballCompetition` and mapped them.

## Testing

- Real-JSON test asserts all nine fields against `EventCompetition.json` (all sources = 2, Duration `2:42`, TimeOfDay `DAY`, WasSuspended false, Necessary true). Football feed-sources are covered via the shared `MapSharedProperties`.
- Competition processor tests — 15/15 pass; `dotnet build` clean.

## Notes

- One migration (Baseball, +4 columns). #1 was schema-free.
- Producer entity/migration change — needs a Producer deploy + migration to take effect; existing rows populate on the phase-2 Mongo replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added baseball competition fields for duration, time of day, suspension status, and necessity.
  - Extended competition ingestion to capture feed-source identifiers for game, boxscore, linescore, play-by-play, and statistics.
- **Bug Fixes**
  - Improved resilience when feed-source identifiers are missing or invalid, ensuring related IDs remain unset instead of causing processing issues.
- **Tests**
  - Added unit coverage to verify both populated and absent/invalid feed-source and baseball competition fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->