### PR TITLE
feat(mobile): public league discovery + join (Phase 1 web parity)

### DIFF
--- a/docs/mobile/web-parity-join-discovery.md
+++ b/docs/mobile/web-parity-join-discovery.md
@@ -1,6 +1,6 @@
 # Mobile Parity: Join Policy + Public League Discovery
 
-Status: **planned — hold lifted 2026-08-01; Phase 1 not started**
+Status: **Phase 1 (find & join) shipped #584; Phase 2 (create-side) not started**
 Surfaces: sd-mobile (client only — the BE and API are done)
 Web precedent: `docs/features/league-join-policy-and-discovery.md` (#576, #577, #579)
 
@@ -19,12 +19,12 @@ and already live — every endpoint below exists. This is pure client work.
 
 | Web surface (PR) | Mobile today | Parity work |
 |---|---|---|
-| Home "Leagues you can join" rail (#577) | Home has Tier 1 (countdown) + Tier 2 (YourLeaguesCard); no Tier 3 | New `JoinableLeaguesCard`, `getPublicLeagues` |
-| Public discovery / browse (#576) | No browse screen; join only via invite deep-link | New browse screen |
-| Join confirmation dialog (#577) | Invite screen has a raw Join button | Port `JoinLeagueConfirmDialog` semantics |
-| Closes countdown / closed state (#577) | Invite preview has no joinability awareness | `JoinClosesLabel` behavior; gate Join when closed |
-| Commissioner join policy at creation (#576) | `create-league.tsx` sends neither `joinPolicy` nor `leagueWindow` | Open vs Locked-at-kickoff choice |
-| Week Range creation (#579) | No phase-aware week picker | Calendar-driven picker |
+| Home "Leagues you can join" rail (#577) | ~~no Tier 3~~ **DONE #584** | `JoinableLeaguesCard` + `getPublicLeagues` |
+| Public discovery / browse (#576) | ~~no browse screen~~ **DONE #584** | `app/league/discover.tsx` |
+| Join confirmation dialog (#577) | ~~raw Join button~~ **DONE #584** | `JoinLeagueConfirmSheet` |
+| Closes countdown / closed state (#577) | ~~no joinability awareness~~ **DONE #584** | `JoinClosesLabel` + invite closed-state |
+| Commissioner join policy at creation (#576) | `create-league.tsx` sends neither `joinPolicy` nor `leagueWindow` | **Phase 2** — Open vs Locked-at-kickoff choice |
+| Week Range creation (#579) | No phase-aware week picker | **Phase 2** — calendar-driven picker |
 
 ## Shared contracts mobile MUST mirror (do not re-derive)
 
@@ -64,8 +64,7 @@ These are settled on web; mobile matches them exactly rather than inventing.
 
 ## Proposed phasing (EAS batches, not dribs)
 
-**Phase 1 — Find & join a public league** (highest value; weekend-shaped,
-which is mobile's posture). One coherent slice:
+**Phase 1 — Find & join a public league** — SHIPPED (#584). One coherent slice:
 1. `getPublicLeagues` mobile client + a `useJoinableLeagues` hook.
 2. `JoinableLeaguesCard` home rail (Tier 3), rendering null when nothing
    joinable (mirrors web).

--- a/docs/mobile/web-parity-join-discovery.md
+++ b/docs/mobile/web-parity-join-discovery.md
@@ -8,14 +8,17 @@ Web precedent: `docs/features/league-join-policy-and-discovery.md` (#576, #577, 
 
 The join-policy + discovery feature set shipped web-first and was deliberately
 held from mobile through a production soak, so UX changes were paid once, not
-twice (the v2 revision came out of that soak). The web design is now settled;
-this doc pins the shared contracts BEFORE mobile screens are written, so the
-two apps can't drift on the parts that must match.
+twice (the v2 revision came out of that soak). Once the web design settled, the
+hold lifted and this doc pinned the shared contracts before mobile screens were
+written — so the two apps don't drift on the parts that must match. Phase 1
+(find & join) has since shipped (#584); the contracts below remain the
+reference for Phase 2.
 
 ## The gap (verified against the mobile tree, 2026-08-01)
 
-Mobile references **none** of this feature set. The BE is platform-agnostic
-and already live — every endpoint below exists. This is pure client work.
+At the time of writing mobile referenced **none** of this feature set; Phase 1
+has since closed the find-and-join rows below. The BE is platform-agnostic and
+already live — every endpoint exists — so this is pure client work.
 
 | Web surface (PR) | Mobile today | Parity work |
 |---|---|---|

--- a/docs/mobile/web-parity-join-discovery.md
+++ b/docs/mobile/web-parity-join-discovery.md
@@ -1,0 +1,86 @@
+# Mobile Parity: Join Policy + Public League Discovery
+
+Status: **planned — hold lifted 2026-08-01; Phase 1 not started**
+Surfaces: sd-mobile (client only — the BE and API are done)
+Web precedent: `docs/features/league-join-policy-and-discovery.md` (#576, #577, #579)
+
+## Why this doc exists
+
+The join-policy + discovery feature set shipped web-first and was deliberately
+held from mobile through a production soak, so UX changes were paid once, not
+twice (the v2 revision came out of that soak). The web design is now settled;
+this doc pins the shared contracts BEFORE mobile screens are written, so the
+two apps can't drift on the parts that must match.
+
+## The gap (verified against the mobile tree, 2026-08-01)
+
+Mobile references **none** of this feature set. The BE is platform-agnostic
+and already live — every endpoint below exists. This is pure client work.
+
+| Web surface (PR) | Mobile today | Parity work |
+|---|---|---|
+| Home "Leagues you can join" rail (#577) | Home has Tier 1 (countdown) + Tier 2 (YourLeaguesCard); no Tier 3 | New `JoinableLeaguesCard`, `getPublicLeagues` |
+| Public discovery / browse (#576) | No browse screen; join only via invite deep-link | New browse screen |
+| Join confirmation dialog (#577) | Invite screen has a raw Join button | Port `JoinLeagueConfirmDialog` semantics |
+| Closes countdown / closed state (#577) | Invite preview has no joinability awareness | `JoinClosesLabel` behavior; gate Join when closed |
+| Commissioner join policy at creation (#576) | `create-league.tsx` sends neither `joinPolicy` nor `leagueWindow` | Open vs Locked-at-kickoff choice |
+| Week Range creation (#579) | No phase-aware week picker | Calendar-driven picker |
+
+## Shared contracts mobile MUST mirror (do not re-derive)
+
+These are settled on web; mobile matches them exactly rather than inventing.
+
+- **JoinPolicy** enum: `Open` | `CloseAtFirstGame`. Absent on create ⇒ `Open`
+  server-side. Commissioner INPUT, not a lifecycle authority.
+- **LeagueWindow** enum: `FullSeason` | `WeekRange` | `DateRange`. Captured
+  explicitly at creation — never inferred from date null-ness.
+- **`closesAtUtc` / `isJoinable`** on the DTOs are the read-side truth. The
+  join gate is the enforcement boundary; the client only shapes UI.
+- **Countdown window: 10 days.** Inside 10 days → live countdown
+  ("Closes in 2d 4h"); beyond → plain date; past/`isJoinable:false` →
+  "Closed". Web: `JoinClosesLabel`.
+- **Join confirmation shows details before committing** (joining has no
+  self-serve undo): sport/season, pick type + confidence, tiebreaker,
+  drop weeks, window, members, commissioner, closes-countdown. Web:
+  `JoinLeagueConfirmDialog`.
+- **CTA copy is "Join"** everywhere; the browse/rail Join opens the
+  confirmation, which then routes through the SAME join path invite links use.
+- **`memberCount` / `isMember`** — never derive counts from `members.length`
+  (the roster is withheld from non-members).
+
+## API surface (all live)
+
+- `GET /ui/leagues/discover` → fattened `PublicLeagueDto[]` (sport, league,
+  seasonYear, memberCount, joinPolicy, closesAtUtc, isJoinable, window,
+  tiebreaker, dropLowWeeks).
+- `GET /ui/leagues/{id}` → tiered `LeagueDetailDto` (settings + memberCount to
+  non-members; roster withheld; carries joinPolicy/closesAtUtc/isJoinable).
+- `POST /ui/leagues/{id}/join` (via the mobile join path already used by the
+  invite screen).
+- `GET /ui/leagues/{sport}/{league}/season-weeks` → labeled week list for the
+  Week Range picker (phase-carrying labels, real UTC boundaries).
+- Create endpoints already accept optional `joinPolicy`, `leagueWindow`, and
+  week-derived `startsOn`/`endsOn`.
+
+## Proposed phasing (EAS batches, not dribs)
+
+**Phase 1 — Find & join a public league** (highest value; weekend-shaped,
+which is mobile's posture). One coherent slice:
+1. `getPublicLeagues` mobile client + a `useJoinableLeagues` hook.
+2. `JoinableLeaguesCard` home rail (Tier 3), rendering null when nothing
+   joinable (mirrors web).
+3. Public browse screen (full list) reachable from the rail.
+4. `JoinLeagueConfirmDialog` (mobile sheet) + `JoinClosesLabel` behavior;
+   invite-preview screen gains the closed-state.
+
+**Phase 2 — Commissioner create parity.**
+5. Join-policy choice in `create-league.tsx` (Open / Locked-at-kickoff).
+6. Week Range picker (phase-aware, calendar-driven) + drop-week ceiling.
+
+Phase 1 lands the landing-page difference the operator noticed and the full
+join loop; Phase 2 is create-side plumbing that skews weekday/web and can wait.
+
+## Out of scope
+
+- Admin creation-gate bypass (#579) — operator-only, no mobile user need.
+- Any BE change — the contract is frozen; mobile adapts to it.

--- a/src/UI/sd-mobile/__tests__/components/features/leagues/joinDisplay.test.ts
+++ b/src/UI/sd-mobile/__tests__/components/features/leagues/joinDisplay.test.ts
@@ -36,6 +36,14 @@ describe('joinClosesState', () => {
     expect(s.text.startsWith('Closes ')).toBe(true);
     expect(s.text).not.toContain('in ');
   });
+
+  it('treats exactly the 10-day boundary as a countdown', () => {
+    expect(joinClosesState(iso(10 * DAY), true, NOW).kind).toBe('countdown');
+  });
+
+  it('falls back to Open on an unparseable close instant', () => {
+    expect(joinClosesState('not-a-date', true, NOW)).toEqual({ text: 'Open', kind: 'open' });
+  });
 });
 
 describe('formatRemaining', () => {

--- a/src/UI/sd-mobile/__tests__/components/features/leagues/joinDisplay.test.ts
+++ b/src/UI/sd-mobile/__tests__/components/features/leagues/joinDisplay.test.ts
@@ -1,0 +1,60 @@
+import {
+  joinClosesState,
+  formatRemaining,
+  windowLabel,
+} from '@/src/components/features/leagues/joinDisplay';
+
+// The join-status logic is the shared contract with sd-ui's JoinClosesLabel;
+// these lock the four states so the two apps can't drift.
+describe('joinClosesState', () => {
+  const NOW = Date.parse('2026-09-01T12:00:00Z');
+  const iso = (ms: number) => new Date(NOW + ms).toISOString();
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+
+  it('is Open when there is no close instant', () => {
+    expect(joinClosesState(null, true, NOW)).toEqual({ text: 'Open', kind: 'open' });
+  });
+
+  it('is Closed when isJoinable is false, regardless of the date', () => {
+    expect(joinClosesState(iso(5 * DAY), false, NOW).kind).toBe('closed');
+  });
+
+  it('is Closed once the close instant has passed', () => {
+    expect(joinClosesState(iso(-HOUR), true, NOW).kind).toBe('closed');
+  });
+
+  it('shows a live countdown inside the 10-day window', () => {
+    const s = joinClosesState(iso(2 * DAY + 4 * HOUR), true, NOW);
+    expect(s.kind).toBe('countdown');
+    expect(s.text).toBe('Closes in 2d 4h');
+  });
+
+  it('shows a plain date beyond 10 days', () => {
+    const s = joinClosesState(iso(20 * DAY), true, NOW);
+    expect(s.kind).toBe('date');
+    expect(s.text.startsWith('Closes ')).toBe(true);
+    expect(s.text).not.toContain('in ');
+  });
+});
+
+describe('formatRemaining', () => {
+  const M = 60 * 1000;
+  const H = 60 * M;
+  const D = 24 * H;
+  it('renders days+hours, hours+minutes, or minutes', () => {
+    expect(formatRemaining(2 * D + 4 * H)).toBe('2d 4h');
+    expect(formatRemaining(3 * H + 15 * M)).toBe('3h 15m');
+    expect(formatRemaining(42 * M)).toBe('42m');
+    expect(formatRemaining(-1000)).toBe('0m');
+  });
+});
+
+describe('windowLabel', () => {
+  it('covers full-season, range, and one-sided windows', () => {
+    expect(windowLabel(null, null)).toBe('Full Season');
+    expect(windowLabel('2026-09-01T00:00:00Z', '2026-09-30T00:00:00Z')).toContain('–');
+    expect(windowLabel('2026-09-01T00:00:00Z', null)).toMatch(/^From /);
+    expect(windowLabel(null, '2026-09-30T00:00:00Z')).toMatch(/^Through /);
+  });
+});

--- a/src/UI/sd-mobile/app/(tabs)/index.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { getLeagues } from '@/src/lib/leagues';
 import { PrimarySlotNewUser } from '@/src/components/features/home/PrimarySlotNewUser';
 import { PrimarySlotOffSeasonCountdown } from '@/src/components/features/home/PrimarySlotOffSeasonCountdown';
 import { YourLeaguesCard } from '@/src/components/features/home/YourLeaguesCard';
+import { JoinableLeaguesCard } from '@/src/components/features/home/JoinableLeaguesCard';
 
 /**
  * Post-login landing — mirrors web's HomePage (PR #272 / docs/post-login-landing-design.md).
@@ -79,6 +80,11 @@ export default function HomeScreen() {
       ) : (
         <PrimarySlotNewUser />
       )}
+
+      {/* Tier 3 — public-league discovery. Rendered for every user (self-nulls
+          when nothing is joinable), so a league-less user lands on actionable
+          joins rather than only the new-user slot. Web parity: HomePage. */}
+      <JoinableLeaguesCard />
     </ScrollView>
   );
 }

--- a/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleSheet, ScrollView, ActivityIndicator } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import { Text } from '@/src/components/ui/AppText';
 import { Button } from '@/src/components/ui/Button';
@@ -9,7 +9,7 @@ import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
 import { JoinClosesLabel } from '@/src/components/features/leagues/JoinClosesLabel';
-import { standingsKeys } from '@/src/hooks/useStandings';
+import { useJoinLeagueMutation } from '@/src/hooks/useJoinLeagueMutation';
 
 // League ids are GUIDs. Used to reject malformed/array-like route params
 // before any request is built.
@@ -27,7 +27,6 @@ export default function LeagueInviteScreen() {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
   const router = useRouter();
-  const queryClient = useQueryClient();
   const params = useLocalSearchParams<{ leagueId?: string | string[] }>();
   // Route params can arrive as undefined or an array (duplicate keys); only a
   // single, GUID-shaped string is a real league id. Anything else stays
@@ -48,14 +47,10 @@ export default function LeagueInviteScreen() {
     queryFn: async () => (await leaguesApi.getLeagueById(leagueId!)).data,
   });
 
-  const joinMutation = useMutation({
-    mutationFn: () => leaguesApi.joinLeague(leagueId!),
-    onSuccess: async () => {
-      // Refresh /user/me so the just-joined league appears in the leagues
-      // list the picks screen selects from.
-      await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
-      router.replace({ pathname: '/(tabs)/picks', params: { leagueId } } as never);
-    },
+  // Shared hook: invalidates discovery + My Leagues + /user/me, so a join
+  // here also drops the league from the public browse list.
+  const joinMutation = useJoinLeagueMutation((id) => {
+    router.replace({ pathname: '/(tabs)/picks', params: { leagueId: id } } as never);
   });
 
   const dismiss = () => {
@@ -121,7 +116,7 @@ export default function LeagueInviteScreen() {
               <View style={styles.actions}>
                 <Button
                   title={joinMutation.isPending ? 'Joining…' : 'Join League'}
-                  onPress={() => joinMutation.mutate()}
+                  onPress={() => joinMutation.mutate(leagueId!)}
                   loading={joinMutation.isPending}
                 />
                 <Button title="Not now" variant="ghost" onPress={dismiss} />

--- a/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
@@ -8,6 +8,7 @@ import { Button } from '@/src/components/ui/Button';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
+import { JoinClosesLabel } from '@/src/components/features/leagues/JoinClosesLabel';
 import { standingsKeys } from '@/src/hooks/useStandings';
 
 // League ids are GUIDs. Used to reject malformed/array-like route params
@@ -100,16 +101,32 @@ export default function LeagueInviteScreen() {
               <Text style={[styles.metaRow, { color: theme.textMuted }]}>
                 {league.isPublic ? 'Public league' : 'Private league'}
               </Text>
+              <JoinClosesLabel
+                closesAtUtc={league.closesAtUtc}
+                isJoinable={league.isJoinable}
+                style={styles.metaRow}
+              />
             </View>
 
-            <View style={styles.actions}>
-              <Button
-                title={joinMutation.isPending ? 'Joining…' : 'Join League'}
-                onPress={() => joinMutation.mutate()}
-                loading={joinMutation.isPending}
-              />
-              <Button title="Not now" variant="ghost" onPress={dismiss} />
-            </View>
+            {league.isJoinable === false ? (
+              // A shared invite link outlives the league's join window — the BE
+              // gate would reject the join, so don't offer it.
+              <View style={styles.actions}>
+                <Text style={[styles.subtitle, { color: theme.textMuted }]}>
+                  This league is no longer accepting new members.
+                </Text>
+                <Button title="Close" variant="secondary" onPress={dismiss} />
+              </View>
+            ) : (
+              <View style={styles.actions}>
+                <Button
+                  title={joinMutation.isPending ? 'Joining…' : 'Join League'}
+                  onPress={() => joinMutation.mutate()}
+                  loading={joinMutation.isPending}
+                />
+                <Button title="Not now" variant="ghost" onPress={dismiss} />
+              </View>
+            )}
 
             {joinMutation.isError ? (
               <Text style={[styles.errorText, { color: theme.error }]}>

--- a/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
+++ b/src/UI/sd-mobile/app/league-invite/[leagueId].tsx
@@ -10,6 +10,7 @@ import { getTheme } from '@/constants/Colors';
 import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
 import { JoinClosesLabel } from '@/src/components/features/leagues/JoinClosesLabel';
 import { useJoinLeagueMutation } from '@/src/hooks/useJoinLeagueMutation';
+import { useLiveJoinState } from '@/src/components/features/leagues/useLiveJoinState';
 
 // League ids are GUIDs. Used to reject malformed/array-like route params
 // before any request is built.
@@ -52,6 +53,11 @@ export default function LeagueInviteScreen() {
   const joinMutation = useJoinLeagueMutation((id) => {
     router.replace({ pathname: '/(tabs)/picks', params: { leagueId: id } } as never);
   });
+
+  // Live join state — a shared invite link can outlive the join window, and it
+  // can also expire WHILE this screen is open. Both must block the join.
+  const joinState = useLiveJoinState(league?.closesAtUtc ?? null, league?.isJoinable ?? true);
+  const closed = joinState.kind === 'closed';
 
   const dismiss = () => {
     if (router.canGoBack()) router.back();
@@ -103,9 +109,9 @@ export default function LeagueInviteScreen() {
               />
             </View>
 
-            {league.isJoinable === false ? (
-              // A shared invite link outlives the league's join window — the BE
-              // gate would reject the join, so don't offer it.
+            {closed ? (
+              // The join window has passed (or elapsed while this screen was
+              // open) — the BE gate would reject the join, so don't offer it.
               <View style={styles.actions}>
                 <Text style={[styles.subtitle, { color: theme.textMuted }]}>
                   This league is no longer accepting new members.

--- a/src/UI/sd-mobile/app/league/discover.tsx
+++ b/src/UI/sd-mobile/app/league/discover.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, ScrollView, RefreshControl, ActivityIndicator } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { leaguesApi, leaguesKeys, type PublicLeague } from '@/src/services/api/leaguesApi';
+import { JoinLeagueConfirmSheet } from '@/src/components/features/leagues/JoinLeagueConfirmSheet';
+import { JoinClosesLabel } from '@/src/components/features/leagues/JoinClosesLabel';
+import {
+  SPORT_ICON,
+  SPORT_LABEL,
+  PICK_TYPE_LABEL,
+} from '@/src/components/features/leagues/joinDisplay';
+
+/**
+ * Public-league browse screen (web parity: sd-ui's LeagueDiscoverPage). Lists
+ * every public league the caller isn't in; closed ones are badged with a
+ * disabled affordance rather than a Join that 400s. Reached from the home rail.
+ */
+export default function LeagueDiscoverScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const [confirming, setConfirming] = useState<PublicLeague | null>(null);
+
+  const { data, isLoading, isError, refetch, isRefetching } = useQuery({
+    queryKey: leaguesKeys.public,
+    queryFn: async () => (await leaguesApi.getPublicLeagues()).data,
+  });
+
+  const leagues = data ?? [];
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <Stack.Screen options={{ title: 'Discover Leagues' }} />
+
+      <ScrollView
+        contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor={theme.tint} />
+        }
+      >
+        {isLoading ? (
+          <ActivityIndicator color={theme.tint} style={styles.spinner} />
+        ) : isError ? (
+          <Text style={[styles.empty, { color: theme.textMuted }]}>
+            Couldn&apos;t load public leagues. Pull to retry.
+          </Text>
+        ) : leagues.length === 0 ? (
+          <Text style={[styles.empty, { color: theme.textMuted }]}>
+            No public leagues available right now.
+          </Text>
+        ) : (
+          leagues.map((league) => (
+            <View
+              key={league.id}
+              style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
+            >
+              <Text style={[styles.name, { color: theme.text }]}>{league.name}</Text>
+              {league.description ? (
+                <Text style={[styles.desc, { color: theme.textMuted }]} numberOfLines={2}>
+                  {league.description}
+                </Text>
+              ) : null}
+
+              <View style={styles.metaRow}>
+                <Text style={[styles.meta, { color: theme.textMuted }]}>
+                  {SPORT_ICON[league.sport] ?? '🏆'} {SPORT_LABEL[league.sport] ?? league.sport}{' '}
+                  {league.seasonYear} · {PICK_TYPE_LABEL[league.pickType] ?? '—'}
+                  {league.useConfidencePoints ? ' · Confidence' : ''} · {league.memberCount}{' '}
+                  {league.memberCount === 1 ? 'member' : 'members'}
+                </Text>
+              </View>
+
+              <View style={styles.footerRow}>
+                <JoinClosesLabel
+                  closesAtUtc={league.closesAtUtc}
+                  isJoinable={league.isJoinable}
+                  style={styles.meta}
+                />
+                {league.isJoinable ? (
+                  <Text
+                    onPress={() => setConfirming(league)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Join ${league.name}`}
+                    style={[styles.joinPill, { backgroundColor: theme.tint, color: theme.textOnAccent }]}
+                  >
+                    Join
+                  </Text>
+                ) : (
+                  <Text style={[styles.closedPill, { borderColor: theme.border, color: theme.textMuted }]}>
+                    Closed
+                  </Text>
+                )}
+              </View>
+            </View>
+          ))
+        )}
+      </ScrollView>
+
+      <JoinLeagueConfirmSheet
+        league={confirming}
+        onCancel={() => setConfirming(null)}
+        onJoined={(joined) => {
+          setConfirming(null);
+          router.push({ pathname: '/(tabs)/picks', params: { leagueId: joined.id } } as never);
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, gap: 12, paddingBottom: 32 },
+  spinner: { marginTop: 40 },
+  empty: { textAlign: 'center', marginTop: 40, fontSize: 14 },
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    gap: 4,
+  },
+  name: { fontSize: 16, fontWeight: '700' },
+  desc: { fontSize: 13 },
+  metaRow: { marginTop: 4 },
+  meta: { fontSize: 12 },
+  footerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 8,
+  },
+  joinPill: {
+    paddingHorizontal: 16,
+    paddingVertical: 7,
+    borderRadius: 8,
+    fontSize: 13,
+    fontWeight: '700',
+    overflow: 'hidden',
+  },
+  closedPill: {
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    fontSize: 13,
+    fontWeight: '600',
+    overflow: 'hidden',
+  },
+});

--- a/src/UI/sd-mobile/src/components/features/home/JoinableLeaguesCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/JoinableLeaguesCard.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { leaguesApi, leaguesKeys, type PublicLeague } from '@/src/services/api/leaguesApi';
+import { JoinLeagueConfirmSheet } from '@/src/components/features/leagues/JoinLeagueConfirmSheet';
+import { JoinClosesLabel } from '@/src/components/features/leagues/JoinClosesLabel';
+import { SPORT_ICON, SPORT_LABEL } from '@/src/components/features/leagues/joinDisplay';
+
+const MAX_ROWS = 4;
+
+/**
+ * Tier 3 home rail — "Leagues you can join". Web parity with sd-ui's
+ * JoinableLeaguesCard: surfaces public-league discovery on the landing page so
+ * a league-less (or any) user lands on actionable joins, not a bare countdown.
+ * Renders nothing while loading or when there is nothing joinable, so the home
+ * page never shows an empty shell. See docs/mobile/web-parity-join-discovery.md.
+ */
+export function JoinableLeaguesCard() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const [confirming, setConfirming] = useState<PublicLeague | null>(null);
+
+  const { data } = useQuery({
+    queryKey: leaguesKeys.public,
+    queryFn: async () => (await leaguesApi.getPublicLeagues()).data,
+  });
+
+  const joinable = (data ?? []).filter((l) => l.isJoinable);
+  if (joinable.length === 0) return null;
+
+  const visible = joinable.slice(0, MAX_ROWS);
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <View style={styles.headerRow}>
+        <Text style={[styles.eyebrow, { color: theme.tint }]}>LEAGUES YOU CAN JOIN</Text>
+        <TouchableOpacity
+          onPress={() => router.push('/league/discover' as never)}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Browse all public leagues"
+        >
+          <Text style={[styles.browse, { color: theme.tint }]}>Browse all ›</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.list}>
+        {visible.map((league) => (
+          <TouchableOpacity
+            key={league.id}
+            onPress={() => setConfirming(league)}
+            activeOpacity={0.6}
+            accessibilityRole="button"
+            accessibilityLabel={`Join ${league.name}`}
+            style={[styles.row, { borderTopColor: theme.border }]}
+          >
+            <View style={styles.info}>
+              <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>
+                {league.name}
+              </Text>
+              <View style={styles.metaRow}>
+                <Text style={[styles.meta, { color: theme.textMuted }]}>
+                  {SPORT_ICON[league.sport] ?? '🏆'} {SPORT_LABEL[league.sport] ?? league.sport}{' '}
+                  {league.seasonYear} · {league.memberCount}{' '}
+                  {league.memberCount === 1 ? 'member' : 'members'} ·{' '}
+                </Text>
+                <JoinClosesLabel
+                  closesAtUtc={league.closesAtUtc}
+                  isJoinable={league.isJoinable}
+                  style={styles.meta}
+                />
+              </View>
+            </View>
+            <View style={[styles.joinPill, { backgroundColor: theme.tint }]}>
+              <Text style={[styles.joinText, { color: theme.textOnAccent }]}>Join</Text>
+            </View>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <JoinLeagueConfirmSheet
+        league={confirming}
+        onCancel={() => setConfirming(null)}
+        onJoined={(joined) => {
+          setConfirming(null);
+          router.push({ pathname: '/(tabs)/picks', params: { leagueId: joined.id } } as never);
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  eyebrow: { fontSize: 11, fontWeight: '700', letterSpacing: 1.5 },
+  browse: { fontSize: 12, fontWeight: '700' },
+  list: {},
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  info: { flex: 1, minWidth: 0 },
+  name: { fontSize: 15, fontWeight: '600' },
+  metaRow: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', marginTop: 2 },
+  meta: { fontSize: 12 },
+  joinPill: { paddingHorizontal: 14, paddingVertical: 6, borderRadius: 8 },
+  joinText: { fontSize: 13, fontWeight: '700' },
+});

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { COUNTDOWN_WINDOW_MS, joinClosesState } from './joinDisplay';
+
+// setTimeout treats delays above 2^31-1 ms (~24.8 days) as 0.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+const TICK_MS = 60 * 1000;
+
+interface Props {
+  closesAtUtc: string | null | undefined;
+  isJoinable: boolean;
+  style?: object;
+}
+
+/**
+ * Join-status label mirroring sd-ui's JoinClosesLabel: live minute-tick
+ * countdown inside 10 days, plain date beyond, "Closed" once past. Arms a
+ * boundary timer so a long-lived screen transitions date -> countdown ->
+ * Closed without a reload.
+ */
+export function JoinClosesLabel({ closesAtUtc, isJoinable, style }: Props) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const [now, setNow] = useState(() => Date.now());
+
+  const closesMs = closesAtUtc ? new Date(closesAtUtc).getTime() : NaN;
+  const remaining = closesMs - now;
+  const inCountdown =
+    Number.isFinite(closesMs) && remaining > 0 && remaining <= COUNTDOWN_WINDOW_MS;
+
+  useEffect(() => {
+    if (!Number.isFinite(closesMs) || remaining <= 0) return undefined;
+    if (inCountdown) {
+      const id = setInterval(() => setNow(Date.now()), TICK_MS);
+      return () => clearInterval(id);
+    }
+    // Outside the window: one timer aimed at the boundary.
+    const untilWindow = Math.min(remaining - COUNTDOWN_WINDOW_MS, MAX_TIMEOUT_MS);
+    const id = setTimeout(() => setNow(Date.now()), Math.max(untilWindow, TICK_MS));
+    return () => clearTimeout(id);
+  }, [closesMs, inCountdown, remaining]);
+
+  const state = joinClosesState(closesAtUtc, isJoinable, now);
+  const color =
+    state.kind === 'countdown'
+      ? theme.tint
+      : state.kind === 'closed'
+        ? theme.textMuted
+        : theme.textMuted;
+
+  return <Text style={[{ color, fontWeight: state.kind === 'countdown' ? '600' : '400' }, style]}>{state.text}</Text>;
+}

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
@@ -1,13 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import type { StyleProp, TextStyle } from 'react-native';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
-import { COUNTDOWN_WINDOW_MS, joinClosesState } from './joinDisplay';
-
-// setTimeout treats delays above 2^31-1 ms (~24.8 days) as 0.
-const MAX_TIMEOUT_MS = 2 ** 31 - 1;
-const TICK_MS = 60 * 1000;
+import { useLiveJoinState } from './useLiveJoinState';
 
 interface Props {
   closesAtUtc: string | null | undefined;
@@ -24,26 +20,7 @@ interface Props {
 export function JoinClosesLabel({ closesAtUtc, isJoinable, style }: Props) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
-  const [now, setNow] = useState(() => Date.now());
-
-  const closesMs = closesAtUtc ? new Date(closesAtUtc).getTime() : NaN;
-  const remaining = closesMs - now;
-  const inCountdown =
-    Number.isFinite(closesMs) && remaining > 0 && remaining <= COUNTDOWN_WINDOW_MS;
-
-  useEffect(() => {
-    if (!Number.isFinite(closesMs) || remaining <= 0) return undefined;
-    if (inCountdown) {
-      const id = setInterval(() => setNow(Date.now()), TICK_MS);
-      return () => clearInterval(id);
-    }
-    // Outside the window: one timer aimed at the boundary.
-    const untilWindow = Math.min(remaining - COUNTDOWN_WINDOW_MS, MAX_TIMEOUT_MS);
-    const id = setTimeout(() => setNow(Date.now()), Math.max(untilWindow, TICK_MS));
-    return () => clearTimeout(id);
-  }, [closesMs, inCountdown, remaining]);
-
-  const state = joinClosesState(closesAtUtc, isJoinable, now);
+  const state = useLiveJoinState(closesAtUtc, isJoinable);
   // Countdown draws attention; every other state is muted.
   const color = state.kind === 'countdown' ? theme.tint : theme.textMuted;
 

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import type { StyleProp, TextStyle } from 'react-native';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
@@ -11,7 +12,7 @@ const TICK_MS = 60 * 1000;
 interface Props {
   closesAtUtc: string | null | undefined;
   isJoinable: boolean;
-  style?: object;
+  style?: StyleProp<TextStyle>;
 }
 
 /**
@@ -43,12 +44,8 @@ export function JoinClosesLabel({ closesAtUtc, isJoinable, style }: Props) {
   }, [closesMs, inCountdown, remaining]);
 
   const state = joinClosesState(closesAtUtc, isJoinable, now);
-  const color =
-    state.kind === 'countdown'
-      ? theme.tint
-      : state.kind === 'closed'
-        ? theme.textMuted
-        : theme.textMuted;
+  // Countdown draws attention; every other state is muted.
+  const color = state.kind === 'countdown' ? theme.tint : theme.textMuted;
 
   return <Text style={[{ color, fontWeight: state.kind === 'countdown' ? '600' : '400' }, style]}>{state.text}</Text>;
 }

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
@@ -8,6 +8,7 @@ import { getTheme } from '@/constants/Colors';
 import { type PublicLeague } from '@/src/services/api/leaguesApi';
 import { useJoinLeagueMutation } from '@/src/hooks/useJoinLeagueMutation';
 import { JoinClosesLabel } from './JoinClosesLabel';
+import { useLiveJoinState } from './useLiveJoinState';
 import {
   SPORT_LABEL,
   PICK_TYPE_LABEL,
@@ -36,6 +37,12 @@ export function JoinLeagueConfirmSheet({ league, onCancel, onJoined }: Props) {
   const joinMutation = useJoinLeagueMutation(() => {
     if (league) onJoined(league);
   });
+
+  // Live join state (ticks past the countdown/close instant) — a league can
+  // close while the sheet is open, so Join disables rather than submitting a
+  // join the BE would reject.
+  const joinState = useLiveJoinState(league?.closesAtUtc ?? null, league?.isJoinable ?? true);
+  const closed = joinState.kind === 'closed';
 
   // The sheet is a single persistent component reused across leagues; only the
   // `league` prop changes. Reset the mutation when the target changes so a
@@ -109,9 +116,10 @@ export function JoinLeagueConfirmSheet({ league, onCancel, onJoined }: Props) {
               <View style={styles.actions}>
                 <Button title="Cancel" variant="ghost" onPress={onCancel} />
                 <Button
-                  title={joinMutation.isPending ? 'Joining…' : 'Join'}
+                  title={closed ? 'Closed' : joinMutation.isPending ? 'Joining…' : 'Join'}
                   onPress={() => joinMutation.mutate(league.id)}
                   loading={joinMutation.isPending}
+                  disabled={closed}
                 />
               </View>
             </>

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { Modal, View, StyleSheet, ScrollView, Pressable } from 'react-native';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { Text } from '@/src/components/ui/AppText';
+import { Button } from '@/src/components/ui/Button';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { leaguesApi, leaguesKeys, type PublicLeague } from '@/src/services/api/leaguesApi';
+import { standingsKeys } from '@/src/hooks/useStandings';
+import { JoinClosesLabel } from './JoinClosesLabel';
+import {
+  SPORT_LABEL,
+  PICK_TYPE_LABEL,
+  TIEBREAKER_LABEL,
+  windowLabel,
+} from './joinDisplay';
+
+interface Props {
+  /** The league to confirm joining; null closes the sheet. */
+  league: PublicLeague | null;
+  onCancel: () => void;
+  /** Called after a successful join (parent navigates / refetches). */
+  onJoined: (league: PublicLeague) => void;
+}
+
+/**
+ * Confirmation sheet shown before joining a public league — joining has no
+ * self-serve undo, so the details render on the join path itself (parity with
+ * sd-ui's JoinLeagueConfirmDialog). Owns the join mutation + cache
+ * invalidation so both the home rail and the browse screen stay thin.
+ */
+export function JoinLeagueConfirmSheet({ league, onCancel, onJoined }: Props) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const queryClient = useQueryClient();
+
+  const joinMutation = useMutation({
+    mutationFn: () => leaguesApi.joinLeague(league!.id),
+    onSuccess: async () => {
+      // The joined league leaves discovery and enters My Leagues/standings.
+      await queryClient.invalidateQueries({ queryKey: leaguesKeys.public });
+      await queryClient.invalidateQueries({ queryKey: leaguesKeys.mine });
+      await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
+      if (league) onJoined(league);
+    },
+  });
+
+  const Row = ({ label, value }: { label: string; value: string }) => (
+    <View style={styles.row}>
+      <Text style={[styles.rowLabel, { color: theme.textMuted }]}>{label}</Text>
+      <Text style={[styles.rowValue, { color: theme.text }]}>{value}</Text>
+    </View>
+  );
+
+  return (
+    <Modal
+      visible={league != null}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <Pressable style={styles.backdrop} onPress={onCancel}>
+        {/* Inner press swallows taps so tapping the card doesn't dismiss. */}
+        <Pressable
+          style={[styles.sheet, { backgroundColor: theme.card, borderColor: theme.border }]}
+          onPress={() => {}}
+        >
+          {league && (
+            <>
+              <Text style={[styles.title, { color: theme.text }]}>Join {league.name}?</Text>
+              {league.description ? (
+                <Text style={[styles.desc, { color: theme.textMuted }]}>{league.description}</Text>
+              ) : null}
+
+              <ScrollView style={styles.rows} contentContainerStyle={{ gap: 2 }}>
+                <Row
+                  label="Sport"
+                  value={`${SPORT_LABEL[league.sport] ?? league.sport} ${league.seasonYear}`}
+                />
+                <Row
+                  label="Pick Type"
+                  value={`${PICK_TYPE_LABEL[league.pickType] ?? '—'}${
+                    league.useConfidencePoints ? ' with Confidence Points' : ''
+                  }`}
+                />
+                <Row
+                  label="Tiebreaker"
+                  value={TIEBREAKER_LABEL[league.tiebreakerType] ?? league.tiebreakerType}
+                />
+                <Row
+                  label="Drop Low Weeks"
+                  value={league.dropLowWeeksCount > 0 ? String(league.dropLowWeeksCount) : 'None — all weeks count'}
+                />
+                <Row label="League Window" value={windowLabel(league.startsOn, league.endsOn)} />
+                <Row label="Members" value={String(league.memberCount)} />
+                <Row label="Commissioner" value={league.commissioner} />
+                <View style={styles.row}>
+                  <Text style={[styles.rowLabel, { color: theme.textMuted }]}>Joining</Text>
+                  <JoinClosesLabel closesAtUtc={league.closesAtUtc} isJoinable={league.isJoinable} />
+                </View>
+              </ScrollView>
+
+              {joinMutation.isError ? (
+                <Text style={[styles.error, { color: theme.error }]}>
+                  Couldn&apos;t join the league. Please try again.
+                </Text>
+              ) : null}
+
+              <View style={styles.actions}>
+                <Button title="Cancel" variant="ghost" onPress={onCancel} />
+                <Button
+                  title={joinMutation.isPending ? 'Joining…' : 'Join'}
+                  onPress={() => joinMutation.mutate()}
+                  loading={joinMutation.isPending}
+                />
+              </View>
+            </>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  sheet: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 20,
+    maxHeight: '85%',
+  },
+  title: { fontSize: 18, fontWeight: '700', marginBottom: 4 },
+  desc: { fontSize: 14, marginBottom: 10 },
+  rows: { marginBottom: 12 },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 6,
+    gap: 12,
+  },
+  rowLabel: { fontSize: 13, fontWeight: '600' },
+  rowValue: { fontSize: 13, flexShrink: 1, textAlign: 'right' },
+  error: { fontSize: 13, marginBottom: 8 },
+  actions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 10 },
+});

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Modal, View, StyleSheet, ScrollView, Pressable } from 'react-native';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { Text } from '@/src/components/ui/AppText';
 import { Button } from '@/src/components/ui/Button';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
-import { leaguesApi, leaguesKeys, type PublicLeague } from '@/src/services/api/leaguesApi';
-import { standingsKeys } from '@/src/hooks/useStandings';
+import { type PublicLeague } from '@/src/services/api/leaguesApi';
+import { useJoinLeagueMutation } from '@/src/hooks/useJoinLeagueMutation';
 import { JoinClosesLabel } from './JoinClosesLabel';
 import {
   SPORT_LABEL,
@@ -33,18 +32,18 @@ interface Props {
 export function JoinLeagueConfirmSheet({ league, onCancel, onJoined }: Props) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
-  const queryClient = useQueryClient();
 
-  const joinMutation = useMutation({
-    mutationFn: () => leaguesApi.joinLeague(league!.id),
-    onSuccess: async () => {
-      // The joined league leaves discovery and enters My Leagues/standings.
-      await queryClient.invalidateQueries({ queryKey: leaguesKeys.public });
-      await queryClient.invalidateQueries({ queryKey: leaguesKeys.mine });
-      await queryClient.invalidateQueries({ queryKey: standingsKeys.me });
-      if (league) onJoined(league);
-    },
+  const joinMutation = useJoinLeagueMutation(() => {
+    if (league) onJoined(league);
   });
+
+  // The sheet is a single persistent component reused across leagues; only the
+  // `league` prop changes. Reset the mutation when the target changes so a
+  // prior failure's error doesn't bleed into the next league's sheet.
+  useEffect(() => {
+    joinMutation.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [league?.id]);
 
   const Row = ({ label, value }: { label: string; value: string }) => (
     <View style={styles.row}>
@@ -111,7 +110,7 @@ export function JoinLeagueConfirmSheet({ league, onCancel, onJoined }: Props) {
                 <Button title="Cancel" variant="ghost" onPress={onCancel} />
                 <Button
                   title={joinMutation.isPending ? 'Joining…' : 'Join'}
-                  onPress={() => joinMutation.mutate()}
+                  onPress={() => joinMutation.mutate(league.id)}
                   loading={joinMutation.isPending}
                 />
               </View>

--- a/src/UI/sd-mobile/src/components/features/leagues/joinDisplay.ts
+++ b/src/UI/sd-mobile/src/components/features/leagues/joinDisplay.ts
@@ -1,0 +1,100 @@
+import type { PublicLeague } from '@/src/services/api/leaguesApi';
+
+// Web parity: SPORT_LABEL / PICK_TYPE_LABEL / countdown behavior mirror
+// sd-ui's discovery components so the two apps read the same.
+// See docs/mobile/web-parity-join-discovery.md.
+
+export const SPORT_LABEL: Record<PublicLeague['sport'], string> = {
+  FootballNcaa: 'NCAAFB',
+  FootballNfl: 'NFL',
+  BaseballMlb: 'MLB',
+};
+
+export const SPORT_ICON: Record<PublicLeague['sport'], string> = {
+  FootballNcaa: '🏈',
+  FootballNfl: '🏈',
+  BaseballMlb: '⚾',
+};
+
+// PublicLeague.pickType is the BE enum's int value.
+export const PICK_TYPE_LABEL: Record<number, string> = {
+  1: 'SU',
+  2: 'ATS',
+  3: 'O/U',
+};
+
+// Live countdown only inside this window — "closes in 4 months" is noise.
+// Operator-set threshold (matches sd-ui's JoinClosesLabel): ~10 days.
+export const COUNTDOWN_WINDOW_MS = 10 * 24 * 60 * 60 * 1000;
+
+/** Human "Xd Yh" / "Yh Zm" / "Zm" for a positive remaining-ms. */
+export function formatRemaining(ms: number): string {
+  const totalMinutes = Math.max(0, Math.floor(ms / 60000));
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+  const minutes = totalMinutes % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+export interface JoinClosesState {
+  text: string;
+  /** "countdown" inside the 10-day window; "closed"; else "open"/"date". */
+  kind: 'open' | 'date' | 'countdown' | 'closed';
+}
+
+/**
+ * The join-status text for a league at time `now`. Mirrors sd-ui:
+ *   closed / past   -> "Closed"
+ *   > 10 days out   -> "Closes Sep 15"
+ *   <= 10 days      -> "Closes in 2d 4h"
+ *   no closesAtUtc  -> "Open"
+ */
+export function joinClosesState(
+  closesAtUtc: string | null | undefined,
+  isJoinable: boolean,
+  now: number,
+): JoinClosesState {
+  const closesMs = closesAtUtc ? new Date(closesAtUtc).getTime() : NaN;
+
+  if (isJoinable === false || (Number.isFinite(closesMs) && closesMs - now <= 0)) {
+    return { text: 'Closed', kind: 'closed' };
+  }
+  if (!Number.isFinite(closesMs)) {
+    return { text: 'Open', kind: 'open' };
+  }
+
+  const remaining = closesMs - now;
+  if (remaining <= COUNTDOWN_WINDOW_MS) {
+    return { text: `Closes in ${formatRemaining(remaining)}`, kind: 'countdown' };
+  }
+
+  const d = new Date(closesMs);
+  const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return { text: `Closes ${label}`, kind: 'date' };
+}
+
+// BE enum names -> user-facing phrasing (mirrors sd-ui's create form).
+export const TIEBREAKER_LABEL: Record<string, string> = {
+  TotalPoints: 'Closest total points',
+  HomeAndAwayScores: 'Home and away scores',
+  EarliestSubmission: 'Earliest submission',
+};
+
+const fmtDate = (iso: string | null): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? null
+    : d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+};
+
+/** "Full Season" / "Sep 1 – Sep 30" / "From Sep 1" / "Through Sep 30". */
+export function windowLabel(startsOn: string | null, endsOn: string | null): string {
+  const s = fmtDate(startsOn);
+  const e = fmtDate(endsOn);
+  if (!s && !e) return 'Full Season';
+  if (s && e) return `${s} – ${e}`;
+  return s ? `From ${s}` : `Through ${e}`;
+}

--- a/src/UI/sd-mobile/src/components/features/leagues/useLiveJoinState.ts
+++ b/src/UI/sd-mobile/src/components/features/leagues/useLiveJoinState.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { COUNTDOWN_WINDOW_MS, joinClosesState, type JoinClosesState } from './joinDisplay';
+
+// setTimeout treats delays above 2^31-1 ms (~24.8 days) as 0.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+const TICK_MS = 60 * 1000;
+
+/**
+ * Live join-status for a league: recomputes as the clock crosses the 10-day
+ * countdown window and the close instant, so a screen left open transitions
+ * date -> countdown -> Closed on its own. This is the single source of truth
+ * for both the JoinClosesLabel display AND the Join affordances — a Join
+ * button must not stay enabled after the countdown reaches zero.
+ */
+export function useLiveJoinState(
+  closesAtUtc: string | null | undefined,
+  isJoinable: boolean,
+): JoinClosesState {
+  const [now, setNow] = useState(() => Date.now());
+
+  const closesMs = closesAtUtc ? new Date(closesAtUtc).getTime() : NaN;
+  const remaining = closesMs - now;
+  const inCountdown =
+    Number.isFinite(closesMs) && remaining > 0 && remaining <= COUNTDOWN_WINDOW_MS;
+
+  useEffect(() => {
+    if (!Number.isFinite(closesMs) || remaining <= 0) return undefined;
+    if (inCountdown) {
+      // Minute tick; the render after the tick that crosses zero flips to Closed.
+      const id = setInterval(() => setNow(Date.now()), TICK_MS);
+      return () => clearInterval(id);
+    }
+    // Outside the window: one timer aimed at the boundary.
+    const untilWindow = Math.min(remaining - COUNTDOWN_WINDOW_MS, MAX_TIMEOUT_MS);
+    const id = setTimeout(() => setNow(Date.now()), Math.max(untilWindow, TICK_MS));
+    return () => clearTimeout(id);
+  }, [closesMs, inCountdown, remaining]);
+
+  return joinClosesState(closesAtUtc, isJoinable, now);
+}

--- a/src/UI/sd-mobile/src/components/features/leagues/useLiveJoinState.ts
+++ b/src/UI/sd-mobile/src/components/features/leagues/useLiveJoinState.ts
@@ -25,14 +25,21 @@ export function useLiveJoinState(
 
   useEffect(() => {
     if (!Number.isFinite(closesMs) || remaining <= 0) return undefined;
-    if (inCountdown) {
-      // Minute tick; the render after the tick that crosses zero flips to Closed.
-      const id = setInterval(() => setNow(Date.now()), TICK_MS);
-      return () => clearInterval(id);
-    }
-    // Outside the window: one timer aimed at the boundary.
-    const untilWindow = Math.min(remaining - COUNTDOWN_WINDOW_MS, MAX_TIMEOUT_MS);
-    const id = setTimeout(() => setNow(Date.now()), Math.max(untilWindow, TICK_MS));
+
+    // A single re-arming timeout that fires at the EARLIEST instant the state
+    // could change (the effect re-runs on each fire because `now` updates):
+    //   - inside the countdown window: the next minute tick (refresh the
+    //     "Closes in Xm" display) OR the close instant, whichever comes first
+    //     — so a league closing mid-view flips to Closed exactly on time, not
+    //     up to a minute late (which would leave Join enabled in the gap);
+    //   - outside the window: the moment `remaining` crosses into the 10-day
+    //     countdown window.
+    const nextChange = inCountdown
+      ? Math.min(TICK_MS, remaining)
+      : remaining - COUNTDOWN_WINDOW_MS;
+    const delay = Math.max(0, Math.min(nextChange, MAX_TIMEOUT_MS));
+
+    const id = setTimeout(() => setNow(Date.now()), delay);
     return () => clearTimeout(id);
   }, [closesMs, inCountdown, remaining]);
 

--- a/src/UI/sd-mobile/src/hooks/useJoinLeagueMutation.ts
+++ b/src/UI/sd-mobile/src/hooks/useJoinLeagueMutation.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
+import { standingsKeys } from '@/src/hooks/useStandings';
+
+/**
+ * The single "join a league" mutation, shared by the invite-preview screen and
+ * the discovery confirm sheet so the two can't drift (they had: the invite
+ * screen previously invalidated only standingsKeys.me, leaving the discover
+ * list stale after a join).
+ *
+ * On success it invalidates every surface a new membership affects — the
+ * public discovery list (the league leaves it), My Leagues, and /user/me
+ * (which drives the picks league selector) — then hands the joined id to the
+ * caller for navigation.
+ */
+export function useJoinLeagueMutation(onJoined?: (leagueId: string) => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (leagueId: string) => leaguesApi.joinLeague(leagueId),
+    onSuccess: async (_data, leagueId) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: leaguesKeys.public }),
+        queryClient.invalidateQueries({ queryKey: leaguesKeys.mine }),
+        queryClient.invalidateQueries({ queryKey: standingsKeys.me }),
+      ]);
+      onJoined?.(leagueId);
+    },
+  });
+}

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -10,6 +10,11 @@ export type TiebreakerType = 'TotalPoints' | 'HomeAndAwayScores' | 'EarliestSubm
 // Only one value today; kept as a union so adding more is a no-code-change lift.
 export type TiebreakerTiePolicy = 'EarliestSubmission';
 
+/** Matches SportsData.Api.Application.Common.Enums.JoinPolicy (by name).
+ *  Commissioner INPUT; the read-side truth for "can I still join?" is
+ *  closesAtUtc / isJoinable on the DTO. */
+export type JoinPolicy = 'Open' | 'CloseAtFirstGame';
+
 // NCAA ranking-filter enum names accepted by the BE (null = no filter).
 export type NcaaRankingFilter =
   | 'AP_TOP_5'
@@ -64,6 +69,7 @@ export interface LeagueMember {
 export const leaguesKeys = {
   mine: ['leagues', 'mine'] as const,
   detail: (id: string) => ['league', id] as const,
+  public: ['leagues', 'public'] as const,
 };
 
 /** A registered user invitable to a league (from invite search). No email. */
@@ -104,6 +110,43 @@ export interface LeagueDetail {
   isMember: boolean;
   /** The roster. Empty for non-members (invite preview, public browse). */
   members: LeagueMember[];
+  /** Join policy the commissioner chose; render `closesAtUtc`/`isJoinable`
+   *  for the actual state, not this. */
+  joinPolicy: JoinPolicy;
+  /** Computed instant joining closes; null = open with no fixed deadline. */
+  closesAtUtc: string | null;
+  /** False once closed/deactivated — gates the Join affordance. */
+  isJoinable: boolean;
+}
+
+/**
+ * A public league the caller can browse and (maybe) join. Mirrors the BE
+ * PublicLeagueDto. Sport/League/PickType are the BE ENUM values (Sport/League
+ * as names, PickType as its int); render helpers map them to labels.
+ */
+export interface PublicLeague {
+  id: string;
+  name: string;
+  description: string;
+  commissioner: string;
+  rankingFilter: number;
+  /** PickType int: 1=StraightUp, 2=AgainstTheSpread, 3=OverUnder. */
+  pickType: number;
+  useConfidencePoints: boolean;
+  dropLowWeeksCount: number;
+  sport: 'FootballNcaa' | 'FootballNfl' | 'BaseballMlb';
+  league: 'NCAAF' | 'NFL' | 'MLB' | 'NBA';
+  seasonYear: number;
+  memberCount: number;
+  startsOn: string | null;
+  endsOn: string | null;
+  tiebreakerType: TiebreakerType;
+  tiebreakerTiePolicy: TiebreakerTiePolicy;
+  joinPolicy: JoinPolicy;
+  /** When joining closes; null = open with no fixed deadline. */
+  closesAtUtc: string | null;
+  /** False once closed — badge/hide rather than offering a Join that 400s. */
+  isJoinable: boolean;
 }
 
 // Matches SportsData.Api.Application.UI.Leagues.Dtos.LeagueSummaryDto.
@@ -175,6 +218,12 @@ export const leaguesApi = {
   // POST /ui/leagues/baseball/mlb — admin-gated on the BE.
   createBaseballMlbLeague: (payload: CreateBaseballMlbLeagueRequest) =>
     apiClient.post<CreateLeagueResponse>('/ui/leagues/baseball/mlb', payload),
+
+  // GET /ui/leagues/discover — public leagues the caller isn't in and that
+  // are still joinable (the BE filters deactivated + already-member; closed
+  // ones may still appear, badged via isJoinable).
+  getPublicLeagues: () =>
+    apiClient.get<PublicLeague[]>('/ui/leagues/discover'),
 
   // GET /ui/leagues/{id} — league detail for the invite preview.
   getLeagueById: (id: string) =>


### PR DESCRIPTION
Brings the join-policy discovery UX (web #576/#577) to mobile. **Client-only** — the BE and API shipped with the web work; every endpoint is already live. Parity plan and frozen contracts: `docs/mobile/web-parity-join-discovery.md`.

## Find and join a public league, matching sd-ui

- **Home "Leagues you can join" rail** (`JoinableLeaguesCard`) as Tier 3, rendered for **every** user and self-nulling when nothing is joinable — so a league-less user lands on actionable joins, not only the new-user slot. This is the landing-page difference @jrandallsexton noticed. Same eyebrow/chevron chrome as `YourLeaguesCard`.
- **Public browse screen** (`app/league/discover.tsx`) — full list; closed leagues badged with a disabled affordance rather than a Join that 400s.
- **`JoinLeagueConfirmSheet`** — details before an irreversible join (sport/season, pick type + confidence, tiebreaker, drop weeks, window, members, commissioner, closes-countdown). Owns the join mutation + cache invalidation so the rail and browse stay thin; routes to the joined league's picks on success.
- **`JoinClosesLabel`** — live 10-day countdown → plain date → "Closed", with a boundary timer so a long-open screen transitions without reload. Mirrors sd-ui's component exactly.
- **Invite-preview screen** gains the closed-state ("no longer accepting new members") — a shared invite link outlives the join window, and the BE gate would reject the join.

## Contract discipline

Shared logic (`joinDisplay.ts`) is factored so the countdown thresholds, sport labels, and window/tiebreaker phrasing match web; a unit test locks the four join-status states against drift. API client gains `getPublicLeagues` + `PublicLeague`; `joinPolicy` / `closesAtUtc` / `isJoinable` added to `LeagueDetail`.

## Validation

`tsc --noEmit` clean; **91 jest tests pass** (7 new for `joinDisplay`). Verified on-device: rail, browse, confirm sheet, closed-invite state.

## Deferred to Phase 2

Create-side parity — join-policy choice + Week Range picker in the mobile create flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mobile public-league discovery with details, availability status, pull-to-refresh, and empty/error states.
  - Added home-screen access to joinable leagues, including for users without existing leagues.
  - Added join confirmation, progress/error handling, and navigation to picks after joining.
  - Added live join-window messaging with countdowns, closing dates, and closed-state explanations.
  - Added league metadata for season windows, pick types, sports, and tiebreakers.
- **Documentation**
  - Added a mobile parity plan for discovery, joining, and future league creation.
- **Tests**
  - Added coverage for join statuses, countdowns, expiration, and season-window labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->