### PR TITLE
fix(producer): make Probable + Odds inserts idempotent under concurrent races

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics.Metrics;
 
+using Microsoft.EntityFrameworkCore;
+
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
@@ -107,6 +109,47 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
                 throw;
             }
         }
+    }
+
+    /// <summary>
+    /// Idempotent recovery for a duplicate-key (Postgres 23505) SaveChanges failure
+    /// caused by a concurrent worker persisting the same deterministic-Id rows
+    /// (at-least-once delivery + parallel Hangfire workers processing the same document).
+    ///
+    /// Runs <paramref name="confirmWrittenAsync"/> to verify the rows this batch attempted
+    /// were actually written by the winner. When confirmed, detaches the failed batch
+    /// (Added / Modified / Deleted) — required because a later SaveChanges (e.g. the
+    /// completion notification in <see cref="ProcessAsync"/>) would otherwise re-attempt
+    /// the duplicate inserts — logs, and returns <c>true</c> (idempotent success).
+    /// Returns <c>false</c> when the expected rows are absent so the caller rethrows the
+    /// unrelated violation.
+    ///
+    /// Call from inside
+    /// <c>catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())</c> and
+    /// <c>throw;</c> when this returns false, preserving the original stack trace. The
+    /// predicate MUST be narrow enough to distinguish a same-document race from an
+    /// unrelated unique violation (e.g. confirm the specific rows/content this batch
+    /// wrote, not merely that the parent entity exists).
+    /// </summary>
+    protected async Task<bool> TryRecoverFromDuplicateInsertAsync(
+        Func<Task<bool>> confirmWrittenAsync,
+        string context)
+    {
+        // Verify BEFORE detaching — the predicate may inspect the still-tracked entries.
+        if (!await confirmWrittenAsync())
+            return false;
+
+        foreach (var entry in _dataContext.ChangeTracker.Entries()
+                     .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+                     .ToList())
+        {
+            entry.State = EntityState.Detached;
+        }
+
+        _logger.LogWarning(
+            "Duplicate key on insert — another worker won the race; treating as idempotent success. {Context}",
+            context);
+        return true;
     }
 
     /// <summary>

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -124,6 +124,15 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
     /// Returns <c>false</c> when the expected rows are absent so the caller rethrows the
     /// unrelated violation.
     ///
+    /// PRECONDITION — the entire pending change set must be the one document's idempotent
+    /// unit (as the competitor/odds callers are). On success this detaches ALL
+    /// Added/Modified/Deleted entries, including this batch's outbox messages: the winner
+    /// committed identical data AND its outbox events atomically, so those events are
+    /// already published — dropping our duplicates avoids a double-publish, and avoids a
+    /// fresh concurrency exception from retrying a Modified row the winner already bumped.
+    /// Do NOT use this helper when the tracker also holds unrelated pending work that must
+    /// still be flushed.
+    ///
     /// Call from inside
     /// <c>catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())</c> and
     /// <c>throw;</c> when this returns false, preserving the original stack trace. The

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
@@ -279,39 +279,27 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
         }
         catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
         {
-            // At-least-once delivery + parallel workers can process the same odds
-            // wrapper concurrently. When both observe no existing rows, both INSERT the
-            // same deterministic per-provider Ids and the loser hits a duplicate-key
-            // here. The winner's rows are already canonical, so treat as idempotent
-            // success. Confirm odds landed for this competition; otherwise the violation
-            // is on an unrelated constraint → rethrow.
-            var oddsExist = await _dataContext.CompetitionOdds
-                .AsNoTracking()
-                .AnyAsync(o => o.CompetitionId == competition.Id);
+            // At-least-once delivery + parallel workers can process the same odds wrapper
+            // concurrently. When both observe no existing rows, both INSERT the same
+            // deterministic per-provider Ids and the loser hits a duplicate-key here.
+            // Recover only if THIS wrapper's rows are already present — same competition
+            // AND the same content hash — i.e. the winner persisted this exact document,
+            // not merely some odds for the competition.
+            var recovered = await TryRecoverFromDuplicateInsertAsync(
+                () => _dataContext.CompetitionOdds
+                    .AsNoTracking()
+                    .AnyAsync(o => o.CompetitionId == competition.Id &&
+                                   o.ContentHash == wrapperContentHash),
+                $"MLB odds CompetitionId={competition.Id}, CorrelationId={command.CorrelationId}");
 
-            if (!oddsExist)
+            if (!recovered)
             {
                 _logger.LogError(ex,
-                    "Unique constraint violation persisting MLB odds but no rows found for competition — " +
-                    "unrelated data-integrity issue. CompetitionId={CompId}, CorrelationId={CorrelationId}",
+                    "Unique constraint violation persisting MLB odds but no rows for this competition + content " +
+                    "hash were found — unrelated data-integrity issue. CompetitionId={CompId}, CorrelationId={CorrelationId}",
                     competition.Id, command.CorrelationId);
                 throw;
             }
-
-            // Detach the failed batch (the new odds rows, and any RemoveRange'd existing
-            // rows) so the completion-notification SaveChanges in the base ProcessAsync
-            // neither re-inserts the duplicates nor deletes the winner's rows.
-            foreach (var entry in _dataContext.ChangeTracker.Entries()
-                         .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
-                         .ToList())
-            {
-                entry.State = EntityState.Detached;
-            }
-
-            _logger.LogWarning(
-                "Duplicate key persisting MLB odds — another worker won the race. Treating as idempotent success. " +
-                "CompetitionId={CompId}, CorrelationId={CorrelationId}",
-                competition.Id, command.CorrelationId);
         }
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessor.cs
@@ -273,6 +273,45 @@ public class BaseballEventCompetitionOddsDocumentProcessor<TDataContext> : Docum
                 command.MessageId));
         }
 
-        await _dataContext.SaveChangesAsync();
+        try
+        {
+            await _dataContext.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
+        {
+            // At-least-once delivery + parallel workers can process the same odds
+            // wrapper concurrently. When both observe no existing rows, both INSERT the
+            // same deterministic per-provider Ids and the loser hits a duplicate-key
+            // here. The winner's rows are already canonical, so treat as idempotent
+            // success. Confirm odds landed for this competition; otherwise the violation
+            // is on an unrelated constraint → rethrow.
+            var oddsExist = await _dataContext.CompetitionOdds
+                .AsNoTracking()
+                .AnyAsync(o => o.CompetitionId == competition.Id);
+
+            if (!oddsExist)
+            {
+                _logger.LogError(ex,
+                    "Unique constraint violation persisting MLB odds but no rows found for competition — " +
+                    "unrelated data-integrity issue. CompetitionId={CompId}, CorrelationId={CorrelationId}",
+                    competition.Id, command.CorrelationId);
+                throw;
+            }
+
+            // Detach the failed batch (the new odds rows, and any RemoveRange'd existing
+            // rows) so the completion-notification SaveChanges in the base ProcessAsync
+            // neither re-inserts the duplicates nor deletes the winner's rows.
+            foreach (var entry in _dataContext.ChangeTracker.Entries()
+                         .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+                         .ToList())
+            {
+                entry.State = EntityState.Detached;
+            }
+
+            _logger.LogWarning(
+                "Duplicate key persisting MLB odds — another worker won the race. Treating as idempotent success. " +
+                "CompetitionId={CompId}, CorrelationId={CorrelationId}",
+                competition.Id, command.CorrelationId);
+        }
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
@@ -160,7 +160,48 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
             competitionId,
             _dataContext.ChangeTracker.HasChanges());
 
-        await _dataContext.SaveChangesAsync();
+        try
+        {
+            await _dataContext.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
+        {
+            // At-least-once delivery + parallel Hangfire workers can process the same
+            // competitor document concurrently. Both run SELECT-then-INSERT for the
+            // competitor and its deterministic-Id child rows (e.g. the MLB
+            // CompetitionCompetitorProbable), and the loser hits a duplicate-key here.
+            // The winner's rows are already canonical (same source doc → identical
+            // deterministic Ids), so this is idempotent success. Confirm the competitor
+            // landed; if not, the violation is on an unrelated constraint → rethrow.
+            var competitorExists = await _dataContext.CompetitionCompetitors
+                .AsNoTracking()
+                .AnyAsync(c => c.ExternalIds.Any(e => e.SourceUrlHash == command.UrlHash &&
+                                                      e.Provider == command.SourceDataProvider));
+
+            if (!competitorExists)
+            {
+                _logger.LogError(ex,
+                    "Unique constraint violation persisting CompetitionCompetitor but no matching row by UrlHash — " +
+                    "unrelated data-integrity issue. UrlHash={UrlHash}, CorrelationId={CorrelationId}",
+                    command.UrlHash, command.CorrelationId);
+                throw;
+            }
+
+            // Detach the failed batch so the completion-notification SaveChanges in the
+            // base ProcessAsync can't re-attempt the duplicate inserts.
+            foreach (var entry in _dataContext.ChangeTracker.Entries()
+                         .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
+                         .ToList())
+            {
+                entry.State = EntityState.Detached;
+            }
+
+            _logger.LogWarning(
+                "Duplicate key persisting CompetitionCompetitor/child rows — another worker won the race. " +
+                "Treating as idempotent success. CompetitionId={CompetitionId}, UrlHash={UrlHash}, CorrelationId={CorrelationId}",
+                competitionId, command.UrlHash, command.CorrelationId);
+            return;
+        }
 
         _logger.LogInformation(
             "✅ SAVE_COMPLETED: SaveChangesAsync completed. All outbox messages should now be flushed to service bus. " +

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
@@ -170,36 +170,36 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
             // competitor document concurrently. Both run SELECT-then-INSERT for the
             // competitor and its deterministic-Id child rows (e.g. the MLB
             // CompetitionCompetitorProbable), and the loser hits a duplicate-key here.
-            // The winner's rows are already canonical (same source doc → identical
-            // deterministic Ids), so this is idempotent success. Confirm the competitor
-            // landed; if not, the violation is on an unrelated constraint → rethrow.
-            var competitorExists = await _dataContext.CompetitionCompetitors
-                .AsNoTracking()
-                .AnyAsync(c => c.ExternalIds.Any(e => e.SourceUrlHash == command.UrlHash &&
-                                                      e.Provider == command.SourceDataProvider));
+            // Recover only if EVERY row this batch attempted to insert is already present
+            // in the database (the winner wrote the identical deterministic-Id rows) —
+            // narrower than "the competitor exists", which is trivially true on the
+            // update path and would mask an unrelated violation.
+            var recovered = await TryRecoverFromDuplicateInsertAsync(
+                async () =>
+                {
+                    var added = _dataContext.ChangeTracker.Entries()
+                        .Where(e => e.State == EntityState.Added)
+                        .ToList();
+                    if (added.Count == 0)
+                        return false;
+                    foreach (var entry in added)
+                    {
+                        if (await entry.GetDatabaseValuesAsync() is null)
+                            return false;
+                    }
+                    return true;
+                },
+                $"CompetitionCompetitor CompetitionId={competitionId}, UrlHash={command.UrlHash}, CorrelationId={command.CorrelationId}");
 
-            if (!competitorExists)
+            if (!recovered)
             {
                 _logger.LogError(ex,
-                    "Unique constraint violation persisting CompetitionCompetitor but no matching row by UrlHash — " +
-                    "unrelated data-integrity issue. UrlHash={UrlHash}, CorrelationId={CorrelationId}",
+                    "Unique constraint violation persisting CompetitionCompetitor but not all attempted rows were " +
+                    "found in the database — unrelated data-integrity issue. UrlHash={UrlHash}, CorrelationId={CorrelationId}",
                     command.UrlHash, command.CorrelationId);
                 throw;
             }
 
-            // Detach the failed batch so the completion-notification SaveChanges in the
-            // base ProcessAsync can't re-attempt the duplicate inserts.
-            foreach (var entry in _dataContext.ChangeTracker.Entries()
-                         .Where(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted)
-                         .ToList())
-            {
-                entry.State = EntityState.Detached;
-            }
-
-            _logger.LogWarning(
-                "Duplicate key persisting CompetitionCompetitor/child rows — another worker won the race. " +
-                "Treating as idempotent success. CompetitionId={CompetitionId}, UrlHash={UrlHash}, CorrelationId={CorrelationId}",
-                competitionId, command.UrlHash, command.CorrelationId);
             return;
         }
 


### PR DESCRIPTION
## Summary

The 2026-07-23 sourcing run surfaced `23505` duplicate-key violations on `PK_CompetitionCompetitorProbable` and `PK_CompetitionOdds` (MLB). This makes both inserts idempotent under concurrent processing. First of the idempotency fixes called out in the connection-saturation incident analysis (the `23505` retries also feed the connection-pressure loop).

## Root cause

Both processors already use **deterministic Ids + check-then-insert**, which is idempotent on *sequential* redelivery. But at-least-once delivery + parallel Hangfire workers processing the **same document concurrently** races the SELECT-then-INSERT: both workers see no existing row, both INSERT the same deterministic Id, and the loser hits a duplicate key on `SaveChanges`.

- **Probable** — `EventCompetitionCompetitorDocumentProcessorBase` batches the competitor + its `CompetitionCompetitorProbable` child rows into one `SaveChanges`; a concurrent same-competitor doc collides on `PK_CompetitionCompetitorProbable`.
- **Odds** — `BaseballEventCompetitionOddsDocumentProcessor`; when two workers both observe no existing odds, both INSERT the same deterministic per-provider Ids and collide on `PK_CompetitionOdds`.

## Fix

Wrap the terminal `SaveChanges` in each with the **established play-processor pattern** (`EventCompetitionPlayDocumentProcessorBase`):

1. `catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())`
2. Confirm the winner's row actually landed (competitor by UrlHash / odds by CompetitionId). If not, the violation is on an unrelated constraint → **rethrow**.
3. **Detach the failed batch** — required because the base `ProcessAsync` issues a *second* `SaveChanges` via `PublishCompletionNotification` (when `NotifyOnCompletion` is set) that would otherwise re-attempt the duplicate inserts (and, for odds, must not re-run the `RemoveRange`).
4. Treat as idempotent success (the winner persisted identical data — same source doc → identical deterministic Ids).

## Testing

- Sequential-redelivery idempotency is **already covered and passing**: `WhenReprocessed_RowIsIdempotent_AndAuditUpdates` (probable) and `WhenContentHashUnchanged_SkipsWrite_DoesNotPublish` (odds).
- The concurrent-race `23505` catch is **not reproducible on the InMemory provider** (it doesn't enforce unique constraints and throws `ArgumentException`, not a `PostgresException` with SqlState 23505), so it can't be unit-tested here — same as the merged play-processor handling it mirrors.
- Full Producer unit suite: **523 passed / 0 failed / 18 skipped**.

## Scope note

This addresses the two **currently-active** `23505` offenders (Probable, Odds). The same race exists on other MLB child tables seen earlier in the logs (Scores, Play already handled, Statistics) — follow-up if they resurface. This PR does **not** address the underlying connection saturation (that's the `project_connection_pool_per_role` work); it removes one of the retry amplifiers feeding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when baseball odds and competitor data are processed concurrently.
  * Added safe, idempotent handling for duplicate-key failures during save operations, avoiding unnecessary errors when another worker has already written the same results.
  * Reduced repeated failed save attempts caused by race conditions.
  * Continued to report genuine data-integrity issues when duplicate-key failures can’t be explained by already-existing records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->