### PR TITLE
feat(producer): by-season contest re-source driver (POST /api/contests/refresh)

### DIFF
--- a/docs/features/season-contest-resource-driver.md
+++ b/docs/features/season-contest-resource-driver.md
@@ -1,0 +1,117 @@
+# By-Season Contest Re-Source Driver
+
+Status: **Designed / not yet implemented** (deferred behind PR #549)
+Last updated: 2026-07-22
+
+## Goal
+
+A single operation that re-sources **every contest for a given `(sport, seasonYear)`**
+through the existing narrowed "Refresh Contest" path — to backfill point-in-time
+records (`CompetitionCompetitorRecord`) and other per-contest documents without
+dragging in athletes/rosters/etc.
+
+Motivating case: NCAA 2025 point-in-time records. Validated manually by hitting
+the admin "refresh contest" button on every LSU 2025 game and watching the
+records appear on the picks page. This driver is "do that, for a whole season."
+
+## Why none of the existing options fit
+
+| Existing | What it does | Why not |
+|---|---|---|
+| `POST /api/sourcing/historical/seasons` (Provider) | Full historical sourcing | Too broad — pulls athletes and everything |
+| `POST /api/contests/{contestId}/update` (the admin button) | Per-contest refresh → `UpdateContestCommand` → narrowed `ContestRefreshDocumentTypes` | Correct mechanism, but one contest at a time |
+| `POST /api/contests/finalize` (`FinalizeContestsBySeasonYear`) | By-season, but **finalizes** (winner/scores/enrichment) | Not a re-source of the record/play documents |
+| `ContestUpdateJob.ExecuteBackfillCurrentSeason` | Fans out the refresh per contest for a season | **Current season only**, filters `FinalizedUtc == null` (excludes finished games — the exact ones we need for 2025 records), flag-gated |
+
+There is **no** ESPN resource index listing every contest for a season, so this
+can't be kicked off from Provider — it must start from Producer's canonical
+contest data.
+
+## Key realization: the refresh path already IS "grab ExternalId → request sourcing"
+
+`ContestUpdateProcessor.ProcessInternal` already does exactly the "grab the
+`ContestExternalId`, request sourcing for that URI" flow — with the narrowing
+that excludes athletes:
+
+```csharp
+var contestExternalId = contest.ExternalIds.FirstOrDefault(x => x.Provider == provider);
+var contestIdentity = _externalIdentityGenerator.Generate(contestExternalId.SourceUrl);
+await _bus.Publish(new DocumentRequested(
+    Uri: new Uri(contestIdentity.CleanUrl),
+    DocumentType: DocumentType.Event,
+    SeasonYear: contest.SeasonYear,
+    IncludeLinkedDocumentTypes: ContestRefreshDocumentTypes));   // Event, EventCompetition, Status,
+                                                                 // Situation, Broadcast, Odds, Competitor,
+                                                                 // CompetitorScore/LineScore/Record,
+                                                                 // Play, Drive, Leaders, Probability
+```
+
+So the driver does **not** replicate the external-id lookup or the
+`DocumentRequested` construction. It just needs the list of **distinct
+ContestIds** and enqueues `UpdateContestCommand` per contest — the same command
+the admin button fires.
+
+## Approach
+
+Producer-side. For a given `(sport, seasonYear)`:
+
+1. Distinct ContestIds via the **FranchiseSeason traversal** (chosen over
+   `Contests.Where(SeasonYear == year)` deliberately, to avoid leaning on the
+   `Contest.SeasonYear` denormalization — see `project_seasonyear_denorm`):
+   ```
+   FranchiseSeason (SeasonYear == year)  →  their Ids
+     → CompetitionCompetitor (FranchiseSeasonId ∈ those)   // indexed on FranchiseSeasonId
+     → Competition.ContestId
+     → Distinct()                                          // each contest has 2 franchise seasons — DEDUP
+   ```
+   `FranchiseSeason` has no direct competition/contest navigation, so the hop is
+   through `CompetitionCompetitor.FranchiseSeasonId → Competition.ContestId`.
+   **The `Distinct()` is load-bearing** — home + away each reference the same
+   contest; without it every contest enqueues twice.
+2. For each distinct ContestId:
+   `Enqueue<IUpdateContests>(p => p.Process(new UpdateContestCommand(contestId, Espn, sport, correlationId)))`.
+3. `ContestUpdateProcessor` does the narrowed sourcing request per contest;
+   Provider sources it (serving from Mongo where cached, ESPN where not).
+
+### Throttling: none needed
+
+The Redis **token bucket** (ESPN circuit breaker / rate limiter) meters ESPN
+load, so the driver can enqueue all contests at once without staggering.
+
+### Cache reality
+
+The Mongo document cache is **partial** — *some* contests have plays/records in
+Mongo, many (e.g. most of NCAA 2025) do not (they were never live-captured; and
+some were lost in the `data-0` drive failure). The refresh serves cache hits
+where available and crawls ESPN for the gaps; the token bucket keeps that safe.
+See [[project_mongo_cache_gap_historical_ncaa]].
+
+## Build plan
+
+- **Endpoint** — `POST /api/contests/refresh` on the Producer `ContestController`,
+  body `{ Sport, SeasonYear }`, returns `Accepted` + correlationId. Mirrors the
+  existing `finalize` endpoint's shape and background-enqueue pattern.
+- **Handler** — `IRefreshContestsBySeasonYearHandler` background job: runs the
+  FranchiseSeason→distinct-ContestId traversal, enqueues `UpdateContestCommand`
+  per contest, logs the enqueued count.
+- **Test** — given franchise seasons that share competitions for a year, the
+  handler enqueues each contest **exactly once** (proves the dedup).
+
+Reuses the proven refresh path end-to-end; the only new code is the
+season → distinct-ContestId fan-out.
+
+## Open option (not decided)
+
+**Contest scope.** Default = *all* contests for the season. A smarter variant
+would target only contests **missing canonical records** (drive off a
+coverage query like `sql/pgsql/_debug_point_in_time_coverage.sql`) so already-
+complete games aren't re-refreshed — smallest ESPN footprint, self-limiting.
+Ship the simple "all" version first; add the gap-filter later if the footprint
+matters.
+
+## Related
+
+- docs/features/point-in-time-team-records.md — the "Sourcing" section this feeds.
+- docs/processing/include-linked-document-types.md — the narrowing mechanism.
+- [[project_mongo_cache_gap_historical_ncaa]] — why NCAA 2025 largely hits ESPN.
+- [[project_seasonyear_denorm]] — why the traversal avoids `Contest.SeasonYear`.

--- a/docs/features/season-contest-resource-driver.md
+++ b/docs/features/season-contest-resource-driver.md
@@ -59,12 +59,14 @@ Producer-side. For a given `(sport, seasonYear)`:
 1. Distinct ContestIds via the **FranchiseSeason traversal** (chosen over
    `Contests.Where(SeasonYear == year)` deliberately, to avoid leaning on the
    `Contest.SeasonYear` denormalization — see `project_seasonyear_denorm`):
-   ```
+
+   ```text
    FranchiseSeason (SeasonYear == year)  →  their Ids
      → CompetitionCompetitor (FranchiseSeasonId ∈ those)   // indexed on FranchiseSeasonId
      → Competition.ContestId
      → Distinct()                                          // each contest has 2 franchise seasons — DEDUP
    ```
+
    `FranchiseSeason` has no direct competition/contest navigation, so the hop is
    through `CompetitionCompetitor.FranchiseSeasonId → Competition.ContestId`.
    **The `Distinct()` is load-bearing** — home + away each reference the same

--- a/docs/features/season-contest-resource-driver.md
+++ b/docs/features/season-contest-resource-driver.md
@@ -1,6 +1,7 @@
 # By-Season Contest Re-Source Driver
 
-Status: **Designed / not yet implemented** (deferred behind PR #549)
+Status: **Implemented** (PR #550) — `RefreshContestsBySeasonYearHandler`, the
+`POST /api/contests/refresh` endpoint, DI + validator registrations, and unit tests.
 Last updated: 2026-07-22
 
 ## Goal

--- a/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearCommand.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearCommand.cs
@@ -1,0 +1,20 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Producer.Application.Contests.Commands;
+
+/// <summary>
+/// Re-source every contest for a (sport, season) through the narrowed
+/// "Refresh Contest" path (<see cref="UpdateContestCommand"/> →
+/// ContestUpdateProcessor → EventCompetition + record/play documents, no
+/// athletes/rosters). The season → distinct-ContestId set is derived from the
+/// FranchiseSeason traversal rather than the Contest.SeasonYear denormalization.
+/// See docs/features/season-contest-resource-driver.md.
+/// </summary>
+public record RefreshContestsBySeasonYearCommand
+{
+    public Sport Sport { get; init; }
+
+    public int SeasonYear { get; init; }
+
+    public Guid CorrelationId { get; init; } = Guid.Empty;
+}

--- a/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearCommandValidator.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearCommandValidator.cs
@@ -1,10 +1,12 @@
 using FluentValidation;
 
+using SportsData.Core.Common;
+
 namespace SportsData.Producer.Application.Contests.Commands;
 
 public class RefreshContestsBySeasonYearCommandValidator : AbstractValidator<RefreshContestsBySeasonYearCommand>
 {
-    public RefreshContestsBySeasonYearCommandValidator()
+    public RefreshContestsBySeasonYearCommandValidator(IDateTimeProvider dateTimeProvider)
     {
         RuleFor(x => x.Sport)
             .IsInEnum()
@@ -13,7 +15,7 @@ public class RefreshContestsBySeasonYearCommandValidator : AbstractValidator<Ref
         RuleFor(x => x.SeasonYear)
             .GreaterThan(2000)
             .WithMessage("Season year must be greater than 2000")
-            .Must(year => year <= DateTime.UtcNow.Year + 1)
+            .Must(year => year <= dateTimeProvider.UtcNow().Year + 1)
             .WithMessage("Season year cannot be more than one year in the future");
 
         RuleFor(x => x.CorrelationId)

--- a/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearCommandValidator.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearCommandValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+
+namespace SportsData.Producer.Application.Contests.Commands;
+
+public class RefreshContestsBySeasonYearCommandValidator : AbstractValidator<RefreshContestsBySeasonYearCommand>
+{
+    public RefreshContestsBySeasonYearCommandValidator()
+    {
+        RuleFor(x => x.Sport)
+            .IsInEnum()
+            .WithMessage("Sport must be a valid enum value");
+
+        RuleFor(x => x.SeasonYear)
+            .GreaterThan(2000)
+            .WithMessage("Season year must be greater than 2000")
+            .Must(year => year <= DateTime.UtcNow.Year + 1)
+            .WithMessage("Season year cannot be more than one year in the future");
+
+        RuleFor(x => x.CorrelationId)
+            .NotEmpty()
+            .WithMessage("CorrelationId is required");
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Commands/RefreshContestsBySeasonYearHandler.cs
@@ -1,0 +1,118 @@
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Contests.Commands
+{
+    public interface IRefreshContestsBySeasonYearHandler
+    {
+        Task<Result<Guid>> ExecuteAsync(
+            RefreshContestsBySeasonYearCommand command,
+            CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Re-sources every contest for a (sport, season) by enqueuing the narrowed
+    /// <see cref="UpdateContestCommand"/> per contest — the same path the admin
+    /// "refresh contest" button fires, at season scale.
+    ///
+    /// The distinct ContestId set comes from the FranchiseSeason traversal
+    /// (FranchiseSeason → CompetitionCompetitor → Competition.ContestId,
+    /// deduped) rather than Contest.SeasonYear, to avoid leaning on that
+    /// denormalized column. Each contest has two CompetitionCompetitors
+    /// (home + away), so the Distinct() is load-bearing. No throttling — the
+    /// Redis token bucket meters ESPN load. See
+    /// docs/features/season-contest-resource-driver.md.
+    /// </summary>
+    public class RefreshContestsBySeasonYearHandler : IRefreshContestsBySeasonYearHandler
+    {
+        private readonly ILogger<RefreshContestsBySeasonYearHandler> _logger;
+        private readonly TeamSportDataContext _dataContext;
+        private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IValidator<RefreshContestsBySeasonYearCommand> _validator;
+
+        public RefreshContestsBySeasonYearHandler(
+            ILogger<RefreshContestsBySeasonYearHandler> logger,
+            TeamSportDataContext dataContext,
+            IProvideBackgroundJobs backgroundJobProvider,
+            IValidator<RefreshContestsBySeasonYearCommand> validator)
+        {
+            _logger = logger;
+            _dataContext = dataContext;
+            _backgroundJobProvider = backgroundJobProvider;
+            _validator = validator;
+        }
+
+        public async Task<Result<Guid>> ExecuteAsync(
+            RefreshContestsBySeasonYearCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            var validationResult = await _validator.ValidateAsync(command, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                return new Failure<Guid>(default!, ResultStatus.Validation, validationResult.Errors);
+            }
+
+            using (_logger.BeginScope(new Dictionary<string, object>
+                   {
+                       ["Sport"] = command.Sport,
+                       ["SeasonYear"] = command.SeasonYear,
+                       ["CorrelationId"] = command.CorrelationId
+                   }))
+            {
+                return await ExecuteInternalAsync(command, cancellationToken);
+            }
+        }
+
+        private async Task<Result<Guid>> ExecuteInternalAsync(
+            RefreshContestsBySeasonYearCommand command,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Distinct ContestIds via the FranchiseSeason traversal (avoids the
+                // Contest.SeasonYear denorm). Each contest has two competitors, so
+                // Distinct() collapses the home/away duplicates.
+                var franchiseSeasonIds = _dataContext.FranchiseSeasons
+                    .AsNoTracking()
+                    .Where(fs => fs.SeasonYear == command.SeasonYear)
+                    .Select(fs => fs.Id);
+
+                var contestIds = await _dataContext.CompetitionCompetitors
+                    .AsNoTracking()
+                    .Where(cc => franchiseSeasonIds.Contains(cc.FranchiseSeasonId))
+                    .Select(cc => cc.Competition.ContestId)
+                    .Distinct()
+                    .ToListAsync(cancellationToken);
+
+                _logger.LogInformation(
+                    "Refreshing {ContestCount} distinct contests for the season.",
+                    contestIds.Count);
+
+                foreach (var contestId in contestIds)
+                {
+                    var cmd = new UpdateContestCommand(
+                        contestId,
+                        SourceDataProvider.Espn,
+                        command.Sport,
+                        command.CorrelationId);
+
+                    _backgroundJobProvider.Enqueue<IUpdateContests>(p => p.Process(cmd));
+                }
+
+                _logger.LogInformation("Contest refresh queueing complete.");
+
+                return new Success<Guid>(command.CorrelationId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to refresh contests by season year");
+                return new Failure<Guid>(default!, ResultStatus.Error, []);
+            }
+        }
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -174,6 +174,34 @@ namespace SportsData.Producer.Application.Contests
             return Accepted(new { CorrelationId = correlationId, Sport = command.Sport, SeasonYear = command.SeasonYear });
         }
 
+        /// <summary>
+        /// Re-source every contest for a (sport, season) through the narrowed
+        /// "Refresh Contest" path — the admin refresh button, at season scale.
+        /// Backfills point-in-time records / play data without pulling athletes.
+        /// See docs/features/season-contest-resource-driver.md.
+        /// </summary>
+        [HttpPost]
+        [Route("refresh")]
+        public IActionResult RefreshContestsBySeasonYear(
+            [FromBody] RefreshContestsBySeasonYearCommand command)
+        {
+            var correlationId = command.CorrelationId == Guid.Empty
+                ? GetCorrelationIdFromRequest()
+                : command.CorrelationId;
+
+            _logger.LogInformation(
+                "RefreshContestsBySeasonYear requested. Sport={Sport}, SeasonYear={SeasonYear}, CorrelationId={CorrelationId}",
+                command.Sport,
+                command.SeasonYear,
+                correlationId);
+
+            var cmd = command with { CorrelationId = correlationId };
+
+            _backgroundJobProvider.Enqueue<IRefreshContestsBySeasonYearHandler>(h => h.ExecuteAsync(cmd, CancellationToken.None));
+
+            return Accepted(new { CorrelationId = correlationId, Sport = command.Sport, SeasonYear = command.SeasonYear });
+        }
+
         [HttpPost]
         [Route("{contestId}/stream")]
         public async Task<IActionResult> StartStream([FromRoute] Guid contestId, CancellationToken cancellationToken)

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -185,6 +185,19 @@ namespace SportsData.Producer.Application.Contests
         public IActionResult RefreshContestsBySeasonYear(
             [FromBody] RefreshContestsBySeasonYearCommand command)
         {
+            // This Producer pod is bound to a single sport (IAppMode.CurrentSport)
+            // and its DbContext is that sport's. Unlike the finalize handler, the
+            // refresh handler's FranchiseSeason traversal does NOT filter on Sport,
+            // so a mismatched body Sport would query the wrong-sport data and enqueue
+            // mis-tagged UpdateContestCommands. Reject synchronously here (established
+            // _appMode guard pattern) before a doomed background job is ever queued.
+            if (command.Sport != _appMode.CurrentSport)
+            {
+                return BadRequest(
+                    $"RefreshContestsBySeasonYear Sport={command.Sport} does not match this " +
+                    $"Producer's CurrentSport={_appMode.CurrentSport}.");
+            }
+
             var correlationId = command.CorrelationId == Guid.Empty
                 ? GetCorrelationIdFromRequest()
                 : command.CorrelationId;

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -306,10 +306,12 @@ namespace SportsData.Producer.DependencyInjection
 
             // Contest Commands
             services.AddScoped<IFinalizeContestsBySeasonYearHandler, FinalizeContestsBySeasonYearHandler>();
+            services.AddScoped<IRefreshContestsBySeasonYearHandler, RefreshContestsBySeasonYearHandler>();
             services.AddScoped<IReenrichContestHandler, ReenrichContestHandler>();
 
             // Contest Command Validators
             services.AddScoped<FluentValidation.IValidator<FinalizeContestsBySeasonYearCommand>, FinalizeContestsBySeasonYearCommandValidator>();
+            services.AddScoped<FluentValidation.IValidator<RefreshContestsBySeasonYearCommand>, RefreshContestsBySeasonYearCommandValidator>();
             services.AddScoped<FluentValidation.IValidator<ReenrichContestCommand>, ReenrichContestCommandValidator>();
 
             // Contest Queries

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Commands/RefreshContestsBySeasonYearHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Commands/RefreshContestsBySeasonYearHandlerTests.cs
@@ -26,8 +26,14 @@ public class RefreshContestsBySeasonYearHandlerTests :
 {
     public RefreshContestsBySeasonYearHandlerTests()
     {
+        // Fixed clock so the validator's "no more than one year in the future"
+        // rule is deterministic (test seasons are 2024/2025).
+        var clock = new Mock<IDateTimeProvider>();
+        clock.Setup(x => x.UtcNow())
+            .Returns(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
         Mocker.Use<IValidator<RefreshContestsBySeasonYearCommand>>(
-            new RefreshContestsBySeasonYearCommandValidator());
+            new RefreshContestsBySeasonYearCommandValidator(clock.Object));
     }
 
     private FranchiseSeason NewFranchiseSeason(int seasonYear) =>

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Commands/RefreshContestsBySeasonYearHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Commands/RefreshContestsBySeasonYearHandlerTests.cs
@@ -1,0 +1,112 @@
+#nullable enable
+
+using AutoFixture;
+
+using FluentAssertions;
+
+using FluentValidation;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Contests;
+using SportsData.Producer.Application.Contests.Commands;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests.Commands;
+
+public class RefreshContestsBySeasonYearHandlerTests :
+    ProducerTestBase<RefreshContestsBySeasonYearHandler>
+{
+    public RefreshContestsBySeasonYearHandlerTests()
+    {
+        Mocker.Use<IValidator<RefreshContestsBySeasonYearCommand>>(
+            new RefreshContestsBySeasonYearCommandValidator());
+    }
+
+    private FranchiseSeason NewFranchiseSeason(int seasonYear) =>
+        Fixture.Build<FranchiseSeason>()
+            .With(x => x.Id, Guid.NewGuid())
+            .With(x => x.SeasonYear, seasonYear)
+            .With(x => x.Abbreviation, "AB")
+            .With(x => x.ColorCodeHex, "#FFFFFF")
+            .With(x => x.DisplayName, "Team")
+            .With(x => x.DisplayNameShort, "T")
+            .With(x => x.Location, "Loc")
+            .With(x => x.Slug, $"team-{Guid.NewGuid():N}")
+            .OmitAutoProperties()
+            .Create();
+
+    private FootballCompetition NewCompetition(Guid contestId) =>
+        Fixture.Build<FootballCompetition>()
+            .With(x => x.Id, Guid.NewGuid())
+            .With(x => x.ContestId, contestId)
+            .OmitAutoProperties()
+            .Create();
+
+    private FootballCompetitionCompetitor NewCompetitor(Guid competitionId, Guid franchiseSeasonId, string homeAway) =>
+        Fixture.Build<FootballCompetitionCompetitor>()
+            .With(x => x.Id, Guid.NewGuid())
+            .With(x => x.CompetitionId, competitionId)
+            .With(x => x.FranchiseSeasonId, franchiseSeasonId)
+            .With(x => x.HomeAway, homeAway)
+            .OmitAutoProperties()
+            .Create();
+
+    [Fact]
+    public async Task SharedContest_HomeAndAway_EnqueuesEachContestExactlyOnce_ExcludesOtherSeasons()
+    {
+        // arrange
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var sut = Mocker.CreateInstance<RefreshContestsBySeasonYearHandler>();
+
+        const int season = 2024;
+
+        // Two franchise seasons that share ONE competition (home vs away).
+        var teamA = NewFranchiseSeason(season);
+        var teamB = NewFranchiseSeason(season);
+        // A third franchise season in a DIFFERENT season — its contest must be excluded.
+        var teamNextSeason = NewFranchiseSeason(season + 1);
+        await FootballDataContext.FranchiseSeasons.AddRangeAsync(teamA, teamB, teamNextSeason);
+
+        // One shared contest for A vs B in the target season.
+        var sharedContestId = Guid.NewGuid();
+        var comp = NewCompetition(sharedContestId);
+        await FootballDataContext.Competitions.AddAsync(comp);
+        await FootballDataContext.CompetitionCompetitors.AddRangeAsync(
+            NewCompetitor(comp.Id, teamA.Id, "home"),
+            NewCompetitor(comp.Id, teamB.Id, "away"));
+
+        // A contest in the next season — reachable only via the excluded franchise season.
+        var otherComp = NewCompetition(Guid.NewGuid());
+        await FootballDataContext.Competitions.AddAsync(otherComp);
+        await FootballDataContext.CompetitionCompetitors.AddAsync(
+            NewCompetitor(otherComp.Id, teamNextSeason.Id, "home"));
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = new RefreshContestsBySeasonYearCommand
+        {
+            Sport = Sport.FootballNcaa,
+            SeasonYear = season,
+            CorrelationId = Guid.NewGuid()
+        };
+
+        // act
+        var result = await sut.ExecuteAsync(command, CancellationToken.None);
+
+        // assert — exactly one enqueue: the shared contest deduped (home+away),
+        // and the next-season contest excluded by the season filter.
+        result.Should().BeOfType<Success<Guid>>();
+        result.IsSuccess.Should().BeTrue();
+        background.Verify(
+            x => x.Enqueue(It.IsAny<Expression<Func<IUpdateContests, Task>>>()),
+            Times.Exactly(1));
+    }
+}


### PR DESCRIPTION
## What

A by-season driver to re-source **every contest for a `(sport, season)`** through the existing narrowed "Refresh Contest" path — the admin refresh button, at season scale — to backfill point-in-time records / play data **without** pulling athletes/rosters.

Motivating case: NCAA 2025 point-in-time records. Validated manually by refreshing LSU 2025 games one at a time; this automates that for a whole season.

## Why Producer-side

Provider has **no** ESPN resource index listing every contest for a season, so this can't be kicked off from Provider — it starts from Producer's canonical data.

## How

- **`POST /api/contests/refresh`** `{ Sport, SeasonYear }` → `Accepted` + correlationId (mirrors `/contests/finalize`).
- **`RefreshContestsBySeasonYearHandler`** derives the distinct ContestId set via the **FranchiseSeason traversal**:
  ```
  FranchiseSeason (SeasonYear == year)
    → CompetitionCompetitor (FranchiseSeasonId ∈ those)   // indexed
    → Competition.ContestId
    → Distinct()                                          // home + away share a contest — dedup
  ```
  This deliberately avoids `Contest.SeasonYear` (the denormalized column). Then enqueues `UpdateContestCommand` per distinct contest → `ContestUpdateProcessor`, which already does the "grab `ContestExternalId` → publish a narrowed `DocumentRequested(Event, IncludeLinkedDocumentTypes: ContestRefreshDocumentTypes)`" flow (no athletes).
- **No throttling** — the Redis token bucket meters ESPN load.
- Command + validator + DI registration mirror `FinalizeContestsBySeasonYear`.

## The dedup is load-bearing

Each contest has two `CompetitionCompetitor` rows (home + away), so without `Distinct()` every contest would enqueue twice. The test proves it.

## Verification

- Test: a shared home/away contest enqueues **exactly once**, and a next-season contest is **excluded** — proving both the dedup and the season scoping.
- Full Producer unit suite: **522 passed / 0 failed / 18 skipped**.

## Notes

- **Cache reality:** the refresh serves from Mongo where cached and crawls ESPN for the gaps (much of NCAA 2025 isn't cached — see `project_mongo_cache_gap_historical_ncaa`); the token bucket keeps that safe.
- **Open option (not done):** scope to only contests *missing canonical records* (drive off a coverage query) for a smaller ESPN footprint. Ships as "all contests for the season" first.

Design: `docs/features/season-contest-resource-driver.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/contests/refresh` to refresh all contests for a given sport and season year.
  * Refresh requests run in the background and return a correlation ID for tracking.
  * Deduplicates refresh jobs so each contest is enqueued exactly once, even when referenced by multiple franchise seasons.
  * Validates sport and season year bounds and requires a non-empty correlation ID.

* **Documentation**
  * Added a guide for the by-season contest refresh process, including traversal logic and throttling/caching expectations.

* **Tests**
  * Added unit coverage to verify deduplication behavior for shared contests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->