### PR TITLE
fix(api): ops proxy paths are resource-relative to the API-root base

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -45,7 +45,7 @@ public class AdminOpsProxyController : ControllerBase
         private static readonly string[] ProducerPrefixes =
         [
             "franchise-seasons",
-            "competition",
+            "competitions",
             "contests"
         ];
 

--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -16,7 +16,7 @@ namespace SportsData.Api.Application.Admin;
 /// surface); this is the deliberate, bounded re-exposure: one route, admin
 /// token required, an explicit path allowlist, GET/POST only.
 ///
-///   POST /admin/ops/producer/football/nfl/api/franchise-seasons/seasonYear/2026/source
+///   POST /admin/ops/producer/football/nfl/franchise-seasons/seasonYear/2026/source
 ///
 /// New op FAMILIES are one allowlist line; new endpoints inside an allowed
 /// family need nothing at all. Sport/league resolve via ModeMapper (the house
@@ -37,16 +37,21 @@ public class AdminOpsProxyController : ControllerBase
     /// </summary>
     public static class Allowlist
     {
+        // Resource-relative, NOT "api/..."-prefixed: the configured base URL
+        // is the service's API ROOT (it already ends in /api, the same
+        // convention the typed clients use), so the relayed target is
+        // composed relative to it. A leading "api/" here would double the
+        // segment (base/api + api/... = /api/api/...) and 404 upstream.
         private static readonly string[] ProducerPrefixes =
         [
-            "api/franchise-seasons",
-            "api/competition",
-            "api/contests"
+            "franchise-seasons",
+            "competition",
+            "contests"
         ];
 
         private static readonly string[] ProviderPrefixes =
         [
-            "api/documents"
+            "documents"
         ];
 
         public static bool IsAllowed(string service, string path)

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
@@ -14,40 +14,42 @@ namespace SportsData.Api.Tests.Unit.Application.Admin;
 public class AdminOpsProxyAllowlistTests
 {
     [Theory]
-    [InlineData("producer", "api/franchise-seasons/seasonYear/2026/source")]
-    [InlineData("producer", "api/competition/123/metrics")]
-    [InlineData("producer", "api/contests/refresh")]
-    [InlineData("producer", "api/contests")]
-    [InlineData("PRODUCER", "API/Franchise-Seasons/x")]
-    [InlineData("provider", "api/documents/replay")]
+    [InlineData("producer", "franchise-seasons/seasonYear/2026/source")]
+    [InlineData("producer", "competition/123/metrics")]
+    [InlineData("producer", "contests/refresh")]
+    [InlineData("producer", "contests")]
+    [InlineData("PRODUCER", "Franchise-Seasons/x")]
+    [InlineData("provider", "documents/replay")]
     public void AllowedFamilies_PassPerService(string service, string path)
     {
         AdminOpsProxyController.Allowlist.IsAllowed(service, path).Should().BeTrue();
     }
 
     [Theory]
-    [InlineData("producer", "api/documents/replay", "provider-only family on producer")]
-    [InlineData("provider", "api/franchise-seasons/x", "producer-only family on provider")]
+    [InlineData("producer", "documents/replay", "provider-only family on producer")]
+    [InlineData("provider", "franchise-seasons/x", "producer-only family on provider")]
     [InlineData("producer", "hangfire", "ops dashboards are never proxied")]
-    [InlineData("producer", "api/test/outbox", "the deleted test surface stays dead")]
-    [InlineData("gateway", "api/contests/refresh", "unknown service")]
+    [InlineData("producer", "test/outbox", "the deleted test surface stays dead")]
+    [InlineData("gateway", "contests/refresh", "unknown service")]
     [InlineData("producer", "", "empty path")]
-    [InlineData("producer", "api/franchise-seasons-admin-delete", "shared textual prefix is not the family — segment boundary required")]
-    [InlineData("producer", "api/contestsX/anything", "no segment boundary after prefix")]
+    [InlineData("producer", "franchise-seasons-admin-delete", "shared textual prefix is not the family — segment boundary required")]
+    [InlineData("producer", "contestsX/anything", "no segment boundary after prefix")]
     public void EverythingElse_IsDenied(string service, string path, string because)
     {
         AdminOpsProxyController.Allowlist.IsAllowed(service, path).Should().BeFalse(because);
     }
 
-    private static readonly Uri BaseUri = new("http://producer.internal/");
+    // Base ends in /api, mirroring the real ProducerClientConfig ApiUrl — the
+    // proxy composes resource-relative paths against the API root.
+    private static readonly Uri BaseUri = new("http://producer.internal/api/");
 
     [Theory]
-    [InlineData("api/contests/../../hangfire", "literal dot-segments normalize OUT of the family")]
-    [InlineData("api/franchise-seasons/../test/outbox", "traversal into the deleted test surface")]
-    [InlineData("api/contests/%2e%2e/%2e%2e/hangfire", "percent-encoded traversal")]
-    [InlineData("api/contests/%252e%252e/hangfire", "double-encoded traversal (residual escape rejected)")]
-    [InlineData("http://attacker.internal/api/contests/refresh", "absolute-URI opPath escapes the base host")]
-    [InlineData("//attacker.internal/api/contests/refresh", "scheme-relative opPath escapes to another host")]
+    [InlineData("contests/../../hangfire", "literal dot-segments normalize OUT of the family")]
+    [InlineData("franchise-seasons/../test/outbox", "traversal into the deleted test surface")]
+    [InlineData("contests/%2e%2e/%2e%2e/hangfire", "percent-encoded traversal")]
+    [InlineData("contests/%252e%252e/hangfire", "double-encoded traversal (residual escape rejected)")]
+    [InlineData("http://attacker.internal/contests/refresh", "absolute-URI opPath escapes the base host")]
+    [InlineData("//attacker.internal/contests/refresh", "scheme-relative opPath escapes to another host")]
     public void TraversalPaths_AreDenied_AfterCanonicalization(string opPath, string because)
     {
         AdminOpsProxyController.Allowlist
@@ -62,7 +64,7 @@ public class AdminOpsProxyAllowlistTests
         // on the canonical destination, not on cosmetic path shape.
         AdminOpsProxyController.Allowlist
             .TryResolveAllowedTarget(
-                "producer", BaseUri, "api/contests/ignored/../refresh", "?seasonYear=2026", out var target)
+                "producer", BaseUri, "contests/ignored/../refresh", "?seasonYear=2026", out var target)
             .Should().BeTrue();
 
         target.AbsolutePath.Should().Be("/api/contests/refresh");

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
@@ -15,7 +15,7 @@ public class AdminOpsProxyAllowlistTests
 {
     [Theory]
     [InlineData("producer", "franchise-seasons/seasonYear/2026/source")]
-    [InlineData("producer", "competition/123/metrics")]
+    [InlineData("producer", "competitions/123/metrics")]
     [InlineData("producer", "contests/refresh")]
     [InlineData("producer", "contests")]
     [InlineData("PRODUCER", "Franchise-Seasons/x")]


### PR DESCRIPTION
First real production relay 404'd. Seq showed the proxy composed a **doubled `/api`**:

```
http://producer-svc-football-nfl/api/api/franchise-seasons/seasonYear/2026/source
```

## Cause

The configured base URL (`ProducerClientConfig:{mode}:ApiUrl`) already ends in `/api` — it's the service's **API root**, the same convention the typed clients (`SeasonClient`, `FranchiseClient`, …) address. My proxy assumed a bare-host base and had callers supply the full `api/...` path, so composition produced `/api/api/...` and Producer's routing 404'd (empty body, relayed back verbatim).

## Fix

Allowlist families and caller paths are now **resource-relative** — `franchise-seasons`, `competition`, `contests`, `documents` — instead of `api/`-prefixed. Composed against the API-root base, the target is a single `/api/franchise-seasons/...`.

The allowlist still validates the canonical **base-relative** path, so the traversal / segment-boundary / host-escape protections from #580 are unchanged. The test base URL now ends in `/api` to mirror prod, and the normalization case proves `base + "contests/ignored/../refresh"` → `/api/contests/refresh`.

**New caller URL:**
```
POST /admin/ops/producer/football/nfl/franchise-seasons/seasonYear/2026/source
```

## Why no AppConfig change

The base value is shared with `ResourceRefGenerator` through the global key — it isn't the proxy's to mutate. The proxy adapts to the base-as-configured instead.

## Validation

API build 0 warnings; 611 unit tests pass (21 proxy cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected admin proxy routing to work with API-root base URLs.
  * Updated allowlist handling for Producer and Provider resources.
  * Preserved protections against path traversal and requests escaping the configured host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->