### PR TITLE
fix(web,mobile): landing hero centering + copy; login button centering

### DIFF
--- a/src/UI/sd-mobile/src/components/features/home/PlayerPickemTeaserCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PlayerPickemTeaserCard.tsx
@@ -77,7 +77,7 @@ export function PlayerPickemTeaserCard() {
       <Text style={[styles.eyebrow, { color: theme.tint }]}>COMING SOON</Text>
       <Text style={[styles.title, { color: theme.text }]}>Player Pick’em</Text>
       <Text style={[styles.pitch, { color: theme.textMuted }]}>
-        Pick any players, any week — no draft, no ownership. Know the matchups
+        Pick any players, any week - no draft, no ownership. Know the matchups
         better than your league and prove it.
       </Text>
 

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -113,7 +113,7 @@ export function PrimarySlotOffSeasonCountdown() {
   const body = allLive
     ? 'Jump into your leagues and lock in your picks before the next kickoff.'
     : allGated
-      ? "Leagues open soon — we'll be ready before Week\u00A01."
+      ? "Leagues open soon - we'll be ready before Week\u00A01."
       : seasonYear
         ? `Spin up your ${seasonYear} pick'em league now so you're ready for Week\u00A01.`
         : "Spin up your pick'em league now so you're ready for Week\u00A01.";

--- a/src/UI/sd-ui/src/components/home/PlayerPickemTeaserCard.jsx
+++ b/src/UI/sd-ui/src/components/home/PlayerPickemTeaserCard.jsx
@@ -51,7 +51,7 @@ function PlayerPickemTeaserCard() {
       <div className="pickem-teaser-eyebrow">Coming Soon</div>
       <div className="pickem-teaser-title">Player Pick&rsquo;em</div>
       <p className="pickem-teaser-pitch">
-        Pick any players, any week &mdash; no draft, no ownership. Know the
+        Pick any players, any week - no draft, no ownership. Know the
         matchups better than your league and prove it.
       </p>
       <div className="pickem-teaser-slots" aria-hidden="true">

--- a/src/UI/sd-ui/src/components/landing/LandingHero.css
+++ b/src/UI/sd-ui/src/components/landing/LandingHero.css
@@ -1,8 +1,9 @@
 .landing-hero {
-  /* Fill the viewport MINUS the header (parent .landing-page is a flex
-     column). The old min-height: 100vh sat below the in-flow header, which
-     pushed the flex-centered content a header-height below the viewport's
-     optical center and added phantom scroll. */
+  /* Fill the viewport MINUS the header (parent .landing-above-fold is a
+     flex column holding only the header + this hero). The old
+     min-height: 100vh sat below the in-flow header, which pushed the
+     flex-centered content a header-height below the viewport's optical
+     center and added phantom scroll. */
   flex: 1;
   background: linear-gradient(to bottom, var(--bg-primary), var(--bg-card));
   display: flex;

--- a/src/UI/sd-ui/src/components/landing/LandingHero.css
+++ b/src/UI/sd-ui/src/components/landing/LandingHero.css
@@ -1,5 +1,9 @@
 .landing-hero {
-  min-height: 100vh;
+  /* Fill the viewport MINUS the header (parent .landing-page is a flex
+     column). The old min-height: 100vh sat below the in-flow header, which
+     pushed the flex-centered content a header-height below the viewport's
+     optical center and added phantom scroll. */
+  flex: 1;
   background: linear-gradient(to bottom, var(--bg-primary), var(--bg-card));
   display: flex;
   justify-content: center;

--- a/src/UI/sd-ui/src/components/landing/LandingHero.jsx
+++ b/src/UI/sd-ui/src/components/landing/LandingHero.jsx
@@ -6,8 +6,8 @@ function LandingHero() {
     <div className="landing-hero">
       <div className="hero-content">
         {/* <img src={Logo} alt="sportDeets Logo" className="hero-logo" /> */}
-        <h1>Win Your Picks. Crush Your Friends.<span className="tm-symbol">™</span></h1>
-        <p>Data-driven insights for <i>every</i> NCAA football matchup.</p>
+        <h1>Win Your Picks.<br />Crush Your Friends.<span className="tm-symbol">™</span></h1>
+        <p>Data-driven insights for <i>every</i> NCAAFB and NFL matchup.</p>
         <div className="hero-buttons">
           <Link to="/signup" className="primary-button">
             Get Started Free

--- a/src/UI/sd-ui/src/components/landing/LandingPage.css
+++ b/src/UI/sd-ui/src/components/landing/LandingPage.css
@@ -2,12 +2,23 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Smooth scrolling is motion - honor the OS-level opt-out. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 /* Header + hero together own exactly one viewport (features start below
    the fold). The hero flex-fills the space under the header, so its
    flex-centered content lands on the visible viewport's optical center -
    no hardcoded header height, no phantom scroll. */
 .landing-above-fold {
-  min-height: 100vh;
+  min-height: 100vh; /* fallback for browsers without dvh */
+  /* Dynamic viewport height: on mobile, 100vh includes the space behind
+     the browser chrome, overflowing the visible area; dvh tracks the
+     actual visible viewport as the chrome expands/collapses. */
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
 }

--- a/src/UI/sd-ui/src/components/landing/LandingPage.css
+++ b/src/UI/sd-ui/src/components/landing/LandingPage.css
@@ -1,4 +1,14 @@
 html {
-    scroll-behavior: smooth;
-  }
+  scroll-behavior: smooth;
+}
+
+/* Header + hero together own exactly one viewport (features start below
+   the fold). The hero flex-fills the space under the header, so its
+   flex-centered content lands on the visible viewport's optical center -
+   no hardcoded header height, no phantom scroll. */
+.landing-above-fold {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
   

--- a/src/UI/sd-ui/src/components/landing/LandingPage.jsx
+++ b/src/UI/sd-ui/src/components/landing/LandingPage.jsx
@@ -9,8 +9,13 @@ import LandingHeader from "./LandingHeader";
 function LandingPage() {
   return (
     <div className="landing-page">
-      <LandingHeader />
-      <LandingHero />
+      {/* Header + hero own exactly the first viewport: the hero flex-fills
+          the remainder under the header, so its content centers on the
+          visible screen and the feature sections start below the fold. */}
+      <div className="landing-above-fold">
+        <LandingHeader />
+        <LandingHero />
+      </div>
       <FeatureHighlights />
       <HowItWorks />
       <LandingFooter />

--- a/src/UI/sd-ui/src/components/login/Login.css
+++ b/src/UI/sd-ui/src/components/login/Login.css
@@ -6,13 +6,6 @@
   box-sizing: border-box;
 }
 
-.login-card form {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 16px;
-}
-
 .login-card h2 {
   margin: 0 0 12px 0;
   font-size: 1.5rem;
@@ -46,8 +39,10 @@
 }
 
 .login-card button {
-  align-self: flex-start;
-  margin-left: 102px;
+  /* True flex centering — replaces a margin-left magic number that only
+     fake-centered the button at one specific card width, leaving it
+     visibly right of the centered heading and Forgot-password link. */
+  align-self: center;
   padding: 10px 20px;
   background-color: var(--accent);
   color: var(--text-on-accent);


### PR DESCRIPTION
## Landing page (web)

- **Copy**: hero tagline now covers both sports — *"Data-driven insights for every NCAAFB and NFL matchup"* (was NCAA-only). NCAAFB abbreviation matches the app's own sport labels.
- **Headline**: breaks after "Win Your Picks." — two stacked lines.
- **True vertical centering**: header + hero share a new `.landing-above-fold` wrapper at `min-height: 100vh`, with the hero `flex: 1`-filling the remainder under the header. The old hero-level `100vh` sat *below* the in-flow header — content centered a header-height below the viewport's optical center, plus phantom scroll. The constraint is scoped to the wrapper (not the whole page) so the feature sections still start below the fold.

## Login (web)

- Sign In button truly flex-centered (`align-self: center`), replacing an `align-self: flex-start` + `margin-left: 102px` magic number that only fake-centered at one specific card width — it sat visibly right of the centered heading and "Forgot password?" link. The ForgotPassword page shares `.login-card` and inherits the fix.
- Removed a duplicate `.login-card form` block (dead `align-items` silently overridden by the later declaration).

## Copy normalization (web + mobile)

Em dashes → plain dashes in the Player Pick'em teaser pitch and the off-season countdown subtitle.

## Validation

- Web: tests 10/10, production build clean
- All landing/login changes verified visually by user (including the above-fold regression caught and fixed during review)
- Mobile changes are text-only; ship via EAS update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated landing page messaging to reference NCAAFB and NFL matchups.
  * Improved the above-the-fold layout and enabled smooth scrolling with reduced-motion support.

* **Bug Fixes**
  * Improved login button centering and form alignment.
  * Standardized punctuation in Player Pick’em and off-season messaging.

* **Style**
  * Adjusted the landing hero headline line break and spacing for improved presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->