### PR TITLE
feat(ui): default My Leagues to newest-first, add A-Z sort pill

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
@@ -51,5 +51,13 @@
         public DateTime? DeactivatedUtc { get; set; }
 
         public string? AvatarUrl { get; set; } // optional for visuals
+
+        /// <summary>
+        /// When the league was created (server-authoritative, off
+        /// <c>PickemGroup.CreatedUtc</c>). Drives the default newest-to-oldest
+        /// sort on the My Leagues page; the client also offers an A-Z sort by
+        /// <see cref="Name"/>.
+        /// </summary>
+        public DateTime CreatedUtc { get; set; }
     }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
@@ -55,7 +55,8 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
                     .Distinct()
                     .OrderBy(w => w)
                     .ToList(),
-                DeactivatedUtc = m.Group.DeactivatedUtc
+                DeactivatedUtc = m.Group.DeactivatedUtc,
+                CreatedUtc = m.Group.CreatedUtc
             })
             .ToListAsync(cancellationToken);
 

--- a/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
@@ -15,6 +15,7 @@ function league(
     avatarUrl: null,
     seasonWeeks: [],
     deactivatedUtc: null,
+    createdUtc: '2025-01-01T00:00:00Z',
     ...partial,
   };
 }

--- a/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
+++ b/src/UI/sd-mobile/__tests__/services/api/leaguesApi.test.ts
@@ -143,6 +143,7 @@ describe('leaguesApi.getUserLeagues', () => {
       seasonYear: 2026,
       seasonWeeks: [1, 2, 3],
       deactivatedUtc: null,
+      createdUtc: '2026-01-01T00:00:00Z',
     };
     (apiClient.get as jest.Mock).mockResolvedValue({ data: [league] });
 

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -116,11 +116,11 @@ export default function LeaguesScreen() {
   // ties (or a missing timestamp) stay deterministic. Copy first — sort mutates.
   const sortedLeagues = [...visibleLeagues].sort((a, b) => {
     if (sortMode === 'alpha') {
-      return (a.name ?? '').localeCompare(b.name ?? '');
+      return (a.name ?? '').localeCompare(b.name ?? '') || a.id.localeCompare(b.id);
     }
     const tb = b.createdUtc ? Date.parse(b.createdUtc) : 0;
     const ta = a.createdUtc ? Date.parse(a.createdUtc) : 0;
-    return tb - ta || (a.name ?? '').localeCompare(b.name ?? '');
+    return tb - ta || (a.name ?? '').localeCompare(b.name ?? '') || a.id.localeCompare(b.id);
   });
 
   const showFilterBar =

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -26,6 +26,11 @@ export const leaguesKeys = {
 };
 
 const ALL_LEAGUES = 'All';
+
+// Sort modes for the league grid. Default newest-first (by createdUtc); the A-Z
+// option sorts by league name. Mirrors sd-ui's Leagues.jsx.
+type SortMode = 'newest' | 'alpha';
+
 const CONTENT_PADDING = 16; // matches styles.content horizontal padding
 const GRID_GAP = 12; // matches styles.grid gap
 
@@ -47,6 +52,7 @@ export default function LeaguesScreen() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showPast, setShowPast] = useState(false);
   const [leagueFilter, setLeagueFilter] = useState<string>(ALL_LEAGUES);
+  const [sortMode, setSortMode] = useState<SortMode>('newest');
 
   // Always fetch past leagues so the toggle is instant rather than a refetch.
   // A user's league count is small, and every row is needed the moment they
@@ -105,7 +111,21 @@ export default function LeaguesScreen() {
   const visibleLeagues =
     activeFilter === ALL_LEAGUES ? scoped : scoped.filter((l) => l.league === activeFilter);
 
-  const showFilterBar = leagues.length > 0 && (hasPast || availableLeagues.length > 1);
+  // Apply the chosen sort. Default is newest-first by createdUtc (the raw API
+  // order is arbitrary); A-Z sorts by name. Both fall back to a name compare so
+  // ties (or a missing timestamp) stay deterministic. Copy first — sort mutates.
+  const sortedLeagues = [...visibleLeagues].sort((a, b) => {
+    if (sortMode === 'alpha') {
+      return (a.name ?? '').localeCompare(b.name ?? '');
+    }
+    const tb = b.createdUtc ? Date.parse(b.createdUtc) : 0;
+    const ta = a.createdUtc ? Date.parse(a.createdUtc) : 0;
+    return tb - ta || (a.name ?? '').localeCompare(b.name ?? '');
+  });
+
+  const showFilterBar =
+    leagues.length > 0 &&
+    (hasPast || availableLeagues.length > 1 || visibleLeagues.length > 1);
   const filterOptions = [ALL_LEAGUES, ...availableLeagues].map((v) => ({ value: v, label: v }));
 
   const openPicks = (leagueId: string) =>
@@ -146,6 +166,17 @@ export default function LeaguesScreen() {
                 options={filterOptions}
                 onChange={setLeagueFilter}
                 accessibilityLabel="Filter by league"
+              />
+            )}
+            {visibleLeagues.length > 1 && (
+              <SegmentedControl<SortMode>
+                value={sortMode}
+                options={[
+                  { value: 'newest', label: 'Newest' },
+                  { value: 'alpha', label: 'A-Z' },
+                ]}
+                onChange={setSortMode}
+                accessibilityLabel="Sort leagues"
               />
             )}
             {hasPast && (
@@ -219,7 +250,7 @@ export default function LeaguesScreen() {
           </Text>
         ) : (
           <View style={styles.grid}>
-            {visibleLeagues.map((league) => (
+            {sortedLeagues.map((league) => (
               <View
                 key={league.id}
                 style={cardWidth != null ? { width: cardWidth } : styles.cardFull}

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -109,6 +109,12 @@ export interface LeagueSummary {
    * currently fetches.
    */
   deactivatedUtc: string | null;
+  /**
+   * When the league was created (ISO 8601, server-authoritative off
+   * PickemGroup.CreatedUtc). Drives the default newest-first sort on the My
+   * Leagues screen; the A-Z option sorts by `name`.
+   */
+  createdUtc: string;
 }
 
 export interface CloneLeagueRequest {

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -130,11 +130,11 @@ const Leagues = () => {
   // mutates, and visibleLeagues derives from state.
   const sortedLeagues = [...visibleLeagues].sort((a, b) => {
     if (sortMode === SORT_ALPHA) {
-      return (a.name ?? "").localeCompare(b.name ?? "");
+      return (a.name ?? "").localeCompare(b.name ?? "") || a.id.localeCompare(b.id);
     }
     const tb = b.createdUtc ? Date.parse(b.createdUtc) : 0;
     const ta = a.createdUtc ? Date.parse(a.createdUtc) : 0;
-    return tb - ta || (a.name ?? "").localeCompare(b.name ?? "");
+    return tb - ta || (a.name ?? "").localeCompare(b.name ?? "") || a.id.localeCompare(b.id);
   });
 
   // Show the bar when any control is useful: filters vary, past leagues exist,

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -11,6 +11,11 @@ import "./Leagues.css"; // for grid styling
 const ALL_LEAGUES = "All";
 const ALL_SEASONS = "All";
 
+// Sort modes for the My Leagues grid. Default is newest-first (by createdUtc);
+// the A-Z pill sorts by league name.
+const SORT_NEWEST = "newest";
+const SORT_ALPHA = "alpha";
+
 // Persist the My Leagues filter state so navigating into a league detail and
 // back (or returning in a later visit) restores the same view instead of
 // resetting to defaults. Stale values are absorbed by the self-healing below.
@@ -38,6 +43,7 @@ const Leagues = () => {
   const [showPast, setShowPast] = useState(() => loadPersistedFilters().showPast);
   const [leagueFilter, setLeagueFilter] = useState(() => loadPersistedFilters().leagueFilter ?? ALL_LEAGUES);
   const [seasonFilter, setSeasonFilter] = useState(() => loadPersistedFilters().seasonFilter ?? ALL_SEASONS);
+  const [sortMode, setSortMode] = useState(() => loadPersistedFilters().sortMode ?? SORT_NEWEST);
 
   // Always fetch past leagues so the toggle is instant rather than a refetch.
   // The user's league count is small, and every row is needed the moment they
@@ -57,12 +63,12 @@ const Leagues = () => {
     try {
       localStorage.setItem(
         FILTERS_STORAGE_KEY,
-        JSON.stringify({ showPast, leagueFilter, seasonFilter })
+        JSON.stringify({ showPast, leagueFilter, seasonFilter, sortMode })
       );
     } catch {
       /* ignore storage failures (private mode, quota) */
     }
-  }, [showPast, leagueFilter, seasonFilter]);
+  }, [showPast, leagueFilter, seasonFilter, sortMode]);
 
   const handleClone = async (name, inviteMembers) => {
     if (!cloneTarget) return;
@@ -118,8 +124,26 @@ const Leagues = () => {
     (l) => activeSeasonFilter === ALL_SEASONS || l.seasonYear === activeSeasonFilter
   );
 
+  // Apply the chosen sort. Default is newest-first by createdUtc (the raw API
+  // order is arbitrary); A-Z sorts by name. Both fall back to a name compare so
+  // ties (or a missing timestamp) stay deterministic. Copy first — Array.sort
+  // mutates, and visibleLeagues derives from state.
+  const sortedLeagues = [...visibleLeagues].sort((a, b) => {
+    if (sortMode === SORT_ALPHA) {
+      return (a.name ?? "").localeCompare(b.name ?? "");
+    }
+    const tb = b.createdUtc ? Date.parse(b.createdUtc) : 0;
+    const ta = a.createdUtc ? Date.parse(a.createdUtc) : 0;
+    return tb - ta || (a.name ?? "").localeCompare(b.name ?? "");
+  });
+
+  // Show the bar when any control is useful: filters vary, past leagues exist,
+  // or there's more than one league to sort.
   const showFilterBar =
-    hasPast || availableLeagues.length > 1 || availableSeasons.length > 1;
+    hasPast ||
+    availableLeagues.length > 1 ||
+    availableSeasons.length > 1 ||
+    visibleLeagues.length > 1;
 
   return (
     <div className="page-container">
@@ -166,6 +190,26 @@ const Leagues = () => {
               ))}
             </div>
           )}
+          {visibleLeagues.length > 1 && (
+            <div className="league-filter-chips" role="group" aria-label="Sort leagues">
+              {[
+                { key: SORT_NEWEST, label: "Newest" },
+                { key: SORT_ALPHA, label: "A-Z" },
+              ].map((option) => (
+                <button
+                  key={option.key}
+                  type="button"
+                  className={`league-filter-chip${
+                    sortMode === option.key ? " active" : ""
+                  }`}
+                  onClick={() => setSortMode(option.key)}
+                  aria-pressed={sortMode === option.key}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          )}
           {hasPast && (
             <button
               type="button"
@@ -189,7 +233,7 @@ const Leagues = () => {
         <p>No leagues match this filter.</p>
       ) : (
         <div className="league-grid">
-          {visibleLeagues.map((league) => (
+          {sortedLeagues.map((league) => (
             <LeagueOverviewCard
               key={league.id}
               league={league}


### PR DESCRIPTION
## Problem

The **My Leagues** list (`/app/leagues` web, My Leagues screen mobile) rendered in whatever order `getUserLeagues` returned — effectively arbitrary. No sensible default and no way to reorder.

## Change

Default the list to **newest → oldest**, and expose a two-option sort control so users can switch to **A-Z**.

**API** (additive, non-breaking)
- `LeagueSummaryDto.CreatedUtc`, projected off `PickemGroup.CreatedUtc` in `GetUserLeaguesQueryHandler`. Both clients consume it.

**Web** (`sd-ui/src/components/leagues/Leagues.jsx`)
- Default sort by `createdUtc` desc, with a league-name tiebreaker so ties / a missing timestamp stay deterministic.
- A **"Newest" / "A-Z"** chip group reusing the existing `league-filter-chips` styling; persisted alongside the other filters in `localStorage`; shown when there's more than one league to sort.

**Mobile** (`sd-mobile/app/leagues.tsx`)
- Same default sort and tiebreak.
- A **"Newest" / "A-Z"** `SegmentedControl` — the two-option primitive the screen already uses for its league filter. Plain component state, matching how the screen handles its other filters (no persistence layer there).
- `LeagueSummary` type gains the required `createdUtc`; two test fixtures updated with a deterministic literal.

## Validation

- API: `dotnet build` clean (0 warnings). No `GetUserLeagues` handler tests exist to run.
- Web: verified in the running app (default newest-first, A-Z toggles, persists across a round-trip); ESLint clean.
- Mobile: `tsc --noEmit` clean; the two touched test suites pass (16 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “My Leagues” sorting options: **Newest** and **A–Z**.
  * Sorting preference is retained for future visits.
* **Improvements**
  * League data now includes a creation timestamp to enable accurate newest-first ordering.
  * Sorting is deterministic, including consistent tie-breaking when timestamps are missing or equal.
  * Sorting controls appear when multiple leagues are available after filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->