### PR TITLE
fix(producer): publish GroupSeason conference/division logos (audit #5)

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/GroupSeasonDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/GroupSeasonDocumentProcessor.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
@@ -145,8 +146,46 @@ public class GroupSeasonDocumentProcessor<TDataContext> : DocumentProcessorBase<
 
         await ProcessChildren(dto, groupSeasonEntity, command);
 
+        await ProcessLogos(dto, groupSeasonEntity, seasonYear, command);
+
         await _dataContext.GroupSeasons.AddAsync(groupSeasonEntity);
         await _dataContext.SaveChangesAsync();
+    }
+
+    private async Task ProcessLogos(
+        EspnGroupSeasonDto dto,
+        GroupSeason groupSeasonEntity,
+        int seasonYear,
+        ProcessDocumentCommand command)
+    {
+        // The conference/division logo (dto.Logos) was previously dropped — no
+        // image request was published, so the GroupSeasonLogo table stayed empty.
+        // Publish a request per logo (the GroupSeasonLogoResponseProcessor writes
+        // the row after download), mirroring TeamSeasonDocumentProcessor.
+        if (dto.Logos is null || dto.Logos.Count == 0)
+        {
+            return;
+        }
+
+        var imageEvents = EventFactory.CreateProcessImageRequests(
+            _externalRefIdentityGenerator,
+            dto.Logos,
+            groupSeasonEntity.Id,
+            command.Sport,
+            seasonYear,
+            DocumentType.GroupSeasonLogo,
+            command.SourceDataProvider,
+            command.CorrelationId,
+            command.MessageId);
+
+        if (imageEvents.Count > 0)
+        {
+            _logger.LogInformation(
+                "Publishing {Count} GroupSeasonLogo image requests for GroupSeason {GroupSeasonId} ({SeasonYear}).",
+                imageEvents.Count, groupSeasonEntity.Id, seasonYear);
+
+            await _publishEndpoint.PublishBatch(imageEvents);
+        }
     }
 
     private async Task ProcessChildren(

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/GroupSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/GroupSeasonDocumentProcessorTests.cs
@@ -78,10 +78,14 @@ public class GroupSeasonDocumentProcessorTests : ProducerTestBase<GroupSeasonDoc
 
         // The SEC logo (dto.Logos) must be published as a GroupSeasonLogo image
         // request — previously dropped, leaving the GroupSeasonLogo table empty.
+        // The fixture carries exactly one logo; assert count, parent, type, and
+        // season year on every request.
         bus.Verify(x => x.PublishBatch(
             It.Is<IEnumerable<ProcessImageRequest>>(reqs =>
-                reqs.Any(r => r.DocumentType == DocumentType.GroupSeasonLogo
-                              && r.ParentEntityId == group.Id)),
+                reqs.Count() == 1
+                && reqs.All(r => r.ParentEntityId == group.Id
+                                 && r.DocumentType == DocumentType.GroupSeasonLogo
+                                 && r.SeasonYear == 2024)),
             It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -140,6 +144,8 @@ public class GroupSeasonDocumentProcessorTests : ProducerTestBase<GroupSeasonDoc
             .OmitAutoProperties()
             .Create();
 
+        var bus = Mocker.GetMock<IEventBus>();
+
         // act
         await sut.ProcessAsync(command);
 
@@ -148,6 +154,18 @@ public class GroupSeasonDocumentProcessorTests : ProducerTestBase<GroupSeasonDoc
         group.Should().NotBeNull();
         group!.SeasonYear.Should().Be(2016,
             "SeasonYear must be extracted from the document $ref URL, not blindly inherited from command.Season");
+
+        // The logo image request must carry the same URL-derived season year
+        // (2016), not command.Season (2023) — proving ProcessLogos uses the year
+        // the processor resolved from the $ref, not the parent command's year.
+        bus.Verify(x => x.PublishBatch(
+            It.Is<IEnumerable<ProcessImageRequest>>(reqs =>
+                reqs.Count() == 1
+                && reqs.All(r => r.ParentEntityId == group.Id
+                                 && r.DocumentType == DocumentType.GroupSeasonLogo
+                                 && r.SeasonYear == 2016)),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact(Skip = "Revisit")]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/GroupSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/GroupSeasonDocumentProcessorTests.cs
@@ -4,8 +4,12 @@ using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Images;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Producer.Application.Documents.Processors.Commands;
@@ -62,6 +66,8 @@ public class GroupSeasonDocumentProcessorTests : ProducerTestBase<GroupSeasonDoc
             .OmitAutoProperties()
             .Create();
 
+        var bus = Mocker.GetMock<IEventBus>();
+
         // act
         await sut.ProcessAsync(command);
 
@@ -69,6 +75,15 @@ public class GroupSeasonDocumentProcessorTests : ProducerTestBase<GroupSeasonDoc
         var group = await FootballDataContext.GroupSeasons.FirstOrDefaultAsync();
         group.Should().NotBeNull();
         group.SeasonYear.Should().Be(2024);
+
+        // The SEC logo (dto.Logos) must be published as a GroupSeasonLogo image
+        // request — previously dropped, leaving the GroupSeasonLogo table empty.
+        bus.Verify(x => x.PublishBatch(
+            It.Is<IEnumerable<ProcessImageRequest>>(reqs =>
+                reqs.Any(r => r.DocumentType == DocumentType.GroupSeasonLogo
+                              && r.ParentEntityId == group.Id)),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     /// <summary>


### PR DESCRIPTION
## What

`GroupSeasonDocumentProcessor` deserialized `dto.Logos` but never published an image request, so the existing `GroupSeasonLogo` pipeline never fired and the `GroupSeasonLogo` table stayed **empty** — every conference/division logo was silently dropped.

The table, FK/nav, `GroupSeasonLogoRequestProcessor`, and `GroupSeasonLogoResponseProcessor` (which writes the row after download) **already existed**. The only missing link was the publish. This is pure wiring — **no schema change, no migration.**

## Changes

- `GroupSeasonDocumentProcessor.HandleNew` now calls `ProcessLogos`, publishing one `ProcessImageRequest` per `dto.Logos` entry with `DocumentType.GroupSeasonLogo`, mirroring `TeamSeasonDocumentProcessor.ProcessLogos` exactly (`EventFactory.CreateProcessImageRequests` + `PublishBatch`). Passes the URL-derived `seasonYear` for consistency with the rest of `HandleNew`'s deliberate year handling.
- Test: the `Sec2024` fixture already carries a real `logos` block, so the durable-prevention requirement (real captured ESPN JSON) was already met. Added a `PublishBatch` verify asserting a `GroupSeasonLogo` request is published for the created group.

## Verification

- Full Producer unit suite: **515 passed / 0 failed / 18 skipped**.

## Notes

- `GroupSeasonLogoResponseProcessor` populates `Uri/Height/Width/OriginalUrlHash` but not `Rel`/`IsForDarkBg` (both nullable, unchanged here). Populating those for group logos is a separate small follow-up if wanted.
- No re-source needed beyond the planned Phase-2 Mongo replay, which will pick up historical GroupSeason docs.

Part of the ESPN processor data-capture audit — **step 5 of 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ESPN group and season processing now correctly triggers logo image processing requests when logo data is available.
  * Fixed an issue that could skip logo publication, leaving group-season logos unrecorded for processing.
  * Logo request `SeasonYear` is now set from the document reference URL when the command and document year differ.
* **Tests**
  * Updated unit tests to verify logo publication behavior and correct `SeasonYear` handling for ESPN group-season documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->