### PR TITLE
feat(web,producer): group team schedule by season phase; per-game timezone

### DIFF
--- a/src/SportsData.Core/Dtos/Canonical/TeamCardScheduleItemDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/TeamCardScheduleItemDto.cs
@@ -8,6 +8,13 @@ public record TeamCardScheduleItemDto
 
     public int Week { get; init; }
 
+    /// <summary>
+    /// Season phase name ("Preseason", "Regular Season", "Postseason").
+    /// Week numbers restart per phase, so this disambiguates and lets the UI
+    /// group the schedule by phase.
+    /// </summary>
+    public string SeasonPhase { get; init; } = default!;
+
     public DateTime Date { get; init; }
 
     public string Opponent { get; init; } = default!;

--- a/src/SportsData.Producer/Infrastructure/Sql/GetTeamCardSchedule.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetTeamCardSchedule.sql
@@ -1,6 +1,7 @@
 SELECT
     C."Id" AS "ContestId",
     sw."Number" AS "Week",
+    sp."Name" AS "SeasonPhase",
     C."StartDateUtc" AS "Date",
     CASE
         WHEN fAway."Slug" = @Slug THEN fHome."DisplayName"
@@ -34,6 +35,7 @@ FROM public."Contest" C
 INNER JOIN public."Competition" COMP on COMP."ContestId" = C."Id"
 INNER JOIN public."CompetitionStatus" CS on CS."CompetitionId" = COMP."Id"
 INNER JOIN public."SeasonWeek" SW on SW."Id" = C."SeasonWeekId"
+INNER JOIN public."SeasonPhase" SP on SP."Id" = SW."SeasonPhaseId"
 INNER JOIN public."FranchiseSeason" fsAway on fsAway."Id" = c."AwayTeamFranchiseSeasonId"
 INNER JOIN public."FranchiseSeason" fsHome on fsHome."Id" = c."HomeTeamFranchiseSeasonId"
 INNER JOIN public."Franchise" fAway on fAway."Id" = fsAway."FranchiseId"

--- a/src/UI/sd-ui/src/components/teams/TeamCard.css
+++ b/src/UI/sd-ui/src/components/teams/TeamCard.css
@@ -260,3 +260,18 @@
     font-size: 1.5rem;
   }
 }
+
+/* Screen-reader-only text: present in the accessibility tree, off-screen
+   visually. Used to explain the record parenthetical, since a title on a
+   non-focusable element is not announced. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/UI/sd-ui/src/components/teams/TeamCard.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamCard.jsx
@@ -29,6 +29,14 @@ function TeamCard() {
 
   const resolvedSeason = seasonYear || new Date().getFullYear();
 
+  // Pro leagues stack teams into divisions; college into conferences. The
+  // record DTO field is `conferenceRecord` for both, so the label is chosen
+  // by league. Explicit set rather than an nfl-only check.
+  const DIVISION_LEAGUES = new Set(["nfl", "mlb", "nba"]);
+  const recordScope = DIVISION_LEAGUES.has((league ?? "").toLowerCase())
+    ? "Division"
+    : "Conference";
+
   useEffect(() => {
     const fetchTeam = async () => {
       try {
@@ -85,14 +93,17 @@ function TeamCard() {
           <p className="team-conference">
             {team.conferenceName}{team.conferenceShortName ? ` (${team.conferenceShortName})` : ''}
           </p>
-          {/* Parenthetical is the division record for pro leagues, conference
-              for college — the DTO field is named conferenceRecord for both.
-              Tooltip so a first-time viewer isn't left guessing. */}
-          <p
-            className="team-record"
-            title={`Overall record (${league?.toLowerCase() === "nfl" ? "Division" : "Conference"} record)`}
-          >
+          {/* The parenthetical record is the DIVISION standing for pro leagues
+              and the CONFERENCE standing for college — the DTO field is named
+              conferenceRecord for both. The visually-hidden span makes that
+              explicit for screen readers (a title on a non-focusable <p> is
+              inaccessible); title stays as a supplemental hover for mouse
+              users. */}
+          <p className="team-record" title={`Overall record (${recordScope} record)`}>
             {team.overallRecord} ({team.conferenceRecord})
+            <span className="visually-hidden">
+              {" "}— overall record and {recordScope.toLowerCase()} record
+            </span>
           </p>
           <br/>
           <p className="team-stadium">

--- a/src/UI/sd-ui/src/components/teams/TeamCard.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamCard.jsx
@@ -85,7 +85,13 @@ function TeamCard() {
           <p className="team-conference">
             {team.conferenceName}{team.conferenceShortName ? ` (${team.conferenceShortName})` : ''}
           </p>
-          <p className="team-record">
+          {/* Parenthetical is the division record for pro leagues, conference
+              for college — the DTO field is named conferenceRecord for both.
+              Tooltip so a first-time viewer isn't left guessing. */}
+          <p
+            className="team-record"
+            title={`Overall record (${league?.toLowerCase() === "nfl" ? "Division" : "Conference"} record)`}
+          >
             {team.overallRecord} ({team.conferenceRecord})
           </p>
           <br/>

--- a/src/UI/sd-ui/src/components/teams/TeamSchedule.css
+++ b/src/UI/sd-ui/src/components/teams/TeamSchedule.css
@@ -132,3 +132,17 @@
   .team-schedule td:nth-child(2):before { content: "Opponent: "; }
   .team-schedule td:nth-child(4):before { content: "Result: "; }
 }
+
+/* Season-phase section header inside the schedule table (Preseason /
+   Regular Season / Postseason). Week numbers restart per phase, so the
+   grouping disambiguates them. */
+.schedule-phase-row th {
+  text-align: left;
+  padding-top: 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent-subtle);
+}

--- a/src/UI/sd-ui/src/components/teams/TeamSchedule.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamSchedule.jsx
@@ -1,4 +1,5 @@
 // src/components/teams/TeamSchedule.jsx
+import { Fragment } from "react";
 import { Link } from "react-router-dom";
 import { formatToUserTime, getZoneAbbreviation, getStartLabel } from "../../utils/timeUtils";
 import { useUserTimeZone } from "../../hooks/useUserTimeZone";
@@ -7,8 +8,18 @@ import "./TeamSchedule.css";
 
 function TeamSchedule({ schedule, seasonYear, sport = 'football', league = 'ncaa' }) {
   const userTz = useUserTimeZone();
-  const zoneAbbrev = getZoneAbbreviation(userTz);
   const startLabel = getStartLabel(sport);
+
+  // Per-game kickoff label: the calendar/time plus the zone abbreviation for
+  // THAT date. A single season-wide header abbreviation is wrong — a season
+  // spans the DST switch, so an August game is EDT and a December game EST.
+  // Midnight ("TBD") carries no meaningful clock zone, so the abbrev is
+  // suppressed there.
+  const kickoffLabel = (game) => {
+    const time = formatToUserTime(game.date, userTz);
+    if (time.endsWith("TBD")) return time;
+    return `${time} ${getZoneAbbreviation(userTz, game.date)}`;
+  };
   // Helper function to format game result
   const formatGameResult = (game) => {
     if (game.status === "STATUS_FINAL") {
@@ -36,7 +47,9 @@ function TeamSchedule({ schedule, seasonYear, sport = 'football', league = 'ncaa
       <table>
         <thead>
           <tr>
-            <th>{startLabel} ({zoneAbbrev})</th>
+            {/* No zone abbreviation here — it's per-row, because the season
+                crosses the DST boundary (see kickoffLabel). */}
+            <th>{startLabel}</th>
             <th>Opponent</th>
             <th>Location</th>
             <th>Result</th>
@@ -44,32 +57,47 @@ function TeamSchedule({ schedule, seasonYear, sport = 'football', league = 'ncaa
         </thead>
         <tbody>
           {schedule?.length ? (
-            schedule.map((game, idx) => (
-              <tr key={idx}>
-                <td>{formatToUserTime(game.date, userTz)}</td>
-                <td>
-                  <Link
-                    to={teamLink(game.opponentSlug, seasonYear, sport, league)}
-                    className="team-link"
-                  >
-                    {game.opponent}
-                  </Link>
-                </td>
-                <td>{game.location}</td>
-                <td className={getResultClass(game)}>
-                  {game.contestId ? (
-                    <Link
-                      to={contestLink(game.contestId, sport, league)}
-                      className="result-link"
-                    >
-                      {formatGameResult(game)}
-                    </Link>
-                  ) : (
-                    formatGameResult(game)
+            schedule.map((game, idx) => {
+              // Schedule is date-ordered and phases are chronologically
+              // contiguous (Preseason -> Regular Season -> Postseason), so a
+              // phase-changed check emits one section header per phase.
+              const prevPhase = idx > 0 ? schedule[idx - 1].seasonPhase : null;
+              const showPhaseHeader =
+                game.seasonPhase && game.seasonPhase !== prevPhase;
+              return (
+                <Fragment key={game.contestId ?? idx}>
+                  {showPhaseHeader && (
+                    <tr className="schedule-phase-row">
+                      <th colSpan="4" scope="colgroup">{game.seasonPhase}</th>
+                    </tr>
                   )}
-                </td>
-              </tr>
-            ))
+                  <tr>
+                    <td>{kickoffLabel(game)}</td>
+                    <td>
+                      <Link
+                        to={teamLink(game.opponentSlug, seasonYear, sport, league)}
+                        className="team-link"
+                      >
+                        {game.opponent}
+                      </Link>
+                    </td>
+                    <td>{game.location}</td>
+                    <td className={getResultClass(game)}>
+                      {game.contestId ? (
+                        <Link
+                          to={contestLink(game.contestId, sport, league)}
+                          className="result-link"
+                        >
+                          {formatGameResult(game)}
+                        </Link>
+                      ) : (
+                        formatGameResult(game)
+                      )}
+                    </td>
+                  </tr>
+                </Fragment>
+              );
+            })
           ) : (
             <tr>
               {/* 4 columns in header → 4 here */}


### PR DESCRIPTION
Three fixes to the team-card schedule, surfaced once NFL 2026 (with preseason) was sourced.

## Season phase grouping

Week numbers restart per phase, so a flat schedule mixing preseason and regular season was ambiguous. `GetTeamCardSchedule.sql` now joins `SeasonPhase` and returns its name; `TeamCardScheduleItemDto` carries `SeasonPhase`; the schedule table renders a **section header per phase** (Preseason / Regular Season / Postseason). Dapper maps by column name, so the contract flows Producer → FranchiseClient → API → UI automatically.

## Per-game timezone

The header showed a single **season-wide** zone abbreviation computed at "now" (August → EDT) — which mislabels games across the DST boundary, since a December kickoff is EST. The abbreviation moves to **each row**, computed for that game's date via `getZoneAbbreviation(tz, game.date)` (a per-date path the util already supported but nothing had wired up). Still honors the user's configured timezone; TBD (midnight) rows omit it.

## Record tooltip

`0-0-0 (0-0-0)` — the parenthetical is the **division** record for pro leagues, **conference** for college (the DTO field is `conferenceRecord` for both). A sport-aware `title` now says which, so a first-time viewer isn't guessing.

## Notes

- **No migration** — the SQL change is a Dapper query resource, not EF.
- **Follow-up, not in this PR:** API carries a dead second copy of `GetTeamCardSchedule.sql` and a `CanonicalDataQueryProvider` — fossils of API reaching directly into Producer's database, which the service-to-service rule forbids. Removal is its own cleanup, deferred until after the app-store push.

## Validation

Producer + Core build 0 warnings; web lint clean, 10 Vitest tests pass, CRA production build compiles. Verified locally by @jrandallsexton against sourced NFL 2026 data — preseason/regular-season delineation and per-game zones confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Team schedules now display season phases, making week numbering clearer.
  - Game times include the applicable time-zone abbreviation when available.
  - Added explanatory text for team records to clarify division or conference records.
- **UI Improvements**
  - Season-phase sections are visually distinguished within schedule tables.
  - “TBD” game times remain free of time-zone labels.
  - Record explanations include accessible screen-reader text for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->