### PR TITLE
feat(mobile,web): Play Store submission prep — Android push prompt, legal pages, 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -436,3 +436,8 @@ Desktop.ini
 
 # Bruno secret environment files
 bruno/**/.env
+
+# sd-mobile local artifacts (build output, test reports) — never commit
+src/UI/sd-mobile/dist/
+src/UI/sd-mobile/coverage/
+src/UI/sd-mobile/junit.xml

--- a/docs/mobile/pre-submission-review-2026-07.md
+++ b/docs/mobile/pre-submission-review-2026-07.md
@@ -55,11 +55,12 @@ activity (own API).
 
 ### 1.4 Play account-deletion web requirement
 
-In-app deletion exists (`profile.tsx` → `usersApi.deleteAccount`) — the hard
-part is done. Play additionally requires a **web URL** for account deletion in
-the Data Safety section (users who uninstalled must be able to request
-deletion without reinstalling). Ensure sportdeets.com has (or gets) that page
-before filling in the form.
+PARTIALLY RESOLVED 2026-07-27: in-app deletion already existed (`profile.tsx`
+→ `usersApi.deleteAccount`), and the public web page Play requires now exists
+at `/account-deletion` in sd-ui (built alongside this review; describes the
+verified anonymize-and-retain handler behavior). REMAINING: deploy sd-ui and
+submit `https://www.sportdeets.com/account-deletion` in the Play Console Data
+Safety form.
 
 ## 2. Security
 
@@ -182,12 +183,16 @@ it's a real utility (nvm-pinned clean reinstall), not cruft.
   accounts; if the account is a business/org account this may not apply —
   check which rules bind before planning the timeline.
 
-## Suggested order of attack
+## Remaining work
 
-1. Remove TEMP diagnostics once deep-link confirmed on device (1.1)
-2. Settle version identity (1.2) — one-line decisions, do before first build
-3. Drop email from Sentry.setUser (1.3)
-4. Account-deletion web URL + Data Safety form (1.4)
-5. Decide Android notification prompt strategy (§5)
-6. `UserPick` index signature + gitignore/cruft (4.2, 4.5)
-7. Backlog: SecureStore persistence, SignalR groups, screen tests, expo-image
+All pre-build code items (1.1–1.3, 4.2, 4.5, and the §5 Android prompt) are
+RESOLVED — see their sections. What's left:
+
+1. Deploy sd-ui, then submit `https://www.sportdeets.com/account-deletion`
+   and the privacy-policy URL in the Play Console Data Safety form (1.4)
+2. Post-build fresh-install device pass: Android permission prompt at
+   sign-in, corrected launcher icon, league-invite deep link (§5)
+3. Verify which closed-testing tester rules bind this Play account (§5)
+4. Backlog (deliberately deferred): SecureStore persistence (2.1),
+   league-invite join semantics decision (2.2), SignalR groups (3.1),
+   screen tests (4.4), `as never` sweep (4.3), expo-image (3.3)

--- a/docs/mobile/pre-submission-review-2026-07.md
+++ b/docs/mobile/pre-submission-review-2026-07.md
@@ -23,12 +23,14 @@ level. The items below are ordered by how much they matter.
 ## 1. Before the store build
 
 ### 1.1 TEMP push diagnostics still ship (app/_layout.tsx)
+
 RESOLVED 2026-07-27: all three `(diag)` Sentry captures removed after the
 deep-link was confirmed end-to-end on iOS and Android. The privacy-safe
 `[push] tapped` / `[push] received` console breadcrumbs were kept — they're
 deliberate crash context (documented in-file), not TEMP.
 
 ### 1.2 Version identity is split
+
 RESOLVED 2026-07-27: launch version decided as **1.0.0** — app.json and
 package.json both bumped ahead of the closed-testing build. The inert
 `android.versionCode` / `ios.buildNumber` were deleted from app.json (EAS
@@ -38,6 +40,7 @@ updates published for 1.0.0 — expected and correct; testers move to the new
 build.
 
 ### 1.3 Sentry user email → Play Data Safety form
+
 RESOLVED 2026-07-27: `Sentry.setUser` now sends uid only — email dropped.
 Crash correlation still works via uid; the Data Safety declaration for Sentry
 simplifies to identifiers + diagnostics. NOTE: the Privacy Policy's crash-report
@@ -51,6 +54,7 @@ crash/error telemetry (Sentry), notification preferences, picks/league
 activity (own API).
 
 ### 1.4 Play account-deletion web requirement
+
 In-app deletion exists (`profile.tsx` → `usersApi.deleteAccount`) — the hard
 part is done. Play additionally requires a **web URL** for account deletion in
 the Data Safety section (users who uninstalled must be able to request
@@ -60,6 +64,7 @@ before filling in the form.
 ## 2. Security
 
 ### 2.1 Auth session in plaintext AsyncStorage (accepted risk — document it)
+
 `initializeAuth(app, { persistence: getReactNativePersistence(AsyncStorage) })`
 stores the Firebase session — including the refresh token — unencrypted in
 AsyncStorage. This is the documented Firebase-JS-SDK-on-RN pattern and the
@@ -70,6 +75,7 @@ AsyncStorage payload encrypted with a SecureStore-held key). Reasonable to
 accept as-is for launch; worth a backlog entry rather than silence.
 
 ### 2.2 league-invite join semantics (server-side question, not a mobile bug)
+
 The deep-link screen validates the GUID shape client-side and treats
 possession of a `leagueId` as sufficient to render Join. That makes the
 leagueId a capability token: anyone authenticated who obtains a private
@@ -79,6 +85,7 @@ that's worth a deliberate decision before growth. GUIDs are unguessable in
 practice; they do leak via screenshots/shares.
 
 ### 2.3 Clean findings (no action)
+
 - No secrets in the repo: `.env.local` untracked; `eas.json` env values are
   all `EXPO_PUBLIC_*` (client-shipped by definition); `google-services.json` /
   `GoogleService-Info.plist` tracked, which Google explicitly permits.
@@ -94,6 +101,7 @@ practice; they do leak via screenshots/shares.
 ## 3. Performance
 
 ### 3.1 SignalR receives all live traffic for all users (BE-shaped, note only)
+
 The hub subscription is app-wide: every authed client receives every
 `FootballPlayCompleted` / `BaseballPlayCompleted` for every live contest,
 whether or not the user views any of them. The mobile side is defensively
@@ -105,12 +113,14 @@ play-by-play), per-contest/per-league SignalR groups server-side is the lever.
 Backend work; parked.
 
 ### 3.2 Poll + push overlap on the game screen
+
 `useContestOverview` polls every 30s while mounted, and SignalR pushes the
 same game's plays. Redundant but bounded, and the poll covers reconnect gaps —
 acceptable. If battery complaints surface, gate the poll on
 `status !== live || signalR disconnected`.
 
 ### 3.3 Clean findings (no action)
+
 - Long lists (`picks`, `standings`) use `FlatList`; the `ScrollView`+`.map`
   screens (welcome, create-league, settings, leagues grid, game box score)
   all render bounded content.
@@ -125,21 +135,25 @@ acceptable. If battery complaints surface, gate the poll on
 ## 4. Structural / best practices
 
 ### 4.1 Dual Firebase stacks — sound, keep documented
+
 Firebase JS SDK for auth + `@react-native-firebase` for messaging is a
 deliberate hybrid (JS SDK has no FCM path on iOS; RNFB handles APNs→FCM).
 The rationale comment in `pushNotifications.ts` is exactly the documentation
 future-you needs. No change; just don't let a third Firebase surface creep in.
 
 ### 4.2 `UserPick`'s index signature undermines strict mode
+
 RESOLVED 2026-07-27: removed. Zero fallout — `tsc --noEmit` clean on first
 run, confirming the hole was load-bearing for nothing.
 
 ### 4.3 21 `as never` router casts
+
 All are the documented typed-routes generator gap. After the next
 `expo start` regenerates `.expo/types`, sweep how many still need the cast —
 each one is a spot where a route rename breaks silently.
 
 ### 4.4 Test suite shape
+
 84 tests, all hooks/lib/api — zero component/screen tests. The money paths
 with real regression history (picks header state machine, DateField platform
 branches, AuthGuard redirects, deep-link flush guards) are exactly the
@@ -148,6 +162,7 @@ Even 3–4 screen tests on picks + sign-in would catch the class of bug this
 review keeps finding fixed-by-hand.
 
 ### 4.5 Local cruft
+
 RESOLVED 2026-07-27: logs deleted; `dist/`, `coverage/`, `junit.xml` added to
 the repo-root `.gitignore` under an sd-mobile section. `reinstall.ps1` kept —
 it's a real utility (nvm-pinned clean reinstall), not cruft.

--- a/docs/mobile/pre-submission-review-2026-07.md
+++ b/docs/mobile/pre-submission-review-2026-07.md
@@ -1,0 +1,174 @@
+# sd-mobile Pre-Submission Review — 2026-07-27
+
+Scope: full review of `src/UI/sd-mobile` (~15k LOC, 90 source files) ahead of
+Play Store submission and closed testing. Lenses: structural, best practices,
+security, performance. Every claim below was verified against the code, not
+inferred.
+
+## Verdict
+
+The codebase is in genuinely good shape — notably strong for a solo project.
+Standouts: the auth/session bootstrap (`firebase.ts` platform-split with
+explicit failure semantics), sign-out sequencing (device unregister →
+`signOut` → `queryClient.clear()` to prevent cross-account cache leakage),
+the push cold-start race handling in `_layout.tsx`, single-flight installation
+ID minting, and OTA apply-on-return policy. TypeScript `strict` is on and only
+5 `any`s exist in app code. Nothing here is submission-blocking at the code
+level. The items below are ordered by how much they matter.
+
+## 1. Before the store build
+
+### 1.1 TEMP push diagnostics still ship (app/_layout.tsx)
+RESOLVED 2026-07-27: all three `(diag)` Sentry captures removed after the
+deep-link was confirmed end-to-end on iOS and Android. The privacy-safe
+`[push] tapped` / `[push] received` console breadcrumbs were kept — they're
+deliberate crash context (documented in-file), not TEMP.
+
+### 1.2 Version identity is split
+RESOLVED 2026-07-27: launch version decided as **1.0.0** — app.json and
+package.json both bumped ahead of the closed-testing build. The inert
+`android.versionCode` / `ios.buildNumber` were deleted from app.json (EAS
+remote versioning owns them). Note for the future: `runtimeVersion.policy:
+"appVersion"` means installed 0.1.0 preview builds no longer receive OTA
+updates published for 1.0.0 — expected and correct; testers move to the new
+build.
+
+### 1.3 Sentry user email → Play Data Safety form
+RESOLVED 2026-07-27: `Sentry.setUser` now sends uid only — email dropped.
+Crash correlation still works via uid; the Data Safety declaration for Sentry
+simplifies to identifiers + diagnostics. NOTE: the Privacy Policy's crash-report
+paragraph still says reports "may include your user identifier and email" —
+now over-declares; safe direction, but can be tightened at the next policy
+edit.
+
+Data the app demonstrably sends off-device (for the form): Firebase auth
+identity (email/display name), FCM token + installation UUID (own API),
+crash/error telemetry (Sentry), notification preferences, picks/league
+activity (own API).
+
+### 1.4 Play account-deletion web requirement
+In-app deletion exists (`profile.tsx` → `usersApi.deleteAccount`) — the hard
+part is done. Play additionally requires a **web URL** for account deletion in
+the Data Safety section (users who uninstalled must be able to request
+deletion without reinstalling). Ensure sportdeets.com has (or gets) that page
+before filling in the form.
+
+## 2. Security
+
+### 2.1 Auth session in plaintext AsyncStorage (accepted risk — document it)
+`initializeAuth(app, { persistence: getReactNativePersistence(AsyncStorage) })`
+stores the Firebase session — including the refresh token — unencrypted in
+AsyncStorage. This is the documented Firebase-JS-SDK-on-RN pattern and the
+practical risk requires a compromised/rooted device, but `expo-secure-store`
+is the stricter home for token material. A custom `Persistence` adapter over
+SecureStore is possible (mind its ~2KB value limit — the common pattern is an
+AsyncStorage payload encrypted with a SecureStore-held key). Reasonable to
+accept as-is for launch; worth a backlog entry rather than silence.
+
+### 2.2 league-invite join semantics (server-side question, not a mobile bug)
+The deep-link screen validates the GUID shape client-side and treats
+possession of a `leagueId` as sufficient to render Join. That makes the
+leagueId a capability token: anyone authenticated who obtains a private
+league's GUID can join it (mobile never sees an invite nonce). If
+`POST joinLeague` doesn't distinguish invited-vs-uninvited users server-side,
+that's worth a deliberate decision before growth. GUIDs are unguessable in
+practice; they do leak via screenshots/shares.
+
+### 2.3 Clean findings (no action)
+- No secrets in the repo: `.env.local` untracked; `eas.json` env values are
+  all `EXPO_PUBLIC_*` (client-shipped by definition); `google-services.json` /
+  `GoogleService-Info.plist` tracked, which Google explicitly permits.
+- HTTPS everywhere in release (EAS env pins `https://api.sportdeets.com`;
+  Android blocks cleartext by default).
+- `admin/push-token` screen is defense-in-depth gated on `me.isAdmin` despite
+  also being link-gated — right convention.
+- Sign-out clears Google session, unregisters the device, and purges the
+  query cache. No cross-account leak path found.
+- Console logging is disciplined (26 call sites, none logging tokens or PII;
+  the push handlers explicitly log only non-content fields).
+
+## 3. Performance
+
+### 3.1 SignalR receives all live traffic for all users (BE-shaped, note only)
+The hub subscription is app-wide: every authed client receives every
+`FootballPlayCompleted` / `BaseballPlayCompleted` for every live contest,
+whether or not the user views any of them. The mobile side is defensively
+built — foreground-only connection (AppState stop/start), per-contest
+selector (`useContestUpdate`) so only affected `MatchupCard`s re-render — so
+the client cost is store writes, radio wake-ups, and payload parse. Fine at
+beta scale; at football-Saturday scale (dozens of concurrent games ×
+play-by-play), per-contest/per-league SignalR groups server-side is the lever.
+Backend work; parked.
+
+### 3.2 Poll + push overlap on the game screen
+`useContestOverview` polls every 30s while mounted, and SignalR pushes the
+same game's plays. Redundant but bounded, and the poll covers reconnect gaps —
+acceptable. If battery complaints surface, gate the poll on
+`status !== live || signalR disconnected`.
+
+### 3.3 Clean findings (no action)
+- Long lists (`picks`, `standings`) use `FlatList`; the `ScrollView`+`.map`
+  screens (welcome, create-league, settings, leagues grid, game box score)
+  all render bounded content.
+- No polling loops beyond the two above (the countdown ticks hourly).
+- React Query defaults are sane (5m stale / 30m gc, no focus refetch on
+  mobile, 401s never retried).
+- Zustand store handlers replace only the affected contest record; selector
+  equality keeps the blast radius to that contest's card.
+- Optional: team/league logos render via RN `Image`; `expo-image` would add
+  proper disk caching for the repeated-logo case. Cosmetic-level win.
+
+## 4. Structural / best practices
+
+### 4.1 Dual Firebase stacks — sound, keep documented
+Firebase JS SDK for auth + `@react-native-firebase` for messaging is a
+deliberate hybrid (JS SDK has no FCM path on iOS; RNFB handles APNs→FCM).
+The rationale comment in `pushNotifications.ts` is exactly the documentation
+future-you needs. No change; just don't let a third Firebase surface creep in.
+
+### 4.2 `UserPick`'s index signature undermines strict mode
+RESOLVED 2026-07-27: removed. Zero fallout — `tsc --noEmit` clean on first
+run, confirming the hole was load-bearing for nothing.
+
+### 4.3 21 `as never` router casts
+All are the documented typed-routes generator gap. After the next
+`expo start` regenerates `.expo/types`, sweep how many still need the cast —
+each one is a spot where a route rename breaks silently.
+
+### 4.4 Test suite shape
+84 tests, all hooks/lib/api — zero component/screen tests. The money paths
+with real regression history (picks header state machine, DateField platform
+branches, AuthGuard redirects, deep-link flush guards) are exactly the
+untested ones. `@testing-library/react-native` is already a devDependency.
+Even 3–4 screen tests on picks + sign-in would catch the class of bug this
+review keeps finding fixed-by-hand.
+
+### 4.5 Local cruft
+RESOLVED 2026-07-27: logs deleted; `dist/`, `coverage/`, `junit.xml` added to
+the repo-root `.gitignore` under an sd-mobile section. `reinstall.ps1` kept —
+it's a real utility (nvm-pinned clean reinstall), not cruft.
+
+## 5. Android-specific submission notes
+
+- **POST_NOTIFICATIONS (Android 13+)**: RESOLVED 2026-07-27. Confirmed on the
+  founder's own device — the silent-only registration meant an Android install
+  received zero pushes until the settings screen's manual action was found.
+  `useRegisterPushDevice` now prompts ONCE on Android at the first
+  authenticated attempt (AsyncStorage `push-permission-prompted` marker); a
+  denial is respected and the settings action remains the re-ask path. iOS
+  stays fully silent by design.
+- `predictiveBackGestureEnabled: false` — deliberate, fine for now; Google is
+  pushing this toward default-on, revisit post-launch.
+- Closed testing: Google requires 12+ testers for 14 days for new personal
+  accounts; if the account is a business/org account this may not apply —
+  check which rules bind before planning the timeline.
+
+## Suggested order of attack
+
+1. Remove TEMP diagnostics once deep-link confirmed on device (1.1)
+2. Settle version identity (1.2) — one-line decisions, do before first build
+3. Drop email from Sentry.setUser (1.3)
+4. Account-deletion web URL + Data Safety form (1.4)
+5. Decide Android notification prompt strategy (§5)
+6. `UserPick` index signature + gitignore/cruft (4.2, 4.5)
+7. Backlog: SecureStore persistence, SignalR groups, screen tests, expo-image

--- a/docs/mobile/pre-submission-review-2026-07.md
+++ b/docs/mobile/pre-submission-review-2026-07.md
@@ -2,8 +2,12 @@
 
 Scope: full review of `src/UI/sd-mobile` (~15k LOC, 90 source files) ahead of
 Play Store submission and closed testing. Lenses: structural, best practices,
-security, performance. Every claim below was verified against the code, not
-inferred.
+security, performance. Code-level findings were verified against the source,
+not inferred. Store-policy and operational statements (Google Play / App Store
+requirements, e.g. the closed-testing tester rule in §5) reflect published
+policies as understood at the time of writing and are NOT code-verifiable —
+confirm current requirements in the Play Console / App Store Connect when
+acting on them.
 
 ## Verdict
 

--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "SportDeets",
     "slug": "sportdeets",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "sportdeets",
@@ -22,8 +22,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "UIRequiresFullScreen": true
-      },
-      "buildNumber": "34"
+      }
     },
     "android": {
       "package": "com.sportdeets.mobile",
@@ -33,8 +32,7 @@
         "foregroundImage": "./assets/images/android-icon-foreground.png",
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
-      "predictiveBackGestureEnabled": false,
-      "versionCode": 2
+      "predictiveBackGestureEnabled": false
     },
     "web": {
       "bundler": "metro",

--- a/src/UI/sd-mobile/app/(auth)/welcome.tsx
+++ b/src/UI/sd-mobile/app/(auth)/welcome.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import { Text } from '@/src/components/ui/AppText';
 import { Wordmark } from '@/src/components/brand/Wordmark';
 import { Button } from '@/src/components/ui/Button';
@@ -116,6 +117,29 @@ export default function WelcomeScreen() {
               <Text style={[styles.signInLinkAccent, { color: theme.tint }]}>Sign in</Text>
             </Text>
           </TouchableOpacity>
+          {/* Clickwrap notice. The web pages are canonical; nested Text
+              onPress keeps the tap targets inline with the sentence. */}
+          <Text style={[styles.legalText, { color: theme.textMuted }]}>
+            By continuing, you agree to our{' '}
+            <Text
+              style={[styles.legalLink, { color: theme.tint }]}
+              onPress={() =>
+                void WebBrowser.openBrowserAsync('https://www.sportdeets.com/terms')
+              }
+            >
+              Terms of Service
+            </Text>{' '}
+            and{' '}
+            <Text
+              style={[styles.legalLink, { color: theme.tint }]}
+              onPress={() =>
+                void WebBrowser.openBrowserAsync('https://www.sportdeets.com/privacy')
+              }
+            >
+              Privacy Policy
+            </Text>
+            .
+          </Text>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -187,5 +211,14 @@ const styles = StyleSheet.create({
   },
   signInLinkAccent: {
     fontWeight: '700',
+  },
+  legalText: {
+    fontSize: 12,
+    lineHeight: 17,
+    textAlign: 'center',
+    paddingHorizontal: 16,
+  },
+  legalLink: {
+    fontWeight: '600',
   },
 });

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -9,6 +9,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { signOut } from 'firebase/auth';
+import * as WebBrowser from 'expo-web-browser';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { signOutGoogle } from '@/src/lib/googleSignIn';
@@ -443,6 +444,22 @@ export default function ProfileScreen() {
         <SettingsRow label="Notifications" onPress={() => router.push('/settings/notifications')} />
         <SettingsRow label="Sign Out" onPress={handleSignOut} destructive />
         <SettingsRow label="Delete Account" onPress={handleDeleteAccount} destructive />
+      </View>
+
+      {/* Legal — both stores require the privacy policy to be reachable from
+          WITHIN the app (Google User Data policy; Apple 5.1.1), not just the
+          store listing. The web pages are the single source of truth; open
+          them in the in-app browser rather than duplicating content. */}
+      <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>About</Text>
+        <SettingsRow
+          label="Terms of Service"
+          onPress={() => void WebBrowser.openBrowserAsync('https://www.sportdeets.com/terms')}
+        />
+        <SettingsRow
+          label="Privacy Policy"
+          onPress={() => void WebBrowser.openBrowserAsync('https://www.sportdeets.com/privacy')}
+        />
       </View>
 
       {/* Developer — admin-only diagnostics. Gated on isAdmin so it

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -20,7 +20,7 @@ import * as Notifications from 'expo-notifications';
 // no web implementation).
 import { type FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import { useEffect, useRef, useState } from 'react';
-import { AppState, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react-native';
 import 'react-native-reanimated';
@@ -126,7 +126,11 @@ function RootLayout() {
   const { user } = useAuth();
   useEffect(() => {
     if (user) {
-      Sentry.setUser({ id: user.uid, email: user.email ?? undefined });
+      // uid only — deliberately NOT email. The uid correlates a crash with an
+      // account when investigating; email would put PII in a third party
+      // (Sentry) and expand the Play Data Safety declaration for no
+      // diagnostic gain.
+      Sentry.setUser({ id: user.uid });
     } else {
       Sentry.setUser(null);
     }
@@ -217,23 +221,6 @@ function NativePushDiagnostics() {
         actionIdentifier: response.actionIdentifier,
       });
 
-      // TEMP diagnostic — remove once the deep-link is confirmed. Store builds
-      // have no console, so surface what the payload actually contains on-device
-      // (which keys arrived, whether `kind`/`leagueId` are present, app state)
-      // to Sentry. leagueId is a non-sensitive GUID; title/body are not captured.
-      Sentry.captureMessage('[push] tapped (diag)', {
-        level: 'info',
-        tags: { pushKind: String(data.kind ?? 'none') },
-        extra: {
-          dataKeys: Object.keys(data),
-          kind: data.kind ?? null,
-          hasLeagueId: typeof data.leagueId === 'string',
-          leagueId: typeof data.leagueId === 'string' ? data.leagueId : null,
-          actionIdentifier: response.actionIdentifier,
-          appState: AppState.currentState,
-        },
-      });
-
       // Deep-link dispatch. Stash the target; the auth-gated effect below
       // navigates once the router/auth tree is ready.
       const inviteLeagueId = getLeagueInviteId(data);
@@ -269,22 +256,9 @@ function NativePushDiagnostics() {
 
     const handleOpen = (
       remoteMessage: FirebaseMessagingTypes.RemoteMessage | null,
-      source: string,
     ) => {
       if (!remoteMessage) return;
-      const data = remoteMessage.data ?? {};
-      // TEMP diagnostic — remove with the expo one once confirmed. Shows what
-      // RNFirebase actually delivered vs. expo's empty content.data.
-      Sentry.captureMessage('[push] rnfb open (diag)', {
-        level: 'info',
-        tags: { source },
-        extra: {
-          dataKeys: Object.keys(data),
-          kind: typeof data.kind === 'string' ? data.kind : null,
-          hasLeagueId: typeof data.leagueId === 'string',
-        },
-      });
-      const inviteLeagueId = getLeagueInviteId(data);
+      const inviteLeagueId = getLeagueInviteId(remoteMessage.data ?? {});
       if (inviteLeagueId) setPendingLeagueId(inviteLeagueId);
     };
 
@@ -298,11 +272,11 @@ function NativePushDiagnostics() {
         const messaging = (await import('@react-native-firebase/messaging')).default;
         if (cancelled) return;
         // Tap while the app is backgrounded.
-        unsubscribe = messaging().onNotificationOpenedApp((m) => handleOpen(m, 'background'));
+        unsubscribe = messaging().onNotificationOpenedApp(handleOpen);
         // Tap that cold-started the app from a quit state.
         const initial = await messaging().getInitialNotification();
         if (cancelled) return;
-        handleOpen(initial, 'quit');
+        handleOpen(initial);
       } catch (e) {
         // Don't leave the import/native calls as an unhandled rejection.
         Sentry.captureException(e);
@@ -324,19 +298,6 @@ function NativePushDiagnostics() {
   // has settled. Keep pendingLeagueId cached until then.
   useEffect(() => {
     if (!pendingLeagueId) return;
-
-    // TEMP diagnostic — remove with the tap one. Shows whether the flush is
-    // blocked (and by which guard) vs. actually navigating.
-    Sentry.captureMessage('[push] flush check (diag)', {
-      level: 'info',
-      extra: {
-        isInitialized,
-        hasUser: !!user,
-        segment0: segments[0] ?? null,
-        willNavigate: isInitialized && !!user && segments[0] !== '(auth)',
-      },
-    });
-
     if (!isInitialized || !user) return;
     if (segments[0] === '(auth)') return;
     const leagueId = pendingLeagueId;

--- a/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
+++ b/src/UI/sd-mobile/src/hooks/useRegisterPushDevice.ts
@@ -1,9 +1,21 @@
 import { useEffect, useRef } from 'react';
 import { AppState, Platform } from 'react-native';
 import messaging from '@react-native-firebase/messaging';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { useAuth } from './useAuth';
 import { registerThisDevice } from '@/src/lib/notifications/registerPushDevice';
+
+// One-time Android permission prompt marker. Android 13+ makes
+// POST_NOTIFICATIONS a runtime permission that starts undetermined, and the
+// silent registration path never prompts — so without this, an Android install
+// receives ZERO pushes until the user finds Settings → Notifications on their
+// own (which is exactly how the founder's own device went unregistered).
+// Asked once ever, at the first authenticated attempt; a denial is respected
+// (no re-nag) and the settings screen's prompt=true action stays the recovery
+// path. iOS keeps the fully silent strategy — its one-shot prompt is too
+// precious to spend at sign-in.
+const ANDROID_PROMPTED_KEY = 'push-permission-prompted';
 
 /**
  * Silently registers this device's FCM token with the API once the user is
@@ -45,14 +57,43 @@ export function useRegisterPushDevice(): void {
     registeredRef.current = false;
 
     let cancelled = false;
+    // Serializes attempts. The Android permission dialog fires an AppState
+    // active transition when dismissed, which would re-enter attempt() while
+    // the first call is still resolving — without this guard that second
+    // entry could double-prompt (the prompted flag isn't written until the
+    // first attempt completes).
+    let attemptInFlight = false;
 
-    // Silent attempt, gated on not-yet-succeeded. A cheap permission check
-    // short-circuits inside registerThisDevice when permission isn't granted,
-    // so foreground retries don't POST-spam while denied.
+    // Gated on not-yet-succeeded. Android's FIRST attempt ever prompts for
+    // permission (see ANDROID_PROMPTED_KEY); every other attempt is silent —
+    // a cheap permission check short-circuits inside registerThisDevice when
+    // permission isn't granted, so foreground retries don't POST-spam while
+    // denied.
     const attempt = async () => {
-      if (cancelled || registeredRef.current) return;
-      const outcome = await registerThisDevice();
-      if (!cancelled && outcome.ok) registeredRef.current = true;
+      if (cancelled || registeredRef.current || attemptInFlight) return;
+      attemptInFlight = true;
+      try {
+        let prompt = false;
+        if (Platform.OS === 'android') {
+          try {
+            prompt = (await AsyncStorage.getItem(ANDROID_PROMPTED_KEY)) === null;
+          } catch {
+            // Storage read failed — stay silent rather than risk re-nagging
+            // a user who was already asked.
+          }
+        }
+        const outcome = await registerThisDevice({ prompt });
+        if (prompt) {
+          // Mark AFTER the dialog resolved so a crash mid-prompt retries next
+          // launch. Written regardless of outcome — the user answered; a
+          // denial must not be re-nagged (the settings action is the
+          // deliberate re-ask path).
+          await AsyncStorage.setItem(ANDROID_PROMPTED_KEY, '1').catch(() => undefined);
+        }
+        if (!cancelled && outcome.ok) registeredRef.current = true;
+      } finally {
+        attemptInFlight = false;
+      }
     };
 
     // Initial attempt for this sign-in.

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -217,7 +217,6 @@ export interface UserPick {
   isCorrect?: boolean | null;
   pointsAwarded?: number | null;
   isSynthetic?: boolean;
-  [key: string]: unknown;
 }
 
 // ─── Standings ───────────────────────────────────────────────────────────────

--- a/src/UI/sd-ui/src/App.js
+++ b/src/UI/sd-ui/src/App.js
@@ -15,6 +15,7 @@ import SignupPage from "./components/signup/SignupPage";
 import LandingPage from "./components/landing/LandingPage";
 import TermsPage from "./components/legal/TermsPage";
 import PrivacyPage from "./components/legal/PrivacyPage";
+import AccountDeletionPage from "./components/legal/AccountDeletionPage";
 import ErrorPage from "components/common/ErrorPage"; // ✅ reusable component
 import Gallery from "./components/gallery/Gallery";
 import ResultsPage from "./components/results/ResultsPage";
@@ -86,6 +87,9 @@ function AppRoutes() {
           />
           <Route path="/terms" element={<TermsPage />} />
           <Route path="/privacy" element={<PrivacyPage />} />
+          {/* Public account-deletion page — the URL submitted in Google
+              Play's Data Safety section. Must stay reachable without auth. */}
+          <Route path="/account-deletion" element={<AccountDeletionPage />} />
         </Routes>
       )}
     </>

--- a/src/UI/sd-ui/src/App.js
+++ b/src/UI/sd-ui/src/App.js
@@ -69,9 +69,13 @@ function AppRoutes() {
           API calls, and /account-deletion is the URL submitted to Google
           Play's Data Safety section — a reviewer (or an uninstalled user)
           must never hit the offline error page there. All other routes keep
-          the existing ErrorPage short-circuit. */}
+          the existing ErrorPage short-circuit. Trailing slashes are stripped
+          before matching — the router itself treats /terms/ as /terms, so the
+          allowlist must too. */}
       {apiOffline &&
-      !["/terms", "/privacy", "/account-deletion"].includes(location.pathname) ? (
+      !["/terms", "/privacy", "/account-deletion"].includes(
+        location.pathname.replace(/\/+$/, "") || "/"
+      ) ? (
         <ErrorPage message="We lost the ball trying to contact the server." />
       ) : (
         <Routes>

--- a/src/UI/sd-ui/src/App.js
+++ b/src/UI/sd-ui/src/App.js
@@ -65,7 +65,13 @@ function AppRoutes() {
   return (
     <>
       <Toaster position="top-center" reverseOrder={false} />
-      {apiOffline ? (
+      {/* Static legal pages stay reachable during an API outage: they make no
+          API calls, and /account-deletion is the URL submitted to Google
+          Play's Data Safety section — a reviewer (or an uninstalled user)
+          must never hit the offline error page there. All other routes keep
+          the existing ErrorPage short-circuit. */}
+      {apiOffline &&
+      !["/terms", "/privacy", "/account-deletion"].includes(location.pathname) ? (
         <ErrorPage message="We lost the ball trying to contact the server." />
       ) : (
         <Routes>

--- a/src/UI/sd-ui/src/components/legal/AccountDeletionPage.jsx
+++ b/src/UI/sd-ui/src/components/legal/AccountDeletionPage.jsx
@@ -1,0 +1,104 @@
+import "./LegalPages.css";
+import { Link } from "react-router-dom";
+
+// Public account-deletion page. This URL is submitted in the Google Play
+// Console's Data Safety section, which requires a web resource where users —
+// including users who have uninstalled the app — can request account deletion
+// without reinstalling. Reviewers spot-check the link, so deletion must be the
+// page's unmistakable purpose.
+//
+// The described behavior mirrors DeleteAccountCommandHandler exactly (login
+// hard-deleted, PII anonymized in place, game history retained without
+// identity, devices/preferences purged via UserDeleted). If that handler's
+// semantics change, update this page and the Privacy Policy's "Data Retention
+// and Deletion" section together.
+function AccountDeletionPage() {
+  return (
+    <div className="legal-page legal-page--policy">
+      <h2>Delete Your sportDeets Account</h2>
+      <p className="legal-page__meta">
+        Applies to accounts created in the sportDeets iOS app, Android app,
+        or at sportdeets.com.
+      </p>
+
+      <section>
+        <h3>How to Delete Your Account</h3>
+        <p>You can delete your account yourself from either product:</p>
+        <ul>
+          <li>
+            <strong>On the web:</strong> sign in and open{" "}
+            <Link to="/app/settings">Settings</Link>, then choose{" "}
+            <strong>Delete Account</strong>. If you&apos;re not signed in,
+            you&apos;ll be asked to sign in first.
+          </li>
+          <li>
+            <strong>In the mobile app:</strong> open the{" "}
+            <strong>Profile</strong> tab and choose{" "}
+            <strong>Delete Account</strong>.
+          </li>
+        </ul>
+        <p>
+          Deletion is permanent and cannot be undone. You&apos;ll be asked to
+          confirm before anything is deleted.
+        </p>
+      </section>
+
+      <section>
+        <h3>What Is Deleted</h3>
+        <ul>
+          <li>
+            <strong>Your login</strong> is removed immediately. You will no
+            longer be able to sign in, and the account cannot be recovered.
+          </li>
+          <li>
+            <strong>Your personal information</strong> — email address,
+            username, and display name — is permanently removed from your
+            account record.
+          </li>
+          <li>
+            <strong>Your devices and notification settings</strong> — push
+            notification tokens, notification preferences, and any scheduled
+            reminders — are removed promptly after deletion: typically within
+            minutes, and no later than 24 hours.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>What Is Retained</h3>
+        <p>
+          Picks and results you submitted in leagues you played in are
+          retained so that other members&apos; leagues, standings, and
+          history remain intact — but they are no longer connected to you.
+          After deletion they appear under the anonymous label
+          &ldquo;Deleted user&rdquo; with no email, name, or other
+          identifying information attached.
+        </p>
+        <p>
+          We may also retain a limited record of the deletion request
+          (without personal data) for fraud prevention and legal compliance,
+          and server logs are retained for up to 90 days as described in our{" "}
+          <Link to="/privacy">Privacy Policy</Link>.
+        </p>
+      </section>
+
+      <section>
+        <h3>If You Can&apos;t Access the App or Website</h3>
+        <p>
+          You can request deletion without reinstalling the app: email{" "}
+          <a href="mailto:privacy@sportdeets.com">privacy@sportdeets.com</a>{" "}
+          from the email address associated with your account and we will
+          process the deletion for you. Requests are typically handled
+          much sooner, and we complete verified requests within 30 days
+          at the latest.
+        </p>
+      </section>
+
+      <div className="back-home-link">
+        <Link to="/">← Back to Home</Link>
+      </div>
+    </div>
+  );
+}
+
+export default AccountDeletionPage;

--- a/src/UI/sd-ui/src/components/legal/PrivacyPage.jsx
+++ b/src/UI/sd-ui/src/components/legal/PrivacyPage.jsx
@@ -203,11 +203,20 @@ function PrivacyPage() {
         </p>
         <p>
           You can delete your sportDeets account at any time from the
-          Profile screen in the mobile app. Account deletion removes
-          your account record, your picks, your league memberships,
-          and your push notification tokens within 30 days. We may
-          retain a limited record of the deletion request (without
+          Profile screen in the mobile app or the Settings page on the
+          web. Deletion immediately removes your login and permanently
+          removes your personal information (email address, username,
+          and display name) from your account record; your push
+          notification tokens and notification preferences are removed
+          promptly after deletion, and no later than 24 hours.
+          Picks and results you submitted in leagues
+          are retained so other members&apos; leagues and standings
+          stay intact, but they are anonymized — after deletion they
+          carry no email, name, or other identifying information. We
+          may retain a limited record of the deletion request (without
           personal data) for fraud prevention and legal compliance.
+          See <Link to="/account-deletion">Delete Your Account</Link>{" "}
+          for details.
         </p>
         <p>
           To request deletion if you cannot access the app, email{" "}

--- a/src/UI/sd-ui/src/components/legal/TermsPage.jsx
+++ b/src/UI/sd-ui/src/components/legal/TermsPage.jsx
@@ -1,19 +1,285 @@
 import "./LegalPages.css";
 import { Link } from "react-router-dom";
 
+// Real Terms of Service (replaced the pre-launch placeholder 2026-07-27).
+// Drafted to match actual product behavior — free-to-play, no wagering,
+// anonymized-retention account deletion (see DeleteAccountCommandHandler),
+// commissioner-run leagues with user-generated names/descriptions. Keep the
+// no-gambling section aligned with reality: it is load-bearing for app-store
+// review (Play's real-money-gambling policy) as well as legally.
 function TermsPage() {
   return (
-    <div className="legal-page">
+    <div className="legal-page legal-page--policy">
       <h2>Terms of Service</h2>
-      <p>
-        These are the placeholder Terms of Service for sportDeets. Actual terms
-        will be provided before public launch.
-      </p>
-      <p>
-        By using sportDeets, you agree to abide by all applicable laws and
-        regulations.
-      </p>
-      <p>For now, just enjoy the picks and bragging rights!</p>
+      <p className="legal-page__meta">Effective date: July 27, 2026</p>
+
+      <section>
+        <h3>1. Agreement</h3>
+        <p>
+          These Terms of Service (&ldquo;Terms&rdquo;) are an agreement
+          between you and sportDeets (&ldquo;sportDeets,&rdquo;
+          &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;),
+          the operator of the sportDeets sports pick&apos;em platform,
+          delivered through our mobile applications and our website at
+          sportdeets.com (together, the &ldquo;Service&rdquo;). By
+          creating an account or using the Service, you agree to these
+          Terms and to our{" "}
+          <Link to="/privacy">Privacy Policy</Link>. If you do not
+          agree, do not use the Service.
+        </p>
+      </section>
+
+      <section>
+        <h3>2. Eligibility</h3>
+        <p>
+          You must be at least 13 years old to use the Service. If you
+          are under the age of majority where you live, you may use the
+          Service only with the consent of a parent or legal guardian.
+          By using the Service, you represent that you meet these
+          requirements.
+        </p>
+      </section>
+
+      <section>
+        <h3>3. Your Account</h3>
+        <ul>
+          <li>
+            You are responsible for your account and for everything
+            that happens under it. Keep your sign-in credentials
+            secure.
+          </li>
+          <li>
+            Provide accurate information when you create your account,
+            and keep it current.
+          </li>
+          <li>
+            Accounts are personal: one account per person, and your
+            account may not be sold, transferred, or shared.
+          </li>
+          <li>
+            You may delete your account at any time — see{" "}
+            <Link to="/account-deletion">Delete Your Account</Link> for
+            exactly what is removed and what is retained.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>4. Free to Play — No Gambling</h3>
+        <p>
+          sportDeets is a free-to-play game of skill and entertainment.
+          For clarity:
+        </p>
+        <ul>
+          <li>
+            The Service involves <strong>no wagering</strong>: no entry
+            fees, no buy-ins, and no deposits. We do not accept,
+            process, or hold money or anything of monetary value from
+            users in connection with picks or leagues.
+          </li>
+          <li>
+            The Service awards <strong>no monetary prizes</strong>.
+            Standings, streaks, and bragging rights have no cash value
+            and cannot be redeemed for anything.
+          </li>
+          <li>
+            Point spreads, totals, odds, and similar figures displayed
+            in the Service are shown for{" "}
+            <strong>entertainment and informational purposes only</strong>.
+            They are not betting advice, an invitation to gamble, or an
+            offer to accept wagers. sportDeets is not a sportsbook,
+            casino, or gambling operator of any kind.
+          </li>
+          <li>
+            Any arrangement between league members outside the Service
+            (for example, a private side arrangement among friends) is
+            solely between those members. We do not facilitate,
+            process, endorse, or enforce any such arrangement, and you
+            are responsible for complying with the laws that apply to
+            you.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>5. Leagues and Your Content</h3>
+        <p>
+          Leagues are created and managed by users
+          (&ldquo;commissioners&rdquo;). League names, descriptions,
+          display names, and anything else you submit to the Service
+          are &ldquo;Your Content.&rdquo;
+        </p>
+        <ul>
+          <li>
+            You own Your Content. You grant us a non-exclusive,
+            worldwide, royalty-free license to host, store, display,
+            and distribute it within the Service so the product can
+            function (for example, showing your league name and picks
+            to your league&apos;s members, or showing a public
+            league&apos;s name to users browsing public leagues).
+          </li>
+          <li>
+            Your Content must not be unlawful, harassing, hateful,
+            defamatory, sexually explicit, or infringing on
+            anyone&apos;s rights. Keep league names and trash talk in
+            the spirit of the game.
+          </li>
+          <li>
+            We may remove content or suspend accounts that violate
+            these rules, at our discretion. To report objectionable
+            content, email{" "}
+            <a href="mailto:support@sportdeets.com">
+              support@sportdeets.com
+            </a>
+            .
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>6. Acceptable Use</h3>
+        <p>You agree not to:</p>
+        <ul>
+          <li>
+            Access the Service by any automated means (bots, scrapers,
+            bulk downloads) or attempt to extract our data at scale.
+          </li>
+          <li>
+            Interfere with or disrupt the Service, probe or circumvent
+            its security, or access accounts or data that are not
+            yours.
+          </li>
+          <li>
+            Impersonate any person, misrepresent your affiliation, or
+            create accounts by automated means.
+          </li>
+          <li>
+            Use the Service in violation of any applicable law or
+            regulation.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>7. Sports Data, Scores, and Results</h3>
+        <p>
+          Game schedules, scores, statistics, spreads, and related data
+          are sourced from third-party providers and are provided
+          &ldquo;as is.&rdquo; They may contain errors, omissions, or
+          delays. We may correct game results, pick scoring, and
+          standings after their initial posting when source data
+          changes or errors are found; our good-faith determination of
+          pick scoring and league standings is final.
+        </p>
+      </section>
+
+      <section>
+        <h3>8. Intellectual Property</h3>
+        <p>
+          The Service — including the sportDeets name, logo, design,
+          and software — is our property and is protected by
+          intellectual-property laws. We grant you a limited,
+          non-exclusive, non-transferable license to use the Service
+          for personal, non-commercial purposes.
+        </p>
+        <p>
+          Team names, league names, and other sports identifiers
+          displayed in the Service are the property of their respective
+          owners and are used for identification purposes only. Their
+          appearance does not imply any affiliation with, or
+          endorsement by, those owners.
+        </p>
+      </section>
+
+      <section>
+        <h3>9. Suspension and Termination</h3>
+        <p>
+          We may suspend or terminate your access to the Service if you
+          violate these Terms, create risk or legal exposure for us or
+          other users, or if we discontinue the Service. Where
+          practical, we will notify you. You may stop using the Service
+          — and delete your account — at any time. Sections of these
+          Terms that by their nature should survive termination
+          (including Sections 5, 8, 10, 11, and 12) survive.
+        </p>
+      </section>
+
+      <section>
+        <h3>10. Disclaimers</h3>
+        <p>
+          The Service is provided &ldquo;as is&rdquo; and &ldquo;as
+          available,&rdquo; without warranties of any kind, express or
+          implied, including merchantability, fitness for a particular
+          purpose, and non-infringement. We do not warrant that the
+          Service will be uninterrupted, error-free, or that data
+          (including scores and results) will be accurate or timely.
+          Features may change, break, or be discontinued.
+        </p>
+      </section>
+
+      <section>
+        <h3>11. Limitation of Liability</h3>
+        <p>
+          To the maximum extent permitted by law, sportDeets will not
+          be liable for any indirect, incidental, special,
+          consequential, or punitive damages, or for lost profits,
+          data, or goodwill, arising out of or related to your use of
+          the Service. To the maximum extent permitted by law, our
+          total aggregate liability for all claims relating to the
+          Service will not exceed one hundred U.S. dollars (US $100).
+          Some jurisdictions do not allow certain limitations, so parts
+          of this section may not apply to you.
+        </p>
+      </section>
+
+      <section>
+        <h3>12. Indemnification</h3>
+        <p>
+          You agree to indemnify and hold sportDeets harmless from
+          claims, damages, and expenses (including reasonable
+          attorneys&apos; fees) arising from Your Content, your use of
+          the Service, or your violation of these Terms or of
+          applicable law.
+        </p>
+      </section>
+
+      <section>
+        <h3>13. Changes to the Service or These Terms</h3>
+        <p>
+          We may modify the Service or these Terms from time to time.
+          When we change these Terms, we will update the effective date
+          above and, for material changes, notify you through the app
+          or by email. Your continued use of the Service after the
+          effective date constitutes acceptance of the updated Terms.
+        </p>
+      </section>
+
+      <section>
+        <h3>14. Governing Law and Disputes</h3>
+        <p>
+          These Terms are governed by the laws of the State of Florida,
+          without regard to its conflict-of-laws rules. Before filing
+          any claim, you agree to first contact us at{" "}
+          <a href="mailto:support@sportdeets.com">
+            support@sportdeets.com
+          </a>{" "}
+          and attempt to resolve the dispute informally for at least 30
+          days. Any dispute that cannot be resolved informally will be
+          brought exclusively in the state or federal courts located in
+          Florida, and you consent to their jurisdiction.
+        </p>
+      </section>
+
+      <section>
+        <h3>15. Contact</h3>
+        <p>
+          Questions about these Terms:{" "}
+          <a href="mailto:support@sportdeets.com">
+            support@sportdeets.com
+          </a>
+          .
+        </p>
+      </section>
 
       <div className="back-home-link">
         <Link to="/">← Back to Home</Link>


### PR DESCRIPTION
Everything the pre-submission mobile review (`docs/mobile/pre-submission-review-2026-07.md`, included in this PR) identified as needed before the closed-testing EAS build, plus the legal surface both stores require. This is the last PR before `eas build --platform android --profile production`.

## Android notification prompt

Android 13+ makes `POST_NOTIFICATIONS` a runtime permission, and the silent registration path never prompted — so an Android install received **zero pushes** until the user found Settings → Notifications on their own. Confirmed on a physical device (the founder's own Moto).

`useRegisterPushDevice` now prompts **once** on Android at the first authenticated attempt (AsyncStorage marker, written after the dialog resolves so a crash mid-prompt retries). A denial is respected — no re-nagging; the settings action remains the deliberate re-ask path. iOS stays fully silent by design. Attempts are serialized: dismissing the Android dialog fires an AppState `active` transition that would otherwise re-enter the attempt and double-prompt.

## Production hygiene

- **`_layout.tsx`**: the three TEMP `(diag)` Sentry captures removed — the LeagueInvite deep-link is now confirmed end-to-end on iOS and Android. Privacy-safe console breadcrumbs kept (deliberate crash context, documented in-file).
- **`Sentry.setUser` sends uid only** — email dropped. Crash correlation still works via uid; the Play Data Safety declaration simplifies to identifiers + diagnostics.
- **`UserPick` index signature removed** (`[key: string]: unknown` let typos compile). `tsc` clean with zero fallout.

## Version → 1.0.0

`app.json` version is now `1.0.0` — the store listing version and, via `runtimeVersion.policy: "appVersion"`, the OTA compatibility key. Inert `android.versionCode` / `ios.buildNumber` deleted (EAS remote versioning owns them). Expected consequence: installed 0.1.0 preview builds stop receiving OTA updates; testers move to the new build.

## Legal surface (both stores)

- **Real Terms of Service** replacing the literal placeholder. Key sections: free-to-play / **no-gambling** (§4 — load-bearing for Play's gambling policy: no wagering, no fees, no prizes, spreads shown for entertainment only, side arrangements disclaimed), UGC + commissioner rules with takedown right (§5), score-correction rights with scoring determinations final (§7), nominative team-name use (§8), Florida governing law (§14).
- **Public `/account-deletion` page** — the URL Google Play's Data Safety section requires (usable without reinstalling the app). Describes verified `DeleteAccountCommandHandler` behavior: login + PII removed immediately, game history retained anonymized ("Deleted user"), devices/preferences purged within 24h, email fallback completed within 30 days.
- **Privacy Policy correction**: it claimed deletion removes picks and league memberships; the handler deliberately retains them anonymized so co-players' leagues stay intact. The policy now matches actual behavior — a GDPR/CCPA accuracy fix independent of store review.
- **In-app links** (both stores require the privacy policy reachable *within* the app): Profile → "About" section (Terms + Privacy via in-app browser) and a welcome-screen clickwrap line with inline links.

## Repo hygiene

`sd-mobile` `dist/`, `coverage/`, `junit.xml` gitignored; stray local logs deleted.

## Verification

- sd-mobile: `tsc --noEmit` clean; jest 12 suites / 84 tests pass
- sd-ui: `eslint --max-warnings=0` clean; vitest 3 files / 10 tests pass
- `/terms`, `/privacy`, `/account-deletion` render-verified in-browser
- **Post-merge device step**: the Android prompt flow requires a fresh install to exercise — validate with the new EAS build (fresh install → sign in → OS permission dialog → league-invite push deep-links)

## Post-merge sequence

1. `eas build --platform android --profile production` (first production Android build — expect signing-key setup). Build also picks up the corrected S-in-D launcher icon, which OTA updates could never deliver.
2. Upload AAB to Play Console closed track
3. Deploy sd-ui; submit `https://www.sportdeets.com/account-deletion` + privacy URL in the Data Safety form
4. Fresh-install verification on device (prompt, icon, deep link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated account-deletion page and public access to its instructions.
  * Added clickable Terms of Service and Privacy Policy links on mobile (sign-in and profile), opening in an in-app browser.
  * Replaced the placeholder Terms with the full Terms of Service content.
* **Improvements**
  * Updated Privacy Policy wording to clarify what is deleted, retained, and by when.
  * Improved Android notification permission prompting to avoid repeated prompts.
  * Improved offline behavior to keep legal pages accessible.
  * Updated the mobile app version to 1.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->