### PR TITLE
feat(mobile): league detail screen, create confirmation, confidence points

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   View,
   Image,
@@ -12,6 +12,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
+import { ConfidencePickerModal } from '@/src/components/features/picks/ConfidencePickerModal';
 import { useMatchups } from '@/src/hooks/useMatchups';
 import { usePicks, useSubmitPick, useContestOverview } from '@/src/hooks/useContest';
 import type {
@@ -432,7 +433,20 @@ export default function GameDetailScreen() {
     matchupStatus === 'completed' ||
     (!isNaN(kickoffMs) && Date.now() >= kickoffMs - 5 * 60 * 1000);
 
-  const handlePick = async (choice: PickChoice, franchiseSeasonId: string) => {
+  // Confidence-league support (web parity): a pick without a distinct 1..N
+  // value is rejected by the BE, so the picker gates the POST. usedPoints
+  // spans the whole week's picks (the envelope is week-scoped).
+  const useConfidence = matchupsResponse?.useConfidencePoints ?? false;
+  const [pendingFranchiseId, setPendingFranchiseId] = useState<string | null>(null);
+  const usedConfidencePoints = useMemo(
+    () =>
+      (picksResult?.picks ?? [])
+        .map((p) => p.confidencePoints)
+        .filter((p): p is number => p != null),
+    [picksResult],
+  );
+
+  const submitWithConfidence = async (franchiseSeasonId: string, confidencePoints?: number) => {
     if (!matchup || !leagueId || !weekNumber) return;
     try {
       await submitPick.mutateAsync({
@@ -441,10 +455,20 @@ export default function GameDetailScreen() {
         pickType,
         franchiseSeasonId,
         week: weekNumber,
+        ...(confidencePoints != null ? { confidencePoints } : {}),
       });
     } catch {
       Alert.alert('Error', 'Could not save your pick. Please try again.');
     }
+  };
+
+  const handlePick = async (choice: PickChoice, franchiseSeasonId: string) => {
+    if (!matchup || !leagueId || !weekNumber) return;
+    if (useConfidence) {
+      setPendingFranchiseId(franchiseSeasonId);
+      return;
+    }
+    await submitWithConfidence(franchiseSeasonId);
   };
 
   const screenTitle = overview
@@ -510,6 +534,19 @@ export default function GameDetailScreen() {
           />
         ) : null}
       </ScrollView>
+
+      <ConfidencePickerModal
+        visible={pendingFranchiseId !== null}
+        totalGames={matchupsResponse?.matchups.length ?? 1}
+        usedPoints={usedConfidencePoints}
+        currentPoint={existingPick?.confidencePoints ?? null}
+        onClose={() => setPendingFranchiseId(null)}
+        onSelect={(point) => {
+          const franchiseSeasonId = pendingFranchiseId;
+          setPendingFranchiseId(null);
+          if (franchiseSeasonId) void submitWithConfidence(franchiseSeasonId, point);
+        }}
+      />
     </>
   );
 }

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -231,19 +231,23 @@ export default function PicksScreen() {
     franchiseSeasonId: string;
     currentPoint: number | null;
   } | null>(null);
-  // Reserves a just-selected point until its mutation settles: entries only
-  // reflect the new pick after invalidation/refetch, so without this a rapid
-  // second selection could reuse the same value.
-  const [inFlightPoint, setInFlightPoint] = useState<number | null>(null);
+  // Reserves just-selected points until their mutations settle: entries only
+  // reflect a new pick after invalidation/refetch, so without this a rapid
+  // second selection could reuse a value. A SET (not a single value) because
+  // several submissions can be in flight at once — each mutation's onSettled
+  // releases only its own point, never another submission's reservation.
+  const [inFlightPoints, setInFlightPoints] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
   const usedConfidencePoints = useMemo(() => {
     const used = entries
       .map((e) => e.pick?.confidencePoints)
       .filter((p): p is number => p != null);
-    if (inFlightPoint != null && !used.includes(inFlightPoint)) {
-      used.push(inFlightPoint);
+    for (const p of inFlightPoints) {
+      if (!used.includes(p)) used.push(p);
     }
     return used;
-  }, [entries, inFlightPoint]);
+  }, [entries, inFlightPoints]);
 
   // Header display cascade — actionable first (one slot on mobile; see
   // docs/features/league-ended-headers.md):
@@ -726,7 +730,7 @@ export default function PicksScreen() {
         onClose={() => setPendingPick(null)}
         onSelect={(point) => {
           if (!pendingPick || !leagueId || !selectedWeek) return;
-          setInFlightPoint(point);
+          setInFlightPoints((prev) => new Set(prev).add(point));
           submitPick.mutate(
             {
               pickemGroupId: leagueId,
@@ -738,8 +742,14 @@ export default function PicksScreen() {
             },
             {
               // Settled either way: on success the refetched entries carry the
-              // point; on failure it must be selectable again.
-              onSettled: () => setInFlightPoint(null),
+              // point; on failure it must be selectable again. Releases only
+              // THIS mutation's point — other in-flight reservations stand.
+              onSettled: () =>
+                setInFlightPoints((prev) => {
+                  const next = new Set(prev);
+                  next.delete(point);
+                  return next;
+                }),
               onError: () =>
                 Toast.show({
                   type: 'error',

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -27,8 +27,7 @@ import { ConfidencePickerModal } from '@/src/components/features/picks/Confidenc
 import { getLeagues } from '@/src/lib/leagues';
 import { resolveSportLeague } from '@/src/utils/sportLinks';
 import { useQuery } from '@tanstack/react-query';
-import { leaguesApi } from '@/src/services/api/leaguesApi';
-import { leaguesKeys } from '../leagues';
+import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
 import type { League, UserPick } from '@/src/types/models';
 import Toast from 'react-native-toast-message';
 
@@ -232,13 +231,19 @@ export default function PicksScreen() {
     franchiseSeasonId: string;
     currentPoint: number | null;
   } | null>(null);
-  const usedConfidencePoints = useMemo(
-    () =>
-      entries
-        .map((e) => e.pick?.confidencePoints)
-        .filter((p): p is number => p != null),
-    [entries],
-  );
+  // Reserves a just-selected point until its mutation settles: entries only
+  // reflect the new pick after invalidation/refetch, so without this a rapid
+  // second selection could reuse the same value.
+  const [inFlightPoint, setInFlightPoint] = useState<number | null>(null);
+  const usedConfidencePoints = useMemo(() => {
+    const used = entries
+      .map((e) => e.pick?.confidencePoints)
+      .filter((p): p is number => p != null);
+    if (inFlightPoint != null && !used.includes(inFlightPoint)) {
+      used.push(inFlightPoint);
+    }
+    return used;
+  }, [entries, inFlightPoint]);
 
   // Header display cascade — actionable first (one slot on mobile; see
   // docs/features/league-ended-headers.md):
@@ -605,6 +610,7 @@ export default function PicksScreen() {
               leagueSport={matchupsResponse?.sport ?? null}
               leagueAsOfDate={matchupsResponse?.asOfDate ?? null}
               pickType={pickType}
+              deferSelection={useConfidence}
               onPress={() => {
                 if (!sportLeague) {
                   // Sport hasn't resolved yet (matchups response still in flight)
@@ -720,14 +726,28 @@ export default function PicksScreen() {
         onClose={() => setPendingPick(null)}
         onSelect={(point) => {
           if (!pendingPick || !leagueId || !selectedWeek) return;
-          submitPick.mutate({
-            pickemGroupId: leagueId,
-            contestId: pendingPick.contestId,
-            pickType,
-            franchiseSeasonId: pendingPick.franchiseSeasonId,
-            week: selectedWeek,
-            confidencePoints: point,
-          });
+          setInFlightPoint(point);
+          submitPick.mutate(
+            {
+              pickemGroupId: leagueId,
+              contestId: pendingPick.contestId,
+              pickType,
+              franchiseSeasonId: pendingPick.franchiseSeasonId,
+              week: selectedWeek,
+              confidencePoints: point,
+            },
+            {
+              // Settled either way: on success the refetched entries carry the
+              // point; on failure it must be selectable again.
+              onSettled: () => setInFlightPoint(null),
+              onError: () =>
+                Toast.show({
+                  type: 'error',
+                  text1: 'Could not save your pick',
+                  text2: 'Please try again.',
+                }),
+            },
+          );
           setPendingPick(null);
         }}
       />

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -23,6 +23,7 @@ import { useMatchups } from '@/src/hooks/useMatchups';
 import { useCurrentUser } from '@/src/hooks/useStandings';
 import { useImportAvailability, useImportPicks } from '@/src/hooks/useImportPicks';
 import { ImportPicksModal } from '@/src/components/features/picks/ImportPicksModal';
+import { ConfidencePickerModal } from '@/src/components/features/picks/ConfidencePickerModal';
 import { getLeagues } from '@/src/lib/leagues';
 import { resolveSportLeague } from '@/src/utils/sportLinks';
 import { useQuery } from '@tanstack/react-query';
@@ -190,6 +191,7 @@ export default function PicksScreen() {
   );
   const submitPick = useSubmitPick();
   const pickType = matchupsResponse?.pickType ?? 'StraightUp';
+  const useConfidence = matchupsResponse?.useConfidencePoints ?? false;
   // Resolves LeagueWeekMatchupsDto.Sport ("FootballNcaa" | "FootballNfl" |
   // "BaseballMlb") to {sport, league} URL segments. null when the response
   // hasn't arrived yet or the sport enum isn't in the known map — in that
@@ -219,6 +221,24 @@ export default function PicksScreen() {
   // on screen.
   const made = entries.filter((e) => e.pick !== null).length;
   const allPicked = total > 0 && made >= total;
+
+  // ── Confidence points (web ConfidencePicker parity) ─────────────────────────
+  // In a confidence league a pick isn't submittable without a distinct 1..N
+  // value (the BE rejects it), so tapping a team stashes the choice and opens
+  // the picker; the POST fires on point selection. usedPoints derives from
+  // entries so it always matches what's on screen.
+  const [pendingPick, setPendingPick] = useState<{
+    contestId: string;
+    franchiseSeasonId: string;
+    currentPoint: number | null;
+  } | null>(null);
+  const usedConfidencePoints = useMemo(
+    () =>
+      entries
+        .map((e) => e.pick?.confidencePoints)
+        .filter((p): p is number => p != null),
+    [entries],
+  );
 
   // Header display cascade — actionable first (one slot on mobile; see
   // docs/features/league-ended-headers.md):
@@ -652,6 +672,16 @@ export default function PicksScreen() {
                   return;
                 }
                 if (!leagueId || !selectedWeek) return;
+                if (useConfidence) {
+                  // Confidence league: the POST fires from the picker's
+                  // onSelect — a pick without a point value is rejected.
+                  setPendingPick({
+                    contestId: m.contestId,
+                    franchiseSeasonId,
+                    currentPoint: pickMap.get(m.contestId)?.confidencePoints ?? null,
+                  });
+                  return;
+                }
                 submitPick.mutate({
                   pickemGroupId: leagueId,
                   contestId: m.contestId,
@@ -681,6 +711,26 @@ export default function PicksScreen() {
           }
         />
       )}
+
+      <ConfidencePickerModal
+        visible={pendingPick !== null}
+        totalGames={total}
+        usedPoints={usedConfidencePoints}
+        currentPoint={pendingPick?.currentPoint ?? null}
+        onClose={() => setPendingPick(null)}
+        onSelect={(point) => {
+          if (!pendingPick || !leagueId || !selectedWeek) return;
+          submitPick.mutate({
+            pickemGroupId: leagueId,
+            contestId: pendingPick.contestId,
+            pickType,
+            franchiseSeasonId: pendingPick.franchiseSeasonId,
+            week: selectedWeek,
+            confidencePoints: point,
+          });
+          setPendingPick(null);
+        }}
+      />
 
       <ImportPicksModal
         visible={!isReadOnly && importOpen}

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -344,6 +344,9 @@ function RootLayoutNav() {
         <Stack.Screen name="leagues" options={{ title: 'My Leagues' }} />
         <Stack.Screen name="create-league" options={{ presentation: 'modal' }} />
         <Stack.Screen name="league-invite/[leagueId]" options={{ presentation: 'modal' }} />
+        {/* League detail — post-create landing page (invite / review / delete);
+            title is set by the screen once the league loads. */}
+        <Stack.Screen name="league/[leagueId]" />
         <Stack.Screen name="admin/push-token" options={{ title: 'Push Token' }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/src/UI/sd-mobile/app/create-league.tsx
+++ b/src/UI/sd-mobile/app/create-league.tsx
@@ -751,9 +751,16 @@ export default function CreateLeagueScreen() {
       };
       return leaguesApi.createBaseballMlbLeague(payload).then((r) => r.data);
     },
-    onSuccess: async () => {
+    onSuccess: async (created) => {
       await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
-      router.back();
+      // Parity with web: land on the new league's detail page (invite
+      // friends, review settings, or delete if you changed your mind) rather
+      // than bouncing back to wherever creation started. replace() so Back
+      // doesn't return to the spent create form.
+      router.replace({
+        pathname: '/league/[leagueId]',
+        params: { leagueId: created.id },
+      } as never);
     },
     onError: (err: unknown) => {
       const serverMessage =
@@ -766,9 +773,24 @@ export default function CreateLeagueScreen() {
     },
   });
 
+  // Two-step submit, parity with web's "Confirm League Settings" dialog:
+  // a valid form opens a summary the user confirms before the POST fires.
+  // The validated snapshot is held in state so the modal renders from what
+  // will actually be sent, not live form values.
+  const [pendingData, setPendingData] = useState<FormData | null>(null);
+
   const onSubmit = (data: FormData) => {
     if (allSportsLocked) return; // nothing creatable; the button is also disabled
-    createMutation.mutate(data);
+    setPendingData(data);
+  };
+
+  const confirmCreate = () => {
+    if (!pendingData || createMutation.isPending) return;
+    createMutation.mutate(pendingData, {
+      // Close the modal on success only — on error it stays up behind the
+      // Alert so the user can retry without re-validating the form.
+      onSuccess: () => setPendingData(null),
+    });
   };
 
   // Tiebreaker options use sport-aware labels for the "total" variant.
@@ -1174,8 +1196,123 @@ export default function CreateLeagueScreen() {
           />
         </ScrollView>
       </KeyboardAvoidingView>
+
+      {/* Confirm League Settings — parity with web's pre-create summary
+          dialog. Renders from the validated pendingData snapshot, not live
+          form values. Stays open on a failed POST (behind the error Alert)
+          so the user can retry without re-validating. */}
+      <Modal
+        visible={pendingData !== null}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => {
+          if (!createMutation.isPending) setPendingData(null);
+        }}
+      >
+        {pendingData && (
+          <View style={[styles.confirmContainer, { backgroundColor: theme.background }]}>
+            <View style={[styles.confirmHeader, { borderBottomColor: theme.border }]}>
+              <Text style={[styles.confirmTitle, { color: theme.text }]}>
+                Confirm League Settings
+              </Text>
+            </View>
+            <ScrollView contentContainerStyle={styles.confirmBody}>
+              {buildConfirmRows(pendingData).map(({ label, value }) => (
+                <View
+                  key={label}
+                  style={[styles.confirmRow, { borderBottomColor: theme.border }]}
+                >
+                  <Text style={[styles.confirmLabel, { color: theme.textMuted }]}>
+                    {label}
+                  </Text>
+                  <Text style={[styles.confirmValue, { color: theme.text }]}>
+                    {value}
+                  </Text>
+                </View>
+              ))}
+            </ScrollView>
+            <View style={[styles.confirmFooter, { borderTopColor: theme.border }]}>
+              <Button
+                title="Back"
+                onPress={() => setPendingData(null)}
+                variant="secondary"
+                size="md"
+                disabled={createMutation.isPending}
+                style={styles.confirmFooterButton}
+              />
+              <Button
+                title="Confirm & Create"
+                onPress={confirmCreate}
+                loading={createMutation.isPending}
+                size="md"
+                style={styles.confirmFooterButton}
+              />
+            </View>
+          </View>
+        )}
+      </Modal>
     </>
   );
+}
+
+// ─── Confirm-dialog summary rows ──────────────────────────────────────────────
+
+// Mirrors the field list of web's "Confirm League Settings" dialog, derived
+// from the validated form snapshot. Kept outside the component so it stays a
+// pure FormData -> rows mapping.
+function buildConfirmRows(data: FormData): { label: string; value: string }[] {
+  const copy = SPORT_COPY[data.sport];
+
+  const divisionNames =
+    data.sport === 'FootballNfl'
+      ? NFL_DIVISIONS
+      : data.sport === 'BaseballMlb'
+        ? MLB_DIVISIONS
+        : [];
+  const selectedDivisions = data.divisionSlugs
+    .map((slug) => divisionNames.find((d) => d.slug === slug)?.shortName ?? slug)
+    .join(', ');
+
+  const pickTypeLabel =
+    PICK_TYPE_OPTIONS.find((o) => o.value === data.pickType)?.label ?? data.pickType;
+  const tiebreakerLabel =
+    data.tiebreakerType === 'TotalPoints' ? copy.tiebreakerTotalLabel : 'Earliest Pick';
+
+  const windowLabel =
+    data.durationMode === DURATION_DATES
+      ? `${data.startsOn ? formatDateOnlyDisplay(data.startsOn) : '—'} to ${
+          data.endsOn ? formatDateOnlyDisplay(data.endsOn) : '—'
+        }`
+      : 'Full Season';
+
+  const rows: { label: string; value: string }[] = [
+    { label: 'Name', value: data.name.trim() },
+    { label: 'Sport', value: copy.label },
+  ];
+  if (divisionNames.length > 0) {
+    rows.push({ label: 'Divisions', value: selectedDivisions || 'None selected' });
+  }
+  if (data.sport === 'FootballNcaa') {
+    rows.push({
+      label: 'Ranking Filter',
+      value:
+        RANKING_OPTIONS.find((o) => o.value === data.rankingFilter)?.label ?? 'All',
+    });
+  }
+  rows.push(
+    { label: 'Pick Type', value: pickTypeLabel },
+    { label: 'Tiebreaker', value: tiebreakerLabel },
+    { label: 'Confidence Points', value: data.useConfidencePoints ? 'Yes' : 'No' },
+    {
+      label: 'Drop Low Weeks',
+      value: data.dropLowWeeksCount === 0 ? 'None. Use All Weeks' : `${data.dropLowWeeksCount}`,
+    },
+    { label: 'League Window', value: windowLabel },
+    { label: 'Visibility', value: data.isPublic ? 'Public' : 'Private' },
+    { label: 'Pick Deadline', value: '5 minutes before kickoff (not configurable)' },
+    { label: 'Description', value: data.description?.trim() || 'None' },
+  );
+  return rows;
 }
 
 // ─── Styles ───────────────────────────────────────────────────────────────────
@@ -1277,4 +1414,30 @@ const styles = StyleSheet.create({
   pickerBarTitle: { fontSize: 15, fontWeight: '700' },
   pickerBarAction: { fontSize: 16 },
   pickerBarDone: { fontWeight: '700' },
+  // Confirm League Settings sheet.
+  confirmContainer: { flex: 1 },
+  confirmHeader: {
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  confirmTitle: { fontSize: 18, fontWeight: '700' },
+  confirmBody: { paddingHorizontal: 20, paddingBottom: 12 },
+  confirmRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 16,
+    paddingVertical: 11,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  confirmLabel: { fontSize: 13, fontWeight: '600', flexShrink: 0 },
+  confirmValue: { fontSize: 13, textAlign: 'right', flex: 1 },
+  confirmFooter: {
+    flexDirection: 'row',
+    gap: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  confirmFooterButton: { flex: 1 },
 });

--- a/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
@@ -7,7 +7,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { Button } from '@/src/components/ui/Button';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
-import { leaguesApi } from '@/src/services/api/leaguesApi';
+import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
 import { standingsKeys } from '@/src/hooks/useStandings';
 
 // League ids are GUIDs. Used to reject malformed/array-like route params
@@ -42,7 +42,7 @@ export default function LeagueInviteScreen() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['league', leagueId],
+    queryKey: leaguesKeys.detail(leagueId ?? 'invalid'),
     enabled: !!leagueId,
     queryFn: async () => (await leaguesApi.getLeagueById(leagueId!)).data,
   });

--- a/src/UI/sd-mobile/app/league/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league/[leagueId].tsx
@@ -19,11 +19,11 @@ import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import {
   leaguesApi,
+  leaguesKeys,
   type InviteableUser,
   type LeagueDetail,
 } from '@/src/services/api/leaguesApi';
 import { useCurrentUser, standingsKeys } from '@/src/hooks/useStandings';
-import { leaguesKeys } from '../leagues';
 
 // League ids are GUIDs — same guard as the league-invite deep-link screen.
 const GUID_RE =
@@ -76,7 +76,7 @@ export default function LeagueDetailScreen() {
     isError,
     refetch,
   } = useQuery({
-    queryKey: ['league', leagueId],
+    queryKey: leaguesKeys.detail(leagueId ?? 'invalid'),
     enabled: !!leagueId,
     queryFn: async () => (await leaguesApi.getLeagueById(leagueId!)).data,
   });
@@ -172,6 +172,9 @@ export default function LeagueDetailScreen() {
   const deleteMutation = useMutation({
     mutationFn: () => leaguesApi.deleteLeague(leagueId!),
     onSuccess: async () => {
+      // The league is gone — drop its detail cache entirely (an invalidate
+      // would just refetch a 404) and refresh the lists that contained it.
+      queryClient.removeQueries({ queryKey: leaguesKeys.detail(leagueId!) });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: leaguesKeys.mine }),
         queryClient.invalidateQueries({ queryKey: standingsKeys.me }),
@@ -226,7 +229,20 @@ export default function LeagueDetailScreen() {
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
-        {isLoading ? (
+        {!leagueId ? (
+          // Malformed/missing id: the query never ran, so a retry can't help —
+          // distinct from a fetch failure on a valid id below.
+          <View style={styles.centered}>
+            <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+              This league link isn&rsquo;t valid.
+            </Text>
+            <Button
+              title="Back"
+              variant="secondary"
+              onPress={() => (router.canGoBack() ? router.back() : router.replace('/(tabs)' as never))}
+            />
+          </View>
+        ) : isLoading ? (
           <ActivityIndicator style={styles.loading} color={theme.tint} />
         ) : isError || !league ? (
           <View style={styles.centered}>

--- a/src/UI/sd-mobile/app/league/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league/[leagueId].tsx
@@ -1,0 +1,469 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator,
+  TouchableOpacity,
+  TextInput,
+  Share,
+  Alert,
+} from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
+
+import { Text } from '@/src/components/ui/AppText';
+import { Button } from '@/src/components/ui/Button';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import {
+  leaguesApi,
+  type InviteableUser,
+  type LeagueDetail,
+} from '@/src/services/api/leaguesApi';
+import { useCurrentUser, standingsKeys } from '@/src/hooks/useStandings';
+import { leaguesKeys } from '../leagues';
+
+// League ids are GUIDs — same guard as the league-invite deep-link screen.
+const GUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// "Sep 1, 2026" from an ISO instant; null for a missing bound.
+function formatWindowBound(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function windowLabel(league: LeagueDetail): string {
+  const start = formatWindowBound(league.startsOn);
+  const end = formatWindowBound(league.endsOn);
+  if (!start && !end) return 'Full Season';
+  if (start && end) return `${start} – ${end}`;
+  if (start) return `From ${start}`;
+  return `Through ${end}`;
+}
+
+/**
+ * League detail — mobile parity with web's /app/league/{id}: the landing page
+ * after creating a league. Shows the league's parameters, its members, invite
+ * affordances (share link, registered-user search, email), and a
+ * commissioner-only delete. Past (deactivated) leagues render read-only:
+ * invite and delete are hidden.
+ */
+export default function LeagueDetailScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const params = useLocalSearchParams<{ leagueId?: string | string[] }>();
+  const { data: me } = useCurrentUser();
+
+  const leagueId =
+    typeof params.leagueId === 'string' && GUID_RE.test(params.leagueId)
+      ? params.leagueId
+      : undefined;
+
+  const {
+    data: league,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['league', leagueId],
+    enabled: !!leagueId,
+    queryFn: async () => (await leaguesApi.getLeagueById(leagueId!)).data,
+  });
+
+  const commissioner = league?.members.find((m) => m.role === 'commissioner');
+  const isCommissioner = !!me?.id && me.id === commissioner?.userId;
+  const isPast = !!league?.deactivatedUtc;
+
+  // ── Invite: registered-user search (debounced, mirrors web) ────────────────
+  const [search, setSearch] = useState('');
+  const [results, setResults] = useState<InviteableUser[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [invitingUserId, setInvitingUserId] = useState<string | null>(null);
+  const searchSeq = useRef(0);
+  // Invited this session — excluded from later searches (the BE has no record
+  // of an in-flight invite). Ref so the async search callback reads current.
+  const invitedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const term = search.trim();
+    if (!leagueId || term.length < 2) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    const seq = ++searchSeq.current;
+    const timer = setTimeout(async () => {
+      try {
+        const { data } = await leaguesApi.searchInviteableUsers(leagueId, term);
+        if (seq === searchSeq.current) {
+          setResults(data.filter((u) => !invitedRef.current.has(u.userId)));
+        }
+      } catch {
+        if (seq === searchSeq.current) setResults([]);
+      } finally {
+        if (seq === searchSeq.current) setSearching(false);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search, leagueId]);
+
+  const inviteUser = async (user: InviteableUser) => {
+    if (!leagueId || invitingUserId) return;
+    setInvitingUserId(user.userId);
+    try {
+      await leaguesApi.inviteUser(leagueId, user.userId);
+      invitedRef.current.add(user.userId);
+      setResults((prev) => prev.filter((u) => u.userId !== user.userId));
+      Toast.show({ type: 'success', text1: `Invited @${user.username}` });
+    } catch {
+      Toast.show({ type: 'error', text1: 'Could not send invite. Please try again.' });
+    } finally {
+      setInvitingUserId(null);
+    }
+  };
+
+  // ── Invite: email ──────────────────────────────────────────────────────────
+  const [inviteeName, setInviteeName] = useState('');
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [sendingEmail, setSendingEmail] = useState(false);
+
+  const sendEmailInvite = async () => {
+    const email = inviteEmail.trim();
+    if (!leagueId || !email || sendingEmail) return;
+    setSendingEmail(true);
+    try {
+      await leaguesApi.sendInvite(leagueId, email, inviteeName.trim() || null);
+      setInviteeName('');
+      setInviteEmail('');
+      Toast.show({ type: 'success', text1: 'Invitation sent!' });
+    } catch {
+      Toast.show({ type: 'error', text1: 'Could not send the invitation.' });
+    } finally {
+      setSendingEmail(false);
+    }
+  };
+
+  // ── Invite: share link (mobile-native affordance for web's copy-link) ──────
+  const shareInviteLink = async () => {
+    if (!leagueId || !league) return;
+    const inviteUrl = `https://www.sportdeets.com/app/join/${leagueId.replace(/-/g, '')}`;
+    try {
+      await Share.share({
+        message: `Join my sportDeets league "${league.name}": ${inviteUrl}`,
+      });
+    } catch {
+      // User dismissed the share sheet — nothing to do.
+    }
+  };
+
+  // ── Commissioner delete ────────────────────────────────────────────────────
+  const deleteMutation = useMutation({
+    mutationFn: () => leaguesApi.deleteLeague(leagueId!),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: leaguesKeys.mine }),
+        queryClient.invalidateQueries({ queryKey: standingsKeys.me }),
+      ]);
+      Toast.show({ type: 'success', text1: 'League deleted.' });
+      router.replace('/leagues' as never);
+    },
+    onError: (err: unknown) => {
+      // Surface the BE's specific refusal (e.g. picks already recorded).
+      const serverMessage = (
+        err as { response?: { data?: { errors?: { errorMessage?: string }[] } } }
+      )?.response?.data?.errors?.[0]?.errorMessage;
+      Alert.alert(
+        'Could not delete league',
+        serverMessage || 'Something went wrong. Please try again.',
+      );
+    },
+  });
+
+  const confirmDelete = () => {
+    Alert.alert(
+      'Delete League?',
+      'Are you sure you want to delete this league? This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Yes, Delete League',
+          style: 'destructive',
+          onPress: () => deleteMutation.mutate(),
+        },
+      ],
+    );
+  };
+
+  const openPicks = () => {
+    if (!leagueId) return;
+    router.push({ pathname: '/(tabs)/picks', params: { leagueId } } as never);
+  };
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: league?.name ?? 'League',
+          headerStyle: { backgroundColor: theme.card },
+          headerTintColor: theme.text,
+          headerBackButtonDisplayMode: 'minimal',
+        }}
+      />
+      <ScrollView
+        style={{ backgroundColor: theme.background }}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        {isLoading ? (
+          <ActivityIndicator style={styles.loading} color={theme.tint} />
+        ) : isError || !league ? (
+          <View style={styles.centered}>
+            <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+              Couldn&rsquo;t load this league.
+            </Text>
+            <Button title="Try again" variant="secondary" onPress={() => refetch()} />
+          </View>
+        ) : (
+          <>
+            {/* Parameters */}
+            <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+              {league.description ? (
+                <Text style={[styles.byline, { color: theme.textMuted }]}>
+                  {league.description}
+                </Text>
+              ) : null}
+              <Button
+                title={isPast ? 'View Picks' : 'Make Your Picks'}
+                onPress={openPicks}
+                fullWidth
+                size="md"
+                style={styles.picksButton}
+              />
+              {(
+                [
+                  ['Pick Type', league.pickType],
+                  ['Tiebreaker', league.tiebreakerType],
+                  ['Tie Policy', league.tiebreakerTiePolicy],
+                  ['Confidence Points', league.useConfidencePoints ? 'Yes' : 'No'],
+                  ['Ranking Filter', league.rankingFilter ?? 'None'],
+                  ['League Window', windowLabel(league)],
+                  ['Visibility', league.isPublic ? 'Public' : 'Private'],
+                  [
+                    'Conferences',
+                    [...new Set(league.conferenceSlugs ?? [])].join(', ') || 'None',
+                  ],
+                ] as const
+              ).map(([label, value]) => (
+                <View
+                  key={label}
+                  style={[styles.paramRow, { borderBottomColor: theme.separator }]}
+                >
+                  <Text style={[styles.paramLabel, { color: theme.textMuted }]}>{label}</Text>
+                  <Text style={[styles.paramValue, { color: theme.text }]}>{value}</Text>
+                </View>
+              ))}
+            </View>
+
+            {/* Members */}
+            <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+              <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>Members</Text>
+              {league.members.length > 0 ? (
+                league.members.map((member) => (
+                  <View key={member.userId} style={styles.memberRow}>
+                    {member.role === 'commissioner' && (
+                      <Text accessibilityLabel="Commissioner">👑 </Text>
+                    )}
+                    <Text style={[styles.memberName, { color: theme.text }]}>
+                      {member.username}
+                    </Text>
+                  </View>
+                ))
+              ) : (
+                <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+                  No members yet.
+                </Text>
+              )}
+            </View>
+
+            {/* Invite — hidden for past leagues (read-only records) */}
+            {!isPast && (
+              <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+                <Text style={[styles.sectionTitle, { color: theme.textMuted }]}>
+                  Invite Friends
+                </Text>
+                <Button
+                  title="Share Invite Link"
+                  onPress={shareInviteLink}
+                  variant="secondary"
+                  fullWidth
+                  size="md"
+                />
+
+                <Text style={[styles.inviteSub, { color: theme.textMuted }]}>
+                  Invite a sportDeets user
+                </Text>
+                <TextInput
+                  style={[
+                    styles.input,
+                    { backgroundColor: theme.background, borderColor: theme.border, color: theme.text },
+                  ]}
+                  placeholder="Search by username or name"
+                  placeholderTextColor={theme.textMuted}
+                  value={search}
+                  onChangeText={setSearch}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+                {searching && (
+                  <Text style={[styles.inviteHint, { color: theme.textMuted }]}>Searching…</Text>
+                )}
+                {results.map((user) => (
+                  <View key={user.userId} style={styles.resultRow}>
+                    <View style={styles.resultText}>
+                      <Text style={[styles.memberName, { color: theme.text }]}>
+                        {user.displayName}
+                      </Text>
+                      <Text style={[styles.inviteHint, { color: theme.textMuted }]}>
+                        @{user.username}
+                      </Text>
+                    </View>
+                    <TouchableOpacity
+                      style={[styles.inviteButton, { borderColor: theme.tint }]}
+                      onPress={() => inviteUser(user)}
+                      disabled={invitingUserId !== null}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Invite ${user.username}`}
+                    >
+                      <Text style={{ color: theme.tint, fontWeight: '600' }}>
+                        {invitingUserId === user.userId ? 'Inviting…' : 'Invite'}
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                ))}
+
+                <Text style={[styles.inviteSub, { color: theme.textMuted }]}>
+                  Or invite by email
+                </Text>
+                <TextInput
+                  style={[
+                    styles.input,
+                    { backgroundColor: theme.background, borderColor: theme.border, color: theme.text },
+                  ]}
+                  placeholder="Name (optional)"
+                  placeholderTextColor={theme.textMuted}
+                  value={inviteeName}
+                  onChangeText={setInviteeName}
+                />
+                <TextInput
+                  style={[
+                    styles.input,
+                    { backgroundColor: theme.background, borderColor: theme.border, color: theme.text },
+                  ]}
+                  placeholder="friend@example.com"
+                  placeholderTextColor={theme.textMuted}
+                  value={inviteEmail}
+                  onChangeText={setInviteEmail}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="email-address"
+                />
+                <Button
+                  title="Send Invitation"
+                  onPress={sendEmailInvite}
+                  loading={sendingEmail}
+                  disabled={!inviteEmail.trim()}
+                  fullWidth
+                  size="md"
+                />
+              </View>
+            )}
+
+            {/* Danger zone — commissioner only, active leagues only */}
+            {isCommissioner && !isPast && (
+              <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.error }]}>
+                <Text style={[styles.sectionTitle, { color: theme.errorText }]}>
+                  Danger Zone
+                </Text>
+                <Button
+                  title={deleteMutation.isPending ? 'Deleting…' : 'Delete League'}
+                  onPress={confirmDelete}
+                  variant="danger"
+                  fullWidth
+                  size="md"
+                  disabled={deleteMutation.isPending}
+                />
+              </View>
+            )}
+          </>
+        )}
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: { padding: 16, gap: 14, paddingBottom: 40 },
+  loading: { marginTop: 48 },
+  centered: { alignItems: 'center', gap: 14, marginTop: 48 },
+  emptyText: { fontSize: 14 },
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    gap: 10,
+  },
+  byline: { fontSize: 13, lineHeight: 18 },
+  picksButton: { marginBottom: 4 },
+  paramRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 16,
+    paddingVertical: 9,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  paramLabel: { fontSize: 13, fontWeight: '600', flexShrink: 0 },
+  paramValue: { fontSize: 13, textAlign: 'right', flex: 1 },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  memberRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 5 },
+  memberName: { fontSize: 15, fontWeight: '600' },
+  inviteSub: { fontSize: 12, fontWeight: '600', marginTop: 8 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+  },
+  inviteHint: { fontSize: 12 },
+  resultRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 6,
+  },
+  resultText: { flex: 1 },
+  inviteButton: {
+    borderWidth: 1.5,
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+  },
+});

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -18,12 +18,11 @@ import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { CloneLeagueModal } from '@/src/components/features/leagues/CloneLeagueModal';
 import { LeagueCard } from '@/src/components/features/leagues/LeagueCard';
-import { leaguesApi, type LeagueSummary } from '@/src/services/api/leaguesApi';
+import { leaguesApi, leaguesKeys, type LeagueSummary } from '@/src/services/api/leaguesApi';
 import { standingsKeys } from '@/src/hooks/useStandings';
 
-export const leaguesKeys = {
-  mine: ['leagues', 'mine'] as const,
-};
+// leaguesKeys moved to services/api/leaguesApi.ts — shared cache keys must
+// not live in a route module (see PR #570 review).
 
 const ALL_LEAGUES = 'All';
 

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -509,6 +509,12 @@ export interface MatchupCardProps {
   /** Tap on a team row → opens that team's page. */
   onPressTeam?: (side: 'home' | 'away') => void;
   onPick?: (matchup: Matchup, choice: PickChoice, franchiseSeasonId: string) => void;
+  /**
+   * Suppress the instant optimistic selection on tap. Set by confidence
+   * leagues, where the tap only opens the point picker — the pick isn't
+   * submitted (and may be canceled) until a point is chosen.
+   */
+  deferSelection?: boolean;
   /** Season year used for team stats API calls. Defaults to the game start year. */
   seasonYear?: number;
   /**
@@ -535,7 +541,7 @@ export interface MatchupCardProps {
   pickType?: PickType | null;
 }
 
-export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seasonYear, leagueSport, pickType }: MatchupCardProps) {
+export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, deferSelection, seasonYear, leagueSport, pickType }: MatchupCardProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
 
@@ -776,7 +782,11 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
   }
 
   const handlePick = (choice: PickChoice, franchiseSeasonId: string) => {
-    setOptimisticFranchiseId(franchiseSeasonId);
+    // Confidence leagues defer: the tap only OPENS the point picker — no
+    // submission happens until a point is chosen, and canceling must not
+    // leave a phantom selection. The server pick arriving via invalidation
+    // renders the selection once the point is confirmed.
+    if (!deferSelection) setOptimisticFranchiseId(franchiseSeasonId);
     onPick?.(matchup, choice, franchiseSeasonId);
   };
 
@@ -903,7 +913,14 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         <PickButtons
           matchup={matchup}
           pickedFranchiseId={effectiveFranchiseId ?? null}
-          confidence={pick?.confidencePoints ?? null}
+          confidence={
+            // Badge only when the PERSISTED pick is the displayed selection —
+            // an optimistic/pending selection of the other team must not
+            // inherit the old pick's point value.
+            pick && pick.franchiseSeasonId === effectiveFranchiseId
+              ? pick.confidencePoints ?? null
+              : null
+          }
           isPickCorrect={isPickCorrect}
           isFinal={isFinal}
           locked={locked}

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -350,12 +350,15 @@ function PickButton({
   pickResult,
   isLocked,
   onPress,
+  confidence,
 }: {
   teamShort: string;
   isSelected: boolean;
   pickResult: 'correct' | 'incorrect' | null;
   isLocked: boolean;
   onPress: () => void;
+  /** Assigned confidence points — badged on the selected button. */
+  confidence?: number | null;
 }) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -405,6 +408,14 @@ function PickButton({
       <Text style={[styles.pickBtnTeam, { color: teamColor }]} numberOfLines={1}>
         {teamShort}
       </Text>
+      {/* Confidence badge — only ever non-null in confidence leagues. */}
+      {isSelected && confidence != null && (
+        <View style={[styles.confidenceBadge, { borderColor: teamColor }]}>
+          <Text style={[styles.confidenceBadgeText, { color: teamColor }]}>
+            {confidence}
+          </Text>
+        </View>
+      )}
     </TouchableOpacity>
   );
 }
@@ -414,6 +425,7 @@ function PickButton({
 function PickButtons({
   matchup,
   pickedFranchiseId,
+  confidence,
   isPickCorrect,
   isFinal,
   locked,
@@ -429,6 +441,7 @@ function PickButtons({
   onPick: (choice: PickChoice, franchiseSeasonId: string) => void;
   onOpenStats?: () => void;
   onOpenPreview?: () => void;
+  confidence?: number | null;
 }) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -449,6 +462,7 @@ function PickButtons({
         pickResult={pickedAway ? pickResultStr : null}
         isLocked={locked}
         onPress={() => onPick('away', matchup.awayFranchiseSeasonId)}
+        confidence={pickedAway ? confidence : null}
       />
       <TouchableOpacity
         style={[styles.actionBtn, { backgroundColor: theme.separator }]}
@@ -479,6 +493,7 @@ function PickButtons({
         pickResult={pickedHome ? pickResultStr : null}
         isLocked={locked}
         onPress={() => onPick('home', matchup.homeFranchiseSeasonId)}
+        confidence={pickedHome ? confidence : null}
       />
     </View>
   );
@@ -888,6 +903,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, seaso
         <PickButtons
           matchup={matchup}
           pickedFranchiseId={effectiveFranchiseId ?? null}
+          confidence={pick?.confidencePoints ?? null}
           isPickCorrect={isPickCorrect}
           isFinal={isFinal}
           locked={locked}
@@ -1116,6 +1132,17 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     gap: 4,
   },
+  confidenceBadge: {
+    marginLeft: 6,
+    minWidth: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  confidenceBadgeText: { fontSize: 11, fontWeight: '800' },
   pickIcon: {
     fontSize: 13,
     fontWeight: '800',

--- a/src/UI/sd-mobile/src/components/features/picks/ConfidencePickerModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/picks/ConfidencePickerModal.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { View, StyleSheet, Modal, TouchableOpacity, ScrollView } from 'react-native';
+
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+
+interface Props {
+  visible: boolean;
+  /** Points run 1..totalGames (web parity: ConfidencePicker.jsx). */
+  totalGames: number;
+  /** Values already assigned to other picks this week — disabled in the grid. */
+  usedPoints: number[];
+  /** The tapped pick's current value (re-assign flow): selectable + highlighted. */
+  currentPoint: number | null;
+  onSelect: (point: number) => void;
+  onClose: () => void;
+}
+
+/**
+ * Confidence-point picker — mobile mirror of web's ConfidencePicker overlay.
+ * A league with confidence points requires every pick to carry a distinct
+ * value from 1..N (N = games this week); values used on other picks are
+ * disabled, the tapped pick's own value stays selectable so re-picking a team
+ * doesn't dead-end.
+ */
+export function ConfidencePickerModal({
+  visible,
+  totalGames,
+  usedPoints,
+  currentPoint,
+  onSelect,
+  onClose,
+}: Props) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const points = Array.from({ length: Math.max(totalGames, 1) }, (_, i) => i + 1);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <TouchableOpacity
+        style={styles.backdrop}
+        activeOpacity={1}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss confidence picker"
+      />
+      <View style={[styles.sheet, { backgroundColor: theme.card, borderTopColor: theme.border }]}>
+        <View style={[styles.header, { borderBottomColor: theme.border }]}>
+          <Text style={[styles.title, { color: theme.text }]}>Select Confidence Points</Text>
+          <TouchableOpacity onPress={onClose} hitSlop={12} accessibilityLabel="Close">
+            <Text style={[styles.close, { color: theme.textMuted }]}>✕</Text>
+          </TouchableOpacity>
+        </View>
+        <ScrollView contentContainerStyle={styles.grid}>
+          {points.map((point) => {
+            const isCurrent = point === currentPoint;
+            const isUsed = usedPoints.includes(point) && !isCurrent;
+            return (
+              <TouchableOpacity
+                key={point}
+                style={[
+                  styles.point,
+                  { borderColor: theme.border, backgroundColor: theme.background },
+                  isCurrent && { borderColor: theme.tint, backgroundColor: theme.tint },
+                  isUsed && styles.pointUsed,
+                ]}
+                onPress={() => onSelect(point)}
+                disabled={isUsed}
+                accessibilityRole="button"
+                accessibilityState={{ disabled: isUsed, selected: isCurrent }}
+                accessibilityLabel={
+                  isUsed
+                    ? `${point} points, already used on another pick`
+                    : `Assign ${point} points`
+                }
+              >
+                <Text
+                  style={[
+                    styles.pointText,
+                    { color: isCurrent ? theme.textOnAccent : theme.text },
+                    isUsed && { color: theme.textMuted },
+                  ]}
+                >
+                  {point}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' },
+  sheet: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingBottom: 28,
+    maxHeight: '65%',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  title: { fontSize: 16, fontWeight: '700' },
+  close: { fontSize: 18, fontWeight: '600' },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    padding: 16,
+  },
+  point: {
+    width: 52,
+    height: 44,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pointUsed: { opacity: 0.45 },
+  pointText: { fontSize: 16, fontWeight: '700' },
+});

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -56,6 +56,13 @@ export interface LeagueMember {
   role: string;
 }
 
+/** A registered user invitable to a league (from invite search). No email. */
+export interface InviteableUser {
+  userId: string;
+  username: string;
+  displayName: string;
+}
+
 // Subset of the BE LeagueDetailDto used by the invite preview and the
 // expandable league overview on My Leagues. Mirrors what sd-ui's LeagueDetail
 // page renders, minus its Danger Zone (mobile has no delete affordance).
@@ -75,6 +82,8 @@ export interface LeagueDetail {
   /** League window. Null on either side = open-ended; both null = full season. */
   startsOn: string | null;
   endsOn: string | null;
+  /** Non-null once the league's season has passed — read-only everywhere. */
+  deactivatedUtc?: string | null;
   members: LeagueMember[];
 }
 
@@ -155,6 +164,32 @@ export const leaguesApi = {
   // POST /ui/leagues/{id}/join — join a league by id.
   joinLeague: (id: string) =>
     apiClient.post<void>(`/ui/leagues/${id}/join`),
+
+  // DELETE /ui/leagues/{id} — commissioner-only; the BE enforces role and
+  // refuses e.g. leagues with recorded picks (surface its error message).
+  deleteLeague: (id: string) =>
+    apiClient.delete<void>(`/ui/leagues/${id}`),
+
+  // POST /ui/leagues/{id}/invite — email an invitation to a non-member.
+  sendInvite: (id: string, email: string, inviteeName: string | null = null) =>
+    apiClient.post<void>(`/ui/leagues/${id}/invite`, {
+      leagueId: id,
+      email,
+      inviteeName,
+    }),
+
+  // GET /ui/leagues/{id}/invite/search?q= — registered users invitable to the
+  // league (BE requires >= 2 chars; excludes self, members, synthetic users).
+  searchInviteableUsers: (id: string, q: string) =>
+    apiClient.get<InviteableUser[]>(`/ui/leagues/${id}/invite/search`, {
+      params: { q },
+    }),
+
+  // POST /ui/leagues/{id}/invite/user — invite a registered user (from
+  // search). Triggers the LeagueInvite push, which deep-links into the mobile
+  // league-invite screen; no email.
+  inviteUser: (id: string, userId: string) =>
+    apiClient.post<void>(`/ui/leagues/${id}/invite/user`, { userId }),
 
   // GET /ui/leagues — the current user's leagues. The BE excludes deactivated
   // (past-season) leagues unless includeDeactivated is passed; those rows come

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -56,6 +56,16 @@ export interface LeagueMember {
   role: string;
 }
 
+/**
+ * React Query key factory for league data — colocated with the API module so
+ * screens and shared components import it from one place (route modules must
+ * not be the home of shared cache keys).
+ */
+export const leaguesKeys = {
+  mine: ['leagues', 'mine'] as const,
+  detail: (id: string) => ['league', id] as const,
+};
+
 /** A registered user invitable to a league (from invite search). No email. */
 export interface InviteableUser {
   userId: string;


### PR DESCRIPTION
Three mobile-parity gaps closed in one coherent arc — everything between tapping Create League and making picks in the league it made. All mobile, pure JS (OTA-able).

## 1. League creation confirmation

Web shows a "Confirm League Settings" summary before the POST; mobile fired immediately. Submit now validates and opens a summary sheet **rendered from the validated snapshot** (not live form values): name, sport, divisions/ranking filter, pick type, sport-aware tiebreaker label, confidence, drop-low weeks, window, visibility, the fixed pick-deadline note, description. On a failed POST the sheet stays open behind the error Alert, so retry doesn't require re-validating the form.

## 2. League detail screen (`app/league/[leagueId].tsx`, new — web's `/app/league/{id}`)

The post-create landing page (`router.replace`, so Back doesn't resurrect the spent form):

- **Parameters card** + description + Make Your Picks (→ View Picks for past leagues)
- **Members** with the commissioner 👑
- **Invite Friends** — native **Share sheet** for the invite link (mobile's version of web's copy-to-clipboard), debounced registered-user search with session-invite dedupe (mirrors web's `invitedRef` behavior), and email invites
- **Danger Zone** — commissioner + active only; destructive confirm; surfaces the BE's *specific* refusal message (e.g. leagues with recorded picks)
- Past leagues hide invite + delete entirely; GUID-validated route param

Nice loop: inviting a registered user fires the LeagueInvite push → the recipient deep-links into the mobile join screen. **Invite → join is now mobile-native end to end.**

## 3. Confidence points (the actual bug: the BE rejected every mobile pick in these leagues)

`POST /ui/picks` correctly demands a confidence value in confidence leagues; mobile had no way to provide one. New shared `ConfidencePickerModal` mirrors web's picker: a 1..N grid (N = games this week), values used on other picks disabled, the tapped pick's own value selectable + highlighted so re-picking never dead-ends. Tapping a team stashes the choice; the POST fires from point selection — wired on **both** the picks screen and the game-detail screen. The selected pick button badges its assigned value. Non-confidence leagues are untouched (the gate only diverts on `useConfidencePoints`).

Known shared limitation (inherited from web deliberately): re-assigning a value already used on another pick requires freeing it there first — same on both platforms.

## API client additions

`deleteLeague`, `sendInvite`, `searchInviteableUsers`, `inviteUser`; `InviteableUser` type; `deactivatedUtc` added to the mobile `LeagueDetail` type (the BE already sends it; web already reads it).

## Verification

- `tsc --noEmit` clean; jest 12 suites / 84 tests
- Local E2E: create → confirm sheet → land on detail → all three invite paths → picks with confidence values accepted by the BE → delete refusal surfaced correctly
- Follow-up (not in this PR): linking the My Leagues cards into the new detail screen — the list currently keeps its expandable-overview pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mobile league detail pages with league settings overview, member list, invitations (username/email) and sharing, plus commissioner-only deletion for active leagues.
  - Added a confidence-points flow for submitting picks, including a confidence picker modal, confidence badges, and preventing used-point conflicts.
- **Bug Fixes**
  - League creation failures now keep the confirmation modal open to support retry.
- **Chores**
  - Standardized league cache keys across screens and added shared API support for league invite management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->