### PR TITLE
feat(picks): ended-league results glance via UserPicksResultDto envelope

### DIFF
--- a/docs/features/league-ended-headers.md
+++ b/docs/features/league-ended-headers.md
@@ -1,0 +1,153 @@
+# Ended-League Picks Header: Results Glance
+
+Status: design approved pending implementation authorization
+Date: 2026-07-26
+Surfaces: SportsData.Api, sd-mobile, sd-ui
+
+## Problem
+
+The picks-page header treats an ended league like an active one:
+
+- One ended league shows **"All Picks Made"** — pick progress is irrelevant once
+  the league is over.
+- Another shows **"24/46"** — same problem; nobody is finishing those picks.
+
+(Screenshots: `src/about/public/gallery/Screenshot 2026-07-26 105305.png`,
+`Screenshot 2026-07-26 105255.png`.)
+
+For an ended league the user's question is "how did I do?", not "how far along
+am I?". Replace the progress slot with a results glance:
+
+```
+X | Y | Z
+```
+
+- **X** — matchups that produced no scored pick (unpicked + picks whose game
+  never resolved, e.g. canceled)
+- **Y** — correct picks
+- **Z** — incorrect picks
+
+Invariant: **X + Y + Z = total matchups for the week**, so the glance always
+adds up. This is why no-result picks fold into X rather than being excluded
+(X+Y+Z < total reads as a bug) or counted as incorrect (punishes the user for a
+canceled game).
+
+## Decisions (grilled 2026-07-26)
+
+| Question | Decision |
+|---|---|
+| Client-side compute vs API change | **API change.** Y/Z are technically derivable client-side from `IsCorrect`, but the endpoint returning a raw `List<UserPickDto>` is an API-shape defect we want fixed regardless; the feature justifies touching the contract. |
+| Rollout of the breaking change | **Coordinated break.** API + web in one PR/deploy; mobile EAS update immediately after. Installed mobile builds see a broken picks page until the OTA lands — acceptable at beta scale. |
+| Where do never-resolved picks land | **Fold into X** ("no result"), preserving X+Y+Z = total. |
+| Envelope machinery | **None invented.** Bespoke `UserPicksResultDto` returned as `Result<UserPicksResultDto>` through the existing `ResultExtensions.ToActionResult()` mapping — same as every other endpoint. The deferred global `Response<T>` initiative is untouched. |
+
+## API change
+
+### Endpoint
+
+`GET /ui/picks/{groupId}/week/{week}` (`PicksController.GetUserPicksByGroupAndWeek`)
+
+**Before:** `200 OK` → `List<UserPickDto>` (raw array — the defect)
+**After:** `200 OK` → `UserPicksResultDto`
+
+### DTO
+
+```csharp
+// Application/UI/Picks/Dtos/UserPicksResultDto.cs
+public record UserPicksResultDto
+{
+    public List<UserPickDto> Picks { get; init; } = [];
+
+    /// Total matchups in this group-week (from PickemGroupMatchup), regardless
+    /// of whether the user picked them.
+    public int TotalMatchups { get; init; }
+
+    /// Picks with IsCorrect == true.
+    public int CorrectCount { get; init; }
+
+    /// Picks with IsCorrect == false.
+    public int IncorrectCount { get; init; }
+}
+```
+
+`X = TotalMatchups - CorrectCount - IncorrectCount` is derived client-side.
+The server sends the minimal orthogonal set; shipping a fourth redundant
+counter invites the three-plus-one drifting out of agreement.
+
+`UserPickDto` itself is unchanged.
+
+### Handler
+
+`GetUserPicksByGroupAndWeekQueryHandler` gains one indexed count alongside the
+existing picks query (`.AsNoTracking()`, same as current):
+
+```csharp
+var totalMatchups = await _dataContext.PickemGroupMatchups
+    .AsNoTracking()
+    .CountAsync(m => m.GroupId == query.GroupId && m.SeasonWeek == query.WeekNumber,
+        cancellationToken);
+```
+
+Covered by the existing `(GroupId, SeasonYear, SeasonWeek)` index. Correct and
+incorrect counts are computed from the already-materialized picks list — no
+extra query. Return type becomes `Result<UserPicksResultDto>`; controller
+signature becomes `ActionResult<UserPicksResultDto>`; everything else flows
+through `ToActionResult()` unchanged.
+
+Note: counts are computed over the **current user's** picks only (the query is
+already user-scoped). `User`/`IsSynthetic` fields on `UserPickDto` are
+unaffected.
+
+## Client changes
+
+### Mobile (`sd-mobile`) — build first, per direction
+
+1. **`src/services/api/picksApi.ts`** — `getByLeagueAndWeek` return type:
+   `UserPick[]` → `UserPicksResult { picks, totalMatchups, correctCount, incorrectCount }`.
+2. **`app/(tabs)/picks.tsx`** — consumers of the response switch to `.picks`.
+   Header (`headerRight` effect):
+   - `isReadOnly === false`: unchanged ("All Picks Made" / `made/total` + Hide
+     Picked).
+   - `isReadOnly === true`: replace the progress slot with the glance —
+     `X | Y | Z` where X renders muted, Y in the success/tint color, Z in the
+     error color. ENDED badge and pick-mode badge stay as-is.
+   - Counts come from the DTO, not client math over entries.
+
+### Web (`sd-ui`) — same PR (it breaks otherwise)
+
+1. **`src/api/picksApi.js`** — no change (thin axios wrapper).
+2. **`src/components/picks/PicksPage.jsx` (~line 400)** — parse the new shape
+   (`response.data.picks`). **Required** or web breaks on deploy.
+3. Web's own ended-league header glance: same treatment where PicksPage renders
+   its read-only header. Kept in scope since the file is already open, but the
+   parsing fix is the mandatory part.
+
+## Rollout
+
+Single PR (monorepo): API + web + mobile. Web deploys with the API, so the
+array→object break never has a window on web. Mobile:
+
+1. Merge + deploy API/web.
+2. Publish EAS update immediately after.
+3. Installed mobile builds are broken on the picks page until they pull the
+   OTA update — accepted (beta scale, friends-only).
+
+Branch: off latest `origin/main` (not the #561 branch). Separate PR from #561.
+
+## Out of scope
+
+- The global `Response<T>` envelope initiative (`project_api_response_envelope`)
+  — this feature neither starts nor depends on it.
+- Other endpoints returning raw collections.
+- The as-of-week point-in-time bug on past-league picks (records/rankings show
+  end-of-season values) — tracked separately.
+- Any change to pick submission or scoring.
+
+## Verification checklist
+
+- API: `dotnet build` + `dotnet test` on SportsData.Api (+ new handler test
+  covering the counts: correct/incorrect/no-result/unpicked mix).
+- Mobile: `tsc --noEmit`, `jest`; manual pass on an ended league (glance shows,
+  X+Y+Z equals the week's matchup count) and an active league (unchanged).
+- Web: `eslint`, `vitest`; PicksPage renders both active and ended leagues
+  against the new response shape.

--- a/docs/features/league-ended-headers.md
+++ b/docs/features/league-ended-headers.md
@@ -1,6 +1,6 @@
 # Ended-League Picks Header: Results Glance
 
-Status: design approved pending implementation authorization
+Status: implemented (PR #563)
 Date: 2026-07-26
 Surfaces: SportsData.Api, sd-mobile, sd-ui
 

--- a/docs/features/league-ended-headers.md
+++ b/docs/features/league-ended-headers.md
@@ -18,7 +18,7 @@ The picks-page header treats an ended league like an active one:
 For an ended league the user's question is "how did I do?", not "how far along
 am I?". Replace the progress slot with a results glance:
 
-```
+```text
 X | Y | Z
 ```
 

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandler.cs
@@ -132,7 +132,7 @@ public class GetLeagueWeekOverviewQueryHandler : IGetLeagueWeekOverviewQueryHand
 
             if (userPicksResult.IsSuccess)
             {
-                result.UserPicks.AddRange(userPicksResult.Value);
+                result.UserPicks.AddRange(userPicksResult.Value.Picks);
             }
             else
             {

--- a/src/SportsData.Api/Application/UI/Picks/Dtos/UserPicksResultDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Dtos/UserPicksResultDto.cs
@@ -1,0 +1,26 @@
+namespace SportsData.Api.Application.UI.Picks.Dtos;
+
+/// <summary>
+/// Envelope for GET /ui/picks/{groupId}/week/{week}: the current user's picks
+/// plus server-computed result counts driving the ended-league header glance
+/// (X|Y|Z). X (no scored pick: unpicked + never-resolved games) is derived
+/// client-side as <c>TotalMatchups - CorrectCount - IncorrectCount</c> — the
+/// server sends the minimal orthogonal set so a redundant fourth counter can't
+/// drift out of agreement. See docs/features/league-ended-headers.md.
+/// </summary>
+public record UserPicksResultDto
+{
+    public List<UserPickDto> Picks { get; init; } = [];
+
+    /// <summary>
+    /// Total matchups in this group-week (from PickemGroupMatchup), regardless
+    /// of whether the user picked them.
+    /// </summary>
+    public int TotalMatchups { get; init; }
+
+    /// <summary>Picks with <c>IsCorrect == true</c>.</summary>
+    public int CorrectCount { get; init; }
+
+    /// <summary>Picks with <c>IsCorrect == false</c>.</summary>
+    public int IncorrectCount { get; init; }
+}

--- a/src/SportsData.Api/Application/UI/Picks/PicksController.cs
+++ b/src/SportsData.Api/Application/UI/Picks/PicksController.cs
@@ -63,7 +63,7 @@ public class PicksController : ApiControllerBase
     }
 
     [HttpGet("{groupId}/week/{week}")]
-    public async Task<ActionResult<List<UserPickDto>>> GetUserPicksByGroupAndWeek(
+    public async Task<ActionResult<UserPicksResultDto>> GetUserPicksByGroupAndWeek(
         Guid groupId,
         int week,
         [FromServices] IGetUserPicksByGroupAndWeekQueryHandler handler,

--- a/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
@@ -10,7 +10,7 @@ namespace SportsData.Api.Application.UI.Picks.Queries.GetUserPicksByGroupAndWeek
 
 public interface IGetUserPicksByGroupAndWeekQueryHandler
 {
-    Task<Result<List<UserPickDto>>> ExecuteAsync(
+    Task<Result<UserPicksResultDto>> ExecuteAsync(
         GetUserPicksByGroupAndWeekQuery query,
         CancellationToken cancellationToken = default);
 }
@@ -28,7 +28,7 @@ public class GetUserPicksByGroupAndWeekQueryHandler : IGetUserPicksByGroupAndWee
         _dataContext = dataContext;
     }
 
-    public async Task<Result<List<UserPickDto>>> ExecuteAsync(
+    public async Task<Result<UserPicksResultDto>> ExecuteAsync(
         GetUserPicksByGroupAndWeekQuery query,
         CancellationToken cancellationToken = default)
     {
@@ -54,6 +54,23 @@ public class GetUserPicksByGroupAndWeekQueryHandler : IGetUserPicksByGroupAndWee
             })
             .ToListAsync(cancellationToken);
 
-        return new Success<List<UserPickDto>>(picks);
+        // Total for the group-week (picked or not) — covered by the
+        // (GroupId, SeasonYear, SeasonWeek) index on PickemGroupMatchup.
+        // Correct/incorrect are counted from the already-materialized picks
+        // rather than issuing further queries.
+        var totalMatchups = await _dataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .CountAsync(m =>
+                m.GroupId == query.GroupId &&
+                m.SeasonWeek == query.WeekNumber,
+                cancellationToken);
+
+        return new Success<UserPicksResultDto>(new UserPicksResultDto
+        {
+            Picks = picks,
+            TotalMatchups = totalMatchups,
+            CorrectCount = picks.Count(p => p.IsCorrect == true),
+            IncorrectCount = picks.Count(p => p.IsCorrect == false)
+        });
     }
 }

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -415,12 +415,12 @@ export default function GameDetailScreen() {
   const { data: overview, isLoading: overviewLoading, error: overviewError } = useContestOverview(id, sport, league);
 
   const { data: matchupsResponse } = useMatchups(leagueId, weekNumber);
-  const { data: myPicks = [] } = usePicks(leagueId, weekNumber);
+  const { data: picksResult } = usePicks(leagueId, weekNumber);
   const submitPick = useSubmitPick();
 
   const matchup = matchupsResponse?.matchups.find((m) => m.contestId === id) ?? null;
   const pickType = matchupsResponse?.pickType ?? 'StraightUp';
-  const existingPick = myPicks.find((p) => p.contestId === id) ?? null;
+  const existingPick = picksResult?.picks.find((p) => p.contestId === id) ?? null;
 
   const matchupStatus = matchup?.status.toLowerCase();
   const kickoffMs = matchup ? new Date(matchup.startDateUtc).getTime() : NaN;

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -28,8 +28,11 @@ import { resolveSportLeague } from '@/src/utils/sportLinks';
 import { useQuery } from '@tanstack/react-query';
 import { leaguesApi } from '@/src/services/api/leaguesApi';
 import { leaguesKeys } from '../leagues';
-import type { League } from '@/src/types/models';
+import type { League, UserPick } from '@/src/types/models';
 import Toast from 'react-native-toast-message';
+
+// Stable fallback while the picks envelope loads (see usePicks call site).
+const EMPTY_PICKS: UserPick[] = [];
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
@@ -164,11 +167,14 @@ export default function PicksScreen() {
   );
 
   const {
-    data: myPicks = [],
+    data: picksResult,
     isLoading: picksLoading,
     refetch,
     isRefetching,
   } = usePicks(leagueId, selectedWeek);
+  // Stable [] fallback so downstream memos don't re-run every render while the
+  // envelope is loading.
+  const myPicks = picksResult?.picks ?? EMPTY_PICKS;
 
   const { data: matchupsResponse, isLoading: matchupsLoading } = useMatchups(
     leagueId,
@@ -205,6 +211,22 @@ export default function PicksScreen() {
   // on screen.
   const made = entries.filter((e) => e.pick !== null).length;
   const allPicked = total > 0 && made >= total;
+
+  // Ended-league header glance (X|Y|Z): counts come from the picks envelope,
+  // not client math over entries — the server owns the result semantics.
+  // X (no scored pick: unpicked + never-resolved games) is derived from the
+  // other three so the glance always sums to the week's matchup total; clamped
+  // defensively so a server miscount can't render a negative. null until the
+  // envelope loads. See docs/features/league-ended-headers.md.
+  const resultsGlance = useMemo(() => {
+    if (!isReadOnly || !picksResult) return null;
+    const { totalMatchups, correctCount, incorrectCount } = picksResult;
+    return {
+      noResult: Math.max(0, totalMatchups - correctCount - incorrectCount),
+      correct: correctCount,
+      incorrect: incorrectCount,
+    };
+  }, [isReadOnly, picksResult]);
 
   // ── Cross-league pick import ────────────────────────────────────────────────
   // Only check availability once picks + matchups have loaded and there are
@@ -361,7 +383,29 @@ export default function PicksScreen() {
               </Text>
             </View>
           ) : null}
-          {allPicked ? (
+          {isReadOnly ? (
+            // Results glance replaces pick progress: "how did I do?", not "how
+            // far along am I?". X muted | correct green | incorrect red. Slot
+            // stays empty (badges only) until the picks envelope loads.
+            resultsGlance && (
+              <Text
+                style={headerStyles.pillText}
+                accessibilityLabel={`${resultsGlance.noResult} without a result, ${resultsGlance.correct} correct, ${resultsGlance.incorrect} incorrect`}
+              >
+                <Text style={[headerStyles.pillText, { color: theme.textMuted }]}>
+                  {resultsGlance.noResult}
+                </Text>
+                <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>{' | '}</Text>
+                <Text style={[headerStyles.pillText, { color: theme.successText }]}>
+                  {resultsGlance.correct}
+                </Text>
+                <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>{' | '}</Text>
+                <Text style={[headerStyles.pillText, { color: theme.errorText }]}>
+                  {resultsGlance.incorrect}
+                </Text>
+              </Text>
+            )
+          ) : allPicked ? (
             <Text style={[headerStyles.pillText, { color: theme.tint }]}>
               All Picks Made
             </Text>
@@ -370,35 +414,33 @@ export default function PicksScreen() {
               <Text style={[headerStyles.pillText, { color: theme.tint }]}>
                 {made}/{total}
               </Text>
-              {/* Ended leagues drop the toggle: it exists to keep the screen
-                  clean while picking, which no longer applies, and the header
-                  has no room for it next to the "ENDED" badge. visibleEntries
-                  treats the filter as inactive here to match. */}
-              {!isReadOnly && (
-                <Pressable
-                  onPress={() => setHidePicked((v) => !v)}
-                  hitSlop={6}
-                  style={headerStyles.hideToggle}
-                  accessibilityRole="checkbox"
-                  accessibilityState={{ checked: hidePicked }}
-                  accessibilityLabel="Hide picked games"
-                >
-                  <Ionicons
-                    name={hidePicked ? 'checkbox' : 'square-outline'}
-                    size={18}
-                    color={hidePicked ? theme.tint : theme.textMuted}
-                  />
-                  <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
-                    {' '}Hide Picked
-                  </Text>
-                </Pressable>
-              )}
+              {/* Ended leagues never reach this branch (the glance above owns
+                  the isReadOnly slot), so Hide Picked only renders while
+                  picking — where it belongs. visibleEntries still treats the
+                  filter as inactive for read-only leagues to match. */}
+              <Pressable
+                onPress={() => setHidePicked((v) => !v)}
+                hitSlop={6}
+                style={headerStyles.hideToggle}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: hidePicked }}
+                accessibilityLabel="Hide picked games"
+              >
+                <Ionicons
+                  name={hidePicked ? 'checkbox' : 'square-outline'}
+                  size={18}
+                  color={hidePicked ? theme.tint : theme.textMuted}
+                />
+                <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>
+                  {' '}Hide Picked
+                </Text>
+              </Pressable>
             </>
           )}
         </View>
       ),
     });
-  }, [made, total, allPicked, hidePicked, theme, pickModeLabel, isReadOnly]);
+  }, [made, total, allPicked, hidePicked, theme, pickModeLabel, isReadOnly, resultsGlance]);
 
   if (meLoading) {
     return <LoadingSpinner message="Loading picks…" fullScreen />;

--- a/src/UI/sd-mobile/src/hooks/useContest.ts
+++ b/src/UI/sd-mobile/src/hooks/useContest.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { picksApi } from '@/src/services/api/picksApi';
 import { contestOverviewApi } from '@/src/services/api/contestOverviewApi';
 import { useAuthStore } from '@/src/stores/authStore';
-import type { UserPick, PickWidgetResponse, ContestOverviewDto } from '@/src/types/models';
+import type { UserPicksResult, PickWidgetResponse, ContestOverviewDto } from '@/src/types/models';
 import type { SubmitPickPayload } from '@/src/services/api/picksApi';
 
 // ─── Query key factory ────────────────────────────────────────────────────────
@@ -14,13 +14,16 @@ export const pickKeys = {
 
 // ─── Hooks ────────────────────────────────────────────────────────────────────
 
-/** Fetches the current user's picks for a given league + week. */
+/**
+ * Fetches the current user's picks for a given league + week, wrapped with
+ * server-computed result counts (see UserPicksResult).
+ */
 export function usePicks(
   leagueId: string | null | undefined,
   week: number | null | undefined,
 ) {
   const { user, isInitialized } = useAuthStore();
-  return useQuery<UserPick[]>({
+  return useQuery<UserPicksResult>({
     queryKey: pickKeys.byLeagueWeek(leagueId ?? '', week ?? 0),
     queryFn: () =>
       picksApi.getByLeagueAndWeek(leagueId!, week!).then((r) => r.data),

--- a/src/UI/sd-mobile/src/services/api/picksApi.ts
+++ b/src/UI/sd-mobile/src/services/api/picksApi.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { UserPick, PickType, PickWidgetResponse } from '@/src/types/models';
+import type { UserPicksResult, PickType, PickWidgetResponse } from '@/src/types/models';
 
 export interface SubmitPickPayload {
   pickemGroupId: string;      // leagueId
@@ -51,9 +51,10 @@ export interface PickImportResult {
 }
 
 export const picksApi = {
-  // GET /ui/picks/{leagueId}/week/{week}
+  // GET /ui/picks/{leagueId}/week/{week} — envelope of picks + result counts
+  // (was a raw UserPick[]; see docs/features/league-ended-headers.md)
   getByLeagueAndWeek: (leagueId: string, week: number) =>
-    apiClient.get<UserPick[]>(`/ui/picks/${leagueId}/week/${week}`),
+    apiClient.get<UserPicksResult>(`/ui/picks/${leagueId}/week/${week}`),
 
   // POST /ui/picks
   submitPick: (payload: SubmitPickPayload) =>

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -187,6 +187,24 @@ export interface LeagueMatchupsResponse {
 
 // ─── Picks ───────────────────────────────────────────────────────────────────
 
+/**
+ * Matches UserPicksResultDto from GET /ui/picks/{groupId}/week/{week}.
+ * Envelope over the user's picks plus server-computed result counts for the
+ * ended-league header glance (X|Y|Z). X (no scored pick) is derived:
+ * totalMatchups - correctCount - incorrectCount — the server sends the minimal
+ * orthogonal set so a redundant fourth counter can't drift out of agreement.
+ * See docs/features/league-ended-headers.md.
+ */
+export interface UserPicksResult {
+  picks: UserPick[];
+  /** All matchups in the group-week, picked or not. */
+  totalMatchups: number;
+  /** Picks with isCorrect === true. */
+  correctCount: number;
+  /** Picks with isCorrect === false. */
+  incorrectCount: number;
+}
+
 /** Matches UserPickDto from GET /ui/picks/{groupId}/week/{week} */
 export interface UserPick {
   id: string;

--- a/src/UI/sd-ui/src/components/picks/PicksPage.css
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.css
@@ -104,6 +104,40 @@
   color: var(--accent);
 }
 
+/* Ended-league results glance (X | Y | Z): replaces .pick-status-badge when the
+   league is read-only. No result muted, correct green, incorrect red — same
+   pill chrome as its siblings. */
+.pick-results-glance {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background-color: var(--active-bg);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.4;
+}
+
+.pick-results-glance .glance-none {
+  color: var(--text-secondary);
+}
+
+.pick-results-glance .glance-sep {
+  color: var(--border-strong);
+  font-weight: 400;
+}
+
+.pick-results-glance .glance-correct {
+  color: var(--success-text);
+}
+
+.pick-results-glance .glance-incorrect {
+  color: var(--error-text);
+}
+
 .pick-mode-badge {
   display: inline-flex;
   align-items: center;

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -76,6 +76,10 @@ function PicksPage() {
   // availability check so a stale pick set — e.g. the previous league, which
   // shares contest ids on same-day games — can't mis-drive the button.
   const [picksLoadedKey, setPicksLoadedKey] = useState(null);
+  // Server-computed result counts off the picks envelope (UserPicksResultDto):
+  // { totalMatchups, correctCount, incorrectCount }. Drives the ended-league
+  // header glance (X|Y|Z). null until the envelope loads.
+  const [picksSummary, setPicksSummary] = useState(null);
 
   // Update 'now' every 15 seconds to keep lock status in sync with MatchupCard
   useEffect(() => {
@@ -403,12 +407,18 @@ function PicksPage() {
         );
         if (cancelled) return;
 
+        // UserPicksResultDto envelope: picks + server-computed result counts
+        // (was a raw array; see docs/features/league-ended-headers.md).
+        const { picks, totalMatchups, correctCount, incorrectCount } =
+          response.data;
+
         const picksByContest = {};
-        for (const pick of response.data) {
+        for (const pick of picks) {
           picksByContest[pick.contestId] = pick; // Store full pick object
         }
 
         setUserPicks(picksByContest);
+        setPicksSummary({ totalMatchups, correctCount, incorrectCount });
         setPicksLoadedKey(`${routeLeagueId}:${selectedWeek}`);
       } catch (error) {
         if (cancelled) return;
@@ -797,14 +807,44 @@ function PicksPage() {
                 </span>
               );
             })()}
-            <span
-              className={`pick-status-badge${allPicked ? " complete" : ""}`}
-              title="Picks made"
-            >
-              {allPicked && "✓ "}
-              {picksMade}/{totalGames}
-            </span>
-            {!allPicked && (
+            {isReadOnly ? (
+              // Ended league: pick progress is irrelevant — show the results
+              // glance instead. X (no scored pick: unpicked + never-resolved)
+              // is derived from the server's counts so the three always sum to
+              // the week's matchup total. Empty until the envelope loads.
+              picksSummary && (
+                <span
+                  className="pick-results-glance"
+                  title="No result | Correct | Incorrect"
+                >
+                  <span className="glance-none">
+                    {Math.max(
+                      0,
+                      picksSummary.totalMatchups -
+                        picksSummary.correctCount -
+                        picksSummary.incorrectCount
+                    )}
+                  </span>
+                  <span className="glance-sep">|</span>
+                  <span className="glance-correct">
+                    {picksSummary.correctCount}
+                  </span>
+                  <span className="glance-sep">|</span>
+                  <span className="glance-incorrect">
+                    {picksSummary.incorrectCount}
+                  </span>
+                </span>
+              )
+            ) : (
+              <span
+                className={`pick-status-badge${allPicked ? " complete" : ""}`}
+                title="Picks made"
+              >
+                {allPicked && "✓ "}
+                {picksMade}/{totalGames}
+              </span>
+            )}
+            {!allPicked && !isReadOnly && (
               <button
                 type="button"
                 className={`hide-picked-toggle${hidePicked ? " active" : ""}`}

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -759,7 +759,11 @@ function PicksPage() {
   ).length;
   const allPicked = totalGames > 0 && picksMade === totalGames;
 
-  const visibleMatchups = hidePicked
+  // hidePicked is inert for read-only leagues: its toggle is suppressed there,
+  // and in an ended league every game is locked, so honoring a stale value
+  // carried over from an active league would render an empty page with no
+  // in-UI escape. Mirrors mobile's visibleEntries gating.
+  const visibleMatchups = hidePicked && !isReadOnly
     ? enrichedMatchups.filter((m) => {
         const isPicked = !!userPicks[m.contestId];
         

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -399,6 +399,10 @@ function PicksPage() {
       // refetch) thus leaves imports gated rather than evaluating against a
       // stale pick set.
       setPicksLoadedKey(null);
+      // Same treatment for the results glance: without this, switching
+      // league/week (or a failed fetch) would keep rendering the previous
+      // selection's counts against the new page.
+      setPicksSummary(null);
 
       try {
         const response = await apiWrapper.Picks.getUserPicksByWeek(

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
@@ -71,7 +71,7 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
         _userPicksQueryHandlerMock
             .Setup(x => x.ExecuteAsync(
                 It.IsAny<GetUserPicksByGroupAndWeekQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<UserPickDto>>([]));
+            .ReturnsAsync(new Success<UserPicksResultDto>(new UserPicksResultDto()));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekOverviewQueryHandler>();
         var query = new GetLeagueWeekOverviewQuery
@@ -152,7 +152,7 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
         _userPicksQueryHandlerMock
             .Setup(x => x.ExecuteAsync(
                 It.IsAny<GetUserPicksByGroupAndWeekQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<UserPickDto>>([]));
+            .ReturnsAsync(new Success<UserPicksResultDto>(new UserPicksResultDto()));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekOverviewQueryHandler>();
         var query = new GetLeagueWeekOverviewQuery
@@ -206,7 +206,7 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
         _userPicksQueryHandlerMock
             .Setup(x => x.ExecuteAsync(
                 It.IsAny<GetUserPicksByGroupAndWeekQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<UserPickDto>>([]));
+            .ReturnsAsync(new Success<UserPicksResultDto>(new UserPicksResultDto()));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekOverviewQueryHandler>();
         var query = new GetLeagueWeekOverviewQuery
@@ -251,12 +251,12 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
             .Setup(x => x.ExecuteAsync(
                 It.Is<GetUserPicksByGroupAndWeekQuery>(q => q.UserId == user1.Id && q.GroupId == league.Id && q.WeekNumber == 5),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<UserPickDto>>(user1Picks));
+            .ReturnsAsync(new Success<UserPicksResultDto>(new UserPicksResultDto { Picks = user1Picks }));
         _userPicksQueryHandlerMock
             .Setup(x => x.ExecuteAsync(
                 It.Is<GetUserPicksByGroupAndWeekQuery>(q => q.UserId == user2.Id && q.GroupId == league.Id && q.WeekNumber == 5),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Success<List<UserPickDto>>(user2Picks));
+            .ReturnsAsync(new Success<UserPicksResultDto>(new UserPicksResultDto { Picks = user2Picks }));
 
         var handler = Mocker.CreateInstance<GetLeagueWeekOverviewQueryHandler>();
         var query = new GetLeagueWeekOverviewQuery

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
@@ -75,7 +75,8 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         await DataContext.UserPicks.AddAsync(pick);
 
         // The matchup the pick belongs to — a pick without its matchup is an
-        // impossible state, and TotalMatchups should reflect it.
+        // impossible state, and TotalMatchups should reflect it. Fixed instant:
+        // the handler never consumes time, so seed timestamps are inert.
         await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
         {
             Id = Guid.NewGuid(),
@@ -84,7 +85,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
             SeasonYear = 2025,
             SeasonWeek = 5,
             SeasonWeekId = Guid.NewGuid(),
-            StartDateUtc = DateTime.UtcNow
+            StartDateUtc = new DateTime(2025, 10, 4, 12, 0, 0, DateTimeKind.Utc)
         });
         await DataContext.SaveChangesAsync();
 
@@ -253,6 +254,9 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         var userId = Guid.NewGuid();
         var groupId = Guid.NewGuid();
         const int week = 5;
+        // Fixed instant: the handler never consumes time, so seed timestamps are
+        // inert — a literal keeps the fixture fully deterministic.
+        var seededUtc = new DateTime(2025, 10, 4, 12, 0, 0, DateTimeKind.Utc);
 
         var user = new UserEntity
         {
@@ -262,7 +266,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
             Email = "test@test.com",
             DisplayName = "Test User",
             SignInProvider = "test",
-            LastLoginUtc = DateTime.UtcNow
+            LastLoginUtc = seededUtc
         };
         await DataContext.Users.AddAsync(user);
 
@@ -277,7 +281,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
                 SeasonYear = 2025,
                 SeasonWeek = week,
                 SeasonWeekId = Guid.NewGuid(),
-                StartDateUtc = DateTime.UtcNow
+                StartDateUtc = seededUtc
             });
         }
 
@@ -290,7 +294,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
             SeasonYear = 2025,
             SeasonWeek = week + 1,
             SeasonWeekId = Guid.NewGuid(),
-            StartDateUtc = DateTime.UtcNow
+            StartDateUtc = seededUtc
         });
 
         bool?[] outcomes = [true, true, false, null]; // contestIds[4] stays unpicked

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
@@ -31,7 +31,10 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeEmpty();
+        result.Value.Picks.Should().BeEmpty();
+        result.Value.TotalMatchups.Should().Be(0);
+        result.Value.CorrectCount.Should().Be(0);
+        result.Value.IncorrectCount.Should().Be(0);
     }
 
     [Fact]
@@ -85,14 +88,16 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().HaveCount(1);
-        result.Value[0].UserId.Should().Be(userId);
-        result.Value[0].ContestId.Should().Be(contestId);
-        result.Value[0].FranchiseSeasonId.Should().Be(franchiseSeasonId);
-        result.Value[0].PickType.Should().Be(PickType.StraightUp);
-        result.Value[0].ConfidencePoints.Should().Be(7);
-        result.Value[0].IsCorrect.Should().BeTrue();
-        result.Value[0].PointsAwarded.Should().Be(7);
+        result.Value.Picks.Should().HaveCount(1);
+        result.Value.Picks[0].UserId.Should().Be(userId);
+        result.Value.Picks[0].ContestId.Should().Be(contestId);
+        result.Value.Picks[0].FranchiseSeasonId.Should().Be(franchiseSeasonId);
+        result.Value.Picks[0].PickType.Should().Be(PickType.StraightUp);
+        result.Value.Picks[0].ConfidencePoints.Should().Be(7);
+        result.Value.Picks[0].IsCorrect.Should().BeTrue();
+        result.Value.Picks[0].PointsAwarded.Should().Be(7);
+        result.Value.CorrectCount.Should().Be(1);
+        result.Value.IncorrectCount.Should().Be(0);
     }
 
     [Fact]
@@ -150,8 +155,8 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().HaveCount(1);
-        result.Value[0].ContestId.Should().Be(pick1.ContestId);
+        result.Value.Picks.Should().HaveCount(1);
+        result.Value.Picks[0].ContestId.Should().Be(pick1.ContestId);
     }
 
     [Fact]
@@ -220,7 +225,93 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().HaveCount(1);
-        result.Value[0].UserId.Should().Be(userId1);
+        result.Value.Picks.Should().HaveCount(1);
+        result.Value.Picks[0].UserId.Should().Be(userId1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldComputeResultCounts_AcrossPickOutcomes()
+    {
+        // Arrange — 5 matchups in the group-week: 2 correct picks, 1 incorrect,
+        // 1 picked-but-never-resolved (IsCorrect null), 1 unpicked. The client
+        // derives X (no scored pick) = TotalMatchups - Correct - Incorrect = 2,
+        // covering both the unpicked and the never-resolved game.
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        const int week = 5;
+
+        var user = new UserEntity
+        {
+            Username = "test_user_19",
+            Id = userId,
+            FirebaseUid = Guid.NewGuid().ToString(),
+            Email = "test@test.com",
+            DisplayName = "Test User",
+            SignInProvider = "test",
+            LastLoginUtc = DateTime.UtcNow
+        };
+        await DataContext.Users.AddAsync(user);
+
+        var contestIds = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToArray();
+        foreach (var contestId in contestIds)
+        {
+            await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                ContestId = contestId,
+                SeasonYear = 2025,
+                SeasonWeek = week,
+                SeasonWeekId = Guid.NewGuid(),
+                StartDateUtc = DateTime.UtcNow
+            });
+        }
+
+        // A matchup for another week must not inflate TotalMatchups.
+        await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            ContestId = Guid.NewGuid(),
+            SeasonYear = 2025,
+            SeasonWeek = week + 1,
+            SeasonWeekId = Guid.NewGuid(),
+            StartDateUtc = DateTime.UtcNow
+        });
+
+        bool?[] outcomes = [true, true, false, null]; // contestIds[4] stays unpicked
+        for (var i = 0; i < outcomes.Length; i++)
+        {
+            await DataContext.UserPicks.AddAsync(new PickemGroupUserPick
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                PickemGroupId = groupId,
+                ContestId = contestIds[i],
+                Week = week,
+                PickType = PickType.StraightUp,
+                IsCorrect = outcomes[i],
+                TiebreakerType = TiebreakerType.TotalPoints
+            });
+        }
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
+        var query = new GetUserPicksByGroupAndWeekQuery
+        {
+            UserId = userId,
+            GroupId = groupId,
+            WeekNumber = week
+        };
+
+        // Act
+        var result = await handler.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Picks.Should().HaveCount(4);
+        result.Value.TotalMatchups.Should().Be(5);
+        result.Value.CorrectCount.Should().Be(2);
+        result.Value.IncorrectCount.Should().Be(1);
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
@@ -73,6 +73,19 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
             TiebreakerType = TiebreakerType.TotalPoints
         };
         await DataContext.UserPicks.AddAsync(pick);
+
+        // The matchup the pick belongs to — a pick without its matchup is an
+        // impossible state, and TotalMatchups should reflect it.
+        await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            ContestId = contestId,
+            SeasonYear = 2025,
+            SeasonWeek = 5,
+            SeasonWeekId = Guid.NewGuid(),
+            StartDateUtc = DateTime.UtcNow
+        });
         await DataContext.SaveChangesAsync();
 
         var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
@@ -98,6 +111,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         result.Value.Picks[0].PointsAwarded.Should().Be(7);
         result.Value.CorrectCount.Should().Be(1);
         result.Value.IncorrectCount.Should().Be(0);
+        result.Value.TotalMatchups.Should().Be(1);
     }
 
     [Fact]


### PR DESCRIPTION
Design doc: `docs/features/league-ended-headers.md` (included in this PR)

## Problem

For an ended league the picks header showed pick progress — "All Picks Made" on one league, "24/46" on another. Progress is irrelevant once the league is over; the user's question is "how did I do?", not "how far along am I?".

## Change

The progress slot in the picks header (mobile and web) is replaced, **for ended leagues only**, with a results glance:

```
X | Y | Z      (no scored pick | correct | incorrect)
```

muted / green / red, with the invariant **X + Y + Z = the week's matchup total**. Never-resolved picks (canceled games) fold into X rather than counting as incorrect. Active leagues are unchanged.

## API: envelope instead of a raw array

`GET /ui/picks/{groupId}/week/{week}` returned a raw `List<UserPickDto>`. A bare array's top level is fully spoken for — there was nowhere to put the counts without a breaking shape change, so this PR pays that break once (beta scale) and moves the endpoint to:

```json
{
  "picks": [ ...UserPickDto... ],
  "totalMatchups": 5,
  "correctCount": 2,
  "incorrectCount": 1
}
```

- X is **derived** (`totalMatchups − correct − incorrect`) — the server sends the minimal orthogonal set so a redundant fourth counter can't drift out of agreement.
- `TotalMatchups` is one indexed `CountAsync` on `PickemGroupMatchup`, covered by the existing `(GroupId, SeasonYear, SeasonWeek)` index. Correct/incorrect are counted from the already-materialized picks — no extra queries.
- The handler flows through the existing `Result<T>` → `ToActionResult()` mapping. No new envelope machinery; the deferred global `Response<T>` initiative is untouched.
- `GetLeagueWeekOverviewQueryHandler` (internal reuse of the picks handler) reads `.Picks` — its own DTO is unchanged.

## Breaking change / rollout

Coordinated break, per the design doc:

1. Merge → API + web deploy together (web parses the new shape in this PR, so there is no broken window on web).
2. **Publish the EAS update immediately after deploy.** Installed mobile builds are broken on the picks page until they pull the OTA update — accepted at beta scale.

## Clients

- **Mobile**: `usePicks` retyped to the envelope; `picks.tsx` and `game/[id].tsx` read `.picks`; ended-league header renders the glance from server counts (slot stays empty until the envelope loads). The now-dead `!isReadOnly` wrapper around Hide Picked was removed — the glance owns the read-only slot, so that branch only renders while picking.
- **Web**: `PicksPage.jsx` parses the envelope and renders the same glance as a pill matching its badge row; Hide Picked is now suppressed for ended leagues (web still showed it there).

## Verification

- **API**: build clean. Affected unit suites 11/11, including a new bucket-mix test — 5 matchups: 2 correct, 1 incorrect, 1 picked-but-never-resolved, 1 unpicked → `TotalMatchups=5, Correct=2, Incorrect=1` (X derives to 2), plus a week-boundary guard proving the count doesn't leak across weeks. Full API unit run 550/551 — the 1 failure is the pre-existing `DisplayNameGenerator` random-collision flake (passes on rerun), unrelated to this change.
- **Mobile**: `tsc --noEmit` clean; jest 12 suites / 84 tests pass.
- **Web**: `eslint --max-warnings=0` clean; vitest 3 files / 10 tests pass.
- **Local E2E**: validated against a live ended league (glance renders, sums to the week's game count; active leagues unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ended-league “results glance” in the picks header (unresolved | correct | incorrect).
  * Updated the picks API response to include server-computed weekly matchup totals and outcome counts.
  * Preserved existing pick-progress behavior for active leagues.
* **Bug Fixes**
  * Improved loading/empty-state handling for picks on mobile and web read-only views.
  * Ensured “hide picked” behavior and header controls remain correct for ended leagues.
  * Added/updated tests to verify count computation across correct, incorrect, and never-resolved outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->