### PR TITLE
feat(picks): PendingCount drives the results glance — no waiting for deactivation

### DIFF
--- a/docs/features/league-ended-headers.md
+++ b/docs/features/league-ended-headers.md
@@ -134,6 +134,32 @@ array→object break never has a window on web. Mobile:
 
 Branch: off latest `origin/main` (not the #561 branch). Separate PR from #561.
 
+## Addendum 2026-07-28 — PendingCount and the actionable-first cascade
+
+Deactivation lags a league's end date by ~7 days, so `isReadOnly` alone showed
+the glance far too late. The envelope gained `PendingCount`: matchups whose
+outcome for THIS user is still open — unpicked games that haven't started
+(still actionable) plus picked games not yet scored (`IsCorrect == null`).
+Unpicked-and-started games are excluded: they are a decided no-result (the X
+bucket), so a failed-to-make pick can never block resolution. Computed
+entirely from local API data (matchup `StartDateUtc` + the user's picks) via
+`IDateTimeProvider` — no Contest-service round-trip.
+
+Display rules ("actionable = unpicked AND not yet started"):
+
+- **Mobile (one header slot), cascade:**
+  1. `isReadOnly || pendingCount == 0` → full X|Y|Z glance (X is only honest
+     once nothing pends — mid-flight it would count in-progress games as
+     no-results)
+  2. any actionable pick → progress n/N + Hide Picked (acting beats watching)
+  3. anything scored → live ✓Y ✗Z chip (no X)
+  4. else → All Picks Made / static n/N
+- **Web (room for both):** same rules, except mid-flight it shows the progress
+  badge AND the ✓/✗ chip side by side once results start landing.
+- Hide Picked (both platforms) renders — and its filter applies — only in the
+  actionable state, preventing the stale-filter empty-page trap in every
+  locked-out configuration.
+
 ## Out of scope
 
 - The global `Response<T>` envelope initiative (`project_api_response_envelope`)

--- a/docs/features/league-ended-headers.md
+++ b/docs/features/league-ended-headers.md
@@ -139,7 +139,10 @@ Branch: off latest `origin/main` (not the #561 branch). Separate PR from #561.
 Deactivation lags a league's end date by ~7 days, so `isReadOnly` alone showed
 the glance far too late. The envelope gained `PendingCount`: matchups whose
 outcome for THIS user is still open — unpicked games that haven't started
-(still actionable) plus picked games not yet scored (`IsCorrect == null`).
+(still actionable) plus picked games not yet scored (`IsCorrect == null`,
+bounded to 24h after kickoff: canceled/void contests never get scored, and
+beyond the horizon a never-scored pick folds into the X bucket instead of
+holding the glance hostage until deactivation).
 Unpicked-and-started games are excluded: they are a decided no-result (the X
 bucket), so a failed-to-make pick can never block resolution. Computed
 entirely from local API data (matchup `StartDateUtc` + the user's picks) via

--- a/src/SportsData.Api/Application/UI/Picks/Dtos/UserPicksResultDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Dtos/UserPicksResultDto.cs
@@ -23,4 +23,15 @@ public record UserPicksResultDto
 
     /// <summary>Picks with <c>IsCorrect == false</c>.</summary>
     public int IncorrectCount { get; init; }
+
+    /// <summary>
+    /// Matchups whose outcome for THIS user is still open: unpicked games that
+    /// haven't started (still actionable) plus picked games not yet scored
+    /// (<c>IsCorrect == null</c>). Unpicked-and-started games are excluded —
+    /// they're a decided no-result. When zero, the user's results are final
+    /// for the week and clients show the results glance instead of pick
+    /// progress, without waiting for league deactivation (which lags the
+    /// league's end date by ~7 days).
+    /// </summary>
+    public int PendingCount { get; init; }
 }

--- a/src/SportsData.Api/Application/UI/Picks/Dtos/UserPicksResultDto.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Dtos/UserPicksResultDto.cs
@@ -27,11 +27,12 @@ public record UserPicksResultDto
     /// <summary>
     /// Matchups whose outcome for THIS user is still open: unpicked games that
     /// haven't started (still actionable) plus picked games not yet scored
-    /// (<c>IsCorrect == null</c>). Unpicked-and-started games are excluded —
-    /// they're a decided no-result. When zero, the user's results are final
-    /// for the week and clients show the results glance instead of pick
-    /// progress, without waiting for league deactivation (which lags the
-    /// league's end date by ~7 days).
+    /// (<c>IsCorrect == null</c>, within 24h of kickoff — beyond that a
+    /// never-scored pick, e.g. a canceled game, folds into the X bucket).
+    /// Unpicked-and-started games are excluded — they're a decided no-result.
+    /// When zero, the user's results are final for the week and clients show
+    /// the results glance instead of pick progress, without waiting for league
+    /// deactivation (which lags the league's end date by ~7 days).
     /// </summary>
     public int PendingCount { get; init; }
 }

--- a/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
@@ -19,13 +19,16 @@ public class GetUserPicksByGroupAndWeekQueryHandler : IGetUserPicksByGroupAndWee
 {
     private readonly ILogger<GetUserPicksByGroupAndWeekQueryHandler> _logger;
     private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     public GetUserPicksByGroupAndWeekQueryHandler(
         ILogger<GetUserPicksByGroupAndWeekQueryHandler> logger,
-        AppDataContext dataContext)
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<UserPicksResultDto>> ExecuteAsync(
@@ -54,23 +57,41 @@ public class GetUserPicksByGroupAndWeekQueryHandler : IGetUserPicksByGroupAndWee
             })
             .ToListAsync(cancellationToken);
 
-        // Total for the group-week (picked or not) — covered by the
-        // (GroupId, SeasonYear, SeasonWeek) index on PickemGroupMatchup.
-        // Correct/incorrect are counted from the already-materialized picks
-        // rather than issuing further queries.
-        var totalMatchups = await _dataContext.PickemGroupMatchups
+        // The group-week's matchups (picked or not) — covered by the
+        // (GroupId, SeasonYear, SeasonWeek) index on PickemGroupMatchup. A
+        // week holds at most a few dozen rows, so the projection is cheap and
+        // lets pending be computed without a Contest-service round-trip.
+        var matchups = await _dataContext.PickemGroupMatchups
             .AsNoTracking()
-            .CountAsync(m =>
+            .Where(m =>
                 m.GroupId == query.GroupId &&
-                m.SeasonWeek == query.WeekNumber,
-                cancellationToken);
+                m.SeasonWeek == query.WeekNumber)
+            .Select(m => new { m.ContestId, m.StartDateUtc })
+            .ToListAsync(cancellationToken);
+
+        // A matchup is PENDING for this user when their week-outcome can still
+        // change or is still being resolved:
+        //   - unpicked and the game hasn't started (still actionable), or
+        //   - picked but not yet scored (IsCorrect == null: game in progress
+        //     or awaiting the scoring processor).
+        // Unpicked-and-started games are NOT pending — they can never be
+        // picked, so they're already a decided no-result (the X bucket).
+        // PendingCount == 0 therefore means the user's results glance is
+        // final, even if a game they skipped is still in progress.
+        var now = _dateTimeProvider.UtcNow();
+        var picksByContest = picks.ToDictionary(p => p.ContestId);
+        var pendingCount = matchups.Count(m =>
+            picksByContest.TryGetValue(m.ContestId, out var pick)
+                ? pick.IsCorrect is null
+                : m.StartDateUtc > now);
 
         return new Success<UserPicksResultDto>(new UserPicksResultDto
         {
             Picks = picks,
-            TotalMatchups = totalMatchups,
+            TotalMatchups = matchups.Count,
             CorrectCount = picks.Count(p => p.IsCorrect == true),
-            IncorrectCount = picks.Count(p => p.IsCorrect == false)
+            IncorrectCount = picks.Count(p => p.IsCorrect == false),
+            PendingCount = pendingCount
         });
     }
 }

--- a/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandler.cs
@@ -73,16 +73,26 @@ public class GetUserPicksByGroupAndWeekQueryHandler : IGetUserPicksByGroupAndWee
         // change or is still being resolved:
         //   - unpicked and the game hasn't started (still actionable), or
         //   - picked but not yet scored (IsCorrect == null: game in progress
-        //     or awaiting the scoring processor).
+        //     or awaiting the scoring processor) — bounded by a window after
+        //     kickoff.
         // Unpicked-and-started games are NOT pending — they can never be
         // picked, so they're already a decided no-result (the X bucket).
         // PendingCount == 0 therefore means the user's results glance is
         // final, even if a game they skipped is still in progress.
+        //
+        // The window exists because canceled/void contests never get scored:
+        // PickScoringProcessor skips result-less and unfinalized matchups, so
+        // their picks keep IsCorrect == null forever. Unbounded, one canceled
+        // game would hold PendingCount above zero until league deactivation.
+        // 24h generously covers the longest games plus scoring/backfill lag;
+        // beyond it a never-scored pick folds into the X bucket — the same
+        // semantics deactivated leagues already display.
         var now = _dateTimeProvider.UtcNow();
+        var scoringHorizon = now - TimeSpan.FromHours(24);
         var picksByContest = picks.ToDictionary(p => p.ContestId);
         var pendingCount = matchups.Count(m =>
             picksByContest.TryGetValue(m.ContestId, out var pick)
-                ? pick.IsCorrect is null
+                ? pick.IsCorrect is null && m.StartDateUtc > scoringHorizon
                 : m.StartDateUtc > now);
 
         return new Success<UserPicksResultDto>(new UserPicksResultDto

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -90,6 +90,14 @@ export default function PicksScreen() {
   const [leagueId, setLeagueId] = useState<string | null>(null);
   const [selectedWeek, setSelectedWeek] = useState<number | null>(null);
   const [hidePicked, setHidePicked] = useState(false);
+  // 15s clock tick, matching web's PicksPage ticker: time-based derivations
+  // (anyActionable) re-evaluate as matchup lock times pass, so the header
+  // cascade flips at kickoff without waiting for a refetch or SignalR event.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 15_000);
+    return () => clearInterval(id);
+  }, []);
   const [importOpen, setImportOpen] = useState(false);
 
   // Latest week = last element of the ascending seasonWeeks list.
@@ -230,7 +238,7 @@ export default function PicksScreen() {
   const anyActionable = entries.some(
     (e) =>
       e.pick === null &&
-      new Date(e.matchup.startDateUtc).getTime() - 5 * 60 * 1000 > Date.now(),
+      new Date(e.matchup.startDateUtc).getTime() - 5 * 60 * 1000 > nowMs,
   );
 
   // Full results glance (X|Y|Z): counts come from the picks envelope, not

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -212,21 +212,42 @@ export default function PicksScreen() {
   const made = entries.filter((e) => e.pick !== null).length;
   const allPicked = total > 0 && made >= total;
 
-  // Ended-league header glance (X|Y|Z): counts come from the picks envelope,
-  // not client math over entries — the server owns the result semantics.
-  // X (no scored pick: unpicked + never-resolved games) is derived from the
+  // Header display cascade — actionable first (one slot on mobile; see
+  // docs/features/league-ended-headers.md):
+  //   1. Resolved (server: pendingCount 0) or ended league → full X|Y|Z glance.
+  //   2. Any unpicked game still open (5-min lock buffer, matching web's
+  //      usePickLocking rule) → progress n/N + Hide Picked: acting matters.
+  //   3. Anything scored → live ✓/✗ chip. The full glance's X waits for
+  //      resolution — mid-flight it would count in-progress games as
+  //      no-results.
+  //   4. Otherwise → the existing All Picks Made / n/N display.
+  // A failed-to-make pick locks at kickoff and drops out of "actionable" AND
+  // out of "pending" (a decided no-result), so it can never block the swap.
+  const weekResolved = picksResult?.pendingCount === 0;
+  const showGlance = isReadOnly || weekResolved;
+  const anyScored =
+    !!picksResult && picksResult.correctCount + picksResult.incorrectCount > 0;
+  const anyActionable = entries.some(
+    (e) =>
+      e.pick === null &&
+      new Date(e.matchup.startDateUtc).getTime() - 5 * 60 * 1000 > Date.now(),
+  );
+
+  // Full results glance (X|Y|Z): counts come from the picks envelope, not
+  // client math over entries — the server owns the result semantics. X (no
+  // scored pick: unpicked-locked + never-resolved games) is derived from the
   // other three so the glance always sums to the week's matchup total; clamped
   // defensively so a server miscount can't render a negative. null until the
-  // envelope loads. See docs/features/league-ended-headers.md.
+  // envelope loads.
   const resultsGlance = useMemo(() => {
-    if (!isReadOnly || !picksResult) return null;
+    if (!showGlance || !picksResult) return null;
     const { totalMatchups, correctCount, incorrectCount } = picksResult;
     return {
       noResult: Math.max(0, totalMatchups - correctCount - incorrectCount),
       correct: correctCount,
       incorrect: incorrectCount,
     };
-  }, [isReadOnly, picksResult]);
+  }, [showGlance, picksResult]);
 
   // ── Cross-league pick import ────────────────────────────────────────────────
   // Only check availability once picks + matchups have loaded and there are
@@ -303,20 +324,17 @@ export default function PicksScreen() {
     [isReadOnly, leagueId, selectedWeek, importPicks],
   );
 
-  // Hide Picked is a no-op wherever its toggle isn't rendered, otherwise a
-  // filter left switched on would strand the user with an empty FlatList
-  // ("No games this week") and no in-UI escape. Two such cases:
-  //   - allPicked — keeps the cards visible after the final pick while the
-  //     header reads "All Picks Made".
-  //   - isReadOnly — an ended league is a record to review, not a surface to
-  //     keep clean while picking, and the header has no room for the toggle
-  //     alongside the "ENDED" badge.
+  // Hide Picked is a no-op wherever its toggle isn't rendered (i.e. whenever
+  // nothing is actionable — the only cascade state that shows the toggle),
+  // otherwise a filter left switched on would strand the user with an empty
+  // FlatList ("No games this week") and no in-UI escape. anyActionable is
+  // false for allPicked, read-only, and locked-out weeks alike.
   const visibleEntries = useMemo(
     () =>
-      hidePicked && !allPicked && !isReadOnly
+      hidePicked && anyActionable
         ? entries.filter((e) => !e.pick)
         : entries,
-    [entries, hidePicked, allPicked, isReadOnly],
+    [entries, hidePicked, anyActionable],
   );
 
   // Responsive columns: phones stay single-column; tablets get a multi-column
@@ -383,9 +401,11 @@ export default function PicksScreen() {
               </Text>
             </View>
           ) : null}
-          {isReadOnly ? (
-            // Results glance replaces pick progress: "how did I do?", not "how
-            // far along am I?". X muted | correct green | incorrect red. Slot
+          {/* One slot; actionable-first cascade — see the derivation comment
+              above the resultsGlance memo. */}
+          {showGlance ? (
+            // 1. Resolved (or ended league): "how did I do?", not "how far
+            // along am I?". X muted | correct green | incorrect red. Slot
             // stays empty (badges only) until the picks envelope loads.
             resultsGlance && (
               <Text
@@ -405,19 +425,13 @@ export default function PicksScreen() {
                 </Text>
               </Text>
             )
-          ) : allPicked ? (
-            <Text style={[headerStyles.pillText, { color: theme.tint }]}>
-              All Picks Made
-            </Text>
-          ) : (
+          ) : anyActionable ? (
+            // 2. Picks can still be made — progress + Hide Picked. Acting
+            // beats watching: an open pick left unmade is a guaranteed miss.
             <>
               <Text style={[headerStyles.pillText, { color: theme.tint }]}>
                 {made}/{total}
               </Text>
-              {/* Ended leagues never reach this branch (the glance above owns
-                  the isReadOnly slot), so Hide Picked only renders while
-                  picking — where it belongs. visibleEntries still treats the
-                  filter as inactive for read-only leagues to match. */}
               <Pressable
                 onPress={() => setHidePicked((v) => !v)}
                 hitSlop={6}
@@ -436,11 +450,37 @@ export default function PicksScreen() {
                 </Text>
               </Pressable>
             </>
+          ) : anyScored ? (
+            // 3. Nothing actionable, results landing — live ✓/✗ ("am I
+            // winning?"). No X: mid-flight it would count in-progress games
+            // as no-results; the full glance waits for resolution.
+            <Text
+              style={headerStyles.pillText}
+              accessibilityLabel={`${picksResult!.correctCount} correct, ${picksResult!.incorrectCount} incorrect so far`}
+            >
+              <Text style={[headerStyles.pillText, { color: theme.successText }]}>
+                ✓{picksResult!.correctCount}
+              </Text>
+              <Text style={[headerStyles.pillSub, { color: theme.textMuted }]}>{'  '}</Text>
+              <Text style={[headerStyles.pillText, { color: theme.errorText }]}>
+                ✗{picksResult!.incorrectCount}
+              </Text>
+            </Text>
+          ) : allPicked ? (
+            // 4. Everything picked, nothing scored yet.
+            <Text style={[headerStyles.pillText, { color: theme.tint }]}>
+              All Picks Made
+            </Text>
+          ) : (
+            // 4b. Locked out of remaining picks, nothing scored yet.
+            <Text style={[headerStyles.pillText, { color: theme.tint }]}>
+              {made}/{total}
+            </Text>
           )}
         </View>
       ),
     });
-  }, [made, total, allPicked, hidePicked, theme, pickModeLabel, isReadOnly, resultsGlance]);
+  }, [made, total, allPicked, hidePicked, theme, pickModeLabel, isReadOnly, resultsGlance, showGlance, anyActionable, anyScored, picksResult]);
 
   if (meLoading) {
     return <LoadingSpinner message="Loading picks…" fullScreen />;

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -203,6 +203,13 @@ export interface UserPicksResult {
   correctCount: number;
   /** Picks with isCorrect === false. */
   incorrectCount: number;
+  /**
+   * Matchups whose outcome for THIS user is still open: unpicked games that
+   * haven't started, plus picked games not yet scored. Zero means the user's
+   * results are final for the week (the full glance can render) — no waiting
+   * for league deactivation, which lags the end date by ~7 days.
+   */
+  pendingCount: number;
 }
 
 /** Matches UserPickDto from GET /ui/picks/{groupId}/week/{week} */

--- a/src/UI/sd-ui/src/components/picks/PicksPage.css
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.css
@@ -138,6 +138,12 @@
   color: var(--error-text);
 }
 
+/* Mid-flight variant: ✓Y ✗Z only (no X — it would count in-progress games as
+   no-results). Rendered beside the progress badge until the week resolves. */
+.pick-live-chip {
+  gap: 8px;
+}
+
 .pick-mode-badge {
   display: inline-flex;
   align-items: center;

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -413,7 +413,7 @@ function PicksPage() {
 
         // UserPicksResultDto envelope: picks + server-computed result counts
         // (was a raw array; see docs/features/league-ended-headers.md).
-        const { picks, totalMatchups, correctCount, incorrectCount } =
+        const { picks, totalMatchups, correctCount, incorrectCount, pendingCount } =
           response.data;
 
         const picksByContest = {};
@@ -422,7 +422,7 @@ function PicksPage() {
         }
 
         setUserPicks(picksByContest);
-        setPicksSummary({ totalMatchups, correctCount, incorrectCount });
+        setPicksSummary({ totalMatchups, correctCount, incorrectCount, pendingCount });
         setPicksLoadedKey(`${routeLeagueId}:${selectedWeek}`);
       } catch (error) {
         if (cancelled) return;
@@ -759,14 +759,35 @@ function PicksPage() {
   ).length;
   const allPicked = totalGames > 0 && picksMade === totalGames;
 
-  // hidePicked is inert for read-only leagues: its toggle is suppressed there,
-  // and in an ended league every game is locked, so honoring a stale value
-  // carried over from an active league would render an empty page with no
-  // in-UI escape. Mirrors mobile's visibleEntries gating.
-  const visibleMatchups = hidePicked && !isReadOnly
+  // Header display cascade (see docs/features/league-ended-headers.md):
+  //   - weekResolved: server says nothing is pending for THIS user (every
+  //     pick scored; unpicked-and-started games are decided no-results), so
+  //     the full X|Y|Z glance is final — no waiting for league deactivation,
+  //     which lags the end date by ~7 days.
+  //   - anyActionable: an unpicked game the user can still pick (5-min lock
+  //     buffer, same rule as usePickLocking). Drives the Hide Picked toggle
+  //     and keeps progress front-and-center while acting matters.
+  //   - anyScored: at least one result is in — mid-flight the header adds a
+  //     live ✓/✗ chip. The full glance's X would be misleading here (it
+  //     would count still-pending games as no-results), so X waits for
+  //     weekResolved.
+  const weekResolved = picksSummary?.pendingCount === 0;
+  const showGlance = isReadOnly || weekResolved;
+  const anyScored =
+    !!picksSummary && picksSummary.correctCount + picksSummary.incorrectCount > 0;
+  const anyActionable = enrichedMatchups.some((m) => {
+    if (userPicks[m.contestId]) return false;
+    const lockTime = new Date(new Date(m.startDateUtc).getTime() - 5 * 60 * 1000);
+    return now <= lockTime;
+  });
+
+  // hidePicked is inert whenever nothing is actionable: the filter keeps only
+  // pickable games, so honoring a stale value in a read-only/locked-out week
+  // would render an empty page with no in-UI escape. Mirrors mobile.
+  const visibleMatchups = hidePicked && anyActionable
     ? enrichedMatchups.filter((m) => {
         const isPicked = !!userPicks[m.contestId];
-        
+
         // Replicate locking logic from usePickLocking (5 min buffer)
         // We do NOT hide based on isReadOnly, only based on time
         const startTime = new Date(m.startDateUtc);
@@ -815,11 +836,14 @@ function PicksPage() {
                 </span>
               );
             })()}
-            {isReadOnly ? (
-              // Ended league: pick progress is irrelevant — show the results
-              // glance instead. X (no scored pick: unpicked + never-resolved)
-              // is derived from the server's counts so the three always sum to
-              // the week's matchup total. Empty until the envelope loads.
+            {showGlance ? (
+              // Resolved week (or ended league): pick progress is irrelevant —
+              // show the results glance. X (no scored pick: unpicked-locked +
+              // never-resolved) is derived from the server's counts so the
+              // three always sum to the week's matchup total, and is only
+              // rendered once nothing is pending — mid-flight it would count
+              // in-progress games as no-results. Empty until the envelope
+              // loads.
               picksSummary && (
                 <span
                   className="pick-results-glance"
@@ -844,15 +868,32 @@ function PicksPage() {
                 </span>
               )
             ) : (
-              <span
-                className={`pick-status-badge${allPicked ? " complete" : ""}`}
-                title="Picks made"
-              >
-                {allPicked && "✓ "}
-                {picksMade}/{totalGames}
-              </span>
+              <>
+                <span
+                  className={`pick-status-badge${allPicked ? " complete" : ""}`}
+                  title="Picks made"
+                >
+                  {allPicked && "✓ "}
+                  {picksMade}/{totalGames}
+                </span>
+                {/* Mid-flight live results: web has room for progress AND a
+                    ✓/✗ chip once results start landing. No X — see above. */}
+                {anyScored && (
+                  <span
+                    className="pick-results-glance pick-live-chip"
+                    title="Correct / incorrect so far"
+                  >
+                    <span className="glance-correct">
+                      ✓{picksSummary.correctCount}
+                    </span>
+                    <span className="glance-incorrect">
+                      ✗{picksSummary.incorrectCount}
+                    </span>
+                  </span>
+                )}
+              </>
             )}
-            {!allPicked && !isReadOnly && (
+            {anyActionable && !allPicked && (
               <button
                 type="button"
                 className={`hide-picked-toggle${hidePicked ? " active" : ""}`}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
@@ -14,10 +14,19 @@ namespace SportsData.Api.Tests.Unit.Application.UI.Picks.Queries.GetUserPicksByG
 
 public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPicksByGroupAndWeekQueryHandler>
 {
+    // Every test must pin the clock: the handler computes a 24h scoring
+    // horizon (now - 24h), and the unmocked IDateTimeProvider default of
+    // DateTime.MinValue makes that subtraction throw.
+    private void PinClock(DateTime utc) =>
+        Mocker.GetMock<SportsData.Core.Common.IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(utc);
+
     [Fact]
     public async Task ExecuteAsync_ShouldReturnEmptyList_WhenNoPicksExist()
     {
         // Arrange
+        PinClock(new DateTime(2025, 10, 5, 12, 0, 0, DateTimeKind.Utc));
         var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
         var query = new GetUserPicksByGroupAndWeekQuery
         {
@@ -89,6 +98,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         });
         await DataContext.SaveChangesAsync();
 
+        PinClock(new DateTime(2025, 10, 4, 14, 0, 0, DateTimeKind.Utc));
         var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
         var query = new GetUserPicksByGroupAndWeekQuery
         {
@@ -157,6 +167,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         await DataContext.UserPicks.AddRangeAsync(pick1, pick2);
         await DataContext.SaveChangesAsync();
 
+        PinClock(new DateTime(2025, 10, 5, 12, 0, 0, DateTimeKind.Utc));
         var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
         var query = new GetUserPicksByGroupAndWeekQuery
         {
@@ -227,6 +238,7 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         await DataContext.UserPicks.AddRangeAsync(pick1, pick2);
         await DataContext.SaveChangesAsync();
 
+        PinClock(new DateTime(2025, 10, 5, 12, 0, 0, DateTimeKind.Utc));
         var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
         var query = new GetUserPicksByGroupAndWeekQuery
         {
@@ -416,5 +428,76 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         after.Value.PendingCount.Should().Be(0);
         after.Value.TotalMatchups.Should().Be(2);
         after.Value.CorrectCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NeverScoredPick_StopsPendingAfterScoringHorizon()
+    {
+        // A canceled/void contest never gets scored (PickScoringProcessor
+        // skips result-less matchups), so its pick keeps IsCorrect == null
+        // forever. Within 24h of kickoff it pends (scoring/backfill lag);
+        // beyond the horizon it folds into the X bucket so one canceled game
+        // can't hold the glance hostage until league deactivation.
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        const int week = 4;
+        var kickoffUtc = new DateTime(2025, 11, 8, 16, 0, 0, DateTimeKind.Utc);
+
+        var user = new UserEntity
+        {
+            Username = "test_user_21",
+            Id = userId,
+            FirebaseUid = Guid.NewGuid().ToString(),
+            Email = "test@test.com",
+            DisplayName = "Test User",
+            SignInProvider = "test",
+            LastLoginUtc = kickoffUtc
+        };
+        await DataContext.Users.AddAsync(user);
+
+        var contestId = Guid.NewGuid();
+        await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            ContestId = contestId,
+            SeasonYear = 2025,
+            SeasonWeek = week,
+            SeasonWeekId = Guid.NewGuid(),
+            StartDateUtc = kickoffUtc
+        });
+        await DataContext.UserPicks.AddAsync(new PickemGroupUserPick
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = groupId,
+            ContestId = contestId,
+            Week = week,
+            PickType = PickType.StraightUp,
+            IsCorrect = null,
+            TiebreakerType = TiebreakerType.TotalPoints
+        });
+        await DataContext.SaveChangesAsync();
+
+        var clock = Mocker.GetMock<SportsData.Core.Common.IDateTimeProvider>();
+        var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
+        var query = new GetUserPicksByGroupAndWeekQuery
+        {
+            UserId = userId,
+            GroupId = groupId,
+            WeekNumber = week
+        };
+
+        // Inside the horizon: awaiting a score -> pending.
+        clock.Setup(x => x.UtcNow()).Returns(kickoffUtc.AddHours(23));
+        (await handler.ExecuteAsync(query)).Value.PendingCount.Should().Be(1);
+
+        // Beyond the horizon: never-scored -> decided no-result (X bucket).
+        clock.Setup(x => x.UtcNow()).Returns(kickoffUtc.AddHours(25));
+        var resolved = await handler.ExecuteAsync(query);
+        resolved.Value.PendingCount.Should().Be(0);
+        resolved.Value.CorrectCount.Should().Be(0);
+        resolved.Value.IncorrectCount.Should().Be(0);
+        resolved.Value.TotalMatchups.Should().Be(1);
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Picks/Queries/GetUserPicksByGroupAndWeek/GetUserPicksByGroupAndWeekQueryHandlerTests.cs
@@ -248,15 +248,18 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
     public async Task ExecuteAsync_ShouldComputeResultCounts_AcrossPickOutcomes()
     {
         // Arrange — 5 matchups in the group-week: 2 correct picks, 1 incorrect,
-        // 1 picked-but-never-resolved (IsCorrect null), 1 unpicked. The client
+        // 1 picked-but-unscored (IsCorrect null), 1 unpicked. The client
         // derives X (no scored pick) = TotalMatchups - Correct - Incorrect = 2,
-        // covering both the unpicked and the never-resolved game.
+        // covering both the unpicked and the unscored game.
         var userId = Guid.NewGuid();
         var groupId = Guid.NewGuid();
         const int week = 5;
-        // Fixed instant: the handler never consumes time, so seed timestamps are
-        // inert — a literal keeps the fixture fully deterministic.
+        // Fixed instants: the clock is pinned AFTER kickoff, so the unpicked
+        // matchup is locked (not pending) and only the unscored pick pends.
         var seededUtc = new DateTime(2025, 10, 4, 12, 0, 0, DateTimeKind.Utc);
+        Mocker.GetMock<SportsData.Core.Common.IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(seededUtc.AddHours(2));
 
         var user = new UserEntity
         {
@@ -331,5 +334,87 @@ public class GetUserPicksByGroupAndWeekQueryHandlerTests : ApiTestBase<GetUserPi
         result.Value.TotalMatchups.Should().Be(5);
         result.Value.CorrectCount.Should().Be(2);
         result.Value.IncorrectCount.Should().Be(1);
+        // Pending = the unscored pick only. The unpicked matchup's game already
+        // started (now = kickoff + 2h), so it's a decided no-result, not pending.
+        result.Value.PendingCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PendingCounts_UnpickedFutureGame_AndZeroWhenResolved()
+    {
+        // Arrange — 2 matchups: one picked-and-scored, one unpicked. With the
+        // clock BEFORE the unpicked game's kickoff it's still actionable
+        // (pending = 1); with the clock AFTER kickoff the user's week is fully
+        // resolved (pending = 0) even though that game may still be running —
+        // the user's results can no longer change.
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        const int week = 3;
+        var kickoffUtc = new DateTime(2025, 11, 1, 16, 0, 0, DateTimeKind.Utc);
+
+        var user = new UserEntity
+        {
+            Username = "test_user_20",
+            Id = userId,
+            FirebaseUid = Guid.NewGuid().ToString(),
+            Email = "test@test.com",
+            DisplayName = "Test User",
+            SignInProvider = "test",
+            LastLoginUtc = kickoffUtc
+        };
+        await DataContext.Users.AddAsync(user);
+
+        var pickedContestId = Guid.NewGuid();
+        var unpickedContestId = Guid.NewGuid();
+        foreach (var contestId in new[] { pickedContestId, unpickedContestId })
+        {
+            await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                ContestId = contestId,
+                SeasonYear = 2025,
+                SeasonWeek = week,
+                SeasonWeekId = Guid.NewGuid(),
+                StartDateUtc = kickoffUtc
+            });
+        }
+
+        await DataContext.UserPicks.AddAsync(new PickemGroupUserPick
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PickemGroupId = groupId,
+            ContestId = pickedContestId,
+            Week = week,
+            PickType = PickType.StraightUp,
+            IsCorrect = true,
+            TiebreakerType = TiebreakerType.TotalPoints
+        });
+        await DataContext.SaveChangesAsync();
+
+        var clock = Mocker.GetMock<SportsData.Core.Common.IDateTimeProvider>();
+        var handler = Mocker.CreateInstance<GetUserPicksByGroupAndWeekQueryHandler>();
+        var query = new GetUserPicksByGroupAndWeekQuery
+        {
+            UserId = userId,
+            GroupId = groupId,
+            WeekNumber = week
+        };
+
+        // Act + Assert — before kickoff: the unpicked game is still actionable.
+        clock.Setup(x => x.UtcNow()).Returns(kickoffUtc.AddHours(-1));
+        var before = await handler.ExecuteAsync(query);
+        before.IsSuccess.Should().BeTrue();
+        before.Value.PendingCount.Should().Be(1);
+
+        // After kickoff: unpicked game is locked -> a decided no-result;
+        // the only pick is scored -> the week is resolved for this user.
+        clock.Setup(x => x.UtcNow()).Returns(kickoffUtc.AddHours(1));
+        var after = await handler.ExecuteAsync(query);
+        after.IsSuccess.Should().BeTrue();
+        after.Value.PendingCount.Should().Be(0);
+        after.Value.TotalMatchups.Should().Be(2);
+        after.Value.CorrectCount.Should().Be(1);
     }
 }


### PR DESCRIPTION
Design doc addendum: `docs/features/league-ended-headers.md` (included)

## Problem

The results glance (X|Y|Z) was gated on league deactivation — but deactivation lags a league's end date by **~7 days**, so a fully-played week kept showing pick progress ("24/46", "All Picks Made") long after nothing could change.

## API: `PendingCount` (additive — no breaking change)

`UserPicksResultDto` gains `PendingCount`: matchups whose outcome for **this user** is still open —

- unpicked games that haven't started (**still actionable**), plus
- picked games not yet scored (`IsCorrect == null`).

**Unpicked-and-started games are excluded** — they're a decided no-result (the X bucket). This is the key property: a failed-to-make pick locks at kickoff and drops out of pending, so it can never block resolution. `PendingCount == 0` means the user's results are final *even if a game they skipped is still in progress* — their X|Y|Z literally cannot change.

Computed entirely from local data (`PickemGroupMatchup.StartDateUtc` + the user's picks) via `IDateTimeProvider` — no Contest-service round-trip on the hot path. The previous `CountAsync` became a small projection over the same `(GroupId, SeasonYear, SeasonWeek)` index. Old clients ignore the new field; deploys in any order.

## Display — "actionable" = unpicked AND not yet started (5-min lock buffer, matching `usePickLocking`)

**Mobile** (one header slot), actionable-first cascade:

1. `isReadOnly || pendingCount == 0` → full **X|Y|Z glance**. X is only honest once nothing pends — mid-flight it would count in-progress games as no-results.
2. Any actionable pick → **progress n/N + Hide Picked**. Acting beats watching: an open pick left unmade is a guaranteed miss.
3. Anything scored → live **✓Y ✗Z** chip (no X).
4. Else → All Picks Made / static n/N.

**Web** (room for both): same rules, but mid-flight shows the progress badge **and** the live ✓/✗ chip side by side once results start landing.

**Hide Picked** (both platforms) renders — and its filter applies — only in the actionable state, closing the stale-filter empty-page trap for every locked-out configuration, not just deactivated leagues.

## Tests

- Bucket-mix test now pins the clock (`IDateTimeProvider` mock) and asserts pending.
- New test drives the clock across a kickoff, proving pending goes **1 → 0** for the failed-to-make-pick case — results final while a skipped game is still live.

## Verification

- API: build clean; affected unit suites 12/12
- sd-ui: `eslint --max-warnings=0` clean; vitest 10/10
- sd-mobile: `tsc --noEmit` clean; jest 12 suites / 84 tests
- Local E2E: validated on a live mid-slate MLB league (chip appears as results land; glance at resolution) and a deactivated league (unchanged)



Mobile's `anyActionable` evaluates at render time — a game crossing its lock threshold flips the header on the next refetch/SignalR-driven render rather than instantly. Web self-corrects faster (ticking `now`). In practice a scoring event or refetch arrives shortly after kickoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a server-provided “pending” count to distinguish unresolved matchups before the league is fully finalized.
  - Picks status can now shift from progress to a results glance as soon as outcomes are no longer pending.
- **Improvements**
  - Mobile and web headers now follow a clearer cascade: results glance, then actionable progress (with optional “Hide Picked”), then live scored ✓/✗.
  - “Hide Picked” now only appears when actionable unpicked games remain to avoid stale/empty states.
- **Documentation**
  - Documented the updated ended-league header behavior, including the 2026-07-28 addendum. 
- **Tests**
  - Added/updated time-based coverage for pending-count transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Post-review updates (CodeRabbit)

- **24h scoring horizon**: canceled/void contests never get scored, so the awaiting-score arm of pending is bounded to 24h after kickoff — beyond it a never-scored pick folds into the X bucket (deactivated-league semantics) instead of holding the glance hostage until deactivation. Test drives the clock across the horizon.
- **Mobile 15s ticker** (matching web's): `anyActionable` re-evaluates as lock times pass, so the header cascade flips at kickoff without waiting for a refetch — the previously-noted render-time limitation is removed.
