### PR TITLE
fix(producer): capture football play scoringType/PAT/wallclock + full remap on update

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -167,6 +167,16 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
             startFranchiseSeasonId,
             endFranchiseSeasonId);
 
+        // SetValues copies the key too; the remap must derive the same canonical id
+        // as the tracked entity (both come from the same play ref). Fail loud rather
+        // than silently mutate the primary key if that invariant is ever violated.
+        if (mapped.Id != footballPlay.Id)
+        {
+            throw new InvalidOperationException(
+                $"Play identity mismatch on update: remapped id {mapped.Id} != tracked id {footballPlay.Id}. " +
+                $"Ref={externalDto.Ref}");
+        }
+
         var createdUtc = footballPlay.CreatedUtc;
         var createdBy = footballPlay.CreatedBy;
         _dataContext.Entry(footballPlay).CurrentValues.SetValues(mapped);

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -147,12 +147,30 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
             externalDto.End.Team, command.SourceDataProvider);
 
         _logger.LogInformation(
-            "Updating CompetitionPlay. PlayId={PlayId}, DriveId={DriveId}",
+            "Updating CompetitionPlay (full remap). PlayId={PlayId}, DriveId={DriveId}",
             entity.Id,
             competitionDriveId);
 
-        footballPlay.StartFranchiseSeasonId = startFranchiseSeasonId;
-        footballPlay.EndFranchiseSeasonId = endFranchiseSeasonId;
-        footballPlay.DriveId = competitionDriveId;
+        // Full remap on reprocess/replay: previously this set only the three FK
+        // fields, so re-sourcing an existing play never refreshed the rest (and
+        // left newly-captured columns null). Build a fresh entity from the same
+        // create mapper and copy its scalar values onto the tracked one — so every
+        // mapped field is refreshed and no field can be missed here. SetValues
+        // touches scalars only, so the ExternalIds navigation is untouched; the
+        // canonical Id is identical (same ref), and the audit columns are
+        // preserved explicitly.
+        var mapped = externalDto.AsFootballEntity(
+            _externalRefIdentityGenerator,
+            command.CorrelationId,
+            footballPlay.CompetitionId,
+            competitionDriveId,
+            startFranchiseSeasonId,
+            endFranchiseSeasonId);
+
+        var createdUtc = footballPlay.CreatedUtc;
+        var createdBy = footballPlay.CreatedBy;
+        _dataContext.Entry(footballPlay).CurrentValues.SetValues(mapped);
+        footballPlay.CreatedUtc = createdUtc;
+        footballPlay.CreatedBy = createdBy;
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionPlayExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionPlayExtensions.cs
@@ -40,7 +40,15 @@ public static class CompetitionPlayExtensions
             StartDown = dto.Start?.Down,
             StartYardLine = dto.Start?.YardLine,
             StartYardsToEndzone = dto.Start?.YardsToEndzone,
-            StatYardage = dto.StatYardage
+            StatYardage = dto.StatYardage,
+            Wallclock = dto.Wallclock == default ? null : dto.Wallclock,
+            ScoringTypeName = dto.ScoringType?.Name,
+            ScoringTypeDisplayName = dto.ScoringType?.DisplayName,
+            ScoringTypeAbbreviation = dto.ScoringType?.Abbreviation,
+            PointAfterAttemptId = dto.PointAfterAttempt?.Id,
+            PointAfterAttemptText = dto.PointAfterAttempt?.Text,
+            PointAfterAttemptAbbreviation = dto.PointAfterAttempt?.Abbreviation,
+            PointAfterAttemptValue = dto.PointAfterAttempt?.Value
         };
 
         MapSharedProperties(dto, entity, identity, correlationId, competitionId, startFranchiseSeasonId);

--- a/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionPlay.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionPlay.cs
@@ -35,12 +35,40 @@ public class FootballCompetitionPlay : CompetitionPlayBase
 
     public int StatYardage { get; set; }
 
+    // Fields ESPN ships on football plays that the mapper previously dropped.
+    // See docs/features/espn-processor-data-capture-audit.md.
+
+    // Real-world timestamp of the play (baseball already keeps one).
+    public DateTime? Wallclock { get; set; }
+
+    // Scoring-play type label (TD / FG / safety / …). Distinguishes what kind of
+    // score a play was without parsing Text; complements ScoringPlay + ScoreValue.
+    public string? ScoringTypeName { get; set; }
+
+    public string? ScoringTypeDisplayName { get; set; }
+
+    public string? ScoringTypeAbbreviation { get; set; }
+
+    // Point-after-attempt / two-point conversion result.
+    public int? PointAfterAttemptId { get; set; }
+
+    public string? PointAfterAttemptText { get; set; }
+
+    public string? PointAfterAttemptAbbreviation { get; set; }
+
+    public int? PointAfterAttemptValue { get; set; }
+
     public new class EntityConfiguration : IEntityTypeConfiguration<FootballCompetitionPlay>
     {
         public void Configure(EntityTypeBuilder<FootballCompetitionPlay> builder)
         {
             builder.Property(x => x.ClockDisplayValue).HasMaxLength(32);
             builder.Property(x => x.DriveId).IsRequired(false);
+            builder.Property(x => x.ScoringTypeName).HasMaxLength(50);
+            builder.Property(x => x.ScoringTypeDisplayName).HasMaxLength(100);
+            builder.Property(x => x.ScoringTypeAbbreviation).HasMaxLength(20);
+            builder.Property(x => x.PointAfterAttemptText).HasMaxLength(100);
+            builder.Property(x => x.PointAfterAttemptAbbreviation).HasMaxLength(20);
 
             builder.HasOne(x => x.Drive)
                 .WithMany(x => x.Plays)

--- a/src/SportsData.Producer/Migrations/Football/20260721191128_21JulV3_FootballPlayCaptureFields.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260721191128_21JulV3_FootballPlayCaptureFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260721191128_21JulV3_FootballPlayCaptureFields")]
+    partial class _21JulV3_FootballPlayCaptureFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260721191128_21JulV3_FootballPlayCaptureFields.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260721191128_21JulV3_FootballPlayCaptureFields.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class _21JulV3_FootballPlayCaptureFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PointAfterAttemptAbbreviation",
+                table: "CompetitionPlay",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PointAfterAttemptId",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PointAfterAttemptText",
+                table: "CompetitionPlay",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PointAfterAttemptValue",
+                table: "CompetitionPlay",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ScoringTypeAbbreviation",
+                table: "CompetitionPlay",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ScoringTypeDisplayName",
+                table: "CompetitionPlay",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ScoringTypeName",
+                table: "CompetitionPlay",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Wallclock",
+                table: "CompetitionPlay",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PointAfterAttemptAbbreviation",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "PointAfterAttemptId",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "PointAfterAttemptText",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "PointAfterAttemptValue",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "ScoringTypeAbbreviation",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "ScoringTypeDisplayName",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "ScoringTypeName",
+                table: "CompetitionPlay");
+
+            migrationBuilder.DropColumn(
+                name: "Wallclock",
+                table: "CompetitionPlay");
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
@@ -415,13 +415,16 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         await FootballDataContext.SaveChangesAsync();
         await SeedInProgressStatusAsync(competitionId);
 
-        // Seed an EXISTING play keyed by the fixture ref's canonical id, with a
-        // deliberately stale Text and preserved audit columns so the remap is
-        // observable. The processor finds it by canonical id and takes the
-        // update path. Derive the id from the FIXTURE'S ref (not PlayUrl, which is
-        // a different play) so the lookup matches.
-        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
-        var playRef = json.FromJson<EspnFootballEventCompetitionPlayDto>()!.Ref;
+        // Use a SCORING play (touchdown) so the update path must refresh the
+        // scoringType / pointAfterAttempt / wallclock columns — seeded null below.
+        // Seed an EXISTING play keyed by that play's canonical id with stale Text +
+        // null new fields + preserved audit, so the full remap is observable. The
+        // processor finds it by canonical id and takes the update path.
+        var plays = (await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlays.json"))
+            .FromJson<List<EspnFootballEventCompetitionPlayDto>>()!;
+        var td = plays.First(p => p.ScoringType?.Abbreviation == "TD" && p.PointAfterAttempt != null);
+        var json = td.ToJson();
+        var playRef = td.Ref;
         var canonicalId = generator.Generate(playRef).CanonicalId;
         var urlHash = generator.Generate(playRef).UrlHash;
         var originalCreatedUtc = new DateTime(2020, 5, 5, 0, 0, 0, DateTimeKind.Utc);
@@ -477,6 +480,17 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         // original row is untouched (not duplicated or replaced).
         updated.ExternalIds.Should().ContainSingle()
             .Which.Id.Should().Be(originalExternalIdRowId);
+
+        // Newly-captured columns backfilled by the full remap (seeded null; the TD
+        // fixture provides them) — this is the resourcing/replay guarantee.
+        updated.Wallclock.Should().Be(td.Wallclock);
+        updated.ScoringTypeName.Should().Be("touchdown");
+        updated.ScoringTypeDisplayName.Should().Be("Touchdown");
+        updated.ScoringTypeAbbreviation.Should().Be("TD");
+        updated.PointAfterAttemptId.Should().Be(61);
+        updated.PointAfterAttemptText.Should().Be("Extra Point Good");
+        updated.PointAfterAttemptAbbreviation.Should().Be("Extra Point Good");
+        updated.PointAfterAttemptValue.Should().Be(1);
     }
 
     [Fact(Skip = "log not throw")]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
@@ -16,6 +16,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 using SportsData.Producer.Infrastructure.Data.Football;
 using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
@@ -107,6 +108,55 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
 
         // assert
         scoringPlays.Count().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task AsFootballEntity_CapturesScoringTypePointAfterAttemptAndWallclock()
+    {
+        // Real fixture: a touchdown play carries scoringType + pointAfterAttempt +
+        // wallclock — all previously dropped by the mapper.
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlays.json");
+        var plays = json.FromJson<List<EspnFootballEventCompetitionPlayDto>>()!;
+        var td = plays.First(p => p.ScoringType?.Abbreviation == "TD" && p.PointAfterAttempt != null);
+
+        var entity = td.AsFootballEntity(
+            new ExternalRefIdentityGenerator(),
+            correlationId: Guid.NewGuid(),
+            competitionId: Guid.NewGuid(),
+            driveId: null,
+            startFranchiseSeasonId: null,
+            endFranchiseSeasonId: null);
+
+        entity.ScoringTypeName.Should().Be("touchdown");
+        entity.ScoringTypeDisplayName.Should().Be("Touchdown");
+        entity.ScoringTypeAbbreviation.Should().Be("TD");
+        entity.PointAfterAttemptId.Should().Be(61);
+        entity.PointAfterAttemptText.Should().Be("Extra Point Good");
+        entity.PointAfterAttemptAbbreviation.Should().Be("Extra Point Good");
+        entity.PointAfterAttemptValue.Should().Be(1);
+        entity.Wallclock.Should().Be(td.Wallclock);
+    }
+
+    [Fact]
+    public async Task AsFootballEntity_NonScoringPlay_LeavesScoringFieldsNull()
+    {
+        // A non-scoring play has no scoringType / pointAfterAttempt.
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlays.json");
+        var plays = json.FromJson<List<EspnFootballEventCompetitionPlayDto>>()!;
+        var nonScoring = plays.First(p => p.ScoringType == null && p.PointAfterAttempt == null);
+
+        var entity = nonScoring.AsFootballEntity(
+            new ExternalRefIdentityGenerator(),
+            correlationId: Guid.NewGuid(),
+            competitionId: Guid.NewGuid(),
+            driveId: null,
+            startFranchiseSeasonId: null,
+            endFranchiseSeasonId: null);
+
+        entity.ScoringTypeName.Should().BeNull();
+        entity.ScoringTypeAbbreviation.Should().BeNull();
+        entity.PointAfterAttemptId.Should().BeNull();
+        entity.PointAfterAttemptValue.Should().BeNull();
     }
 
     [Fact]
@@ -345,55 +395,88 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         play.Competition!.Id.Should().Be(competitionId);
     }
 
-    [Fact(Skip="Updates not yet implemented")]
-    public async Task WhenEntityExists_ShouldUpdateExistingPlay()
+    [Fact]
+    public async Task WhenEntityExists_FullRemap_RefreshesFields_PreservesIdentityAuditAndExternalIds()
     {
         // arrange
         var generator = new ExternalRefIdentityGenerator();
         Mocker.Use<IGenerateExternalRefIdentities>(generator);
 
         var competitionId = Guid.NewGuid();
-        var competition = Fixture.Build<FootballCompetition>()
-            .With(x => x.Id, competitionId)
-            .With(x => x.ContestId, Guid.NewGuid())
-            .With(x => x.CreatedBy, Guid.NewGuid())
-            .Create();
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = UtcNow(),
+            CreatedUtc = UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        };
         await FootballDataContext.Competitions.AddAsync(competition);
-
-        var playId = Guid.NewGuid();
-        var play = Fixture.Build<FootballCompetitionPlay>()
-            .With(x => x.Id, playId)
-            .With(x => x.CompetitionId, competitionId)
-            .With(x => x.CreatedBy, Guid.NewGuid())
-            .Create();
-        await FootballDataContext.CompetitionPlays.AddAsync(play);
-
-        var externalId = Fixture.Build<CompetitionPlayExternalId>()
-            .With(x => x.CompetitionPlayId, playId)
-            .With(x => x.Provider, SourceDataProvider.Espn)
-            .With(x => x.SourceUrlHash, generator.Generate(PlayUrl).UrlHash)
-            .With(x => x.CreatedBy, Guid.NewGuid())
-            .Create();
-        play.ExternalIds.Add(externalId);
-
         await FootballDataContext.SaveChangesAsync();
+        await SeedInProgressStatusAsync(competitionId);
+
+        // Seed an EXISTING play keyed by the fixture ref's canonical id, with a
+        // deliberately stale Text and preserved audit columns so the remap is
+        // observable. The processor finds it by canonical id and takes the
+        // update path. Derive the id from the FIXTURE'S ref (not PlayUrl, which is
+        // a different play) so the lookup matches.
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+        var playRef = json.FromJson<EspnFootballEventCompetitionPlayDto>()!.Ref;
+        var canonicalId = generator.Generate(playRef).CanonicalId;
+        var urlHash = generator.Generate(playRef).UrlHash;
+        var originalCreatedUtc = new DateTime(2020, 5, 5, 0, 0, 0, DateTimeKind.Utc);
+        var originalCreatedBy = Guid.NewGuid();
+
+        var play = new FootballCompetitionPlay
+        {
+            Id = canonicalId,
+            CompetitionId = competitionId,
+            EspnId = "stale-espn-id",
+            SequenceNumber = "0",
+            Text = "STALE TEXT",
+            TypeId = "0",
+            CreatedUtc = originalCreatedUtc,
+            CreatedBy = originalCreatedBy
+        };
+        var externalId = new CompetitionPlayExternalId
+        {
+            Id = Guid.NewGuid(),
+            CompetitionPlayId = canonicalId,
+            Provider = SourceDataProvider.Espn,
+            Value = urlHash,
+            SourceUrl = playRef.AbsoluteUri,
+            SourceUrlHash = urlHash,
+            CreatedBy = Guid.NewGuid()
+        };
+        play.ExternalIds.Add(externalId);
+        await FootballDataContext.CompetitionPlays.AddAsync(play);
+        await FootballDataContext.SaveChangesAsync();
+        var originalExternalIdRowId = externalId.Id;
+
+        // Fresh DI scope per message in production.
+        FootballDataContext.ChangeTracker.Clear();
 
         var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
 
-        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
-        var command = CreateCommand(json, competitionId.ToString());
-
-        // act
-        await sut.ProcessAsync(command);
+        // act — reprocess the same play (update path).
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
 
         // assert
-        var updatedPlay = await FootballDataContext.CompetitionPlays
+        var updated = await FootballDataContext.CompetitionPlays
+            .AsNoTracking()
             .Include(x => x.ExternalIds)
-            .FirstOrDefaultAsync(x => x.Id == playId);
+            .FirstAsync(x => x.Id == canonicalId);
 
-        updatedPlay.Should().NotBeNull();
-        updatedPlay!.ExternalIds.Should().NotBeEmpty();
-        updatedPlay.ModifiedBy.Should().NotBeNull();
+        // Full remap refreshed the field (previously the update path left it stale).
+        updated.Text.Should().NotBe("STALE TEXT");
+        // Identity + audit preserved.
+        updated.Id.Should().Be(canonicalId);
+        updated.CreatedUtc.Should().Be(originalCreatedUtc);
+        updated.CreatedBy.Should().Be(originalCreatedBy);
+        // ExternalIds is a navigation — SetValues touches scalars only, so the
+        // original row is untouched (not duplicated or replaced).
+        updated.ExternalIds.Should().ContainSingle()
+            .Which.Id.Should().Be(originalExternalIdRowId);
     }
 
     [Fact(Skip = "log not throw")]


### PR DESCRIPTION
## Summary

Step 3 of the ESPN capture-drop fixes (`docs/features/espn-processor-data-capture-audit.md`) — football play fields (#7 `scoringType`, #8 `pointAfterAttempt`, #9 `wallclock`), plus the update-path fix needed to make the processor **replay-ready**.

## Capture

`AsFootballEntity` dropped three fields ESPN ships on football plays. Added to `FootballCompetitionPlay` and mapped:
- **`Wallclock`** — real-world play timestamp (baseball already keeps one).
- **`ScoringType`** (name / displayName / abbreviation) — TD vs FG vs safety, without parsing `Text`.
- **`PointAfterAttempt`** (id / text / abbreviation / value) — PAT / two-point result.

These are single nested value objects, so flattening to columns matches the codebase's existing pattern (`FormatOvertime*`, `Type*`) — not the EAV flattening avoided earlier.

## Resourcing readiness (update path)

`ApplyUpdateAsync` previously set only **3 FK fields**, so re-sourcing/replaying an existing play never refreshed the rest — and would leave the new columns null. Now it does a **full remap**: build a fresh entity from the same create mapper (`AsFootballEntity`) and copy its scalar values onto the tracked entity via `SetValues`. Every mapped field refreshes and none can be missed here; **Id, audit columns, and the `ExternalIds` navigation are preserved** (SetValues touches scalars only).

**Publishing unchanged / already replay-safe:** `PublishSportPlayCompletedAsync` fires only on the *create* branch and only when the competition is in-progress, so a historical replay (update path, finished games) never floods `*PlayCompleted` events.

## Testing

- Real-JSON mapper tests: a TD play captures all three fields; a non-scoring play leaves them null.
- **Un-skipped** the `WhenEntityExists_...` test (was `Skip="Updates not yet implemented"`) — rewritten to actually hit the update path and assert the stale field refreshes while Id / CreatedUtc / CreatedBy / ExternalIds are preserved.
- Football play processor tests green; `dotnet build` clean.

## Notes

One migration (Football, +8 columns). Producer entity/migration change — needs a Producer deploy + migration; existing rows backfill on the phase-2 Mongo replay (which the full-remap update path now makes effective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional ESPN football play capture fields: wall-clock time, scoring type (name/display/abbrev), and point-after-attempt (id/text/abbrev/value).
  * Updated the database schema to store these new play details.

* **Bug Fixes**
  * During replay/reprocessing, existing play records are now fully refreshed with the latest mapped values rather than only partially updated.
  * Preserves play identity and audit info, and avoids duplicating external references.

* **Tests**
  * Expanded unit tests to verify scoring vs. non-scoring mapping, wall-clock behavior, and full-refresh updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->