### PR TITLE
fix(producer): idempotent no-op for re-delivered SeasonTypeWeekRankings

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessor.cs
@@ -117,7 +117,7 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
         }
         else
         {
-            await ProcessExistingEntity();
+            ProcessExistingEntity(dto, pollWeek);
         }
     }
 
@@ -348,9 +348,36 @@ public class SeasonTypeWeekRankingsDocumentProcessor<TDataContext> : DocumentPro
     }
 
 
-    private async Task ProcessExistingEntity()
+    private void ProcessExistingEntity(
+        EspnFootballSeasonTypeWeekRankingsDto dto,
+        SeasonPollWeek existing)
     {
-        _logger.LogError("Update detected. Not implemented");
-        await Task.CompletedTask;
+        var incomingLastUpdated = dto.LastUpdated.TryParseUtcNullable();
+
+        // ESPN stamps each poll-week with a lastUpdated timestamp. During backfills
+        // and at-least-once redelivery the same document arrives repeatedly with
+        // identical content, so its lastUpdated has not advanced past what we stored
+        // — there is nothing to do. This is the overwhelmingly common path (and was
+        // previously logged at Error, which spammed Seq during re-sourcing); keep it
+        // quiet.
+        var isRevision = incomingLastUpdated is not null &&
+                         (existing.LastUpdatedUtc is null || incomingLastUpdated > existing.LastUpdatedUtc);
+
+        if (!isRevision)
+        {
+            _logger.LogDebug(
+                "SeasonPollWeek {SeasonPollWeekId} already current (stored lastUpdated {StoredLastUpdated}); no update needed.",
+                existing.Id, existing.LastUpdatedUtc);
+            return;
+        }
+
+        // ESPN revised this poll-week (e.g. an end-of-week correction). Applying the
+        // revision in place — reconciling scalar fields plus the ranked Entries
+        // collection — is not yet implemented; surfaced at Information (not Error) so a
+        // genuine revision stays visible without drowning Seq. Revisions do not occur
+        // for completed seasons, so this path is dormant during historical backfills.
+        _logger.LogInformation(
+            "SeasonPollWeek {SeasonPollWeekId} was revised upstream (incoming lastUpdated {IncomingLastUpdated} > stored {StoredLastUpdated}); in-place update not yet implemented.",
+            existing.Id, incomingLastUpdated, existing.LastUpdatedUtc);
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessorTests.cs
@@ -289,6 +289,104 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
         }
 
         [Fact]
+        public async Task ProcessExistingSeasonTypeWeekRankings_WhenUnchanged_IsIdempotentNoOp()
+        {
+            var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaSeasonTypeWeekRankings.json");
+            var dto = json.FromJson<EspnFootballSeasonTypeWeekRankingsDto>();
+
+            // Arrange — same setup as ProcessNewSeasonTypeWeekRankings_CreatesRankingEntity
+            var correlationId = Guid.NewGuid();
+            var seasonId = Guid.NewGuid();
+            var seasonPhaseId = Guid.NewGuid();
+
+            var generator = new ExternalRefIdentityGenerator();
+            Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+            var seasonPollRef = EspnUriMapper.SeasonPollWeekRefToSeasonPollRef(dto!.Ref);
+            var seasonPollIdentity = generator.Generate(seasonPollRef);
+
+            var seasonPoll = new SeasonPoll
+            {
+                Id = seasonPollIdentity.CanonicalId,
+                Name = "AFCA Coaches Poll",
+                ShortName = "Coaches",
+                SeasonYear = 2025,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            };
+            await FootballDataContext.SeasonPolls.AddAsync(seasonPoll);
+
+            var season = new Season
+            {
+                Id = seasonId,
+                Name = "2025 NCAA Football Season",
+                Year = 2025,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            };
+
+            var seasonPhase = new SeasonPhase
+            {
+                Id = seasonPhaseId,
+                SeasonId = seasonId,
+                Name = "2025 Regular Season",
+                Slug = "Regular Season",
+                Abbreviation = "REG",
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            };
+
+            var seasonWeekIdentity = generator.Generate(dto.Season.Type.Week.Ref);
+            var weekRefUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/types/1/weeks/1/rankings/2?lang=en&region=us";
+            var weekHash = generator.Generate(weekRefUrl).UrlHash;
+
+            var seasonWeek = new SeasonWeek
+            {
+                Id = seasonWeekIdentity.CanonicalId,
+                Number = 2,
+                SeasonId = seasonId,
+                SeasonPhaseId = seasonPhaseId,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            };
+
+            await FootballDataContext.Seasons.AddAsync(season);
+            await FootballDataContext.SeasonPhases.AddAsync(seasonPhase);
+            await FootballDataContext.SeasonWeeks.AddAsync(seasonWeek);
+            await FootballDataContext.SaveChangesAsync();
+
+            await SeedFranchisesAndSeasonsFromDto(dto, generator);
+
+            var command = new ProcessDocumentCommand(
+                SourceDataProvider.Espn,
+                Sport.FootballNcaa,
+                2025,
+                DocumentType.SeasonTypeWeekRankings,
+                json,
+                messageId: Guid.NewGuid(),
+                correlationId: correlationId,
+                parentId: seasonPollIdentity.CanonicalId.ToString(),
+                sourceUri: new Uri(weekRefUrl),
+                urlHash: weekHash
+            );
+
+            var sut = Mocker.CreateInstance<SeasonTypeWeekRankingsDocumentProcessor<FootballDataContext>>();
+
+            // Act — process the same document twice (simulates at-least-once redelivery / backfill re-source)
+            await sut.ProcessAsync(command);
+            await sut.ProcessAsync(command);
+
+            // Assert — still exactly one SeasonPollWeek with its full entry set; the second
+            // pass is a no-op (no duplicate rows, no exception).
+            var rankings = await FootballDataContext.SeasonPollWeeks
+                .Include(r => r.Entries)
+                .ToListAsync();
+
+            rankings.Should().ContainSingle("re-delivering an unchanged document must not create a duplicate");
+            rankings.Single().Entries.Should().HaveCount(51);
+        }
+
+        [Fact]
         public async Task WhenParentIdIsNotGuid_DerivesSeasonPollIdFromRef()
         {
             var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaSeasonTypeWeekRankings.json");


### PR DESCRIPTION
## Problem

`SeasonTypeWeekRankingsDocumentProcessor.ProcessExistingEntity` logged at **Error** — `"Update detected. Not implemented"` — on every re-delivery of an already-persisted `SeasonPollWeek`. During historical backfills and at-least-once redelivery, the same completed-season poll documents arrive repeatedly with identical content, so this fires constantly and spams Seq at Error level. (Observed live during the NCAA 2025 re-source.)

## Change

Compare ESPN's `dto.LastUpdated` against the stored `LastUpdatedUtc` (already populated from the same field on create):

- **Not newer** — the backfill / redelivery of unchanged content: quiet `Debug` no-op. This is the overwhelmingly common path and removes the noise.
- **Newer** — a genuine upstream poll revision (only possible mid-live-season): `Information`, with in-place reconciliation of the ranked `Entries` collection **explicitly deferred**. The revision is surfaced, not silently dropped.

Control flow is unchanged — the method still returns without throwing, so there is no message-requeue behavior shift. Only the logging and the change-detection guard are new.

## Deferred follow-up

Actually applying a revision in place (update scalar fields + replace the `Entries` collection) is dormant for a completed season and can't be validated until football goes live and ESPN corrects a real poll. Left as the `Information` signal rather than shipping untested reconciliation logic.

## Tests

- Adds `ProcessExistingSeasonTypeWeekRankings_WhenUnchanged_IsIdempotentNoOp` — processes the same document twice and asserts a single `SeasonPollWeek` with its full 51-entry set, no duplicate, no exception.
- Full processor suite green (6/6). `dotnet build` clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unchanged ranking updates from creating duplicate records when the same data is processed more than once.
  * Added timestamp checks to identify whether incoming ranking data is already current or represents a revision.

* **Tests**
  * Added coverage confirming repeated processing remains idempotent and preserves the expected ranking entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->