### PR TITLE
fix(web): focus trap captures Tab when focus is on the dialog container

### DIFF
--- a/src/UI/sd-ui/src/components/leagues/JoinLeagueConfirmDialog.jsx
+++ b/src/UI/sd-ui/src/components/leagues/JoinLeagueConfirmDialog.jsx
@@ -67,10 +67,25 @@ function JoinLeagueConfirmDialog({ league, onCancel, onConfirm }) {
       if (focusables.length === 0) return;
       const first = focusables[0];
       const last = focusables[focusables.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
+      const active = document.activeElement;
+
+      // Right after open, focus sits on the dialog CONTAINER (tabIndex=-1),
+      // which is neither boundary — and focus can conceivably sit outside
+      // the dialog entirely. In both cases the trap must still capture Tab:
+      // forward goes to the first control, backward to the last.
+      const activeIsInsideControls =
+        active instanceof HTMLElement &&
+        Array.prototype.includes.call(focusables, active);
+      if (!activeIsInsideControls) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+        return;
+      }
+
+      if (e.shiftKey && active === first) {
         e.preventDefault();
         last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
+      } else if (!e.shiftKey && active === last) {
         e.preventDefault();
         first.focus();
       }


### PR DESCRIPTION
Cherry-pick of a CodeRabbit follow-up fix that was committed locally during the #577 review cycle but merged out — the PR landed without it (caught during post-merge branch audit).

On open, `JoinLeagueConfirmDialog` places focus on the dialog **container** (`tabIndex={-1}`), which matches neither the first nor last focusable control — so an immediate Shift+Tab escaped the trap into the page. The trap now detects focus outside the control set (container or beyond) and captures Tab in both directions: forward to the first control, backward to the last. Boundary wrapping between controls is unchanged.

Validation: web lint clean, 10 Vitest tests pass, CRA production build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the league join confirmation dialog.
  * Tab focus is now correctly trapped when starting from the dialog or outside its controls.
  * Forward and reverse Tab navigation move to the appropriate first or last control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->