### PR TITLE
fix(ui): mobile league-creation entry point, date pickers, and countdown copy

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -281,14 +281,20 @@ export default function PicksScreen() {
     [isReadOnly, leagueId, selectedWeek, importPicks],
   );
 
-  // Hide Picked is a no-op once allPicked flips true — the toggle is also
-  // hidden in that branch of the header, so respecting it would strand the
-  // user with an empty FlatList ("No games this week") and no in-UI escape.
-  // Treating the filter as inactive when allPicked === true keeps the cards
-  // visible after the final pick while the header reads "All Picks Made".
+  // Hide Picked is a no-op wherever its toggle isn't rendered, otherwise a
+  // filter left switched on would strand the user with an empty FlatList
+  // ("No games this week") and no in-UI escape. Two such cases:
+  //   - allPicked — keeps the cards visible after the final pick while the
+  //     header reads "All Picks Made".
+  //   - isReadOnly — an ended league is a record to review, not a surface to
+  //     keep clean while picking, and the header has no room for the toggle
+  //     alongside the "ENDED" badge.
   const visibleEntries = useMemo(
-    () => (hidePicked && !allPicked ? entries.filter((e) => !e.pick) : entries),
-    [entries, hidePicked, allPicked],
+    () =>
+      hidePicked && !allPicked && !isReadOnly
+        ? entries.filter((e) => !e.pick)
+        : entries,
+    [entries, hidePicked, allPicked, isReadOnly],
   );
 
   // Responsive columns: phones stay single-column; tablets get a multi-column
@@ -364,23 +370,29 @@ export default function PicksScreen() {
               <Text style={[headerStyles.pillText, { color: theme.tint }]}>
                 {made}/{total}
               </Text>
-              <Pressable
-                onPress={() => setHidePicked((v) => !v)}
-                hitSlop={6}
-                style={headerStyles.hideToggle}
-                accessibilityRole="checkbox"
-                accessibilityState={{ checked: hidePicked }}
-                accessibilityLabel="Hide picked games"
-              >
-                <Ionicons
-                  name={hidePicked ? 'checkbox' : 'square-outline'}
-                  size={18}
-                  color={hidePicked ? theme.tint : theme.textMuted}
-                />
-                <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
-                  {' '}Hide Picked
-                </Text>
-              </Pressable>
+              {/* Ended leagues drop the toggle: it exists to keep the screen
+                  clean while picking, which no longer applies, and the header
+                  has no room for it next to the "ENDED" badge. visibleEntries
+                  treats the filter as inactive here to match. */}
+              {!isReadOnly && (
+                <Pressable
+                  onPress={() => setHidePicked((v) => !v)}
+                  hitSlop={6}
+                  style={headerStyles.hideToggle}
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ checked: hidePicked }}
+                  accessibilityLabel="Hide picked games"
+                >
+                  <Ionicons
+                    name={hidePicked ? 'checkbox' : 'square-outline'}
+                    size={18}
+                    color={hidePicked ? theme.tint : theme.textMuted}
+                  />
+                  <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
+                    {' '}Hide Picked
+                  </Text>
+                </Pressable>
+              )}
             </>
           )}
         </View>

--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -351,7 +351,15 @@ function DateField({
   const [iosOpen, setIosOpen] = useState(false);
   const [draft, setDraft] = useState<Date | null>(null);
 
-  const dateValue = value ? parseDateOnly(value) : new Date();
+  // Seed at or after `minimumDate`. With an empty field the fallback is today,
+  // which can precede a later floor — the End field's floor is `startsOn` when
+  // that's in the future. iOS clamps the wheel's *display* to minimumDate but
+  // doesn't fire onChange for that clamp, so a straight Done would commit the
+  // earlier seeded date rather than the one on screen. Android's dialog opens
+  // on this value too, so it wants the same floor.
+  const parsedValue = value ? parseDateOnly(value) : new Date();
+  const dateValue =
+    minimumDate && parsedValue < minimumDate ? minimumDate : parsedValue;
   const display = value ? formatDateOnlyDisplay(value) : placeholder;
   const hasValue = value.length > 0;
 

--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -9,8 +9,10 @@ import {
   Switch,
   TouchableOpacity,
   Alert,
+  Modal,
 } from 'react-native';
 import DateTimePicker, {
+  DateTimePickerAndroid,
   type DateTimePickerEvent,
 } from '@react-native-community/datetimepicker';
 import { Text } from '@/src/components/ui/AppText';
@@ -21,7 +23,7 @@ import { z } from 'zod';
 import { useRouter, Stack, useLocalSearchParams } from 'expo-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { getTheme } from '@/constants/Colors';
+import { getTheme, type ColorScheme } from '@/constants/Colors';
 import { Button } from '@/src/components/ui/Button';
 import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
 import {
@@ -308,27 +310,104 @@ type DateFieldProps = {
   placeholder: string;
   accessibilityLabel: string;
   theme: ThemePalette;
+  scheme: ColorScheme;
   error?: string;
   minimumDate?: Date;
 };
 
-// Pressable that shows the formatted date (or placeholder) and opens the
-// native picker on tap. Android dismisses the picker after any interaction;
-// iOS keeps it on screen until the user taps away, so we drive visibility
-// from local state and only commit form value on `event.type === 'set'`.
-function DateField({ value, onChange, placeholder, accessibilityLabel, theme, error, minimumDate }: DateFieldProps) {
-  const [show, setShow] = useState(false);
+/**
+ * Date input backed by each platform's own picker. A single
+ * `<DateTimePicker display="default">` render path misbehaved on two of the
+ * three targets, so each gets the interaction its picker is actually built for:
+ *
+ *  - **Android** — the imperative `DateTimePickerAndroid.open()` API. This is
+ *    the library's documented Android path: it fires the dialog exactly once,
+ *    where a declaratively-rendered picker can re-open or desync when the tree
+ *    re-renders while the dialog is up.
+ *  - **iOS** — a spinner in an explicit Cancel/Done modal, editing a *draft*
+ *    date. `display="default"` renders the picker INLINE on iOS 14+, which is
+ *    the stray calendar that appeared below the field. Worse, the committed
+ *    value was fed straight back in as `value`, so every scroll tick
+ *    round-tripped through `dateToIsoDateOnly` (which drops the time and
+ *    re-anchors at local midnight) and snapped the wheel back — the "fighting
+ *    it" symptom. The draft breaks that loop: nothing commits until Done.
+ *  - **Web** — the library ships no web implementation; it renders `null` and
+ *    console-warns, which is why Chrome showed no picker at all. A native
+ *    `<input type="date">` stands in (react-native-web renders to the DOM, so a
+ *    host element is legal here), and its value format is already the
+ *    `YYYY-MM-DD` we store. Date inputs ignore `placeholder` and supply their
+ *    own `mm/dd/yyyy` hint, so it's only used for the native branches' label.
+ */
+function DateField({
+  value,
+  onChange,
+  placeholder,
+  accessibilityLabel,
+  theme,
+  scheme,
+  error,
+  minimumDate,
+}: DateFieldProps) {
+  const [iosOpen, setIosOpen] = useState(false);
+  const [draft, setDraft] = useState<Date | null>(null);
 
   const dateValue = value ? parseDateOnly(value) : new Date();
   const display = value ? formatDateOnlyDisplay(value) : placeholder;
   const hasValue = value.length > 0;
 
-  const handleChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
-    if (Platform.OS === 'android') setShow(false);
-    if (event.type === 'set' && selectedDate) {
-      onChange(dateToIsoDateOnly(selectedDate));
+  const commit = (d: Date) => onChange(dateToIsoDateOnly(d));
+
+  const openPicker = () => {
+    if (Platform.OS === 'android') {
+      DateTimePickerAndroid.open({
+        value: dateValue,
+        mode: 'date',
+        minimumDate,
+        onChange: (event: DateTimePickerEvent, selected?: Date) => {
+          if (event.type === 'set' && selected) commit(selected);
+        },
+      });
+      return;
     }
+    // Seed the draft from the current value so Done-without-scrolling is a
+    // no-op commit rather than a jump to today.
+    setDraft(dateValue);
+    setIosOpen(true);
   };
+
+  const errorNode = error ? (
+    <Text style={[styles.fieldError, { color: theme.error }]}>{error}</Text>
+  ) : null;
+
+  if (Platform.OS === 'web') {
+    return (
+      <>
+        {React.createElement('input', {
+          type: 'date',
+          value,
+          min: minimumDate ? dateToIsoDateOnly(minimumDate) : undefined,
+          'aria-label': accessibilityLabel,
+          onChange: (e: { target: { value: string } }) => onChange(e.target.value),
+          style: {
+            backgroundColor: theme.card,
+            color: theme.text,
+            borderWidth: 1.5,
+            borderStyle: 'solid',
+            borderColor: error ? theme.error : theme.border,
+            borderRadius: 10,
+            padding: '12px 14px',
+            fontSize: 16,
+            fontFamily: 'inherit',
+            width: '100%',
+            boxSizing: 'border-box',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- DOM host
+          // element: RN's JSX typings don't declare intrinsic web elements.
+        } as any)}
+        {errorNode}
+      </>
+    );
+  }
 
   return (
     <>
@@ -341,7 +420,7 @@ function DateField({ value, onChange, placeholder, accessibilityLabel, theme, er
             justifyContent: 'center',
           },
         ]}
-        onPress={() => setShow(true)}
+        onPress={openPicker}
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel}
       >
@@ -349,16 +428,55 @@ function DateField({ value, onChange, placeholder, accessibilityLabel, theme, er
           {display}
         </Text>
       </TouchableOpacity>
-      {show && (
-        <DateTimePicker
-          value={dateValue}
-          mode="date"
-          display="default"
-          onChange={handleChange}
-          minimumDate={minimumDate}
+
+      {/* iOS only — Android's dialog is driven imperatively above. */}
+      <Modal
+        visible={iosOpen}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setIosOpen(false)}
+      >
+        <TouchableOpacity
+          style={styles.pickerBackdrop}
+          activeOpacity={1}
+          onPress={() => setIosOpen(false)}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss date picker"
         />
-      )}
-      {error && <Text style={[styles.fieldError, { color: theme.error }]}>{error}</Text>}
+        <View style={[styles.pickerSheet, { backgroundColor: theme.card, borderTopColor: theme.border }]}>
+          <View style={[styles.pickerBar, { borderBottomColor: theme.border }]}>
+            <TouchableOpacity onPress={() => setIosOpen(false)} hitSlop={12}>
+              <Text style={[styles.pickerBarAction, { color: theme.textMuted }]}>Cancel</Text>
+            </TouchableOpacity>
+            <Text style={[styles.pickerBarTitle, { color: theme.text }]}>{accessibilityLabel}</Text>
+            <TouchableOpacity
+              onPress={() => {
+                if (draft) commit(draft);
+                setIosOpen(false);
+              }}
+              hitSlop={12}
+            >
+              <Text style={[styles.pickerBarAction, styles.pickerBarDone, { color: theme.tint }]}>
+                Done
+              </Text>
+            </TouchableOpacity>
+          </View>
+          <DateTimePicker
+            value={draft ?? dateValue}
+            mode="date"
+            display="spinner"
+            // Without this the wheel follows the OS appearance, which renders
+            // dark text on the dark sheet when the in-app theme is overridden.
+            themeVariant={scheme}
+            minimumDate={minimumDate}
+            onChange={(_event: DateTimePickerEvent, selected?: Date) => {
+              if (selected) setDraft(selected);
+            }}
+          />
+        </View>
+      </Modal>
+
+      {errorNode}
     </>
   );
 }
@@ -804,6 +922,7 @@ export default function CreateLeagueScreen() {
                         placeholder="Select start"
                         accessibilityLabel="Start Date"
                         theme={theme}
+                        scheme={scheme}
                         error={errors.startsOn?.message}
                         minimumDate={parseDateOnly(todayIsoDate)}
                       />
@@ -822,6 +941,7 @@ export default function CreateLeagueScreen() {
                         placeholder="Select end"
                         accessibilityLabel="End Date"
                         theme={theme}
+                        scheme={scheme}
                         error={errors.endsOn?.message}
                         minimumDate={parseDateOnly(endsOnMinIsoDate)}
                       />
@@ -1128,4 +1248,25 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: 6,
   },
+  // iOS date-picker sheet. Anchored to the bottom over a dimmed backdrop so the
+  // wheel never displaces form content the way the old inline picker did.
+  pickerBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  pickerSheet: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingBottom: 24,
+  },
+  pickerBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  pickerBarTitle: { fontSize: 15, fontWeight: '700' },
+  pickerBarAction: { fontSize: 16 },
+  pickerBarDone: { fontWeight: '700' },
 });

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -151,6 +151,23 @@ export default function LeaguesScreen() {
           // The parent (tabs) group has no title, so iOS would otherwise render
           // the raw route name ("(tabs)") as the back label. Show just the chevron.
           headerBackButtonDisplayMode: 'minimal',
+          // Mirrors sd-ui's Leagues.jsx header (title left, "+ Create League"
+          // right). The in-content button below only renders on the empty state,
+          // so without this there's no way to create a second league from here.
+          // Left unconditional to match web: the create screen surfaces the
+          // per-sport availability gate, and the API enforces it server-side.
+          headerRight: () => (
+            <TouchableOpacity
+              style={styles.headerCreate}
+              onPress={() => router.push('/create-league' as never)}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Create league"
+            >
+              <Ionicons name="add" size={18} color={theme.tint} />
+              <Text style={[styles.headerCreateText, { color: theme.tint }]}>Create</Text>
+            </TouchableOpacity>
+          ),
         }}
       />
 
@@ -301,6 +318,18 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   pastToggleText: { fontSize: 12, fontWeight: '700' },
+  // Nav-bar "+ Create" action. Text alongside the glyph (rather than a bare "+")
+  // so the affordance is unambiguous; hitSlop covers the small visual footprint.
+  // marginRight matches picks.tsx's headerRight inset — the native stack doesn't
+  // pad headerRight content, so without it the label butts the screen edge.
+  headerCreate: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    paddingVertical: 4,
+    marginRight: 12,
+  },
+  headerCreateText: { fontSize: 15, fontWeight: '700' },
   loading: { marginTop: 32 },
   empty: { alignItems: 'center', gap: 16, marginTop: 48 },
   emptyText: { fontSize: 15, textAlign: 'center' },

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -104,15 +104,19 @@ export function PrimarySlotOffSeasonCountdown() {
   // Every surfaced sport is gated from creation → don't urge "spin up a league
   // now" when no CTA can act on it. (Live sports are never active gates.)
   const allGated = phrases.every((s) => Boolean(gates[s.sportEnum]));
-  const eyebrow = seasonYear ? `${seasonYear} SEASON` : 'UPCOMING SEASON';
+  // Frame the per-sport countdowns as *kickoff* dates so "NCAAFB in 35 days"
+  // isn't misread against the earlier "Opens Aug 18" league-creation gate. Drop
+  // "KICKOFFS" once everything's underway (nothing is counting down anymore).
+  const seasonLabel = seasonYear ? `${seasonYear} SEASON` : 'UPCOMING SEASON';
+  const eyebrow = allLive ? seasonLabel : `${seasonLabel} KICKOFFS`;
 
   const body = allLive
     ? 'Jump into your leagues and lock in your picks before the next kickoff.'
     : allGated
-      ? "Leagues open soon — we'll be ready before Week 1."
+      ? "Leagues open soon — we'll be ready before Week\u00A01."
       : seasonYear
-        ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week 1.`
-        : "Spin up your pick'em league now so you're ready for Week 1.";
+        ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week\u00A01.`
+        : "Spin up your pick'em league now so you're ready for Week\u00A01.";
 
   if (loading) {
     return (
@@ -177,11 +181,19 @@ export function PrimarySlotOffSeasonCountdown() {
               return (
                 <Button
                   key={s.key}
-                  title={`${s.label} opens ${formatGateDateOrSoon(opensUtc)}`}
+                  // Two balanced lines — "{sport} Leagues" on top, "Open {date}"
+                  // below — reads cleaner than one string that wraps mid-phrase at
+                  // half-width on a phone, and matches web's "leagues open" wording.
+                  title={`${s.label} Leagues\nOpen ${formatGateDateOrSoon(opensUtc)}`}
                   onPress={() => {}}
                   disabled
+                  // Muted outline (not a solid primary fill) so it reads as an
+                  // informational "coming soon" chip, not a tappable CTA — matching
+                  // web's gated affordance.
+                  variant="secondary"
                   size="md"
-                  style={styles.actionButton}
+                  style={{ ...styles.actionButton, borderColor: theme.border, opacity: 0.75 }}
+                  textStyle={{ ...styles.gatedCtaText, color: theme.textMuted }}
                 />
               );
             }
@@ -249,5 +261,12 @@ const styles = StyleSheet.create({
   // all-live "Go to picks" button fills the row on its own.
   actionButton: {
     flex: 1,
+  },
+  // Gated "Opens {date}" CTA: two centered lines, smaller/tighter than the
+  // default md label so both fit the half-width button on a phone.
+  gatedCtaText: {
+    fontSize: 13,
+    lineHeight: 17,
+    textAlign: 'center',
   },
 });

--- a/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
+++ b/src/UI/sd-ui/src/components/home/PrimarySlotOffSeasonCountdown.jsx
@@ -132,6 +132,12 @@ function PrimarySlotOffSeasonCountdown() {
   const seasonYear =
     sportsWithPhrases.find((s) => s.seasonYear)?.seasonYear ?? null;
 
+  // Frame the per-sport countdowns as *kickoff* dates so "NCAAFB in 35 days"
+  // isn't misread against the earlier "leagues open Aug 18" gate. Drop "Kickoffs"
+  // once everything's underway (nothing is counting down anymore).
+  const seasonLabel = seasonYear ? `${seasonYear} Season` : "Upcoming Season";
+  const eyebrow = allLive ? seasonLabel : `${seasonLabel} Kickoffs`;
+
   // Headline strategy:
   //   - All sports kicked off → "Picks are live" mode, drive users to picks.
   //   - Any sport still upcoming (or coming soon) → render each sport's phrase
@@ -148,10 +154,10 @@ function PrimarySlotOffSeasonCountdown() {
   const body = allLive
     ? "Jump into your leagues and lock in your picks before the next kickoff."
     : allGated
-    ? "Leagues open soon — we'll be ready before Week 1."
+    ? "Leagues open soon — we'll be ready before Week\u00A01."
     : seasonYear
-    ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week 1.`
-    : "Spin up your pick'em league now so you're ready for Week 1.";
+    ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week\u00A01.`
+    : "Spin up your pick'em league now so you're ready for Week\u00A01.";
 
   // CTAs — per-sport when any sport is still upcoming, single collapsed
   // button when all sports are live. For a sport that's already live, the
@@ -211,7 +217,7 @@ function PrimarySlotOffSeasonCountdown() {
 
   return (
     <div className="home-primary home-primary--countdown">
-      <div className="home-primary__eyebrow">{seasonYear ? `${seasonYear} Season` : "Upcoming Season"}</div>
+      <div className="home-primary__eyebrow">{eyebrow}</div>
       <h1 className="home-primary__headline">{headline}</h1>
       <p className="home-primary__body">{body}</p>
       <div className="home-primary__actions">{renderActions()}</div>


### PR DESCRIPTION
Three unrelated UI fixes batched into one mobile release (individually too thin to justify a PR + EAS update).

## 1. Create League entry point — mobile parity

`/leagues` only rendered a Create League button in its **empty state**, so once a user belonged to one league there was no path to create a second. Web renders it in the page header unconditionally (`Leagues.jsx:150-155`).

Adds a matching `+ Create` action to the native header (`Stack.Screen` `headerRight`), using the same `marginRight: 12` inset `picks.tsx` already uses for that slot.

Left **unconditional** to match web: the create screen already surfaces the per-sport availability gate and the API enforces it server-side, so gating the entry point would only duplicate that. The empty-state button stays — web keeps its inline "Create one" link too.

## 2. Date pickers on create-league

A single `<DateTimePicker display="default">` render path misbehaved on two of three targets. Each platform now gets the interaction its picker is actually built for:

| Platform | Symptom | Fix |
|---|---|---|
| Web | No picker at all | Library ships **no web implementation** — `src/datetimepicker.js` is `return null` plus a `console.warn`. Replaced with a native `input[type=date]`; react-native-web renders to the DOM, and the input's value format is already the `YYYY-MM-DD` we store. |
| iOS | Stray calendar below the field; selection fights back | `display="default"` renders **inline** on iOS 14+. Worse, the committed value was fed straight back in as `value`, so every scroll tick round-tripped through `dateToIsoDateOnly` (drops the time, re-anchors at local midnight) and snapped the wheel back. Now a spinner in an explicit Cancel/Done sheet editing a **draft** date — nothing commits until Done. |
| Android | — | Switched to the imperative `DateTimePickerAndroid.open()`, the library's documented Android path, which fires once instead of re-rendering a live dialog. |

`themeVariant` is now passed through so the iOS wheel doesn't follow OS appearance and render dark text on the dark sheet when the in-app theme is overridden.

## 3. Off-season countdown copy (mobile + web)

- Frames the per-sport countdowns as kickoff dates — `2026 Season Kickoffs` — so "NCAAFB in 35 days" isn't misread against the earlier league-creation gate date. The suffix drops once every sport is live.
- Non-breaking space in "Week 1" so it can't wrap.
- Mobile's gated CTA becomes a muted two-line outline chip (`{sport} Leagues` / `Open {date}`) instead of a solid primary fill, so it reads as informational rather than tappable — matching web's gated affordance.

## Verification

- `sd-mobile`: `tsc --noEmit` clean; `jest` 12 suites / 84 tests pass
- `sd-ui`: `eslint --max-warnings=0` clean; `vitest` 3 files / 10 tests pass

**Not yet verified:** the iOS sheet and Android dialog need a physical-device pass. Local debugging was against Expo's web target, which only exercises the new `input[type=date]` branch.

## Note

An initial report that mobile pushed a single-day league's end date to tomorrow was investigated and is **not** a defect — mobile and web create payloads are byte-identical (`startsOn: 2026-07-26T04:00:00.000Z`, `endsOn: 2026-07-27T03:59:59.000Z`). The stored `EndsOn` landing on the next UTC day is by design: the conversion is anchored in the user's local timezone so the window captures that evening's local games. The original league simply had the wrong end date selected — plausibly a symptom of the picker bug fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “+ Create” action to the Leagues screen for quick access to league creation.
  - Enhanced date selection on the Create League screen with platform-appropriate pickers and theme-aware iOS presentation.

- **Bug Fixes**
  - Date changes now update only after confirmation on mobile (and use correct, styled date input on web).

- **Style**
  - Updated offseason countdown messaging to emphasize kickoffs and improve Week 1 formatting.
  - Restyled gated (disabled) league actions with clearer two-line text and improved alignment/spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->