### PR TITLE
feat(api,web): commissioner join policy + public league discovery

### DIFF
--- a/docs/features/league-join-policy-and-discovery.md
+++ b/docs/features/league-join-policy-and-discovery.md
@@ -1,0 +1,166 @@
+# League Join Policy + Public League Discovery
+
+Status: **Phases 1-2 (API + web) implemented — awaiting local E2E + migration validation; Phase 3 (mobile) not started**
+Date: 2026-07-30
+Surfaces: SportsData.Api, sd-ui, sd-mobile
+Driver: public leagues must be browsable/joinable to drive home-page content;
+single-day MLB test leagues surfaced the "when does a league close?" question.
+
+## Decisions (settled with the operator, 2026-07-30)
+
+1. **The commissioner decides, per league, at creation.** No platform-wide
+   default behavior — join policy is an explicit choice on the create form,
+   alongside pick type and visibility. Editable in league settings until
+   deactivation.
+2. **Exactly two options.** Deliberately no custom date in v1:
+   - `Open` — joinable while the league is live (implemented name; the
+     working name `OpenUntilLastLock` was shortened)
+   - `CloseAtFirstGame` — closed once the league's first contest starts
+3. **Applies to ALL leagues, not just public ones.** Visibility (`IsPublic`)
+   controls who can *find* a league; join policy controls until when anyone can
+   *enter* it. Both public joins and invite-link joins flow through
+   `JoinLeagueCommandHandler`, so one check covers both — and shared invite
+   links therefore expire naturally when the league closes. That was the
+   operator's instinct ("if the commissioner sends an invite, it should expire
+   at a certain time") and it is the zero-extra-work outcome.
+4. **No "close now" button.** Flipping `OpenUntilLastLock` →
+   `CloseAtFirstGame` after the first game has started closes the league
+   immediately; flipping back re-opens it. Two enum values give close-now and
+   re-open as consequences, not features.
+
+## Current state (verified 2026-07-30)
+
+- `GetPublicLeaguesQueryHandler` returns every `IsPublic` league the caller
+  isn't in — **including deactivated ones**; no sport/season filter; DTO lacks
+  `memberCount`, sport, league, seasonYear, window info.
+- Web `LeagueDiscoverPage` exists and works (Join → `/app/join/{id}` →
+  `AutoJoinRedirect`). Mobile has **no** discovery surface — only the
+  invite deep-link preview screen.
+- `JoinLeagueCommandHandler` checks: league exists, not already a member.
+  **A deactivated league is joinable today — straight bug**, fixed here
+  regardless of policy work.
+- `PickemGroup` has `StartsOn`/`EndsOn` (contest window), `DeactivatedUtc`,
+  `IsPublic`. No joinability concept.
+- The IDOR work (#572) already gives non-members a tiered league-detail
+  preview (settings + `MemberCount`, roster withheld) — the browse card's
+  data needs are mostly served.
+
+## Semantics
+
+**`CloseAtFirstGame`** — closed when `min(StartDateUtc)` over the league's
+`PickemGroupMatchup` rows is in the past. Computed **at join time**, never
+stored: the slate builds asynchronously after league creation (see
+league-slate-async quirk), so a stored close date computed at creation would
+be wrong/absent. Empty slate → league is open (nothing has started).
+
+**`OpenUntilLastLock`** — joinable until `DeactivatedUtc` is set. NOT
+implemented as `max(StartDateUtc) < now`: weekly slates build progressively,
+so the max over *existing* matchups would wrongly close a football league in
+the gap between week N's last kickoff and week N+1's slate build.
+Known accepted wrinkle: a single-day league remains technically joinable
+between its last first-pitch and its deactivation sweep (an evening,
+roughly), during which a joiner has nothing left to pick. Harmless; not worth
+machinery in v1.
+
+**Deactivated → never joinable**, under any policy.
+
+### Considered and rejected: storing the close time as a DateTime
+
+The operator raised storing `JoinDeadlineUtc` directly (backfilled by an event
+when matchups generate) — cleaner to read, one column to compare. Rejected for
+v1 because it is a standing consistency job, not a one-time backfill:
+
+- **Kickoff times move.** `ContestStartTimeUpdated` exists because ESPN
+  reshuffles start times routinely; a stored deadline derived from first-game
+  time silently drifts unless every reschedule also resyncs it. Same failure
+  class as the countdown-anchoring bug: precomputed time values rot, derived
+  ones cannot.
+- **`OpenUntilLastLock` has no storable value.** Weekly slates build
+  progressively; the "last game time" is unknowable until season end. The
+  column would hold null-meaning-open — the enum again, hidden in a nullable.
+
+The read-side cleanliness is kept anyway: DTOs expose a **computed
+`closesAtUtc`** (`CloseAtFirstGame` → `min(matchup.StartDateUtc)` at read
+time; `OpenUntilLastLock` → null). Clients render a concrete timestamp;
+nothing is stored that can go stale.
+
+If commissioner-set custom close dates ever ship (cut from v1), those are
+*authored* values, not derived — a nullable `JoinDeadlineUtc` column arrives
+naturally then, alongside the enum, with no rework of this design.
+
+### Do the two options make sense for season-long leagues?
+
+Raised by the operator: `CloseAtFirstGame` reads single-day-shaped — for a
+season league, is the cutoff week 1? week 2? Resolution: the option's real
+semantic is **"roster locks when play begins"**, which is shape-independent:
+
+- Single-day league → closes at first pitch (everyone picks the same slate)
+- Season league → closes at the first game inside the league's window
+  (everyone competes over the identical season — the competitive-purity pool)
+- Custom-window league → `min()` over its matchups is already window-scoped
+
+The middle ground — "open through week N, then lock" — is the deferred custom
+deadline in week clothing. Deliberately not built speculatively; if beta
+leagues ask for week-N cutoffs, that is the signal.
+
+**The leading v2 candidate (operator insight, 2026-07-30): derive the window
+from `DropLowWeeksCount`.** A league that drops its 3 lowest weeks can absorb
+a joiner through week 3 at zero competitive penalty — the weeks they missed
+are exactly the weeks the scoring already discards. So a third enum value
+(`OpenThroughDroppedWeeks`: closed once week `DropLowWeeksCount` completes)
+is derived-not-authored, consistent with the no-stored-DateTime doctrine, and
+needs NO new data captured today: `JoinPolicy` stores as an int (house style —
+`HasConversion<int>` like the other league enums; a new enum value is a code
+change, no migration) and `DropLowWeeksCount` already exists on
+`PickemGroup`. v1 proceeds with the two options knowing this slots in clean.
+
+## Implementation plan
+
+### Phase 1 — API
+
+1. `JoinPolicy` enum (string-stored) + `PickemGroup.JoinPolicy`, migration
+   backfilling `OpenUntilLastLock` (today's de-facto behavior — existing MLB
+   test leagues unchanged).
+2. `JoinLeagueCommandHandler`: reject deactivated (bug fix) and
+   policy-closed joins with human-readable `Validation` failures ("This
+   league closed when its first game started.").
+3. Creation commands (all three sports) + validators accept `JoinPolicy` —
+   DONE via the shared `CreateLeagueRequestBase`/handler base (optional
+   string, absent → `Open`, so pre-existing clients are unaffected).
+   **Commissioner edit is deferred**: no update-league command exists at all
+   today (league settings are create-only), so policy editing is part of a
+   future league-settings-edit feature, not a rider here.
+4. `GetPublicLeaguesQueryHandler`: exclude deactivated; compute
+   `IsJoinable`/`ClosesAtFirstGame`; fatten `PublicLeagueDto` (sport, league,
+   seasonYear, memberCount, window label). Filter or badge closed leagues —
+   badge, so a nearly-started league still advertises itself.
+5. `LeagueDetailDto`: add `joinPolicy` + `isJoinable` so the invite preview
+   and browse detail can render truthfully.
+6. Unit tests per guarded path (policy × deactivation × slate-empty).
+
+### Phase 2 — Web (first client, per operator lean)
+
+1. Create flow: "Who can join, and until when?" — two radios.
+2. League settings: same control, commissioner-only, hidden when past.
+3. Home page: "Leagues you can join" rail fed by the fattened query — the
+   content-gap driver for this feature.
+4. `LeagueDiscoverPage`: closed badges, join CTA disabled when unjoinable.
+5. Invite affordances hidden when league is closed (mirrors `isPast`
+   treatment).
+
+### Phase 3 — Mobile (own PR, ships via EAS)
+
+1. Browse screen (new leagues rail on home + full list).
+2. Invite preview screen: closed state ("This league is no longer accepting
+   members.") instead of a Join button that 400s.
+3. League detail: joinability surfaced; invite card hidden when closed.
+
+## Out of scope (v1)
+
+- Custom close dates (third enum value later if asked)
+- Invite-record expiry (`PickemGroupInvitation` has no invitee/lifecycle —
+  separate feature; see the IDOR design's Option B notes)
+- Blocking commissioners from *sending* invites to closed leagues (the join
+  gate makes stale links safe; UI hiding covers the common path)
+- Late-join scoring adjustments (`DropLowWeeksCount` already softens; revisit
+  only if leaderboard complaints materialize)

--- a/docs/features/league-join-policy-and-discovery.md
+++ b/docs/features/league-join-policy-and-discovery.md
@@ -10,11 +10,11 @@ single-day MLB test leagues surfaced the "when does a league close?" question.
 
 1. **The commissioner decides, per league, at creation.** No platform-wide
    default behavior — join policy is an explicit choice on the create form,
-   alongside pick type and visibility. Editable in league settings until
-   deactivation.
+   alongside pick type and visibility. Post-creation editing is DEFERRED —
+   no update-league command exists (league settings are create-only today);
+   see the Phase 1 notes below.
 2. **Exactly two options.** Deliberately no custom date in v1:
-   - `Open` — joinable while the league is live (implemented name; the
-     working name `OpenUntilLastLock` was shortened)
+   - `Open` — joinable while the league is live
    - `CloseAtFirstGame` — closed once the league's first contest starts
 3. **Applies to ALL leagues, not just public ones.** Visibility (`IsPublic`)
    controls who can *find* a league; join policy controls until when anyone can
@@ -23,10 +23,11 @@ single-day MLB test leagues surfaced the "when does a league close?" question.
    links therefore expire naturally when the league closes. That was the
    operator's instinct ("if the commissioner sends an invite, it should expire
    at a certain time") and it is the zero-extra-work outcome.
-4. **No "close now" button.** Flipping `OpenUntilLastLock` →
-   `CloseAtFirstGame` after the first game has started closes the league
-   immediately; flipping back re-opens it. Two enum values give close-now and
-   re-open as consequences, not features.
+4. **No "close now" button.** Once policy editing ships (deferred with the
+   settings-edit feature), flipping `Open` → `CloseAtFirstGame` after the
+   first game has started closes the league immediately; flipping back
+   re-opens it. Two enum values give close-now and re-open as consequences,
+   not features.
 
 ## Current state (verified 2026-07-30)
 
@@ -53,7 +54,7 @@ stored: the slate builds asynchronously after league creation (see
 league-slate-async quirk), so a stored close date computed at creation would
 be wrong/absent. Empty slate → league is open (nothing has started).
 
-**`OpenUntilLastLock`** — joinable until `DeactivatedUtc` is set. NOT
+**`Open`** — joinable until `DeactivatedUtc` is set. NOT
 implemented as `max(StartDateUtc) < now`: weekly slates build progressively,
 so the max over *existing* matchups would wrongly close a football league in
 the gap between week N's last kickoff and week N+1's slate build.
@@ -75,13 +76,13 @@ v1 because it is a standing consistency job, not a one-time backfill:
   time silently drifts unless every reschedule also resyncs it. Same failure
   class as the countdown-anchoring bug: precomputed time values rot, derived
   ones cannot.
-- **`OpenUntilLastLock` has no storable value.** Weekly slates build
+- **`Open` has no storable value.** Weekly slates build
   progressively; the "last game time" is unknowable until season end. The
   column would hold null-meaning-open — the enum again, hidden in a nullable.
 
 The read-side cleanliness is kept anyway: DTOs expose a **computed
 `closesAtUtc`** (`CloseAtFirstGame` → `min(matchup.StartDateUtc)` at read
-time; `OpenUntilLastLock` → null). Clients render a concrete timestamp;
+time; `Open` → null). Clients render a concrete timestamp;
 nothing is stored that can go stale.
 
 If commissioner-set custom close dates ever ship (cut from v1), those are
@@ -118,9 +119,9 @@ change, no migration) and `DropLowWeeksCount` already exists on
 
 ### Phase 1 — API
 
-1. `JoinPolicy` enum (string-stored) + `PickemGroup.JoinPolicy`, migration
-   backfilling `OpenUntilLastLock` (today's de-facto behavior — existing MLB
-   test leagues unchanged).
+1. `JoinPolicy` enum (int-stored via `HasConversion<int>`, house style) +
+   `PickemGroup.JoinPolicy`, migration backfilling `Open` (today's de-facto
+   behavior — existing MLB test leagues unchanged).
 2. `JoinLeagueCommandHandler`: reject deactivated (bug fix) and
    policy-closed joins with human-readable `Validation` failures ("This
    league closed when its first game started.").

--- a/src/SportsData.Api/Application/Common/Enums/JoinPolicy.cs
+++ b/src/SportsData.Api/Application/Common/Enums/JoinPolicy.cs
@@ -1,0 +1,29 @@
+namespace SportsData.Api.Application.Common.Enums;
+
+/// <summary>
+/// Until when a league accepts new members. Chosen by the commissioner at
+/// creation and editable until deactivation. Applies to ALL leagues — public
+/// browse joins and invite-link joins flow through the same gate, so a shared
+/// invite link to a closed league dies with the listing.
+///
+/// Deliberately two values in v1. The close moment for
+/// <see cref="CloseAtFirstGame"/> is DERIVED at read time from the league's
+/// matchups (kickoff times move after slates generate; a stored deadline
+/// would rot). A future derived option — open through the league's
+/// DropLowWeeksCount dropped weeks — slots in as a third value with no
+/// migration. See docs/features/league-join-policy-and-discovery.md.
+/// </summary>
+public enum JoinPolicy
+{
+    /// <summary>Joinable while the league is live (until deactivation).</summary>
+    Open = 0,
+
+    /// <summary>
+    /// Roster locks when play begins: closed once the league's first
+    /// scheduled contest starts. For a single-day league that is first
+    /// pitch; for a season league, week-1 kickoff inside its window.
+    /// An empty slate (built asynchronously after creation) means nothing
+    /// has started, so the league is open.
+    /// </summary>
+    CloseAtFirstGame = 1
+}

--- a/src/SportsData.Api/Application/Common/Enums/JoinPolicy.cs
+++ b/src/SportsData.Api/Application/Common/Enums/JoinPolicy.cs
@@ -2,7 +2,8 @@ namespace SportsData.Api.Application.Common.Enums;
 
 /// <summary>
 /// Until when a league accepts new members. Chosen by the commissioner at
-/// creation and editable until deactivation. Applies to ALL leagues — public
+/// creation (post-creation editing is deferred with the league-settings-edit
+/// feature — settings are create-only today). Applies to ALL leagues — public
 /// browse joins and invite-link joins flow through the same gate, so a shared
 /// invite link to a closed league dies with the listing.
 ///

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -176,6 +176,10 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
         var pickType = Enum.Parse<PickType>(request.PickType, ignoreCase: true);
         var tiebreakerType = Enum.Parse<TiebreakerType>(request.TiebreakerType, ignoreCase: true);
         var tiebreakerTiePolicy = Enum.Parse<TiebreakerTiePolicy>(request.TiebreakerTiePolicy, ignoreCase: true);
+        // Absent -> Open: pre-existing clients keep today's always-joinable behavior.
+        var joinPolicy = request.JoinPolicy is null
+            ? JoinPolicy.Open
+            : Enum.Parse<JoinPolicy>(request.JoinPolicy, ignoreCase: true);
 
         var seasonYear = request.SeasonYear ?? _dateTimeProvider.UtcNow().Year;
         var slugs = GetGroupingSlugs(request);
@@ -202,6 +206,7 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
             CreatedBy = currentUserId,
             Description = request.Description?.Trim(),
             IsPublic = request.IsPublic,
+            JoinPolicy = joinPolicy,
             League = LeagueMode,
             MaxUsers = DefaultMaxUsers,
             Name = request.Name.Trim(),

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBase.cs
@@ -19,6 +19,13 @@ public abstract class CreateLeagueRequestBase
 
     public bool IsPublic { get; set; }
 
+    /// <summary>
+    /// JoinPolicy enum name. Optional so pre-existing clients that do not
+    /// send it keep today's behavior (Open); the create forms surface it as
+    /// an explicit choice.
+    /// </summary>
+    public string? JoinPolicy { get; set; }
+
     public int? DropLowWeeksCount { get; set; }
 
     /// <summary>

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidator.cs
@@ -30,6 +30,10 @@ public abstract class CreateLeagueRequestBaseValidator<TRequest> : AbstractValid
             .Must(IsDefinedEnumName<TiebreakerType>)
             .WithMessage(x => $"Invalid tiebreaker type: {x.TiebreakerType}");
 
+        RuleFor(x => x.JoinPolicy)
+            .Must(v => v is null || IsDefinedEnumName<JoinPolicy>(v))
+            .WithMessage(x => $"Invalid join policy: {x.JoinPolicy}");
+
         RuleFor(x => x.TiebreakerTiePolicy)
             .Must(IsDefinedEnumName<TiebreakerTiePolicy>)
             .WithMessage(x => $"Invalid tiebreaker tie policy: {x.TiebreakerTiePolicy}");

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueCommandHandler.cs
@@ -22,15 +22,18 @@ namespace SportsData.Api.Application.UI.Leagues.Commands.JoinLeague
         private readonly ILogger<JoinLeagueCommandHandler> _logger;
         private readonly AppDataContext _dbContext;
         private readonly IEventBus _eventBus;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public JoinLeagueCommandHandler(
             ILogger<JoinLeagueCommandHandler> logger,
             AppDataContext dbContext,
-            IEventBus eventBus)
+            IEventBus eventBus,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
             _dbContext = dbContext;
             _eventBus = eventBus;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task<Result<Guid?>> ExecuteAsync(
@@ -52,6 +55,34 @@ namespace SportsData.Api.Application.UI.Leagues.Commands.JoinLeague
                     command.PickemGroupId,
                     ResultStatus.Validation,
                     [new ValidationFailure(nameof(command.UserId), "User is already a member of this league")]);
+
+            // This gate covers BOTH public-browse joins and invite-link joins
+            // (they share this handler), so a shared invite link to a closed
+            // league dies with the listing. See
+            // docs/features/league-join-policy-and-discovery.md.
+            if (league.DeactivatedUtc is not null)
+                return new Failure<Guid?>(
+                    command.PickemGroupId,
+                    ResultStatus.Validation,
+                    [new ValidationFailure(nameof(command.PickemGroupId), "This league's season has ended.")]);
+
+            if (league.JoinPolicy == JoinPolicy.CloseAtFirstGame)
+            {
+                // Derived at join time, never stored: kickoff times move after
+                // slates generate. An empty slate (built asynchronously after
+                // creation) yields null — nothing has started, league is open.
+                var firstGameUtc = await _dbContext.PickemGroupMatchups
+                    .AsNoTracking()
+                    .Where(m => m.GroupId == league.Id)
+                    .Select(m => (DateTime?)m.StartDateUtc)
+                    .MinAsync(cancellationToken);
+
+                if (firstGameUtc is not null && firstGameUtc <= _dateTimeProvider.UtcNow())
+                    return new Failure<Guid?>(
+                        command.PickemGroupId,
+                        ResultStatus.Validation,
+                        [new ValidationFailure(nameof(command.PickemGroupId), "This league closed to new members when its first game started.")]);
+            }
 
             _logger.LogInformation(
                 "User {UserId} joining league {LeagueId}",

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueCommandHandler.cs
@@ -93,7 +93,7 @@ namespace SportsData.Api.Application.UI.Leagues.Commands.JoinLeague
             {
                 Id = Guid.NewGuid(),
                 CreatedBy = command.UserId,
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = _dateTimeProvider.UtcNow(),
                 PickemGroupId = command.PickemGroupId,
                 Role = LeagueRole.Member,
                 UserId = command.UserId

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueDetailDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueDetailDto.cs
@@ -49,6 +49,20 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
         /// </summary>
         public bool IsMember { get; set; }
 
+        /// <summary>JoinPolicy enum name, lowercased like the other enums here.</summary>
+        public string JoinPolicy { get; set; } = "open";
+
+        /// <summary>
+        /// When this league stops (or stopped) accepting members. Derived at
+        /// read time from the slate for close-at-first-game leagues; null for
+        /// open leagues or an ungenerated slate.
+        /// </summary>
+        public DateTime? ClosesAtUtc { get; set; }
+
+        /// <summary>False once closed or deactivated — the invite preview and
+        /// browse detail render a closed state instead of a Join button.</summary>
+        public bool IsJoinable { get; set; }
+
         /// <summary>
         /// The roster — members only. Empty for non-members (invite preview,
         /// public-league browsing).

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/PublicLeagueDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/PublicLeagueDto.cs
@@ -1,4 +1,5 @@
 using SportsData.Api.Application.Common.Enums;
+using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.UI.Leagues.Dtos
 {
@@ -12,6 +13,27 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
         public int PickType { get; set; }
         public bool UseConfidencePoints { get; set; }
         public int DropLowWeeksCount { get; set; }
-    }
 
+        public Sport Sport { get; set; }
+        public League League { get; set; }
+        public int SeasonYear { get; set; }
+        public int MemberCount { get; set; }
+
+        /// <summary>League window; both null = full season.</summary>
+        public DateTime? StartsOn { get; set; }
+        public DateTime? EndsOn { get; set; }
+
+        public JoinPolicy JoinPolicy { get; set; }
+
+        /// <summary>
+        /// When this league stops (or stopped) accepting members. Derived at
+        /// read time from the slate for CloseAtFirstGame; null for Open or
+        /// when the slate hasn't been generated yet.
+        /// </summary>
+        public DateTime? ClosesAtUtc { get; set; }
+
+        /// <summary>False once closed — clients badge instead of hiding, so a
+        /// nearly-started league still advertises itself.</summary>
+        public bool IsJoinable { get; set; }
+    }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueById/GetLeagueByIdQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueById/GetLeagueByIdQueryHandler.cs
@@ -18,10 +18,14 @@ public interface IGetLeagueByIdQueryHandler
 public class GetLeagueByIdQueryHandler : IGetLeagueByIdQueryHandler
 {
     private readonly AppDataContext _dbContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
-    public GetLeagueByIdQueryHandler(AppDataContext dbContext)
+    public GetLeagueByIdQueryHandler(
+        AppDataContext dbContext,
+        IDateTimeProvider dateTimeProvider)
     {
         _dbContext = dbContext;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<LeagueDetailDto>> ExecuteAsync(
@@ -50,6 +54,21 @@ public class GetLeagueByIdQueryHandler : IGetLeagueByIdQueryHandler
         // to show a prospective member what they'd be joining.
         var isMember = league.Members.Any(m => m.UserId == query.UserId);
 
+        // Derived at read time, never stored (kickoff times move after slates
+        // generate). Empty slate -> null -> joinable: nothing has started.
+        DateTime? closesAtUtc = null;
+        if (league.JoinPolicy == JoinPolicy.CloseAtFirstGame)
+        {
+            closesAtUtc = await _dbContext.PickemGroupMatchups
+                .AsNoTracking()
+                .Where(m => m.GroupId == league.Id)
+                .Select(m => (DateTime?)m.StartDateUtc)
+                .MinAsync(cancellationToken);
+        }
+
+        var isJoinable = league.DeactivatedUtc is null
+            && (closesAtUtc is null || closesAtUtc > _dateTimeProvider.UtcNow());
+
         var dto = new LeagueDetailDto
         {
             Id = league.Id,
@@ -69,6 +88,9 @@ public class GetLeagueByIdQueryHandler : IGetLeagueByIdQueryHandler
             // roster itself.
             MemberCount = league.Members.Count,
             IsMember = isMember,
+            JoinPolicy = league.JoinPolicy.ToString().ToLowerInvariant(),
+            ClosesAtUtc = closesAtUtc,
+            IsJoinable = isJoinable,
             Members = isMember
                 ? league.Members.Select(m => new LeagueDetailDto.LeagueMemberDto
                 {

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetPublicLeagues/GetPublicLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetPublicLeagues/GetPublicLeaguesQueryHandler.cs
@@ -17,13 +17,16 @@ public class GetPublicLeaguesQueryHandler : IGetPublicLeaguesQueryHandler
 {
     private readonly ILogger<GetPublicLeaguesQueryHandler> _logger;
     private readonly AppDataContext _dbContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     public GetPublicLeaguesQueryHandler(
         ILogger<GetPublicLeaguesQueryHandler> logger,
-        AppDataContext dbContext)
+        AppDataContext dbContext,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dbContext = dbContext;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<List<PublicLeagueDto>>> ExecuteAsync(
@@ -32,23 +35,64 @@ public class GetPublicLeaguesQueryHandler : IGetPublicLeaguesQueryHandler
     {
         _logger.LogDebug("Getting public leagues for user {UserId}", query.UserId);
 
+        // Deactivated leagues are finished seasons — never browsable. Closed
+        // ones ARE returned (badged unjoinable) so a nearly-started league
+        // still advertises itself.
         var leagues = await _dbContext.PickemGroups
-            .Include(g => g.CommissionerUser)
-            .Include(g => g.Members)
-            .Where(g => g.IsPublic && !g.Members.Any(x => x.UserId == query.UserId))
             .AsNoTracking()
+            .Where(g => g.IsPublic
+                && g.DeactivatedUtc == null
+                && !g.Members.Any(x => x.UserId == query.UserId))
+            .Select(x => new
+            {
+                x.Id,
+                x.Name,
+                x.Description,
+                Commissioner = x.CommissionerUser != null ? x.CommissionerUser.DisplayName : null,
+                x.RankingFilter,
+                x.PickType,
+                x.UseConfidencePoints,
+                x.DropLowWeeksCount,
+                x.Sport,
+                x.League,
+                x.SeasonYear,
+                x.StartsOn,
+                x.EndsOn,
+                x.JoinPolicy,
+                MemberCount = x.Members.Count,
+                // Derived, never stored: kickoff times move after slates
+                // generate. Null when the slate hasn't been built yet.
+                FirstGameUtc = _dbContext.PickemGroupMatchups
+                    .Where(m => m.GroupId == x.Id)
+                    .Select(m => (DateTime?)m.StartDateUtc)
+                    .Min()
+            })
             .ToListAsync(cancellationToken);
 
-        var result = leagues.Select(x => new PublicLeagueDto
+        var now = _dateTimeProvider.UtcNow();
+        var result = leagues.Select(x =>
         {
-            Id = x.Id,
-            Name = x.Name,
-            Description = x.Description ?? string.Empty,
-            Commissioner = x.CommissionerUser?.DisplayName ?? "Unknown",
-            RankingFilter = (int?)x.RankingFilter ?? 0,
-            PickType = (int)x.PickType,
-            UseConfidencePoints = x.UseConfidencePoints,
-            DropLowWeeksCount = x.DropLowWeeksCount ?? 0
+            var closesAtUtc = x.JoinPolicy == JoinPolicy.CloseAtFirstGame ? x.FirstGameUtc : null;
+            return new PublicLeagueDto
+            {
+                Id = x.Id,
+                Name = x.Name,
+                Description = x.Description ?? string.Empty,
+                Commissioner = x.Commissioner ?? "Unknown",
+                RankingFilter = (int?)x.RankingFilter ?? 0,
+                PickType = (int)x.PickType,
+                UseConfidencePoints = x.UseConfidencePoints,
+                DropLowWeeksCount = x.DropLowWeeksCount ?? 0,
+                Sport = x.Sport,
+                League = x.League,
+                SeasonYear = x.SeasonYear,
+                MemberCount = x.MemberCount,
+                StartsOn = x.StartsOn,
+                EndsOn = x.EndsOn,
+                JoinPolicy = x.JoinPolicy,
+                ClosesAtUtc = closesAtUtc,
+                IsJoinable = closesAtUtc is null || closesAtUtc > now
+            };
         }).ToList();
 
         _logger.LogInformation(

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
@@ -36,8 +36,9 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         /// <summary>
         /// Until when this league accepts new members. Commissioner-chosen at
-        /// creation, editable until deactivation. The CloseAtFirstGame close
-        /// moment is derived from matchups at read time, never stored.
+        /// creation (editing deferred — league settings are create-only
+        /// today). The CloseAtFirstGame close moment is derived from
+        /// matchups at read time, never stored.
         /// </summary>
         public JoinPolicy JoinPolicy { get; set; } = JoinPolicy.Open;
 

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 using SportsData.Api.Application.Common.Enums;
@@ -33,6 +33,13 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         public bool UseConfidencePoints { get; set; }
 
         public bool IsPublic { get; set; }
+
+        /// <summary>
+        /// Until when this league accepts new members. Commissioner-chosen at
+        /// creation, editable until deactivation. The CloseAtFirstGame close
+        /// moment is derived from matchups at read time, never stored.
+        /// </summary>
+        public JoinPolicy JoinPolicy { get; set; } = JoinPolicy.Open;
 
         public int? MaxUsers { get; set; }
 
@@ -112,6 +119,13 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
                 builder.Property(x => x.TiebreakerTiePolicy)
                     .HasConversion<int>() // store as int
+                    .IsRequired();
+
+                // DB default 0 (Open) backfills pre-existing rows — Open is
+                // today's de-facto behavior, so existing leagues are unchanged.
+                builder.Property(x => x.JoinPolicy)
+                    .HasConversion<int>()
+                    .HasDefaultValue(JoinPolicy.Open)
                     .IsRequired();
 
                 builder

--- a/src/SportsData.Api/Migrations/20260730133626_AddPickemGroupJoinPolicy.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260730133626_AddPickemGroupJoinPolicy.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260730133626_AddPickemGroupJoinPolicy")]
+    partial class AddPickemGroupJoinPolicy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260730133626_AddPickemGroupJoinPolicy.cs
+++ b/src/SportsData.Api/Migrations/20260730133626_AddPickemGroupJoinPolicy.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPickemGroupJoinPolicy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "JoinPolicy",
+                table: "PickemGroup",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "JoinPolicy",
+                table: "PickemGroup");
+        }
+    }
+}

--- a/src/UI/sd-ui/src/api/leagues/requests/createLeagueRequests.js
+++ b/src/UI/sd-ui/src/api/leagues/requests/createLeagueRequests.js
@@ -56,6 +56,7 @@ const buildShared = ({
   tiebreaker,
   useConfidencePoints,
   isPublic,
+  joinPolicy,
   dropLowWeeksCount,
   durationMode,
   startsOn,
@@ -69,6 +70,8 @@ const buildShared = ({
   tiebreakerTiePolicy: "EarliestSubmission",
   useConfidencePoints,
   isPublic,
+  // BE enum name; absent/null falls back to Open server-side.
+  joinPolicy: joinPolicy || "Open",
   dropLowWeeksCount: toNonNegativeInt(dropLowWeeksCount),
   ...buildWindow({ durationMode, startsOn, endsOn }),
 });

--- a/src/UI/sd-ui/src/components/home/HomePage.jsx
+++ b/src/UI/sd-ui/src/components/home/HomePage.jsx
@@ -2,6 +2,7 @@ import "./HomePage.css";
 import { useUserDto } from "../../contexts/UserContext";
 import PrimarySlotOffSeasonCountdown from "./PrimarySlotOffSeasonCountdown";
 import YourLeaguesCard from "./YourLeaguesCard";
+import JoinableLeaguesCard from "./JoinableLeaguesCard";
 
 /**
  * Post-login landing — date-aware, segment-aware.
@@ -58,8 +59,13 @@ function HomePage() {
         </section>
       )}
 
-      {/* Tier 3 — compact secondary row. Stub; session 3. */}
-      <section className="home-tier home-tier--secondary home-tier--stub" aria-hidden="true" />
+      {/* Tier 3 — public-league discovery. THE content driver for
+          league-less users: actionable joins instead of a bare countdown.
+          The card renders null when nothing is joinable, leaving the
+          prior stub behavior. */}
+      <section className="home-tier home-tier--secondary">
+        <JoinableLeaguesCard />
+      </section>
     </div>
   );
 }

--- a/src/UI/sd-ui/src/components/home/JoinableLeaguesCard.css
+++ b/src/UI/sd-ui/src/components/home/JoinableLeaguesCard.css
@@ -1,0 +1,89 @@
+/* JoinableLeaguesCard — Tier 3 "Leagues you can join" rail. Visual parity
+   with YourLeaguesCard above it: same card chrome, width, and row rhythm. */
+.joinable-leagues-card {
+  background-color: var(--bg-card);
+  border: 1px solid var(--accent-subtle);
+  border-radius: 14px;
+  box-shadow: var(--shadow-md);
+  padding: 1rem 1.25rem;
+  max-width: 880px;
+  box-sizing: border-box;
+  margin: 0 auto;
+  color: var(--text-primary);
+}
+
+.joinable-leagues-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.joinable-leagues-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.joinable-leagues-more {
+  font-size: 0.85rem;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.joinable-leagues-more:hover {
+  text-decoration: underline;
+}
+
+.joinable-leagues-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.joinable-league-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-top: 1px solid var(--accent-subtle);
+}
+
+.joinable-league-row:first-child {
+  border-top: none;
+}
+
+.joinable-league-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.joinable-league-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.joinable-league-meta {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.joinable-league-join {
+  flex-shrink: 0;
+  padding: 0.35rem 0.9rem;
+  border-radius: 8px;
+  background-color: var(--accent);
+  color: var(--text-on-accent, #fff);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.joinable-league-join:hover {
+  filter: brightness(1.1);
+}

--- a/src/UI/sd-ui/src/components/home/JoinableLeaguesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/JoinableLeaguesCard.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import LeaguesApi from "api/leagues/leaguesApi";
+import "./JoinableLeaguesCard.css";
+
+const SPORT_LABEL = {
+  FootballNcaa: "NCAAFB",
+  FootballNfl: "NFL",
+  BaseballMlb: "MLB",
+};
+
+// Same glyph convention as YourLeaguesCard — stand-in until per-league icons.
+const SPORT_ICON = {
+  FootballNcaa: "🏈",
+  FootballNfl: "🏈",
+  BaseballMlb: "⚾",
+};
+
+const MAX_ROWS = 4;
+
+/**
+ * Tier 3 — "Leagues you can join". Public-league discovery surfaced directly
+ * on the home page so a new (or league-less) user lands on actionable content
+ * instead of a bare countdown. Shows joinable leagues only — the full discover
+ * page handles closed ones (badged there). Renders nothing while loading or
+ * when there is nothing joinable, so the home page never shows an empty shell.
+ */
+function JoinableLeaguesCard() {
+  const [leagues, setLeagues] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    LeaguesApi.getPublicLeagues()
+      .then((data) => {
+        if (!cancelled) setLeagues((data || []).filter((l) => l.isJoinable));
+      })
+      .catch((err) => {
+        console.error("Failed to load joinable leagues:", err);
+        if (!cancelled) setLeagues([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!leagues || leagues.length === 0) return null;
+
+  const visible = leagues.slice(0, MAX_ROWS);
+
+  return (
+    <section className="joinable-leagues-card">
+      <div className="joinable-leagues-header">
+        <h3>Leagues you can join</h3>
+        <Link to="/app/league/discover" className="joinable-leagues-more">
+          Browse all →
+        </Link>
+      </div>
+      <ul className="joinable-leagues-list">
+        {visible.map((league) => (
+          <li key={league.id} className="joinable-league-row">
+            <div className="joinable-league-info">
+              <span className="joinable-league-name">{league.name}</span>
+              <span className="joinable-league-meta">
+                <span aria-hidden="true">{SPORT_ICON[league.sport] ?? "🏆"}</span>{" "}
+                {SPORT_LABEL[league.sport] ?? league.sport} {league.seasonYear} ·{" "}
+                {league.memberCount} {league.memberCount === 1 ? "member" : "members"}
+              </span>
+            </div>
+            <Link
+              to={`/app/join/${league.id.replace(/-/g, "")}`}
+              className="joinable-league-join"
+            >
+              Join
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default JoinableLeaguesCard;

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -867,6 +867,12 @@ const LeagueCreatePage = () => {
               <li>
                 <strong>Visibility:</strong> {isPublic ? "Public" : "Private"}
               </li>
+              <li>
+                <strong>Joining:</strong>{" "}
+                {joinPolicy === "CloseAtFirstGame"
+                  ? "Locked at kickoff — closes when the first game starts"
+                  : "Open while the league is live"}
+              </li>
             </ul>
             <div className="modal-actions">
               <button onClick={() => setShowConfirmDialog(false)}>

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -156,6 +156,9 @@ const LeagueCreatePage = () => {
   const [rankingFilter, setRankingFilter] = useState("");
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [isPublic, setIsPublic] = useState(false);
+  // BE JoinPolicy enum name. "Open" = joinable while the league is live;
+  // "CloseAtFirstGame" = roster locks when the first scheduled game starts.
+  const [joinPolicy, setJoinPolicy] = useState("Open");
   const [dropLowWeeksCount, setDropLowWeeksCount] = useState(0);
   const [allConferences, setAllConferences] = useState([]);
   const [fbsOnly, setFbsOnly] = useState(true);
@@ -371,6 +374,7 @@ const LeagueCreatePage = () => {
       rankingFilter,
       teamFilter,
       isPublic,
+      joinPolicy,
       dropLowWeeksCount,
       durationMode,
       startsOn,
@@ -740,6 +744,32 @@ const LeagueCreatePage = () => {
                     onChange={(e) => setIsPublic(e.target.checked)}
                   />{" "}
                   Make this league public (anyone can join)
+                </label>
+              </div>
+
+              {/* Applies to invite links too, not just public discovery — a
+                  shared link to a closed league stops working at kickoff. */}
+              <h4>🚪 Who can join, and until when?</h4>
+              <div className="inline-options join-policy-options">
+                <label>
+                  <input
+                    type="radio"
+                    name="joinPolicy"
+                    value="Open"
+                    checked={joinPolicy === "Open"}
+                    onChange={() => setJoinPolicy("Open")}
+                  />{" "}
+                  Open — new members can join any time while the league is live
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="joinPolicy"
+                    value="CloseAtFirstGame"
+                    checked={joinPolicy === "CloseAtFirstGame"}
+                    onChange={() => setJoinPolicy("CloseAtFirstGame")}
+                  />{" "}
+                  Locked at kickoff — closes when the first game starts
                 </label>
               </div>
             </div>

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -131,6 +131,13 @@ const LeagueDetail = () => {
             <li><strong>Ranking Filter:</strong> {league.rankingFilter || "None"}</li>
             <li><strong>League Window:</strong> {windowLabel}</li>
             <li><strong>Visibility:</strong> {league.isPublic ? "Public" : "Private"}</li>
+            <li><strong>Joining:</strong> {
+              league.isJoinable === false
+                ? "Closed to new members"
+                : league.joinPolicy === "closeatfirstgame"
+                  ? "Open until the first game starts"
+                  : "Open"
+            }</li>
             <li><strong>Conferences:</strong> {
               (() => {
                 const slugs = Array.isArray(league.conferenceSlugs) ? league.conferenceSlugs : [];
@@ -174,7 +181,7 @@ const LeagueDetail = () => {
           )}
         </div>
 
-        {!isPast && isMember && (
+        {!isPast && isMember && league.isJoinable !== false && (
           <LeagueInvitation leagueId={league.id} leagueName={league.name} />
         )}
 

--- a/src/UI/sd-ui/src/components/leagues/LeagueDiscoverPage.css
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDiscoverPage.css
@@ -34,7 +34,7 @@
   background-color: var(--bg-tooltip);
   border-bottom: 2px solid var(--accent);
   display: grid;
-  grid-template-columns: 2fr 1.5fr 3fr 1fr;
+  grid-template-columns: 2.5fr 1fr 1fr 1.2fr 1.3fr 1fr;
   gap: 16px;
   padding: 16px 20px;
   font-weight: 600;
@@ -46,7 +46,7 @@
 
 .table-row {
   display: grid;
-  grid-template-columns: 2fr 1.5fr 3fr 1fr;
+  grid-template-columns: 2.5fr 1fr 1fr 1.2fr 1.3fr 1fr;
   gap: 16px;
   padding: 16px 20px;
   border-bottom: 1px solid var(--border-strong);
@@ -199,4 +199,21 @@
   .table-row {
     padding: 12px;
   }
+}
+
+/* Joinability badge + disabled CTA (closed leagues are shown, not hidden) */
+.league-joinable--closed {
+  opacity: 0.7;
+}
+
+.join-button--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.league-description {
+  font-size: 0.82rem;
+  opacity: 0.7;
+  margin-top: 2px;
 }

--- a/src/UI/sd-ui/src/components/leagues/LeagueDiscoverPage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDiscoverPage.jsx
@@ -3,6 +3,31 @@ import { Link } from "react-router-dom";
 import LeaguesApi from "api/leagues/leaguesApi";
 import "./LeagueDiscoverPage.css";
 
+// PublicLeagueDto.sport enum name -> short display label.
+const SPORT_LABEL = {
+  FootballNcaa: "NCAAFB",
+  FootballNfl: "NFL",
+  BaseballMlb: "MLB",
+};
+
+// Same glyph convention as YourLeaguesCard — stand-in until per-league icons.
+const SPORT_ICON = {
+  FootballNcaa: "🏈",
+  FootballNfl: "🏈",
+  BaseballMlb: "⚾",
+};
+
+// Closed leagues are returned (badged) rather than hidden, so a nearly-started
+// league still advertises itself — see league-join-policy-and-discovery.md.
+const closesLabel = (league) => {
+  if (!league.isJoinable) return "Closed";
+  if (!league.closesAtUtc) return "Open";
+  const d = new Date(league.closesAtUtc);
+  return Number.isNaN(d.getTime())
+    ? "Open"
+    : `Closes ${d.toLocaleDateString(undefined, { month: "short", day: "numeric" })} ${d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}`;
+};
+
 function LeagueDiscoverPage() {
   const [leagues, setLeagues] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -21,7 +46,7 @@ function LeagueDiscoverPage() {
   return (
     <div className="league-discover-page">
       <h2>Discover Public Leagues</h2>
-      
+
       {loading ? (
         <div className="loading-message">Loading leagues...</div>
       ) : leagues.length === 0 ? (
@@ -30,23 +55,49 @@ function LeagueDiscoverPage() {
         <div className="leagues-table">
           <div className="table-header">
             <div>League Name</div>
+            <div>Sport</div>
+            <div>Members</div>
             <div>Commissioner</div>
-            <div>Description</div>
+            <div>Joinable</div>
             <div>Action</div>
           </div>
-          
+
           {leagues.map((league) => (
             <div key={league.id} className="table-row">
-              <div className="league-name">{league.name}</div>
+              <div className="league-name">
+                {league.name}
+                {league.description ? (
+                  <div className="league-description">{league.description}</div>
+                ) : null}
+              </div>
+              <div className="league-sport">
+                <span className="league-sport-icon" aria-hidden="true">
+                  {SPORT_ICON[league.sport] ?? "🏆"}
+                </span>{" "}
+                {SPORT_LABEL[league.sport] ?? league.sport} {league.seasonYear}
+              </div>
+              <div className="league-members">
+                {league.memberCount} {league.memberCount === 1 ? "member" : "members"}
+              </div>
               <div className="commissioner-name">{league.commissioner}</div>
-              <div className="league-description">{league.description}</div>
+              <div className={`league-joinable ${league.isJoinable ? "" : "league-joinable--closed"}`}>
+                {closesLabel(league)}
+              </div>
               <div className="join-action">
-                <Link 
-                  to={`/app/join/${league.id.replace(/-/g, "")}`}
-                  className="join-button"
-                >
-                  Join League
-                </Link>
+                {league.isJoinable ? (
+                  <Link
+                    to={`/app/join/${league.id.replace(/-/g, "")}`}
+                    className="join-button"
+                  >
+                    Join League
+                  </Link>
+                ) : (
+                  // The BE join gate rejects closed leagues; don't offer a
+                  // button that 400s.
+                  <span className="join-button join-button--disabled" aria-disabled="true">
+                    Closed
+                  </span>
+                )}
               </div>
             </div>
           ))}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Authorization/LeagueAuthorizationTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Authorization/LeagueAuthorizationTests.cs
@@ -168,7 +168,7 @@ public class LeagueAuthorizationTests : ApiTestBase<LeagueMembershipGuard>
     {
         var memberId = Guid.NewGuid();
         var leagueId = await SeedLeagueAsync(memberId);
-        var handler = new GetLeagueByIdQueryHandler(DataContext);
+        var handler = new GetLeagueByIdQueryHandler(DataContext, new DateTimeProvider());
 
         var result = await handler.ExecuteAsync(new GetLeagueByIdQuery
         {
@@ -189,7 +189,7 @@ public class LeagueAuthorizationTests : ApiTestBase<LeagueMembershipGuard>
         // the league is and how big it is, but not WHO is in it.
         var memberId = Guid.NewGuid();
         var leagueId = await SeedLeagueAsync(memberId);
-        var handler = new GetLeagueByIdQueryHandler(DataContext);
+        var handler = new GetLeagueByIdQueryHandler(DataContext, new DateTimeProvider());
 
         var result = await handler.ExecuteAsync(new GetLeagueByIdQuery
         {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Authorization/LeagueAuthorizationTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Authorization/LeagueAuthorizationTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Leaderboard.Queries.GetLeaderboard;
 using SportsData.Api.Application.UI.Leagues.Authorization;
@@ -29,6 +31,13 @@ namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Authorization;
 public class LeagueAuthorizationTests : ApiTestBase<LeagueMembershipGuard>
 {
     private static readonly DateTime FixedNow = new(2026, 7, 29, 12, 0, 0, DateTimeKind.Utc);
+
+    private static IDateTimeProvider FixedClock()
+    {
+        var clock = new Mock<IDateTimeProvider>();
+        clock.Setup(x => x.UtcNow()).Returns(FixedNow);
+        return clock.Object;
+    }
 
     private static UserEntity NewUser(Guid id) => new()
     {
@@ -168,7 +177,7 @@ public class LeagueAuthorizationTests : ApiTestBase<LeagueMembershipGuard>
     {
         var memberId = Guid.NewGuid();
         var leagueId = await SeedLeagueAsync(memberId);
-        var handler = new GetLeagueByIdQueryHandler(DataContext, new DateTimeProvider());
+        var handler = new GetLeagueByIdQueryHandler(DataContext, FixedClock());
 
         var result = await handler.ExecuteAsync(new GetLeagueByIdQuery
         {
@@ -189,7 +198,7 @@ public class LeagueAuthorizationTests : ApiTestBase<LeagueMembershipGuard>
         // the league is and how big it is, but not WHO is in it.
         var memberId = Guid.NewGuid();
         var leagueId = await SeedLeagueAsync(memberId);
-        var handler = new GetLeagueByIdQueryHandler(DataContext, new DateTimeProvider());
+        var handler = new GetLeagueByIdQueryHandler(DataContext, FixedClock());
 
         var result = await handler.ExecuteAsync(new GetLeagueByIdQuery
         {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueJoinPolicyTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Commands/JoinLeague/JoinLeagueJoinPolicyTests.cs
@@ -1,0 +1,155 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.Leagues.Commands.JoinLeague;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues.Commands.JoinLeague;
+
+/// <summary>
+/// Join-gate behavior for league join policies. This handler serves BOTH
+/// public-browse joins and invite-link joins, so these tests cover invite
+/// links dying with the listing too.
+/// See docs/features/league-join-policy-and-discovery.md.
+/// </summary>
+public class JoinLeagueJoinPolicyTests : ApiTestBase<JoinLeagueCommandHandler>
+{
+    private static readonly DateTime Now = new(2026, 8, 1, 18, 0, 0, DateTimeKind.Utc);
+
+    private JoinLeagueCommandHandler CreateHandler()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+        return Mocker.CreateInstance<JoinLeagueCommandHandler>();
+    }
+
+    private async Task<Guid> SeedLeagueAsync(
+        JoinPolicy policy,
+        DateTime? deactivatedUtc = null,
+        params DateTime[] matchupStarts)
+    {
+        var commissionerId = Guid.NewGuid();
+        var leagueId = Guid.NewGuid();
+
+        await DataContext.Users.AddAsync(new UserEntity
+        {
+            Id = commissionerId,
+            Username = $"user_{commissionerId:N}"[..20],
+            FirebaseUid = $"uid-{commissionerId:N}",
+            Email = "test@test.com",
+            DisplayName = "Commish",
+            SignInProvider = "test",
+            LastLoginUtc = Now
+        });
+
+        await DataContext.PickemGroups.AddAsync(new PickemGroup
+        {
+            Id = leagueId,
+            Name = "Test League",
+            CommissionerUserId = commissionerId,
+            Sport = Sport.BaseballMlb,
+            League = League.MLB,
+            PickType = PickType.StraightUp,
+            TiebreakerType = TiebreakerType.TotalPoints,
+            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
+            SeasonYear = 2026,
+            JoinPolicy = policy,
+            DeactivatedUtc = deactivatedUtc,
+            CreatedUtc = Now,
+            CreatedBy = commissionerId
+        });
+
+        var week = Guid.NewGuid();
+        foreach (var start in matchupStarts)
+        {
+            await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
+            {
+                Id = Guid.NewGuid(),
+                GroupId = leagueId,
+                SeasonWeekId = week,
+                ContestId = Guid.NewGuid(),
+                StartDateUtc = start,
+                SeasonYear = 2026,
+                SeasonWeek = 1,
+                CreatedUtc = Now,
+                CreatedBy = commissionerId
+            });
+        }
+
+        await DataContext.SaveChangesAsync();
+        return leagueId;
+    }
+
+    private static JoinLeagueCommand Join(Guid leagueId) => new()
+    {
+        PickemGroupId = leagueId,
+        UserId = Guid.NewGuid()
+    };
+
+    [Fact]
+    public async Task OpenLeague_IsJoinable_EvenAfterGamesStart()
+    {
+        // Open = joinable while the league is live; started games don't close it.
+        var leagueId = await SeedLeagueAsync(JoinPolicy.Open,
+            matchupStarts: [Now.AddHours(-5), Now.AddHours(2)]);
+
+        var result = await CreateHandler().ExecuteAsync(Join(leagueId));
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CloseAtFirstGame_BeforeFirstGame_IsJoinable()
+    {
+        var leagueId = await SeedLeagueAsync(JoinPolicy.CloseAtFirstGame,
+            matchupStarts: [Now.AddHours(1), Now.AddHours(4)]);
+
+        var result = await CreateHandler().ExecuteAsync(Join(leagueId));
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CloseAtFirstGame_AfterFirstGame_IsClosed()
+    {
+        // Second game hasn't started — the FIRST start is what closes it.
+        var leagueId = await SeedLeagueAsync(JoinPolicy.CloseAtFirstGame,
+            matchupStarts: [Now.AddHours(-1), Now.AddHours(3)]);
+
+        var result = await CreateHandler().ExecuteAsync(Join(leagueId));
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task CloseAtFirstGame_EmptySlate_IsJoinable()
+    {
+        // The slate builds asynchronously after creation. No matchups yet
+        // means nothing has started — the league must be open, not closed.
+        var leagueId = await SeedLeagueAsync(JoinPolicy.CloseAtFirstGame);
+
+        var result = await CreateHandler().ExecuteAsync(Join(leagueId));
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeactivatedLeague_IsNeverJoinable_RegardlessOfPolicy()
+    {
+        // Pre-existing bug fixed by this feature: a finished season was joinable.
+        var leagueId = await SeedLeagueAsync(JoinPolicy.Open,
+            deactivatedUtc: Now.AddDays(-10));
+
+        var result = await CreateHandler().ExecuteAsync(Join(leagueId));
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+}


### PR DESCRIPTION
Public leagues must be browsable and joinable to drive home-page content, and single-day MLB test leagues surfaced the question this answers: **when does a league stop accepting members?** Design and decision record: `docs/features/league-join-policy-and-discovery.md`.

## The model

The commissioner decides, per league, at creation. Two options, deliberately no custom date in v1:

| Policy | Meaning |
|---|---|
| `Open` (default) | joinable while the league is live (until deactivation) |
| `CloseAtFirstGame` | roster locks when the league's first scheduled game starts |

**Applies to all leagues, not just public ones.** Visibility controls who can *find* a league; join policy controls until when anyone can *enter* it. Public joins and invite-link joins share `JoinLeagueCommandHandler`, so one gate covers both — a shared invite link to a closed league dies with the listing. Flipping the policy after kickoff closes/re-opens the league, so close-now and re-open fall out of two enum values rather than being features.

**The close moment is derived at read time** (`min(matchup.StartDateUtc)`), never stored: kickoff times move after slates generate, and slates build asynchronously after creation — an empty slate means nothing has started, so the league is open. A stored `JoinDeadlineUtc` was considered and rejected as a standing consistency job (trade-off recorded in the doc). DTOs still expose a computed `closesAtUtc` so clients render a concrete timestamp.

## API

- `JoinPolicy` enum + `PickemGroup.JoinPolicy`, int-stored per house style. Migration is a single `ALTER TABLE ... ADD ... DEFAULT 0` — existing leagues backfill to `Open`, today's de-facto behavior.
- Join gate: policy-closed joins rejected with a human-readable message; deactivated leagues rejected — **fixing a pre-existing bug where a finished season was still joinable**.
- Creation: one optional string on the shared request base covers all three sports; absent → `Open`, so pre-existing clients are unaffected.
- `GetPublicLeagues`: deactivated excluded; eager `Include(Members)` replaced with a projection; DTO fattened (sport, league, seasonYear, memberCount, window, joinPolicy, closesAtUtc, isJoinable). Closed leagues are **badged, not hidden** — a nearly-started league still advertises itself.
- `LeagueDetailDto`: `joinPolicy`, `closesAtUtc`, `isJoinable`.

## Web

- Create form: "🚪 Who can join, and until when?" radio pair (Open default).
- Home page Tier 3: new `JoinableLeaguesCard` — "Leagues you can join" rail (top 4, sport glyph, member count, Join CTA, Browse all →). Renders null when nothing is joinable; shown to every user — the BE already excludes leagues the caller belongs to.
- Discover page: sport glyph + season, member count, joinability column ("Closes Aug 30 6:00 PM" / "Closed"), disabled CTA on closed leagues.
- League detail: "Joining:" status row; invite affordances hidden once closed (the links would be dead).

## Deferred (recorded in the doc)

- **Commissioner editing of the policy post-creation** — no update-league command exists at all today (league settings are create-only); that's a future settings-edit feature.
- **`OpenThroughDroppedWeeks`** — derive the join window from `DropLowWeeksCount`: a league dropping its 3 lowest weeks can absorb a week-3 joiner at zero competitive penalty. Slots in as a code-only enum addition, no migration.
- **Mobile browse + closed invite state** — Phase 3, its own PR, ships via EAS.

## Validation

API build 0 warnings; 579 unit tests pass (5 new: open-after-start, close before/after first game, empty slate → open, deactivated → never joinable). Web lint clean; 10 Vitest tests pass; CRA production build compiles.

Migration applied and E2E-tested locally by @jrandallsexton with two users: create-with-policy, home-rail visibility for league-less vs league-having accounts, and join flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-league join policies: **Open** or **CloseAtFirstGame** (locks when the first matchup starts).
  * Public league discovery now shows **joinability**, **member count**, and **closing time**; joinable leagues are surfaced on the home page.
  * League creation and details now display the selected joining policy and joining status.
* **Bug Fixes**
  * Deactivated leagues are no longer joinable.
  * Join/invitation UI is hidden or disabled when leagues are closed.
* **Documentation**
  * Published the “League Join Policy + Public League Discovery” feature specification and rollout notes.
* **Tests**
  * Added unit coverage for joinability rules and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->