### PR TITLE
fix(ui): anchor MiniSchedule on game kickoff, not week end

### DIFF
--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -502,11 +502,11 @@ export interface MatchupCardProps {
   leagueSport?: string | null;
   /**
    * SeasonWeek.EndDate of the displayed week (ISO 8601), surfaced via
-   * LeagueWeekMatchupsDto.asOfDate. Passed into MiniSchedule's fetch as an
-   * inclusive FinalizedUtc upper bound so the historical-pick-review case
-   * doesn't show results from games the picker couldn't yet have seen. Date
-   * filter (not week number) so MLB same-week games and football post-season
-   * Week-1 reuse both behave correctly.
+   * LeagueWeekMatchupsDto.asOfDate. Retained for prop compatibility with the
+   * screen-level caller but no longer consumed: the MiniSchedule now anchors
+   * its FinalizedUtc cutoff on THIS game's kickoff (matchup.startDateUtc), not
+   * the week end — see scheduleAsOfDate in the body. Week-end sat after the card
+   * game finalized, so it wrongly pulled the card's own game into its schedule.
    */
   leagueAsOfDate?: string | null;
   /**
@@ -518,7 +518,7 @@ export interface MatchupCardProps {
   pickType?: PickType | null;
 }
 
-export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear, leagueSport, leagueAsOfDate, pickType }: MatchupCardProps) {
+export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear, leagueSport, pickType }: MatchupCardProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
 
@@ -618,6 +618,14 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   const year = seasonYear ?? new Date(matchup.startDateUtc).getFullYear();
   const sportLeague = resolveSportLeague(leagueSport);
 
+  // Point-in-time anchor for the MiniSchedule — THIS game's kickoff, not the
+  // week's end. The endpoint filters FinalizedUtc <= asOfDate, and a game's
+  // FinalizedUtc is always after its own StartDateUtc, so anchoring on
+  // startDateUtc excludes the card game (and any not-yet-played same-day game,
+  // e.g. an MLB doubleheader's later game) while keeping every game already
+  // completed at kickoff. (Web parity: MatchupCard.jsx scheduleAsOfDate.)
+  const scheduleAsOfDate = matchup.startDateUtc;
+
   // Only fetch when the sport enum resolves — otherwise we'd issue a
   // football/ncaa request for a slug that lives in a different sport
   // (resolveSportLeague returns null for unmapped/unknown enums by design).
@@ -627,7 +635,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
     sportLeague?.sport ?? 'football',
     sportLeague?.league ?? 'ncaa',
     showAwaySchedule && !!sportLeague,
-    leagueAsOfDate ?? null,
+    scheduleAsOfDate,
   );
   const homeFinalizedGames = useTeamFinalizedGames(
     matchup.homeSlug ?? null,
@@ -635,7 +643,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
     sportLeague?.sport ?? 'football',
     sportLeague?.league ?? 'ncaa',
     showHomeSchedule && !!sportLeague,
-    leagueAsOfDate ?? null,
+    scheduleAsOfDate,
   );
 
   const handleOpenStats = async () => {

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -31,8 +31,7 @@ function MatchupCard({
   usedConfidencePoints = [],
   totalGames,
   leagueSport, // Backend Sport enum name (e.g. "BaseballMlb") — drives team-link routing
-  leagueSeasonYear, // From LeagueWeekMatchupsDto.SeasonYear — canonical for all matchups in this response
-  leagueAsOfDate // From LeagueWeekMatchupsDto.AsOfDate (= SeasonWeek.EndDate of the displayed week). Threaded into MiniSchedule as an inclusive FinalizedUtc upper bound so historical pick reviews don't show future game results.
+  leagueSeasonYear // From LeagueWeekMatchupsDto.SeasonYear — canonical for all matchups in this response
 }) {
   const { userDto } = useUserDto();
   // seasonYear is authoritative from leagueSeasonYear (set by the backend
@@ -42,6 +41,16 @@ function MatchupCard({
   // season-specific fetches / omitting the URL segment rather than silently
   // rendering a stale year.
   const seasonYear = leagueSeasonYear ?? matchup.seasonYear;
+
+  // Point-in-time anchor for the embedded MiniSchedule. Must be THIS game's
+  // kickoff, not the week's end. The endpoint filters FinalizedUtc <= asOfDate,
+  // and a game's FinalizedUtc is always after its own StartDateUtc — so
+  // anchoring on startDateUtc excludes the card game (and any not-yet-played
+  // same-day game, e.g. an MLB doubleheader's later game) for free, while
+  // keeping every game already completed at kickoff. The old league-level
+  // asOfDate (= SeasonWeek.EndDate) sat after the card game finalized, which
+  // wrongly pulled the card's own game into its own schedule.
+  const scheduleAsOfDate = matchup.startDateUtc;
 
   // /picks routes don't carry sport in the URL — resolve it from the matchups
   // DTO's leagueSport so contest links, etc. point at the right sport-aware
@@ -85,7 +94,7 @@ function MatchupCard({
     homeLoading,
     awayError,
     homeError
-  } = useTeamFinalizedGames(matchup.awaySlug, matchup.homeSlug, seasonYear, leagueSport, leagueAsOfDate);
+  } = useTeamFinalizedGames(matchup.awaySlug, matchup.homeSlug, seasonYear, leagueSport, scheduleAsOfDate);
 
   const userTz = useUserTimeZone();
 
@@ -187,7 +196,7 @@ function MatchupCard({
           loading={awayLoading}
           error={awayError}
           probablePitcher={matchup.awayProbablePitcher}
-          asOfDate={leagueAsOfDate}
+          asOfDate={scheduleAsOfDate}
         />
 
         {/* Home Team Row */}
@@ -210,7 +219,7 @@ function MatchupCard({
           loading={homeLoading}
           error={homeError}
           probablePitcher={matchup.homeProbablePitcher}
-          asOfDate={leagueAsOfDate}
+          asOfDate={scheduleAsOfDate}
         />
 
         {/* Spread and Over/Under */}


### PR DESCRIPTION
## Problem

The matchup card's embedded **MiniSchedule** (the mini-schedule you expand per team) fetched a team's finalized games with `asOfDate = LeagueWeekMatchupsDto.AsOfDate`, which is the **`SeasonWeek.EndDate` of the displayed week**. The endpoint filters `FinalizedUtc <= @AsOfDate`.

Because the card's **own game** lives inside that week and finalizes *before* the week ends, `cardGame.FinalizedUtc <= weekEndDate` was true — so on past weeks the card game appeared as a row in its own mini-schedule, even though at that point-in-time it hadn't been played yet.

Concrete case: Miami vs. opponent, kickoff Nov 1 2025 12pm ET (`16:00Z`), but the request carried `asOfDate=2025-11-03T07:59:00Z` (the week end) — so the game passed the filter.

## Fix

Anchor the MiniSchedule on the **card game's kickoff** (`matchup.startDateUtc`) instead of the week end. A game's `FinalizedUtc` is always after its own `StartDateUtc`, so `FinalizedUtc <= kickoff` excludes the card game **for free**, while keeping every game already completed when this one started.

This also correctly excludes any not-yet-played **same-day** game (e.g. an MLB doubleheader's later game) *without* a time buffer — a "minus one hour/day" fudge would have wrongly dropped the earlier doubleheader game that finished shortly before kickoff.

**No backend change.** The endpoint already filters `FinalizedUtc <= @AsOfDate` end-to-end as a `DateTime?` with full time-of-day precision; only the anchor value passed from the card changed.

## Scope

- **Web** — `sd-ui/src/components/matchups/MatchupCard.jsx`: `scheduleAsOfDate = matchup.startDateUtc` feeds the finalized-games hook + both `TeamRow`/`MiniSchedule` props (so the away/home expand and the recursive opponent drilldown share the kickoff anchor).
- **Mobile** — `sd-mobile/.../MatchupCard.tsx`: same anchor into both `useTeamFinalizedGames` calls. (Mobile MiniSchedule has no drilldown, so `asOfDate` only lived in those two calls.)
- `leagueAsOfDate` is retained on the props/interface for caller compatibility but no longer consumed.

## Validation

- Web: verified in the running app — the card's own game no longer appears; the GET now sends `asOfDate` = kickoff.
- Mobile: `tsc --noEmit` clean (0 errors).
- Web ESLint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matchup schedules and finalized-game filtering now use each game’s kickoff time, improving accuracy when viewing team schedules.
  * Resolved inconsistencies caused by using the broader league or week end date for matchup-specific schedule information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->