### PR TITLE
fix(web): replace stream webcam icon with Game Preview link on scheduled games

### DIFF
--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-import { Webcam } from "lucide-react";
 import { FaCheck } from "react-icons/fa";
 import { contestLink } from '../../utils/sportLinks';
 import FootballGameStatusInProgress from './FootballGameStatusInProgress';
@@ -84,7 +83,6 @@ function GameStatus({
   leagueSport,
   sport,
   league,
-  streamScheduledTimeUtc,
   // Pick-mode-aware result indicator inputs. pickType drives which
   // outcome we summarize ("X covered" / "Over 8.5 ✓" / "✓ NYY"); the
   // *FranchiseSeasonId fields come off the canonical Contest row and
@@ -239,17 +237,22 @@ function GameStatus({
         {broadcasts && <div>{broadcasts}</div>}
         <div>{venue} | {location}</div>
       </div>
-      {streamScheduledTimeUtc && contestId && (
-        <div className="game-result game-result-stream">
+      {/* Bottom-of-status affordance for "open the Contest Overview" —
+          mirrors mobile's OverviewLink ("Game Preview ›" on scheduled
+          games). Replaces the old webcam icon + "View" block, which was
+          an internal marker for stream-scheduled games but read to users
+          like a watch-the-game link. Renders for every scheduled game
+          with a contestId, matching mobile. */}
+      {contestId && (
+        <div className="game-preview-link-row">
           <Link
             to={contestLink(contestId, sport, league)}
-            className="final-score-link"
+            className="game-preview-link"
             target="_blank"
             rel="noopener noreferrer"
-            aria-label={`View live stream: ${awayShort ?? 'Away'} at ${homeShort ?? 'Home'}${gameTime ? `, ${gameTime}` : ''}`}
+            aria-label={`Game preview: ${awayShort ?? 'Away'} at ${homeShort ?? 'Home'}${gameTime ? `, ${gameTime}` : ''}`}
           >
-            <Webcam size={16} aria-hidden="true" />
-            <span style={{ marginLeft: 6 }}>View</span>
+            Game Preview ›
           </Link>
         </div>
       )}

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -242,8 +242,11 @@ function GameStatus({
           games). Replaces the old webcam icon + "View" block, which was
           an internal marker for stream-scheduled games but read to users
           like a watch-the-game link. Renders for every scheduled game
-          with a contestId, matching mobile. */}
-      {contestId && (
+          with a contestId, matching mobile. The explicit STATUS_SCHEDULED
+          check keeps the link out of this branch's other role as the
+          defensive fallback for unrecognized status strings (mobile
+          renders those as a bare label with no link). */}
+      {contestId && status === 'STATUS_SCHEDULED' && (
         <div className="game-preview-link-row">
           <Link
             to={contestLink(contestId, sport, league)}

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -314,6 +314,11 @@
   text-decoration: underline;
 }
 
+.game-preview-link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
 .result-label {
   font-size: 0.75rem;
   font-weight: 600;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -292,6 +292,28 @@
   color: var(--accent);
 }
 
+/* "Game Preview ›" link below the scheduled-game time/venue block.
+   Mirrors mobile's OverviewLink affordance (small accent-colored text
+   link). Replaced the old webcam-icon "View" block, which implied a
+   watchable stream. */
+.game-preview-link-row {
+  text-align: center;
+  margin-top: 4px;
+}
+
+.game-preview-link {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.game-preview-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
 .result-label {
   font-size: 0.75rem;
   font-weight: 600;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -282,7 +282,6 @@ function MatchupCard({
           leagueSport={leagueSport}
           sport={sportLeague?.sport}
           league={sportLeague?.league}
-          streamScheduledTimeUtc={matchup.streamScheduledTimeUtc}
           // Final-score quick-scan indicator inputs. pickType is the
           // league's mode; the *FranchiseSeasonId/Result/spread fields
           // come off the canonical Contest row populated by enrichment.


### PR DESCRIPTION
## Problem

Scheduled MatchupCards rendered a webcam icon + "View" link (`game-result-stream`) for games scheduled for live processing. That was an internal operator marker, but to users it implies the game can literally be watched in-app. Stream scheduling has been live-tested for 30+ days — the marker has outlived its purpose.

## Change

Web now mirrors mobile's `OverviewLink` affordance: a **Game Preview ›** text link to the contest overview, rendered for every scheduled game with a `contestId` (mobile never gated this on stream scheduling).

- `GameStatus.jsx` — webcam block removed, Game Preview link added, `streamScheduledTimeUtc` prop dropped (it only fed the old gate), `Webcam` import removed
- `MatchupCard.jsx` — stops passing `streamScheduledTimeUtc`
- `MatchupCard.css` — `.game-preview-link` styles mirroring mobile (0.75rem / 600 / accent / centered / hover underline)

## Validation

- Web tests: 10/10 pass
- Production build: clean
- Visual check by user on local

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled games with a contest now display a clearly styled “Game Preview” link.
  * Improved accessibility text, hover behavior, and keyboard focus styling make the preview link easier to understand and use.

* **Bug Fixes**
  * Replaced the conditional webcam stream link with consistent game preview access for scheduled contests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->