### PR TITLE
fix(web,mobile): single-card grid stretch; season-phase dividers on mobile TeamCard

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/team/[slug].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/team/[slug].tsx
@@ -268,16 +268,32 @@ export default function TeamCard() {
             Schedule ({selectedSeason})
           </Text>
           {team.schedule?.length ? (
-            team.schedule.map((game, idx) => (
-              <ScheduleRow
-                key={game.contestId ?? idx}
-                game={game}
-                teamName={team.name}
-                season={selectedSeason}
-                sport={sport}
-                league={league}
-              />
-            ))
+            team.schedule.map((game, idx) => {
+              // Schedule is date-ordered and phases are chronologically
+              // contiguous (Preseason -> Regular Season -> Postseason), so a
+              // phase-changed check emits one divider per phase. Mirrors
+              // web's TeamSchedule phase header rows.
+              const prevPhase = idx > 0 ? team.schedule![idx - 1].seasonPhase : null;
+              const showPhaseHeader = !!game.seasonPhase && game.seasonPhase !== prevPhase;
+              return (
+                <React.Fragment key={game.contestId ?? idx}>
+                  {showPhaseHeader ? (
+                    <View style={[styles.phaseHeaderRow, { borderBottomColor: theme.separator }]}>
+                      <Text style={[styles.phaseHeaderText, { color: theme.tint }]}>
+                        {game.seasonPhase}
+                      </Text>
+                    </View>
+                  ) : null}
+                  <ScheduleRow
+                    game={game}
+                    teamName={team.name}
+                    season={selectedSeason}
+                    sport={sport}
+                    league={league}
+                  />
+                </React.Fragment>
+              );
+            })
           ) : (
             <Text style={[styles.emptyText, { color: theme.textMuted }]}>No games scheduled.</Text>
           )}
@@ -325,6 +341,21 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
     gap: 10,
+  },
+  // Season-phase divider row (Preseason / Regular Season / Postseason) —
+  // parity with web's schedule-phase-row. Styled as a compact section
+  // label between game rows.
+  phaseHeaderRow: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  phaseHeaderText: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
   },
   gameDate: { fontSize: 11, width: 72 },
   gameMiddle: { flex: 1, gap: 2 },

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -423,6 +423,12 @@ export interface ContestOverviewDto {
 
 export interface TeamCardScheduleGame {
   date: string;
+  /**
+   * Season phase name from the backend ("Preseason" | "Regular Season" |
+   * "Postseason"). Drives the phase divider rows in the TeamCard schedule
+   * (parity with web's TeamSchedule). Nullable defensively for legacy rows.
+   */
+  seasonPhase?: string | null;
   opponent: string;
   opponentSlug?: string | null;
   location?: string | null;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -315,7 +315,7 @@
 }
 
 .game-preview-link:focus-visible {
-  outline: 2px solid currentColor;
+  outline: 2px solid currentcolor;
   outline-offset: 2px;
 }
 

--- a/src/UI/sd-ui/src/components/matchups/MatchupList.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupList.css
@@ -9,7 +9,7 @@
 @media (min-width: 768px) {
   .matchup-list {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 20px;
   }
 }
@@ -17,7 +17,7 @@
 /* Large desktop - allow more columns with smaller minimum width */
 @media (min-width: 1200px) {
   .matchup-list {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     gap: 24px;
   }
 }
@@ -25,7 +25,7 @@
 /* Extra large screens - optimize for 32" monitors and similar */
 @media (min-width: 1600px) {
   .matchup-list {
-    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
     gap: 28px;
   }
 }
@@ -33,7 +33,7 @@
 /* Ultra wide screens - 4+ columns for very large monitors */
 @media (min-width: 2000px) {
   .matchup-list {
-    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
     gap: 32px;
   }
 } 


### PR DESCRIPTION
## Changes

### 1. Web — single game no longer stretches full-width (`MatchupList.css`)

An NFL preseason week with one game exposed that `repeat(auto-fit, ...)` collapses empty tracks — a lone MatchupCard stretched across the entire container (~1500px). Swapped `auto-fit` → `auto-fill` in all four breakpoints: empty tracks are kept, so a lone card occupies a normal single-column slot. Matches mobile, which pads incomplete FlatList rows with spacers. Full weeks render identically (every track occupied).

### 2. Mobile — season-phase dividers on TeamCard schedule (parity)

Web's TeamSchedule recently gained phase header rows (Preseason / Regular Season / Postseason). Mobile now renders the same delineation: compact uppercase accent label rows between phases, using the same contiguous-phase logic (date-ordered schedule; divider emitted on phase change). The shared `/ui/teamcard` endpoint already ships `seasonPhase` — mobile's `TeamCardScheduleGame` type now declares it. JS-only; ships via EAS update.

### 3. Web — `currentcolor` casing (`MatchupCard.css`)

Stylelint nit from #587, merged before the one-character fix could ride along.

## Validation

- Mobile: `tsc --noEmit` clean, Jest 96/96
- Web: production build clean
- Both verified visually by user locally (Expo dev server for mobile, localhost for web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team schedules now display clear dividers for preseason, regular season, and postseason games.
* **Improvements**
  * Matchup grids now use available screen space more consistently across desktop and larger displays.
  * Improved responsive layout behavior while preserving existing column sizing and spacing.
* **Style**
  * Standardized keyboard-focus outline styling for matchup links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->