### PR TITLE
feat(provider): serve in-season immutable plays from Mongo (PoC) — stop live ESPN re-fetch storm

### DIFF
--- a/docs/features/in-season-cache-bypass-fix.md
+++ b/docs/features/in-season-cache-bypass-fix.md
@@ -1,0 +1,204 @@
+# In-Season Cache Bypass — Stop Re-Fetching Immutable Documents
+
+Status: **Proposed / awaiting authorization**
+Last updated: 2026-07-22
+Scope: MLB live sourcing (in-season). Applies to any current-season sport.
+
+## Problem
+
+During a **live** MLB game, the **same individual play** is fetched from ESPN
+**15–20 times** (verified in Seq for a single play URI, e.g.
+`…/competitions/401816227/plays/4018162270203990099`). A completed play is
+**immutable** — it should be served from Mongo, never re-fetched. This redundant
+fetching saturates ESPN's IP rate limiter (ESPN returns **403**, not 429), which
+is the direct cause of the **live-slate-freeze / stuck-finalization** issue
+(`reference_stuck_live_finalization_rate_limit`) currently worked around with
+spaced manual refreshes.
+
+### Amplification math
+
+`CompetitionStreamerBase` polls a live competition **every 30s** for up to a
+**5-hour** `MaxStreamDuration`, re-requesting the play index each cycle. A
+~3-hour baseball game (~360 cycles) × ~150–300 completed plays =
+**tens of thousands of redundant ESPN fetches per game**, none of which return
+new data. At the `RequestDelayMs=1000` throttle + 403 retry policy, this
+massively exceeds ESPN's tolerance → 403 storm → the live pipeline stalls and
+games don't finalize.
+
+## Root cause
+
+Cache-bypass is decided **per-season**, then applied uniformly to **every item**:
+
+- `ShouldBypassCache(seasonYear)` returns `true` when `seasonYear >=
+  CurrentSeason` (or `CurrentSeason == 0`). MLB 2026 → `true`. Two identical
+  copies: `DocumentRequestedHandler.cs:120` and `ResourceIndexJob.cs:212`.
+- The item command inherits that as `command.BypassCache = true`
+  (`DocumentRequestedHandler.cs:202`, `ResourceIndexJob.cs:243`) — correctly
+  *not* the index's hardcoded bypass, but season-based.
+- `ResourceIndexItemProcessor.cs:186` — `if (dbItem is not null &&
+  !command.BypassCache)` — with `BypassCache=true`, this short-circuits **past
+  the Mongo-serve path**, so a perfectly good cached play is ignored and
+  re-fetched from ESPN (`:265→284`).
+- The unchanged-content / cooldown suppression that would otherwise stop the
+  re-publish (`:210`) is itself gated on `!IsCurrentSeason(...)` → also skipped
+  in-season.
+
+**The bug: `season` is the wrong axis for an individual item. The right axis is
+`document mutability`.** The index *listing* legitimately bypasses (new plays
+appear); an individual completed *play* never should.
+
+## Key principle: mutability ≠ season
+
+| Behavior in-season | Correct for |
+|---|---|
+| **Bypass cache** (re-fetch, data changes) | the play/competitor **index listings**, and mutable aggregates |
+| **Serve from Mongo** (immutable once created) | individual completed **plays / drives** |
+
+### Draft document-type classification (LOAD-BEARING — needs confirmation)
+
+**Immutable once created** (serve from Mongo even in-season):
+- `EventCompetitionPlay` — the primary offender (highest volume, re-paged every 30s)
+- `EventCompetitionDrive` (football)
+- `EventCompetitionCompetitorRoster` (static per game once set) — *confirm*
+
+**Mutable in-season** (keep bypassing — must stay fresh):
+- `EventCompetition`, `EventCompetitionStatus`, `EventCompetitionSituation`
+- `EventCompetitionCompetitorScore`, `…LineScore`, `…Record`
+- `…CompetitorStatistics`, `…AthleteStatistics`, `…Leaders`
+- `EventCompetitionOdds`, `…Probability`, `…Prediction`, `…PowerIndex`
+
+The classification is the crux and the main thing to get right — a
+mis-classified mutable type would go stale mid-game; a mis-classified immutable
+type just wastes an occasional fetch. **Bias the initial allow-list small
+(start with `EventCompetitionPlay` only)** — it captures ~all the bleeding —
+then expand.
+
+## The one real correctness tension: the finalizing edge
+
+Older plays are immutable, but the **most-recent play may still be finalizing**
+(an in-progress at-bat fetched with partial data, then completed). A blanket
+"never re-fetch a cached play" would miss that transition and show a stale last
+play. Also relevant: rare post-game ESPN **corrections** (scoring changes).
+
+**Resolution (chosen): re-fetch only the live edge, identified as the last index
+item.** VERIFIED against a real MLB plays index: `EspnResourceIndexDto.Items` is
+ordered **ascending** by play id (639 plays / 26 pages, ids strictly
+increasing). So the newest play is deterministically the **last item on the last
+page**: `dto.PageIndex == dto.PageCount && i == dto.Items.Count - 1`. That single
+item keeps re-fetching (may still be finalizing); every other cached play serves
+from Mongo. Result: **1 ESPN play fetch/cycle** instead of hundreds.
+
+This is cleaner than reading the Situation doc's `lastPlay` ref: the decision is
+made *right where the index is already being iterated* (`ProcessResourceIndex` /
+`ResourceIndexJob`), with no cross-document lookup and no coupling to Situation
+processing.
+
+Two safety nets for corrections beyond the edge:
+- **Finalization refresh forces a full re-validate.** The streamer already fires
+  `PublishContestRefreshOnFinalAsync` at game end — that pass MUST bypass cache
+  for plays (re-fetch all) so any missed mid-game correction is caught once, at
+  final. So the immutable-serve applies to the *live polling cycles*, not the
+  on-final refresh.
+- (Optional, later) periodic full re-validate every M minutes during the game.
+
+Note: this is likely belt-and-suspenders — ESPN generally only lists a play in
+the index once it's complete, so most cached plays are already final. But
+re-fetching one item/cycle is cheap insurance and costs nothing meaningful.
+
+## Design options (the actual fix)
+
+1. **Item-mutability cache honesty (core fix).** At the item cache decision, for
+   immutable-type items, serve from Mongo when `dbItem` is present **regardless
+   of `BypassCache`**. Also relax the `IsCurrentSeason` gate on the cooldown/
+   unchanged suppression for immutable types so we don't re-publish an unchanged
+   cached play every cycle (reduces Producer + Rabbit churn too). Collapses
+   15–20 → ~1.
+2. **Reduce demand at the source (follow-on).** Have the streamer / index
+   processing only request plays it doesn't already have (presence-diff against
+   Mongo), instead of re-enqueueing the whole index each cycle. Cuts the request
+   volume before it reaches the cache. Higher leverage on the limiter, but
+   touches the live worker + has the same finalizing-edge caveat.
+3. **Short in-season read-cache TTL (stopgap).** Type-agnostic: cache in-season
+   docs for ~30–60s so rapid re-requests inside the window serve from Mongo.
+   Simple, broad, no per-type knowledge — but blunter (delays legitimately
+   mutable updates by up to the TTL). Good as a fast relief valve if needed
+   before the classification work lands.
+
+## Recommendation
+
+**#1 (core) + the "re-fetch only the live edge" correctness handling**, with **#2
+as a follow-on** once #1 proves out. #1 makes the cache honest so *every* caller
+benefits (streamer, manual refresh, re-source), and it's a contained change to
+one decision point plus a mutability classifier. Keep an initial allow-list of
+just `EventCompetitionPlay`.
+
+## Bonus: faster live updates (not just fewer calls)
+
+This is not only a cost fix. Today, a brand-new play must queue behind tens of
+thousands of redundant immutable re-fetches and the resulting 403 back-off — so
+new plays land **late**. Once immutable plays serve from Mongo, the rate limiter
+has headroom and the only ESPN calls are the mutable aggregates + the live-edge
+play → **new plays land in ~one fetch instead of waiting out the storm.** Better
+logic → lower ESPN load **and** faster live play latency.
+
+## Implementation sketch (refined — decide bypass at enqueue, keep the item processor dumb)
+
+The key insight: all the context needed (document type, page position, whether
+this is the live edge) exists **at the point the index enqueues items**, not in
+the item processor. So compute the *effective* bypass there and keep
+`ResourceIndexItemProcessor` honoring a single `BypassCache` flag — **no change
+to its core decision** (`:186` already serves from Mongo when
+`BypassCache == false`).
+
+- **Mutability classifier** — a small `IsImmutableInSeason(DocumentType)` /
+  static allow-list in Provider, single source of truth. **PoC = {
+  `EventCompetitionPlay` }.**
+- **`ProcessResourceIndex` (`DocumentRequestedHandler`) and `ResourceIndexJob`**
+  — the two item-enqueue loops. Replace the flat
+  `BypassCache: ShouldBypassCache(seasonYear)` with a per-item computation:
+  ```
+  var isLiveEdge = dto.PageIndex == dto.PageCount && i == dto.Items.Count - 1;
+  var bypass = ShouldBypassCache(seasonYear)
+               && (!IsImmutableInSeason(docType) || isLiveEdge);
+  ```
+  So: mutable types + the live-edge play → bypass (unchanged); every other
+  immutable item → `false` → served from Mongo by the existing item path. This
+  is the whole core fix.
+- **`ResourceIndexItemProcessor`** — no change required for the ESPN-call
+  reduction. *Optional churn reduction*: relax the `IsCurrentSeason` gate on the
+  cooldown/unchanged suppression (`:210`) for immutable types so an unchanged
+  cached play isn't re-published to Producer every cycle either.
+- **Finalization** — confirm `PublishContestRefreshOnFinalAsync` re-sources plays
+  with bypass (full re-validate at game end). If it flows through the same
+  enqueue path, it will treat plays as immutable and skip them — so it needs an
+  explicit "force bypass" for the final pass (or exempt the on-final refresh from
+  `IsImmutableInSeason`).
+- **`ShouldBypassCache` itself is untouched** — the season predicate stays; we
+  only *gate* it per-item by mutability + edge at enqueue time.
+
+## Testing
+
+- Unit: `IsImmutableInSeason` per DocumentType (locks the classification).
+- Unit: in-season + `EventCompetitionPlay` + doc in Mongo → served from cache,
+  no ESPN fetch, `espn.cache.hit` increments, `espn.live.fetch` does not.
+- Unit: in-season + `EventCompetitionStatus` (mutable) → still bypasses.
+- Unit: unchanged cached play within cooldown → suppressed re-publish.
+
+## Rollout / risk
+
+- Guard behind a config flag (allow-list is itself the flag — empty = today's
+  behavior).
+- Success metric: for a live MLB game, `espn.cache.hit` goes from ~0 to
+  **dominant**, `espn.live.fetch` drops by ~2 orders of magnitude, 403s
+  disappear, games finalize without manual spacing.
+- Risk if mis-classified: a mutable type served stale mid-game (visible, quickly
+  correctable by shrinking the allow-list). Starting with `EventCompetitionPlay`
+  only makes this near-zero-risk.
+
+## Related
+
+- `reference_stuck_live_finalization_rate_limit` — the symptom this fixes.
+- `project_in_season_completed_cache` — the deferred item this concretizes
+  (per-season → per-mutability).
+- `docs/processing/include-linked-document-types.md` — the refresh-narrowing
+  mechanism (orthogonal but adjacent).

--- a/docs/features/in-season-cache-bypass-fix.md
+++ b/docs/features/in-season-cache-bypass-fix.md
@@ -87,7 +87,7 @@ play. Also relevant: rare post-game ESPN **corrections** (scoring changes).
 item.** VERIFIED against a real MLB plays index: `EspnResourceIndexDto.Items` is
 ordered **ascending** by play id (639 plays / 26 pages, ids strictly
 increasing). So the newest play is deterministically the **last item on the last
-page**: `dto.PageIndex == dto.PageCount && i == dto.Items.Count - 1`. That single
+page**: `dto.PageIndex >= dto.PageCount && i == dto.Items.Count - 1`. That single
 item keeps re-fetching (may still be finalizing); every other cached play serves
 from Mongo. Result: **1 ESPN play fetch/cycle** instead of hundreds.
 
@@ -171,7 +171,7 @@ to its core decision** (`:186` already serves from Mongo when
   `BypassCache: ShouldBypassCache(seasonYear)` with a per-item computation:
 
   ```csharp
-  var isLiveEdge = dto.PageIndex == dto.PageCount && i == dto.Items.Count - 1;
+  var isLiveEdge = dto.PageIndex >= dto.PageCount && i == dto.Items.Count - 1;
   var bypass = ShouldBypassCache(seasonYear)
                && (!IsImmutableInSeason(docType) || isLiveEdge);
   ```

--- a/docs/features/in-season-cache-bypass-fix.md
+++ b/docs/features/in-season-cache-bypass-fix.md
@@ -1,6 +1,9 @@
 # In-Season Cache Bypass — Stop Re-Fetching Immutable Documents
 
-Status: **Proposed / awaiting authorization**
+Status: **PoC implemented** (PR #549) — `DocumentRequestedHandler.ProcessResourceIndex`
+path only, allow-list `{ EventCompetitionPlay }`. Follow-ons deferred (see Scope):
+`ResourceIndexJob` paged loop, single-item/leaf paths, on-final force-bypass
+re-validate, in-season cooldown relaxation.
 Last updated: 2026-07-22
 Scope: MLB live sourcing (in-season). Applies to any current-season sport.
 
@@ -89,21 +92,31 @@ item keeps re-fetching (may still be finalizing); every other cached play serves
 from Mongo. Result: **1 ESPN play fetch/cycle** instead of hundreds.
 
 This is cleaner than reading the Situation doc's `lastPlay` ref: the decision is
-made *right where the index is already being iterated* (`ProcessResourceIndex` /
-`ResourceIndexJob`), with no cross-document lookup and no coupling to Situation
-processing.
+made *right where the index is already being iterated*, with no cross-document
+lookup and no coupling to Situation processing. **Implemented in the PoC for the
+`DocumentRequestedHandler.ProcessResourceIndex` path only** — the `ResourceIndexJob`
+paged loop is a deferred follow-on (see Scope below).
 
-Two safety nets for corrections beyond the edge:
-- **Finalization refresh forces a full re-validate.** The streamer already fires
-  `PublishContestRefreshOnFinalAsync` at game end — that pass MUST bypass cache
-  for plays (re-fetch all) so any missed mid-game correction is caught once, at
-  final. So the immutable-serve applies to the *live polling cycles*, not the
-  on-final refresh.
-- (Optional, later) periodic full re-validate every M minutes during the game.
+### Correction coverage for non-edge cached plays — DEFERRED (not in the PoC)
 
-Note: this is likely belt-and-suspenders — ESPN generally only lists a play in
-the index once it's complete, so most cached plays are already final. But
-re-fetching one item/cycle is cheap insurance and costs nothing meaningful.
+The PoC serves cached non-edge plays from Mongo and re-fetches only the live
+edge. It does **not** implement any re-validation of already-cached non-edge
+plays, so a rare mid-game **correction** (a scoring/stat change to an older play)
+would not be picked up. In particular:
+
+- **The finalization refresh does NOT currently force a full re-validate.**
+  `PublishContestRefreshOnFinalAsync` flows through the same enqueue path, so
+  post-PoC it will *also* serve plays from cache — corrections are not re-fetched
+  at final. Making the on-final pass force-bypass plays is a **required follow-on**
+  before broad rollout; it is not implemented here.
+- A periodic mid-game full re-validate is a possible later addition, also not
+  implemented.
+
+Why this is acceptable for the PoC: ESPN generally only lists a play in the index
+once it's complete, so most cached plays are already final; corrections are rare.
+The live-edge re-fetch covers the still-finalizing play. But the correction gap
+is real and is why the on-final force-bypass is called out as a follow-on rather
+than "coverage we already have."
 
 ## Design options (the actual fix)
 
@@ -156,11 +169,13 @@ to its core decision** (`:186` already serves from Mongo when
 - **`ProcessResourceIndex` (`DocumentRequestedHandler`) and `ResourceIndexJob`**
   — the two item-enqueue loops. Replace the flat
   `BypassCache: ShouldBypassCache(seasonYear)` with a per-item computation:
-  ```
+
+  ```csharp
   var isLiveEdge = dto.PageIndex == dto.PageCount && i == dto.Items.Count - 1;
   var bypass = ShouldBypassCache(seasonYear)
                && (!IsImmutableInSeason(docType) || isLiveEdge);
   ```
+
   So: mutable types + the live-edge play → bypass (unchanged); every other
   immutable item → `false` → served from Mongo by the existing item path. This
   is the whole core fix.

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -334,9 +334,19 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 // "live edge": the newest item (last item on the last page — the
                 // index is ordered ascending), which may still be finalizing, so it
                 // keeps bypassing. See docs/features/in-season-cache-bypass-fix.md.
+                //
+                // Scope the immutable exception to EXACTLY the current season. When
+                // the feature is disabled (CurrentSeason == 0), the season is unknown
+                // (null), or the request is for a future season, keep the original
+                // bypass behavior for every item (no immutable-serve). Historical
+                // seasons already serve from cache via ShouldBypassCache == false.
                 var isLiveEdge = dto.PageIndex >= dto.PageCount && i == dto.Items.Count - 1;
-                var bypassCache = ShouldBypassCache(evt.SeasonYear)
-                    && (!InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType) || isLiveEdge);
+                var isCurrentSeason = _commonConfig.CurrentSeason != 0
+                    && evt.SeasonYear == _commonConfig.CurrentSeason;
+                var serveImmutableFromCache = isCurrentSeason
+                    && InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType)
+                    && !isLiveEdge;
+                var bypassCache = ShouldBypassCache(evt.SeasonYear) && !serveImmutableFromCache;
 
                 var cmd = new ProcessResourceIndexItemCommand(
                     CorrelationId: evt.CorrelationId,

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -327,6 +327,17 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 // hardcoding BypassCache=true, forcing an ESPN call for every child of
                 // every resource index — defeating Mongo cache entirely for re-finalize
                 // and historical-sourcing runs.
+                //
+                // In-season immutable items (e.g. a completed play) are served from
+                // Mongo instead of re-fetched from ESPN every live-poll cycle — the
+                // fix for the live-slate rate-limit storm. The one exception is the
+                // "live edge": the newest item (last item on the last page — the
+                // index is ordered ascending), which may still be finalizing, so it
+                // keeps bypassing. See docs/features/in-season-cache-bypass-fix.md.
+                var isLiveEdge = dto.PageIndex >= dto.PageCount && i == dto.Items.Count - 1;
+                var bypassCache = ShouldBypassCache(evt.SeasonYear)
+                    && (!InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType) || isLiveEdge);
+
                 var cmd = new ProcessResourceIndexItemCommand(
                     CorrelationId: evt.CorrelationId,
                     CausationId: evt.CausationId,
@@ -339,7 +350,7 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                     DocumentType: evt.DocumentType,
                     ParentId: evt.ParentId,
                     SeasonYear: evt.SeasonYear,
-                    BypassCache: ShouldBypassCache(evt.SeasonYear),
+                    BypassCache: bypassCache,
                     IncludeLinkedDocumentTypes: evt.IncludeLinkedDocumentTypes,
                     InlineJson: useInlineJson == true ? rawItemJsonList![i] : null);
 

--- a/src/SportsData.Provider/Application/Processors/InSeasonDocumentPolicy.cs
+++ b/src/SportsData.Provider/Application/Processors/InSeasonDocumentPolicy.cs
@@ -1,0 +1,37 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Provider.Application.Processors
+{
+    /// <summary>
+    /// Classifies whether a document type is <b>immutable once created</b>, for
+    /// in-season cache decisions.
+    ///
+    /// Cache-bypass is otherwise decided per-season (<c>ShouldBypassCache</c>):
+    /// anything in the current season is re-fetched from ESPN so live-mutable
+    /// data (status, situation, score, odds, ...) stays fresh. But that is the
+    /// wrong axis for an individual immutable item: a completed play never
+    /// changes, yet the live streamer re-pages the play index every 30s and
+    /// re-fetches every play from ESPN each cycle — saturating ESPN's 403 rate
+    /// limiter and stalling live finalization.
+    ///
+    /// Immutable-in-season types should be served from Mongo even during the
+    /// current season (except the live edge — the newest, still-finalizing item,
+    /// handled at the enqueue site). Mutable aggregates must NOT be listed here.
+    ///
+    /// PoC allow-list = <see cref="DocumentType.EventCompetitionPlay"/> only —
+    /// that captures effectively all of the bleeding at near-zero risk. Expand
+    /// deliberately (drives, per-game roster) once proven.
+    ///
+    /// See docs/features/in-season-cache-bypass-fix.md.
+    /// </summary>
+    public static class InSeasonDocumentPolicy
+    {
+        private static readonly HashSet<DocumentType> ImmutableInSeasonTypes = new()
+        {
+            DocumentType.EventCompetitionPlay,
+        };
+
+        public static bool IsImmutableInSeason(DocumentType documentType)
+            => ImmutableInSeasonTypes.Contains(documentType);
+    }
+}

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -21,7 +21,10 @@ using SportsData.Provider.Infrastructure.Providers.Espn;
 
 using FluentValidation.Results;
 
+using SportsData.Core.Config;
+
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 
 using Xunit;
 
@@ -65,6 +68,69 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         // assert
         background.Verify(x => x.Enqueue<IProcessResourceIndexItems>(
             It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.AtLeastOnce);
+    }
+
+    [Theory]
+    // Immutable type in-season: non-edge items served from Mongo (BypassCache=false);
+    // the live edge (last item) still bypasses. Mutable type: every item bypasses.
+    [InlineData(DocumentType.EventCompetitionPlay, false)]
+    [InlineData(DocumentType.EventCompetitionStatus, true)]
+    public async Task InSeason_ImmutableItems_ServeFromCache_ExceptLiveEdge(
+        DocumentType documentType,
+        bool expectNonEdgeBypass)
+    {
+        // arrange — in-season: SeasonYear == CurrentSeason so ShouldBypassCache is true.
+        const int season = 2026;
+        var cfg = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
+        cfg.CurrentSeason = season;
+        Mocker.Use<IOptions<CommonConfig>>(Options.Create(cfg));
+
+        // Single-page plays index, 3 items ($ref-only → non-hybrid), ascending ids.
+        const string baseUrl = "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816227/competitions/401816227/plays";
+        var json =
+            "{\"count\":3,\"pageIndex\":1,\"pageSize\":25,\"pageCount\":1,\"items\":[" +
+            "{\"$ref\":\"" + baseUrl + "/1?lang=en\"}," +
+            "{\"$ref\":\"" + baseUrl + "/2?lang=en\"}," +
+            "{\"$ref\":\"" + baseUrl + "/3?lang=en\"}]}";
+
+        var espnApi = Mocker.GetMock<IProvideEspnApiData>();
+        espnApi.Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(json));
+
+        var captured = new List<ProcessResourceIndexItemCommand>();
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        background
+            .Setup(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
+            .Callback<Expression<Func<IProcessResourceIndexItems, Task>>>(expr =>
+            {
+                var call = (MethodCallExpression)expr.Body;
+                var cmd = (ProcessResourceIndexItemCommand)Expression
+                    .Lambda(call.Arguments[0]).Compile().DynamicInvoke()!;
+                captured.Add(cmd);
+            })
+            .Returns(string.Empty);
+
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = Fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, new Uri($"{baseUrl}?lang=en"))
+            .With(x => x.DocumentType, documentType)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.SeasonYear, (int?)season)
+            .OmitAutoProperties()
+            .Create();
+
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert
+        captured.Should().HaveCount(3);
+        captured[^1].BypassCache.Should().BeTrue("the live edge (last item) may still be finalizing and must re-fetch");
+        captured[0].BypassCache.Should().Be(expectNonEdgeBypass);
+        captured[1].BypassCache.Should().Be(expectNonEdgeBypass);
     }
 
     [Fact]

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -133,6 +133,64 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         captured[1].BypassCache.Should().Be(expectNonEdgeBypass);
     }
 
+    [Theory]
+    // The immutable exception applies ONLY to exactly the current season. For a
+    // future season or when the feature is disabled (CurrentSeason == 0), every
+    // item keeps the original bypass behavior — no immutable-serve, non-edge included.
+    [InlineData(2026, 2027)] // future season
+    [InlineData(0, 2026)]    // feature disabled
+    public async Task NotCurrentSeason_ImmutablePlays_StillBypassEveryItem(
+        int currentSeason,
+        int requestedSeason)
+    {
+        // arrange
+        var cfg = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
+        cfg.CurrentSeason = currentSeason;
+        Mocker.Use<IOptions<CommonConfig>>(Options.Create(cfg));
+
+        const string baseUrl = "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816227/competitions/401816227/plays";
+        var json =
+            "{\"count\":3,\"pageIndex\":1,\"pageSize\":25,\"pageCount\":1,\"items\":[" +
+            "{\"$ref\":\"" + baseUrl + "/1?lang=en\"}," +
+            "{\"$ref\":\"" + baseUrl + "/2?lang=en\"}," +
+            "{\"$ref\":\"" + baseUrl + "/3?lang=en\"}]}";
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(json));
+
+        var captured = new List<ProcessResourceIndexItemCommand>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
+            .Callback<Expression<Func<IProcessResourceIndexItems, Task>>>(expr =>
+            {
+                var call = (MethodCallExpression)expr.Body;
+                captured.Add((ProcessResourceIndexItemCommand)Expression
+                    .Lambda(call.Arguments[0]).Compile().DynamicInvoke()!);
+            })
+            .Returns(string.Empty);
+
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = Fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, new Uri($"{baseUrl}?lang=en"))
+            .With(x => x.DocumentType, DocumentType.EventCompetitionPlay)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.SeasonYear, (int?)requestedSeason)
+            .OmitAutoProperties()
+            .Create();
+
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — immutable exception does not apply; every item bypasses.
+        captured.Should().HaveCount(3);
+        captured.Should().OnlyContain(c => c.BypassCache);
+    }
+
     [Fact]
     public async Task WhenResourceIndexHasNoItems_NothingHappens()
     {

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -135,13 +135,14 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
 
     [Theory]
     // The immutable exception applies ONLY to exactly the current season. For a
-    // future season or when the feature is disabled (CurrentSeason == 0), every
-    // item keeps the original bypass behavior — no immutable-serve, non-edge included.
+    // future season, a disabled feature (CurrentSeason == 0), or a null/non-seasonal
+    // SeasonYear, every item keeps the original bypass — no immutable-serve, non-edge included.
     [InlineData(2026, 2027)] // future season
     [InlineData(0, 2026)]    // feature disabled
+    [InlineData(2026, null)] // null / non-seasonal
     public async Task NotCurrentSeason_ImmutablePlays_StillBypassEveryItem(
         int currentSeason,
-        int requestedSeason)
+        int? requestedSeason)
     {
         // arrange
         var cfg = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
@@ -177,7 +178,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
             .With(x => x.Uri, new Uri($"{baseUrl}?lang=en"))
             .With(x => x.DocumentType, DocumentType.EventCompetitionPlay)
             .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
-            .With(x => x.SeasonYear, (int?)requestedSeason)
+            .With(x => x.SeasonYear, requestedSeason)
             .OmitAutoProperties()
             .Create();
 
@@ -189,6 +190,66 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         // assert — immutable exception does not apply; every item bypasses.
         captured.Should().HaveCount(3);
         captured.Should().OnlyContain(c => c.BypassCache);
+    }
+
+    [Fact]
+    public async Task InSeason_MultiPageIndex_OnlyFinalPageLastItem_IsLiveEdge()
+    {
+        // arrange — current season, immutable plays, 2-page index of 4 plays.
+        const int season = 2026;
+        var cfg = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
+        cfg.CurrentSeason = season;
+        Mocker.Use<IOptions<CommonConfig>>(Options.Create(cfg));
+
+        const string baseUrl = "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816227/competitions/401816227/plays";
+        static string Page(int pageIndex, int pageCount, string baseUrl, params int[] ids)
+        {
+            var items = string.Join(",", ids.Select(id => "{\"$ref\":\"" + baseUrl + "/" + id + "?lang=en\"}"));
+            return $"{{\"count\":4,\"pageIndex\":{pageIndex},\"pageSize\":2,\"pageCount\":{pageCount},\"items\":[{items}]}}";
+        }
+
+        var espnApi = Mocker.GetMock<IProvideEspnApiData>();
+        // Page 2 request carries page=2 in the query; the initial request does not.
+        espnApi.Setup(x => x.GetResource(
+                It.Is<Uri>(u => u.Query.Contains("page=2")), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(Page(2, 2, baseUrl, 3, 4)));
+        espnApi.Setup(x => x.GetResource(
+                It.Is<Uri>(u => !u.Query.Contains("page=2")), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(Page(1, 2, baseUrl, 1, 2)));
+
+        var captured = new List<ProcessResourceIndexItemCommand>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
+            .Callback<Expression<Func<IProcessResourceIndexItems, Task>>>(expr =>
+            {
+                var call = (MethodCallExpression)expr.Body;
+                captured.Add((ProcessResourceIndexItemCommand)Expression
+                    .Lambda(call.Arguments[0]).Compile().DynamicInvoke()!);
+            })
+            .Returns(string.Empty);
+
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = Fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, new Uri($"{baseUrl}?lang=en"))
+            .With(x => x.DocumentType, DocumentType.EventCompetitionPlay)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.SeasonYear, (int?)season)
+            .OmitAutoProperties()
+            .Create();
+
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — 4 items across 2 pages; only the FINAL page's LAST item is the live edge.
+        captured.Should().HaveCount(4);
+        captured[0].BypassCache.Should().BeFalse();
+        captured[1].BypassCache.Should().BeFalse("page-1's last item is NOT the live edge — it isn't the final page");
+        captured[2].BypassCache.Should().BeFalse();
+        captured[3].BypassCache.Should().BeTrue("only the last item on the final page is the live edge");
     }
 
     [Fact]

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Processors/InSeasonDocumentPolicyTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Processors/InSeasonDocumentPolicyTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+
+using SportsData.Core.Common;
+using SportsData.Provider.Application.Processors;
+
+using Xunit;
+
+namespace SportsData.Provider.Tests.Unit.Application.Processors;
+
+public class InSeasonDocumentPolicyTests
+{
+    [Theory]
+    // Immutable once created → served from Mongo even in-season (the fix).
+    [InlineData(DocumentType.EventCompetitionPlay, true)]
+    // Mutable aggregates → must keep bypassing cache in-season to stay fresh.
+    [InlineData(DocumentType.EventCompetitionStatus, false)]
+    [InlineData(DocumentType.EventCompetitionSituation, false)]
+    [InlineData(DocumentType.EventCompetitionCompetitorScore, false)]
+    [InlineData(DocumentType.EventCompetitionCompetitorRecord, false)]
+    [InlineData(DocumentType.EventCompetitionOdds, false)]
+    [InlineData(DocumentType.EventCompetition, false)]
+    [InlineData(DocumentType.Athlete, false)]
+    public void IsImmutableInSeason_ClassifiesCorrectly(DocumentType type, bool expected)
+    {
+        InSeasonDocumentPolicy.IsImmutableInSeason(type).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## What

During a **live** game, `CompetitionStreamerBase` re-pages the play index every 30s and Provider re-fetches **every play from ESPN each cycle** — the *same completed play 15–20×* (verified in Seq). A completed play is **immutable** and should come from Mongo. This redundant fetching saturates ESPN's IP rate limiter (403), which is the root cause of the **live-slate-freeze / stuck-finalization** issue.

**Root cause:** cache-bypass is decided **per-season** (`ShouldBypassCache`: `seasonYear >= CurrentSeason`) and applied uniformly to every item. The right axis for an individual item is **mutability**, not season.

## Fix (PoC — live path only)

Decide bypass **per-item at the index enqueue**. For immutable-in-season types, serve from Mongo (`BypassCache=false`) instead of re-fetching — except the **live edge** (last item on the last page; the index is ordered ascending, verified against a real MLB plays index) which may still be finalizing and keeps bypassing. `ResourceIndexItemProcessor` is unchanged — its `:186` path already serves from Mongo when `BypassCache=false`.

```csharp
var isLiveEdge = dto.PageIndex >= dto.PageCount && i == dto.Items.Count - 1;
var bypassCache = ShouldBypassCache(evt.SeasonYear)
    && (!InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType) || isLiveEdge);
```

- **`InSeasonDocumentPolicy`** — new classifier. PoC allow-list = `{ EventCompetitionPlay }` (captures ~all the bleeding at near-zero risk). Mutable aggregates (status, situation, score, odds, stats, record, …) are **not** listed → keep bypassing.
- **`DocumentRequestedHandler.ProcessResourceIndex`** — the per-item bypass computation above.
- **Tests** — classifier classification; handler-level proof that non-edge plays get `BypassCache=false` and the last item stays `true`, while a mutable type bypasses all items.

## Impact

Collapses per-cycle ESPN play fetches from ~N (639 in a sampled game) to **~2** (a genuinely-new play + the live edge). Frees the rate limiter → **new plays land faster** too, not just fewer calls.

## Verification

- Full Provider unit suite: **66 passed / 0 failed / 7 skipped**.

## Design doc

`docs/features/in-season-cache-bypass-fix.md` — full mechanism, the mutability classification, the finalizing-edge handling, options + tradeoffs.

## Scope / known follow-ons (in the doc)

This is intentionally a focused PoC on the **live path**. Not yet done:
- The `ResourceIndexJob` paged loop (bulk/historical) and the single-item/leaf paths.
- **Force a full re-validate on the finalization refresh** — the on-final `PublishContestRefreshOnFinalAsync` currently flows through the same enqueue path, so it will now serve plays from cache; it should force-bypass once at final so rare mid-game **corrections** to already-cached non-edge plays are caught. (Trade-off: today, corrections to cached non-edge plays aren't re-fetched until a forced re-validate.)
- Relaxing the in-season cooldown gate for immutable types to cut Producer re-publish churn.

Belt-and-suspenders note: ESPN generally only lists a play once it's complete, so most cached plays are already final — the live-edge re-fetch is cheap insurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-season caching behavior to reduce repeated refetching of immutable content, helping prevent rate limiting and stalled live finalization.
  * Refined refresh handling so the newest “live-edge” item can be re-fetched while earlier in-season immutable items are served from cache as expected.
* **Documentation**
  * Added a proposal document detailing the in-season cache bypass approach, safety considerations, rollout plan, and testing strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->