### PR TITLE
feat(web,mobile): add password reset on both platforms

### DIFF
--- a/src/UI/sd-mobile/app/(auth)/_layout.tsx
+++ b/src/UI/sd-mobile/app/(auth)/_layout.tsx
@@ -9,6 +9,7 @@ export default function AuthLayout() {
     <Stack screenOptions={{ headerShown: false, animation: 'fade' }}>
       <Stack.Screen name="welcome" />
       <Stack.Screen name="sign-in" />
+      <Stack.Screen name="forgot-password" />
     </Stack>
   );
 }

--- a/src/UI/sd-mobile/app/(auth)/forgot-password.tsx
+++ b/src/UI/sd-mobile/app/(auth)/forgot-password.tsx
@@ -1,0 +1,207 @@
+import React, { useState } from 'react';
+import {
+  View,
+  TextInput,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { sendPasswordResetEmail } from 'firebase/auth';
+import { router, useLocalSearchParams } from 'expo-router';
+
+import { Text } from '@/src/components/ui/AppText';
+import { auth } from '@/src/lib/firebase';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { Button } from '@/src/components/ui/Button';
+import { Wordmark } from '@/src/components/brand/Wordmark';
+import { getTheme } from '@/constants/Colors';
+
+// ─── Validation schema ────────────────────────────────────────────────────────
+
+const schema = z.object({
+  email: z.string().email('Please enter a valid email'),
+});
+
+type FormData = z.infer<typeof schema>;
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+export default function ForgotPasswordScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  // Sign-in hands over whatever address was already typed so the user doesn't
+  // retype it after a failed login.
+  const { email: prefilledEmail } = useLocalSearchParams<{ email?: string }>();
+
+  const [sent, setSent] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    control,
+    handleSubmit,
+    getValues,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: prefilledEmail ?? '' },
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setFormError(null);
+    try {
+      await sendPasswordResetEmail(auth, data.email.trim());
+      setSent(true);
+    } catch (e) {
+      const code = (e as { code?: string })?.code ?? '';
+
+      // Never disclose whether an address has an account. An unknown address
+      // gets the same confirmation a real one does — otherwise this screen
+      // becomes an account-enumeration oracle. (Firebase projects with email
+      // enumeration protection enabled already return success here; this
+      // keeps the behavior identical either way.)
+      if (code === 'auth/user-not-found' || code === 'auth/invalid-email') {
+        setSent(true);
+        return;
+      }
+
+      if (code === 'auth/too-many-requests') {
+        setFormError('Too many attempts. Please wait a few minutes and try again.');
+        return;
+      }
+
+      if (code === 'auth/network-request-failed') {
+        setFormError('Network error. Check your connection and try again.');
+        return;
+      }
+
+      setFormError('Something went wrong. Please try again.');
+    }
+  };
+
+  const backToSignIn = () => {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace('/(auth)/sign-in');
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: theme.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView contentContainerStyle={styles.inner} keyboardShouldPersistTaps="handled">
+        <View style={styles.header}>
+          <Wordmark />
+        </View>
+
+        {sent ? (
+          <View style={styles.card}>
+            <Text style={[styles.title, { color: theme.text }]}>Check your email</Text>
+            <Text style={[styles.body, { color: theme.textMuted }]}>
+              If an account exists for {getValues('email').trim()}, we&apos;ve sent a
+              link to reset your password. It may take a minute to arrive — check
+              your spam folder if you don&apos;t see it.
+            </Text>
+            <Button
+              title="Back to Sign In"
+              onPress={backToSignIn}
+              fullWidth
+              size="lg"
+              style={{ marginTop: 16 }}
+            />
+          </View>
+        ) : (
+          <View style={styles.card}>
+            <Text style={[styles.title, { color: theme.text }]}>Reset your password</Text>
+            <Text style={[styles.body, { color: theme.textMuted }]}>
+              Enter your email and we&apos;ll send you a link to reset your password.
+            </Text>
+
+            <View style={styles.field}>
+              <Text style={[styles.label, { color: theme.textMuted }]}>Email</Text>
+              <Controller
+                control={control}
+                name="email"
+                render={({ field: { onChange, onBlur, value } }) => (
+                  <TextInput
+                    style={[
+                      styles.input,
+                      {
+                        backgroundColor: theme.card,
+                        borderColor: errors.email ? theme.error : theme.border,
+                        color: theme.text,
+                      },
+                    ]}
+                    placeholder="you@example.com"
+                    placeholderTextColor={theme.textMuted}
+                    autoCapitalize="none"
+                    autoComplete="email"
+                    keyboardType="email-address"
+                    onBlur={onBlur}
+                    onChangeText={onChange}
+                    value={value}
+                  />
+                )}
+              />
+              {errors.email && (
+                <Text style={[styles.fieldError, { color: theme.error }]}>
+                  {errors.email.message}
+                </Text>
+              )}
+            </View>
+
+            {formError && (
+              <Text style={[styles.fieldError, { color: theme.error }]}>{formError}</Text>
+            )}
+
+            <Button
+              title="Send reset link"
+              onPress={handleSubmit(onSubmit)}
+              loading={isSubmitting}
+              fullWidth
+              size="lg"
+              style={{ marginTop: 8 }}
+            />
+
+            <TouchableOpacity style={styles.backLink} onPress={backToSignIn}>
+              <Text style={[styles.backText, { color: theme.tint }]}>
+                ← Back to sign in
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: { flexGrow: 1, justifyContent: 'center', padding: 20 },
+  header: { alignItems: 'center', marginBottom: 32, gap: 8 },
+  card: { gap: 4 },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: 4 },
+  body: { fontSize: 14, lineHeight: 20, marginBottom: 12 },
+  field: { marginBottom: 12 },
+  label: { fontSize: 13, fontWeight: '600', marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  fieldError: { fontSize: 13, marginTop: 6 },
+  backLink: { alignSelf: 'center', marginTop: 20, padding: 8 },
+  backText: { fontSize: 14, fontWeight: '600' },
+});

--- a/src/UI/sd-mobile/app/(auth)/forgot-password.tsx
+++ b/src/UI/sd-mobile/app/(auth)/forgot-password.tsx
@@ -39,13 +39,16 @@ export default function ForgotPasswordScreen() {
   // retype it after a failed login.
   const { email: prefilledEmail } = useLocalSearchParams<{ email?: string }>();
 
+  // The address the reset was actually requested for. Captured at submit
+  // rather than read back from the form so the confirmation cannot drift from
+  // what was sent.
+  const [submittedEmail, setSubmittedEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
   const {
     control,
     handleSubmit,
-    getValues,
     formState: { errors, isSubmitting },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -54,8 +57,10 @@ export default function ForgotPasswordScreen() {
 
   const onSubmit = async (data: FormData) => {
     setFormError(null);
+    const address = data.email.trim();
+    setSubmittedEmail(address);
     try {
-      await sendPasswordResetEmail(auth, data.email.trim());
+      await sendPasswordResetEmail(auth, address);
       setSent(true);
     } catch (e) {
       const code = (e as { code?: string })?.code ?? '';
@@ -106,7 +111,7 @@ export default function ForgotPasswordScreen() {
           <View style={styles.card}>
             <Text style={[styles.title, { color: theme.text }]}>Check your email</Text>
             <Text style={[styles.body, { color: theme.textMuted }]}>
-              If an account exists for {getValues('email').trim()}, we&apos;ve sent a
+              If an account exists for {submittedEmail}, we&apos;ve sent a
               link to reset your password. It may take a minute to arrive — check
               your spam folder if you don&apos;t see it.
             </Text>

--- a/src/UI/sd-mobile/app/(auth)/sign-in.tsx
+++ b/src/UI/sd-mobile/app/(auth)/sign-in.tsx
@@ -13,6 +13,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { router } from 'expo-router';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '@/src/lib/firebase';
 import {
@@ -57,6 +58,7 @@ export default function SignInScreen() {
   const {
     control,
     handleSubmit,
+    getValues,
     formState: { errors, isSubmitting },
     setError,
     clearErrors,
@@ -64,6 +66,14 @@ export default function SignInScreen() {
     resolver: zodResolver(schema),
     defaultValues: { email: '', password: '' },
   });
+
+  const goToForgotPassword = () => {
+    const typed = getValues('email').trim();
+    router.push({
+      pathname: '/(auth)/forgot-password',
+      params: typed ? { email: typed } : {},
+    });
+  };
 
   const onSubmit = async ({ email, password }: FormData) => {
     try {
@@ -268,13 +278,9 @@ export default function SignInScreen() {
             style={{ marginTop: 8 }}
           />
 
-          {/* TODO: wire password-reset flow. TouchableOpacity has no onPress
-              today — visually a button, functionally a no-op. Two paths when
-              we pick this up: (a) call Firebase `sendPasswordResetEmail(auth,
-              email)` inline with a simple prompt for the address, or (b)
-              navigate to a dedicated reset screen. CodeRabbit flagged this on
-              PR #274; deferred pending product decision on the flow. */}
-          <TouchableOpacity style={styles.forgotLink}>
+          {/* Carries whatever address is already typed so the user doesn't
+              retype it after a failed sign-in. */}
+          <TouchableOpacity style={styles.forgotLink} onPress={goToForgotPassword}>
             <Text style={[styles.forgotText, { color: theme.tint }]}>
               Forgot password?
             </Text>

--- a/src/UI/sd-ui/src/App.js
+++ b/src/UI/sd-ui/src/App.js
@@ -69,12 +69,14 @@ function AppRoutes() {
       {/* Static legal pages stay reachable during an API outage: they make no
           API calls, and /account-deletion is the URL submitted to Google
           Play's Data Safety section — a reviewer (or an uninstalled user)
-          must never hit the offline error page there. All other routes keep
-          the existing ErrorPage short-circuit. Trailing slashes are stripped
-          before matching — the router itself treats /terms/ as /terms, so the
-          allowlist must too. */}
+          must never hit the offline error page there. /forgot-password belongs
+          here for the same reason and one more: it talks only to Firebase, and
+          an API outage is exactly when a locked-out user is most likely to be
+          trying to get back in. All other routes keep the existing ErrorPage
+          short-circuit. Trailing slashes are stripped before matching — the
+          router itself treats /terms/ as /terms, so the allowlist must too. */}
       {apiOffline &&
-      !["/terms", "/privacy", "/account-deletion"].includes(
+      !["/terms", "/privacy", "/account-deletion", "/forgot-password"].includes(
         location.pathname.replace(/\/+$/, "") || "/"
       ) ? (
         <ErrorPage message="We lost the ball trying to contact the server." />

--- a/src/UI/sd-ui/src/App.js
+++ b/src/UI/sd-ui/src/App.js
@@ -12,6 +12,7 @@ import "./App.css";
 
 import MainApp from "./MainApp";
 import SignupPage from "./components/signup/SignupPage";
+import ForgotPassword from "./components/login/ForgotPassword";
 import LandingPage from "./components/landing/LandingPage";
 import TermsPage from "./components/legal/TermsPage";
 import PrivacyPage from "./components/legal/PrivacyPage";
@@ -81,6 +82,7 @@ function AppRoutes() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/signup" element={<SignupPage />} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/gallery" element={<Gallery />} />
           <Route
             path="/results/:sport/:league/:seasonYear"

--- a/src/UI/sd-ui/src/components/login/ForgotPassword.jsx
+++ b/src/UI/sd-ui/src/components/login/ForgotPassword.jsx
@@ -1,0 +1,113 @@
+// src/components/login/ForgotPassword.jsx
+import React, { useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { auth } from "../../firebase";
+import { FaEnvelope } from "react-icons/fa";
+import "./Login.css";
+
+const ForgotPassword = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // The sign-in form hands over whatever address was already typed so the user
+  // doesn't retype it after a failed login.
+  const [email, setEmail] = useState(location.state?.email ?? "");
+  const [sent, setSent] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMsg("");
+    setSubmitting(true);
+
+    try {
+      await sendPasswordResetEmail(auth, email.trim());
+      setSent(true);
+    } catch (error) {
+      const code = error?.code ?? "";
+
+      // Never disclose whether an address has an account. An unknown address
+      // gets the same confirmation a real one does — otherwise this page
+      // becomes an account-enumeration oracle. (Firebase projects with email
+      // enumeration protection enabled already return success here; this keeps
+      // the behavior identical either way.)
+      if (code === "auth/user-not-found" || code === "auth/invalid-email") {
+        setSent(true);
+      } else if (code === "auth/too-many-requests") {
+        setErrorMsg("Too many attempts. Please wait a few minutes and try again.");
+      } else if (code === "auth/network-request-failed") {
+        setErrorMsg("Network error. Check your connection and try again.");
+      } else {
+        // Deliberately not error.message — Firebase's raw strings leak
+        // internals like "Firebase: Error (auth/...)".
+        setErrorMsg("Something went wrong. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (sent) {
+    return (
+      <div className="login-page">
+        <div className="login-card">
+          <h2>Check your email</h2>
+          <p className="forgot-blurb">
+            If an account exists for <strong>{email.trim()}</strong>, we&apos;ve sent a
+            link to reset your password. It may take a minute to arrive — check your
+            spam folder if you don&apos;t see it.
+          </p>
+          <button
+            type="button"
+            className="login-button"
+            onClick={() => navigate("/signup")}
+          >
+            Back to Sign In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <h2>Reset your password</h2>
+        <p className="forgot-blurb">
+          Enter your email and we&apos;ll send you a link to reset your password.
+        </p>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="reset-email">Email:</label>
+            <div className="input-wrapper">
+              <FaEnvelope />
+              <input
+                id="reset-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+              />
+            </div>
+          </div>
+
+          {errorMsg && <div className="error-message">{errorMsg}</div>}
+
+          <button type="submit" className="login-button" disabled={submitting}>
+            {submitting ? "Sending…" : "Send reset link"}
+          </button>
+        </form>
+
+        <p className="forgot-back">
+          <Link to="/signup">← Back to sign in</Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/src/UI/sd-ui/src/components/login/Login.css
+++ b/src/UI/sd-ui/src/components/login/Login.css
@@ -142,3 +142,47 @@
 .input-wrapper input::placeholder {
   color: var(--text-muted);
 }
+
+/* ── Password reset ─────────────────────────────────────────────────────────
+   Shared by the "Forgot password?" affordance on the embedded sign-in card
+   and by the standalone /forgot-password page, which reuses .login-card. */
+
+.forgot-password-link,
+.forgot-back {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.forgot-password-link a,
+.forgot-back a {
+  color: #4da3ff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.forgot-password-link a:hover,
+.forgot-back a:hover {
+  text-decoration: underline;
+}
+
+.forgot-blurb {
+  margin: 0 0 18px;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  opacity: 0.85;
+}
+
+.login-card button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* .error-message was only ever styled under .email-signup-form, so the
+   sign-in card's errors have been rendering as unstyled body text. Matches
+   the signup form's treatment. */
+.login-card .error-message {
+  color: var(--error);
+  font-size: 0.9rem;
+  margin-bottom: 12px;
+}

--- a/src/UI/sd-ui/src/components/login/Login.jsx
+++ b/src/UI/sd-ui/src/components/login/Login.jsx
@@ -1,6 +1,6 @@
 // src/components/Login.jsx
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "../../firebase"; // ✅ centralized Firebase setup
 import { FaEnvelope, FaLock } from "react-icons/fa";
@@ -66,6 +66,14 @@ const Login = () => {
             Sign In
           </button>
         </form>
+
+        {/* Carries whatever address is already typed so the user doesn't
+            retype it after a failed sign-in. */}
+        <p className="forgot-password-link">
+          <Link to="/forgot-password" state={{ email }}>
+            Forgot password?
+          </Link>
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes audit **P0-6**.

## Problem

There was no password recovery anywhere. Mobile's "Forgot password?" was a `TouchableOpacity` with no `onPress` — a no-op since PR #274, left pending a product decision on the flow. Web had no forgot-password affordance or route at all.

Any user who forgot their password was locked out with no self-service path; the only recovery was emailing the operator.

## Approach

`sendPasswordResetEmail` is entirely client-side Firebase, so this is UI on both platforms — **no API change, nothing new to deploy server-side.**

Dedicated screens rather than an inline mode, matched across platforms:

| Platform | Location |
|---|---|
| Mobile | `app/(auth)/forgot-password.tsx`, registered in the `(auth)` stack |
| Web | `/forgot-password` → `components/login/ForgotPassword.jsx` |

Both prefill from whatever address was already typed on sign-in, so a failed login doesn't cost a retype. Mobile's dead button now navigates there and the TODO is gone.

**Note on the web wiring:** there is no `/login` route — sign-in is embedded at the bottom of `/signup` via `<Login />`. That's where the "Forgot password?" link lives and where "Back to sign in" returns. If a dedicated sign-in route is ever added, those are the two targets to update.

## Account enumeration

**An unknown address gets the same confirmation a real one does.** `sendPasswordResetEmail` throws `auth/user-not-found`, and surfacing that would turn this page into an account-enumeration oracle — anyone could test whether an address has a sportDeets account.

Both platforms treat `user-not-found` as success and render "If an account exists for X, we've sent a link." Only actionable failures surface (`auth/too-many-requests`, `auth/network-request-failed`); everything else gets a generic message rather than Firebase's raw `error.message`, which leaks strings like `Firebase: Error (auth/...)`.

## Known limitation

The reset link lands on Firebase's **default hosted action page** (`<project>.firebaseapp.com/__/auth/action`). Zero configuration and it works, but it carries no sportDeets branding and shows the Firebase project name. Acceptable for closed testing; a custom action URL is worth doing before public launch.

## Also included

One unrelated styling fix in a file already being touched: `.error-message` was only ever styled under `.email-signup-form`, so the sign-in card's error text has been rendering as unstyled body text. Added a scoped rule in `Login.css` matching the signup form's treatment.

## Validation

Verified end to end on web by @jrandallsexton — a real reset email was received, and the non-existent-address path confirmed to return the same response. Mobile will be verified once deployed.

Mobile `tsc --noEmit` clean, 84 mobile Jest tests pass, web lint clean, 10 web Vitest tests pass, CRA production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Forgot password?” flow to both mobile and web sign-in experiences.
  * Introduced dedicated password reset screens/routes, including mobile navigation to the reset page.
  * Prefills the reset form with the entered email and displays a confirmation state after requesting a reset.
  * Improves outage resilience by keeping the forgot-password route reachable during API downtime.
* **Style**
  * Added dedicated styling for forgot-password elements, reset forms, error messages, and disabled buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->