### PR TITLE
chore(core): downgrade EF pre-catch save/command failure logs to Debug

### DIFF
--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -5,6 +5,7 @@ using Hangfire.Tags.PostgreSql;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -167,7 +168,22 @@ namespace SportsData.Core.DependencyInjection
                     builder.EnableRetryOnFailure(5, TimeSpan.FromSeconds(10), ["40001"]);
                 });
                 options.ConfigureWarnings(w =>
-                    w.Throw(RelationalEventId.MultipleCollectionIncludeWarning));
+                {
+                    w.Throw(RelationalEventId.MultipleCollectionIncludeWarning);
+
+                    // Downgrade EF's own pre-catch save/command failure logs to Debug.
+                    // Under at-least-once delivery + parallel workers, processors race
+                    // to insert the same row; the losers hit a unique/PK violation that
+                    // the processors' `catch when (ex.IsUniqueConstraintViolation())`
+                    // idempotency guards absorb as success. EF logs the failed
+                    // SaveChanges at Error BEFORE that catch runs, producing high-volume
+                    // noise (especially during bulk re-seeds) that buries real errors.
+                    // Genuinely unhandled failures still surface at Error via each
+                    // service's own exception handling (e.g. DocumentProcessorBase).
+                    w.Log(
+                        (RelationalEventId.CommandError, LogLevel.Debug),
+                        (CoreEventId.SaveChangesFailed, LogLevel.Debug));
+                });
 
             });
 


### PR DESCRIPTION
## What

EF Core logs **every** failed `SaveChanges`/command at **Error** via its own `Microsoft.EntityFrameworkCore.Update` / `Database.Command` loggers — *before* the application's `catch` runs. Under at-least-once delivery + parallel workers, processors race to insert the same row (same canonical `Id`); the losers hit a unique/PK violation that the `catch when (ex.IsUniqueConstraintViolation())` idempotency guards absorb as **success**. But EF has already emitted an Error-level log for the failed save. During bulk re-seeds this produces high-volume noise that buries genuine errors in Seq.

## Change

Downgrade `RelationalEventId.CommandError` and `CoreEventId.SaveChangesFailed` to `Debug` in the shared `AddDbContext` `ConfigureWarnings` (`Core/DependencyInjection/ServiceRegistration.cs`).

## Why it's safe

Only EF's **redundant pre-catch** logging is suppressed. Genuinely unhandled failures still throw and are logged at Error by each service's own exception handling (e.g. `DocumentProcessorBase` → "Processing failed"). Applies to API/Provider/Producer, which share the same idempotency-guard pattern.

## Context

Found while triaging `PK_CompetitionPlay` duplicate-key **Errors** in Seq during the post-seed scan. Verified the play processing is **working correctly** (idempotent — the guard catches the race and treats it as success); the Error events were EF's internal `SaveChangesFailed` logs (`SourceContext = Microsoft.EntityFrameworkCore.Update`), **not** unhandled application failures. No data loss. This PR removes the noise so real errors stay visible — particularly relevant ahead of a bulk data re-seed.

## Verification

- `SportsData.Core` builds clean. Config-only change (logging severity); no behavioral/data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database operation warnings and failures.
  * Database command errors and failed save operations are now recorded at a lower diagnostic level, reducing unnecessary noise in application logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->