### PR TITLE
feat(user): UserOption entity + gambling-content visibility (API, web, mobile)

### DIFF
--- a/docs/features/user-options.md
+++ b/docs/features/user-options.md
@@ -120,9 +120,12 @@ predicate.
 
 ## Open items
 
-- `UserDeleted` purge: add UserOption rows to the Notification/API-side
-  deletion path so deleted accounts leave no orphan rows (harmless but
-  untidy; the rows carry no PII).
+- ~~`UserDeleted` purge~~ RESOLVED in this PR: `DeleteAccountCommandHandler`
+  purges the user's UserOption rows atomically with the anonymization. The
+  anonymize-in-place strategy keeps the User row, so the FK cascade never
+  fires on its own — and option values can themselves be sensitive (the
+  gambling-content preference can signal recovery or religious context), so
+  they must not survive deletion.
 - Future options ride the same registry + DTO; if the option count grows a
   dedicated preferences screen replaces the settings section (deferred).
 - **Kids / under-13 mode (idea, 2026-07-28):** a future policy layer could

--- a/docs/features/user-options.md
+++ b/docs/features/user-options.md
@@ -1,0 +1,142 @@
+# UserOption: Per-User Options + Gambling-Content Visibility
+
+Status: implemented
+Date: 2026-07-28
+Surfaces: SportsData.Api (entity + migration + endpoints), sd-ui, sd-mobile
+
+## Problem and rationale
+
+Some users should not be shown gambling-related content — recovering from
+addiction, religious conviction, or simple preference. Straight-Up leagues
+display spreads and over/unders as informational flavor even though nothing in
+SU play requires them. We want an inclusive default: gambling content appears
+only where the game functionally requires it, or where the user has said they
+want it. This is the first of an expected family of per-user options, so the
+storage must extend without ceremony.
+
+## Decisions (grilled 2026-07-28)
+
+| Question | Decision |
+|---|---|
+| Storage shape | **Key/value rows + typed DTO.** `UserOption` = (UserId, Key, Value) rows; the API projects known keys into a typed `UserOptionsDto`. Adding an option = registry entry + DTO field — never a migration. Unknown/stale keys ignored. |
+| First option semantics | **`ShowGamblingContent`, default OFF.** Render rule: gambling info shows iff the league's pick type requires it (ATS, O/U — lines are the game) OR the user opted in. Per-user only — never a league setting. **Deliberate behavior change:** existing SU-league users stop seeing spreads until they opt in. |
+| Enforcement | **Client-side hide.** Display preference, not a security boundary; keeps responses cacheable. One shared predicate per client. |
+| Edit surface | **Settings/Profile toggle.** Web: new "Content" section on `/app/settings` (settings-row idiom). Mobile: matching section on Profile. Endpoints mirror notification-preferences. |
+
+## API
+
+### Entity + migration
+
+```csharp
+// Infrastructure/Data/Entities/UserOption.cs
+public class UserOption : CanonicalEntityBase<Guid>
+{
+    public Guid UserId { get; set; }
+    public string Key { get; set; } = null!;   // max 64
+    public string Value { get; set; } = null!; // max 256
+    // Unique index (UserId, Key). FK -> User, cascade delete
+    // (account deletion's anonymize-in-place keeps the row harmless:
+    // options carry no PII — but UserDeleted purge SHOULD remove them;
+    // see Open items).
+}
+```
+
+One EF migration adds the table. Per repo rule: **validate the migration
+locally before pushing** (apply against local PG, run the API, exercise the
+endpoints).
+
+### Known-keys registry + DTO
+
+```csharp
+// Application/User/UserOptionKeys.cs — single source of truth
+public static class UserOptionKeys
+{
+    public const string ShowGamblingContent = "ShowGamblingContent";
+}
+
+// Application/User/Dtos/UserOptionsDto.cs — typed projection
+public record UserOptionsDto
+{
+    /// Default false: gambling info renders only where the league's pick
+    /// type requires it (ATS/OU) until the user opts in.
+    public bool ShowGamblingContent { get; init; } // = false
+}
+```
+
+The Get handler reads the user's rows, projects known keys (bool parse,
+default on absence/garbage); the Update handler upserts rows for the keys
+present in the DTO (full-replacement PATCH of known options, mirroring
+notification-preferences' race-guard pattern). Unknown rows are left alone —
+forward-compatible with options added by newer clients.
+
+### Endpoints (UserController, mirroring notification-preferences)
+
+- `GET /ui/user/me/options` → `UserOptionsDto` (200; defaults when no rows)
+- `PATCH /ui/user/me/options` body `UserOptionsDto` → 204
+
+No cross-service projection (unlike notification prefs): options are consumed
+by clients only.
+
+## Client rule — one predicate, both platforms
+
+```ts
+// shouldShowGambling(pickType, options)
+// ATS / OverUnder: lines are the game — always show.
+// StraightUp (or unknown): only when the user opted in.
+pickType === "AgainstTheSpread" || pickType === "OverUnder"
+  ? true
+  : options?.showGamblingContent === true;
+```
+
+Fetched once per session via React Query (`['user','me','options']`,
+staleTime generous — it changes only from the settings screen; invalidate on
+PATCH).
+
+### Render sites to gate (verified inventory)
+
+- **Web**: `BettingDisplays.jsx` (primary), `MatchupCard.jsx`,
+  `GameStatus.jsx`, `FinalScoreResult.jsx`, `MatchupGrid.jsx`,
+  `PicksPage.jsx` (pass-through of pickType/options where needed)
+- **Mobile**: `MatchupCard.tsx`, `GameStatus.tsx`, `FinalScoreResult.tsx`
+
+FinalScoreResult nuance: in an ATS/OU league the cover/O-U result IS the pick
+result — always shown. In SU leagues any spread-result adornment follows the
+predicate.
+
+### Edit surfaces
+
+- **Web `/app/settings`**: new "Content" section (settings-row idiom): switch
+  "Show gambling content" with hint "Spreads, totals, and odds in leagues
+  that don't require them". aria-live save feedback like the others.
+- **Mobile Profile**: matching "Content" section with a Switch, same
+  optimistic PATCH + revert pattern as notifications settings.
+
+## Rollout
+
+- Additive API (new table + endpoints) — deploy in any order.
+- The default-off flip changes SU-league display for existing users the
+  moment clients ship. Release note for beta testers recommended.
+- Mobile change is OTA-able (pure JS).
+
+## Open items
+
+- `UserDeleted` purge: add UserOption rows to the Notification/API-side
+  deletion path so deleted accounts leave no orphan rows (harmless but
+  untidy; the rows carry no PII).
+- Future options ride the same registry + DTO; if the option count grows a
+  dedicated preferences screen replaces the settings section (deferred).
+- **Kids / under-13 mode (idea, 2026-07-28):** a future policy layer could
+  force gambling content hidden regardless of the user option or league type,
+  making the app openable to younger fans in a wholesome mode. This is why
+  ALL surfaces must go through the single `shouldShowGambling` predicate and
+  never check the raw option — kids-mode then becomes a one-function change.
+  (The real lift there is COPPA; the privacy policy currently disclaims
+  under-13 use.)
+- Prediction-market surfaces (Polymarket/Kalshi) are gated by this same
+  option when they arrive — that was the backlog trigger for this feature.
+
+## Out of scope
+
+- Server-side stripping of gambling fields.
+- Per-league or league-configurable visibility (explicitly rejected).
+- ATS/O-U league behavior (unchanged by design).

--- a/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandler.cs
@@ -90,6 +90,17 @@ public class DeleteAccountCommandHandler : IDeleteAccountCommandHandler
         user.Timezone = null;
         user.DeletedUtc = _clock.UtcNow();
 
+        // Purge the user's option rows. The anonymize-in-place strategy keeps
+        // the User row, so the UserOption FK cascade never fires — and option
+        // VALUES can themselves be sensitive (e.g. the gambling-content
+        // preference can signal recovery or religious context), so deletion
+        // means they go. Loaded + RemoveRange (not ExecuteDelete) so the purge
+        // commits atomically with the anonymization in the same SaveChanges.
+        var options = await _db.UserOptions
+            .Where(o => o.UserId == userId)
+            .ToListAsync(cancellationToken);
+        _db.UserOptions.RemoveRange(options);
+
         // Publish before SaveChanges so the outbox row persists atomically with
         // the anonymization (EF bus outbox flushes on save).
         await _eventBus.Publish(

--- a/src/SportsData.Api/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommand.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommand.cs
@@ -1,0 +1,12 @@
+namespace SportsData.Api.Application.User.Commands.UpdateUserOptions;
+
+/// <summary>
+/// Full replacement of the KNOWN user options (see <c>UserOptionKeys</c>) —
+/// mirrors notification-preferences' full-set PATCH so a stale client can't
+/// partially clobber newer options it doesn't know about (unknown rows are
+/// never touched).
+/// </summary>
+public record UpdateUserOptionsCommand
+{
+    public bool ShowGamblingContent { get; init; }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommandHandler.cs
@@ -1,0 +1,161 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+
+namespace SportsData.Api.Application.User.Commands.UpdateUserOptions;
+
+public interface IUpdateUserOptionsCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateUserOptionsCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Upserts the KNOWN user-option rows (see <c>UserOptionKeys</c>) from the
+/// typed command. Rows for keys this build doesn't know are left untouched —
+/// a stale client can't clobber options added later. No eventing: options are
+/// consumed by clients only (unlike notification preferences, which project
+/// to the Notification service). See docs/features/user-options.md.
+/// </summary>
+public class UpdateUserOptionsCommandHandler : IUpdateUserOptionsCommandHandler
+{
+    private readonly AppDataContext _db;
+    private readonly IDateTimeProvider _clock;
+    private readonly IValidator<UpdateUserOptionsCommand> _validator;
+    private readonly ILogger<UpdateUserOptionsCommandHandler> _logger;
+
+    public UpdateUserOptionsCommandHandler(
+        AppDataContext db,
+        IDateTimeProvider clock,
+        IValidator<UpdateUserOptionsCommand> validator,
+        ILogger<UpdateUserOptionsCommandHandler> logger)
+    {
+        _db = db;
+        _clock = clock;
+        _validator = validator;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        Guid userId,
+        UpdateUserOptionsCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default!, ResultStatus.BadRequest, validation.Errors);
+        }
+
+        var userExists = await _db.Users.AnyAsync(u => u.Id == userId, cancellationToken);
+        if (!userExists)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(userId), $"User with ID {userId} not found.")]);
+        }
+
+        var now = _clock.UtcNow();
+
+        // The known keys this build writes. Future options append here.
+        var desired = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [UserOptionKeys.ShowGamblingContent] = command.ShowGamblingContent.ToString()
+        };
+
+        var keys = desired.Keys.ToList();
+        var existing = await _db.UserOptions
+            .Where(o => o.UserId == userId && keys.Contains(o.Key))
+            .ToListAsync(cancellationToken);
+
+        var inserted = new List<UserOption>();
+        foreach (var (key, value) in desired)
+        {
+            var row = existing.FirstOrDefault(o => o.Key == key);
+            if (row is null)
+            {
+                row = new UserOption
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    Key = key,
+                    Value = value,
+                    CreatedUtc = now,
+                    CreatedBy = userId
+                };
+                await _db.UserOptions.AddAsync(row, cancellationToken);
+                inserted.Add(row);
+            }
+            else if (row.Value != value)
+            {
+                row.Value = value;
+                row.ModifiedUtc = now;
+                row.ModifiedBy = userId;
+            }
+        }
+
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (inserted.Count > 0 && ex.IsUniqueConstraintViolation())
+        {
+            // Race: a concurrent first-time request inserted one of this user's
+            // option rows between our read and SaveChanges; the (UserId, Key)
+            // unique index rejects ours. Detach the orphans, re-read the
+            // winners, apply the requested values, retry as updates. Mirrors
+            // UpdateNotificationPreferencesCommandHandler.
+            _logger.LogWarning(ex,
+                "Concurrent insert of user options. UserId={UserId}. Retrying as update.", userId);
+
+            foreach (var orphan in inserted)
+            {
+                _db.Entry(orphan).State = EntityState.Detached;
+            }
+
+            var current = await _db.UserOptions
+                .Where(o => o.UserId == userId && keys.Contains(o.Key))
+                .ToListAsync(cancellationToken);
+
+            foreach (var (key, value) in desired)
+            {
+                var row = current.FirstOrDefault(o => o.Key == key);
+                if (row is null)
+                {
+                    // Still absent (the racing insert was for a different key):
+                    // re-add ours.
+                    await _db.UserOptions.AddAsync(new UserOption
+                    {
+                        Id = Guid.NewGuid(),
+                        UserId = userId,
+                        Key = key,
+                        Value = value,
+                        CreatedUtc = now,
+                        CreatedBy = userId
+                    }, cancellationToken);
+                }
+                else if (row.Value != value)
+                {
+                    row.Value = value;
+                    row.ModifiedUtc = now;
+                    row.ModifiedBy = userId;
+                }
+            }
+
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+
+        _logger.LogInformation("User options updated. UserId={UserId}", userId);
+
+        return new Success<Guid>(userId);
+    }
+}

--- a/src/SportsData.Api/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.User.Commands.UpdateUserOptions;
+
+/// <summary>
+/// Nothing to reject today (a bool is a bool), but the validator exists so
+/// future options with real constraints (enums, ranges) slot into the same
+/// pipeline every other command uses.
+/// </summary>
+public class UpdateUserOptionsCommandValidator : AbstractValidator<UpdateUserOptionsCommand>
+{
+}

--- a/src/SportsData.Api/Application/User/Dtos/UserOptionsDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserOptionsDto.cs
@@ -1,0 +1,16 @@
+namespace SportsData.Api.Application.User.Dtos;
+
+/// <summary>
+/// Typed projection of a user's <c>UserOption</c> rows (known keys only —
+/// see <c>UserOptionKeys</c>). Absent or unparsable rows yield each option's
+/// default, so clients always receive a full, well-typed set.
+/// </summary>
+public record UserOptionsDto
+{
+    /// <summary>
+    /// Default false: gambling content (spreads, totals, odds) renders only
+    /// where the league's pick type requires it (ATS/OU) until the user opts
+    /// in. Per-user only — never a league setting.
+    /// </summary>
+    public bool ShowGamblingContent { get; init; }
+}

--- a/src/SportsData.Api/Application/User/Queries/GetUserOptions/GetUserOptionsQuery.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetUserOptions/GetUserOptionsQuery.cs
@@ -1,0 +1,6 @@
+namespace SportsData.Api.Application.User.Queries.GetUserOptions;
+
+public record GetUserOptionsQuery
+{
+    public Guid UserId { get; init; }
+}

--- a/src/SportsData.Api/Application/User/Queries/GetUserOptions/GetUserOptionsQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetUserOptions/GetUserOptionsQueryHandler.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.User.Dtos;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.User.Queries.GetUserOptions;
+
+public interface IGetUserOptionsQueryHandler
+{
+    Task<Result<UserOptionsDto>> ExecuteAsync(
+        GetUserOptionsQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Projects a user's <c>UserOption</c> key/value rows into the typed
+/// <c>UserOptionsDto</c>. Unknown keys are ignored; absent or unparsable
+/// values fall back to each option's default, so the client always gets a
+/// full set. See docs/features/user-options.md.
+/// </summary>
+public class GetUserOptionsQueryHandler : IGetUserOptionsQueryHandler
+{
+    private readonly AppDataContext _db;
+    private readonly ILogger<GetUserOptionsQueryHandler> _logger;
+
+    public GetUserOptionsQueryHandler(
+        AppDataContext db,
+        ILogger<GetUserOptionsQueryHandler> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<Result<UserOptionsDto>> ExecuteAsync(
+        GetUserOptionsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Getting user options for UserId={UserId}", query.UserId);
+
+        var rows = await _db.UserOptions
+            .AsNoTracking()
+            .Where(o => o.UserId == query.UserId)
+            .Select(o => new { o.Key, o.Value })
+            .ToListAsync(cancellationToken);
+
+        var byKey = rows.ToDictionary(r => r.Key, r => r.Value, StringComparer.Ordinal);
+
+        return new Success<UserOptionsDto>(new UserOptionsDto
+        {
+            ShowGamblingContent = ParseBool(byKey, UserOptionKeys.ShowGamblingContent, defaultValue: false)
+        });
+    }
+
+    private static bool ParseBool(
+        IReadOnlyDictionary<string, string> byKey,
+        string key,
+        bool defaultValue)
+        => byKey.TryGetValue(key, out var raw) && bool.TryParse(raw, out var parsed)
+            ? parsed
+            : defaultValue;
+}

--- a/src/SportsData.Api/Application/User/UserController.cs
+++ b/src/SportsData.Api/Application/User/UserController.cs
@@ -5,11 +5,13 @@ using SportsData.Api.Application.User.Commands.DeleteAccount;
 using SportsData.Api.Application.User.Commands.UpdateDisplayName;
 using SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
+using SportsData.Api.Application.User.Commands.UpdateUserOptions;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Dtos;
 using SportsData.Api.Application.User.Queries.GetMe;
 using SportsData.Api.Application.User.Queries.GetNotificationPreferences;
+using SportsData.Api.Application.User.Queries.GetUserOptions;
 using SportsData.Api.Extensions;
 using SportsData.Core.Common;
 using SportsData.Core.Extensions;
@@ -109,6 +111,29 @@ public class UserController : ApiControllerBase
     public async Task<ActionResult<Guid>> UpdateNotificationPreferences(
         [FromBody] UpdateNotificationPreferencesCommand command,
         [FromServices] IUpdateNotificationPreferencesCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await handler.ExecuteAsync(userId, command, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpGet("me/options")]
+    [Authorize]
+    public async Task<ActionResult<UserOptionsDto>> GetUserOptions(
+        [FromServices] IGetUserOptionsQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetUserOptionsQuery { UserId = HttpContext.GetCurrentUserId() };
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpPatch("me/options")]
+    [Authorize]
+    public async Task<ActionResult<Guid>> UpdateUserOptions(
+        [FromBody] UpdateUserOptionsCommand command,
+        [FromServices] IUpdateUserOptionsCommandHandler handler,
         CancellationToken cancellationToken)
     {
         var userId = HttpContext.GetCurrentUserId();

--- a/src/SportsData.Api/Application/User/UserOptionKeys.cs
+++ b/src/SportsData.Api/Application/User/UserOptionKeys.cs
@@ -1,0 +1,18 @@
+namespace SportsData.Api.Application.User;
+
+/// <summary>
+/// Registry of known per-user option keys — the single source of truth for
+/// what the <c>UserOption</c> key/value rows may contain. Adding an option:
+/// add a constant here, a typed field on <c>UserOptionsDto</c>, and map it in
+/// the Get/Update handlers. No migration. See docs/features/user-options.md.
+/// </summary>
+public static class UserOptionKeys
+{
+    /// <summary>
+    /// Opt-IN to gambling-related content (spreads, totals, odds) on surfaces
+    /// that don't functionally require it. Default false: Straight-Up leagues
+    /// hide lines until the user opts in; ATS and O/U leagues always show them
+    /// (the lines are the game). Stored as bool.ToString().
+    /// </summary>
+    public const string ShowGamblingContent = "ShowGamblingContent";
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -84,10 +84,12 @@ using SportsData.Api.Application.User.Commands.DeleteAccount;
 using SportsData.Api.Application.User.Commands.UpdateDisplayName;
 using SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
 using SportsData.Api.Application.User.Commands.UpdateUsername;
+using SportsData.Api.Application.User.Commands.UpdateUserOptions;
 using SportsData.Api.Application.User.Commands.UpdateUserTimezone;
 using SportsData.Api.Application.User.Commands.UpsertUser;
 using SportsData.Api.Application.User.Queries.GetMe;
 using SportsData.Api.Application.User.Queries.GetNotificationPreferences;
+using SportsData.Api.Application.User.Queries.GetUserOptions;
 using SportsData.Api.Config;
 using SportsData.Api.Infrastructure.Auth;
 using SportsData.Api.Infrastructure.Data.Canonical;
@@ -290,6 +292,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IUpdateDisplayNameCommandHandler, UpdateDisplayNameCommandHandler>();
             services.AddScoped<IDeleteAccountCommandHandler, DeleteAccountCommandHandler>();
             services.AddScoped<IUpdateNotificationPreferencesCommandHandler, UpdateNotificationPreferencesCommandHandler>();
+            services.AddScoped<IUpdateUserOptionsCommandHandler, UpdateUserOptionsCommandHandler>();
             services.AddSingleton<IFirebaseUserAdmin, FirebaseUserAdmin>();
 
             // User Validators
@@ -298,6 +301,7 @@ namespace SportsData.Api.DependencyInjection
             // User Queries
             services.AddScoped<IGetMeQueryHandler, GetMeQueryHandler>();
             services.AddScoped<IGetNotificationPreferencesQueryHandler, GetNotificationPreferencesQueryHandler>();
+            services.AddScoped<IGetUserOptionsQueryHandler, GetUserOptionsQueryHandler>();
 
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<MatchupPreviewGenerator>();

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -16,6 +16,7 @@ public class AppDataContext : DbContext
     public DbSet<User> Users { get; set; }
 
     public DbSet<UserNotificationPreferences> UserNotificationPreferences { get; set; }
+    public DbSet<UserOption> UserOptions { get; set; }
 
     public DbSet<ContestPrediction> ContestPredictions { get; set; }
 

--- a/src/SportsData.Api/Infrastructure/Data/Entities/UserOption.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/UserOption.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// Per-user option as a key/value row — deliberately EAV-shaped so new
+    /// options are a code change (registry constant + DTO field), never a
+    /// migration. The API projects known keys into the typed
+    /// <c>UserOptionsDto</c>; unknown/stale keys are ignored on read and left
+    /// untouched on write, keeping old and new clients forward-compatible.
+    /// Known keys live in <c>UserOptionKeys</c>. A user with no row for a key
+    /// gets that option's default. See docs/features/user-options.md.
+    /// </summary>
+    public class UserOption : CanonicalEntityBase<Guid>
+    {
+        public Guid UserId { get; set; }
+
+        public User User { get; set; } = null!;
+
+        public string Key { get; set; } = null!;
+
+        public string Value { get; set; } = null!;
+
+        public class EntityConfiguration : IEntityTypeConfiguration<UserOption>
+        {
+            public void Configure(EntityTypeBuilder<UserOption> builder)
+            {
+                builder.ToTable(nameof(UserOption));
+
+                builder.HasKey(x => x.Id);
+
+                builder.Property(x => x.Key).IsRequired().HasMaxLength(64);
+                builder.Property(x => x.Value).IsRequired().HasMaxLength(256);
+
+                // One row per (user, option).
+                builder.HasIndex(x => new { x.UserId, x.Key }).IsUnique();
+
+                builder.HasOne(x => x.User)
+                    .WithMany()
+                    .HasForeignKey(x => x.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260728124612_AddUserOption.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260728124612_AddUserOption.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260728124612_AddUserOption")]
+    partial class AddUserOption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260728124612_AddUserOption.cs
+++ b/src/SportsData.Api/Migrations/20260728124612_AddUserOption.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserOption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserOption",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Key = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Value = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserOption", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserOption_User_UserId",
+                        column: x => x.UserId,
+                        principalTable: "User",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserOption_UserId_Key",
+                table: "UserOption",
+                columns: new[] { "UserId", "Key" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserOption");
+        }
+    }
+}

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -7,10 +7,11 @@ import {
   Alert,
   Platform,
   ScrollView,
+  Switch,
 } from 'react-native';
 import { signOut } from 'firebase/auth';
 import * as WebBrowser from 'expo-web-browser';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { signOutGoogle } from '@/src/lib/googleSignIn';
 import { Text } from '@/src/components/ui/AppText';
@@ -20,6 +21,8 @@ import { getTheme } from '@/constants/Colors';
 import { auth } from '@/src/lib/firebase';
 import { useAuthStore } from '@/src/stores/authStore';
 import { useCurrentUser, standingsKeys } from '@/src/hooks/useStandings';
+import { useUserOptions, userOptionsKeys } from '@/src/hooks/useUserOptions';
+import type { UserOptions } from '@/src/types/models';
 import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
 import { usersApi } from '@/src/services/api/usersApi';
 import { devicesApi } from '@/src/services/api/devicesApi';
@@ -118,6 +121,32 @@ export default function ProfileScreen() {
   const { mode, setMode } = useThemeMode();
   const { size: textSize, setSize: setTextSize } = useTextSize();
   const queryClient = useQueryClient();
+
+  // Per-user options (see docs/features/user-options.md). Optimistic toggle
+  // mirroring the notifications-settings pattern: apply to the cache, PATCH,
+  // revert on failure.
+  const { data: userOptions } = useUserOptions();
+  const [optionsMessage, setOptionsMessage] = useState('');
+  const optionsMutation = useMutation<unknown, unknown, UserOptions, { previous?: UserOptions }>({
+    mutationFn: (next) => usersApi.updateUserOptions(next),
+    onMutate: (next) => {
+      const previous = queryClient.getQueryData<UserOptions>(userOptionsKeys.me);
+      queryClient.setQueryData(userOptionsKeys.me, next);
+      setOptionsMessage('');
+      return { previous };
+    },
+    onError: (_err, _next, context) => {
+      if (context?.previous) queryClient.setQueryData(userOptionsKeys.me, context.previous);
+      setOptionsMessage('Could not save. Please try again.');
+    },
+  });
+  const handleToggleShowGambling = () => {
+    if (!userOptions || optionsMutation.isPending) return;
+    optionsMutation.mutate({
+      ...userOptions,
+      showGamblingContent: !userOptions.showGamblingContent,
+    });
+  };
   const router = useRouter();
 
   const deviceTz = useMemo(() => detectDeviceTimezone(), []);
@@ -382,6 +411,35 @@ export default function ProfileScreen() {
         </View>
       </View>
 
+      {/* Content — per-user options (see docs/features/user-options.md).
+          Mirrors web's Settings "Content" section. */}
+      <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>Content</Text>
+        <View style={[styles.settingsRow, { borderBottomColor: theme.separator }]}>
+          <View style={styles.optionTextWrap}>
+            <Text style={[styles.settingsLabel, { color: theme.text }]}>
+              Show Gambling Content
+            </Text>
+            <Text style={[styles.sectionHint, { color: theme.textMuted }]}>
+              Spreads, totals, and odds in leagues that don&rsquo;t require them
+            </Text>
+            {optionsMessage ? (
+              <Text style={[styles.sectionHint, { color: theme.error }]}>
+                {optionsMessage}
+              </Text>
+            ) : null}
+          </View>
+          <Switch
+            value={userOptions?.showGamblingContent === true}
+            disabled={!userOptions || optionsMutation.isPending}
+            onValueChange={handleToggleShowGambling}
+            trackColor={{ false: theme.border, true: theme.tint }}
+            thumbColor="#fff"
+            accessibilityLabel="Show gambling content"
+          />
+        </View>
+      </View>
+
       {/* Account */}
       <View style={[styles.section, { backgroundColor: theme.card, borderColor: theme.border }]}>
         <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>Account</Text>
@@ -562,6 +620,9 @@ const styles = StyleSheet.create({
   },
   settingsLabel: { fontSize: 16 },
   settingsValue: { fontSize: 14 },
+  // Content-option rows: label + hint stack left of the Switch; flex so long
+  // hints wrap instead of pushing the control off-screen.
+  optionTextWrap: { flex: 1, gap: 2, paddingRight: 12 },
   destructive: { fontWeight: '600' },
   fieldEditor: {
     paddingHorizontal: 16,

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -9,6 +9,8 @@ import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
 import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
 import { useCurrentUser } from '@/src/hooks/useStandings';
+import { useUserOptions } from '@/src/hooks/useUserOptions';
+import { shouldShowGambling } from '@/src/lib/gamblingContent';
 import { useTeamFinalizedGames } from '@/src/hooks/useTeamFinalizedGames';
 import { resolveSportLeague } from '@/src/utils/sportLinks';
 import { InsightModal } from './InsightModal';
@@ -522,6 +524,11 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
 
+  // Gambling-content gate (see lib/gamblingContent.ts): ATS/O-U leagues
+  // always show lines; Straight-Up leagues only when the user opted in.
+  const { data: userOptions } = useUserOptions();
+  const showGambling = shouldShowGambling(pickType, userOptions);
+
   // Live-update subscription. Only re-renders this card when its own
   // contestId's record changes — see contestUpdatesStore selector design.
   const live = useContestUpdate(matchup.contestId);
@@ -852,14 +859,18 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         )}
       </View>
 
-      {/* Spread & O/U — tap goes to the contest overview. */}
-      <TouchableOpacity
-        onPress={onPress}
-        activeOpacity={onPress ? 0.75 : 1}
-        disabled={!onPress}
-      >
-        <OddsRow matchup={enrichedMatchup} />
-      </TouchableOpacity>
+      {/* Spread & O/U — tap goes to the contest overview. Gated: ATS/O-U
+          leagues always show lines (they ARE the game); Straight-Up leagues
+          only when the user opted in. See lib/gamblingContent.ts. */}
+      {showGambling && (
+        <TouchableOpacity
+          onPress={onPress}
+          activeOpacity={onPress ? 0.75 : 1}
+          disabled={!onPress}
+        >
+          <OddsRow matchup={enrichedMatchup} />
+        </TouchableOpacity>
+      )}
 
       {/* Game status — time/score/live; GameStatus owns its own touchable
           and routes to the contest overview via onPressGameDetail.

--- a/src/UI/sd-mobile/src/hooks/useUserOptions.ts
+++ b/src/UI/sd-mobile/src/hooks/useUserOptions.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { usersApi } from '@/src/services/api/usersApi';
+import type { UserOptions } from '@/src/types/models';
+import { useAuthStore } from '@/src/stores/authStore';
+
+export const userOptionsKeys = {
+  me: ['user', 'me', 'options'] as const,
+};
+
+/**
+ * The signed-in user's typed options (UserOptionsDto). Consumers treat
+ * `undefined` (loading / fetch failure) as all-defaults via
+ * {@link shouldShowGambling}-style predicates, so a failed fetch degrades to
+ * the safe defaults rather than blocking render. Long staleTime: options only
+ * change from the Profile toggle, which writes the cache directly.
+ */
+export function useUserOptions() {
+  const { user, isInitialized } = useAuthStore();
+  return useQuery<UserOptions>({
+    queryKey: userOptionsKeys.me,
+    queryFn: () => usersApi.getUserOptions().then((r) => r.data),
+    enabled: isInitialized && !!user,
+    staleTime: 1000 * 60 * 60,
+  });
+}

--- a/src/UI/sd-mobile/src/lib/gamblingContent.ts
+++ b/src/UI/sd-mobile/src/lib/gamblingContent.ts
@@ -1,0 +1,20 @@
+import type { PickType, UserOptions } from '@/src/types/models';
+
+// Single choke point for gambling-content visibility (spreads, totals, odds).
+// EVERY surface must route through this predicate rather than checking the
+// raw user option — that keeps a future policy layer (e.g. an under-13 mode
+// that force-hides regardless of preference) a one-function change.
+// Mirrors sd-ui's utils/gamblingContent.js. See docs/features/user-options.md.
+
+export function shouldShowGambling(
+  pickType: PickType | null | undefined,
+  options: UserOptions | null | undefined,
+): boolean {
+  // ATS / O-U leagues: the lines ARE the game — always show.
+  if (pickType === 'AgainstTheSpread' || pickType === 'OverUnder') {
+    return true;
+  }
+  // Straight-Up (or unknown) context: only when the user opted in. Missing
+  // options (loading / fetch failure) mean the safe default: hidden.
+  return options?.showGamblingContent === true;
+}

--- a/src/UI/sd-mobile/src/services/api/usersApi.ts
+++ b/src/UI/sd-mobile/src/services/api/usersApi.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { NotificationPreferences, UserDto } from '@/src/types/models';
+import type { NotificationPreferences, UserDto, UserOptions } from '@/src/types/models';
 
 /**
  * Wrapper for /user/* endpoints. Mirrors the web app's `src/api/usersApi.js`.
@@ -36,4 +36,12 @@ export const usersApi = {
   // PATCH /user/me/notification-preferences — full replacement; send every flag.
   updateNotificationPreferences: (prefs: NotificationPreferences) =>
     apiClient.patch('/user/me/notification-preferences', prefs),
+
+  // GET /user/me/options → typed per-user options (defaults when the user has
+  // never changed anything). PATCH is a full replacement of KNOWN options —
+  // unknown/newer options are never touched server-side.
+  // See docs/features/user-options.md.
+  getUserOptions: () => apiClient.get<UserOptions>('/user/me/options'),
+  updateUserOptions: (options: UserOptions) =>
+    apiClient.patch('/user/me/options', options),
 };

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -185,6 +185,21 @@ export interface LeagueMatchupsResponse {
   sport: string;
 }
 
+// ─── User options ────────────────────────────────────────────────────────────
+
+/**
+ * Matches UserOptionsDto from GET /user/me/options — the typed projection of
+ * the per-user key/value UserOption rows. Absent rows yield defaults, so this
+ * is always a full set. See docs/features/user-options.md.
+ */
+export interface UserOptions {
+  /**
+   * Default false: gambling content (spreads, totals, odds) renders only
+   * where the league's pick type requires it (ATS/OU) until the user opts in.
+   */
+  showGamblingContent: boolean;
+}
+
 // ─── Picks ───────────────────────────────────────────────────────────────────
 
 /**

--- a/src/UI/sd-ui/src/api/usersApi.js
+++ b/src/UI/sd-ui/src/api/usersApi.js
@@ -11,6 +11,12 @@ const UsersApi = {
   getNotificationPreferences: () => apiClient.get("/user/me/notification-preferences"),
   updateNotificationPreferences: (prefs) =>
     apiClient.patch("/user/me/notification-preferences", prefs),
+  // Typed per-user options (UserOptionsDto). GET returns defaults when the
+  // user has never changed anything; PATCH is a full replacement of KNOWN
+  // options (unknown/newer options are never touched server-side).
+  // See docs/features/user-options.md.
+  getUserOptions: () => apiClient.get("/user/me/options"),
+  updateUserOptions: (options) => apiClient.patch("/user/me/options", options),
   // DELETE /user/me — server anonymizes the record and removes the Firebase
   // login; caller signs out afterward. Mirrors the mobile app's deleteAccount.
   deleteAccount: () => apiClient.delete("/user/me")

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -15,6 +15,7 @@ import { resolveSportLeague } from "../../utils/sportLinks";
 import { useTheme } from "../../contexts/ThemeContext";
 import PickButton from "./PickButton";
 import { SpreadAndOverUnderDisplay } from "./BettingDisplays";
+import { shouldShowGambling } from "../../utils/gamblingContent";
 import DeetsMeter from "./DeetsMeter";
 import ConfidencePicker from "./ConfidencePicker";
 
@@ -33,7 +34,10 @@ function MatchupCard({
   leagueSport, // Backend Sport enum name (e.g. "BaseballMlb") — drives team-link routing
   leagueSeasonYear // From LeagueWeekMatchupsDto.SeasonYear — canonical for all matchups in this response
 }) {
-  const { userDto } = useUserDto();
+  const { userDto, userOptions } = useUserDto();
+  // Gambling-content gate: ATS/O-U leagues always show lines (they ARE the
+  // game); Straight-Up leagues show them only when the user opted in.
+  const showGambling = shouldShowGambling(pickType, userOptions);
   // seasonYear is authoritative from leagueSeasonYear (set by the backend
   // handler from PickemGroupMatchup.SeasonYear); fall through to the matchup
   // itself only if the response shape ever changes. No hardcoded year fallback
@@ -222,14 +226,16 @@ function MatchupCard({
           asOfDate={scheduleAsOfDate}
         />
 
-        {/* Spread and Over/Under */}
-        <SpreadAndOverUnderDisplay
-          spread={matchup.spreadCurrent}
-          spreadOpen={matchup.spreadOpen}
-          overUnder={matchup.overUnderCurrent}
-          overUnderOpen={matchup.overUnderOpen}
-          providerName={matchup.providerName}
-        />
+        {/* Spread and Over/Under — gated: see utils/gamblingContent.js */}
+        {showGambling && (
+          <SpreadAndOverUnderDisplay
+            spread={matchup.spreadCurrent}
+            spreadOpen={matchup.spreadOpen}
+            overUnder={matchup.overUnderCurrent}
+            overUnderOpen={matchup.overUnderOpen}
+            providerName={matchup.providerName}
+          />
+        )}
 
         {/* Game Status */}
         <GameStatus

--- a/src/UI/sd-ui/src/components/matchups/MatchupGrid.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupGrid.css
@@ -14,6 +14,16 @@
   display: grid;
   grid-template-columns: 2fr 1fr 2fr 1fr 1fr 2fr 1fr 0.5fr;
   gap: 10px;
+}
+
+/* Hide-gambling variant: the Spread and O/U columns are omitted entirely
+   (cells conditionally unrendered in JSX), so the template drops their two
+   1fr tracks. See utils/gamblingContent.js. */
+.matchup-grid--no-gambling .grid-row {
+  grid-template-columns: 2fr 1fr 2fr 2fr 1fr 0.5fr;
+}
+
+.grid-row {
   padding: 16px;
   align-items: center;
   border-bottom: 1px solid var(--border-primary);

--- a/src/UI/sd-ui/src/components/matchups/MatchupGrid.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupGrid.css
@@ -151,6 +151,13 @@
     padding: 10px;
   }
 
+  /* The desktop no-gambling override outranks the rule above on specificity
+     (media queries add none), so restate the mobile track list for the
+     variant — cells auto-flow, so the two removed cells simply reflow. */
+  .matchup-grid--no-gambling .grid-row {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
   .grid-header {
     display: none; /* Hide header on mobile */
   }

--- a/src/UI/sd-ui/src/components/matchups/MatchupGrid.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupGrid.jsx
@@ -12,6 +12,10 @@ function MatchupGrid({
   onViewInsight,
   isSubscribed,
   fadingOut = [],
+  // Gambling-content gate (see utils/gamblingContent.js — computed by the
+  // caller, which knows the league's pick type). Defaults to the historical
+  // behavior so other consumers are unaffected until they opt in.
+  showGambling = true,
 }) {
   if (loading) {
     return (
@@ -23,14 +27,14 @@ function MatchupGrid({
   }
 
   return (
-    <div className="matchup-grid">
+    <div className={`matchup-grid${showGambling ? "" : " matchup-grid--no-gambling"}`}>
       {/* Grid Header */}
       <div className="grid-row grid-header">
         <div>Game</div>
         <div>Time</div>
         <div>Location</div>
-        <div>Spread</div>
-        <div>O/U</div>
+        {showGambling && <div>Spread</div>}
+        {showGambling && <div>O/U</div>}
         <div>Pick</div>
         <div>Consensus</div>
         <div>Insight</div>
@@ -98,18 +102,22 @@ function MatchupGrid({
             </div>
 
             {/* Spread */}
-            <div className="grid-cell">
-              <div className="spread" style={{ fontSize: "0.9rem" }}>
-                {spread}
+            {showGambling && (
+              <div className="grid-cell">
+                <div className="spread" style={{ fontSize: "0.9rem" }}>
+                  {spread}
+                </div>
               </div>
-            </div>
+            )}
 
             {/* Over/Under */}
-            <div className="grid-cell">
-              <div className="over-under" style={{ fontSize: "0.9rem" }}>
-                {overUnder}
+            {showGambling && (
+              <div className="grid-cell">
+                <div className="over-under" style={{ fontSize: "0.9rem" }}>
+                  {overUnder}
+                </div>
               </div>
-            </div>
+            )}
 
             {/* Pick */}
             <div className="grid-cell">

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -14,9 +14,10 @@ import LeaguesApi from "../../api/leagues/leaguesApi";
 import LeagueWeekSelector from "./LeagueWeekSelector.jsx";
 import MatchupList from "../matchups/MatchupList.jsx";
 import MatchupGrid from "../matchups/MatchupGrid.jsx";
+import { shouldShowGambling } from "../../utils/gamblingContent";
 
 function PicksPage() {
-  const { userDto, loading: userLoading, refreshUserDto } = useUserDto();
+  const { userDto, loading: userLoading, refreshUserDto, userOptions } = useUserDto();
   const {
     selectedLeagueId: globalLeagueId,
     setSelectedLeagueId: setGlobalLeagueId,
@@ -949,6 +950,7 @@ function PicksPage() {
                 onViewInsight={handleViewInsight}
                 isSubscribed={isSubscribed}
                 fadingOut={fadingOut}
+                showGambling={shouldShowGambling(pickType, userOptions)}
               />
             )}
           </>

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -74,17 +74,26 @@ function SettingsPage() {
   const { theme, toggleTheme } = useTheme();
   const { refreshUserDto, userOptions, updateUserOptions } = useUserDto();
   const [optionsMessage, setOptionsMessage] = useState("");
+  const [optionsSaving, setOptionsSaving] = useState(false);
 
   // Optimistic write-through lives in UserContext (apply → PATCH → revert on
-  // failure); this handler just wraps it with user-facing feedback.
+  // failure); this handler wraps it with user-facing feedback and serializes
+  // saves — a second toggle built from a stale base would clobber the
+  // in-flight full-replacement PATCH (same guard as the notification
+  // preferences toggle).
   const handleToggleShowGambling = async () => {
-    if (userOptions === null) return;
+    if (userOptions === null || optionsSaving) return;
+    setOptionsSaving(true);
     setOptionsMessage("");
-    const ok = await updateUserOptions({
-      ...userOptions,
-      showGamblingContent: !userOptions.showGamblingContent,
-    });
-    setOptionsMessage(ok ? "Saved." : "Could not save. Please try again.");
+    try {
+      const ok = await updateUserOptions({
+        ...userOptions,
+        showGamblingContent: !userOptions.showGamblingContent,
+      });
+      setOptionsMessage(ok ? "Saved." : "Could not save. Please try again.");
+    } finally {
+      setOptionsSaving(false);
+    }
   };
   const [user, setUser] = useState(null);
   const [error, setError] = useState("");
@@ -422,7 +431,7 @@ function SettingsPage() {
                   type="checkbox"
                   aria-label="Show gambling content"
                   checked={userOptions?.showGamblingContent === true}
-                  disabled={userOptions === null}
+                  disabled={userOptions === null || optionsSaving}
                   onChange={handleToggleShowGambling}
                 />
                 <span className="settings-switch-track" aria-hidden="true" />

--- a/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
+++ b/src/UI/sd-ui/src/components/settings/SettingsPage.jsx
@@ -72,7 +72,20 @@ function detectBrowserTimezone() {
 function SettingsPage() {
   const navigate = useNavigate();
   const { theme, toggleTheme } = useTheme();
-  const { refreshUserDto } = useUserDto();
+  const { refreshUserDto, userOptions, updateUserOptions } = useUserDto();
+  const [optionsMessage, setOptionsMessage] = useState("");
+
+  // Optimistic write-through lives in UserContext (apply → PATCH → revert on
+  // failure); this handler just wraps it with user-facing feedback.
+  const handleToggleShowGambling = async () => {
+    if (userOptions === null) return;
+    setOptionsMessage("");
+    const ok = await updateUserOptions({
+      ...userOptions,
+      showGamblingContent: !userOptions.showGamblingContent,
+    });
+    setOptionsMessage(ok ? "Saved." : "Could not save. Please try again.");
+  };
   const [user, setUser] = useState(null);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -386,6 +399,34 @@ function SettingsPage() {
                   Dark
                 </span>
               </button>
+            </div>
+          </section>
+
+          <section className="settings-section">
+            <h3>Content</h3>
+            <div className="settings-row">
+              <div className="settings-row-label">
+                <span className="settings-row-title">Show gambling content</span>
+                <span className="settings-row-hint">
+                  Spreads, totals, and odds in leagues that don&apos;t require
+                  them
+                </span>
+                {/* Persistently mounted aria-live region — see the display-name
+                    hint on this page for why. */}
+                <span className="settings-row-hint" aria-live="polite">
+                  {optionsMessage}
+                </span>
+              </div>
+              <label className="settings-switch">
+                <input
+                  type="checkbox"
+                  aria-label="Show gambling content"
+                  checked={userOptions?.showGamblingContent === true}
+                  disabled={userOptions === null}
+                  onChange={handleToggleShowGambling}
+                />
+                <span className="settings-switch-track" aria-hidden="true" />
+              </label>
             </div>
           </section>
 

--- a/src/UI/sd-ui/src/contexts/UserContext.jsx
+++ b/src/UI/sd-ui/src/contexts/UserContext.jsx
@@ -8,10 +8,15 @@ export const UserProvider = ({ children }) => {
   const { user, loading: authLoading } = useAuth();
   const [userDto, setUserDto] = useState(null);
   const [loading, setLoading] = useState(true);
+  // Typed per-user options (UserOptionsDto). null until loaded — consumers
+  // treat null as all-defaults via shouldShowGambling & co., so a fetch
+  // failure degrades to the safe defaults rather than blocking render.
+  const [userOptions, setUserOptions] = useState(null);
 
   const loadUserDto = useCallback(async () => {
     if (!user) {
       setUserDto(null);
+      setUserOptions(null);
       setLoading(false);
       return;
     }
@@ -24,6 +29,16 @@ export const UserProvider = ({ children }) => {
       setUserDto(null);
     } finally {
       setLoading(false);
+    }
+
+    // Off the critical path: options only refine display (safe defaults
+    // apply until they arrive), so they must not delay first render.
+    try {
+      const options = await UsersApi.getUserOptions();
+      setUserOptions(options.data);
+    } catch (err) {
+      console.error('Failed to load user options:', err);
+      setUserOptions(null);
     }
   }, [user]);
 
@@ -44,8 +59,25 @@ export const UserProvider = ({ children }) => {
     }
   }, [user, authLoading, loadUserDto]);
 
+  // Optimistic write-through for the settings toggle: apply locally, PATCH,
+  // revert on failure. Returns true on success so the caller can message.
+  const updateUserOptions = useCallback(async (next) => {
+    const previous = userOptions;
+    setUserOptions(next);
+    try {
+      await UsersApi.updateUserOptions(next);
+      return true;
+    } catch (err) {
+      console.error('Failed to update user options:', err);
+      setUserOptions(previous);
+      return false;
+    }
+  }, [userOptions]);
+
   return (
-    <UserContext.Provider value={{ userDto, loading, refreshUserDto }}>
+    <UserContext.Provider
+      value={{ userDto, loading, refreshUserDto, userOptions, updateUserOptions }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/src/UI/sd-ui/src/utils/gamblingContent.js
+++ b/src/UI/sd-ui/src/utils/gamblingContent.js
@@ -1,0 +1,22 @@
+// Single choke point for gambling-content visibility (spreads, totals, odds).
+// EVERY surface must route through this predicate rather than checking the
+// raw user option — that keeps a future policy layer (e.g. an under-13 mode
+// that force-hides regardless of preference) a one-function change.
+// See docs/features/user-options.md.
+
+/**
+ * @param {string|null|undefined} pickType League pick type wire value
+ *   ("StraightUp" | "AgainstTheSpread" | "OverUnder" | unknown).
+ * @param {{showGamblingContent?: boolean}|null|undefined} userOptions
+ *   Typed options from UserContext; null while loading / on failure.
+ * @returns {boolean} true when gambling content should render.
+ */
+export function shouldShowGambling(pickType, userOptions) {
+  // ATS / O-U leagues: the lines ARE the game — always show.
+  if (pickType === "AgainstTheSpread" || pickType === "OverUnder") {
+    return true;
+  }
+  // Straight-Up (or unknown) context: only when the user opted in.
+  // null options (loading / fetch failure) mean the safe default: hidden.
+  return userOptions?.showGamblingContent === true;
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/DeleteAccount/DeleteAccountCommandHandlerTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 
 using FluentValidation;
 
+using Microsoft.EntityFrameworkCore;
+
 using Moq;
 
 using SportsData.Api.Application.User.Commands.DeleteAccount;
@@ -13,6 +15,7 @@ using SportsData.Core.Eventing.Events.Users;
 using Xunit;
 
 using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+using UserOptionEntity = SportsData.Api.Infrastructure.Data.Entities.UserOption;
 
 namespace SportsData.Api.Tests.Unit.Application.User.Commands.DeleteAccount;
 
@@ -123,5 +126,33 @@ public class DeleteAccountCommandHandlerTests : ApiTestBase<DeleteAccountCommand
         reloaded.Username.Should().Be("del_prior");
         reloaded.DisplayName.Should().Be("Deleted user");
         reloaded.FirebaseUid.Should().Be("deleted-prior");
+    }
+
+    [Fact]
+    public async Task Execute_PurgesUserOptions()
+    {
+        // Option values can themselves be sensitive (the gambling-content
+        // preference can signal recovery or religious context). The
+        // anonymize-in-place strategy keeps the User row, so the FK cascade
+        // never fires — the handler must purge the rows explicitly.
+        var userId = await SeedUserAsync();
+        await DataContext.UserOptions.AddAsync(new UserOptionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Key = SportsData.Api.Application.User.UserOptionKeys.ShowGamblingContent,
+            Value = "True",
+            CreatedUtc = FixedNow,
+            CreatedBy = userId
+        });
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<DeleteAccountCommandHandler>();
+        var result = await handler.ExecuteAsync(new DeleteAccountCommand { UserId = userId });
+
+        result.IsSuccess.Should().BeTrue();
+        DataContext.ChangeTracker.Clear();
+        (await DataContext.UserOptions.AnyAsync(o => o.UserId == userId))
+            .Should().BeFalse("deletion must leave no option rows behind");
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateUserOptions/UpdateUserOptionsCommandHandlerTests.cs
@@ -1,0 +1,128 @@
+using FluentAssertions;
+
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.User;
+using SportsData.Api.Application.User.Commands.UpdateUserOptions;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.User.Commands.UpdateUserOptions;
+
+public class UpdateUserOptionsCommandHandlerTests : ApiTestBase<UpdateUserOptionsCommandHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 7, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    public UpdateUserOptionsCommandHandlerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use<IValidator<UpdateUserOptionsCommand>>(new UpdateUserOptionsCommandValidator());
+    }
+
+    private static UserEntity NewUser(Guid id) => new()
+    {
+        Id = id,
+        Username = $"user_{id:N}"[..20],
+        FirebaseUid = $"uid-{id:N}",
+        Email = "test@test.com",
+        DisplayName = "Test User",
+        SignInProvider = "test",
+        LastLoginUtc = FixedNow
+    };
+
+    [Fact]
+    public async Task UnknownUser_ReturnsNotFound()
+    {
+        var handler = Mocker.CreateInstance<UpdateUserOptionsCommandHandler>();
+
+        var result = await handler.ExecuteAsync(
+            Guid.NewGuid(),
+            new UpdateUserOptionsCommand { ShowGamblingContent = true });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task FirstChange_InsertsRow()
+    {
+        var userId = Guid.NewGuid();
+        await DataContext.Users.AddAsync(NewUser(userId));
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<UpdateUserOptionsCommandHandler>();
+        var result = await handler.ExecuteAsync(
+            userId, new UpdateUserOptionsCommand { ShowGamblingContent = true });
+
+        result.IsSuccess.Should().BeTrue();
+        var rows = await DataContext.UserOptions.Where(o => o.UserId == userId).ToListAsync();
+        rows.Should().HaveCount(1);
+        rows[0].Key.Should().Be(UserOptionKeys.ShowGamblingContent);
+        rows[0].Value.Should().Be(true.ToString());
+        rows[0].CreatedUtc.Should().Be(FixedNow);
+        rows[0].ModifiedUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SecondChange_UpdatesInPlace()
+    {
+        var userId = Guid.NewGuid();
+        await DataContext.Users.AddAsync(NewUser(userId));
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<UpdateUserOptionsCommandHandler>();
+        await handler.ExecuteAsync(userId, new UpdateUserOptionsCommand { ShowGamblingContent = true });
+        await handler.ExecuteAsync(userId, new UpdateUserOptionsCommand { ShowGamblingContent = false });
+
+        var rows = await DataContext.UserOptions.Where(o => o.UserId == userId).ToListAsync();
+        rows.Should().HaveCount(1, "the second change must overwrite, not duplicate");
+        rows[0].Value.Should().Be(false.ToString());
+        rows[0].ModifiedUtc.Should().Be(FixedNow);
+    }
+
+    [Fact]
+    public async Task UnchangedValue_DoesNotStampModified()
+    {
+        var userId = Guid.NewGuid();
+        await DataContext.Users.AddAsync(NewUser(userId));
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<UpdateUserOptionsCommandHandler>();
+        await handler.ExecuteAsync(userId, new UpdateUserOptionsCommand { ShowGamblingContent = true });
+        await handler.ExecuteAsync(userId, new UpdateUserOptionsCommand { ShowGamblingContent = true });
+
+        var row = await DataContext.UserOptions.SingleAsync(o => o.UserId == userId);
+        row.ModifiedUtc.Should().BeNull("a no-op write must not churn audit stamps");
+    }
+
+    [Fact]
+    public async Task UnknownKeyRows_AreLeftUntouched()
+    {
+        // A row written by a future build survives a PATCH from this build.
+        var userId = Guid.NewGuid();
+        await DataContext.Users.AddAsync(NewUser(userId));
+        await DataContext.UserOptions.AddAsync(new UserOption
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Key = "SomeFutureOption",
+            Value = "precious",
+            CreatedUtc = FixedNow,
+            CreatedBy = userId
+        });
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<UpdateUserOptionsCommandHandler>();
+        await handler.ExecuteAsync(userId, new UpdateUserOptionsCommand { ShowGamblingContent = true });
+
+        var rows = await DataContext.UserOptions.Where(o => o.UserId == userId).ToListAsync();
+        rows.Should().HaveCount(2);
+        rows.Single(r => r.Key == "SomeFutureOption").Value.Should().Be("precious");
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetUserOptions/GetUserOptionsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Queries/GetUserOptions/GetUserOptionsQueryHandlerTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.User;
+using SportsData.Api.Application.User.Queries.GetUserOptions;
+using SportsData.Api.Infrastructure.Data.Entities;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.User.Queries.GetUserOptions;
+
+public class GetUserOptionsQueryHandlerTests : ApiTestBase<GetUserOptionsQueryHandler>
+{
+    private static UserEntity NewUser(Guid id) => new()
+    {
+        Id = id,
+        Username = $"user_{id:N}"[..20],
+        FirebaseUid = $"uid-{id:N}",
+        Email = "test@test.com",
+        DisplayName = "Test User",
+        SignInProvider = "test",
+        LastLoginUtc = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private UserOption NewOption(Guid userId, string key, string value) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        Key = key,
+        Value = value,
+        CreatedUtc = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+        CreatedBy = userId
+    };
+
+    [Fact]
+    public async Task NoRows_YieldsDefaults()
+    {
+        var handler = Mocker.CreateInstance<GetUserOptionsQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetUserOptionsQuery { UserId = Guid.NewGuid() });
+
+        result.IsSuccess.Should().BeTrue();
+        // The inclusive default: gambling content hidden until opted in.
+        result.Value.ShowGamblingContent.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Row_True_ProjectsTrue()
+    {
+        var userId = Guid.NewGuid();
+        await DataContext.Users.AddAsync(NewUser(userId));
+        await DataContext.UserOptions.AddAsync(
+            NewOption(userId, UserOptionKeys.ShowGamblingContent, "True"));
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetUserOptionsQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetUserOptionsQuery { UserId = userId });
+
+        result.Value.ShowGamblingContent.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GarbageValue_FallsBackToDefault()
+    {
+        var userId = Guid.NewGuid();
+        await DataContext.Users.AddAsync(NewUser(userId));
+        await DataContext.UserOptions.AddAsync(
+            NewOption(userId, UserOptionKeys.ShowGamblingContent, "not-a-bool"));
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetUserOptionsQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetUserOptionsQuery { UserId = userId });
+
+        result.Value.ShowGamblingContent.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UnknownKeys_AreIgnored()
+    {
+        // Rows written by a future build must not break older code.
+        var userId = Guid.NewGuid();
+        await DataContext.Users.AddAsync(NewUser(userId));
+        await DataContext.UserOptions.AddRangeAsync(
+            NewOption(userId, "SomeFutureOption", "whatever"),
+            NewOption(userId, UserOptionKeys.ShowGamblingContent, "True"));
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetUserOptionsQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetUserOptionsQuery { UserId = userId });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ShowGamblingContent.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OtherUsersRows_DoNotLeak()
+    {
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        await DataContext.Users.AddRangeAsync(NewUser(userA), NewUser(userB));
+        await DataContext.UserOptions.AddAsync(
+            NewOption(userA, UserOptionKeys.ShowGamblingContent, "True"));
+        await DataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetUserOptionsQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetUserOptionsQuery { UserId = userB });
+
+        result.Value.ShowGamblingContent.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Design doc: `docs/features/user-options.md` (included; decisions grilled and recorded)

## Why

First of an expected family of per-user options, with an inclusion-driven first use case: users sensitive to gambling content — recovery from addiction, religious conviction, or simple preference — should not have spreads and over/unders pushed at them where the game doesn't require it.

## Storage: `UserOption` (EAV by design)

`(UserId, Key, Value)` rows, unique on `(UserId, Key)`, cascade FK. **Future options are a registry constant (`UserOptionKeys`) + a typed DTO field — never another migration.** The API projects known keys into `UserOptionsDto`:

- absent / unparsable rows → the option's default
- unknown rows → ignored on read, **left untouched on write** (a stale client can't clobber options added by a newer one; a newer client's rows survive an older build's PATCH)

## Semantics — per-user only, never a league setting

`ShowGamblingContent`, **default OFF**. One shared predicate on both clients:

> render gambling info **iff** the league's pick type requires it (ATS, O/U — the lines ARE the game) **or** the user opted in.

**Deliberate behavior change:** Straight-Up leagues hide spreads/O-U *by default* — the sensitive user is protected without having to discover a setting. Existing SU-league users will notice; worth a line in beta-tester notes.

All surfaces route through `shouldShowGambling()` rather than the raw option — a future policy layer (e.g. an under-13 wholesome mode that force-hides regardless of preference) becomes a one-function change.

## Surfaces

- **API**: `GET`/`PATCH /ui/user/me/options`, mirroring notification-preferences including its full-replacement race guard (concurrent first-insert → detach orphans → retry as update). No eventing — clients are the only consumers.
- **Web**: options load in `UserContext` off the critical path (safe defaults until they arrive; fetch failure degrades to defaults, never blocks render). Optimistic toggle in a new Settings "Content" section. Gates: `MatchupCard`'s spread/O-U display; `MatchupGrid`'s Spread + O/U **columns removed structurally** (CSS grid variant), not blanked.
- **Mobile**: `useUserOptions` hook, Profile "Content" Switch (optimistic + revert), gate on `MatchupCard`'s `OddsRow`.
- **`FinalScoreResult` untouched on both platforms** — verified its spread/O-U branches only execute for ATS/O-U pick types, which always show.

## Migration

`AddUserOption` — validated locally per house rule: applied to local `sdApi.All`, endpoints exercised end-to-end (SU league hides by default → toggle restores → ATS league unchanged → state syncs across web and mobile).

## Verification

- API: build clean; unit suite **563/563** — 10 new tests covering defaults, garbage-value tolerance, unknown-key preservation in both directions, upsert/no-op audit stamps, and cross-user isolation
- sd-ui: `eslint --max-warnings=0` clean; vitest 10/10
- sd-mobile: `tsc --noEmit` clean; jest 12 suites / 84 tests
- Local E2E on both clients against the migrated local DB

## Rollout notes

- Additive API — deploys in any order; old clients ignore the endpoints.
- The default-off flip takes effect when clients ship (web deploy / mobile EAS update — pure JS, OTA-able).
- Open item (doc): add `UserOption` purge to the `UserDeleted` path (tidiness — rows carry no PII).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-user “Show gambling content” preference with new API endpoints to retrieve and update it.
  * Added content toggle UI on web and mobile profile/settings screens.
  * Gambling line visibility is now driven by a single shared rule (always shown for ATS and Over/Under).
* **Bug Fixes**
  * Gambling content defaults to hidden when preferences are missing or invalid.
  * Deleting an account now purges stored user option records.
* **Tests**
  * Added unit tests covering option updates, defaults/invalid values, unknown keys, and delete purging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->