### PR TITLE
chore(producer): quiet the null child-link skip (Warning -> Debug)

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -353,8 +353,12 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
         {
             if (hasRef is null)
             {
-                _logger.LogWarning(
-                    "⏭️ SKIP_CHILD_DOCUMENT: parent DTO link is null. ChildDocumentType={ChildDocumentType}, ParentId={ParentId}",
+                // Expected, not an error: ESPN doesn't ship every optional facet for
+                // every game (e.g. no EventCompetitionPlay `details` link for a
+                // lower-division game with no play-by-play). Debug, not Warning, so a
+                // full-season backfill doesn't flood Seq with benign skips.
+                _logger.LogDebug(
+                    "⏭️ SKIP_CHILD_DOCUMENT: parent DTO has no {ChildDocumentType} link (facet not present). ParentId={ParentId}",
                     documentType,
                     parentId?.ToString());
                 return;


### PR DESCRIPTION
## Summary

A full-season NCAA 2025 backfill flooded Seq with `⏭️ SKIP_CHILD_DOCUMENT: parent DTO link is null` **Warning**s (dominantly `ChildDocumentType=EventCompetitionPlay`). Investigation confirmed they're **benign**:

- The record chain (`EventCompetition → EventCompetitionCompetitor → EventCompetitionCompetitorRecord`) sources and completes successfully — 372k `CompetitionCompetitorRecord` rows and climbing.
- `EventCompetitionPlay` docs **also** source and complete for games that have play-by-play (verified in Seq for NCAA 2025 events).
- So `dto.Details` maps correctly; the null-link skips are just games ESPN has **no play-by-play** for (lower-division / non-major), which is most of a full-season backfill.

A missing **optional** child facet (plays, situation, leaders, …) is an **expected absence**, not an error — ESPN simply doesn't ship every facet for every game.

## Change

Downgrade the `hasRef is null` skip in `DocumentProcessorBase.PublishChildDocumentRequest` from **Warning → Debug**, so a backfill doesn't drown Seq in benign skips. Kept the separate `hasRef.Ref is null` case ("link present but `$ref` null") at **Warning** — that's a genuine malformed-link anomaly worth surfacing.

No behavior change (log level only); no test asserts on the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning messages when a parent document does not include a child-document link.
  * Child-document requests continue to be skipped when the required link is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->