### PR TITLE
feat(web,mobile): invitation polish; Player Pick'em teaser

### DIFF
--- a/docs/features/player-pickem.md
+++ b/docs/features/player-pickem.md
@@ -1,0 +1,277 @@
+# Player Pick'em
+
+## Overview
+
+Allow users to pick position players (QB, RB, WR, TE, K, etc.) as well as
+teams (DEF) — much as is done for Fantasy Football.
+
+However, there is **zero draft**. Users can pick any player even if others
+in their league have picked them. No ownership, no waivers, no trades.
+
+This is not a game based on drafting the correct players, but a game of
+**knowing the best matchups from week to week**.
+
+The thesis, in one exchange: "Yeah, you have Joe Smith — but he's going
+against Michigan this weekend. I'm taking Joe Blow; they're playing
+UAB." A stud facing a Top-10 defense can be the worse play than a
+lesser-known player facing an overmatched opponent. Surfacing exactly
+that judgment is the game — and the AI insights product.
+
+**Tagline: "Know the matchups. Win the league."**
+
+A "teaser" for this upcoming functionality will ship to both web and mobile
+ahead of the feature itself to stir interest (see Teaser below).
+
+---
+
+## Competitive landscape and the design risk
+
+Why this game shape is rarely seen — and why the empty space is both the
+opportunity and the one real design risk.
+
+**The adjacent products all exist; none occupy this quadrant:**
+
+- **DFS (DraftKings / FanDuel)** — "no draft, any players, weekly
+  lineups" ... but with a **salary cap and entry fees**. Closest
+  mechanical neighbor.
+- **Best Ball (Underdog, Yahoo)** — dropped in-season management but
+  KEPT the draft; the draft is the product.
+- **Player-prop pick games (PrizePicks, Underdog Picks, Sleeper
+  Picks)** — over/under threshold picks; the shape this feature
+  deliberately rejects (gambling-classification exposure).
+- **Season-long fantasy (ESPN / Yahoo / Sleeper)** — the draft is the
+  identity; scarcity/ownership is the whole game.
+- Occasional free "pick a weekly lineup" promo games have existed, but
+  nobody has made it *the* product with real league infrastructure
+  (invites, discovery, standings, message boards) around it.
+
+The quadrant this feature occupies — **no draft, no salary cap, no
+money, league-social** — is genuinely sparse.
+
+**Why the quadrant is empty (respect this): the salary cap in DFS is not
+a monetization gimmick — it is the differentiation engine.** Without a
+cap or scarcity, every rational player picks the consensus studs,
+lineups converge, and the week is decided by whichever FLEX got lucky.
+Convergence-to-consensus is the failure mode that has kept this game
+shape unexplored.
+
+Note the risk is **sport-asymmetric**: it is at its worst in the NFL
+(shallow elite pool + industrial consensus rankings) and diminishes
+sharply in NCAAFB (huge pool, no public college-fantasy consensus,
+matchup-driven variance) — a major input to the NCAAFB-first decision
+above.
+
+**Why this design believes it survives anyway** (from the original
+2026-07 analysis):
+
+1. Shared slots are **neutral** slots — identical picks cancel, moving
+   the contest to the slots where entries diverge. Convergence
+   sharpens the skill test rather than breaking it.
+2. Multi-slot rosters make FULL convergence combinatorially unlikely;
+   identical complete lineups ≈ never.
+3. DEF / FLEX / K are natural divergence points (DEF-by-matchup
+   especially — a pure weekly knowledge play).
+4. The framing is *stronger* without a cap: DFS tests "who optimizes
+   under a constraint"; this tests purely **"who reads matchups
+   better."** That is also exactly the question the AI insights
+   product answers — which is why the subscription synergy is
+   structural, not bolted on.
+
+**But that is a hypothesis, and the backtest exists to test it.** Run
+the draft scoring table over a past season; simulate a "consensus"
+lineup (weekly stud-picks) against plausible divergent lineups; check
+whether the leaderboard actually separates. Outcomes:
+
+- Divergence pays → the empty quadrant was an oversight; we're early.
+- Consensus dominates → tune the scoring BEFORE building UI
+  (threshold/ceiling bonuses widen divergence vs. floor-heavy
+  continuous scoring) and re-run.
+
+Either way the dragon is confronted for the price of a query, right
+after the athlete-stats audit confirms the data exists.
+
+**Overall take:** justified excitement, one known dragon, and a cheap
+test that either slays it or teaches us how to. The mechanic is
+unproven, not disproven — and the pieces that make it viable here
+(league infrastructure already built, college/NFL data pipeline, AI
+matchup insights as the paid companion) are precisely the assets a
+generic competitor lacks.
+
+---
+
+## Product decisions
+
+### Decided
+
+1. **Scoring model: performance points, NOT player props.**
+   Players earn points from real statistical performance. Example: a QB
+   passing for 200 yards scores X; reaching 300 scores Y. The scoring
+   config supports both continuous accrual (points per yard/reception/TD)
+   and threshold bonuses (hit 300 passing yards → bonus) — the exact rule
+   set is a config decision, not an architecture decision.
+
+   Deliberately rejected: over/under threshold *picks* ("will player X
+   exceed N yards?"). That is structurally a player prop — the
+   PrizePicks/Underdog shape that has drawn gambling-classification
+   challenges in multiple states. Even free-to-play, it would change our
+   store content-rating posture. Performance scoring sits inside the
+   long-established fantasy-sports carve-out.
+
+2. **Weekly lineups with carry-over.**
+   Users CAN change their lineup every week, but selections carry over
+   from the previous week as the starting point for the next. Starting
+   every user from an empty lineup weekly would be a retention killer;
+   carry-over means the default action is "tweak," not "rebuild."
+   Implication: the weekly rollover job clones the prior week's lineup
+   into the new week (excluding players on bye / inactive — see Open
+   Questions), and users edit from there.
+
+3. **No draft, unrestricted selection.** Any user may roster any player
+   regardless of other members' choices. The skill expression is matchup
+   evaluation, not scarcity management.
+
+4. **Built on the existing league infrastructure.** This is a new league
+   type on PickemGroup, not a parallel system. Invites, join policy +
+   expiry, public discovery, pending-invitation cards, standings,
+   message boards — all inherited. The delta is the pick entity (weekly
+   lineup), the scoring engine, and the player-facing UI.
+
+5. **NCAAFB first** (reversed from an initial NFL-first lean,
+   2026-08-04). Three reasons, in order:
+   - **The convergence risk is sport-asymmetric.** The NFL consensus
+     machine (shallow elite pool, weekly rankings everywhere) makes
+     stud-stacking trivial — the exact failure mode in Competitive
+     Landscape below. College inverts every input: 130+ FBS teams,
+     thousands of players, NO mainstream weekly fantasy consensus to
+     copy, and a talent gradient that makes production violently
+     matchup-dependent. The divergence the game needs occurs naturally.
+   - **The v1 audience is the founder's own league — NCAAFB people.**
+     The first season lives or dies on dogfooding; build where the
+     test community actually plays.
+   - **The college data pipeline is the moat.** College fantasy is a
+     wasteland because of the data problem this platform spent 2.5
+     years solving. Build where the unique asset is everyone else's
+     barrier to entry.
+
+   NFL follows once the game proves out (larger mainstream draw; also
+   the sport where scoring-table tuning against convergence matters
+   most). Costs accepted with NCAAFB-first: much larger player pool
+   (a picker-UX problem — search + AI insights carry it) and roster
+   churn/transfer-portal noise. The athlete-stat audit covers BOTH
+   sports.
+
+6. **AI insights are the companion product.** Player-matchup insights
+   ("this WR faces a bottom-5 pass defense") are exactly the
+   subscription content already planned (AI previews / DeetsMeter). The
+   game creates weekly demand for the insights; the insights make the
+   game winnable for engaged users. Free game, paid brainpower.
+
+### Open
+
+1. **Lineup shape** — proposed: 1 QB / 2 RB / 2 WR / 1 TE / 1 FLEX /
+   1 K / 1 DEF (classic), configurable per league later. Needs a call on
+   whether v1 offers config or one fixed shape (recommend fixed for v1).
+2. **Lock granularity** — recommend per-player lock at that player's
+   kickoff (a Thursday player locks Thursday; the rest of the lineup
+   stays editable). A single weekly lock is simpler but makes Thursday
+   slots dead weight. Per-player locking is real engine work; decide
+   before schema design.
+3. **Scoring rule set v1** — the specific points table (per-yard rates,
+   TD values, threshold bonuses, DEF scoring). Needs a worked draft +
+   validation against a few real 2025 box scores.
+4. **Carry-over edge cases** — bye weeks, injured/inactive players,
+   players who changed teams. Proposal: carry the player over regardless
+   but badge the problem ("BYE", "OUT") loudly; auto-dropping surprises
+   users more than a flagged empty-ish slot.
+5. **Standings math** — weekly points summed season-long? Weekly
+   head-to-head? Recommend cumulative points with weekly winners
+   highlighted (matches existing pick'em standings mental model; no
+   schedule pairing needed).
+
+---
+
+## Data requirements (the gating factor)
+
+Scoring requires **per-player, per-game box-score statistics** in the
+canonical store. Current known state:
+
+- Player/athlete entities: sourced (Player service; ESPN athletes,
+  including rosters via franchise-season).
+- Team-level game statistics: canonicalized
+  (CompetitionCompetitorStatistics).
+- **Per-athlete game statistics: UNVERIFIED.** Whether ESPN's per-athlete
+  event statistics documents are currently captured by Provider and
+  processed into canonical rows by Producer must be audited before any
+  timeline is promised. This is the first concrete task (read-only
+  audit; see also docs/features/espn-processor-data-capture-audit.md).
+
+If athlete box scores are not yet ingested, the long pole is:
+Provider capture → Producer processor(s) → canonical player-game-stat
+rows → scoring engine. If they are, the long pole shrinks to the scoring
+engine + UI.
+
+Not required for v1: injury reports, depth charts, projections, live
+in-progress scoring (post-game scoring is fine; live comes later and
+feeds the Command Center vision).
+
+---
+
+## Architecture sketch
+
+New pieces (names illustrative):
+
+- **League type**: PickemGroup gains a player-pickem variant (enum or
+  discriminator — decide during design). All membership/discovery
+  machinery reused.
+- **Lineup entities**: PlayerLineup (group, user, week) +
+  PlayerLineupSlot (position slot, athleteId, lockedUtc). Weekly
+  rollover clones week N's lineup into week N+1 (carry-over decision).
+- **Scoring config**: per-league scoring rule set (v1: one fixed rule
+  set; schema shaped for per-league config later).
+- **Scoring engine**: on game finalization, resolve each locked slot's
+  athlete game stats → points; write per-slot and per-lineup results
+  (mirrors the existing pick-scoring flow on game finalization).
+- **API surface** (BFF, `/ui/leagues/...`): player search/browse with
+  matchup context (opponent, opponent's positional rank later), lineup
+  get/put, weekly + season standings.
+- **UI**: lineup screen (web + mobile), player picker with matchup
+  context, results/standings views. The picker is the largest UI item —
+  it must answer "who SHOULD I pick this week?" which is where the AI
+  insights slot in.
+
+---
+
+## Teaser (ships first, independent of everything above)
+
+A "Coming Soon: Player Pick'em" card on the web + mobile home pages.
+Design chosen (2026-08-04): the **lineup-slot banner** — an empty roster
+row (QB filled/pulsing accent, the rest dashed) that shows the game
+rather than describing it. Built entirely from existing tokens; one
+flourish (field hash marks along the bottom edge).
+
+- Slot row uses COUNTS, not duplicates: "RB ×2", "WR ×2" — density wins
+  in an advertisement. The gameplay lineup UI uses individual slots
+  (each is a distinct interactive target holding a distinct player).
+- Copy direction: "Pick any players. No draft. No ownership. Just
+  matchups." No dates, no betting-flavored language.
+- Static/dismissible; no interactivity required for v1 of the teaser.
+  (Optional later: an "I'm interested" tap for demand signal.)
+- Mobile ships via EAS update (JS-only) — deliberately NOT part of the
+  initial Play Store AAB; store submission is not gated on this.
+
+---
+
+## Sequencing
+
+1. Play Store submission proceeds (independent).
+2. **Audit**: per-athlete game-stat capture state (read-only, one
+   session). Converts "a few weeks" into an estimate.
+3. **Backtest**: draft scoring table run over a past season;
+   consensus-vs-divergent lineup comparison (see Competitive landscape
+   above). Validates "fun" before any UI exists.
+4. Decisions: lineup shape, lock granularity, scoring table v1
+   (informed by the backtest), carry-over edge cases, standings math.
+5. Design doc v2 with schema + processor plan (await authorization
+   before build).
+6. Teaser ships (any time after 1; independent of 2–5). Status: built
+   on web + mobile 2026-08-04, in tree awaiting bundle/PR.

--- a/docs/features/player-pickem.md
+++ b/docs/features/player-pickem.md
@@ -245,9 +245,12 @@ New pieces (names illustrative):
 
 A "Coming Soon: Player Pick'em" card on the web + mobile home pages.
 Design chosen (2026-08-04): the **lineup-slot banner** — an empty roster
-row (QB filled/pulsing accent, the rest dashed) that shows the game
-rather than describing it. Built entirely from existing tokens; one
-flourish (field hash marks along the bottom edge).
+row (QB filled in accent, the rest dashed) that shows the game rather
+than describing it. Built entirely from existing tokens. Platform
+difference: the web QB slot pulses; mobile renders it static
+(deliberate — an infinite animation on a phone home screen costs
+battery for no message gain). The field hash-mark flourish was cut
+during preview.
 
 - Slot row uses COUNTS, not duplicates: "RB ×2", "WR ×2" — density wins
   in an advertisement. The gameplay lineup UI uses individual slots

--- a/src/UI/sd-mobile/app/(tabs)/index.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
 import { useCurrentUser } from '@/src/hooks/useStandings';
 import { getLeagues } from '@/src/lib/leagues';
 import { PrimarySlotOffSeasonCountdown } from '@/src/components/features/home/PrimarySlotOffSeasonCountdown';
+import { PlayerPickemTeaserCard } from '@/src/components/features/home/PlayerPickemTeaserCard';
 import { PendingInvitesCard } from '@/src/components/features/home/PendingInvitesCard';
 import { YourLeaguesCard } from '@/src/components/features/home/YourLeaguesCard';
 import { JoinableLeaguesCard } from '@/src/components/features/home/JoinableLeaguesCard';
@@ -91,23 +92,27 @@ export default function HomeScreen() {
         <View style={styles.twoCol}>
           <View style={styles.col}>
             <PrimarySlotOffSeasonCountdown />
+            {/* Directly below the countdown — web parity: HomePage places
+                the teaser between the countdown and Pending Invitations. */}
+            <PlayerPickemTeaserCard />
           </View>
           <View style={styles.col}>
+            {/* Above Your Leagues — an unanswered invite is the most
+                actionable thing on the page. Web parity: HomePage renders
+                PendingInvitesCard before YourLeaguesCard. Self-nulls when
+                there are none. */}
+            <PendingInvitesCard />
             <YourLeaguesCard leagues={leagues} />
           </View>
         </View>
       ) : (
         <>
           <PrimarySlotOffSeasonCountdown />
+          <PlayerPickemTeaserCard />
+          <PendingInvitesCard />
           {hasLeagues && <YourLeaguesCard leagues={leagues} />}
         </>
       )}
-
-      {/* Pending league invitations — above discovery because an unanswered
-          invite is the most actionable thing on the page. Self-nulls when
-          there are none. Closes the notification-badge-but-nothing-in-app
-          gap. Web parity: HomePage. */}
-      <PendingInvitesCard />
 
       {/* Tier 3 — public-league discovery. Rendered for every user (self-nulls
           when nothing is joinable), so a league-less user lands on actionable
@@ -126,5 +131,6 @@ const styles = StyleSheet.create({
   // Countdown | leagues side by side; top-aligned so the leagues list can grow
   // without stretching the countdown column.
   twoCol: { flexDirection: 'row', gap: 16, alignItems: 'flex-start' },
-  col: { flex: 1 },
+  // gap covers the invites + leagues stack sharing the right column.
+  col: { flex: 1, gap: 16 },
 });

--- a/src/UI/sd-mobile/src/components/features/home/PendingInvitesCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PendingInvitesCard.tsx
@@ -12,6 +12,7 @@ import {
   type PendingInvitation,
 } from '@/src/services/api/leaguesApi';
 import { JoinLeagueConfirmSheet } from '@/src/components/features/leagues/JoinLeagueConfirmSheet';
+import { JoinClosesLabel } from '@/src/components/features/leagues/JoinClosesLabel';
 import { SPORT_ICON, SPORT_LABEL } from '@/src/components/features/leagues/joinDisplay';
 
 /**
@@ -69,10 +70,21 @@ export function PendingInvitesCard() {
                 <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>
                   {league.name}
                 </Text>
-                <Text style={[styles.meta, { color: theme.textMuted }]} numberOfLines={1}>
-                  {SPORT_ICON[league.sport] ?? '🏆'} {SPORT_LABEL[league.sport] ?? league.sport}{' '}
-                  {league.seasonYear} · Invited by {invite.invitedBy}
-                </Text>
+                {/* Wrapping row so the JoinClosesLabel (with its live
+                    countdown) can flow after the static meta — same shape
+                    as JoinableLeaguesCard's metaRow. */}
+                <View style={styles.metaRow}>
+                  <Text style={[styles.meta, { color: theme.textMuted }]}>
+                    {SPORT_ICON[league.sport] ?? '🏆'} {SPORT_LABEL[league.sport] ?? league.sport}{' '}
+                    {league.seasonYear} · Invited by {invite.invitedBy} ·{' '}
+                  </Text>
+                  <JoinClosesLabel
+                    closesAtUtc={league.closesAtUtc}
+                    isJoinable={league.isJoinable}
+                    verb="Expires"
+                    style={styles.meta}
+                  />
+                </View>
                 {errorId === invite.invitationId ? (
                   <Text style={[styles.errorText, { color: theme.error }]}>
                     Failed — try again
@@ -144,7 +156,8 @@ const styles = StyleSheet.create({
   },
   info: { flex: 1, minWidth: 0 },
   name: { fontSize: 15, fontWeight: '600' },
-  meta: { fontSize: 12, marginTop: 2 },
+  metaRow: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', marginTop: 2 },
+  meta: { fontSize: 12 },
   errorText: { fontSize: 12, marginTop: 2, fontWeight: '600' },
   actions: { flexDirection: 'row', gap: 8 },
   declineBtn: {

--- a/src/UI/sd-mobile/src/components/features/home/PlayerPickemTeaserCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PlayerPickemTeaserCard.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+
+// Dismissal survives sessions — a teaser that resurrects every launch is an
+// ad, not an announcement. Mirrors web's localStorage key semantics.
+const DISMISSED_KEY = 'playerPickemTeaserDismissed';
+
+// Teaser lineup shape (illustrative — the real lineup shape is a v1 design
+// decision, see docs/features/player-pickem.md). Counts, not duplicate
+// boxes: density wins in an advertisement; the gameplay UI will render
+// individual slots. Mirrors web's PlayerPickemTeaserCard.
+const SLOTS: { label: string; filled?: boolean; count?: number }[] = [
+  { label: 'QB', filled: true },
+  { label: 'RB', count: 2 },
+  { label: 'WR', count: 2 },
+  { label: 'TE' },
+  { label: 'FLEX' },
+  { label: 'K' },
+  { label: 'DEF' },
+];
+
+/**
+ * "Coming Soon: Player Pick'em" teaser — the lineup-slot banner (design
+ * chosen 2026-08-04; docs/features/player-pickem.md). The empty roster row
+ * shows the game rather than describing it: QB filled in accent, the rest
+ * dashed ("yours to pick"). No dates, no interactivity beyond dismiss.
+ * Web parity: sd-ui's PlayerPickemTeaserCard (minus the pulse — static on
+ * mobile). Renders nothing until the persisted dismissal has been read, so
+ * a dismissed card never flashes on launch.
+ */
+export function PlayerPickemTeaserCard() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  // null = not yet hydrated from AsyncStorage.
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(DISMISSED_KEY)
+      .then((v) => {
+        if (!cancelled) setDismissed(v === 'true');
+      })
+      .catch(() => {
+        if (!cancelled) setDismissed(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (dismissed !== false) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    // Fire-and-forget — a failed write just means the teaser returns next
+    // launch, which is harmless.
+    AsyncStorage.setItem(DISMISSED_KEY, 'true').catch(() => {});
+  };
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <TouchableOpacity
+        onPress={dismiss}
+        style={styles.dismiss}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss announcement"
+      >
+        <Text style={[styles.dismissText, { color: theme.textMuted }]}>✕</Text>
+      </TouchableOpacity>
+
+      <Text style={[styles.eyebrow, { color: theme.tint }]}>COMING SOON</Text>
+      <Text style={[styles.title, { color: theme.text }]}>Player Pick’em</Text>
+      <Text style={[styles.pitch, { color: theme.textMuted }]}>
+        Pick any players, any week — no draft, no ownership. Know the matchups
+        better than your league and prove it.
+      </Text>
+
+      <View style={styles.slotRow}>
+        {SLOTS.map((slot) => (
+          <View
+            key={slot.label}
+            style={[
+              styles.slot,
+              { borderColor: theme.textMuted },
+              slot.filled && {
+                borderStyle: 'solid',
+                borderColor: theme.tint,
+                backgroundColor: theme.accentSubtle,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.slotText,
+                { color: slot.filled ? theme.tint : theme.textMuted },
+              ]}
+            >
+              {slot.label}
+              {slot.count ? <Text style={styles.slotCount}> ×{slot.count}</Text> : null}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+  },
+  dismiss: {
+    position: 'absolute',
+    top: 10,
+    right: 12,
+    zIndex: 1,
+    padding: 4,
+  },
+  dismissText: { fontSize: 14, fontWeight: '600' },
+  eyebrow: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '800',
+    marginTop: 2,
+    marginBottom: 2,
+  },
+  pitch: {
+    fontSize: 13,
+    marginBottom: 12,
+  },
+  slotRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  slot: {
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    minWidth: 34,
+    alignItems: 'center',
+  },
+  slotText: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+  },
+  slotCount: {
+    fontWeight: '400',
+    letterSpacing: 0,
+  },
+});

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinClosesLabel.tsx
@@ -4,10 +4,13 @@ import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import { useLiveJoinState } from './useLiveJoinState';
+import type { JoinClosesVerb } from './joinDisplay';
 
 interface Props {
   closesAtUtc: string | null | undefined;
   isJoinable: boolean;
+  /** "Closes" (join windows — default) or "Expires" (invitations). */
+  verb?: JoinClosesVerb;
   style?: StyleProp<TextStyle>;
 }
 
@@ -17,10 +20,10 @@ interface Props {
  * boundary timer so a long-lived screen transitions date -> countdown ->
  * Closed without a reload.
  */
-export function JoinClosesLabel({ closesAtUtc, isJoinable, style }: Props) {
+export function JoinClosesLabel({ closesAtUtc, isJoinable, verb, style }: Props) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
-  const state = useLiveJoinState(closesAtUtc, isJoinable);
+  const state = useLiveJoinState(closesAtUtc, isJoinable, verb);
   // Countdown draws attention; every other state is muted.
   const color = state.kind === 'countdown' ? theme.tint : theme.textMuted;
 

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
@@ -119,7 +119,13 @@ export function JoinLeagueConfirmSheet({ league, invitationId, onCancel, onJoine
                 <Row label="Commissioner" value={league.commissioner} />
                 <View style={styles.row}>
                   <Text style={[styles.rowLabel, { color: theme.textMuted }]}>Joining</Text>
-                  <JoinClosesLabel closesAtUtc={league.closesAtUtc} isJoinable={league.isJoinable} />
+                  {/* Invitation accepts phrase this as expiry — an invitation
+                      expires; a league's join window closes. */}
+                  <JoinClosesLabel
+                    closesAtUtc={league.closesAtUtc}
+                    isJoinable={league.isJoinable}
+                    verb={invitationId ? 'Expires' : 'Closes'}
+                  />
                 </View>
               </ScrollView>
 

--- a/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/JoinLeagueConfirmSheet.tsx
@@ -17,6 +17,7 @@ import {
   PICK_TYPE_LABEL,
   TIEBREAKER_LABEL,
   windowLabel,
+  type JoinClosesVerb,
 } from './joinDisplay';
 
 interface Props {
@@ -53,10 +54,19 @@ export function JoinLeagueConfirmSheet({ league, invitationId, onCancel, onJoine
   // Both hooks always mount (rules of hooks); invitationId picks the active one.
   const joinMutation = invitationId ? acceptInvite : publicJoin;
 
+  // Single verb derivation for every surface in the sheet — the "Joining"
+  // row AND the disabled button title. An invitation expires; a league's
+  // join window closes.
+  const closesVerb: JoinClosesVerb = invitationId ? 'Expires' : 'Closes';
+
   // Live join state (ticks past the countdown/close instant) — a league can
   // close while the sheet is open, so Join disables rather than submitting a
   // join the BE would reject.
-  const joinState = useLiveJoinState(league?.closesAtUtc ?? null, league?.isJoinable ?? true);
+  const joinState = useLiveJoinState(
+    league?.closesAtUtc ?? null,
+    league?.isJoinable ?? true,
+    closesVerb,
+  );
   const closed = joinState.kind === 'closed';
 
   // The sheet is a single persistent component reused across leagues; only the
@@ -119,12 +129,10 @@ export function JoinLeagueConfirmSheet({ league, invitationId, onCancel, onJoine
                 <Row label="Commissioner" value={league.commissioner} />
                 <View style={styles.row}>
                   <Text style={[styles.rowLabel, { color: theme.textMuted }]}>Joining</Text>
-                  {/* Invitation accepts phrase this as expiry — an invitation
-                      expires; a league's join window closes. */}
                   <JoinClosesLabel
                     closesAtUtc={league.closesAtUtc}
                     isJoinable={league.isJoinable}
-                    verb={invitationId ? 'Expires' : 'Closes'}
+                    verb={closesVerb}
                   />
                 </View>
               </ScrollView>
@@ -138,7 +146,9 @@ export function JoinLeagueConfirmSheet({ league, invitationId, onCancel, onJoine
               <View style={styles.actions}>
                 <Button title="Cancel" variant="ghost" onPress={onCancel} />
                 <Button
-                  title={closed ? 'Closed' : joinMutation.isPending ? 'Joining…' : 'Join'}
+                  // joinState.text is "Closed" / "Expired" in the closed
+                  // state, matching the sheet's verb.
+                  title={closed ? joinState.text : joinMutation.isPending ? 'Joining…' : 'Join'}
                   onPress={() => joinMutation.mutate(invitationId ?? league.id)}
                   loading={joinMutation.isPending}
                   disabled={closed}

--- a/src/UI/sd-mobile/src/components/features/leagues/joinDisplay.ts
+++ b/src/UI/sd-mobile/src/components/features/leagues/joinDisplay.ts
@@ -44,9 +44,13 @@ export interface JoinClosesState {
   kind: 'open' | 'date' | 'countdown' | 'closed';
 }
 
+/** "Closes" for league join windows (default); "Expires" for invitations —
+ *  an invitation expires, a league's join window closes. */
+export type JoinClosesVerb = 'Closes' | 'Expires';
+
 /**
  * The join-status text for a league at time `now`. Mirrors sd-ui:
- *   closed / past   -> "Closed"
+ *   closed / past   -> "Closed" (or "Expired" with verb "Expires")
  *   > 10 days out   -> "Closes Sep 15"
  *   <= 10 days      -> "Closes in 2d 4h"
  *   no closesAtUtc  -> "Open"
@@ -55,11 +59,13 @@ export function joinClosesState(
   closesAtUtc: string | null | undefined,
   isJoinable: boolean,
   now: number,
+  verb: JoinClosesVerb = 'Closes',
 ): JoinClosesState {
   const closesMs = closesAtUtc ? new Date(closesAtUtc).getTime() : NaN;
+  const pastVerb = verb === 'Expires' ? 'Expired' : 'Closed';
 
   if (isJoinable === false || (Number.isFinite(closesMs) && closesMs - now <= 0)) {
-    return { text: 'Closed', kind: 'closed' };
+    return { text: pastVerb, kind: 'closed' };
   }
   if (!Number.isFinite(closesMs)) {
     return { text: 'Open', kind: 'open' };
@@ -67,12 +73,12 @@ export function joinClosesState(
 
   const remaining = closesMs - now;
   if (remaining <= COUNTDOWN_WINDOW_MS) {
-    return { text: `Closes in ${formatRemaining(remaining)}`, kind: 'countdown' };
+    return { text: `${verb} in ${formatRemaining(remaining)}`, kind: 'countdown' };
   }
 
   const d = new Date(closesMs);
   const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  return { text: `Closes ${label}`, kind: 'date' };
+  return { text: `${verb} ${label}`, kind: 'date' };
 }
 
 // BE enum names -> user-facing phrasing (mirrors sd-ui's create form).

--- a/src/UI/sd-mobile/src/components/features/leagues/useLiveJoinState.ts
+++ b/src/UI/sd-mobile/src/components/features/leagues/useLiveJoinState.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
-import { COUNTDOWN_WINDOW_MS, joinClosesState, type JoinClosesState } from './joinDisplay';
+import {
+  COUNTDOWN_WINDOW_MS,
+  joinClosesState,
+  type JoinClosesState,
+  type JoinClosesVerb,
+} from './joinDisplay';
 
 // setTimeout treats delays above 2^31-1 ms (~24.8 days) as 0.
 const MAX_TIMEOUT_MS = 2 ** 31 - 1;
@@ -15,6 +20,7 @@ const TICK_MS = 60 * 1000;
 export function useLiveJoinState(
   closesAtUtc: string | null | undefined,
   isJoinable: boolean,
+  verb?: JoinClosesVerb,
 ): JoinClosesState {
   const [now, setNow] = useState(() => Date.now());
 
@@ -43,5 +49,5 @@ export function useLiveJoinState(
     return () => clearTimeout(id);
   }, [closesMs, inCountdown, remaining]);
 
-  return joinClosesState(closesAtUtc, isJoinable, now);
+  return joinClosesState(closesAtUtc, isJoinable, now, verb);
 }

--- a/src/UI/sd-ui/src/components/home/HomePage.jsx
+++ b/src/UI/sd-ui/src/components/home/HomePage.jsx
@@ -1,6 +1,7 @@
 import "./HomePage.css";
 import { useUserDto } from "../../contexts/UserContext";
 import PrimarySlotOffSeasonCountdown from "./PrimarySlotOffSeasonCountdown";
+import PlayerPickemTeaserCard from "./PlayerPickemTeaserCard";
 import PendingInvitesCard from "./PendingInvitesCard";
 import YourLeaguesCard from "./YourLeaguesCard";
 import JoinableLeaguesCard from "./JoinableLeaguesCard";
@@ -48,6 +49,13 @@ function HomePage() {
     <div className="home-page">
       <section className="home-tier home-tier--primary">
         <PrimarySlotOffSeasonCountdown hasLeagues={hasLeagues} />
+      </section>
+
+      {/* Player Pick'em teaser — the coming-soon lineup-slot banner
+          (docs/features/player-pickem.md). Directly below the countdown;
+          dismissible, self-nulls once dismissed. */}
+      <section className="home-tier home-tier--context">
+        <PlayerPickemTeaserCard />
       </section>
 
       {/* Pending league invitations — above the league list because an

--- a/src/UI/sd-ui/src/components/home/PendingInvitesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/PendingInvitesCard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import LeaguesApi from "api/leagues/leaguesApi";
 import { useUserDto } from "../../contexts/UserContext";
+import JoinClosesLabel from "../leagues/JoinClosesLabel";
 import JoinLeagueConfirmDialog from "../leagues/JoinLeagueConfirmDialog";
 import "./PendingInvitesCard.css";
 
@@ -114,6 +115,12 @@ function PendingInvitesCard() {
                   <span aria-hidden="true">{SPORT_ICON[league.sport] ?? "🏆"}</span>{" "}
                   {SPORT_LABEL[league.sport] ?? league.sport} {league.seasonYear} ·
                   Invited by {invite.invitedBy}
+                  {" · "}
+                  <JoinClosesLabel
+                    closesAtUtc={league.closesAtUtc}
+                    isJoinable={league.isJoinable}
+                    verb="Expires"
+                  />
                   {state === "error" && (
                     <span className="pending-invite-error"> · Failed — try again</span>
                   )}
@@ -144,6 +151,7 @@ function PendingInvitesCard() {
       {/* Same dialog as discovery — league parameters shown before joining. */}
       <JoinLeagueConfirmDialog
         league={confirming?.league ?? null}
+        closesVerb="Expires"
         onCancel={() => setConfirming(null)}
         onConfirm={() => confirming && accept(confirming)}
       />

--- a/src/UI/sd-ui/src/components/home/PlayerPickemTeaserCard.css
+++ b/src/UI/sd-ui/src/components/home/PlayerPickemTeaserCard.css
@@ -1,0 +1,103 @@
+/* PlayerPickemTeaserCard — "Coming Soon" lineup-slot banner. Same card
+   chrome family as the other home cards; the slot row is the pitch. */
+.pickem-teaser {
+  background-color: var(--bg-card);
+  border: 1px solid var(--accent-subtle);
+  border-radius: 14px;
+  box-shadow: var(--shadow-md);
+  padding: 1.15rem 1.35rem 1.25rem;
+  max-width: 880px;
+  box-sizing: border-box;
+  margin: 0 auto;
+  color: var(--text-primary);
+  position: relative;
+  overflow: hidden;
+}
+
+.pickem-teaser-dismiss {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: none;
+  border: none;
+  color: var(--text-muted, #8d96a0);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.pickem-teaser-dismiss:hover,
+.pickem-teaser-dismiss:focus-visible {
+  color: var(--text-primary);
+  outline: 1px solid var(--accent-subtle);
+}
+
+/* Matches the sibling home cards' eyebrow treatment. */
+.pickem-teaser-eyebrow {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.pickem-teaser-title {
+  font-size: 1.25rem;
+  font-weight: 800;
+  margin: 2px 0 4px;
+}
+
+.pickem-teaser-pitch {
+  color: var(--text-muted, #8d96a0);
+  font-size: 0.88rem;
+  margin: 0 0 14px;
+}
+
+.pickem-teaser-slots {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pickem-teaser-slot {
+  border: 1px dashed color-mix(in srgb, var(--text-muted, #8d96a0) 55%, transparent);
+  color: var(--text-muted, #8d96a0);
+  border-radius: 8px;
+  padding: 6px 12px;
+  min-width: 34px;
+  text-align: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.pickem-teaser-slot-count {
+  font-weight: 400;
+  opacity: 0.75;
+  letter-spacing: 0;
+}
+
+.pickem-teaser-slot--filled {
+  border-style: solid;
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .pickem-teaser-slot--filled {
+    animation: pickem-teaser-pulse 3.2s ease-in-out infinite;
+  }
+
+  @keyframes pickem-teaser-pulse {
+    0%,
+    100% {
+      background: color-mix(in srgb, var(--accent) 12%, transparent);
+    }
+    50% {
+      background: color-mix(in srgb, var(--accent) 22%, transparent);
+    }
+  }
+}

--- a/src/UI/sd-ui/src/components/home/PlayerPickemTeaserCard.jsx
+++ b/src/UI/sd-ui/src/components/home/PlayerPickemTeaserCard.jsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import "./PlayerPickemTeaserCard.css";
+
+// Dismissal survives sessions — a teaser that resurrects every visit is an
+// ad, not an announcement.
+const DISMISSED_KEY = "playerPickemTeaserDismissed";
+
+// Teaser lineup shape (illustrative — the real lineup shape is a v1 design
+// decision, see docs/features/player-pickem.md). Counts, not duplicate
+// boxes: density wins in an advertisement; the gameplay UI will render
+// individual slots.
+const SLOTS = [
+  { label: "QB", filled: true },
+  { label: "RB", count: 2 },
+  { label: "WR", count: 2 },
+  { label: "TE" },
+  { label: "FLEX" },
+  { label: "K" },
+  { label: "DEF" },
+];
+
+/**
+ * "Coming Soon: Player Pick'em" teaser — the lineup-slot banner concept
+ * (design chosen 2026-08-04; see docs/features/player-pickem.md). The empty
+ * roster row shows the game rather than describing it: QB filled in accent,
+ * the rest dashed ("yours to pick"). No dates, no interactivity beyond
+ * dismiss.
+ */
+function PlayerPickemTeaserCard() {
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISSED_KEY) === "true"
+  );
+
+  if (dismissed) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, "true");
+    setDismissed(true);
+  };
+
+  return (
+    <section className="pickem-teaser" aria-label="Coming soon: Player Pick'em">
+      <button
+        type="button"
+        className="pickem-teaser-dismiss"
+        aria-label="Dismiss announcement"
+        onClick={dismiss}
+      >
+        &times;
+      </button>
+      <div className="pickem-teaser-eyebrow">Coming Soon</div>
+      <div className="pickem-teaser-title">Player Pick&rsquo;em</div>
+      <p className="pickem-teaser-pitch">
+        Pick any players, any week &mdash; no draft, no ownership. Know the
+        matchups better than your league and prove it.
+      </p>
+      <div className="pickem-teaser-slots" aria-hidden="true">
+        {SLOTS.map((slot) => (
+          <div
+            key={slot.label}
+            className={`pickem-teaser-slot${slot.filled ? " pickem-teaser-slot--filled" : ""}`}
+          >
+            {slot.label}
+            {slot.count ? (
+              <span className="pickem-teaser-slot-count"> &times;{slot.count}</span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default PlayerPickemTeaserCard;

--- a/src/UI/sd-ui/src/components/leagues/JoinClosesLabel.jsx
+++ b/src/UI/sd-ui/src/components/leagues/JoinClosesLabel.jsx
@@ -30,7 +30,10 @@ const formatRemaining = (ms) => {
  *   - <= 10 days    -> live countdown, minute tick ("Closes in 2d 4h")
  *   - no value      -> "Open"
  */
-function JoinClosesLabel({ closesAtUtc, isJoinable }) {
+// verb: "Closes" (join windows - default) or "Expires" (invitations).
+// An invitation expires; a league's join window closes.
+function JoinClosesLabel({ closesAtUtc, isJoinable, verb = "Closes" }) {
+  const pastVerb = verb === "Expires" ? "Expired" : "Closed";
   const [now, setNow] = useState(() => Date.now());
 
   const closesMs = closesAtUtc ? new Date(closesAtUtc).getTime() : NaN;
@@ -56,7 +59,7 @@ function JoinClosesLabel({ closesAtUtc, isJoinable }) {
   }, [closesMs, inCountdownWindow, remaining]);
 
   if (isJoinable === false || (Number.isFinite(closesMs) && remaining <= 0)) {
-    return <span className="join-closes join-closes--closed">Closed</span>;
+    return <span className="join-closes join-closes--closed">{pastVerb}</span>;
   }
 
   if (!Number.isFinite(closesMs)) {
@@ -66,7 +69,7 @@ function JoinClosesLabel({ closesAtUtc, isJoinable }) {
   if (inCountdownWindow) {
     return (
       <span className="join-closes join-closes--countdown">
-        Closes in {formatRemaining(remaining)}
+        {verb} in {formatRemaining(remaining)}
       </span>
     );
   }
@@ -74,7 +77,7 @@ function JoinClosesLabel({ closesAtUtc, isJoinable }) {
   const d = new Date(closesMs);
   return (
     <span className="join-closes">
-      Closes {d.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+      {verb} {d.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
     </span>
   );
 }

--- a/src/UI/sd-ui/src/components/leagues/JoinLeagueConfirmDialog.jsx
+++ b/src/UI/sd-ui/src/components/leagues/JoinLeagueConfirmDialog.jsx
@@ -43,7 +43,9 @@ const windowLabel = (league) => {
   return start ? `From ${start}` : `Through ${end}`;
 };
 
-function JoinLeagueConfirmDialog({ league, onCancel, onConfirm }) {
+// closesVerb: "Closes" (public joins - default) or "Expires" (invitation
+// accepts) - an invitation expires; a league's join window closes.
+function JoinLeagueConfirmDialog({ league, onCancel, onConfirm, closesVerb = "Closes" }) {
   const dialogRef = useRef(null);
 
   // Keyboard modality: aria-modal alone constrains nothing. On open, move
@@ -145,7 +147,7 @@ function JoinLeagueConfirmDialog({ league, onCancel, onConfirm }) {
           </li>
           <li>
             <strong>Joining:</strong>{" "}
-            <JoinClosesLabel closesAtUtc={league.closesAtUtc} isJoinable={league.isJoinable} />
+            <JoinClosesLabel closesAtUtc={league.closesAtUtc} isJoinable={league.isJoinable} verb={closesVerb} />
           </li>
         </ul>
         <div className="join-confirm-actions">


### PR DESCRIPTION
## Invitation polish (follow-ups to #589)

- **Mobile card placement**: Pending Invitations moved **above** Your Leagues in both layouts (phone stack + tablet right column) — web parity.
- **Expiry on invitation rows** (both platforms): renders the `JoinClosesLabel` (live ≤10-day countdown included) from the `closesAtUtc`/`isJoinable` already embedded on each invitation's league. No BE change.
- **Vocabulary**: `JoinClosesLabel` gains a `verb` prop (`Closes` default / `Expires`, past tense `Closed`/`Expired`) — an invitation *expires*; a league's join window *closes*. Invitation surfaces (card + confirm dialog/sheet when opened from an invitation) say Expires; discovery and public joins keep Closes. One component, one wording switch — no forked label logic.

## Player Pick'em teaser

New "Coming Soon" card on web + mobile home, directly below the countdown — the lineup-slot banner design (see `docs/features/player-pickem.md`): QB slot filled in accent, remaining slots dashed, **counts not duplicate boxes** (RB ×2, WR ×2). Copy: no dates, no betting-flavored language.

- Dismissible, persisted (localStorage web / AsyncStorage mobile — mobile renders nothing until the flag hydrates, so a dismissed card never flashes on launch).
- Mobile omits the pulse animation deliberately (battery).
- `docs/features/player-pickem.md` rides along: full feature doc — decided (performance scoring not props; weekly carry-over lineups; NCAAFB-first with rationale), competitive-landscape/convergence-risk analysis, athlete-stat audit + backtest sequencing, chosen teaser design.

JS-only on mobile — ships via EAS update, independent of the Play Store AAB.

## Validation

- Mobile: `tsc --noEmit` clean, Jest 96/96
- Web: tests 10/10, production build clean
- Both previewed locally by user (teaser iterated: hash-mark flourish removed, pitch width fixed, italics dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismissible “Coming Soon” Player Pick’em teaser to web and mobile home screens.
  * Added a product specification outlining the Player Pick’em experience and rollout.
  * Added matchup-based lineup preview visuals to the teaser.

* **Improvements**
  * Invitation cards now show when an invitation expires.
  * Updated join-status wording to distinguish invitations that “Expire” from leagues that “Close.”
  * Improved card spacing and responsive home-screen layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->