### PR TITLE
feat(api): admin endpoint to re-source contests by season via Producer

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -225,10 +225,8 @@ namespace SportsData.Api.Application.Admin
                 .Resolve(mode)
                 .RefreshContestsBySeasonYear(mode, seasonYear, correlationId, cancellationToken);
 
-            if (!result.IsSuccess)
-                return result.ToActionResult().Result!;
-
-            return Accepted(new { correlationId, sport = mode.ToString(), seasonYear });
+            return result.ToActionResult(_ =>
+                Accepted(new { correlationId, sport = mode.ToString(), seasonYear }));
         }
 
         [HttpPost]

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -189,6 +189,48 @@ namespace SportsData.Api.Application.Admin
             return result.ToActionResult();
         }
 
+        /// <summary>
+        /// Admin "re-source every contest for a (sport, season)". Fans out the
+        /// narrowed Contest Refresh per contest through the matching per-sport
+        /// Producer to backfill point-in-time records / play data (no athletes).
+        /// Producer enqueues the work and returns 202.
+        ///
+        /// This is the front door for the by-season driver: Producer's own
+        /// <c>/api/contests/refresh</c> endpoint is not internet-facing, so
+        /// operator access routes through here (AdminApiToken-gated) and over to
+        /// the correct Producer pod via the contest client factory. See
+        /// docs/features/season-contest-resource-driver.md.
+        ///
+        /// Example: POST /admin/contests/refresh?sport=baseball&amp;league=mlb&amp;seasonYear=2026
+        /// </summary>
+        [HttpPost]
+        [Route("contests/refresh")]
+        public async Task<IActionResult> RefreshContestsBySeasonYear(
+            [FromQuery] int seasonYear,
+            [FromServices] IContestClientFactory contestClientFactory,
+            [FromQuery] string sport = "football",
+            [FromQuery] string league = "ncaa",
+            CancellationToken cancellationToken = default)
+        {
+            // API runs in Sport.All; sport+league → a concrete Sport so the
+            // client factory routes to the matching per-sport Producer pod.
+            var mode = ModeMapper.ResolveMode(sport, league);
+            var correlationId = ActivityExtensions.GetCorrelationId();
+
+            _logger.LogInformation(
+                "RefreshContestsBySeasonYear requested. Sport={Sport}, SeasonYear={SeasonYear}, CorrelationId={CorrelationId}",
+                mode, seasonYear, correlationId);
+
+            var result = await contestClientFactory
+                .Resolve(mode)
+                .RefreshContestsBySeasonYear(mode, seasonYear, correlationId, cancellationToken);
+
+            if (!result.IsSuccess)
+                return result.ToActionResult().Result!;
+
+            return Accepted(new { correlationId, sport = mode.ToString(), seasonYear });
+        }
+
         [HttpPost]
         [Route("ai-refresh")]
         public IActionResult RefreshAiExistence()

--- a/src/SportsData.Core/Extensions/ResultExtensions.cs
+++ b/src/SportsData.Core/Extensions/ResultExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+
+using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Core.Common;
 
@@ -6,6 +8,22 @@ namespace SportsData.Core.Extensions
 {
     public static class ResultExtensions
     {
+        /// <summary>
+        /// Maps a <see cref="Result{T}"/> to an <see cref="ActionResult"/>, projecting a
+        /// successful value through <paramref name="onSuccess"/> (e.g. a custom 202/201
+        /// payload) while routing failures through the shared status→result mapping in
+        /// the parameterless overload. Use when the success shape differs from the raw
+        /// <c>result.Value</c> but failures should map identically.
+        /// </summary>
+        public static ActionResult ToActionResult<T>(this Result<T> result, Func<T, ActionResult> onSuccess)
+        {
+            if (result.IsSuccess)
+                return onSuccess(result.Value);
+
+            // Failures always populate ActionResult<T>.Result; fall back to 500 defensively.
+            return result.ToActionResult().Result ?? new StatusCodeResult(500);
+        }
+
         public static ActionResult<T> ToActionResult<T>(this Result<T> result)
         {
             if (result.IsSuccess)

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
@@ -60,6 +60,21 @@ public interface IProvideContests : IProvideHealthChecks
     Task<Result<ReenrichContestResponse>> ReenrichContest(Guid contestId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Admin "re-source every contest for a (sport, season)". Producer fans out
+    /// the narrowed Contest Refresh per contest to backfill point-in-time
+    /// records / play data (no athletes), enqueues the work, and returns 202.
+    /// <paramref name="sport"/> is echoed in the body so Producer can guard it
+    /// against the pod's <c>CurrentSport</c>; <paramref name="correlationId"/>
+    /// threads the API trace id into Producer's logs. See
+    /// docs/features/season-contest-resource-driver.md.
+    /// </summary>
+    Task<Result<bool>> RefreshContestsBySeasonYear(
+        Sport sport,
+        int seasonYear,
+        Guid correlationId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Triggers a replay of a stored contest's plays through the bus →
     /// SignalR pipeline. Producer enqueues the work and returns
     /// 202 Accepted; the bus then emits <c>ContestStatusChanged</c> once
@@ -321,6 +336,21 @@ public class ContestClient : ClientBase, IProvideContests
                 ResultStatus.Error,
                 [new ValidationFailure(operationName, $"{operationName} timed out: {ex.Message}")]);
         }
+    }
+
+    public async Task<Result<bool>> RefreshContestsBySeasonYear(
+        Sport sport,
+        int seasonYear,
+        Guid correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new RefreshContestsBySeasonYearRequest(sport, seasonYear, correlationId);
+
+        return await PostWithResultAsync(
+            "contests/refresh",
+            request,
+            "RefreshContestsBySeasonYear",
+            cancellationToken);
     }
 
     // ========== Matchup query methods (Phase 2) ==========

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/RefreshContestsBySeasonYearRequest.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/RefreshContestsBySeasonYearRequest.cs
@@ -1,0 +1,19 @@
+using System;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Infrastructure.Clients.Contest;
+
+/// <summary>
+/// POST body for Producer's <c>contests/refresh</c> endpoint. The property
+/// shape mirrors Producer's <c>RefreshContestsBySeasonYearCommand</c> so the
+/// <c>[FromBody]</c> bind succeeds. <see cref="Sport"/> is echoed even though
+/// the client already routed to the matching per-sport Producer pod — Producer
+/// guards it against its own <c>CurrentSport</c>. <see cref="CorrelationId"/>
+/// threads the API trace id through so the same id appears in Producer's Seq
+/// logs. See docs/features/season-contest-resource-driver.md.
+/// </summary>
+public record RefreshContestsBySeasonYearRequest(
+    Sport Sport,
+    int SeasonYear,
+    Guid CorrelationId);

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/Clients/Contest/ContestClientTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/Clients/Contest/ContestClientTests.cs
@@ -161,10 +161,50 @@ public class ContestClientTests
         failure.Errors.Should().ContainSingle(e => e.PropertyName == "Contest");
     }
 
+    [Fact]
+    public async Task RefreshContestsBySeasonYear_PostsToContestsRefresh_WithSportSeasonAndCorrelation()
+    {
+        // Arrange — Producer returns 202 Accepted (enqueues the fan-out).
+        _handler.SetResponse(HttpStatusCode.Accepted, string.Empty);
+        var correlationId = Guid.NewGuid();
+
+        // Act
+        var result = await _sut.RefreshContestsBySeasonYear(Sport.BaseballMlb, 2026, correlationId);
+
+        // Assert — success, correct route, and the Sport enum round-trips in the
+        // body (the contract that lets Producer's [FromBody] bind succeed).
+        result.Should().BeOfType<Success<bool>>();
+        _handler.LastRequestUri.Should().EndWith("/contests/refresh");
+
+        _handler.LastRequestBody.Should().NotBeNullOrEmpty();
+        var posted = _handler.LastRequestBody.FromJson<RefreshContestsBySeasonYearRequest>();
+        posted.Should().NotBeNull();
+        posted!.Sport.Should().Be(Sport.BaseballMlb);
+        posted.SeasonYear.Should().Be(2026);
+        posted.CorrelationId.Should().Be(correlationId);
+    }
+
+    [Fact]
+    public async Task RefreshContestsBySeasonYear_OnBadRequest_MapsFailure()
+    {
+        // Arrange — Producer rejects (e.g. sport mismatch guard).
+        _handler.SetResponse(HttpStatusCode.BadRequest, "Sport mismatch");
+
+        // Act
+        var result = await _sut.RefreshContestsBySeasonYear(Sport.FootballNcaa, 2025, Guid.NewGuid());
+
+        // Assert
+        result.Should().BeOfType<Failure<bool>>();
+        ((Failure<bool>)result).Status.Should().Be(ResultStatus.BadRequest);
+    }
+
     private class TestHttpMessageHandler : HttpMessageHandler
     {
         private HttpStatusCode _statusCode = HttpStatusCode.OK;
         private string _content = string.Empty;
+
+        public string LastRequestUri { get; private set; } = string.Empty;
+        public string LastRequestBody { get; private set; } = string.Empty;
 
         public void SetResponse(HttpStatusCode statusCode, string content)
         {
@@ -172,15 +212,19 @@ public class ContestClientTests
             _content = content;
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(
+        protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            LastRequestUri = request.RequestUri?.ToString();
+            if (request.Content is not null)
+                LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+
             var response = new HttpResponseMessage(_statusCode)
             {
                 Content = new StringContent(_content, Encoding.UTF8, "application/json")
             };
-            return Task.FromResult(response);
+            return response;
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an API admin endpoint that fronts the by-season contest re-source driver (#550), so operators trigger it through **API behind an admin token** instead of hitting Producer directly.

This is the first slice of a deliberate shift: **Producer/Provider stop being internet-facing; any verified operator need routes through API behind `AdminApiToken`.** It also sidesteps a Cloudflare edge-cert problem — the per-sport `producer.*.sportdeets.com` hostnames are two-label subdomains that Cloudflare's `*.sportdeets.com` wildcard doesn't cover, so direct browser/Postman POSTs fail the TLS handshake. Going through API (`api.sportdeets.com`, one label, covered) avoids that entirely, and the API→Producer hop is cluster-internal.

## What it does

```
POST /admin/contests/refresh?sport=football&league=ncaa&seasonYear=2025
Header: X-Admin-Token: <token>   (or Firebase Admin role)
```

- `[AdminApiToken]`-gated (inherited from `AdminController`).
- Resolves `sport`+`league` → `Sport` via `ModeMapper`, then uses the existing `IContestClientFactory` to reach the **matching per-sport Producer** and forward the call.
- Returns `202 Accepted { correlationId, sport, seasonYear }`.

Producer's own `/api/contests/refresh` endpoint is unchanged; it just no longer needs to be internet-facing. The `ContestClient` base URL already resolves to cluster-internal service DNS (`http://producer-svc-<sport>/api/`), so the call never leaves the cluster.

## Changes

- **API** (`AdminController.cs`): the new endpoint.
- **Core** (`ContestClient.cs` + `RefreshContestsBySeasonYearRequest.cs`): new `IProvideContests.RefreshContestsBySeasonYear(sport, seasonYear, correlationId, ct)` that POSTs to Producer's `contests/refresh`. Correlation id threads through so admin → API → Producer traces under one id in Seq.
- **Tests** (`ContestClientTests.cs`): 2 added — verifies the POST target and that the `Sport` enum round-trips in the body (the contract that makes Producer's `[FromBody]` bind succeed), plus failure mapping.

## Validation

- API + Core build clean (0 warnings / 0 errors).
- `ContestClientTests` — 10/10 pass.

## Reuses existing infrastructure

- `AdminApiTokenAttribute` (X-Admin-Token or Firebase Admin role) — no new auth.
- `IContestClientFactory` seam — the same path `ReenrichContest` already uses to call Producer per sport.

## Follow-on

This is the pilot for the pattern. Once proven, the same shape wraps any other Producer/Provider op with a verified need, after which the public `producer.*` / `provider.*` ingress + certs + DNS can be decommissioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin endpoint to refresh contests by sport and season year, returning `202 Accepted` with a correlation ID and echoing the selected sport and season year.
  * Added client support to trigger the same `/contests/refresh` operation and return success/failure results.
* **Bug Fixes**
  * Improved result-to-ActionResult mapping to safely handle success projections.
* **Tests**
  * Added unit tests covering successful refresh request routing/body and bad-request failure mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->