### PR TITLE
feat(producer): capture football per-play participants (audit #3)

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -273,6 +273,14 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
                 $"Ref={externalDto.Ref}");
         }
 
+        // Resolve participants BEFORE mutating the tracked entity. A missing
+        // dependency throws ExternalDocumentNotSourcedException, and the base's
+        // retry handler calls SaveChangesAsync — so any tracked mutation made
+        // before the throw would be persisted despite "withhold for retry". By
+        // building participants first, a throw here leaves the tracked play
+        // completely unmodified.
+        var participants = await BuildParticipantsAsync(command, externalDto);
+
         var createdUtc = footballPlay.CreatedUtc;
         var createdBy = footballPlay.CreatedBy;
         _dataContext.Entry(footballPlay).CurrentValues.SetValues(mapped);
@@ -283,8 +291,6 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
         // refresh them. Replace the set wholesale: simpler than diffing per-row, and
         // ESPN can re-order or swap participants on a play between fetches. Mirrors
         // the baseball processor.
-        var participants = await BuildParticipantsAsync(command, externalDto);
-
         var existingParticipants = await _dataContext.Set<FootballCompetitionPlayParticipant>()
             .Where(p => p.CompetitionPlayId == footballPlay.Id)
             .ToListAsync();

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -9,6 +9,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
 using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
+using SportsData.Producer.Exceptions;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -61,6 +62,91 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
         return status is null ? null : !status.IsCompleted;
     }
 
+    /// <summary>
+    /// Build the per-play participant rows (passer / rusher / receiver / tackler
+    /// / …), resolving each athlete ref to a canonical AthleteSeason id and each
+    /// position ref to an AthletePosition id. ESPN names the field "athlete" but
+    /// the URL is season-scoped (`/seasons/{year}/athletes/{id}`), so it resolves
+    /// against AthleteSeason, not the global AthleteBase.
+    ///
+    /// When a referenced athlete/position isn't sourced yet, request that
+    /// dependency and throw <see cref="ExternalDocumentNotSourcedException"/> so
+    /// the base retries this play after the dependency lands (the established
+    /// dependency-sourcing pattern — see the athlete processor's
+    /// ProcessCurrentPosition). Every missing dependency across the participant
+    /// set is requested before the single throw, so one retry cycle sources them
+    /// all rather than one-per-retry. Deliberately stricter than the baseball
+    /// participant processor (which tolerates null): a persisted football play
+    /// always has fully-resolved participant attribution.
+    /// </summary>
+    private async Task<List<FootballCompetitionPlayParticipant>> BuildParticipantsAsync(
+        ProcessDocumentCommand command,
+        EspnFootballEventCompetitionPlayDto dto)
+    {
+        var result = new List<FootballCompetitionPlayParticipant>();
+        if (dto.Participants is null || dto.Participants.Count == 0) return result;
+
+        var provider = command.SourceDataProvider;
+        var anyMissing = false;
+
+        foreach (var participant in dto.Participants)
+        {
+            Guid? athleteSeasonId = null;
+            if (participant.Athlete?.Ref is not null)
+            {
+                athleteSeasonId = await _dataContext.ResolveIdAsync<AthleteSeason, AthleteSeasonExternalId>(
+                    participant.Athlete,
+                    provider,
+                    () => _dataContext.AthleteSeasons,
+                    externalIdsNav: "ExternalIds",
+                    key: a => a.Id);
+
+                if (athleteSeasonId is null)
+                {
+                    await PublishDependencyRequest<string?>(
+                        command, participant.Athlete, parentId: null, DocumentType.AthleteSeason);
+                    anyMissing = true;
+                }
+            }
+
+            Guid? positionId = null;
+            if (participant.Position?.Ref is not null)
+            {
+                positionId = await _dataContext.ResolveIdAsync<AthletePosition, AthletePositionExternalId>(
+                    participant.Position,
+                    provider,
+                    () => _dataContext.AthletePositions,
+                    externalIdsNav: "ExternalIds",
+                    key: p => p.Id);
+
+                if (positionId is null)
+                {
+                    await PublishDependencyRequest<string?>(
+                        command, participant.Position, parentId: null, DocumentType.AthletePosition);
+                    anyMissing = true;
+                }
+            }
+
+            result.Add(new FootballCompetitionPlayParticipant
+            {
+                Order = participant.Order,
+                Type = participant.Type ?? string.Empty,
+                AthleteSeasonId = athleteSeasonId,
+                PositionId = positionId,
+                StatisticsRef = participant.Statistics?.Ref?.ToString()
+            });
+        }
+
+        if (anyMissing)
+        {
+            throw new ExternalDocumentNotSourcedException(
+                "One or more play participants reference an AthleteSeason/AthletePosition that isn't sourced yet. " +
+                "Requested the missing dependencies; will retry this play.");
+        }
+
+        return result;
+    }
+
     protected override async Task<CompetitionPlayBase> BuildNewPlayAsync(
         ProcessDocumentCommand command,
         EspnFootballEventCompetitionPlayDto externalDto,
@@ -80,19 +166,29 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
         var endFranchiseSeasonId = await ResolveFranchiseSeasonIdAsync(
             externalDto.End.Team, command.SourceDataProvider);
 
+        var participants = await BuildParticipantsAsync(command, externalDto);
+
         _logger.LogInformation(
-            "Creating new CompetitionPlay. CompetitionId={CompId}, DriveId={DriveId}, PlayType={PlayType}",
+            "Creating new CompetitionPlay. CompetitionId={CompId}, DriveId={DriveId}, PlayType={PlayType}, ParticipantCount={Count}",
             competition.Id,
             competitionDriveId,
-            externalDto.Type?.Text);
+            externalDto.Type?.Text,
+            participants.Count);
 
-        return externalDto.AsFootballEntity(
+        var play = externalDto.AsFootballEntity(
             _externalRefIdentityGenerator,
             command.CorrelationId,
             competition.Id,
             competitionDriveId,
             startFranchiseSeasonId,
             endFranchiseSeasonId);
+
+        foreach (var participant in participants)
+        {
+            play.Participants.Add(participant);
+        }
+
+        return play;
     }
 
     protected override Task PublishSportPlayCompletedAsync(
@@ -182,5 +278,26 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
         _dataContext.Entry(footballPlay).CurrentValues.SetValues(mapped);
         footballPlay.CreatedUtc = createdUtc;
         footballPlay.CreatedBy = createdBy;
+
+        // Participants live in a separate table, so SetValues (scalars only) can't
+        // refresh them. Replace the set wholesale: simpler than diffing per-row, and
+        // ESPN can re-order or swap participants on a play between fetches. Mirrors
+        // the baseball processor.
+        var participants = await BuildParticipantsAsync(command, externalDto);
+
+        var existingParticipants = await _dataContext.Set<FootballCompetitionPlayParticipant>()
+            .Where(p => p.CompetitionPlayId == footballPlay.Id)
+            .ToListAsync();
+
+        if (existingParticipants.Count > 0)
+        {
+            _dataContext.Set<FootballCompetitionPlayParticipant>().RemoveRange(existingParticipants);
+        }
+
+        foreach (var participant in participants)
+        {
+            participant.CompetitionPlayId = footballPlay.Id;
+            await _dataContext.Set<FootballCompetitionPlayParticipant>().AddAsync(participant);
+        }
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionPlay.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionPlay.cs
@@ -58,6 +58,13 @@ public class FootballCompetitionPlay : CompetitionPlayBase
 
     public int? PointAfterAttemptValue { get; set; }
 
+    // Per-play athlete attribution (passer / rusher / receiver / tackler + order
+    // and per-participant stats ref). Rows live in the shared
+    // `CompetitionPlayParticipant` TPH table; the FK/relationship is configured on
+    // FootballCompetitionPlayParticipant. Previously dropped by the mapper.
+    public ICollection<FootballCompetitionPlayParticipant> Participants { get; set; }
+        = new List<FootballCompetitionPlayParticipant>();
+
     public new class EntityConfiguration : IEntityTypeConfiguration<FootballCompetitionPlay>
     {
         public void Configure(EntityTypeBuilder<FootballCompetitionPlay> builder)

--- a/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionPlayParticipant.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/Entities/FootballCompetitionPlayParticipant.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+/// <summary>
+/// Football participant row. Backed by the shared `CompetitionPlayParticipant`
+/// TPH table (configured on `CompetitionPlayParticipantBase`); the
+/// auto-generated discriminator distinguishes football rows from the baseball
+/// subclass. No football-specific fields today — the subclass exists so
+/// participant taxonomy (passer / rusher / receiver / tackler / …) can diverge
+/// cleanly per sport when needed, and because the FK navigation back to the
+/// play is sport-specific (FK configured here, not on the abstract base, so a
+/// sport without participants doesn't drag the base into its model). Mirrors
+/// BaseballCompetitionPlayParticipant.
+/// </summary>
+public class FootballCompetitionPlayParticipant : CompetitionPlayParticipantBase
+{
+    public FootballCompetitionPlay CompetitionPlay { get; set; } = null!;
+
+    public new class EntityConfiguration : IEntityTypeConfiguration<FootballCompetitionPlayParticipant>
+    {
+        public void Configure(EntityTypeBuilder<FootballCompetitionPlayParticipant> builder)
+        {
+            builder.HasOne(t => t.CompetitionPlay)
+                .WithMany(p => p.Participants)
+                .HasForeignKey(t => t.CompetitionPlayId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
@@ -20,6 +20,8 @@ namespace SportsData.Producer.Infrastructure.Data.Football
 
         public new DbSet<FootballCompetitionPlay> CompetitionPlays { get; set; }
 
+        public DbSet<FootballCompetitionPlayParticipant> CompetitionPlayParticipants { get; set; }
+
         // Drives are football-only (a "drive" is a contiguous offensive
         // possession terminating in a result). Lifted off TeamSportDataContext
         // so EF doesn't discover FootballCompetitionPlay via the
@@ -43,6 +45,8 @@ namespace SportsData.Producer.Infrastructure.Data.Football
             modelBuilder.ApplyConfiguration(new FootballCompetition.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionCompetitor.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionPlay.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new CompetitionPlayParticipantBase.EntityConfiguration());
+            modelBuilder.ApplyConfiguration(new FootballCompetitionPlayParticipant.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new FootballCompetitionStatus.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionDrive.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionDriveExternalId.EntityConfiguration());

--- a/src/SportsData.Producer/Migrations/Football/20260722122125_22JulV1_FootballCompetitionPlayParticipant.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260722122125_22JulV1_FootballCompetitionPlayParticipant.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260722122125_22JulV1_FootballCompetitionPlayParticipant")]
+    partial class _22JulV1_FootballCompetitionPlayParticipant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260722122125_22JulV1_FootballCompetitionPlayParticipant.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260722122125_22JulV1_FootballCompetitionPlayParticipant.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class _22JulV1_FootballCompetitionPlayParticipant : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CompetitionPlayParticipant",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CompetitionPlayId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Order = table.Column<int>(type: "integer", nullable: false),
+                    Type = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    AthleteSeasonId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PositionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StatisticsRef = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Discriminator = table.Column<string>(type: "character varying(34)", maxLength: 34, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionPlayParticipant", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CompetitionPlayParticipant_CompetitionPlay_CompetitionPlayId",
+                        column: x => x.CompetitionPlayId,
+                        principalTable: "CompetitionPlay",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionPlayParticipant_AthleteSeasonId",
+                table: "CompetitionPlayParticipant",
+                column: "AthleteSeasonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionPlayParticipant_CompetitionPlayId_Type",
+                table: "CompetitionPlayParticipant",
+                columns: new[] { "CompetitionPlayId", "Type" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionPlayParticipant_PositionId",
+                table: "CompetitionPlayParticipant",
+                column: "PositionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CompetitionPlayParticipant");
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
@@ -148,6 +148,69 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         return (kicker, returner);
     }
 
+    /// <summary>
+    /// Seed AthleteSeason + AthletePosition rows for the given season-scoped
+    /// athlete refs and position refs so participant resolution succeeds. Used by
+    /// tests processing plays whose participant deps aren't otherwise seeded.
+    /// </summary>
+    private async Task SeedParticipantDepsAsync(
+        ExternalRefIdentityGenerator generator,
+        IEnumerable<string> athleteRefs,
+        IEnumerable<string> positionRefs)
+    {
+        foreach (var refUrl in athleteRefs.Distinct())
+        {
+            FootballDataContext.AthleteSeasons.Add(new FootballAthleteSeason
+            {
+                Id = Guid.NewGuid(),
+                AthleteId = Guid.NewGuid(),
+                FranchiseSeasonId = Guid.NewGuid(),
+                PositionId = Guid.NewGuid(),
+                CreatedUtc = UtcNow(),
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds = new List<AthleteSeasonExternalId>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        Value = generator.Generate(refUrl).UrlHash,
+                        SourceUrl = new Uri(refUrl).ToCleanUrl(),
+                        SourceUrlHash = generator.Generate(refUrl).UrlHash,
+                        CreatedBy = Guid.NewGuid()
+                    }
+                }
+            });
+        }
+
+        foreach (var refUrl in positionRefs.Distinct())
+        {
+            FootballDataContext.AthletePositions.Add(new AthletePosition
+            {
+                Id = Guid.NewGuid(),
+                Name = "Position",
+                DisplayName = "Position",
+                Abbreviation = "POS",
+                CreatedUtc = UtcNow(),
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds = new List<AthletePositionExternalId>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        Value = generator.Generate(refUrl).UrlHash,
+                        SourceUrl = new Uri(refUrl).ToCleanUrl(),
+                        SourceUrlHash = generator.Generate(refUrl).UrlHash,
+                        CreatedBy = Guid.NewGuid()
+                    }
+                }
+            });
+        }
+
+        await FootballDataContext.SaveChangesAsync();
+    }
+
     private ProcessDocumentCommand CreateCommand(string jsonFile, string? parentId = null)
     {
         var generator = new ExternalRefIdentityGenerator();
@@ -580,6 +643,82 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
     }
 
     [Fact]
+    public async Task WhenReprocessingExistingPlay_ParticipantNotSourced_LeavesPlayUnmodified_AndRequestsDependency()
+    {
+        // arrange — an existing play, reprocessed while its participants are NOT
+        // sourced. The update path must throw BEFORE mutating the tracked entity,
+        // because the base's retry handler calls SaveChangesAsync — otherwise the
+        // remapped scalars would be persisted despite "withhold for retry".
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var bus = Mocker.GetMock<IEventBus>();
+
+        var competitionId = Guid.NewGuid();
+        await FootballDataContext.Competitions.AddAsync(new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = UtcNow(),
+            CreatedUtc = UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+        await SeedInProgressStatusAsync(competitionId);
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+        var playRef = json.FromJson<EspnFootballEventCompetitionPlayDto>()!.Ref;
+        var canonicalId = generator.Generate(playRef).CanonicalId;
+        var urlHash = generator.Generate(playRef).UrlHash;
+
+        // Seed the existing play with stale scalars (and NO participant deps).
+        var play = new FootballCompetitionPlay
+        {
+            Id = canonicalId,
+            CompetitionId = competitionId,
+            EspnId = "stale-espn-id",
+            SequenceNumber = "0",
+            Text = "STALE TEXT",
+            TypeId = "0",
+            CreatedUtc = UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        };
+        play.ExternalIds.Add(new CompetitionPlayExternalId
+        {
+            Id = Guid.NewGuid(),
+            CompetitionPlayId = canonicalId,
+            Provider = SourceDataProvider.Espn,
+            Value = urlHash,
+            SourceUrl = playRef.AbsoluteUri,
+            SourceUrlHash = urlHash,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.CompetitionPlays.AddAsync(play);
+        await FootballDataContext.SaveChangesAsync();
+        FootballDataContext.ChangeTracker.Clear();
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+
+        // act — update path; participants unsourced → withhold for retry.
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
+
+        // assert — the existing play is untouched (scalars NOT remapped), no
+        // participants were written, and sourcing was requested.
+        var reloaded = await FootballDataContext.CompetitionPlays
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == canonicalId);
+        reloaded.Text.Should().Be("STALE TEXT", "the tracked play must not be mutated before the dependency throw");
+
+        (await FootballDataContext.CompetitionPlayParticipants
+            .AnyAsync(p => p.CompetitionPlayId == canonicalId))
+            .Should().BeFalse();
+
+        bus.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeason),
+            It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
     public async Task WhenEntityExists_FullRemap_RefreshesFields_PreservesIdentityAuditAndExternalIds()
     {
         // arrange
@@ -639,6 +778,22 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         await FootballDataContext.CompetitionPlays.AddAsync(play);
         await FootballDataContext.SaveChangesAsync();
         var originalExternalIdRowId = externalId.Id;
+
+        // The TD play carries participants; seed their athlete/position deps so the
+        // update path resolves them and performs the full remap (rather than
+        // withholding for retry).
+        await SeedParticipantDepsAsync(
+            generator,
+            athleteRefs: new[]
+            {
+                "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/4429059?lang=en",
+                "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/4430026?lang=en"
+            },
+            positionRefs: new[]
+            {
+                "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/positions/9?lang=en",
+                "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/positions/22?lang=en"
+            });
 
         // Fresh DI scope per message in production.
         FootballDataContext.ChangeTracker.Clear();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
@@ -10,6 +10,8 @@ using Moq;
 
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Football;
@@ -32,6 +34,15 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     private const string PlayUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334/competitions/401628334/plays/401628334123";
+
+    // The two participants in the KickoffReturnOffense fixture (kicker + returner).
+    // The play processor now requests sourcing + throws for retry when a
+    // participant's athlete/position can't be resolved, so tests expecting the
+    // play to persist must seed these deps.
+    private const string KickerAthleteRef = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/4430026?lang=en";
+    private const string ReturnerAthleteRef = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/4869748?lang=en";
+    private const string KickerPositionRef = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/positions/22?lang=en";
+    private const string ReturnerPositionRef = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/positions/1?lang=en";
 
     // Fixed "now" for every CreatedUtc in this file. Per CLAUDE.md, tests
     // route timestamps through IDateTimeProvider so seeded entities are
@@ -65,6 +76,76 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
             CreatedBy = Guid.NewGuid()
         });
         await FootballDataContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Seed the AthleteSeason + AthletePosition rows referenced by the two
+    /// participants in the KickoffReturnOffense fixture so the play processor's
+    /// strict participant resolution finds them instead of requesting sourcing
+    /// and throwing for retry. Returns the (kicker, returner) AthleteSeason ids.
+    /// </summary>
+    private async Task<(Guid KickerSeasonId, Guid ReturnerSeasonId)> SeedKickoffReturnParticipantDepsAsync(
+        ExternalRefIdentityGenerator generator)
+    {
+        Guid SeedAthlete(string refUrl)
+        {
+            var id = Guid.NewGuid();
+            FootballDataContext.AthleteSeasons.Add(new FootballAthleteSeason
+            {
+                Id = id,
+                AthleteId = Guid.NewGuid(),
+                FranchiseSeasonId = Guid.NewGuid(),
+                PositionId = Guid.NewGuid(),
+                CreatedUtc = UtcNow(),
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds = new List<AthleteSeasonExternalId>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        Value = generator.Generate(refUrl).UrlHash,
+                        SourceUrl = new Uri(refUrl).ToCleanUrl(),
+                        SourceUrlHash = generator.Generate(refUrl).UrlHash,
+                        CreatedBy = Guid.NewGuid()
+                    }
+                }
+            });
+            return id;
+        }
+
+        void SeedPosition(string refUrl)
+        {
+            FootballDataContext.AthletePositions.Add(new AthletePosition
+            {
+                Id = Guid.NewGuid(),
+                Name = "Position",
+                DisplayName = "Position",
+                Abbreviation = "POS",
+                CreatedUtc = UtcNow(),
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds = new List<AthletePositionExternalId>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        Value = generator.Generate(refUrl).UrlHash,
+                        SourceUrl = new Uri(refUrl).ToCleanUrl(),
+                        SourceUrlHash = generator.Generate(refUrl).UrlHash,
+                        CreatedBy = Guid.NewGuid()
+                    }
+                }
+            });
+        }
+
+        var kicker = SeedAthlete(KickerAthleteRef);
+        var returner = SeedAthlete(ReturnerAthleteRef);
+        SeedPosition(KickerPositionRef);
+        SeedPosition(ReturnerPositionRef);
+        await FootballDataContext.SaveChangesAsync();
+
+        return (kicker, returner);
     }
 
     private ProcessDocumentCommand CreateCommand(string jsonFile, string? parentId = null)
@@ -255,6 +336,8 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         await FootballDataContext.FranchiseSeasons.AddAsync(returnTeam);
         await FootballDataContext.SaveChangesAsync();
 
+        await SeedKickoffReturnParticipantDepsAsync(generator);
+
         var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
@@ -376,6 +459,8 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
 
         await FootballDataContext.SaveChangesAsync();
 
+        await SeedKickoffReturnParticipantDepsAsync(generator);
+
         var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
@@ -393,6 +478,105 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         play!.ExternalIds.Should().NotBeEmpty();
         play.Competition.Should().NotBeNull();
         play.Competition!.Id.Should().Be(competitionId);
+    }
+
+    [Fact]
+    public async Task WhenProcessingPlay_PersistsParticipants_WithResolvedAthleteSeason()
+    {
+        // arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var competitionId = Guid.NewGuid();
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = UtcNow(),
+            CreatedUtc = UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        };
+        await FootballDataContext.Competitions.AddAsync(competition);
+        await FootballDataContext.SaveChangesAsync();
+        await SeedInProgressStatusAsync(competitionId);
+
+        var (kickerSeasonId, returnerSeasonId) = await SeedKickoffReturnParticipantDepsAsync(generator);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+        var command = CreateCommand(json, competitionId.ToString());
+
+        // act
+        await sut.ProcessAsync(command);
+
+        // assert - both participants persisted with order/type + resolved athlete/position
+        var play = await FootballDataContext.CompetitionPlays
+            .FirstAsync(x => x.CompetitionId == competitionId);
+
+        var participants = await FootballDataContext.CompetitionPlayParticipants
+            .Where(p => p.CompetitionPlayId == play.Id)
+            .OrderBy(p => p.Order)
+            .ToListAsync();
+
+        participants.Should().HaveCount(2);
+
+        participants[0].Type.Should().Be("kicker");
+        participants[0].Order.Should().Be(1);
+        participants[0].AthleteSeasonId.Should().Be(kickerSeasonId);
+        participants[0].PositionId.Should().NotBeNull();
+        participants[0].StatisticsRef.Should().NotBeNullOrEmpty();
+
+        participants[1].Type.Should().Be("returner");
+        participants[1].Order.Should().Be(2);
+        participants[1].AthleteSeasonId.Should().Be(returnerSeasonId);
+        participants[1].PositionId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task WhenParticipantAthleteNotSourced_RequestsDependency_AndDoesNotPersistPlay()
+    {
+        // arrange — competition + status seeded, but NOT the participant athletes
+        // or positions, so participant resolution fails.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var bus = Mocker.GetMock<IEventBus>();
+
+        var competitionId = Guid.NewGuid();
+        await FootballDataContext.Competitions.AddAsync(new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = UtcNow(),
+            CreatedUtc = UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.SaveChangesAsync();
+        await SeedInProgressStatusAsync(competitionId);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+        var command = CreateCommand(json, competitionId.ToString());
+
+        // act — the base swallows ExternalDocumentNotSourcedException and schedules
+        // a retry, so ProcessAsync returns without throwing.
+        await sut.ProcessAsync(command);
+
+        // assert — the play was NOT persisted (withheld for retry), and sourcing
+        // was requested for the unresolved participant dependencies.
+        var play = await FootballDataContext.CompetitionPlays
+            .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
+        play.Should().BeNull("the play must be withheld until its participants are sourced");
+
+        bus.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeason),
+            It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+        bus.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthletePosition),
+            It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
     }
 
     [Fact]


### PR DESCRIPTION
## What

`FootballEventCompetitionPlayDocumentProcessor` deserialized `participants[]` (passer / rusher / receiver / tackler + `order` + per-participant `statistics` ref) but **dropped** them — no football participant table existed, so all per-play athlete attribution was lost.

## Changes

- **New `FootballCompetitionPlayParticipant`** subclass on the shared `CompetitionPlayParticipant` TPH table (mirrors `BaseballCompetitionPlayParticipant`); `Participants` nav on `FootballCompetitionPlay`; DbSet + configs registered on `FootballDataContext` (configs are explicit per-context here, not assembly-scanned).
- **Processor**: `BuildParticipantsAsync` resolves each `athlete` (season-scoped ref → `AthleteSeason`) and `position` (→ `AthletePosition`), captures the `statistics` ref verbatim; wired into create and **wholesale-replaced** on the update path (`SetValues` can't touch a separate table).
- **Dependency sourcing (the established pattern):** when a participant's athlete/position isn't sourced yet, request that dependency and throw `ExternalDocumentNotSourcedException` so the base retries the play after it lands (see the athlete processor's `ProcessCurrentPosition`). **All** missing deps are requested before a **single** throw, so one retry cycle sources them all. Safe in the base flow — the throw precedes play persistence + `PlayCompleted` publish (create) and the update save, so no partial state or double publish. Deliberately **stricter** than the baseball participant processor (which tolerates null): a persisted football play has fully-resolved attribution.
- **Migration** (football only — baseball model unchanged): creates the `CompetitionPlayParticipant` table with the TPH discriminator + FK to the football `CompetitionPlay`. `has-pending-model-changes` clean for both contexts.
- **Tests**: real `KickoffReturnOffense` fixture (kicker + returner) with a shared helper seeding the participant athletes/positions; asserts participants persist with resolved athlete/position; plus a test asserting an unsourced participant **withholds the play** and requests `AthleteSeason` + `AthletePosition`.

## Verification

- Full Producer unit suite: **519 passed / 0 failed / 18 skipped**.

## Notes / follow-ups

- **Baseball now diverges deliberately.** `BaseballCompetitionPlayParticipant` still tolerates null (documented to avoid a live-game throw-retry loop). Football is now aligned with the rest of the play processor (which already throws when competition status isn't sourced). Open question whether to bring baseball in line — flagged for a separate follow-up.
- Football's separate `teamParticipants` array remains unmapped (team-level, not audit-flagged).

Part of the ESPN processor data-capture audit — **step 8, part 1 of 2** (#2 baseball baserunners remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Football play records now retain detailed participant information (athlete season/position, type, and order).
  * Participant data is fully refreshed when football plays are updated.
* **Bug Fixes**
  * Prevented participant details from being dropped during football play creation and mapping.
  * Improved robustness: if participant athlete-season or position data is missing, the processor requests the needed documents and avoids persisting incomplete plays.
* **Tests**
  * Expanded unit coverage for kickoff-return participant resolution and dependency-request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->