### PR TITLE
fix(producer): direct-deliver sourcing events; the outbox never flushed

### DIFF
--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
@@ -82,6 +82,7 @@ public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSea
         var correlationId = Guid.NewGuid();
         var requested = 0;
         var skipped = 0;
+        var failed = 0;
 
         // Direct delivery, NOT the bus-outbox: this handler only READS
         // (AsNoTracking) and writes no entity, so SaveChangesAsync would have
@@ -111,26 +112,41 @@ public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSea
 
                 var identity = _externalRefIdentityGenerator.Generate(sourceUrl);
 
-                await _eventBus.Publish(new DocumentRequested(
-                    Id: identity.UrlHash,
-                    ParentId: fs.Id.ToString(),
-                    Uri: new Uri(identity.CleanUrl),
-                    Ref: null,
-                    Sport: command.Sport,
-                    SeasonYear: command.SeasonYear,
-                    DocumentType: DocumentType.TeamSeason,
-                    SourceDataProvider: SourceDataProvider.Espn,
-                    CorrelationId: correlationId,
-                    CausationId: CausationId.Producer.FranchiseSeasonService
-                ), cancellationToken);
+                try
+                {
+                    await _eventBus.Publish(new DocumentRequested(
+                        Id: identity.UrlHash,
+                        ParentId: fs.Id.ToString(),
+                        Uri: new Uri(identity.CleanUrl),
+                        Ref: null,
+                        Sport: command.Sport,
+                        SeasonYear: command.SeasonYear,
+                        DocumentType: DocumentType.TeamSeason,
+                        SourceDataProvider: SourceDataProvider.Espn,
+                        CorrelationId: correlationId,
+                        CausationId: CausationId.Producer.FranchiseSeasonService
+                    ), cancellationToken);
 
-                requested++;
+                    requested++;
+                }
+                catch (Exception ex)
+                {
+                    // Same log-and-continue contract as the missing-ref skip: a
+                    // broker hiccup on one franchise must not abandon the rest
+                    // of the batch (and the correlation id). Under at-least-once
+                    // this is safe to re-request — a later re-run publishes the
+                    // same idempotent DocumentRequested for the failed ones.
+                    _logger.LogError(ex,
+                        "Failed to publish sourcing request for franchise season {FranchiseSeasonId}. SeasonYear={SeasonYear}",
+                        fs.Id, command.SeasonYear);
+                    failed++;
+                }
             }
         }
 
         _logger.LogInformation(
-            "FranchiseSeason sourcing requested. SeasonYear={SeasonYear}, Sport={Sport}, Requested={Requested}, Skipped={Skipped}, CorrelationId={CorrelationId}",
-            command.SeasonYear, command.Sport, requested, skipped, correlationId);
+            "FranchiseSeason sourcing requested. SeasonYear={SeasonYear}, Sport={Sport}, Requested={Requested}, Skipped={Skipped}, Failed={Failed}, CorrelationId={CorrelationId}",
+            command.SeasonYear, command.Sport, requested, skipped, failed, correlationId);
 
         return new Success<Guid>(correlationId, ResultStatus.Accepted);
     }

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
@@ -36,19 +36,22 @@ public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSea
     private readonly IEventBus _eventBus;
     private readonly IGenerateExternalRefIdentities _externalRefIdentityGenerator;
     private readonly IValidator<RequestFranchiseSeasonSourcingCommand> _validator;
+    private readonly IMessageDeliveryScope _deliveryScope;
 
     public RequestFranchiseSeasonSourcingCommandHandler(
         ILogger<RequestFranchiseSeasonSourcingCommandHandler> logger,
         TeamSportDataContext dataContext,
         IEventBus eventBus,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,
-        IValidator<RequestFranchiseSeasonSourcingCommand> validator)
+        IValidator<RequestFranchiseSeasonSourcingCommand> validator,
+        IMessageDeliveryScope deliveryScope)
     {
         _logger = logger;
         _dataContext = dataContext;
         _eventBus = eventBus;
         _externalRefIdentityGenerator = externalRefIdentityGenerator;
         _validator = validator;
+        _deliveryScope = deliveryScope;
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
@@ -80,44 +83,50 @@ public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSea
         var requested = 0;
         var skipped = 0;
 
-        foreach (var fs in franchiseSeasons)
+        // Direct delivery, NOT the bus-outbox: this handler only READS
+        // (AsNoTracking) and writes no entity, so SaveChangesAsync would have
+        // nothing to persist and would never flush the outbox — the events
+        // would be enqueued into the tracker and silently dropped. Publish
+        // straight to the broker instead. See
+        // feedback_direct_publish_no_dbcontext / AdminController's
+        // BroadcastDebugContestStatus.
+        using (_deliveryScope.Use(DeliveryMode.Direct))
         {
-            var externalId = fs.ExternalIds
-                .FirstOrDefault(x => x.Provider == SourceDataProvider.Espn);
-
-            if (externalId is null || string.IsNullOrWhiteSpace(externalId.SourceUrl) ||
-                !Uri.TryCreate(externalId.SourceUrl, UriKind.Absolute, out var sourceUrl))
+            foreach (var fs in franchiseSeasons)
             {
-                // Log-and-continue: one franchise's missing/garbage ref must
-                // not stop the other 31. The count surfaces in the summary.
-                _logger.LogWarning(
-                    "Skipping franchise season {FranchiseSeasonId}: no usable ESPN SourceUrl. SeasonYear={SeasonYear}",
-                    fs.Id, command.SeasonYear);
-                skipped++;
-                continue;
+                var externalId = fs.ExternalIds
+                    .FirstOrDefault(x => x.Provider == SourceDataProvider.Espn);
+
+                if (externalId is null || string.IsNullOrWhiteSpace(externalId.SourceUrl) ||
+                    !Uri.TryCreate(externalId.SourceUrl, UriKind.Absolute, out var sourceUrl))
+                {
+                    // Log-and-continue: one franchise's missing/garbage ref must
+                    // not stop the other 31. The count surfaces in the summary.
+                    _logger.LogWarning(
+                        "Skipping franchise season {FranchiseSeasonId}: no usable ESPN SourceUrl. SeasonYear={SeasonYear}",
+                        fs.Id, command.SeasonYear);
+                    skipped++;
+                    continue;
+                }
+
+                var identity = _externalRefIdentityGenerator.Generate(sourceUrl);
+
+                await _eventBus.Publish(new DocumentRequested(
+                    Id: identity.UrlHash,
+                    ParentId: fs.Id.ToString(),
+                    Uri: new Uri(identity.CleanUrl),
+                    Ref: null,
+                    Sport: command.Sport,
+                    SeasonYear: command.SeasonYear,
+                    DocumentType: DocumentType.TeamSeason,
+                    SourceDataProvider: SourceDataProvider.Espn,
+                    CorrelationId: correlationId,
+                    CausationId: CausationId.Producer.FranchiseSeasonService
+                ), cancellationToken);
+
+                requested++;
             }
-
-            var identity = _externalRefIdentityGenerator.Generate(sourceUrl);
-
-            await _eventBus.Publish(new DocumentRequested(
-                Id: identity.UrlHash,
-                ParentId: fs.Id.ToString(),
-                Uri: new Uri(identity.CleanUrl),
-                Ref: null,
-                Sport: command.Sport,
-                SeasonYear: command.SeasonYear,
-                DocumentType: DocumentType.TeamSeason,
-                SourceDataProvider: SourceDataProvider.Espn,
-                CorrelationId: correlationId,
-                CausationId: CausationId.Producer.FranchiseSeasonService
-            ), cancellationToken);
-
-            requested++;
         }
-
-        // Flush the outbox: with the EF outbox, Publish only enqueues into the
-        // DbContext tracker — SaveChangesAsync persists and dispatches.
-        await _dataContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(
             "FranchiseSeason sourcing requested. SeasonYear={SeasonYear}, Sport={Sport}, Requested={Requested}, Skipped={Skipped}, CorrelationId={CorrelationId}",

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
@@ -98,6 +98,11 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
                 Guid.NewGuid(),
                 u.ToString().GetHashCode().ToString("X"),
                 u.ToString()));
+        // Direct delivery is required (read-only handler; the bus-outbox would
+        // never flush). Return a real disposable so `using` is safe.
+        Mocker.GetMock<IMessageDeliveryScope>()
+            .Setup(x => x.Use(It.IsAny<DeliveryMode>()))
+            .Returns(new NoopDisposable());
         return Mocker.CreateInstance<RequestFranchiseSeasonSourcingCommandHandler>();
     }
 
@@ -127,6 +132,17 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
 
         // One batch, one correlation id — the stated Seq handle for the run.
         published.Select(e => e.CorrelationId).Distinct().Should().ContainSingle();
+
+        // Direct delivery, not the bus-outbox — this handler saves nothing, so
+        // the outbox would silently swallow the events (the prod bug that let
+        // Producer log 202 while Provider received nothing).
+        Mocker.GetMock<IMessageDeliveryScope>()
+            .Verify(x => x.Use(DeliveryMode.Direct), Times.Once);
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public void Dispose() { }
     }
 
     private static bool CaptureAndMatch(List<DocumentRequested> sink, DocumentRequested e)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
@@ -175,6 +175,29 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
     }
 
     [Fact]
+    public async Task PublishFailure_ForOneSeason_DoesNotAbandonTheBatch()
+    {
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/1");
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/2");
+
+        // First publish throws (broker hiccup), the second succeeds.
+        Mocker.GetMock<IEventBus>()
+            .SetupSequence(x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("broker hiccup"))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(SeasonYear, Sport.FootballNfl));
+
+        // The batch completes (correlation id preserved) and BOTH seasons were
+        // attempted -- a single failure must not strand the rest.
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task SkipsFranchiseSeasonsWithoutUsableRef_ContinuesBatch()
     {
         await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/1");


### PR DESCRIPTION
The ops proxy returned **202** and Producer logged the fan-out, but **Provider received nothing**.

## Root cause

`RequestFranchiseSeasonSourcingCommandHandler` reads `AsNoTracking` and writes **no entity**, then relied on `SaveChangesAsync` to flush the bus-outbox. With nothing tracked, `SaveChangesAsync` is a no-op — the published `DocumentRequested` events were enqueued into the DbContext tracker and silently dropped. The 202 was honest about "requested," dishonest about "delivered."

## Fix

Wrap the publish loop in `IMessageDeliveryScope.Use(DeliveryMode.Direct)` so events go straight to the broker, and drop the misleading `SaveChangesAsync`. This is the established pattern for publish-only work (`AdminController.BroadcastDebugContestStatus`; the competition streamers) and exactly the case `feedback_direct_publish_no_dbcontext` documents — a note I had and failed to apply here.

`DbContext` is retained because the handler genuinely *reads* through it; only the delivery mode changes.

A new test asserts `Use(DeliveryMode.Direct)` is entered, so a future refactor back to the outbox can't silently re-drop the events.

## Validation

Producer build 0 warnings; 529 unit tests pass (5 sourcing tests).

Once merged + deployed, re-fire the same trigger — this time Provider should pick up all 32 TeamSeason `DocumentRequested` events and the cascade proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery of franchise season sourcing requests by ensuring events are sent directly and reliably.
  * Prevented unnecessary persistence operations when processing sourcing requests.
* **Tests**
  * Added coverage confirming direct event delivery is used during franchise season sourcing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->