### PR TITLE
feat(api,web): wire Week Range to the season calendar; admin gate bypass

### DIFF
--- a/docs/features/league-creation-availability-gate.md
+++ b/docs/features/league-creation-availability-gate.md
@@ -170,3 +170,19 @@ the worst case is a slightly worse UX on a transient outage, never a broken leag
    Aug 17, 2026; other sports unset (absent = no gate).
 2. **NFL — leave open for now.** Only NCAAFB is gated in this pass. Setting NFL's
    config value later locks it with **no code change**.
+
+## Admin bypass (2026-07-31)
+
+Admins bypass creation gates entirely, on both sides of the contract:
+
+- `GET /ui/leagues/creation-availability` returns an **empty gate list** for
+  admin callers — the FE locks exactly the sports this endpoint returns, so
+  every tab unlocks with zero client changes.
+- The create handlers apply the same bypass at enforcement (one indexed
+  `IsAdmin` read, only on the gated path), so the deep-link / direct-API path
+  agrees with the UI. Bypass is logged with the admin's user id.
+
+Driver: the operator needs to exercise gated sports before their season opens
+— immediately, NFL league creation for the WeekRange window work (MLB is a
+poor WeekRange candidate: ~100 games per "week" on the picks page; NCAAFB/NFL
+are the focus). Regular users still see and hit the gate unchanged.

--- a/docs/features/league-creation-availability-gate.md
+++ b/docs/features/league-creation-availability-gate.md
@@ -173,16 +173,22 @@ the worst case is a slightly worse UX on a transient outage, never a broken leag
 
 ## Admin bypass (2026-07-31)
 
-Admins bypass creation gates entirely, on both sides of the contract:
+Admins bypass the league-creation availability gate on both sides of the contract (request validation and the blackout guard still apply):
 
 - `GET /ui/leagues/creation-availability` returns an **empty gate list** for
   admin callers — the FE locks exactly the sports this endpoint returns, so
   every tab unlocks with zero client changes.
-- The create handlers apply the same bypass at enforcement (one indexed
+- The create handlers apply the same availability-gate bypass at enforcement (one indexed
   `IsAdmin` read, only on the gated path), so the deep-link / direct-API path
   agrees with the UI. Bypass is logged with the admin's user id.
 
-Driver: the operator needs to exercise gated sports before their season opens
-— immediately, NFL league creation for the WeekRange window work (MLB is a
-poor WeekRange candidate: ~100 games per "week" on the picks page; NCAAFB/NFL
-are the focus). Regular users still see and hit the gate unchanged.
+Driver: the operator needs to exercise gated sports before their season
+opens. The immediate focus is NFL Week Range league-creation work (MLB is a
+poor Week Range candidate: ~100 games per "week" on the picks page; NCAAFB
+and NFL are the focus). Regular users still see and hit the gate unchanged.
+
+Note on admin-status sources (deliberate asymmetry): the availability
+endpoint's bypass reads the middleware's cached identity (house norm for
+isAdmin-driven UI; up to 15 minutes stale after an admin change, cosmetic),
+while the create handlers' enforcement bypass reads `IsAdmin` fresh from the
+database. UI may briefly lag an admin change; enforcement never does.

--- a/src/SportsData.Api/Application/PickemGroups/LeagueJoinExpiryCalculator.cs
+++ b/src/SportsData.Api/Application/PickemGroups/LeagueJoinExpiryCalculator.cs
@@ -122,10 +122,14 @@ public class LeagueJoinExpiryCalculator : ILeagueJoinExpiryCalculator
                 return firstKickoff;
 
             // Provisional: the season calendar's week-(N+1) boundary.
+            // EXACT phase match — week numbers restart per phase, and the
+            // overview is StartDate-ordered, so a Contains("post") exclusion
+            // would resolve NFL "week 4" to PRESEASON week 4 (five weeks
+            // early). Verified against the real Season/SeasonPhase/SeasonWeek
+            // schema, 2026-07-31.
             var overview = await GetSeasonOverviewAsync(group, cancellationToken);
             return overview?.Weeks
-                // Regular-season weeks only — postseason numbering restarts.
-                .Where(w => !w.SeasonPhaseName.Contains("post", StringComparison.OrdinalIgnoreCase))
+                .Where(w => w.SeasonPhaseName.Equals("Regular Season", StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault(w => w.Number == targetWeek)?.StartDate;
         }
 

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -130,6 +130,9 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
             // Admin bypass, mirroring the creation-availability endpoint: the
             // operator needs to exercise gated sports (e.g. NFL) before their
             // season opens. One indexed read, only on the gated path.
+            // Deliberately FRESH from the database (not the middleware's
+            // 15-minute cached identity the endpoint uses): enforcement
+            // decisions never ride a cache; only UI shaping does.
             var isAdmin = await _dbContext.Users
                 .AsNoTracking()
                 .Where(u => u.Id == currentUserId)

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueCommandHandlerBase.cs
@@ -127,17 +127,35 @@ public abstract class CreateLeagueCommandHandlerBase<TRequest>
         var opensUtc = _availability.GetOpensUtc(SportMode);
         if (opensUtc is not null)
         {
-            _logger.LogInformation(
-                "Rejecting create-league: {Sport} creation opens {OpensUtc:o}.",
-                SportMode, opensUtc);
+            // Admin bypass, mirroring the creation-availability endpoint: the
+            // operator needs to exercise gated sports (e.g. NFL) before their
+            // season opens. One indexed read, only on the gated path.
+            var isAdmin = await _dbContext.Users
+                .AsNoTracking()
+                .Where(u => u.Id == currentUserId)
+                .Select(u => u.IsAdmin)
+                .FirstOrDefaultAsync(cancellationToken);
 
-            return new Failure<Guid>(
-                default!,
-                ResultStatus.Validation,
-                // User-facing copy — no raw Sport enum; the user is already in a
-                // specific sport's create flow.
-                [new ValidationFailure(nameof(request),
-                    $"League creation opens {opensUtc:MMMM d, yyyy}. Check back then.")]);
+            if (isAdmin)
+            {
+                _logger.LogInformation(
+                    "Creation gate bypassed by admin {UserId}: {Sport} opens {OpensUtc:o}.",
+                    currentUserId, SportMode, opensUtc);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Rejecting create-league: {Sport} creation opens {OpensUtc:o}.",
+                    SportMode, opensUtc);
+
+                return new Failure<Guid>(
+                    default!,
+                    ResultStatus.Validation,
+                    // User-facing copy — no raw Sport enum; the user is already in a
+                    // specific sport's create flow.
+                    [new ValidationFailure(nameof(request),
+                        $"League creation opens {opensUtc:MMMM d, yyyy}. Check back then.")]);
+            }
         }
 
         // Blackout guard: a windowed league whose date range contains no games

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSeasonWeeksDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSeasonWeeksDto.cs
@@ -1,0 +1,18 @@
+namespace SportsData.Api.Application.UI.Leagues.Dtos;
+
+/// <summary>
+/// The season calendar as the create-league form consumes it: every week that
+/// can hold games (Off Season excluded), ordered by start date, labeled with
+/// its phase where numbering is ambiguous ("Week 4" vs "Preseason - Week 4" —
+/// week numbers RESTART per phase; see docs/features/
+/// league-join-policy-and-discovery.md, WeekRange section).
+/// </summary>
+public record LeagueSeasonWeeksDto(int SeasonYear, IReadOnlyList<LeagueSeasonWeekOptionDto> Weeks);
+
+public record LeagueSeasonWeekOptionDto(
+    Guid Id,
+    int Number,
+    string Label,
+    string PhaseName,
+    DateTime StartDateUtc,
+    DateTime EndDateUtc);

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Core.Infrastructure.Clients.Season;
+
 using SportsData.Api.Application.UI.Leagues.Authorization;
 using SportsData.Api.Application.UI.Leagues.Commands.AddMatchup;
 using SportsData.Api.Application.UI.Leagues.Commands.CloneLeague;
@@ -123,11 +125,58 @@ public class LeagueController : ApiControllerBase
     /// and shows an "opens {date}" affordance. The create endpoints enforce the same
     /// gate server-side. See docs/features/league-creation-availability-gate.md.
     /// </summary>
+    /// <summary>
+    /// The season calendar for a sport's current (or given) season year — the
+    /// labeled week list the create-league form's Week Range picker and
+    /// drop-week limits are driven by. Thin pass-through to Producer's season
+    /// overview; week numbers restart per phase, so labels carry the phase.
+    /// </summary>
+    [HttpGet("season-weeks")]
+    [Authorize]
+    public async Task<ActionResult<LeagueSeasonWeeksDto>> GetSeasonWeeks(
+        [FromQuery] string sport,
+        [FromQuery] int? seasonYear,
+        [FromServices] ISeasonClientFactory seasonClientFactory,
+        [FromServices] IDateTimeProvider dateTimeProvider,
+        CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<Sport>(sport, ignoreCase: true, out var parsedSport))
+            return BadRequest($"Unknown sport: {sport}");
+
+        // Same convention as league creation (request.SeasonYear ?? current
+        // year) so the picker and the created league agree on the season.
+        var year = seasonYear ?? dateTimeProvider.UtcNow().Year;
+
+        var overview = await seasonClientFactory
+            .Resolve(parsedSport)
+            .GetSeasonOverview(year, cancellationToken);
+
+        if (!overview.IsSuccess)
+            return NotFound($"Season calendar unavailable for {parsedSport} {year}.");
+
+        var weeks = overview.Value.Weeks
+            .Where(w => !w.SeasonPhaseName.Equals("Off Season", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(w => w.StartDate)
+            .Select(w => new LeagueSeasonWeekOptionDto(
+                w.Id, w.Number, w.Label, w.SeasonPhaseName, w.StartDate, w.EndDate))
+            .ToList();
+
+        return Ok(new LeagueSeasonWeeksDto(year, weeks));
+    }
+
     [HttpGet("creation-availability")]
     [Authorize]
     public ActionResult<LeagueCreationAvailabilityDto> GetCreationAvailability(
         [FromServices] ILeagueCreationAvailability availability)
     {
+        // Admins bypass creation gates entirely (e.g. testing NFL WeekRange
+        // work before the season opens). The FE locks exactly the sports this
+        // returns, so an empty list unlocks every tab with zero client
+        // changes; the create handlers apply the same admin bypass so the
+        // deep-link path agrees.
+        if (HttpContext.GetCurrentUser().IsAdmin)
+            return Ok(new LeagueCreationAvailabilityDto([]));
+
         return Ok(new LeagueCreationAvailabilityDto(availability.GetActiveGates()));
     }
 

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using SportsData.Core.Common.Mapping;
 using SportsData.Core.Infrastructure.Clients.Season;
 
 using SportsData.Api.Application.UI.Leagues.Authorization;
@@ -131,17 +132,25 @@ public class LeagueController : ApiControllerBase
     /// drop-week limits are driven by. Thin pass-through to Producer's season
     /// overview; week numbers restart per phase, so labels carry the phase.
     /// </summary>
-    [HttpGet("season-weeks")]
+    [HttpGet("{sport}/{league}/season-weeks")]
     [Authorize]
     public async Task<ActionResult<LeagueSeasonWeeksDto>> GetSeasonWeeks(
-        [FromQuery] string sport,
+        [FromRoute] string sport,
+        [FromRoute] string league,
         [FromQuery] int? seasonYear,
         [FromServices] ISeasonClientFactory seasonClientFactory,
         [FromServices] IDateTimeProvider dateTimeProvider,
         CancellationToken cancellationToken)
     {
-        if (!Enum.TryParse<Sport>(sport, ignoreCase: true, out var parsedSport))
-            return BadRequest($"Unknown sport: {sport}");
+        Sport parsedSport;
+        try
+        {
+            parsedSport = ModeMapper.ResolveMode(sport, league);
+        }
+        catch (NotSupportedException)
+        {
+            return BadRequest($"Unsupported sport/league: {sport}/{league}");
+        }
 
         // Same convention as league creation (request.SeasonYear ?? current
         // year) so the picker and the created league agree on the season.
@@ -169,11 +178,18 @@ public class LeagueController : ApiControllerBase
     public ActionResult<LeagueCreationAvailabilityDto> GetCreationAvailability(
         [FromServices] ILeagueCreationAvailability availability)
     {
-        // Admins bypass creation gates entirely (e.g. testing NFL WeekRange
+        // Admins bypass the availability gate (e.g. testing NFL WeekRange
         // work before the season opens). The FE locks exactly the sports this
         // returns, so an empty list unlocks every tab with zero client
         // changes; the create handlers apply the same admin bypass so the
         // deep-link path agrees.
+        //
+        // Deliberate asymmetry with the handler's bypass: this UI-shaping
+        // read uses the middleware's cached identity (the house norm for
+        // every isAdmin-driven UI gate; <=15-min staleness after an admin
+        // change is cosmetic), while ENFORCEMENT in the create handlers
+        // reads IsAdmin fresh from the database. UI may briefly lag; the
+        // enforcement decision never does.
         if (HttpContext.GetCurrentUser().IsAdmin)
             return Ok(new LeagueCreationAvailabilityDto([]));
 

--- a/src/UI/sd-ui/src/api/leagues/leaguesApi.js
+++ b/src/UI/sd-ui/src/api/leagues/leaguesApi.js
@@ -143,6 +143,21 @@ const getPublicLeagues = async () => {
  * are returned; a sport not listed is open.
  * @returns {Promise<{ gates: { sport: string, opensUtc: string }[] }>}
  */
+/**
+ * Fetches the season calendar for a sport — every week that can hold games
+ * (Off Season excluded), StartDate-ordered, labeled with its phase where
+ * numbering is ambiguous ("Week 4" vs "Preseason - Week 4"; week numbers
+ * restart per phase). Drives the Week Range picker and drop-week limits.
+ * @param {string} sport BE Sport enum name, e.g. "FootballNfl"
+ * @returns {Promise<{ seasonYear: number, weeks: { id: string, number: number, label: string, phaseName: string, startDateUtc: string, endDateUtc: string }[] }>}
+ */
+const getSeasonWeeks = async (sport) => {
+  const response = await apiClient.get(`${BASE_PATH}/season-weeks`, {
+    params: { sport },
+  });
+  return response.data;
+};
+
 const getCreationAvailability = async () => {
   const response = await apiClient.get(`${BASE_PATH}/creation-availability`);
   return response.data;
@@ -178,6 +193,7 @@ const LeaguesApi = {
   inviteUser,
   getPublicLeagues,
   getCreationAvailability,
+  getSeasonWeeks,
   getLeagueWeekOverview,
   getLeagueScores
 };

--- a/src/UI/sd-ui/src/api/leagues/leaguesApi.js
+++ b/src/UI/sd-ui/src/api/leagues/leaguesApi.js
@@ -151,10 +151,18 @@ const getPublicLeagues = async () => {
  * @param {string} sport BE Sport enum name, e.g. "FootballNfl"
  * @returns {Promise<{ seasonYear: number, weeks: { id: string, number: number, label: string, phaseName: string, startDateUtc: string, endDateUtc: string }[] }>}
  */
+const SPORT_ROUTE = {
+  FootballNcaa: "football/ncaa",
+  FootballNfl: "football/nfl",
+  BaseballMlb: "baseball/mlb",
+};
+
 const getSeasonWeeks = async (sport) => {
-  const response = await apiClient.get(`${BASE_PATH}/season-weeks`, {
-    params: { sport },
-  });
+  // Route follows the API's {sport}/{league}/{resource} convention (same as
+  // game-dates), so the BE enum name translates to route slugs here.
+  const route = SPORT_ROUTE[sport];
+  if (!route) throw new Error(`Unknown sport: ${sport}`);
+  const response = await apiClient.get(`${BASE_PATH}/${route}/season-weeks`);
   return response.data;
 };
 

--- a/src/UI/sd-ui/src/api/leagues/requests/createLeagueRequests.js
+++ b/src/UI/sd-ui/src/api/leagues/requests/createLeagueRequests.js
@@ -17,14 +17,19 @@ const toEndOfDayIso = (dateStr) => {
   return new Date(year, month - 1, day, 23, 59, 59).toISOString();
 };
 
-const buildWindow = ({ durationMode, startsOn, endsOn }) => {
+const buildWindow = ({ durationMode, startsOn, endsOn, weekStartsOnIso, weekEndsOnIso }) => {
   if (durationMode === "dates") {
     return {
       startsOn: toStartOfDayIso(startsOn),
       endsOn: toEndOfDayIso(endsOn),
     };
   }
-  // Full season or Week Range (week→date translation is a BE follow-up).
+  if (durationMode === "weeks") {
+    // The selected SeasonWeeks' real UTC boundaries, passed through raw --
+    // these are authored instants from the season calendar, NOT date-input
+    // values needing local-midnight conversion.
+    return { startsOn: weekStartsOnIso ?? null, endsOn: weekEndsOnIso ?? null };
+  }
   return { startsOn: null, endsOn: null };
 };
 
@@ -61,6 +66,8 @@ const buildShared = ({
   durationMode,
   startsOn,
   endsOn,
+  weekStartsOnIso,
+  weekEndsOnIso,
 }) => ({
   name: leagueName,
   description: description?.trim() || null,
@@ -75,17 +82,15 @@ const buildShared = ({
   // Explicit window shape — the BE stores this rather than inferring it
   // from the dates. Mapping matches the form's duration modes.
   //
-  // "weeks" is DELIBERATELY sent as WeekRange even though buildWindow can't
-  // yet resolve its date bounds (the create form blocks submission upstream).
-  // If it ever slips through, the BE validator rejects the window/dates
-  // mismatch loudly — strictly better than the pre-LeagueWindow behavior,
-  // where null bounds silently created a mislabeled FullSeason league.
+  // "weeks" carries the selected SeasonWeeks' boundaries via buildWindow; a
+  // WeekRange submission without them is rejected by the BE validator's
+  // window/dates consistency check.
   leagueWindow:
     durationMode === "dates" ? "DateRange"
     : durationMode === "weeks" ? "WeekRange"
     : "FullSeason",
   dropLowWeeksCount: toNonNegativeInt(dropLowWeeksCount),
-  ...buildWindow({ durationMode, startsOn, endsOn }),
+  ...buildWindow({ durationMode, startsOn, endsOn, weekStartsOnIso, weekEndsOnIso }),
 });
 
 export const buildCreateFootballNcaaLeagueRequest = (form) => ({

--- a/src/UI/sd-ui/src/api/leagues/requests/createLeagueRequests.js
+++ b/src/UI/sd-ui/src/api/leagues/requests/createLeagueRequests.js
@@ -5,13 +5,13 @@
 // instant that represents midnight/end-of-day in the caller's local timezone.
 // Appending "Z" would wrongly treat the local calendar date as UTC, skewing
 // the window by up to 24 hours for non-UTC users.
-const toStartOfDayIso = (dateStr) => {
+export const toStartOfDayIso = (dateStr) => {
   if (!dateStr) return null;
   const [year, month, day] = dateStr.split("-").map(Number);
   return new Date(year, month - 1, day, 0, 0, 0).toISOString();
 };
 
-const toEndOfDayIso = (dateStr) => {
+export const toEndOfDayIso = (dateStr) => {
   if (!dateStr) return null;
   const [year, month, day] = dateStr.split("-").map(Number);
   return new Date(year, month - 1, day, 23, 59, 59).toISOString();

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -11,6 +11,8 @@ import {
 import "./LeagueCreatePage.css";
 
 import {
+  toStartOfDayIso,
+  toEndOfDayIso,
   buildCreateFootballNcaaLeagueRequest,
   buildCreateFootballNflLeagueRequest,
   buildCreateBaseballMlbLeagueRequest,
@@ -285,8 +287,12 @@ const LeagueCreatePage = () => {
     }
     if (durationMode === DURATION_DATES) {
       if (!startsOn || !endsOn) return null;
-      const from = new Date(`${startsOn}T00:00:00Z`).getTime();
-      const to = new Date(`${endsOn}T23:59:59Z`).getTime();
+      // Same LOCAL-day boundary convention the submission uses
+      // (toStartOfDayIso/toEndOfDayIso) -- forced-UTC bounds here would
+      // count a different week set than the range actually submitted for
+      // users outside UTC.
+      const from = new Date(toStartOfDayIso(startsOn)).getTime();
+      const to = new Date(toEndOfDayIso(endsOn)).getTime();
       const count = seasonWeeks.filter((w) => {
         const ws = new Date(w.startDateUtc).getTime();
         const we = new Date(w.endDateUtc).getTime();

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -49,7 +49,6 @@ const SPORT_COPY = {
     tiebreakerTotalLabel: "Closest to Total Points",
     namePlaceholder: "e.g., Saturday Showdown",
     descPlaceholder: "A fun league for SEC fans.",
-    maxWeeks: 16,
   },
   [SPORT_NFL]: {
     label: "NFL",
@@ -58,7 +57,6 @@ const SPORT_COPY = {
     tiebreakerTotalLabel: "Closest to Total Points",
     namePlaceholder: "e.g., Sunday Funday",
     descPlaceholder: "A fun league for NFL fans.",
-    maxWeeks: 22,
   },
   [SPORT_MLB]: {
     label: "MLB",
@@ -67,7 +65,6 @@ const SPORT_COPY = {
     tiebreakerTotalLabel: "Closest to Total Runs",
     namePlaceholder: "e.g., Ninth Inning",
     descPlaceholder: "A fun league for MLB fans.",
-    maxWeeks: 26,
   },
 };
 
@@ -163,8 +160,16 @@ const LeagueCreatePage = () => {
   const [allConferences, setAllConferences] = useState([]);
   const [fbsOnly, setFbsOnly] = useState(true);
   const [durationMode, setDurationMode] = useState(DURATION_FULL);
-  const [startWeek, setStartWeek] = useState(1);
-  const [endWeek, setEndWeek] = useState(1);
+  // Week Range selections are SeasonWeek ids from the season calendar, not
+  // bare numbers -- week numbers restart per phase ("Week 4" exists in both
+  // Preseason and Regular Season), so only the id is unambiguous.
+  const [startWeekId, setStartWeekId] = useState("");
+  const [endWeekId, setEndWeekId] = useState("");
+  // The sport's season calendar (all phases except Off Season, StartDate
+  // order). Drives the Week Range picker, the week->date translation at
+  // submit, and the drop-week limit for every window mode.
+  const [seasonWeeks, setSeasonWeeks] = useState([]);
+  const [seasonWeeksLoaded, setSeasonWeeksLoaded] = useState(false);
   const [startsOn, setStartsOn] = useState("");
   const [endsOn, setEndsOn] = useState("");
 
@@ -238,13 +243,78 @@ const LeagueCreatePage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gatesLoaded, userLoading, creationGates, sport, eligibleSports]);
 
+  const startWeekIndex = seasonWeeks.findIndex((w) => w.id === startWeekId);
+  const endWeekIndex = seasonWeeks.findIndex((w) => w.id === endWeekId);
+  const startWeekObj = startWeekIndex >= 0 ? seasonWeeks[startWeekIndex] : null;
+  const endWeekObj = endWeekIndex >= 0 ? seasonWeeks[endWeekIndex] : null;
+
+  // End >= Start: if the start moves past the end (or end is unset), pull the
+  // end up to match.
+  useEffect(() => {
+    if (!startWeekId) return;
+    if (!endWeekId || (endWeekIndex >= 0 && startWeekIndex > endWeekIndex)) {
+      setEndWeekId(startWeekId);
+    }
+  }, [startWeekId, endWeekId, startWeekIndex, endWeekIndex]);
+
+  // "MM/DD" from the week's UTC boundary instants. Formatted in UTC so the
+  // authored wall-clock day isn't shifted in western timezones (same trick as
+  // formatGateDate).
+  const fmtWeekDate = (iso) => {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime())
+      ? ""
+      : d.toLocaleDateString(undefined, {
+          month: "2-digit",
+          day: "2-digit",
+          timeZone: "UTC",
+        });
+  };
+  const weekOptionLabel = (w) =>
+    `${w.label}: ${fmtWeekDate(w.startDateUtc)}-${fmtWeekDate(w.endDateUtc)}`;
+  const isWeekPast = (w) => new Date(w.endDateUtc).getTime() <= Date.now();
+
+  // How many weeks the chosen window spans -- the drop-week ceiling is one
+  // less ("drop all weeks" is not a league). null = unknown (calendar not
+  // loaded / dates not chosen) -> legacy cap of 3.
+  const leagueWeekCount = (() => {
+    if (!seasonWeeksLoaded || seasonWeeks.length === 0) return null;
+    if (durationMode === DURATION_WEEKS) {
+      if (startWeekIndex < 0 || endWeekIndex < 0) return null;
+      return endWeekIndex - startWeekIndex + 1;
+    }
+    if (durationMode === DURATION_DATES) {
+      if (!startsOn || !endsOn) return null;
+      const from = new Date(`${startsOn}T00:00:00Z`).getTime();
+      const to = new Date(`${endsOn}T23:59:59Z`).getTime();
+      const count = seasonWeeks.filter((w) => {
+        const ws = new Date(w.startDateUtc).getTime();
+        const we = new Date(w.endDateUtc).getTime();
+        return ws <= to && we >= from;
+      }).length;
+      return count > 0 ? count : null;
+    }
+    // Full season scores over the regular season.
+    const reg = seasonWeeks.filter((w) =>
+      /regular/i.test(w.phaseName)
+    ).length;
+    return reg > 0 ? reg : null;
+  })();
+  const maxDropWeeks = leagueWeekCount === null ? 3 : Math.max(leagueWeekCount - 1, 0);
+
+  // Keep the selection valid as the window shrinks.
+  useEffect(() => {
+    setDropLowWeeksCount((c) => Math.min(c, maxDropWeeks));
+  }, [maxDropWeeks]);
+
   // Human-readable window for the suggested description: a single day, a date
   // range, a single week, or a week range. null for a full-season league.
   const descriptionWindowLabel = (() => {
     if (durationMode === DURATION_WEEKS) {
-      return startWeek === endWeek
-        ? `Week ${startWeek}`
-        : `Weeks ${startWeek}–${endWeek}`;
+      if (!startWeekObj || !endWeekObj) return null;
+      return startWeekObj.id === endWeekObj.id
+        ? startWeekObj.label
+        : `${startWeekObj.label} – ${endWeekObj.label}`;
     }
     if (durationMode === DURATION_DATES) {
       const s = formatDateShort(startsOn);
@@ -305,11 +375,35 @@ const LeagueCreatePage = () => {
     if (!isNcaa) {
       setRankingFilter("");
     }
-    // Clamp week selection if switching to a sport with fewer weeks.
-    const max = SPORT_COPY[sport].maxWeeks;
-    setStartWeek((w) => Math.min(w, max));
-    setEndWeek((w) => Math.min(w, max));
+    // Week selections don't survive a sport switch -- ids are season-scoped.
+    setStartWeekId("");
+    setEndWeekId("");
   }, [sport, isNcaa]);
+
+  // Season calendar per sport. Needed beyond Week Range: drop-week limits for
+  // Full Season and Date Range derive from it too. Fails soft -- an empty
+  // list disables the Week Range tab and leaves drop weeks on a legacy cap.
+  useEffect(() => {
+    let cancelled = false;
+    setSeasonWeeksLoaded(false);
+    setSeasonWeeks([]);
+    LeaguesApi.getSeasonWeeks(sport)
+      .then((data) => {
+        if (cancelled) return;
+        setSeasonWeeks(data?.weeks ?? []);
+        setSeasonWeeksLoaded(true);
+      })
+      .catch((err) => {
+        console.error("Failed to load season weeks:", err);
+        if (cancelled) return;
+        setSeasonWeeks([]);
+        setSeasonWeeksLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sport]);
+
 
   const chunk = (array, size) => {
     const result = [];
@@ -354,17 +448,15 @@ const LeagueCreatePage = () => {
       }
     }
 
+    if (durationMode === DURATION_WEEKS && (!startWeekObj || !endWeekObj)) {
+      toast.error("Choose a start and end week for your league.");
+      return;
+    }
+
     setShowConfirmDialog(true);
   };
 
   const finalizeLeagueCreation = async () => {
-    if (durationMode === DURATION_WEEKS) {
-      toast.error(
-        "Week Range isn't wired up yet — it needs the season calendar endpoint. Use Full Season or Date Range for now."
-      );
-      return;
-    }
-
     const formState = {
       leagueName,
       description: effectiveDescription,
@@ -379,6 +471,10 @@ const LeagueCreatePage = () => {
       durationMode,
       startsOn,
       endsOn,
+      // Week Range translated to the selected weeks' real UTC boundaries --
+      // raw ISO pass-through, NOT the date-input local-midnight conversion.
+      weekStartsOnIso: startWeekObj?.startDateUtc ?? null,
+      weekEndsOnIso: endWeekObj?.endDateUtc ?? null,
     };
 
     const dispatch = {
@@ -543,20 +639,6 @@ const LeagueCreatePage = () => {
               </select>
             </div>
 
-            <div className="form-group">
-              <label htmlFor="dropLowWeeksCount">Drop Low Weeks</label>
-              <select
-                id="dropLowWeeksCount"
-                name="dropLowWeeksCount"
-                value={dropLowWeeksCount}
-                onChange={(e) => setDropLowWeeksCount(Number(e.target.value))}
-              >
-                <option value={0}>None. Use All Weeks</option>
-                <option value={1}>1</option>
-                <option value={2}>2</option>
-                <option value={3}>3</option>
-              </select>
-            </div>
           </div>
 
           <div className="form-group">
@@ -581,6 +663,12 @@ const LeagueCreatePage = () => {
                 type="button"
                 role="tab"
                 aria-selected={durationMode === DURATION_WEEKS}
+                disabled={seasonWeeksLoaded && seasonWeeks.length === 0}
+                title={
+                  seasonWeeksLoaded && seasonWeeks.length === 0
+                    ? "Season calendar unavailable"
+                    : undefined
+                }
                 className={`segmented-tab${
                   durationMode === DURATION_WEEKS ? " active" : ""
                 }`}
@@ -607,15 +695,16 @@ const LeagueCreatePage = () => {
                   <label htmlFor="startWeek">Start Week</label>
                   <select
                     id="startWeek"
-                    value={startWeek}
-                    onChange={(e) => setStartWeek(Number(e.target.value))}
+                    value={startWeekId}
+                    onChange={(e) => setStartWeekId(e.target.value)}
                   >
-                    {Array.from(
-                      { length: copy.maxWeeks },
-                      (_, i) => i + 1
-                    ).map((w) => (
-                      <option key={w} value={w}>
-                        Week {w}
+                    <option value="">Select...</option>
+                    {/* Past weeks stay visible but disabled; an in-progress
+                        week remains selectable (you can still pick its
+                        remaining games). */}
+                    {seasonWeeks.map((w) => (
+                      <option key={w.id} value={w.id} disabled={isWeekPast(w)}>
+                        {weekOptionLabel(w)}
                       </option>
                     ))}
                   </select>
@@ -624,15 +713,20 @@ const LeagueCreatePage = () => {
                   <label htmlFor="endWeek">End Week</label>
                   <select
                     id="endWeek"
-                    value={endWeek}
-                    onChange={(e) => setEndWeek(Number(e.target.value))}
+                    value={endWeekId}
+                    onChange={(e) => setEndWeekId(e.target.value)}
                   >
-                    {Array.from(
-                      { length: copy.maxWeeks },
-                      (_, i) => i + 1
-                    ).map((w) => (
-                      <option key={w} value={w}>
-                        Week {w}
+                    <option value="">Select...</option>
+                    {seasonWeeks.map((w, i) => (
+                      <option
+                        key={w.id}
+                        value={w.id}
+                        disabled={
+                          isWeekPast(w) ||
+                          (startWeekIndex >= 0 && i < startWeekIndex)
+                        }
+                      >
+                        {weekOptionLabel(w)}
                       </option>
                     ))}
                   </select>
@@ -664,6 +758,30 @@ const LeagueCreatePage = () => {
                 </div>
               </div>
             )}
+
+            {/* Below League Window because the window drives its ceiling:
+                a league can drop at most LeagueWeekCount - 1 weeks. The
+                count derives from the season calendar for every mode
+                (selected span for Week Range, overlapping weeks for Date
+                Range, regular-season weeks for Full Season). */}
+            <div className="form-group duration-detail">
+              <label htmlFor="dropLowWeeksCount">Drop Low Weeks</label>
+              <select
+                id="dropLowWeeksCount"
+                name="dropLowWeeksCount"
+                value={dropLowWeeksCount}
+                onChange={(e) => setDropLowWeeksCount(Number(e.target.value))}
+              >
+                <option value={0}>None. Use All Weeks</option>
+                {Array.from({ length: maxDropWeeks }, (_, i) => i + 1).map(
+                  (n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  )
+                )}
+              </select>
+            </div>
           </div>
 
           <div className="form-group">
@@ -860,7 +978,11 @@ const LeagueCreatePage = () => {
                 <strong>League Window:</strong>{" "}
                 {durationMode === DURATION_FULL && "Full Season"}
                 {durationMode === DURATION_WEEKS &&
-                  `Weeks ${startWeek}–${endWeek}`}
+                  (startWeekObj && endWeekObj
+                    ? startWeekObj.id === endWeekObj.id
+                      ? startWeekObj.label
+                      : `${startWeekObj.label} – ${endWeekObj.label}`
+                    : "—")}
                 {durationMode === DURATION_DATES &&
                   `${startsOn || "—"} to ${endsOn || "—"}`}
               </li>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/LeagueJoinExpiryCalculatorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/PickemGroups/LeagueJoinExpiryCalculatorTests.cs
@@ -106,6 +106,10 @@ public class LeagueJoinExpiryCalculatorTests : ApiTestBase<LeagueJoinExpiryCalcu
         EndDate = new DateTime(2027, 1, 20, 0, 0, 0, DateTimeKind.Utc),
         Weeks =
         [
+            // Preseason week 4 shares its NUMBER with regular-season week 4 and
+            // sorts FIRST (StartDate order) — the real NFL shape. The drop-week
+            // fallback must resolve to the REGULAR SEASON week.
+            new SeasonWeekDto { Id = Guid.NewGuid(), Number = 4, SeasonPhaseName = "Preseason", StartDate = new DateTime(2026, 8, 27), EndDate = new DateTime(2026, 9, 8) },
             new SeasonWeekDto { Id = Guid.NewGuid(), Number = 3, SeasonPhaseName = "Regular Season", StartDate = new DateTime(2026, 9, 8), EndDate = new DateTime(2026, 9, 14) },
             new SeasonWeekDto { Id = Guid.NewGuid(), Number = 4, SeasonPhaseName = "Regular Season", StartDate = new DateTime(2026, 9, 15), EndDate = new DateTime(2026, 9, 21) },
             // Postseason numbering restarts — must NOT satisfy a week-4 lookup.
@@ -142,7 +146,8 @@ public class LeagueJoinExpiryCalculatorTests : ApiTestBase<LeagueJoinExpiryCalcu
 
         await CreateCalculator(Overview()).RecomputeAsync(league.Id);
 
-        league.InvitationsExpireUtc.Should().Be(new DateTime(2026, 9, 15));
+        league.InvitationsExpireUtc.Should().Be(new DateTime(2026, 9, 15),
+            "the REGULAR SEASON week 4 boundary — not preseason week 4, which shares the number and sorts first");
     }
 
     // ── CloseAtFirstGame ──────────────────────────────────────────────────────


### PR DESCRIPTION
Four related pieces, one story: NFL becomes testable before its season opens, and the create form's Week Range mode goes from blocked placeholder to real season-calendar data. NCAAFB/NFL are the product focus; NFL preseason (opening **Aug 6**) is the live-data window for exercising it.

## Admin creation-gate bypass

The league-creation availability gate now exempts admins **on both sides of the contract**: the availability endpoint returns an empty gate list for admin callers — the FE locks exactly what the endpoint returns, so every tab unlocks with zero client changes — and the create handlers apply the same bypass at enforcement (one indexed `IsAdmin` read, only on the gated path, logged). Regular users see the gate unchanged.

## Season-weeks endpoint

`GET /ui/leagues/season-weeks?sport=X` — thin pass-through to Producer's season overview: every week that can hold games (Off Season excluded), StartDate-ordered, real UTC boundaries, phase-carrying labels.

**The load-bearing fact, verified against the actual `Season`/`SeasonPhase`/`SeasonWeek` schema: week numbers restart per phase.** NFL has a Preseason week 4 (Aug 27) *and* a Regular Season week 4 (Sep 30). Week identity is the `SeasonWeek` id; labels disambiguate ("Week 4" vs "Preseason - Week 4").

## Week Range picker (operator-specified behavior)

- Real calendar options with dates in the label — `Week 1: 09/09-09/16`, `Preseason - Week 1: 08/06-08/13` — UTC-formatted so authored wall-clock days don't shift across timezones
- Past weeks visible but **disabled**; an in-progress week stays selectable (remaining games are still pickable)
- End Week disables options before Start and auto-bumps when Start moves past it
- **Drop Low Weeks relocated below League Window**, ceiling = `LeagueWeekCount − 1` where the count derives from the window: selected span (Week Range), calendar weeks overlapping the dates (Date Range), regular-season count (Full Season); auto-clamps as the window shrinks
- Submission translates selected weeks to their real UTC boundary instants (raw ISO pass-through), satisfying the `WeekRange` window/dates validator end-to-end; the "isn't wired up yet" toast is gone
- Hardcoded per-sport `maxWeeks` constants deleted — the calendar is the only source of week truth in the form

## Preseason-collision bugfix (expiry calculator)

The drop-week calendar fallback excluded phases containing "post" and took the first number match from a StartDate-ordered list — resolving NFL "week 4" to **Preseason** week 4, five weeks early. Now an exact "Regular Season" phase match. No production impact existed (the bug required a drop-week FullSeason league on a sport with a preseason phase, and NFL creation was gated), but the test fixture now models the real shape — a preseason week sharing its number and sorting first — so the test proves the fix.

## Known limitation, deliberate

E2E league **play** for WeekRange leagues is unproven until preseason games exist to pick. This PR makes the creation path real; the first live validation window opens Aug 6.

## Validation

API build 0 warnings; 590 unit tests pass. Web lint clean; 10 Vitest tests pass; CRA production build compiles. Creation flow E2E-tested locally by @jrandallsexton — NFL Week Range spanning preseason into regular season, drop-week clamping, date-range overlap counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - League creation now uses sport-specific season calendars with labeled week ranges and dates.
  - Past weeks are disabled, selections must remain ordered, and drop-week limits adjust automatically.
  - Added support for retrieving available season weeks and submitting accurate UTC boundaries.
  - Administrators can create leagues before availability gates open.

- **Bug Fixes**
  - Improved week expiry handling when preseason and regular-season weeks share numbers.
  - Week Range is unavailable when calendar data cannot be loaded, with graceful fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->