### PR TITLE
fix(producer): don't write CompetitionSource FK = 0 (feed-source not-sourced sentinel)

### DIFF
--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionExtensions.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Extensions/CompetitionExtensions.cs
@@ -126,7 +126,12 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Extensions
             };
         }
 
+        // ESPN ships source id "0" for a facet that isn't sourced yet (e.g. a live
+        // game's boxscore before it exists). There's no CompetitionSource row for
+        // 0 (the lookup seeds 1/2/4), so treat non-positive ids as "no source" →
+        // null FK, rather than writing 0 and violating
+        // FK_Competition_CompetitionSource_*SourceId.
         private static int? ParseSourceId(string? espnSourceId) =>
-            int.TryParse(espnSourceId, out var id) ? id : null;
+            int.TryParse(espnSourceId, out var id) && id > 0 ? id : null;
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
@@ -142,16 +142,17 @@ public class BaseballEventCompetitionDocumentProcessorTests
     {
         var (competitionId, _, cmd) = await SetupAndBuildCommand();
 
-        // Mutate the fixture: drop one source entirely (absent) and give the rest
-        // non-numeric ids. ParseSourceId must leave every FK null rather than
-        // throw or FK-violate.
+        // Mutate the fixture: drop one source entirely (absent), one with the "0"
+        // ESPN ships for a not-yet-sourced facet (no CompetitionSource row for 0 —
+        // this was FK-violating in prod), and the rest non-numeric. ParseSourceId
+        // must leave every FK null rather than throw or FK-violate.
         var json = await LoadJsonTestData("EspnBaseballMlb/EventCompetition.json");
         var dto = json.FromJson<EspnBaseballEventCompetitionDto>()!;
         dto.GameSource = null!;          // absent → ParseSourceId(null)
-        dto.BoxscoreSource.Id = "abc";   // non-numeric
+        dto.BoxscoreSource.Id = "0";     // not-sourced-yet sentinel (prod FK bug)
         dto.LinescoreSource.Id = "";     // empty
-        dto.PlayByPlaySource.Id = "n/a";
-        dto.StatsSource.Id = "full";
+        dto.PlayByPlaySource.Id = "n/a"; // non-numeric
+        dto.StatsSource.Id = "-1";       // negative
 
         var mutatedCmd = Fixture.Build<ProcessDocumentCommand>()
             .With(x => x.ParentId, cmd.ParentId)


### PR DESCRIPTION
## Summary

**Hotfix for a live-prod DB error storm** found in Seq (47 of 60 recent DB errors, bursting on MLB ingest).

ESPN ships a feed-source id of `"0"` for a facet that isn't sourced yet — e.g. a live MLB game's **boxscore** before it exists. `ParseSourceId` parsed `"0"` → `0`, but there's no `CompetitionSource` row for `0` (the lookup seeds 1/2/4), so every such Competition save hit:

```
23503: insert or update on table "Competition" violates foreign key constraint
"FK_Competition_CompetitionSource_BoxscoreSourceId"
DETAIL: Key (BoxscoreSourceId)=(0) is not present in table "CompetitionSource".
```

The whole competition failed to persist (the FK violation aborts the save), so those live MLB competitions weren't stored at all. **Regression from #537** — before it these shadow FKs were never populated, so a `0` never got written.

## Fix

`ParseSourceId` treats a **non-positive** parsed id as "no source" → **null FK**, matching the absent/non-numeric cases it already handled. One-line change.

## Testing

- Extended the existing negative-path test with the `"0"` (the exact prod trigger) and a negative id — all five FK columns stay null.
- The valid-id case (`"2"` → `GameSourceId = 2`, etc.) is unchanged and still passes.

## Notes

- **No data cleanup needed** — the FK violation aborted the inserts, so no rows with `SourceId = 0` exist. Those competitions are unpersisted (DLQ / to be re-sourced); after this deploys they'll process cleanly with null source FKs.
- Producer change — needs a Producer deploy to stop the storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid or non-positive ESPN source identifiers from being saved as competition feed references.
  * Competition records now correctly leave unsourced feed references empty.

* **Tests**
  * Added coverage for zero and negative ESPN source identifiers to ensure they are handled as missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->