### PR TITLE
fix(mobile): allow landscape on tablets; keep phones portrait-locked

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "SportDeets",
     "slug": "sportdeets",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "sportdeets",

--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -3,7 +3,7 @@
     "name": "SportDeets",
     "slug": "sportdeets",
     "version": "1.0.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "sportdeets",
     "userInterfaceStyle": "automatic",

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -14,13 +14,14 @@ import { useFonts } from 'expo-font';
 import { Poppins_400Regular, Poppins_700Bold_Italic } from '@expo-google-fonts/poppins';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import * as Notifications from 'expo-notifications';
 // Type-only import — erased at compile time. The runtime module is loaded via a
 // gated dynamic import below so it never enters the web bundle (RNFirebase has
 // no web implementation).
 import { type FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import { useEffect, useRef, useState } from 'react';
-import { Platform } from 'react-native';
+import { Dimensions, Platform } from 'react-native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react-native';
 import 'react-native-reanimated';
@@ -113,6 +114,26 @@ function RootLayout() {
     Poppins_400Regular,
     Poppins_700Bold_Italic,
   });
+
+  // Orientation policy. app.json declares "default" (rotation allowed) so
+  // Android tablets get real landscape width instead of Android 12L+'s
+  // letterboxed portrait column (portrait-locked apps are pillarboxed on
+  // large screens, which starved the responsive layouts of width). Phones
+  // keep the previous portrait-only behavior via this runtime lock; the
+  // phone layouts are portrait-designed. Smallest screen dimension < 600dp
+  // is the phone/tablet boundary — Android's own sw600dp convention. iPads
+  // already rotated freely (supportsTablet) and are >= 600dp, so iOS
+  // behavior is unchanged.
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+    const { width, height } = Dimensions.get('screen');
+    if (Math.min(width, height) < 600) {
+      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP).catch((e) => {
+        // A failed lock leaves rotation enabled — cosmetic, not fatal.
+        Sentry.captureException(e);
+      });
+    }
+  }, []);
 
   // Kick off Firebase auth listener immediately.
   useAuthInit();

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -124,6 +124,12 @@ function RootLayout() {
   // is the phone/tablet boundary — Android's own sw600dp convention. iPads
   // already rotated freely (supportsTablet) and are >= 600dp, so iOS
   // behavior is unchanged.
+  //
+  // PORTRAIT_UP (not PORTRAIT) is deliberate: upside-down portrait is
+  // hardware-unsupported on all Face ID iPhones, and the previous Android
+  // manifest behavior under orientation "portrait" was portrait-up only —
+  // PORTRAIT would newly enable reverse-portrait on Android phones rather
+  // than preserve the old behavior.
   useEffect(() => {
     if (Platform.OS === 'web') return;
     const { width, height } = Dimensions.get('screen');

--- a/src/UI/sd-mobile/package-lock.json
+++ b/src/UI/sd-mobile/package-lock.json
@@ -32,6 +32,7 @@
         "expo-modules-core": "~55.0.25",
         "expo-notifications": "~55.0.23",
         "expo-router": "~55.0.14",
+        "expo-screen-orientation": "~55.0.18",
         "expo-splash-screen": "~55.0.21",
         "expo-status-bar": "~55.0.6",
         "expo-symbols": "~55.0.8",
@@ -7278,6 +7279,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-screen-orientation": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-55.0.18.tgz",
+      "integrity": "sha512-Y/u4rTUoxQVyW2kAgqljgxd1HmRvALhFZLMxcDvY1aclhh29PcA0JzvCXO1mVixidOv5WFDtOFROUkA6C7FhFA==",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-server": {

--- a/src/UI/sd-mobile/package.json
+++ b/src/UI/sd-mobile/package.json
@@ -62,6 +62,7 @@
     "expo-modules-core": "~55.0.25",
     "expo-notifications": "~55.0.23",
     "expo-router": "~55.0.14",
+    "expo-screen-orientation": "~55.0.18",
     "expo-splash-screen": "~55.0.21",
     "expo-status-bar": "~55.0.6",
     "expo-symbols": "~55.0.8",


### PR DESCRIPTION
## Problem

Android tablet testing (7" and 10" AVDs) for the Play Store submission surfaced that the app renders as a letterboxed portrait column in landscape on Android tablets — the tablet-responsive layouts (home, picks, leagues) never engage. Android 12L+ letterboxes portrait-locked apps on large screens instead of stretching them, so the width-driven responsive code was starved of real width. iPad is unaffected because iOS with supportsTablet allows all orientations regardless of the portrait preference.

## Fix

- **app.json**: `orientation: portrait` → `default` — rotation allowed at the manifest level. Native config change; requires a fresh build (not OTA).
- **_layout.tsx**: runtime lock keeps screens with smallest dimension < 600dp (Android's own sw600dp phone/tablet boundary) locked to PORTRAIT_UP — existing phone behavior preserved on both platforms; tablets rotate freely. Web untouched; a failed lock reports to Sentry rather than crashing.
- **expo-screen-orientation ~55.0.18** added via `npx expo install` (SDK 55 pinned).

## Validation

- `tsc --noEmit` clean
- Jest: 96/96 pass
- Post-merge: new preview APK to be validated on 7"/10" AVDs (landscape multi-column, phone still portrait-locked) and iPhone/iPad sanity pass before the production AAB for Play upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive orientation behavior for mobile devices.
  * Smaller screens remain locked to portrait mode, while larger screens and web support the default orientation.
  * Updated the mobile app version to 1.0.1.

* **Bug Fixes**
  * Orientation-locking errors are now captured for monitoring without preventing app startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->