### PR TITLE
fix(mobile): resolve manifest-merge conflict on FCM notification color

### DIFF
--- a/src/UI/sd-mobile/plugins/withFirebaseNotificationDefaults.js
+++ b/src/UI/sd-mobile/plugins/withFirebaseNotificationDefaults.js
@@ -53,7 +53,11 @@ const withFirebaseNotificationDefaults = (config) => {
       (item) => item.$?.['android:name'] === colorAttrs['android:name'],
     );
     if (existing) {
-      existing.$ = colorAttrs;
+      // Merge rather than replace so unrelated attributes another plugin may
+      // have set survive; android:value is removed explicitly because value
+      // and resource are mutually exclusive forms of the same meta-data.
+      existing.$ = { ...existing.$, ...colorAttrs };
+      delete existing.$['android:value'];
     } else {
       app['meta-data'].push({ $: colorAttrs });
     }

--- a/src/UI/sd-mobile/plugins/withFirebaseNotificationDefaults.js
+++ b/src/UI/sd-mobile/plugins/withFirebaseNotificationDefaults.js
@@ -20,6 +20,18 @@ const { withAndroidManifest, AndroidConfig } = require('@expo/config-plugins');
  */
 const withFirebaseNotificationDefaults = (config) => {
   return withAndroidManifest(config, (config) => {
+    // react-native-firebase_messaging's library manifest ships its OWN
+    // default_notification_color (@color/white). The manifest merger
+    // refuses two different values for the same key, so our color entry
+    // must carry tools:replace="android:resource" ("ours wins") — which
+    // requires the tools namespace on the manifest root. The icon entry
+    // has no library-side counterpart and needs no override.
+    const manifest = config.modResults.manifest;
+    manifest.$ = manifest.$ ?? {};
+    if (!manifest.$['xmlns:tools']) {
+      manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
+    }
+
     const app = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 
     AndroidConfig.Manifest.addMetaDataItemToMainApplication(
@@ -28,12 +40,23 @@ const withFirebaseNotificationDefaults = (config) => {
       '@drawable/notification_icon',
       'resource',
     );
-    AndroidConfig.Manifest.addMetaDataItemToMainApplication(
-      app,
-      'com.google.firebase.messaging.default_notification_color',
-      '@color/notification_icon_color',
-      'resource',
+
+    // Added manually (not via addMetaDataItemToMainApplication) because the
+    // helper has no way to attach the tools:replace attribute.
+    app['meta-data'] = app['meta-data'] ?? [];
+    const colorAttrs = {
+      'android:name': 'com.google.firebase.messaging.default_notification_color',
+      'android:resource': '@color/notification_icon_color',
+      'tools:replace': 'android:resource',
+    };
+    const existing = app['meta-data'].find(
+      (item) => item.$?.['android:name'] === colorAttrs['android:name'],
     );
+    if (existing) {
+      existing.$ = colorAttrs;
+    } else {
+      app['meta-data'].push({ $: colorAttrs });
+    }
 
     return config;
   });


### PR DESCRIPTION
## Problem

EAS Android build failed at `:app:processReleaseMainManifest`:

```
Attribute meta-data#com.google.firebase.messaging.default_notification_color@resource
value=(@color/notification_icon_color) from AndroidManifest.xml
is also present at [:react-native-firebase_messaging] AndroidManifest.xml value=(@color/white).
```

`react-native-firebase_messaging`'s library manifest ships its **own** default notification color, and the manifest merger refuses two different values for the same key.

## Fix

Exactly what the merger suggests: the color meta-data in `withFirebaseNotificationDefaults.js` now carries `tools:replace="android:resource"` (our value wins), with the `xmlns:tools` namespace ensured on the manifest root. The entry is added manually because `addMetaDataItemToMainApplication` can't attach `tools:` attributes. The **icon** meta-data has no library-side counterpart (it didn't conflict in the failed build) and stays on the helper unchanged.

## Validation

- `expo config --type prebuild` resolves the plugin cleanly
- Definitive proof is the next EAS build — config-plugin manifest mods only execute at prebuild time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android notification configuration so default notification colors are applied reliably.
  * Added safer manifest handling when overriding notification color settings, preventing conflicting values.
  * Preserved existing notification icon behavior while applying these updates.
  * Ensured notification settings remain compatible across Android configurations for more consistent notification appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->