### PR TITLE
fix(provider): close the leaf-path ESPN re-fetch hole for in-season immutable plays

### DIFF
--- a/docs/features/in-season-cache-bypass-fix.md
+++ b/docs/features/in-season-cache-bypass-fix.md
@@ -1,8 +1,10 @@
 # In-Season Cache Bypass — Stop Re-Fetching Immutable Documents
 
 Status: **PoC implemented** (PR #549) — `DocumentRequestedHandler.ProcessResourceIndex`
-path only, allow-list `{ EventCompetitionPlay }`. Follow-ons deferred (see Scope):
-`ResourceIndexJob` paged loop, single-item/leaf paths, on-final force-bypass
+fan-out path, allow-list `{ EventCompetitionPlay }`. **Leaf-path follow-on implemented**
+(uncommitted, review pending) — `DocumentRequestedHandler.ProcessResourceIndexItem`, the
+single dependency-sourced doc path (e.g. situation `lastPlay.$ref`); see "Leaf path" below.
+Follow-ons still deferred (see Scope): `ResourceIndexJob` paged loop, on-final force-bypass
 re-validate, in-season cooldown relaxation.
 Last updated: 2026-07-22
 Scope: MLB live sourcing (in-season). Applies to any current-season sport.
@@ -117,6 +119,58 @@ once it's complete, so most cached plays are already final; corrections are rare
 The live-edge re-fetch covers the still-finalizing play. But the correction gap
 is real and is why the on-final force-bypass is called out as a follow-on rather
 than "coverage we already have."
+
+## Leaf path (`ProcessResourceIndexItem`) — follow-on, implemented (review pending)
+
+After #549 deployed, Grafana (`provider-baseball-mlb-worker-metrics`, *MongoDB Cache
+Hits vs ESPN Live Fetches*) showed the intended inversion: at deploy the red
+(ESPN fetches) plateau collapsed from ~5,000/interval to a ~500 floor and green
+(cache hits) went from **zero to dominant**. But a **residual red floor crept
+back to ~2,500–3,000/interval** — a second, independent amplification path the
+fan-out fix never touched.
+
+Seq isolated it to a single immutable play fetched repeatedly *after* the deploy
+(e.g. `…/competitions/401816230/plays/4018162301401020033`, 3+ `ESPN live fetch`
+events, same `CorrelationId`), all with `SourceContext =
+ResourceIndexItemProcessor` and `BypassCache = true` — the **leaf** branch of
+`DocumentRequestedHandler.ConsumeInternal`, not the index fan-out.
+
+**Root cause.** Producer's live `EventCompetitionSituation` processor is mutable
+and re-runs every cycle. Each run resolves `dto.LastPlay.$ref`; when that play
+isn't in the canonical DB yet it calls `PublishDependencyRequest(...,
+EventCompetitionPlay)` and throws `ExternalDocumentNotSourcedException` to retry.
+That publish (`DocumentProcessorBase`, `SeasonYear: command.SeasonYear`) lands on
+the Provider **leaf path**, which still hardcoded `BypassCache:
+ShouldBypassCache(evt.SeasonYear)` → in-season → fetch. So the same immutable play
+was re-fetched from ESPN on **every situation retry** — the leaf-path twin of the
+live-slate storm.
+
+**Fix.** The leaf path now honors the same immutable-in-season policy, with **two
+deliberate differences** from the fan-out path:
+
+1. **No live-edge carve-out.** A single leaf has no positional "newest item"
+   signal and doesn't need one: a cache **miss** still fetches (a never-seen play
+   is sourced exactly once), and the fan-out path keeps the current game's edge
+   play fresh every cycle. Serving the leaf from Mongo is at most one cycle stale,
+   then immutable. It also breaks the situation retry loop *faster* — the play is
+   republished from Mongo, persists canonically, and the situation stops asking.
+2. **Gate on feature-enabled (`CurrentSeason != 0`), NOT exact current season.**
+   Dependency-sourced leaf requests (e.g. `lastPlay`) do **not** reliably carry a
+   usable `SeasonYear`, so an "`== current season`" gate would silently no-op on
+   exactly this traffic. Immutability is season-independent: a cache hit for a
+   play from any season is correct, and historical seasons already serve from
+   cache via `ShouldBypassCache` regardless.
+
+```csharp
+// ProcessResourceIndexItem — leaf path
+var serveImmutableFromCache = _commonConfig.CurrentSeason != 0
+    && InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType);
+var bypassCache = ShouldBypassCache(evt.SeasonYear) && !serveImmutableFromCache;
+```
+
+Tests: `Leaf_ImmutablePlay_ServesFromCache_WhenFeatureEnabled_RegardlessOfSeason`
+covers current-season, the null-season `lastPlay` case, historical, future,
+feature-disabled, and the mutable-type control.
 
 ## Design options (the actual fix)
 

--- a/docs/features/in-season-cache-bypass-fix.md
+++ b/docs/features/in-season-cache-bypass-fix.md
@@ -1,12 +1,12 @@
 # In-Season Cache Bypass — Stop Re-Fetching Immutable Documents
 
-Status: **PoC implemented** (PR #549) — `DocumentRequestedHandler.ProcessResourceIndex`
+Status: **Implemented** (PR #549) — `DocumentRequestedHandler.ProcessResourceIndex`
 fan-out path, allow-list `{ EventCompetitionPlay }`. **Leaf-path follow-on implemented**
-(uncommitted, review pending) — `DocumentRequestedHandler.ProcessResourceIndexItem`, the
-single dependency-sourced doc path (e.g. situation `lastPlay.$ref`); see "Leaf path" below.
+(PR #551) — `DocumentRequestedHandler.ProcessResourceIndexItem`, the single
+dependency-sourced doc path (e.g. situation `lastPlay.$ref`); see "Leaf path" below.
 Follow-ons still deferred (see Scope): `ResourceIndexJob` paged loop, on-final force-bypass
 re-validate, in-season cooldown relaxation.
-Last updated: 2026-07-22
+Last updated: 2026-07-23
 Scope: MLB live sourcing (in-season). Applies to any current-season sport.
 
 ## Problem

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -187,6 +187,30 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
         //   - Historical season → serve from Mongo. Immutable; nothing to gain by hitting
         //     ESPN. (Trade-off: in-season games that finish early in the year will still
         //     re-source until the season flips. Acceptable for now.)
+        //
+        // Immutable-in-season override (companion to the ProcessResourceIndex fan-out fix
+        // in docs/features/in-season-cache-bypass-fix.md): an EventCompetitionPlay is
+        // immutable once ESPN emits it. Producer's live situation processor resolves
+        // `lastPlay.$ref` as a SINGLE leaf request and, when the play isn't canonical yet,
+        // throws-to-retry — so the same immutable play was re-fetched from ESPN on every
+        // situation retry/poll cycle: the leaf-path twin of the live-slate rate-limit storm.
+        //
+        // Two deliberate differences from the fan-out path:
+        //   1. No live-edge carve-out. A single leaf has no positional "newest item"
+        //      signal, and it doesn't need one — a cache MISS still fetches (so a never-seen
+        //      play is sourced exactly once), and the fan-out path keeps the current game's
+        //      edge play fresh every cycle. Serving the leaf from Mongo is at most one cycle
+        //      stale, then immutable.
+        //   2. Gate on feature-enabled (CurrentSeason != 0), NOT exact current season.
+        //      Dependency-sourced leaf requests (e.g. lastPlay) do not reliably carry a
+        //      SeasonYear, so an "== current season" gate would silently no-op on exactly
+        //      the traffic we need to catch. Immutability is season-independent: a cache hit
+        //      for a play from any season is correct, and historical seasons already serve
+        //      from cache via ShouldBypassCache regardless.
+        var serveImmutableFromCache = _commonConfig.CurrentSeason != 0
+            && InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType);
+        var bypassCache = ShouldBypassCache(evt.SeasonYear) && !serveImmutableFromCache;
+
         var cmd = new ProcessResourceIndexItemCommand(
             CorrelationId: evt.CorrelationId,
             CausationId: evt.CausationId,
@@ -199,7 +223,7 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
             DocumentType: evt.DocumentType,
             ParentId: evt.ParentId,
             SeasonYear: evt.SeasonYear,
-            BypassCache: ShouldBypassCache(evt.SeasonYear),
+            BypassCache: bypassCache,
             IncludeLinkedDocumentTypes: evt.IncludeLinkedDocumentTypes);
 
         _logger.LogInformation(

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -645,4 +645,72 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         capturedCommands[0].InlineJson.Should().BeNull(
             "leaf path defers fetch+persist to ProcessResourceIndexItem; no inline data is attached at this stage");
     }
+
+    [Theory]
+    // Leaf path (single dependency-sourced doc — e.g. Producer's live situation processor
+    // resolving lastPlay.$ref). Companion to the ProcessResourceIndex fan-out fix. Two
+    // deliberate differences from the fan-out path:
+    //   - no live-edge carve-out (a single leaf has no positional "newest" signal), and
+    //   - the gate is feature-enabled (CurrentSeason != 0), NOT exact current season,
+    //     because dependency-sourced leaf requests don't reliably carry a SeasonYear.
+    // The DocumentType (not the URI) drives the policy; the URI here is a generic numeric
+    // play leaf so classification is unambiguous.
+    //          currentSeason, requestedSeason, docType, expectBypass
+    [InlineData(2026, 2026, DocumentType.EventCompetitionPlay, false)]    // current-season immutable → serve from cache
+    [InlineData(2026, null, DocumentType.EventCompetitionPlay, false)]    // the lastPlay bug: null season, feature on → cache
+    [InlineData(2026, 2024, DocumentType.EventCompetitionPlay, false)]    // historical immutable → cache (already the case)
+    [InlineData(2026, 2027, DocumentType.EventCompetitionPlay, false)]    // future immutable, feature on → cache (season-independent)
+    [InlineData(0, 2026, DocumentType.EventCompetitionPlay, true)]        // feature disabled → bypass
+    [InlineData(0, null, DocumentType.EventCompetitionPlay, true)]        // feature disabled → bypass
+    [InlineData(2026, 2026, DocumentType.EventCompetitionStatus, true)]   // mutable type → bypass (unchanged)
+    [InlineData(2026, null, DocumentType.EventCompetitionStatus, true)]   // mutable type → bypass (unchanged)
+    public async Task Leaf_ImmutablePlay_ServesFromCache_WhenFeatureEnabled_RegardlessOfSeason(
+        int currentSeason,
+        int? requestedSeason,
+        DocumentType documentType,
+        bool expectBypass)
+    {
+        // arrange
+        var cfg = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
+        cfg.CurrentSeason = currentSeason;
+        Mocker.Use<IOptions<CommonConfig>>(Options.Create(cfg));
+
+        // Single play URI (ends in a numeric id) → classified as a leaf, not an index.
+        var leafUri = new Uri(
+            "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816230/competitions/401816230/plays/4018162301401020033?lang=en");
+
+        ProcessResourceIndexItemCommand? captured = null;
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
+            .Callback<Expression<Func<IProcessResourceIndexItems, Task>>>(expr =>
+            {
+                var call = (MethodCallExpression)expr.Body;
+                captured = (ProcessResourceIndexItemCommand)Expression
+                    .Lambda(call.Arguments[0]).Compile().DynamicInvoke()!;
+            })
+            .Returns(string.Empty);
+
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = Fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, leafUri)
+            .With(x => x.DocumentType, documentType)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.BaseballMlb)
+            .With(x => x.SeasonYear, requestedSeason)
+            .OmitAutoProperties()
+            .Create();
+
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — leaf path enqueues exactly one command (itself); its BypassCache
+        // reflects the immutable-in-season override.
+        captured.Should().NotBeNull();
+        captured!.Uri.Should().Be(leafUri);
+        captured.BypassCache.Should().Be(expectBypass);
+    }
 }

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -679,15 +679,15 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         var leafUri = new Uri(
             "http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/events/401816230/competitions/401816230/plays/4018162301401020033?lang=en");
 
-        ProcessResourceIndexItemCommand? captured = null;
+        var captured = new List<ProcessResourceIndexItemCommand>();
         Mocker.GetMock<IProvideBackgroundJobs>()
             .Setup(x => x.Enqueue<IProcessResourceIndexItems>(
                 It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
             .Callback<Expression<Func<IProcessResourceIndexItems, Task>>>(expr =>
             {
                 var call = (MethodCallExpression)expr.Body;
-                captured = (ProcessResourceIndexItemCommand)Expression
-                    .Lambda(call.Arguments[0]).Compile().DynamicInvoke()!;
+                captured.Add((ProcessResourceIndexItemCommand)Expression
+                    .Lambda(call.Arguments[0]).Compile().DynamicInvoke()!);
             })
             .Returns(string.Empty);
 
@@ -709,8 +709,8 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
 
         // assert — leaf path enqueues exactly one command (itself); its BypassCache
         // reflects the immutable-in-season override.
-        captured.Should().NotBeNull();
-        captured!.Uri.Should().Be(leafUri);
-        captured.BypassCache.Should().Be(expectBypass);
+        var command = captured.Should().ContainSingle().Subject;
+        command.Uri.Should().Be(leafUri);
+        command.BypassCache.Should().Be(expectBypass);
     }
 }


### PR DESCRIPTION
## Summary

Companion follow-on to #549. That PoC fixed the **index fan-out** path (`ProcessResourceIndex`), and Grafana confirmed the win — live ESPN fetches collapsed ~5,000 → ~500/interval and Mongo cache hits went dominant. But a **second, independent** amplification path survived and crept the fetch floor back up to ~2,500–3,000/interval.

This PR closes that path.

## Root cause

There are two entry points into the Provider cache, and #549 only patched one:

- `…/plays` (a collection) → `ProcessResourceIndex` ← **fixed in #549**
- `…/plays/{id}` (a single doc) → `ProcessResourceIndexItem` ← **never touched**

Producer's **live `EventCompetitionSituation` processor** resolves `lastPlay.$ref` as a **single-play** `DocumentRequested` and throws-to-retry until that play is canonical. Every situation retry emitted one leaf request → `ProcessResourceIndexItem`, which still hardcoded `BypassCache = ShouldBypassCache(evt.SeasonYear)` → in-season → **ESPN fetch**. So the same immutable play was re-fetched every situation retry/poll cycle — the leaf-path twin of the live-slate storm.

## Evidence

- **Grafana** (`provider-baseball-mlb-worker-metrics`): the residual red floor after #549.
- **Seq**: a single immutable play (`…/plays/4018162301401020033`) fetched 3+ times, same `CorrelationId`, all `SourceContext = ResourceIndexItemProcessor`.

## Fix

The leaf path now honors `InSeasonDocumentPolicy.IsImmutableInSeason`, with **two deliberate differences** from the fan-out path (both documented in code + design doc):

1. **No live-edge carve-out.** A single leaf has no positional "newest item" signal and doesn't need one — a cache **miss** still fetches once, and the fan-out path keeps the current game's edge play fresh each cycle. Serving the leaf from Mongo is at most one cycle stale, then immutable.
2. **Gate on feature-enabled (`CurrentSeason != 0`), not exact current season.** Dependency-sourced leaf requests (`lastPlay`) don't reliably carry a `SeasonYear`, so an "`== current season`" gate would silently no-op on exactly this traffic. Immutability is season-independent; historical seasons already serve from cache regardless.

```csharp
var serveImmutableFromCache = _commonConfig.CurrentSeason != 0
    && InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType);
var bypassCache = ShouldBypassCache(evt.SeasonYear) && !serveImmutableFromCache;
```

Side benefit: it also breaks the situation retry loop faster — the play is republished from Mongo, persists canonically, and the situation stops asking.

## Tests

`Leaf_ImmutablePlay_ServesFromCache_WhenFeatureEnabled_RegardlessOfSeason` — 8 cases: current-season, the null-season `lastPlay` case, historical, future, feature-disabled (×2), and the mutable-type control (×2). Full Provider unit suite green.

## Docs

`docs/features/in-season-cache-bypass-fix.md` updated: status header + a new "Leaf path" section documenting the Grafana crossover, the Seq isolation, the situation-`lastPlay` root cause, and the feature-enabled gate rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-season caching for immutable play documents.
  * Prevented unnecessary re-fetching during retries, including requests for non-current seasons.
  * Preserved cache-bypass behavior for mutable documents and when the in-season feature is disabled.

* **Tests**
  * Added coverage for cache behavior across seasons, feature states, and document types.

* **Documentation**
  * Updated documentation with the implemented leaf-path caching behavior and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->