### PR TITLE
feat(leagues): per-sport league-creation availability gate (NCAAFB until AP Poll)

### DIFF
--- a/docs/features/league-creation-availability-gate.md
+++ b/docs/features/league-creation-availability-gate.md
@@ -1,0 +1,170 @@
+# League creation: per-sport availability gate
+
+**Status:** Implemented (backend + web + mobile). Pending: set the NCAA config
+value in AppConfig; PR + CodeRabbit.
+**Owner:** Randall.
+**Scope:** `SportsData.Api` (config + service + guard + endpoint),
+`src/UI/sd-ui` + `src/UI/sd-mobile` (CTA + create-form gate). **No Producer / Core
+change** — league-creation availability is a Pick'em rule, owned entirely by API.
+
+## Problem
+
+We must not allow league creation for a sport before that sport's data is ready.
+
+- **NCAAFB:** many leagues rank teams by the **AP Poll**, which isn't released until
+  **Aug 17, 2026**. A league created before then has no rankings to work from — a
+  broken first experience during our launch window.
+- **NFL:** could technically be created now, but we may want to hold it too. The
+  handling (and the exact date) is **not yet decided** — the gate must apply to NFL
+  by changing a single config value, not by writing new code.
+
+This is distinct from [[league-creation-blackout-dates]] (which days *have games*
+inside a chosen window). This gate is about *when the sport opens for creation at
+all*, and it is **time-based so it auto-unlocks** with no deploy.
+
+## Why API, not Producer
+
+Producer is the keeper of canonical data; API is the keeper of all things Pick'em.
+League-creation availability is a Pick'em rule — it has no place on
+`CurrentSeasonDto` or forcing Producer to populate it. Keeping it in API also means
+the create guard reads the value **locally** instead of round-tripping to Producer.
+
+## Mechanism
+
+A single nullable UTC timestamp per sport, held in API config and enforced at the
+create seam, exposed to the FE by one endpoint.
+
+### Semantics of the gate
+
+| Value for a sport | Meaning |
+|---|---|
+| absent | No gate — creatable now (e.g. MLB, already admin-gated separately). |
+| future timestamp | **Locked** until that instant; UI shows "opens {date}". |
+| past timestamp | Creatable (the gate expired; harmless to leave configured). |
+
+Because it's a timestamp compared to `now`, NCAAFB opens automatically at Aug 17
+with **no redeploy and no OTA push**. NFL is the same map with a different value.
+
+### Source — `ApiConfig.LeagueCreationOpensUtc` (per-sport config)
+
+**`Dictionary<string, string>`** on `ApiConfig` (`SportsData.Api:ApiConfig`), keyed by
+**Sport enum name**. API is mode=All, so the map is sport-keyed (the
+`feedback_appconfig_sport_keyed` pattern). Set the NCAA gate as a hierarchical key in
+the API's AppConfig label:
+
+```
+SportsData.Api:ApiConfig:LeagueCreationOpensUtc:FootballNcaa = 2026-08-17T00:00:00Z
+```
+
+> **Why string-keyed, not `Dictionary<Sport, DateTime>`:** the .NET configuration
+> binder does **not** reliably populate *enum-keyed* dictionaries — they bind empty
+> (and nothing else in this codebase relies on that; the `Dictionary<Sport, …>` props
+> on `CommonConfig` are vestigial, with real sport config read via direct string
+> keys). String-keyed dictionaries bind reliably (cf. `LoggingConfig.Overrides`). Do
+> **not** collapse this to a single `…:LeagueCreationOpensUtc` key holding a JSON
+> dictionary — that only binds if the AppConfig value is also marked
+> `content-type: application/json` (an extra, brittle step). The hierarchical per-key
+> form above is the idiomatic approach.
+
+`ILeagueCreationAvailability` parses each entry once at construction: the key
+`"FootballNcaa"` → `Sport`, the value → a UTC instant (`DateTimeStyles.AssumeUniversal
+| AdjustToUniversal`, so both `…Z` and a bare `2026-08-17T00:00:00` resolve to the
+same UTC instant, never shifted by the host timezone). Unknown sport names /
+unparseable dates are dropped. No migration; change the date or unlock early live in
+AppConfig.
+
+### One service, two consumers
+
+`ILeagueCreationAvailability` (`Application/UI/Leagues/LeagueCreationAvailability.cs`)
+reads the config + `IDateTimeProvider`:
+
+- `GetOpensUtc(Sport)` → the future open instant, or `null` if open (absent/elapsed).
+  Used by the **create guard**.
+- `GetActiveGates()` → all currently-gated sports (future only), earliest first.
+  Used by the **FE endpoint**.
+
+### Enforcement (correctness floor)
+
+Create-time guard in `CreateLeagueCommandHandlerBase.ExecuteAsync`, before the
+blackout guard and any downstream work:
+
+```csharp
+var opensUtc = _availability.GetOpensUtc(SportMode);
+if (opensUtc is not null)
+    return new Failure<Guid>(default!, ResultStatus.Validation,
+        [new ValidationFailure(nameof(request),
+            $"League creation opens {opensUtc:MMMM d, yyyy}. Check back then.")]);
+```
+
+Same failure shape the FE already surfaces. Closes the deep-link
+(`?sport=FootballNcaa`) and direct-API holes that CTA-hiding alone leaves open.
+
+### FE-facing endpoint
+
+`GET /ui/leagues/creation-availability` → `LeagueCreationAvailabilityDto`:
+
+```json
+{ "gates": [ { "sport": "FootballNcaa", "opensUtc": "2026-08-17T00:00:00Z" } ] }
+```
+
+Returns only **active** gates; a sport not listed is open. One call covers every
+sport — better than per-sport `seasons/current`, since the create page and
+off-season countdown both juggle multiple sports at once.
+
+### Frontend gate (both platforms, mirror the `isMlbAvailable` pattern)
+
+1. **Create form** (`LeagueCreatePage.jsx` / `create-league.tsx`) — the real UX
+   choke point. Fetch the availability once; a sport in `gates` renders its tab
+   **disabled with an "opens {date}" hint** (not silently hidden). Guard
+   `initialSport` / the `?sport=` deep-link so a locked sport doesn't land on a dead
+   form; fall back to the first open sport / show the locked state.
+2. **Off-season countdown** (`PrimarySlotOffSeasonCountdown`) — when a sport is
+   locked, swap its "Create {sport} league" CTA for a disabled "{sport} leagues open
+   {date}" affordance.
+3. **Generic CTAs** (`PrimarySlotNewUser`, `LeagueMembership`, `Leagues` /
+   `leagues.tsx`) — route to the create form, which shows the locked state, so these
+   need no per-sport logic.
+
+If the availability call fails, the FE fails **open** (sports appear creatable);
+the server guard still rejects a locked create with the "opens {date}" message, so
+the worst case is a slightly worse UX on a transient outage, never a broken league.
+
+## Rollout
+
+1. NCAAFB: set `...:LeagueCreationOpensUtc:FootballNcaa = 2026-08-17T00:00:00` in the
+   API's AppConfig label.
+2. NFL: set its key once decided — **no code change**.
+
+## Files touched
+
+- `SportsData.Api`:
+  - `Config/ApiConfig.cs` — `LeagueCreationOpensUtc` map.
+  - `Application/UI/Leagues/LeagueCreationAvailability.cs` — service (+ interface).
+  - `Application/UI/Leagues/Dtos/LeagueCreationAvailabilityDto.cs` — endpoint DTOs.
+  - `Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs` — guard
+    (+ ctor param threaded through the 3 sport subclasses).
+  - `Application/UI/Leagues/LeagueController.cs` — `GET creation-availability`.
+  - `DependencyInjection/ServiceRegistration.cs` — register the service.
+- `sd-ui`: `LeagueCreatePage.jsx` (tab gate + deep-link), `PrimarySlotOffSeasonCountdown.jsx` (CTA), availability api client.
+- `sd-mobile`: `create-league.tsx` (tab gate + deep-link), `PrimarySlotOffSeasonCountdown.tsx` (CTA), availability api method.
+- Tests: `LeagueCreationAvailabilityTests`, gated-sport case on the NCAA create handler.
+
+## Testing
+
+- **Service:** future gate → `GetOpensUtc` returns the instant; absent/past → null;
+  Unspecified config instant treated as UTC; `GetActiveGates` returns future-only,
+  earliest first. (`LeagueCreationAvailabilityTests`, 7 cases.)
+- **Guard:** future `OpensUtc` → `Failure(Validation)`, **no** `PickemGroupCreated`
+  published. (`CreateFootballNcaaLeagueCommandHandlerTests.ShouldFail_WhenSportCreationNotYetOpen`.)
+  Existing create-handler tests auto-mock the service (returns null → open), so they
+  stay green with no behavior change.
+- **FE:** locked sport tab disabled with hint; locked `?sport=` deep-link doesn't
+  dead-end; open sport creates normally.
+
+## Decisions (resolved)
+
+1. **Where the date lives — per-sport API config (`ApiConfig`).** No migration,
+   changeable live in AppConfig, API-owned (not Producer/Core). NCAA label gets
+   Aug 17, 2026; other sports unset (absent = no gate).
+2. **NFL — leave open for now.** Only NCAAFB is gated in this pass. Setting NFL's
+   config value later locks it with **no code change**.

--- a/docs/features/league-creation-availability-gate.md
+++ b/docs/features/league-creation-availability-gate.md
@@ -52,7 +52,7 @@ with **no redeploy and no OTA push**. NFL is the same map with a different value
 `feedback_appconfig_sport_keyed` pattern). Set the NCAA gate as a hierarchical key in
 the API's AppConfig label:
 
-```
+```ini
 SportsData.Api:ApiConfig:LeagueCreationOpensUtc:FootballNcaa = 2026-08-17T00:00:00Z
 ```
 
@@ -69,9 +69,10 @@ SportsData.Api:ApiConfig:LeagueCreationOpensUtc:FootballNcaa = 2026-08-17T00:00:
 `ILeagueCreationAvailability` parses each entry once at construction: the key
 `"FootballNcaa"` → `Sport`, the value → a UTC instant (`DateTimeStyles.AssumeUniversal
 | AdjustToUniversal`, so both `…Z` and a bare `2026-08-17T00:00:00` resolve to the
-same UTC instant, never shifted by the host timezone). Unknown sport names /
-unparseable dates are dropped. No migration; change the date or unlock early live in
-AppConfig.
+same UTC instant, never shifted by the host timezone). An unknown sport name is
+logged and skipped; a **known** sport with an unparseable date is logged and kept
+**closed** (fail-closed — a misconfigured gate must never silently open the sport).
+No migration; change the date or unlock early live in AppConfig.
 
 ### One service, two consumers
 
@@ -152,8 +153,9 @@ the worst case is a slightly worse UX on a transient outage, never a broken leag
 ## Testing
 
 - **Service:** future gate → `GetOpensUtc` returns the instant; absent/past → null;
-  Unspecified config instant treated as UTC; `GetActiveGates` returns future-only,
-  earliest first. (`LeagueCreationAvailabilityTests`, 7 cases.)
+  Unspecified config instant treated as UTC; a malformed date for a **known** sport →
+  fail-closed (stays locked, not silently opened); `GetActiveGates` returns
+  future-only, earliest first. (`LeagueCreationAvailabilityTests`, 7 cases.)
 - **Guard:** future `OpensUtc` → `Failure(Validation)`, **no** `PickemGroupCreated`
   published. (`CreateFootballNcaaLeagueCommandHandlerTests.ShouldFail_WhenSportCreationNotYetOpen`.)
   Existing create-handler tests auto-mock the service (returns null → open), so they

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateBaseballMlbLeague/CreateBaseballMlbLeagueCommandHandler.cs
@@ -29,8 +29,9 @@ public class CreateBaseballMlbLeagueCommandHandler
         IFranchiseClientFactory franchiseClientFactory,
         IContestClientFactory contestClientFactory,
         IValidator<CreateBaseballMlbLeagueRequest> validator,
-        IDateTimeProvider dateTimeProvider)
-        : base(logger, dbContext, eventBus, franchiseClientFactory, contestClientFactory, validator, dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        ILeagueCreationAvailability availability)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, contestClientFactory, validator, dateTimeProvider, availability)
     {
     }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandler.cs
@@ -30,8 +30,9 @@ public class CreateFootballNcaaLeagueCommandHandler
         IFranchiseClientFactory franchiseClientFactory,
         IContestClientFactory contestClientFactory,
         IValidator<CreateFootballNcaaLeagueRequest> validator,
-        IDateTimeProvider dateTimeProvider)
-        : base(logger, dbContext, eventBus, franchiseClientFactory, contestClientFactory, validator, dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        ILeagueCreationAvailability availability)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, contestClientFactory, validator, dateTimeProvider, availability)
     {
     }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateFootballNflLeague/CreateFootballNflLeagueCommandHandler.cs
@@ -29,8 +29,9 @@ public class CreateFootballNflLeagueCommandHandler
         IFranchiseClientFactory franchiseClientFactory,
         IContestClientFactory contestClientFactory,
         IValidator<CreateFootballNflLeagueRequest> validator,
-        IDateTimeProvider dateTimeProvider)
-        : base(logger, dbContext, eventBus, franchiseClientFactory, contestClientFactory, validator, dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        ILeagueCreationAvailability availability)
+        : base(logger, dbContext, eventBus, franchiseClientFactory, contestClientFactory, validator, dateTimeProvider, availability)
     {
     }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -56,6 +56,7 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
     private readonly IContestClientFactory _contestClientFactory;
     private readonly IValidator<TRequest> _validator;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILeagueCreationAvailability _availability;
 
     protected CreateLeagueCommandHandlerBase(
         ILogger logger,
@@ -64,7 +65,8 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
         IFranchiseClientFactory franchiseClientFactory,
         IContestClientFactory contestClientFactory,
         IValidator<TRequest> validator,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        ILeagueCreationAvailability availability)
     {
         _logger = logger;
         _dbContext = dbContext;
@@ -73,6 +75,7 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
         _contestClientFactory = contestClientFactory;
         _validator = validator;
         _dateTimeProvider = dateTimeProvider;
+        _availability = availability;
     }
 
     protected abstract Sport SportMode { get; }
@@ -116,6 +119,26 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
         var validation = await _validator.ValidateAsync(request, cancellationToken);
         if (!validation.IsValid)
             return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+
+        // Availability gate: some sports aren't open for league creation yet — e.g.
+        // NCAAFB waits for AP Poll release. This is the correctness floor behind the
+        // FE tab-hiding: it closes the deep-link / direct-API path. Reject before any
+        // downstream work. See docs/features/league-creation-availability-gate.md.
+        var opensUtc = _availability.GetOpensUtc(SportMode);
+        if (opensUtc is not null)
+        {
+            _logger.LogInformation(
+                "Rejecting create-league: {Sport} creation opens {OpensUtc:o}.",
+                SportMode, opensUtc);
+
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                // User-facing copy — no raw Sport enum; the user is already in a
+                // specific sport's create flow.
+                [new ValidationFailure(nameof(request),
+                    $"League creation opens {opensUtc:MMMM d, yyyy}. Check back then.")]);
+        }
 
         // Blackout guard: a windowed league whose date range contains no games
         // bootstraps to zero matchups (e.g. an MLB league created on the

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueCreationAvailabilityDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueCreationAvailabilityDto.cs
@@ -1,0 +1,14 @@
+namespace SportsData.Api.Application.UI.Leagues.Dtos;
+
+/// <summary>
+/// Which sports are currently gated from league creation. Only <b>active</b> gates
+/// are listed (open instant still in the future); a sport not present is open. The
+/// FE locks exactly the sports it sees here and shows "opens {date}".
+/// </summary>
+public record LeagueCreationAvailabilityDto(IReadOnlyList<LeagueCreationGateDto> Gates);
+
+/// <summary>
+/// A sport gated from league creation, with the UTC instant it opens. <see cref="Sport"/>
+/// is the backend enum name (e.g. "FootballNcaa") the FE keys sports by.
+/// </summary>
+public record LeagueCreationGateDto(string Sport, DateTime OpensUtc);

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -116,6 +116,21 @@ public class LeagueController : ApiControllerBase
     }
 
     /// <summary>
+    /// Sports currently gated from league creation, each with the UTC instant it
+    /// opens (e.g. NCAAFB waits for AP Poll release). Only active gates are returned;
+    /// a sport not listed is open. The create-league UI locks exactly these sports
+    /// and shows an "opens {date}" affordance. The create endpoints enforce the same
+    /// gate server-side. See docs/features/league-creation-availability-gate.md.
+    /// </summary>
+    [HttpGet("creation-availability")]
+    [Authorize]
+    public ActionResult<LeagueCreationAvailabilityDto> GetCreationAvailability(
+        [FromServices] ILeagueCreationAvailability availability)
+    {
+        return Ok(new LeagueCreationAvailabilityDto(availability.GetActiveGates()));
+    }
+
+    /// <summary>
     /// Clones one of the user's leagues into a new one they own: copies the config
     /// and regenerates the same slate, optionally inviting the source's members.
     /// Deactivated leagues can't be cloned.

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueCreationAvailability.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueCreationAvailability.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using SportsData.Api.Application.UI.Leagues.Dtos;
@@ -38,18 +39,19 @@ public class LeagueCreationAvailability : ILeagueCreationAvailability
 
     public LeagueCreationAvailability(
         IOptions<ApiConfig> config,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        ILogger<LeagueCreationAvailability> logger)
     {
         _dateTimeProvider = dateTimeProvider;
-        _opensUtc = ParseGates(config.Value.LeagueCreationOpensUtc);
+        _opensUtc = ParseGates(config.Value.LeagueCreationOpensUtc, logger);
     }
 
     // Config is a string→string map keyed by Sport name (the binder populates
     // string-keyed dictionaries reliably; enum-keyed ones bind empty). Parse once:
-    // "FootballNcaa" → Sport, the value → a UTC instant. Silently drop unknown
-    // sport names / unparseable dates so a stray config value can't break creation.
+    // "FootballNcaa" → Sport, the value → a UTC instant.
     private static IReadOnlyDictionary<Sport, DateTime> ParseGates(
-        IReadOnlyDictionary<string, string>? configured)
+        IReadOnlyDictionary<string, string>? configured,
+        ILogger logger)
     {
         var parsed = new Dictionary<Sport, DateTime>();
         if (configured is null)
@@ -57,8 +59,15 @@ public class LeagueCreationAvailability : ILeagueCreationAvailability
 
         foreach (var (name, value) in configured)
         {
+            // Unknown sport name: nothing to gate (no real sport it maps to), so
+            // skip — but log, since it's almost certainly a typo that leaves the
+            // intended sport ungated.
             if (!Enum.TryParse<Sport>(name, ignoreCase: true, out var sport))
+            {
+                logger.LogWarning(
+                    "Ignoring league-creation gate for unrecognized sport name '{SportName}'.", name);
                 continue;
+            }
 
             // AssumeUniversal: a bare "2026-08-17T00:00:00" is the intended UTC
             // instant. AdjustToUniversal normalizes a "…Z"/offset value to UTC.
@@ -71,6 +80,17 @@ public class LeagueCreationAvailability : ILeagueCreationAvailability
                     out var opens))
             {
                 parsed[sport] = opens;
+            }
+            else
+            {
+                // Fail CLOSED: a gate is configured for a real sport but its date is
+                // unparseable. Dropping it would silently OPEN the sport — defeating
+                // the gate. Keep the sport locked (until the config is corrected) and
+                // make the misconfiguration loud.
+                logger.LogError(
+                    "League-creation gate for {Sport} has an unparseable date '{Value}'; " +
+                    "keeping the sport CLOSED until the config is corrected.", sport, value);
+                parsed[sport] = DateTime.MaxValue;
             }
         }
 

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueCreationAvailability.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueCreationAvailability.cs
@@ -1,0 +1,98 @@
+using System.Globalization;
+
+using Microsoft.Extensions.Options;
+
+using SportsData.Api.Application.UI.Leagues.Dtos;
+using SportsData.Api.Config;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.UI.Leagues;
+
+/// <summary>
+/// Answers "is league creation open for this sport?" from the API-owned
+/// <see cref="ApiConfig.LeagueCreationOpensUtc"/> gate config. League-creation
+/// availability is a Pick'em rule and lives entirely in the API — it is not
+/// canonical season data. One source consumed by both the create-time guard
+/// (<see cref="Commands.CreateLeagueCommandHandlerBase{TRequest}"/>) and the
+/// FE-facing endpoint. See docs/features/league-creation-availability-gate.md.
+/// </summary>
+public interface ILeagueCreationAvailability
+{
+    /// <summary>
+    /// The future UTC instant at which the sport's league creation opens, or
+    /// <c>null</c> if it is open now (no gate, or the gate has already elapsed).
+    /// </summary>
+    DateTime? GetOpensUtc(Sport sport);
+
+    /// <summary>
+    /// Every sport currently gated (open instant still in the future), earliest
+    /// first. Sports not returned are open.
+    /// </summary>
+    IReadOnlyList<LeagueCreationGateDto> GetActiveGates();
+}
+
+public class LeagueCreationAvailability : ILeagueCreationAvailability
+{
+    private readonly IReadOnlyDictionary<Sport, DateTime> _opensUtc;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public LeagueCreationAvailability(
+        IOptions<ApiConfig> config,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _dateTimeProvider = dateTimeProvider;
+        _opensUtc = ParseGates(config.Value.LeagueCreationOpensUtc);
+    }
+
+    // Config is a string→string map keyed by Sport name (the binder populates
+    // string-keyed dictionaries reliably; enum-keyed ones bind empty). Parse once:
+    // "FootballNcaa" → Sport, the value → a UTC instant. Silently drop unknown
+    // sport names / unparseable dates so a stray config value can't break creation.
+    private static IReadOnlyDictionary<Sport, DateTime> ParseGates(
+        IReadOnlyDictionary<string, string>? configured)
+    {
+        var parsed = new Dictionary<Sport, DateTime>();
+        if (configured is null)
+            return parsed;
+
+        foreach (var (name, value) in configured)
+        {
+            if (!Enum.TryParse<Sport>(name, ignoreCase: true, out var sport))
+                continue;
+
+            // AssumeUniversal: a bare "2026-08-17T00:00:00" is the intended UTC
+            // instant. AdjustToUniversal normalizes a "…Z"/offset value to UTC.
+            // Either way the result is Kind=Utc, so comparisons against UtcNow()
+            // are by instant and never shifted by the host timezone.
+            if (DateTime.TryParse(
+                    value,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var opens))
+            {
+                parsed[sport] = opens;
+            }
+        }
+
+        return parsed;
+    }
+
+    public DateTime? GetOpensUtc(Sport sport)
+    {
+        if (!_opensUtc.TryGetValue(sport, out var opensUtc))
+            return null;
+
+        return opensUtc > _dateTimeProvider.UtcNow() ? opensUtc : null;
+    }
+
+    public IReadOnlyList<LeagueCreationGateDto> GetActiveGates()
+    {
+        var now = _dateTimeProvider.UtcNow();
+
+        return _opensUtc
+            .Where(kvp => kvp.Value > now)
+            .OrderBy(kvp => kvp.Value)
+            .Select(kvp => new LeagueCreationGateDto(kvp.Key.ToString(), kvp.Value))
+            .ToList();
+    }
+}

--- a/src/SportsData.Api/Config/ApiConfig.cs
+++ b/src/SportsData.Api/Config/ApiConfig.cs
@@ -7,5 +7,25 @@
         public required string BaseUrl { get; set; }
 
         public required Guid UserIdSystem { get; set; }
+
+        /// <summary>
+        /// Per-sport instant at which league creation opens, keyed by <b>Sport enum
+        /// name</b> (e.g. "FootballNcaa"). A sport present with a future value is blocked
+        /// from creation until then (e.g. NCAAFB waits for AP Poll release ~Aug 17); a
+        /// sport that is absent, or whose value is in the past, is open. Author values as
+        /// ISO-8601 UTC (e.g. "2026-08-17T00:00:00Z" — a bare "2026-08-17T00:00:00" is
+        /// also treated as UTC). Set per key in the API's AppConfig label:
+        /// SportsData.Api:ApiConfig:LeagueCreationOpensUtc:{SportName} (e.g. :FootballNcaa).
+        ///
+        /// <para>
+        /// String-keyed (not <c>Dictionary&lt;Sport, DateTime&gt;</c>) deliberately: the
+        /// .NET configuration binder reliably populates string-keyed dictionaries (cf.
+        /// <see cref="SportsData.Core.Config.CommonConfig.LoggingConfig.Overrides"/>),
+        /// whereas enum-keyed dictionaries bind empty. <see cref="ILeagueCreationAvailability"/>
+        /// parses the name → Sport and the value → a UTC instant.
+        /// See docs/features/league-creation-availability-gate.md.
+        /// </para>
+        /// </summary>
+        public Dictionary<string, string> LeagueCreationOpensUtc { get; set; } = new();
     }
 }

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -121,6 +121,12 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<ISendLeagueInviteCommandHandler, SendLeagueInviteCommandHandler>();
             services.AddScoped<IInviteUserToLeagueCommandHandler, InviteUserToLeagueCommandHandler>();
 
+            // League creation availability gate (config-driven; used by the create
+            // guard and the /ui/leagues/creation-availability endpoint).
+            services.AddScoped<
+                Application.UI.Leagues.ILeagueCreationAvailability,
+                Application.UI.Leagues.LeagueCreationAvailability>();
+
             // League Queries
             services.AddScoped<IGetLeagueByIdQueryHandler, GetLeagueByIdQueryHandler>();
             services.AddScoped<

--- a/src/UI/sd-mobile/__tests__/hooks/useLeagueCreationGates.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useLeagueCreationGates.test.ts
@@ -1,0 +1,36 @@
+// Mock the shared axios instance so importing the hook module doesn't pull in
+// the real API client (and its firebase chain) — we only exercise the module's
+// pure date helpers here. Mirrors __tests__/services/api/leaguesApi.test.ts.
+jest.mock('@/src/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+import {
+  formatGateDate,
+  formatGateDateOrSoon,
+} from '@/src/hooks/useLeagueCreationGates';
+
+describe('formatGateDate', () => {
+  it('formats a valid ISO instant in UTC (no timezone shift)', () => {
+    // Midnight UTC on Aug 17 must read "Aug 17", not roll back a day in
+    // western timezones.
+    expect(formatGateDate('2026-08-17T00:00:00Z')).toBe('Aug 17');
+  });
+
+  it('returns null for an unparseable value', () => {
+    expect(formatGateDate('not-a-date')).toBeNull();
+  });
+});
+
+describe('formatGateDateOrSoon', () => {
+  it('returns the formatted date for a valid instant', () => {
+    expect(formatGateDateOrSoon('2026-09-01T00:00:00Z')).toBe('Sep 1');
+  });
+
+  it('falls back to "soon" for an unparseable value (never renders "null")', () => {
+    expect(formatGateDateOrSoon('nope')).toBe('soon');
+  });
+});

--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -37,7 +37,7 @@ import { standingsKeys } from '@/src/hooks/useStandings';
 import { useCurrentUser } from '@/src/hooks/useStandings';
 import {
   useLeagueCreationGates,
-  formatGateDate,
+  formatGateDateOrSoon,
 } from '@/src/hooks/useLeagueCreationGates';
 
 // ─── Sport config ─────────────────────────────────────────────────────────────
@@ -524,29 +524,37 @@ export default function CreateLeagueScreen() {
     setValue('sport', 'BaseballMlb');
   }, [isAdmin, params.sport, sport, setValue]);
 
+  // The sports this user may create, before gating (MLB is admin-only). Single
+  // source so the visible picker and the locked-sport fallback never drift.
+  const availableSportsForUser = useMemo<SportKey[]>(
+    () => ['FootballNcaa', 'FootballNfl', ...(isAdmin ? (['BaseballMlb'] as SportKey[]) : [])],
+    [isAdmin],
+  );
+
   // If the preselected / deep-linked sport is gated from creation, fall back to
   // the first open sport so the form isn't stuck on a hidden option. Mirrors the
   // MLB promotion effect above, inverted; runs once gates resolve.
   useEffect(() => {
     if (!gates[sport]) return; // current sport open
-    const fallback = (
-      ['FootballNcaa', 'FootballNfl', ...(isAdmin ? ['BaseballMlb'] : [])] as SportKey[]
-    ).find((k) => !gates[k]);
+    const fallback = availableSportsForUser.find((k) => !gates[k]);
     if (fallback && fallback !== sport) {
       setValue('sport', fallback);
     }
-  }, [gates, sport, isAdmin, setValue]);
+  }, [gates, sport, availableSportsForUser, setValue]);
 
   const sportOptions = useMemo<{ value: SportKey; label: string }[]>(() => {
     // Emoji pulled from SPORT_COPY so the icon stays in lockstep with the
     // Divisions header (which also reads copy.emoji) — single source of truth.
     const fmt = (k: SportKey) => ({ value: k, label: `${SPORT_COPY[k].emoji} ${SPORT_COPY[k].label}` });
-    const base: { value: SportKey; label: string }[] = [fmt('FootballNcaa'), fmt('FootballNfl')];
-    if (isAdmin) base.push(fmt('BaseballMlb'));
     // Hide sports currently gated from creation — they surface as an "opens
     // {date}" note below the picker instead. The server enforces the same gate.
-    return base.filter((o) => !gates[o.value]);
-  }, [isAdmin, gates]);
+    return availableSportsForUser.filter((k) => !gates[k]).map(fmt);
+  }, [availableSportsForUser, gates]);
+
+  // Every selectable sport is gated → nothing can be created (availableSportsForUser
+  // is never empty, so an empty option list means all-locked). Disable submission
+  // and show an unavailable note; the server enforces this too.
+  const allSportsLocked = sportOptions.length === 0;
 
   // Gated football sports to call out under the picker (e.g. "NCAA leagues open
   // Aug 17"). MLB isn't advertised here — it's admin-only and unannounced.
@@ -556,7 +564,7 @@ export default function CreateLeagueScreen() {
         .filter((k) => gates[k])
         .map((k) => ({
           key: k,
-          text: `${SPORT_COPY[k].emoji} ${SPORT_COPY[k].label} leagues open ${formatGateDate(gates[k])}`,
+          text: `${SPORT_COPY[k].emoji} ${SPORT_COPY[k].label} leagues open ${formatGateDateOrSoon(gates[k])}`,
         })),
     [gates],
   );
@@ -632,7 +640,10 @@ export default function CreateLeagueScreen() {
     },
   });
 
-  const onSubmit = (data: FormData) => createMutation.mutate(data);
+  const onSubmit = (data: FormData) => {
+    if (allSportsLocked) return; // nothing creatable; the button is also disabled
+    createMutation.mutate(data);
+  };
 
   // Tiebreaker options use sport-aware labels for the "total" variant.
   const tiebreakerOptions: { value: FormData['tiebreakerType']; label: string }[] = [
@@ -1009,10 +1020,17 @@ export default function CreateLeagueScreen() {
             )}
           </View>
 
+          {allSportsLocked && (
+            <Text style={[styles.gateNote, { color: theme.textMuted, marginTop: 12 }]}>
+              League creation isn’t open yet. Check back when your sport unlocks.
+            </Text>
+          )}
+
           <Button
             title="Create League"
             onPress={handleSubmit(onSubmit)}
             loading={createMutation.isPending}
+            disabled={allSportsLocked}
             fullWidth
             size="lg"
             style={{ marginTop: 12 }}

--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -35,6 +35,10 @@ import {
 } from '@/src/services/api/leaguesApi';
 import { standingsKeys } from '@/src/hooks/useStandings';
 import { useCurrentUser } from '@/src/hooks/useStandings';
+import {
+  useLeagueCreationGates,
+  formatGateDate,
+} from '@/src/hooks/useLeagueCreationGates';
 
 // ─── Sport config ─────────────────────────────────────────────────────────────
 //
@@ -369,6 +373,11 @@ export default function CreateLeagueScreen() {
   const params = useLocalSearchParams<{ sport?: string }>();
   const { data: me } = useCurrentUser();
   const isAdmin = me?.isAdmin === true;
+  // Active league-creation gates: { FootballNcaa: "2026-08-17T00:00:00Z", ... }.
+  // A sport present is locked until that instant (e.g. NCAAFB awaiting AP Poll
+  // release). Empty until loaded / on fetch failure — the server guard is the
+  // real enforcement. See docs/features/league-creation-availability-gate.md.
+  const gates = useLeagueCreationGates();
 
   // Safe initial sport for useForm defaultValues (which are cached on first
   // render and don't respond to later changes). MLB is admin-gated and
@@ -515,14 +524,42 @@ export default function CreateLeagueScreen() {
     setValue('sport', 'BaseballMlb');
   }, [isAdmin, params.sport, sport, setValue]);
 
+  // If the preselected / deep-linked sport is gated from creation, fall back to
+  // the first open sport so the form isn't stuck on a hidden option. Mirrors the
+  // MLB promotion effect above, inverted; runs once gates resolve.
+  useEffect(() => {
+    if (!gates[sport]) return; // current sport open
+    const fallback = (
+      ['FootballNcaa', 'FootballNfl', ...(isAdmin ? ['BaseballMlb'] : [])] as SportKey[]
+    ).find((k) => !gates[k]);
+    if (fallback && fallback !== sport) {
+      setValue('sport', fallback);
+    }
+  }, [gates, sport, isAdmin, setValue]);
+
   const sportOptions = useMemo<{ value: SportKey; label: string }[]>(() => {
     // Emoji pulled from SPORT_COPY so the icon stays in lockstep with the
     // Divisions header (which also reads copy.emoji) — single source of truth.
     const fmt = (k: SportKey) => ({ value: k, label: `${SPORT_COPY[k].emoji} ${SPORT_COPY[k].label}` });
     const base: { value: SportKey; label: string }[] = [fmt('FootballNcaa'), fmt('FootballNfl')];
     if (isAdmin) base.push(fmt('BaseballMlb'));
-    return base;
-  }, [isAdmin]);
+    // Hide sports currently gated from creation — they surface as an "opens
+    // {date}" note below the picker instead. The server enforces the same gate.
+    return base.filter((o) => !gates[o.value]);
+  }, [isAdmin, gates]);
+
+  // Gated football sports to call out under the picker (e.g. "NCAA leagues open
+  // Aug 17"). MLB isn't advertised here — it's admin-only and unannounced.
+  const gateNotes = useMemo(
+    () =>
+      (['FootballNcaa', 'FootballNfl'] as SportKey[])
+        .filter((k) => gates[k])
+        .map((k) => ({
+          key: k,
+          text: `${SPORT_COPY[k].emoji} ${SPORT_COPY[k].label} leagues open ${formatGateDate(gates[k])}`,
+        })),
+    [gates],
+  );
 
   const currentDivisions = useMemo(() => {
     if (sport === 'FootballNfl') return NFL_DIVISIONS;
@@ -637,6 +674,11 @@ export default function CreateLeagueScreen() {
                 />
               )}
             />
+            {gateNotes.map((n) => (
+              <Text key={n.key} style={[styles.gateNote, { color: theme.textMuted }]}>
+                {n.text}
+              </Text>
+            ))}
           </View>
 
           {/* Name */}
@@ -1001,6 +1043,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
+  },
+  gateNote: {
+    fontSize: 12,
+    lineHeight: 16,
   },
   input: {
     borderWidth: 1.5,

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/src/services/api/seasonApi';
 import {
   useLeagueCreationGates,
-  formatGateDate,
+  formatGateDateOrSoon,
 } from '@/src/hooks/useLeagueCreationGates';
 
 // ─── Sports ─────────────────────────────────────────────────────────────────
@@ -177,7 +177,7 @@ export function PrimarySlotOffSeasonCountdown() {
               return (
                 <Button
                   key={s.key}
-                  title={`${s.label} opens ${formatGateDate(opensUtc)}`}
+                  title={`${s.label} opens ${formatGateDateOrSoon(opensUtc)}`}
                   onPress={() => {}}
                   disabled
                   size="md"

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -11,6 +11,10 @@ import {
   REGULAR_SEASON_TYPE_CODE,
   type CurrentSeason,
 } from '@/src/services/api/seasonApi';
+import {
+  useLeagueCreationGates,
+  formatGateDate,
+} from '@/src/hooks/useLeagueCreationGates';
 
 // ─── Sports ─────────────────────────────────────────────────────────────────
 //
@@ -67,6 +71,11 @@ export function PrimarySlotOffSeasonCountdown() {
     return () => clearInterval(id);
   }, []);
 
+  // Active creation gates keyed by backend Sport enum: { FootballNcaa: opensUtc }.
+  // A gated sport's create CTA becomes a disabled "opens {date}". See
+  // docs/features/league-creation-availability-gate.md.
+  const gates = useLeagueCreationGates();
+
   const results = useQueries({
     queries: SPORTS.map((s) => ({
       queryKey: ['season', 'current', s.sport, s.league],
@@ -92,13 +101,18 @@ export function PrimarySlotOffSeasonCountdown() {
     results.map((r) => r.data?.seasonYear).find((y) => y != null) ?? null;
 
   const allLive = phrases.every((s) => s.phrase.status === 'live');
+  // Every surfaced sport is gated from creation → don't urge "spin up a league
+  // now" when no CTA can act on it. (Live sports are never active gates.)
+  const allGated = phrases.every((s) => Boolean(gates[s.sportEnum]));
   const eyebrow = seasonYear ? `${seasonYear} SEASON` : 'UPCOMING SEASON';
 
   const body = allLive
     ? 'Jump into your leagues and lock in your picks before the next kickoff.'
-    : seasonYear
-      ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week 1.`
-      : "Spin up your pick'em league now so you're ready for Week 1.";
+    : allGated
+      ? "Leagues open soon — we'll be ready before Week 1."
+      : seasonYear
+        ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week 1.`
+        : "Spin up your pick'em league now so you're ready for Week 1.";
 
   if (loading) {
     return (
@@ -144,19 +158,45 @@ export function PrimarySlotOffSeasonCountdown() {
         ) : (
           phrases.map((s) => {
             const isLive = s.phrase.status === 'live';
+            if (isLive) {
+              return (
+                <Button
+                  key={s.key}
+                  title={`Pick ${s.label} games`}
+                  onPress={() => router.push('/(tabs)/picks' as never)}
+                  size="md"
+                  style={styles.actionButton}
+                />
+              );
+            }
+
+            // Creation gated (e.g. NCAAFB awaiting AP Poll release) — show when it
+            // opens instead of a create action. The server enforces the same gate.
+            const opensUtc = gates[s.sportEnum];
+            if (opensUtc) {
+              return (
+                <Button
+                  key={s.key}
+                  title={`${s.label} opens ${formatGateDate(opensUtc)}`}
+                  onPress={() => {}}
+                  disabled
+                  size="md"
+                  style={styles.actionButton}
+                />
+              );
+            }
+
             return (
               <Button
                 key={s.key}
-                title={isLive ? `Pick ${s.label} games` : `Create ${s.label} league`}
+                title={`Create ${s.label} league`}
                 onPress={() =>
-                  isLive
-                    ? router.push('/(tabs)/picks' as never)
-                    : router.push(
-                        {
-                          pathname: '/create-league',
-                          params: { sport: s.sportEnum },
-                        } as never,
-                      )
+                  router.push(
+                    {
+                      pathname: '/create-league',
+                      params: { sport: s.sportEnum },
+                    } as never,
+                  )
                 }
                 size="md"
                 style={styles.actionButton}

--- a/src/UI/sd-mobile/src/hooks/useLeagueCreationGates.ts
+++ b/src/UI/sd-mobile/src/hooks/useLeagueCreationGates.ts
@@ -49,3 +49,13 @@ export function formatGateDate(iso: string): string | null {
   if (Number.isNaN(d.getTime())) return null;
   return `${MONTHS_SHORT[d.getUTCMonth()]} ${d.getUTCDate()}`;
 }
+
+/**
+ * User-facing variant of {@link formatGateDate}: falls back to "soon" when the
+ * instant is missing or unparseable, so a bad value never renders as the literal
+ * "null" in a CTA or note. Use this for display strings; use formatGateDate when
+ * you need to distinguish an unparseable value.
+ */
+export function formatGateDateOrSoon(iso: string): string {
+  return formatGateDate(iso) ?? 'soon';
+}

--- a/src/UI/sd-mobile/src/hooks/useLeagueCreationGates.ts
+++ b/src/UI/sd-mobile/src/hooks/useLeagueCreationGates.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { leaguesApi } from '@/src/services/api/leaguesApi';
+
+/**
+ * League-creation availability gate (see
+ * docs/features/league-creation-availability-gate.md). Some sports aren't open
+ * for league creation until their data is ready — e.g. NCAAFB waits for the AP
+ * Poll release. The create-league UI hides/notes gated sports; the create
+ * endpoints enforce the same gate server-side.
+ */
+
+const MONTHS_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+/**
+ * The active creation gates as a lookup of backend Sport enum ("FootballNcaa")
+ * → the UTC ISO instant it opens. A sport absent is open. Fails open (empty map)
+ * on error — the server still enforces the gate, so the worst case is a user
+ * seeing a create option the API then rejects.
+ */
+export function useLeagueCreationGates(): Record<string, string> {
+  const { data } = useQuery({
+    queryKey: ['leagues', 'creation-availability'],
+    queryFn: () => leaguesApi.getCreationAvailability().then((r) => r.data),
+    staleTime: 1000 * 60 * 60, // gate dates barely move; refetch hourly at most
+    retry: false, // a failed fetch fails open; don't hammer it
+  });
+
+  return useMemo(() => {
+    const gates: Record<string, string> = {};
+    for (const g of data?.gates ?? []) {
+      if (g?.sport && g?.opensUtc) gates[g.sport] = g.opensUtc;
+    }
+    return gates;
+  }, [data]);
+}
+
+/**
+ * "Aug 17" from a UTC ISO instant. Uses UTC getters so the gate's authored
+ * calendar day isn't shifted a day in western timezones, and avoids Intl (not
+ * guaranteed on Hermes). Returns null for an unparseable value.
+ */
+export function formatGateDate(iso: string): string | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return `${MONTHS_SHORT[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -122,6 +122,19 @@ export interface CloneLeagueRequest {
   inviteMembers: boolean;
 }
 
+// Matches SportsData.Api.Application.UI.Leagues.Dtos.LeagueCreationGateDto.
+export interface LeagueCreationGate {
+  /** Backend Sport enum name, e.g. "FootballNcaa". */
+  sport: string;
+  /** UTC instant league creation opens for this sport. */
+  opensUtc: string;
+}
+
+// Matches SportsData.Api.Application.UI.Leagues.Dtos.LeagueCreationAvailabilityDto.
+export interface LeagueCreationAvailability {
+  gates: LeagueCreationGate[];
+}
+
 export const leaguesApi = {
   // POST /ui/leagues/football/ncaa
   createFootballNcaaLeague: (payload: CreateFootballNcaaLeagueRequest) =>
@@ -157,4 +170,10 @@ export const leaguesApi = {
   // Returns the new league's id.
   cloneLeague: (id: string, payload: CloneLeagueRequest) =>
     apiClient.post<{ id: string }>(`/ui/leagues/${id}/clone`, payload),
+
+  // GET /ui/leagues/creation-availability — sports currently gated from league
+  // creation, each with the UTC instant it opens (only active gates; a sport not
+  // listed is open). The create endpoints enforce the same gate server-side.
+  getCreationAvailability: () =>
+    apiClient.get<LeagueCreationAvailability>('/ui/leagues/creation-availability'),
 };

--- a/src/UI/sd-ui/src/api/leagues/leaguesApi.js
+++ b/src/UI/sd-ui/src/api/leagues/leaguesApi.js
@@ -137,6 +137,17 @@ const getPublicLeagues = async () => {
   return response.data;
 };
 
+/**
+ * Fetches the sports currently gated from league creation, each with the UTC
+ * instant it opens (e.g. NCAAFB waits for AP Poll release). Only active gates
+ * are returned; a sport not listed is open.
+ * @returns {Promise<{ gates: { sport: string, opensUtc: string }[] }>}
+ */
+const getCreationAvailability = async () => {
+  const response = await apiClient.get(`${BASE_PATH}/creation-availability`);
+  return response.data;
+};
+
 const getLeagueWeekOverview = async (leagueId, weekNumber) => {
   return apiClient.get(
     `${BASE_PATH}/${encodeURIComponent(leagueId)}/overview/${weekNumber}`
@@ -166,6 +177,7 @@ const LeaguesApi = {
   searchInviteableUsers,
   inviteUser,
   getPublicLeagues,
+  getCreationAvailability,
   getLeagueWeekOverview,
   getLeagueScores
 };

--- a/src/UI/sd-ui/src/components/home/HomePage.css
+++ b/src/UI/sd-ui/src/components/home/HomePage.css
@@ -366,6 +366,16 @@ h2 {
   background-color: var(--accent-subtle);
 }
 
+/* Locked create CTA — league creation for this sport is gated until its data is
+   ready (e.g. NCAAFB awaiting AP Poll release). Reads "NCAAFB leagues open Aug 17". */
+.home-primary__cta--disabled {
+  background-color: transparent;
+  color: var(--text-secondary, var(--text-primary));
+  border: 1.5px solid var(--border-input, rgba(255, 255, 255, 0.15));
+  opacity: 0.75;
+  cursor: default;
+}
+
 .home-primary__cta:focus-visible {
   outline: 2px solid var(--accent-hover);
   outline-offset: 2px;

--- a/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
+++ b/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import SeasonApi from "../../api/seasonApi";
+import {
+  getLeagueCreationGates,
+  formatGateDate,
+} from "../../utils/leagueCreationGates";
 
 /**
  * Tier 1 primary slot — fallback shown when the user has at least one
@@ -56,6 +60,10 @@ function sportPhrase(sport, nowMs) {
 function PrimarySlotOffSeasonCountdown() {
   // { NCAAFB: { kickoff, seasonYear } | null, ... } once loaded.
   const [seasons, setSeasons] = useState(null);
+  // Active creation gates keyed by backend Sport enum: { FootballNcaa: opensUtc }.
+  // A sport present is locked (create CTA becomes "opens {date}"). See
+  // docs/features/league-creation-availability-gate.md.
+  const [gates, setGates] = useState({});
 
   useEffect(() => {
     let cancelled = false;
@@ -77,6 +85,10 @@ function PrimarySlotOffSeasonCountdown() {
       setSeasons(
         Object.fromEntries(results.map((r) => [r.key, r]))
       );
+    });
+
+    getLeagueCreationGates().then((g) => {
+      if (!cancelled) setGates(g);
     });
 
     return () => {
@@ -101,6 +113,10 @@ function PrimarySlotOffSeasonCountdown() {
   }));
 
   const allLive = sportsWithPhrases.every((s) => s.phrase.status === "live");
+  // Every surfaced sport is gated from creation → don't urge "spin up a league
+  // now" when no CTA can act on it. (Live sports are never active gates, so this
+  // implies none are live.)
+  const allGated = sportsWithPhrases.every((s) => Boolean(gates[s.sportEnum]));
 
   // Eyebrow season year — first sport that reported one. Falls back to a
   // generic label if no season is sourced yet.
@@ -122,6 +138,8 @@ function PrimarySlotOffSeasonCountdown() {
 
   const body = allLive
     ? "Jump into your leagues and lock in your picks before the next kickoff."
+    : allGated
+    ? "Leagues open soon — we'll be ready before Week 1."
     : seasonYear
     ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week 1.`
     : "Spin up your pick'em league now so you're ready for Week 1.";
@@ -142,13 +160,41 @@ function PrimarySlotOffSeasonCountdown() {
 
     return sportsWithPhrases.map((s) => {
       const isLive = s.phrase.status === "live";
+      if (isLive) {
+        return (
+          <Link
+            key={s.key}
+            to="/app/picks"
+            className="home-primary__cta home-primary__cta--primary"
+          >
+            {`Pick ${s.label} games`}
+          </Link>
+        );
+      }
+
+      // Creation gated (e.g. NCAAFB awaiting AP Poll release) — show when it
+      // opens instead of a create link. The server enforces the same gate.
+      const opensUtc = gates[s.sportEnum];
+      if (opensUtc) {
+        return (
+          <span
+            key={s.key}
+            className="home-primary__cta home-primary__cta--disabled"
+            aria-disabled="true"
+            title={`${s.label} league creation opens ${formatGateDate(opensUtc)}`}
+          >
+            {`${s.label} leagues open ${formatGateDate(opensUtc)}`}
+          </span>
+        );
+      }
+
       return (
         <Link
           key={s.key}
-          to={isLive ? "/app/picks" : `/app/league/create?sport=${s.sportEnum}`}
+          to={`/app/league/create?sport=${s.sportEnum}`}
           className="home-primary__cta home-primary__cta--primary"
         >
-          {isLive ? `Pick ${s.label} games` : `Create ${s.label} league`}
+          {`Create ${s.label} league`}
         </Link>
       );
     });

--- a/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
+++ b/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import SeasonApi from "../../api/seasonApi";
 import {
   getLeagueCreationGates,
-  formatGateDate,
+  formatGateDateOrSoon,
 } from "../../utils/leagueCreationGates";
 
 /**
@@ -113,10 +113,19 @@ function PrimarySlotOffSeasonCountdown() {
   }));
 
   const allLive = sportsWithPhrases.every((s) => s.phrase.status === "live");
+
+  // A sport is gated only while its "opens" instant is still ahead of nowMs, so a
+  // gate that elapses clears on re-render without a reload. (nowMs is snapshotted
+  // per render; the gate flips once weeks out, so no page-lifetime timer.)
+  const isGated = (sportEnum) => {
+    const opensUtc = gates[sportEnum];
+    return Boolean(opensUtc) && new Date(opensUtc).getTime() > nowMs;
+  };
+
   // Every surfaced sport is gated from creation → don't urge "spin up a league
   // now" when no CTA can act on it. (Live sports are never active gates, so this
   // implies none are live.)
-  const allGated = sportsWithPhrases.every((s) => Boolean(gates[s.sportEnum]));
+  const allGated = sportsWithPhrases.every((s) => isGated(s.sportEnum));
 
   // Eyebrow season year — first sport that reported one. Falls back to a
   // generic label if no season is sourced yet.
@@ -174,16 +183,16 @@ function PrimarySlotOffSeasonCountdown() {
 
       // Creation gated (e.g. NCAAFB awaiting AP Poll release) — show when it
       // opens instead of a create link. The server enforces the same gate.
-      const opensUtc = gates[s.sportEnum];
-      if (opensUtc) {
+      if (isGated(s.sportEnum)) {
+        const opensUtc = gates[s.sportEnum];
         return (
           <span
             key={s.key}
             className="home-primary__cta home-primary__cta--disabled"
             aria-disabled="true"
-            title={`${s.label} league creation opens ${formatGateDate(opensUtc)}`}
+            title={`${s.label} league creation opens ${formatGateDateOrSoon(opensUtc)}`}
           >
-            {`${s.label} leagues open ${formatGateDate(opensUtc)}`}
+            {`${s.label} leagues open ${formatGateDateOrSoon(opensUtc)}`}
           </span>
         );
       }

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.css
@@ -232,6 +232,20 @@
   background-color: var(--bg-muted, rgba(255, 255, 255, 0.05));
 }
 
+/* Locked sport tab (league creation gated until its data is ready — e.g. NCAAFB
+   awaiting AP Poll release). Muted + not-allowed; the suffix reads "· opens Aug 17". */
+.segmented-tab:disabled,
+.segmented-tab.locked {
+  opacity: 0.5;
+  cursor: not-allowed;
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+.segmented-tab.locked:hover {
+  background-color: transparent;
+}
+
 .inline-options label {
   font-weight: normal;
   display: inline-flex;

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.css
@@ -291,8 +291,21 @@ input[type="checkbox"] {
   transition: background-color 0.2s ease;
 }
 
-.submit-button:hover {
+.submit-button:hover:not(:disabled) {
   background-color: var(--accent-hover);
+}
+
+.submit-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Shown when every selectable sport is gated from creation (e.g. NCAAFB + NFL
+   both awaiting their open date). Pairs with the disabled submit button. */
+.sport-locked-note {
+  color: var(--text-secondary, var(--text-primary));
+  font-size: 0.9rem;
+  margin: 0 0 0.25rem;
 }
 
 .radio-group {

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -5,7 +5,7 @@ import apiWrapper from "../../api/apiWrapper.js";
 import { useUserDto } from "../../contexts/UserContext";
 import {
   getLeagueCreationGates,
-  formatGateDate,
+  formatGateDateOrSoon,
 } from "../../utils/leagueCreationGates";
 
 import "./LeagueCreatePage.css";
@@ -183,7 +183,15 @@ const LeagueCreatePage = () => {
   const isMlbAvailable = userDto?.isAdmin === true;
   const copy = SPORT_COPY[sport];
 
-  const isSportLocked = (s) => Boolean(creationGates[s]);
+  // Locked while the sport's configured "opens" instant is still in the future.
+  // Derived from the current time (not merely presence in the fetched snapshot),
+  // so a gate that elapses while the page is open clears on the next render —
+  // no reload. (The gate flips once, weeks out; a page-lifetime setTimeout at
+  // that instant would be unreliable and exceeds the ~24.8-day timer ceiling.)
+  const isSportLocked = (s) => {
+    const opensUtc = creationGates[s];
+    return Boolean(opensUtc) && new Date(opensUtc).getTime() > Date.now();
+  };
 
   // Load the active creation gates once on mount. Fails open (empty map) — the
   // server guard still rejects a locked create.
@@ -199,16 +207,27 @@ const LeagueCreatePage = () => {
     };
   }, []);
 
+  // The sports this user can choose from (MLB is admin-only). Single source for
+  // the fallback selection and the all-locked guard so they can't drift.
+  const eligibleSports = useMemo(
+    () => [SPORT_NCAA, SPORT_NFL, ...(isMlbAvailable ? [SPORT_MLB] : [])],
+    [isMlbAvailable]
+  );
+
+  // Every selectable sport is currently gated → nothing can be created. Disable
+  // submission and show an unavailable note (the server enforces this too).
+  const allSportsLocked =
+    gatesLoaded && eligibleSports.every((s) => isSportLocked(s));
+
   // If the preselected / deep-linked sport is locked, fall back to the first
   // open sport so the form isn't stranded on a disabled tab. Only moves off a
   // locked selection; locked tabs can't be picked (they're disabled).
   useEffect(() => {
     if (!gatesLoaded || !isSportLocked(sport)) return;
-    const fallback = [SPORT_NCAA, SPORT_NFL, ...(isMlbAvailable ? [SPORT_MLB] : [])]
-      .find((s) => !isSportLocked(s));
+    const fallback = eligibleSports.find((s) => !isSportLocked(s));
     if (fallback) setSport(fallback);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gatesLoaded, creationGates, sport, isMlbAvailable]);
+  }, [gatesLoaded, creationGates, sport, eligibleSports]);
 
   // Human-readable window for the suggested description: a single day, a date
   // range, a single week, or a week range. null for a full-season league.
@@ -300,6 +319,15 @@ const LeagueCreatePage = () => {
 
   const handleFormSubmit = (e) => {
     e.preventDefault();
+
+    // Every eligible sport is gated — nothing can be created. Guards the
+    // Enter-key submit path (the button is also disabled). Server enforces too.
+    if (allSportsLocked) {
+      toast.error(
+        "League creation isn't open yet — check back when your sport unlocks."
+      );
+      return;
+    }
 
     // Mirror of the server `EffectiveEndsOn > now` rule. The `min` attribute
     // on the date inputs handles the native-picker UX, but the keyboard /
@@ -407,7 +435,7 @@ const LeagueCreatePage = () => {
             disabled={isSportLocked(SPORT_NCAA)}
             title={
               isSportLocked(SPORT_NCAA)
-                ? `Opens ${formatGateDate(creationGates[SPORT_NCAA])}`
+                ? `Opens ${formatGateDateOrSoon(creationGates[SPORT_NCAA])}`
                 : undefined
             }
             className={`segmented-tab${sport === SPORT_NCAA ? " active" : ""}${
@@ -417,7 +445,7 @@ const LeagueCreatePage = () => {
           >
             NCAA
             {isSportLocked(SPORT_NCAA) &&
-              ` · opens ${formatGateDate(creationGates[SPORT_NCAA])}`}
+              ` · opens ${formatGateDateOrSoon(creationGates[SPORT_NCAA])}`}
           </button>
           <button
             type="button"
@@ -426,7 +454,7 @@ const LeagueCreatePage = () => {
             disabled={isSportLocked(SPORT_NFL)}
             title={
               isSportLocked(SPORT_NFL)
-                ? `Opens ${formatGateDate(creationGates[SPORT_NFL])}`
+                ? `Opens ${formatGateDateOrSoon(creationGates[SPORT_NFL])}`
                 : undefined
             }
             className={`segmented-tab${sport === SPORT_NFL ? " active" : ""}${
@@ -436,7 +464,7 @@ const LeagueCreatePage = () => {
           >
             NFL
             {isSportLocked(SPORT_NFL) &&
-              ` · opens ${formatGateDate(creationGates[SPORT_NFL])}`}
+              ` · opens ${formatGateDateOrSoon(creationGates[SPORT_NFL])}`}
           </button>
           {isMlbAvailable && (
             <button
@@ -446,7 +474,7 @@ const LeagueCreatePage = () => {
               disabled={isSportLocked(SPORT_MLB)}
               title={
                 isSportLocked(SPORT_MLB)
-                  ? `Opens ${formatGateDate(creationGates[SPORT_MLB])}`
+                  ? `Opens ${formatGateDateOrSoon(creationGates[SPORT_MLB])}`
                   : undefined
               }
               className={`segmented-tab${sport === SPORT_MLB ? " active" : ""}${
@@ -456,7 +484,7 @@ const LeagueCreatePage = () => {
             >
               MLB
               {isSportLocked(SPORT_MLB) &&
-                ` · opens ${formatGateDate(creationGates[SPORT_MLB])}`}
+                ` · opens ${formatGateDateOrSoon(creationGates[SPORT_MLB])}`}
             </button>
           )}
         </div>
@@ -729,7 +757,17 @@ const LeagueCreatePage = () => {
             />
           </div>
 
-          <button type="submit" className="submit-button">
+          {allSportsLocked && (
+            <p className="sport-locked-note">
+              League creation isn’t open yet. Check back when your sport unlocks.
+            </p>
+          )}
+
+          <button
+            type="submit"
+            className="submit-button"
+            disabled={allSportsLocked}
+          >
             Create League
           </button>
         </form>

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -126,7 +126,7 @@ const DURATION_DATES = "dates";
 const VALID_SPORT_PARAMS = new Set([SPORT_NCAA, SPORT_NFL, SPORT_MLB]);
 
 const LeagueCreatePage = () => {
-  const { userDto, refreshUserDto } = useUserDto();
+  const { userDto, loading: userLoading, refreshUserDto } = useUserDto();
   const [searchParams] = useSearchParams();
   // Preselect the sport tab when the landing page (or any other caller)
   // deep-links here with ?sport=FootballNcaa / FootballNfl / BaseballMlb.
@@ -219,15 +219,21 @@ const LeagueCreatePage = () => {
   const allSportsLocked =
     gatesLoaded && eligibleSports.every((s) => isSportLocked(s));
 
-  // If the preselected / deep-linked sport is locked, fall back to the first
-  // open sport so the form isn't stranded on a disabled tab. Only moves off a
-  // locked selection; locked tabs can't be picked (they're disabled).
+  // Keep the selected sport valid. The current sport is a valid selection only
+  // if it's eligible for this user (MLB is admin-only) AND not gated; otherwise
+  // fall back to the first eligible, open sport. This covers both a locked
+  // eligible sport and an unlocked-but-ineligible deep-link (e.g.
+  // ?sport=BaseballMlb for a non-admin). Wait until gates AND the user (admin
+  // status) are known so an admin's MLB deep-link isn't bounced mid-load, and
+  // only move when a valid fallback exists.
   useEffect(() => {
-    if (!gatesLoaded || !isSportLocked(sport)) return;
+    if (!gatesLoaded || userLoading) return;
+    const isSelectable = eligibleSports.includes(sport) && !isSportLocked(sport);
+    if (isSelectable) return;
     const fallback = eligibleSports.find((s) => !isSportLocked(s));
     if (fallback) setSport(fallback);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gatesLoaded, creationGates, sport, eligibleSports]);
+  }, [gatesLoaded, userLoading, creationGates, sport, eligibleSports]);
 
   // Human-readable window for the suggested description: a single day, a date
   // range, a single week, or a week range. null for a full-season league.

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -3,6 +3,10 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import toast from "react-hot-toast";
 import apiWrapper from "../../api/apiWrapper.js";
 import { useUserDto } from "../../contexts/UserContext";
+import {
+  getLeagueCreationGates,
+  formatGateDate,
+} from "../../utils/leagueCreationGates";
 
 import "./LeagueCreatePage.css";
 
@@ -134,6 +138,12 @@ const LeagueCreatePage = () => {
     return raw && VALID_SPORT_PARAMS.has(raw) ? raw : SPORT_NCAA;
   })();
   const [sport, setSport] = useState(initialSport);
+  // Active league-creation gates: { FootballNcaa: "2026-08-17T00:00:00Z", ... }.
+  // A sport present here is locked until that instant; empty until loaded (and
+  // on fetch failure — the server guard is the real enforcement). See
+  // docs/features/league-creation-availability-gate.md.
+  const [creationGates, setCreationGates] = useState({});
+  const [gatesLoaded, setGatesLoaded] = useState(false);
   const [leagueName, setLeagueName] = useState("");
   const [description, setDescription] = useState("");
   // True once the user types in the description field, which freezes the
@@ -172,6 +182,33 @@ const LeagueCreatePage = () => {
   const isNcaa = sport === SPORT_NCAA;
   const isMlbAvailable = userDto?.isAdmin === true;
   const copy = SPORT_COPY[sport];
+
+  const isSportLocked = (s) => Boolean(creationGates[s]);
+
+  // Load the active creation gates once on mount. Fails open (empty map) — the
+  // server guard still rejects a locked create.
+  useEffect(() => {
+    let cancelled = false;
+    getLeagueCreationGates().then((gates) => {
+      if (cancelled) return;
+      setCreationGates(gates);
+      setGatesLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // If the preselected / deep-linked sport is locked, fall back to the first
+  // open sport so the form isn't stranded on a disabled tab. Only moves off a
+  // locked selection; locked tabs can't be picked (they're disabled).
+  useEffect(() => {
+    if (!gatesLoaded || !isSportLocked(sport)) return;
+    const fallback = [SPORT_NCAA, SPORT_NFL, ...(isMlbAvailable ? [SPORT_MLB] : [])]
+      .find((s) => !isSportLocked(s));
+    if (fallback) setSport(fallback);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gatesLoaded, creationGates, sport, isMlbAvailable]);
 
   // Human-readable window for the suggested description: a single day, a date
   // range, a single week, or a week range. null for a full-season league.
@@ -367,29 +404,59 @@ const LeagueCreatePage = () => {
             type="button"
             role="tab"
             aria-selected={sport === SPORT_NCAA}
-            className={`segmented-tab${sport === SPORT_NCAA ? " active" : ""}`}
+            disabled={isSportLocked(SPORT_NCAA)}
+            title={
+              isSportLocked(SPORT_NCAA)
+                ? `Opens ${formatGateDate(creationGates[SPORT_NCAA])}`
+                : undefined
+            }
+            className={`segmented-tab${sport === SPORT_NCAA ? " active" : ""}${
+              isSportLocked(SPORT_NCAA) ? " locked" : ""
+            }`}
             onClick={() => setSport(SPORT_NCAA)}
           >
             NCAA
+            {isSportLocked(SPORT_NCAA) &&
+              ` · opens ${formatGateDate(creationGates[SPORT_NCAA])}`}
           </button>
           <button
             type="button"
             role="tab"
             aria-selected={sport === SPORT_NFL}
-            className={`segmented-tab${sport === SPORT_NFL ? " active" : ""}`}
+            disabled={isSportLocked(SPORT_NFL)}
+            title={
+              isSportLocked(SPORT_NFL)
+                ? `Opens ${formatGateDate(creationGates[SPORT_NFL])}`
+                : undefined
+            }
+            className={`segmented-tab${sport === SPORT_NFL ? " active" : ""}${
+              isSportLocked(SPORT_NFL) ? " locked" : ""
+            }`}
             onClick={() => setSport(SPORT_NFL)}
           >
             NFL
+            {isSportLocked(SPORT_NFL) &&
+              ` · opens ${formatGateDate(creationGates[SPORT_NFL])}`}
           </button>
           {isMlbAvailable && (
             <button
               type="button"
               role="tab"
               aria-selected={sport === SPORT_MLB}
-              className={`segmented-tab${sport === SPORT_MLB ? " active" : ""}`}
+              disabled={isSportLocked(SPORT_MLB)}
+              title={
+                isSportLocked(SPORT_MLB)
+                  ? `Opens ${formatGateDate(creationGates[SPORT_MLB])}`
+                  : undefined
+              }
+              className={`segmented-tab${sport === SPORT_MLB ? " active" : ""}${
+                isSportLocked(SPORT_MLB) ? " locked" : ""
+              }`}
               onClick={() => setSport(SPORT_MLB)}
             >
               MLB
+              {isSportLocked(SPORT_MLB) &&
+                ` · opens ${formatGateDate(creationGates[SPORT_MLB])}`}
             </button>
           )}
         </div>

--- a/src/UI/sd-ui/src/utils/leagueCreationGates.js
+++ b/src/UI/sd-ui/src/utils/leagueCreationGates.js
@@ -44,3 +44,13 @@ export function formatGateDate(iso) {
         timeZone: "UTC",
       });
 }
+
+/**
+ * User-facing variant of {@link formatGateDate}: falls back to "soon" when the
+ * instant is missing or unparseable, so a bad value never renders as the literal
+ * "null" in a CTA or tab. Use this for display strings; use formatGateDate when
+ * you need to distinguish an unparseable value.
+ */
+export function formatGateDateOrSoon(iso) {
+  return formatGateDate(iso) ?? "soon";
+}

--- a/src/UI/sd-ui/src/utils/leagueCreationGates.js
+++ b/src/UI/sd-ui/src/utils/leagueCreationGates.js
@@ -1,0 +1,46 @@
+import LeaguesApi from "../api/leagues/leaguesApi";
+
+/**
+ * League-creation availability gate (see
+ * docs/features/league-creation-availability-gate.md). Some sports aren't open
+ * for league creation until their data is ready — e.g. NCAAFB waits for the AP
+ * Poll release. The API exposes the currently-active gates; the create-league
+ * UI locks exactly those sports, and the create endpoints enforce the same gate
+ * server-side.
+ */
+
+/**
+ * Fetches the active creation gates as a lookup of backend Sport enum
+ * ("FootballNcaa") → the UTC ISO instant it opens. A sport absent from the map
+ * is open. Fails OPEN (empty map) on error — the server still enforces the gate,
+ * so the worst case is a user seeing a create option the API then rejects.
+ * @returns {Promise<Record<string, string>>}
+ */
+export async function getLeagueCreationGates() {
+  try {
+    const data = await LeaguesApi.getCreationAvailability();
+    const gates = {};
+    for (const g of data?.gates ?? []) {
+      if (g?.sport && g?.opensUtc) gates[g.sport] = g.opensUtc;
+    }
+    return gates;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * "Aug 17" from a UTC ISO instant. Formatted in UTC so the gate's authored
+ * calendar day (a UTC wall-clock) isn't shifted back a day in western
+ * timezones. Returns null for an unparseable value.
+ */
+export function formatGateDate(iso) {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? null
+    : d.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      });
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
@@ -230,7 +230,17 @@ public class CreateFootballNcaaLeagueCommandHandlerTests : ApiTestBase<CreateFoo
 
         var result = await sut.ExecuteAsync(BuildValidRequest(), Guid.NewGuid());
 
+        // Gate-specific rejection (not some other validation failure).
         result.IsSuccess.Should().BeFalse();
+        var failure = result.Should().BeOfType<Failure<Guid>>().Subject;
+        failure.Status.Should().Be(ResultStatus.Validation);
+        failure.Errors.Should().ContainSingle()
+            // Culture-stable prefix — the full message carries the localized date.
+            .Which.ErrorMessage.Should().Contain("League creation opens");
+
+        // Rejected at the gate before any downstream work: nothing persisted,
+        // nothing published.
+        (await DataContext.PickemGroups.CountAsync()).Should().Be(0);
         eventBusMock.Verify(
             x => x.Publish(It.IsAny<PickemGroupCreated>(), It.IsAny<CancellationToken>()),
             Times.Never);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/CreateFootballNcaaLeague/CreateFootballNcaaLeagueCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Moq;
 
 using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Leagues;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague.Dtos;
 using SportsData.Api.Infrastructure.Data.Entities;
@@ -213,6 +214,26 @@ public class CreateFootballNcaaLeagueCommandHandlerTests : ApiTestBase<CreateFoo
 
         var saved = await DataContext.PickemGroups.FirstAsync(g => g.Id == leagueId);
         saved.RankingFilter.Should().Be(TeamRankingFilter.AP_TOP_25);
+    }
+
+    [Fact]
+    public async Task ShouldFail_WhenSportCreationNotYetOpen()
+    {
+        // Availability gate (correctness floor): NCAAFB is closed until AP Poll
+        // release. Reject before any downstream work; nothing is published.
+        Mocker.GetMock<ILeagueCreationAvailability>()
+            .Setup(x => x.GetOpensUtc(Sport.FootballNcaa))
+            .Returns(new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc));
+
+        var eventBusMock = Mocker.GetMock<IEventBus>();
+        var sut = Mocker.CreateInstance<CreateFootballNcaaLeagueCommandHandler>();
+
+        var result = await sut.ExecuteAsync(BuildValidRequest(), Guid.NewGuid());
+
+        result.IsSuccess.Should().BeFalse();
+        eventBusMock.Verify(
+            x => x.Publish(It.IsAny<PickemGroupCreated>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/LeagueCreationAvailabilityTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/LeagueCreationAvailabilityTests.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using SportsData.Api.Application.UI.Leagues;
+using SportsData.Api.Config;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues;
+
+public class LeagueCreationAvailabilityTests
+{
+    private static readonly DateTime Now = new(2026, 7, 25, 12, 0, 0, DateTimeKind.Utc);
+
+    private static LeagueCreationAvailability Build(Dictionary<Sport, DateTime> gates)
+    {
+        var config = new ApiConfig
+        {
+            BaseUrl = "https://api.test",
+            UserIdSystem = Guid.NewGuid(),
+            // Mirror how AppConfig delivers the gate: a string→string map keyed by
+            // Sport name, with an ISO-8601 value. "o" round-trips the Kind (…Z for
+            // Utc, bare for Unspecified) so the service's parsing is exercised.
+            LeagueCreationOpensUtc = gates.ToDictionary(
+                kvp => kvp.Key.ToString(),
+                kvp => kvp.Value.ToString("o", CultureInfo.InvariantCulture)),
+        };
+
+        var clock = new Mock<IDateTimeProvider>();
+        clock.Setup(x => x.UtcNow()).Returns(Now);
+
+        return new LeagueCreationAvailability(Options.Create(config), clock.Object);
+    }
+
+    [Fact]
+    public void GetOpensUtc_ReturnsInstant_WhenSportGatedInFuture()
+    {
+        var opens = new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc);
+        var sut = Build(new() { [Sport.FootballNcaa] = opens });
+
+        sut.GetOpensUtc(Sport.FootballNcaa).Should().Be(opens);
+    }
+
+    [Fact]
+    public void GetOpensUtc_ReturnsNull_WhenSportAbsent()
+    {
+        var sut = Build(new() { [Sport.FootballNcaa] = new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc) });
+
+        sut.GetOpensUtc(Sport.FootballNfl).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetOpensUtc_ReturnsNull_WhenGateAlreadyElapsed()
+    {
+        var sut = Build(new() { [Sport.FootballNcaa] = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
+
+        sut.GetOpensUtc(Sport.FootballNcaa).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetOpensUtc_TreatsUnspecifiedConfigInstantAsUtc()
+    {
+        // Config binding yields Kind=Unspecified; the service must compare by the
+        // authored UTC instant, not shift it by the host timezone.
+        var opens = new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Unspecified);
+        var sut = Build(new() { [Sport.FootballNcaa] = opens });
+
+        var result = sut.GetOpensUtc(Sport.FootballNcaa);
+
+        result.Should().NotBeNull();
+        result!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        result.Value.Should().Be(DateTime.SpecifyKind(opens, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void GetActiveGates_ReturnsOnlyFutureGates_EarliestFirst()
+    {
+        var sut = Build(new()
+        {
+            [Sport.FootballNcaa] = new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc), // future
+            [Sport.FootballNfl] = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),   // past -> excluded
+            [Sport.BaseballMlb] = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),   // future, earlier
+        });
+
+        var gates = sut.GetActiveGates();
+
+        gates.Should().HaveCount(2);
+        gates[0].Sport.Should().Be(nameof(Sport.BaseballMlb));
+        gates[0].OpensUtc.Should().Be(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        gates[1].Sport.Should().Be(nameof(Sport.FootballNcaa));
+    }
+
+    [Fact]
+    public void GetActiveGates_Empty_WhenNoGatesConfigured()
+    {
+        Build(new()).GetActiveGates().Should().BeEmpty();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/LeagueCreationAvailabilityTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/LeagueCreationAvailabilityTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 using FluentAssertions;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 using Moq;
@@ -19,24 +20,30 @@ public class LeagueCreationAvailabilityTests
 {
     private static readonly DateTime Now = new(2026, 7, 25, 12, 0, 0, DateTimeKind.Utc);
 
-    private static LeagueCreationAvailability Build(Dictionary<Sport, DateTime> gates)
+    private static LeagueCreationAvailability Build(Dictionary<Sport, DateTime> gates) =>
+        BuildRaw(gates.ToDictionary(
+            // Mirror how AppConfig delivers the gate: a string→string map keyed by
+            // Sport name, with an ISO-8601 value. "o" round-trips the Kind (…Z for
+            // Utc, bare for Unspecified) so the service's parsing is exercised.
+            kvp => kvp.Key.ToString(),
+            kvp => kvp.Value.ToString("o", CultureInfo.InvariantCulture)));
+
+    private static LeagueCreationAvailability BuildRaw(Dictionary<string, string> configured)
     {
         var config = new ApiConfig
         {
             BaseUrl = "https://api.test",
             UserIdSystem = Guid.NewGuid(),
-            // Mirror how AppConfig delivers the gate: a string→string map keyed by
-            // Sport name, with an ISO-8601 value. "o" round-trips the Kind (…Z for
-            // Utc, bare for Unspecified) so the service's parsing is exercised.
-            LeagueCreationOpensUtc = gates.ToDictionary(
-                kvp => kvp.Key.ToString(),
-                kvp => kvp.Value.ToString("o", CultureInfo.InvariantCulture)),
+            LeagueCreationOpensUtc = configured,
         };
 
         var clock = new Mock<IDateTimeProvider>();
         clock.Setup(x => x.UtcNow()).Returns(Now);
 
-        return new LeagueCreationAvailability(Options.Create(config), clock.Object);
+        return new LeagueCreationAvailability(
+            Options.Create(config),
+            clock.Object,
+            NullLogger<LeagueCreationAvailability>.Instance);
     }
 
     [Fact]
@@ -101,5 +108,20 @@ public class LeagueCreationAvailabilityTests
     public void GetActiveGates_Empty_WhenNoGatesConfigured()
     {
         Build(new()).GetActiveGates().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MalformedDate_ForKnownSport_FailsClosed_NotOpen()
+    {
+        // A configured gate for a real sport with an unparseable date must not
+        // silently OPEN the sport (that would defeat the gate). It stays locked.
+        var sut = BuildRaw(new Dictionary<string, string>
+        {
+            ["FootballNcaa"] = "not-a-date",
+        });
+
+        sut.GetOpensUtc(Sport.FootballNcaa).Should().NotBeNull();
+        sut.GetActiveGates().Should().ContainSingle()
+            .Which.Sport.Should().Be(nameof(Sport.FootballNcaa));
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Config/ApiConfigBindingTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Config/ApiConfigBindingTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+
+using Microsoft.Extensions.Configuration;
+
+using SportsData.Api.Config;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Config;
+
+public class ApiConfigBindingTests
+{
+    [Fact]
+    public void LeagueCreationOpensUtc_BindsFromHierarchicalKeys_LikeScalarProps()
+    {
+        // Mimics how Azure App Configuration delivers keys into IConfiguration:
+        // colon-delimited hierarchical keys under the ApiConfig section. A scalar
+        // prop (BaseUrl) and a Dictionary<string,string> prop should both bind.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SportsData.Api:ApiConfig:BaseUrl"] = "https://api.test",
+                ["SportsData.Api:ApiConfig:UserIdSystem"] = Guid.NewGuid().ToString(),
+                ["SportsData.Api:ApiConfig:LeagueCreationOpensUtc:FootballNcaa"] = "2026-08-17T00:00:00Z",
+                ["SportsData.Api:ApiConfig:LeagueCreationOpensUtc:FootballNfl"] = "2026-09-01T00:00:00Z",
+            })
+            .Build();
+
+        var apiConfig = configuration.GetSection("SportsData.Api:ApiConfig").Get<ApiConfig>();
+
+        apiConfig.Should().NotBeNull();
+        apiConfig!.BaseUrl.Should().Be("https://api.test");
+        apiConfig.LeagueCreationOpensUtc.Should().HaveCount(2);
+        apiConfig.LeagueCreationOpensUtc.Should().ContainKey("FootballNcaa");
+        apiConfig.LeagueCreationOpensUtc["FootballNcaa"].Should().Be("2026-08-17T00:00:00Z");
+    }
+}


### PR DESCRIPTION
## What & why
Gate league creation **per sport** behind a configurable "opens" instant, so a sport can't be created before its data is ready. NCAAFB leagues commonly rank by the **AP Poll**, which isn't released until **~Aug 17** — creating before then yields a broken, rankings-less league during launch. The gate is **time-based**, so it auto-unlocks with no deploy/OTA, and any sport (e.g. NFL) is gated by a single config value with **no code change**.

## Design
API owns this — it's a Pick'em rule, not canonical data, so it does **not** touch Producer / `CurrentSeasonDto`. Full design: `docs/features/league-creation-availability-gate.md`.

- **Config:** `ApiConfig.LeagueCreationOpensUtc` — `Dictionary<string,string>` keyed by Sport enum name, value an ISO-8601 UTC instant. String-keyed **deliberately**: the .NET config binder does not reliably populate *enum*-keyed dictionaries (added `ApiConfigBindingTests` documenting the key→property contract).
- **Service:** `ILeagueCreationAvailability` — one source consumed by both the guard and the endpoint.
- **Enforcement (correctness floor):** create-time guard in `CreateLeagueCommandHandlerBase` rejects a closed sport before any work — closes the deep-link (`?sport=`) and direct-API paths that CTA-hiding alone leaves open.
- **FE contract:** `GET /ui/leagues/creation-availability` returns only active gates.
- **Web + mobile:** create form disables/omits a locked sport with an "opens {date}" hint and falls back off a locked `?sport=` deep-link; off-season countdown swaps the create CTA for "{sport} leagues open {date}" and softens the body copy when every surfaced sport is gated. FE **fails open** — the server guard is the real enforcement.

## Config (set out-of-band)
```
SportsData.Api:ApiConfig:LeagueCreationOpensUtc:FootballNcaa = 2026-08-17T00:00:00Z
```
Set in the API's AppConfig label(s). The IaC `manifest.json` update follows in a separate change.

## Tests
- `LeagueCreationAvailabilityTests` — service: future/absent/past, UTC parsing, active-gate ordering.
- `CreateFootballNcaaLeagueCommandHandlerTests.ShouldFail_WhenSportCreationNotYetOpen` — guard rejects, no `PickemGroupCreated` published; existing handler tests unaffected (service auto-mocked → open).
- `ApiConfigBindingTests` — proves the dictionary binds from hierarchical AppConfig keys.
- Web build + mobile `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sport-specific league creation availability gates with configurable UTC opening times.
  * Added an availability endpoint powering web and mobile gating.
  * Locked sports now show “opens <date>” messaging, disable selection, and update related CTAs/prompts.
* **Bug Fixes**
  * Server-side validation now blocks league creation until the configured per-sport opening time.
* **Tests**
  * Added unit and client tests covering gate parsing, elapsed handling, ordering, config binding, UI date formatting, and blocked creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->