### PR TITLE
feat(producer,api): bulk franchise-season sourcing + allowlisted ops proxy

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -1,0 +1,161 @@
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Mapping;
+using SportsData.Core.Config;
+
+using System.Text;
+
+namespace SportsData.Api.Application.Admin;
+
+/// <summary>
+/// The single allowlisted pass-through for internal ops endpoints. Producer
+/// and Provider came off public ingress on 2026-07-23 (unauthenticated ops
+/// surface); this is the deliberate, bounded re-exposure: one route, admin
+/// token required, an explicit path allowlist, GET/POST only.
+///
+///   POST /admin/ops/producer/football/nfl/api/franchise-seasons/seasonYear/2026/source
+///
+/// New op FAMILIES are one allowlist line; new endpoints inside an allowed
+/// family need nothing at all. Sport/league resolve via ModeMapper (the house
+/// convention), and the internal base URL comes from the same CommonConfig
+/// keys the typed client factories use — per-sport Producer pods route
+/// correctly in mode=All.
+/// </summary>
+[ApiController]
+[Route("admin/ops")]
+[AdminApiToken]
+public class AdminOpsProxyController : ControllerBase
+{
+    /// <summary>
+    /// What the proxy may reach, per service. Prefix match on the forwarded
+    /// path. Deliberately explicit and code-level: the allowlist IS the
+    /// security boundary that lets the rest of the internal API surface stay
+    /// unreachable even with a valid admin token.
+    /// </summary>
+    public static class Allowlist
+    {
+        private static readonly string[] ProducerPrefixes =
+        [
+            "api/franchise-seasons",
+            "api/competition",
+            "api/contests"
+        ];
+
+        private static readonly string[] ProviderPrefixes =
+        [
+            "api/documents"
+        ];
+
+        public static bool IsAllowed(string service, string path)
+        {
+            var prefixes = service.ToLowerInvariant() switch
+            {
+                "producer" => ProducerPrefixes,
+                "provider" => ProviderPrefixes,
+                _ => null
+            };
+
+            return prefixes is not null && prefixes.Any(p =>
+                path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    private readonly ILogger<AdminOpsProxyController> _logger;
+    private readonly IConfiguration _configuration;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public AdminOpsProxyController(
+        ILogger<AdminOpsProxyController> logger,
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory)
+    {
+        _logger = logger;
+        _configuration = configuration;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    [HttpGet("{service}/{sport}/{league}/{**opPath}")]
+    [HttpPost("{service}/{sport}/{league}/{**opPath}")]
+    public async Task<IActionResult> Relay(
+        [FromRoute] string service,
+        [FromRoute] string sport,
+        [FromRoute] string league,
+        [FromRoute] string opPath,
+        CancellationToken cancellationToken)
+    {
+        Sport mode;
+        try
+        {
+            mode = ModeMapper.ResolveMode(sport, league);
+        }
+        catch (NotSupportedException)
+        {
+            return BadRequest($"Unsupported sport/league: {sport}/{league}");
+        }
+
+        if (!Allowlist.IsAllowed(service, opPath))
+        {
+            _logger.LogWarning(
+                "Ops proxy refused non-allowlisted path. Service={Service}, Path={Path}",
+                service, opPath);
+            return NotFound();
+        }
+
+        var baseUrl = ResolveBaseUrl(service, mode);
+        if (baseUrl is null)
+        {
+            _logger.LogError(
+                "Ops proxy has no base URL configured. Service={Service}, Mode={Mode}",
+                service, mode);
+            return StatusCode(StatusCodes.Status502BadGateway,
+                $"No internal base URL configured for {service}/{mode}.");
+        }
+
+        var targetUri = new Uri(new Uri(baseUrl.TrimEnd('/') + "/"), opPath + Request.QueryString);
+
+        using var upstreamRequest = new HttpRequestMessage(
+            HttpMethod.Parse(Request.Method), targetUri);
+
+        // Only the body crosses; inbound headers (bearer token, admin token,
+        // cookies) deliberately do NOT — the internal services must never see
+        // or depend on public-edge credentials.
+        if (HttpMethods.IsPost(Request.Method))
+        {
+            using var reader = new StreamReader(Request.Body);
+            var body = await reader.ReadToEndAsync(cancellationToken);
+            upstreamRequest.Content = new StringContent(
+                body, Encoding.UTF8, Request.ContentType ?? "application/json");
+        }
+
+        _logger.LogInformation(
+            "Ops proxy relaying {Method} {Target}. Service={Service}, Mode={Mode}",
+            Request.Method, targetUri, service, mode);
+
+        var client = _httpClientFactory.CreateClient(nameof(AdminOpsProxyController));
+        using var upstreamResponse = await client.SendAsync(upstreamRequest, cancellationToken);
+        var responseBody = await upstreamResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        return new ContentResult
+        {
+            StatusCode = (int)upstreamResponse.StatusCode,
+            Content = responseBody,
+            ContentType = upstreamResponse.Content.Headers.ContentType?.ToString() ?? "application/json"
+        };
+    }
+
+    private string? ResolveBaseUrl(string service, Sport mode)
+    {
+        return service.ToLowerInvariant() switch
+        {
+            "producer" => _configuration[CommonConfigKeys.GetProducerProviderUri(mode)]
+                          ?? _configuration[CommonConfigKeys.GetProducerProviderUri()],
+            // Provider has no per-mode key helper today; probe the mode-keyed
+            // shape first (matching Producer's convention and the sport-keyed
+            // Prod.All config pattern) and fall back to the global key.
+            "provider" => _configuration[$"{nameof(CommonConfig)}:ProviderClientConfig:{mode}:ApiUrl"]
+                          ?? _configuration[CommonConfigKeys.GetProviderProviderUri()],
+            _ => null
+        };
+    }
+}

--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -65,6 +65,40 @@ public class AdminOpsProxyController : ControllerBase
                 path.StartsWith(p, StringComparison.OrdinalIgnoreCase)
                 && (path.Length == p.Length || path[p.Length] == '/'));
         }
+
+        /// <summary>
+        /// Resolves the target URI and checks the allowlist against the
+        /// CANONICAL path that will actually be sent — not the raw opPath.
+        /// URI construction normalizes dot-segments, so a raw check alone is
+        /// bypassable: "api/contests/../../hangfire" starts with an allowed
+        /// family but relays to /hangfire. Checking post-normalization closes
+        /// literal traversal; rejecting any residual percent-escapes in the
+        /// canonical path closes encoded and double-encoded variants (ops
+        /// paths are plain segments — guids, years, slugs — so '%' has no
+        /// legitimate use here).
+        /// </summary>
+        public static bool TryResolveAllowedTarget(
+            string service,
+            Uri baseUri,
+            string opPath,
+            string queryString,
+            out Uri targetUri)
+        {
+            targetUri = new Uri(baseUri, opPath + queryString);
+
+            if (!baseUri.IsBaseOf(targetUri))
+                return false;
+
+            var canonical = baseUri.MakeRelativeUri(targetUri).ToString();
+            var queryIndex = canonical.IndexOf('?');
+            if (queryIndex >= 0)
+                canonical = canonical[..queryIndex];
+
+            if (canonical.Contains('%'))
+                return false;
+
+            return IsAllowed(service, canonical);
+        }
     }
 
     private readonly ILogger<AdminOpsProxyController> _logger;
@@ -100,14 +134,6 @@ public class AdminOpsProxyController : ControllerBase
             return BadRequest($"Unsupported sport/league: {sport}/{league}");
         }
 
-        if (!Allowlist.IsAllowed(service, opPath))
-        {
-            _logger.LogWarning(
-                "Ops proxy refused non-allowlisted path. Service={Service}, Path={Path}",
-                service.Sanitize(), opPath.Sanitize());
-            return NotFound();
-        }
-
         var baseUrl = ResolveBaseUrl(service, mode);
         if (baseUrl is null)
         {
@@ -118,19 +144,25 @@ public class AdminOpsProxyController : ControllerBase
                 $"No internal base URL configured for {service}/{mode}.");
         }
 
-        var baseUri = new Uri(baseUrl.TrimEnd('/') + "/");
-        var targetUri = new Uri(baseUri, opPath + Request.QueryString);
-
-        // Belt-and-braces: the allowlist's "api/..." prefix requirement
-        // already prevents an absolute-URI opPath from surviving, but the
-        // final URI must still live under the configured base — if URI
-        // composition ever surprises us, the relay refuses rather than
-        // wanders.
-        if (!baseUri.IsBaseOf(targetUri))
+        // Resolve first, THEN allowlist-check the canonical result — the
+        // check must see what will actually be sent, not the raw opPath
+        // (dot-segment normalization would otherwise let a traversal path
+        // relay outside its allowed family). See Allowlist.TryResolveAllowedTarget.
+        var baseUri = new Uri(baseUrl.TrimEnd('/') + "/", UriKind.Absolute);
+        Uri targetUri;
+        try
         {
-            _logger.LogError(
-                "Ops proxy target escaped the configured base. Base={Base}, Target={Target}",
-                baseUri, targetUri.ToString().Sanitize());
+            if (!Allowlist.TryResolveAllowedTarget(
+                    service, baseUri, opPath, Request.QueryString.Value ?? string.Empty, out targetUri))
+            {
+                _logger.LogWarning(
+                    "Ops proxy refused path outside the allowlist after canonicalization. Service={Service}, Path={Path}",
+                    service.Sanitize(), opPath.Sanitize());
+                return NotFound();
+            }
+        }
+        catch (UriFormatException)
+        {
             return BadRequest("Invalid ops path.");
         }
 

--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Mapping;
 using SportsData.Core.Config;
+using SportsData.Core.Extensions;
 
+using System.Net.Http.Headers;
 using System.Text;
 
 namespace SportsData.Api.Application.Admin;
@@ -56,8 +58,12 @@ public class AdminOpsProxyController : ControllerBase
                 _ => null
             };
 
+            // Segment boundary required: "api/franchise-seasons" must not
+            // admit "api/franchise-seasons-admin-delete". Exact match or the
+            // prefix followed by '/'.
             return prefixes is not null && prefixes.Any(p =>
-                path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+                path.StartsWith(p, StringComparison.OrdinalIgnoreCase)
+                && (path.Length == p.Length || path[p.Length] == '/'));
         }
     }
 
@@ -98,7 +104,7 @@ public class AdminOpsProxyController : ControllerBase
         {
             _logger.LogWarning(
                 "Ops proxy refused non-allowlisted path. Service={Service}, Path={Path}",
-                service, opPath);
+                service.Sanitize(), opPath.Sanitize());
             return NotFound();
         }
 
@@ -107,7 +113,7 @@ public class AdminOpsProxyController : ControllerBase
         {
             _logger.LogError(
                 "Ops proxy has no base URL configured. Service={Service}, Mode={Mode}",
-                service, mode);
+                service.Sanitize(), mode);
             return StatusCode(StatusCodes.Status502BadGateway,
                 $"No internal base URL configured for {service}/{mode}.");
         }
@@ -124,23 +130,37 @@ public class AdminOpsProxyController : ControllerBase
         {
             using var reader = new StreamReader(Request.Body);
             var body = await reader.ReadToEndAsync(cancellationToken);
-            upstreamRequest.Content = new StringContent(
-                body, Encoding.UTF8, Request.ContentType ?? "application/json");
+            // NOT the 3-arg StringContent overload: it feeds the raw media
+            // type to MediaTypeHeaderValue's bare type/subtype parser, so a
+            // normal "application/json; charset=utf-8" would throw
+            // FormatException before SendAsync. Parse-or-default instead.
+            var content = new StringContent(body, Encoding.UTF8);
+            content.Headers.ContentType =
+                MediaTypeHeaderValue.TryParse(Request.ContentType, out var parsed)
+                    ? parsed
+                    : new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+            upstreamRequest.Content = content;
         }
 
         _logger.LogInformation(
             "Ops proxy relaying {Method} {Target}. Service={Service}, Mode={Mode}",
-            Request.Method, targetUri, service, mode);
+            Request.Method, targetUri.ToString().Sanitize(), service.Sanitize(), mode);
 
         var client = _httpClientFactory.CreateClient(nameof(AdminOpsProxyController));
         using var upstreamResponse = await client.SendAsync(upstreamRequest, cancellationToken);
         var responseBody = await upstreamResponse.Content.ReadAsStringAsync(cancellationToken);
 
+        // The response content type is PINNED to JSON and marked nosniff
+        // rather than echoing the upstream header: the ops surface speaks
+        // JSON, and reflecting an upstream-declared type would let a
+        // text/html body render in a browser — the classic reflected-XSS
+        // sink CodeQL flags on proxies.
+        Response.Headers["X-Content-Type-Options"] = "nosniff";
         return new ContentResult
         {
             StatusCode = (int)upstreamResponse.StatusCode,
             Content = responseBody,
-            ContentType = upstreamResponse.Content.Headers.ContentType?.ToString() ?? "application/json"
+            ContentType = "application/json"
         };
     }
 

--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -118,7 +118,21 @@ public class AdminOpsProxyController : ControllerBase
                 $"No internal base URL configured for {service}/{mode}.");
         }
 
-        var targetUri = new Uri(new Uri(baseUrl.TrimEnd('/') + "/"), opPath + Request.QueryString);
+        var baseUri = new Uri(baseUrl.TrimEnd('/') + "/");
+        var targetUri = new Uri(baseUri, opPath + Request.QueryString);
+
+        // Belt-and-braces: the allowlist's "api/..." prefix requirement
+        // already prevents an absolute-URI opPath from surviving, but the
+        // final URI must still live under the configured base — if URI
+        // composition ever surprises us, the relay refuses rather than
+        // wanders.
+        if (!baseUri.IsBaseOf(targetUri))
+        {
+            _logger.LogError(
+                "Ops proxy target escaped the configured base. Base={Base}, Target={Target}",
+                baseUri, targetUri.ToString().Sanitize());
+            return BadRequest("Invalid ops path.");
+        }
 
         using var upstreamRequest = new HttpRequestMessage(
             HttpMethod.Parse(Request.Method), targetUri);

--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -148,10 +148,13 @@ public class AdminOpsProxyController : ControllerBase
         // check must see what will actually be sent, not the raw opPath
         // (dot-segment normalization would otherwise let a traversal path
         // relay outside its allowed family). See Allowlist.TryResolveAllowedTarget.
-        var baseUri = new Uri(baseUrl.TrimEnd('/') + "/", UriKind.Absolute);
         Uri targetUri;
         try
         {
+            // baseUri inside the try too: a malformed configured base is as
+            // much a UriFormatException source as a malformed opPath, and
+            // both should surface as 400, not an unhandled 500.
+            var baseUri = new Uri(baseUrl.TrimEnd('/') + "/", UriKind.Absolute);
             if (!Allowlist.TryResolveAllowedTarget(
                     service, baseUri, opPath, Request.QueryString.Value ?? string.Empty, out targetUri))
             {

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -136,14 +136,24 @@ namespace SportsData.Api.DependencyInjection
             // docs/audit/league-authorization-idor.md.
             services.AddScoped<ILeagueMembershipGuard, LeagueMembershipGuard>();
 
-            // The ops proxy's named client: redirects are NOT followed. An
-            // allowlisted upstream (or anything that can answer as one) must
-            // not be able to bounce the proxy to an unvalidated target — the
-            // relay goes exactly where the allowlist said, or nowhere.
+            // The ops proxy's named client: redirects are NOT followed (an
+            // allowlisted upstream must not bounce the relay to an
+            // unvalidated target) and cookies are NOT retained (the pooled
+            // handler would otherwise replay upstream Set-Cookie values on
+            // later relays to the same host). The relay goes exactly where
+            // the allowlist said, carries nothing it wasn't given, or goes
+            // nowhere.
+            //
+            // No BaseAddress on purpose: the target varies PER REQUEST
+            // (service x sport mode), so the controller resolves the full
+            // URI per call from the same AppConfig-backed CommonConfig keys
+            // the typed client factories use, then verifies the resolved
+            // base actually owns the final URI.
             services.AddHttpClient(nameof(Application.Admin.AdminOpsProxyController))
                 .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
                 {
-                    AllowAutoRedirect = false
+                    AllowAutoRedirect = false,
+                    UseCookies = false
                 });
             services.AddScoped<IGetLeagueByIdQueryHandler, GetLeagueByIdQueryHandler>();
             services.AddScoped<

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -135,6 +135,16 @@ namespace SportsData.Api.DependencyInjection
             // Single authority for by-group authorization — see
             // docs/audit/league-authorization-idor.md.
             services.AddScoped<ILeagueMembershipGuard, LeagueMembershipGuard>();
+
+            // The ops proxy's named client: redirects are NOT followed. An
+            // allowlisted upstream (or anything that can answer as one) must
+            // not be able to bounce the proxy to an unvalidated target — the
+            // relay goes exactly where the allowlist said, or nowhere.
+            services.AddHttpClient(nameof(Application.Admin.AdminOpsProxyController))
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+                {
+                    AllowAutoRedirect = false
+                });
             services.AddScoped<IGetLeagueByIdQueryHandler, GetLeagueByIdQueryHandler>();
             services.AddScoped<
                 Application.UI.Leagues.Queries.GetLeagueGameDates.IGetLeagueGameDatesQueryHandler,

--- a/src/SportsData.Core/Common/CausationId.cs
+++ b/src/SportsData.Core/Common/CausationId.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace SportsData.Core.Common
 {
@@ -36,6 +36,7 @@ namespace SportsData.Core.Common
             public static Guid FranchiseDocumentProcessor = new Guid("10000000-0000-0000-0000-000000000011");
             public static Guid FranchiseSeasonCreated = new Guid("10000000-0000-0000-0000-000000000012");
             public static Guid FranchiseSeasonEnrichmentProcessor = new Guid("10000001-0000-0000-0000-00000000001F");
+            public static Guid FranchiseSeasonService = new Guid("10000A00-0000-0000-0000-000000000007");
             public static Guid GroupSeasonDocumentProcessor = new Guid("10000000-0000-0000-0000-000000000013");
             public static Guid ImageRequestedProcessor = new Guid("10000000-0000-0000-0000-000000000014");
             public static Guid PositionDocumentProcessor = new Guid("10000000-0000-0000-0000-000000000015");

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommand.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommand.cs
@@ -1,0 +1,5 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
+
+public record RequestFranchiseSeasonSourcingCommand(int SeasonYear, Sport Sport);

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
@@ -1,0 +1,119 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
+
+public interface IRequestFranchiseSeasonSourcingCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        RequestFranchiseSeasonSourcingCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Fans out a DocumentRequested per FranchiseSeason for a season year — the
+/// bulk-sourcing entry point for a season's team data (immediate driver: the
+/// NFL 2026 schedule). Provider fetches each TeamSeason document from ESPN and
+/// publishes DocumentCreated; TeamSeasonDocumentProcessor takes it from there.
+///
+/// IncludeLinkedDocumentTypes is DELIBERATELY omitted: null means "spawn
+/// everything" (see DocumentProcessorBase.ShouldSpawn), so the full document
+/// tree — events/schedule included — cascades from each team season. The
+/// filter also PROPAGATES to children, so narrowing it here (e.g. to Event
+/// only) would strangle the cascade below the first hop, not just limit it.
+/// </summary>
+public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSeasonSourcingCommandHandler
+{
+    private readonly ILogger<RequestFranchiseSeasonSourcingCommandHandler> _logger;
+    private readonly TeamSportDataContext _dataContext;
+    private readonly IEventBus _eventBus;
+    private readonly IGenerateExternalRefIdentities _externalRefIdentityGenerator;
+
+    public RequestFranchiseSeasonSourcingCommandHandler(
+        ILogger<RequestFranchiseSeasonSourcingCommandHandler> logger,
+        TeamSportDataContext dataContext,
+        IEventBus eventBus,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _eventBus = eventBus;
+        _externalRefIdentityGenerator = externalRefIdentityGenerator;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        RequestFranchiseSeasonSourcingCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var franchiseSeasons = await _dataContext.FranchiseSeasons
+            .AsNoTracking()
+            .Include(fs => fs.Franchise)
+            .Include(fs => fs.ExternalIds)
+            .Where(fs =>
+                fs.SeasonYear == command.SeasonYear &&
+                fs.Franchise.Sport == command.Sport)
+            .ToListAsync(cancellationToken);
+
+        if (franchiseSeasons.Count == 0)
+        {
+            _logger.LogWarning(
+                "No franchise seasons found to source. SeasonYear={SeasonYear}, Sport={Sport}",
+                command.SeasonYear, command.Sport);
+            return new Success<Guid>(Guid.Empty, ResultStatus.NotFound);
+        }
+
+        var correlationId = Guid.NewGuid();
+        var requested = 0;
+        var skipped = 0;
+
+        foreach (var fs in franchiseSeasons)
+        {
+            var externalId = fs.ExternalIds
+                .FirstOrDefault(x => x.Provider == SourceDataProvider.Espn);
+
+            if (externalId is null || string.IsNullOrWhiteSpace(externalId.SourceUrl) ||
+                !Uri.TryCreate(externalId.SourceUrl, UriKind.Absolute, out var sourceUrl))
+            {
+                // Log-and-continue: one franchise's missing/garbage ref must
+                // not stop the other 31. The count surfaces in the summary.
+                _logger.LogWarning(
+                    "Skipping franchise season {FranchiseSeasonId}: no usable ESPN SourceUrl. SeasonYear={SeasonYear}",
+                    fs.Id, command.SeasonYear);
+                skipped++;
+                continue;
+            }
+
+            var identity = _externalRefIdentityGenerator.Generate(sourceUrl);
+
+            await _eventBus.Publish(new DocumentRequested(
+                Id: identity.UrlHash,
+                ParentId: fs.Id.ToString(),
+                Uri: new Uri(identity.CleanUrl),
+                Ref: null,
+                Sport: command.Sport,
+                SeasonYear: command.SeasonYear,
+                DocumentType: DocumentType.TeamSeason,
+                SourceDataProvider: SourceDataProvider.Espn,
+                CorrelationId: correlationId,
+                CausationId: CausationId.Producer.FranchiseSeasonService
+            ), cancellationToken);
+
+            requested++;
+        }
+
+        // Flush the outbox: with the EF outbox, Publish only enqueues into the
+        // DbContext tracker — SaveChangesAsync persists and dispatches.
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "FranchiseSeason sourcing requested. SeasonYear={SeasonYear}, Sport={Sport}, Requested={Requested}, Skipped={Skipped}, CorrelationId={CorrelationId}",
+            command.SeasonYear, command.Sport, requested, skipped, correlationId);
+
+        return new Success<Guid>(correlationId, ResultStatus.Accepted);
+    }
+}

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
@@ -33,23 +35,30 @@ public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSea
     private readonly TeamSportDataContext _dataContext;
     private readonly IEventBus _eventBus;
     private readonly IGenerateExternalRefIdentities _externalRefIdentityGenerator;
+    private readonly IValidator<RequestFranchiseSeasonSourcingCommand> _validator;
 
     public RequestFranchiseSeasonSourcingCommandHandler(
         ILogger<RequestFranchiseSeasonSourcingCommandHandler> logger,
         TeamSportDataContext dataContext,
         IEventBus eventBus,
-        IGenerateExternalRefIdentities externalRefIdentityGenerator)
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        IValidator<RequestFranchiseSeasonSourcingCommand> validator)
     {
         _logger = logger;
         _dataContext = dataContext;
         _eventBus = eventBus;
         _externalRefIdentityGenerator = externalRefIdentityGenerator;
+        _validator = validator;
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
         RequestFranchiseSeasonSourcingCommand command,
         CancellationToken cancellationToken = default)
     {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+
         var franchiseSeasons = await _dataContext.FranchiseSeasons
             .AsNoTracking()
             .Include(fs => fs.Franchise)

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandValidator.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandValidator.cs
@@ -5,9 +5,12 @@ using SportsData.Core.Common;
 namespace SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
 
 /// <summary>
-/// Bounds mirror RefreshContestsBySeasonYearCommandValidator: sourcing a
-/// season more than one year out asks ESPN for documents that don't exist
-/// yet, and pre-2000 predates the historical sourcing floor.
+/// Sourcing a season more than one year out asks ESPN for documents that
+/// don't exist yet, and pre-2000 predates the historical sourcing floor —
+/// 2000 itself IS a sourced season (NCAA history runs through 2000), so the
+/// floor is inclusive. (The sibling RefreshContestsBySeasonYear validator
+/// uses an exclusive GreaterThan(2000); that off-by-one is pre-existing and
+/// out of scope here.)
 /// </summary>
 public class RequestFranchiseSeasonSourcingCommandValidator
     : AbstractValidator<RequestFranchiseSeasonSourcingCommand>
@@ -19,8 +22,8 @@ public class RequestFranchiseSeasonSourcingCommandValidator
             .WithMessage("Sport must be a valid enum value");
 
         RuleFor(x => x.SeasonYear)
-            .GreaterThan(2000)
-            .WithMessage("Season year must be greater than 2000")
+            .GreaterThanOrEqualTo(2000)
+            .WithMessage("Season year must be 2000 or later")
             .Must(year => year <= dateTimeProvider.UtcNow().Year + 1)
             .WithMessage("Season year cannot be more than one year in the future");
     }

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandValidator.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
+
+/// <summary>
+/// Bounds mirror RefreshContestsBySeasonYearCommandValidator: sourcing a
+/// season more than one year out asks ESPN for documents that don't exist
+/// yet, and pre-2000 predates the historical sourcing floor.
+/// </summary>
+public class RequestFranchiseSeasonSourcingCommandValidator
+    : AbstractValidator<RequestFranchiseSeasonSourcingCommand>
+{
+    public RequestFranchiseSeasonSourcingCommandValidator(IDateTimeProvider dateTimeProvider)
+    {
+        RuleFor(x => x.Sport)
+            .IsInEnum()
+            .WithMessage("Sport must be a valid enum value");
+
+        RuleFor(x => x.SeasonYear)
+            .GreaterThan(2000)
+            .WithMessage("Season year must be greater than 2000")
+            .Must(year => year <= dateTimeProvider.UtcNow().Year + 1)
+            .WithMessage("Season year cannot be more than one year in the future");
+    }
+}

--- a/src/SportsData.Producer/Application/FranchiseSeasons/FranchiseSeasonController.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/FranchiseSeasonController.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonEnrichment;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonMetricsGeneration;
+using SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
 using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonCompetitionResults;
 using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonMetricsById;
 using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonMetricsBySeasonYear;
@@ -38,6 +39,28 @@ public class FranchiseSeasonController : ControllerBase
     {
         var query = new GetFranchiseSeasonMetricsBySeasonYearQuery(seasonYear);
         var result = await handler.ExecuteAsync(query, cancellationToken);
+
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Requests ESPN sourcing for every FranchiseSeason in the season year:
+    /// one DocumentRequested (TeamSeason) per franchise, full cascade — the
+    /// linked-document filter is deliberately omitted so events (the
+    /// schedule), rosters, and the rest of the tree source along with it.
+    /// </summary>
+    [HttpPost("seasonYear/{seasonYear}/source")]
+    public async Task<ActionResult<Guid>> RequestFranchiseSeasonSourcing(
+        [FromRoute] int seasonYear,
+        [FromServices] IRequestFranchiseSeasonSourcingCommandHandler handler,
+        [FromServices] IAppMode appMode,
+        CancellationToken cancellationToken)
+    {
+        var command = new RequestFranchiseSeasonSourcingCommand(
+            seasonYear,
+            appMode.CurrentSport);
+
+        var result = await handler.ExecuteAsync(command, cancellationToken);
 
         return result.ToActionResult();
     }

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 
 using Hangfire;
 
@@ -48,6 +48,7 @@ using SportsData.Producer.Application.FranchiseSeasonRankings.Queries.GetRanking
 using SportsData.Producer.Application.FranchiseSeasons.Commands.CalculateFranchiseSeasonMetrics;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonEnrichment;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonMetricsGeneration;
+using SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
 using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonById;
 using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonCompetitionResults;
 using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonMetricsById;
@@ -275,6 +276,7 @@ namespace SportsData.Producer.DependencyInjection
 
             // FranchiseSeason Commands
             services.AddScoped<IEnqueueFranchiseSeasonMetricsGenerationCommandHandler, EnqueueFranchiseSeasonMetricsGenerationCommandHandler>();
+            services.AddScoped<IRequestFranchiseSeasonSourcingCommandHandler, RequestFranchiseSeasonSourcingCommandHandler>();
             services.AddScoped<IEnqueueFranchiseSeasonEnrichmentCommandHandler, EnqueueFranchiseSeasonEnrichmentCommandHandler>();
             if (mode is Sport.FootballNcaa or Sport.FootballNfl)
             {

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -277,6 +277,7 @@ namespace SportsData.Producer.DependencyInjection
             // FranchiseSeason Commands
             services.AddScoped<IEnqueueFranchiseSeasonMetricsGenerationCommandHandler, EnqueueFranchiseSeasonMetricsGenerationCommandHandler>();
             services.AddScoped<IRequestFranchiseSeasonSourcingCommandHandler, RequestFranchiseSeasonSourcingCommandHandler>();
+            services.AddScoped<FluentValidation.IValidator<RequestFranchiseSeasonSourcingCommand>, RequestFranchiseSeasonSourcingCommandValidator>();
             services.AddScoped<IEnqueueFranchiseSeasonEnrichmentCommandHandler, EnqueueFranchiseSeasonEnrichmentCommandHandler>();
             if (mode is Sport.FootballNcaa or Sport.FootballNfl)
             {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.Admin;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Admin;
+
+/// <summary>
+/// The allowlist IS the security boundary of the ops proxy — with a valid
+/// admin token, only these path families are reachable on the internal
+/// services. Deny-by-default for everything else.
+/// </summary>
+public class AdminOpsProxyAllowlistTests
+{
+    [Theory]
+    [InlineData("producer", "api/franchise-seasons/seasonYear/2026/source")]
+    [InlineData("producer", "api/competition/123/metrics")]
+    [InlineData("producer", "api/contests/refresh")]
+    [InlineData("PRODUCER", "API/Franchise-Seasons/x")]
+    [InlineData("provider", "api/documents/replay")]
+    public void AllowedFamilies_PassPerService(string service, string path)
+    {
+        AdminOpsProxyController.Allowlist.IsAllowed(service, path).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("producer", "api/documents/replay", "provider-only family on producer")]
+    [InlineData("provider", "api/franchise-seasons/x", "producer-only family on provider")]
+    [InlineData("producer", "hangfire", "ops dashboards are never proxied")]
+    [InlineData("producer", "api/test/outbox", "the deleted test surface stays dead")]
+    [InlineData("gateway", "api/contests/refresh", "unknown service")]
+    [InlineData("producer", "", "empty path")]
+    public void EverythingElse_IsDenied(string service, string path, string because)
+    {
+        AdminOpsProxyController.Allowlist.IsAllowed(service, path).Should().BeFalse(because);
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
@@ -17,6 +17,7 @@ public class AdminOpsProxyAllowlistTests
     [InlineData("producer", "api/franchise-seasons/seasonYear/2026/source")]
     [InlineData("producer", "api/competition/123/metrics")]
     [InlineData("producer", "api/contests/refresh")]
+    [InlineData("producer", "api/contests")]
     [InlineData("PRODUCER", "API/Franchise-Seasons/x")]
     [InlineData("provider", "api/documents/replay")]
     public void AllowedFamilies_PassPerService(string service, string path)
@@ -31,6 +32,8 @@ public class AdminOpsProxyAllowlistTests
     [InlineData("producer", "api/test/outbox", "the deleted test surface stays dead")]
     [InlineData("gateway", "api/contests/refresh", "unknown service")]
     [InlineData("producer", "", "empty path")]
+    [InlineData("producer", "api/franchise-seasons-admin-delete", "shared textual prefix is not the family — segment boundary required")]
+    [InlineData("producer", "api/contestsX/anything", "no segment boundary after prefix")]
     public void EverythingElse_IsDenied(string service, string path, string because)
     {
         AdminOpsProxyController.Allowlist.IsAllowed(service, path).Should().BeFalse(because);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
@@ -38,4 +38,32 @@ public class AdminOpsProxyAllowlistTests
     {
         AdminOpsProxyController.Allowlist.IsAllowed(service, path).Should().BeFalse(because);
     }
+
+    private static readonly Uri BaseUri = new("http://producer.internal/");
+
+    [Theory]
+    [InlineData("api/contests/../../hangfire", "literal dot-segments normalize OUT of the family")]
+    [InlineData("api/franchise-seasons/../test/outbox", "traversal into the deleted test surface")]
+    [InlineData("api/contests/%2e%2e/%2e%2e/hangfire", "percent-encoded traversal")]
+    [InlineData("api/contests/%252e%252e/hangfire", "double-encoded traversal (residual escape rejected)")]
+    public void TraversalPaths_AreDenied_AfterCanonicalization(string opPath, string because)
+    {
+        AdminOpsProxyController.Allowlist
+            .TryResolveAllowedTarget("producer", BaseUri, opPath, string.Empty, out _)
+            .Should().BeFalse(because);
+    }
+
+    [Fact]
+    public void InFamilyDotSegments_NormalizeAndStayAllowed()
+    {
+        // Normalization that stays INSIDE the family is fine — the check is
+        // on the canonical destination, not on cosmetic path shape.
+        AdminOpsProxyController.Allowlist
+            .TryResolveAllowedTarget(
+                "producer", BaseUri, "api/contests/ignored/../refresh", "?seasonYear=2026", out var target)
+            .Should().BeTrue();
+
+        target.AbsolutePath.Should().Be("/api/contests/refresh");
+        target.Query.Should().Be("?seasonYear=2026");
+    }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
@@ -46,6 +46,8 @@ public class AdminOpsProxyAllowlistTests
     [InlineData("api/franchise-seasons/../test/outbox", "traversal into the deleted test surface")]
     [InlineData("api/contests/%2e%2e/%2e%2e/hangfire", "percent-encoded traversal")]
     [InlineData("api/contests/%252e%252e/hangfire", "double-encoded traversal (residual escape rejected)")]
+    [InlineData("http://attacker.internal/api/contests/refresh", "absolute-URI opPath escapes the base host")]
+    [InlineData("//attacker.internal/api/contests/refresh", "scheme-relative opPath escapes to another host")]
     public void TraversalPaths_AreDenied_AfterCanonicalization(string opPath, string because)
     {
         AdminOpsProxyController.Allowlist

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.FranchiseSeasons;
+
+/// <summary>
+/// Bulk sourcing fan-out: one DocumentRequested (TeamSeason, full cascade)
+/// per franchise season with a usable ESPN ref; the rest are counted and
+/// skipped rather than failing the batch.
+/// </summary>
+public class RequestFranchiseSeasonSourcingCommandHandlerTests
+    : ProducerTestBase<RequestFranchiseSeasonSourcingCommandHandler>
+{
+    private const int SeasonYear = 2026;
+
+#nullable enable
+    private async Task<FranchiseSeason> SeedFranchiseSeasonAsync(string? sourceUrl)
+    {
+        var franchiseId = Guid.NewGuid();
+        var fsId = Guid.NewGuid();
+
+        await FootballDataContext.Franchises.AddAsync(new Franchise
+        {
+            Id = franchiseId,
+            Sport = Sport.FootballNfl,
+            Name = $"Team {franchiseId:N}"[..12],
+            Nickname = "Testers",
+            Location = "Testville",
+            Abbreviation = "TST",
+            DisplayName = "Test Team",
+            DisplayNameShort = "Test",
+            Slug = $"team-{franchiseId:N}"[..20],
+            ColorCodeHex = "000000",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        var fs = new FranchiseSeason
+        {
+            Id = fsId,
+            FranchiseId = franchiseId,
+            SeasonYear = SeasonYear,
+            Slug = $"fs-{fsId:N}"[..20],
+            Location = "Testville",
+            Name = "Test Team",
+            Abbreviation = "TST",
+            DisplayName = "Test Team",
+            DisplayNameShort = "Test",
+            ColorCodeHex = "000000",
+            IsActive = true,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        if (sourceUrl is not null)
+        {
+            fs.ExternalIds.Add(new FranchiseSeasonExternalId
+            {
+                Id = Guid.NewGuid(),
+                FranchiseSeasonId = fsId,
+                Provider = SourceDataProvider.Espn,
+                Value = fsId.ToString(),
+                SourceUrlHash = fsId.ToString("N"),
+                SourceUrl = sourceUrl,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+
+        await FootballDataContext.FranchiseSeasons.AddAsync(fs);
+        await FootballDataContext.SaveChangesAsync();
+        return fs;
+    }
+
+    private RequestFranchiseSeasonSourcingCommandHandler CreateHandler()
+    {
+        Mocker.GetMock<IGenerateExternalRefIdentities>()
+            .Setup(x => x.Generate(It.IsAny<Uri>()))
+            .Returns((Uri u) => new ExternalRefIdentity(
+                Guid.NewGuid(),
+                u.ToString().GetHashCode().ToString("X"),
+                u.ToString()));
+        return Mocker.CreateInstance<RequestFranchiseSeasonSourcingCommandHandler>();
+    }
+
+    [Fact]
+    public async Task PublishesOneRequestPerFranchiseSeason_FullCascade()
+    {
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/1");
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/2");
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(SeasonYear, Sport.FootballNfl));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e =>
+                    e.DocumentType == DocumentType.TeamSeason &&
+                    e.Sport == Sport.FootballNfl &&
+                    e.SeasonYear == SeasonYear &&
+                    // Full cascade: no linked-type filter (it would propagate
+                    // down the tree and strangle the schedule's children).
+                    e.IncludeLinkedDocumentTypes == null),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task SkipsFranchiseSeasonsWithoutUsableRef_ContinuesBatch()
+    {
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/1");
+        await SeedFranchiseSeasonAsync(sourceUrl: null);
+        await SeedFranchiseSeasonAsync(sourceUrl: "not-a-uri");
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(SeasonYear, Sport.FootballNfl));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NoFranchiseSeasons_ReturnsNotFound_PublishesNothing()
+    {
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(SeasonYear, Sport.FootballNfl));
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
@@ -136,6 +136,17 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
     }
 
     [Fact]
+    public async Task SeasonYear2000_IsTheInclusiveFloor_PassesValidation()
+    {
+        // 2000 is a SOURCED season (the historical floor). NotFound (no
+        // seeded franchise seasons) proves the command got past validation.
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(2000, Sport.FootballNfl));
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
     public async Task ImplausibleSeasonYear_FailsValidation_PublishesNothing()
     {
         var result = await CreateHandler().ExecuteAsync(

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
@@ -23,6 +23,9 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
 {
     private const int SeasonYear = 2026;
 
+    // Fixed clock: deterministic seed data, per the no-DateTime.UtcNow rule.
+    private static readonly DateTime FixedNow = new(2026, 7, 31, 12, 0, 0, DateTimeKind.Utc);
+
 #nullable enable
     private async Task<FranchiseSeason> SeedFranchiseSeasonAsync(string? sourceUrl)
     {
@@ -41,7 +44,7 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
             DisplayNameShort = "Test",
             Slug = $"team-{franchiseId:N}"[..20],
             ColorCodeHex = "000000",
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         });
 
@@ -58,7 +61,7 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
             DisplayNameShort = "Test",
             ColorCodeHex = "000000",
             IsActive = true,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedNow,
             CreatedBy = Guid.NewGuid()
         };
 
@@ -72,7 +75,7 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
                 Value = fsId.ToString(),
                 SourceUrlHash = fsId.ToString("N"),
                 SourceUrl = sourceUrl,
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = FixedNow,
                 CreatedBy = Guid.NewGuid()
             });
         }
@@ -84,6 +87,11 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
 
     private RequestFranchiseSeasonSourcingCommandHandler CreateHandler()
     {
+        // Real validator with a fixed clock — bounds behavior is part of the
+        // contract, not something to mock away.
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use<FluentValidation.IValidator<RequestFranchiseSeasonSourcingCommand>>(
+            new RequestFranchiseSeasonSourcingCommandValidator(Mocker.Get<IDateTimeProvider>()));
         Mocker.GetMock<IGenerateExternalRefIdentities>()
             .Setup(x => x.Generate(It.IsAny<Uri>()))
             .Returns((Uri u) => new ExternalRefIdentity(
@@ -103,9 +111,11 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
             new RequestFranchiseSeasonSourcingCommand(SeasonYear, Sport.FootballNfl));
 
         result.IsSuccess.Should().BeTrue();
+        var published = new List<DocumentRequested>();
         Mocker.GetMock<IEventBus>().Verify(
             x => x.Publish(
                 It.Is<DocumentRequested>(e =>
+                    CaptureAndMatch(published, e) &&
                     e.DocumentType == DocumentType.TeamSeason &&
                     e.Sport == Sport.FootballNfl &&
                     e.SeasonYear == SeasonYear &&
@@ -114,6 +124,27 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
                     e.IncludeLinkedDocumentTypes == null),
                 It.IsAny<CancellationToken>()),
             Times.Exactly(2));
+
+        // One batch, one correlation id — the stated Seq handle for the run.
+        published.Select(e => e.CorrelationId).Distinct().Should().ContainSingle();
+    }
+
+    private static bool CaptureAndMatch(List<DocumentRequested> sink, DocumentRequested e)
+    {
+        sink.Add(e);
+        return true;
+    }
+
+    [Fact]
+    public async Task ImplausibleSeasonYear_FailsValidation_PublishesNothing()
+    {
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(1999, Sport.FootballNfl));
+
+        result.Status.Should().Be(ResultStatus.Validation);
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
Two pieces, one goal: source the NFL 2026 schedule (and everything else ESPN publishes for the season) **without port-forwarding into the cluster**.

## Bulk sourcing endpoint (Producer)

`POST api/franchise-seasons/seasonYear/{seasonYear}/source` fans out one `DocumentRequested` (`DocumentType.TeamSeason`) per `FranchiseSeason` in the season year, under a single correlation id. Provider fetches each TeamSeason from ESPN; `TeamSeasonDocumentProcessor` takes the cascade from there. Sport comes from `IAppMode.CurrentSport` — each per-sport Producer pod sources its own.

**`IncludeLinkedDocumentTypes` is deliberately omitted.** Null means "spawn everything" (`DocumentProcessorBase.ShouldSpawn`), and the filter *propagates to child documents* — an Event-only filter wouldn't merely narrow the first hop, it would strangle the cascade below it (competitions, competitors, plays). Full cascade is both the operator's call and the technically correct one; documented in the handler and pinned by a test so a filter doesn't get helpfully added later.

Mechanics mirror the `RefreshCompetitionDrives` precedent: ESPN `SourceUrl` → `IGenerateExternalRefIdentities` → `DocumentRequested(Id: UrlHash, Uri: CleanUrl)`, `SaveChangesAsync` to flush the EF outbox. Bad refs log-and-skip with counts — one row can't sink the batch. Returns `Accepted` + correlation id (the Seq handle). New `CausationId.Producer.FranchiseSeasonService` follows the service-prefix convention.

## Allowlisted ops proxy (API)

Producer/Provider came off public ingress 2026-07-23 (unauthenticated ops surface). This is the deliberate, bounded re-exposure — **one controller instead of an ever-growing pile of per-op `/admin` proxies**:

```
POST /admin/ops/{service}/{sport}/{league}/{**path}    [AdminApiToken]
POST /admin/ops/producer/football/nfl/api/franchise-seasons/seasonYear/2026/source
```

- Sport/league resolve via `ModeMapper` (house convention, mirrors `RefreshContestsBySeasonYear`); base URLs come from the same `CommonConfig` keys the typed client factories use, so per-sport pods route correctly under mode=All.
- **The allowlist is the security boundary**: `producer → api/franchise-seasons, api/competition, api/contests`; `provider → api/documents`. Deny-by-default, 404 on everything else (no existence oracle). Tests pin the denials that matter: Hangfire never proxied, the deleted `api/test/outbox` surface stays dead, families don't leak across services.
- **Inbound headers do not cross** — no bearer/admin token/cookies reach internal services; only body and query relay. GET/POST only. Upstream status + body return verbatim.
- Growth: a new op *family* is one allowlist line; a new endpoint inside an allowed family is zero lines.

## Deliberately not run locally

The document processors are proven in production daily; the sourcing run will be triggered in production post-deploy via the proxy, watched by correlation id in Seq. (Pre-verified: NFL 2026 `FranchiseSeason` rows exist.)

## Validation

Producer build 0 warnings, 527 unit tests pass (3 new). API build 0 warnings, 601 unit tests pass (11 new allowlist cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a protected administrative operations proxy for approved Producer and Provider actions, supporting GET and POST requests with clear error handling.
  - Added the ability to request ESPN sourcing for all franchise seasons in a selected year and sport.
  - Valid source references now generate document requests, with a correlation ID returned for tracking.
- **Bug Fixes**
  - Invalid or missing source URLs are skipped without stopping other valid requests.
  - Added validation for unsupported sports and invalid season years.
- **Tests**
  - Added coverage for proxy access rules and franchise-season sourcing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->