### PR TITLE
feat(web): per-team scores in MatchupCard team rows (mobile parity)

### DIFF
--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -127,6 +127,20 @@
   gap: 1rem;
 }
 
+/* Per-team score at the row's far right (mobile parity). Neutral while the
+   game is live; the winner's score takes the accent once FINAL. */
+.team-score {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.team-score--winner {
+  color: var(--accent);
+}
+
 .team-info {
   display: flex;
   align-items: center;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -116,7 +116,7 @@
   margin-top: auto;
 }
 
-.team-row {
+.matchup-card .team-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -129,7 +129,7 @@
 
 /* Per-team score at the row's far right (mobile parity). Neutral while the
    game is live; the winner's score takes the accent once FINAL. */
-.team-score {
+.matchup-card .team-score {
   font-size: 1.6rem;
   font-weight: 700;
   color: var(--text-primary);
@@ -137,7 +137,7 @@
   flex-shrink: 0;
 }
 
-.team-score--winner {
+.matchup-card .team-score--winner {
   color: var(--accent);
 }
 
@@ -663,7 +663,7 @@
 
 /* Mobile responsiveness */
 @media (max-width: 768px) {
-  .team-row {
+  .matchup-card .team-row {
     padding: 0.75rem;
     gap: 0.5rem;
   }
@@ -715,7 +715,7 @@
 }
 
 @media (max-width: 480px) {
-  .team-row {
+  .matchup-card .team-row {
     padding: 0.5rem;
     flex-wrap: wrap; /* Allow wrapping on very small screens */
   }

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -102,6 +102,15 @@ function MatchupCard({
 
   const userTz = useUserTimeZone();
 
+  // Per-team score display (mobile parity): score renders in each team row
+  // whenever present (live via the SignalR merge, or final from the DTO);
+  // the winner's score accents only once the game is FINAL — during play
+  // both render neutral. Strict > means a tie accents neither.
+  const isFinalStatus = matchup.status === 'STATUS_FINAL';
+  const bothScored = matchup.awayScore != null && matchup.homeScore != null;
+  const awayIsWinner = isFinalStatus && bothScored && matchup.awayScore > matchup.homeScore;
+  const homeIsWinner = isFinalStatus && bothScored && matchup.homeScore > matchup.awayScore;
+
   // Game details
   const gameTime = formatToUserTime(matchup.startDateUtc, userTz);
   const venue = matchup.venue ?? "TBD";
@@ -201,6 +210,8 @@ function MatchupCard({
           error={awayError}
           probablePitcher={matchup.awayProbablePitcher}
           asOfDate={scheduleAsOfDate}
+          score={matchup.awayScore}
+          isWinner={awayIsWinner}
         />
 
         {/* Home Team Row */}
@@ -224,6 +235,8 @@ function MatchupCard({
           error={homeError}
           probablePitcher={matchup.homeProbablePitcher}
           asOfDate={scheduleAsOfDate}
+          score={matchup.homeScore}
+          isWinner={homeIsWinner}
         />
 
         {/* Spread and Over/Under — gated: see utils/gamblingContent.js */}

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -22,6 +22,11 @@ import TeamLogo from "../common/TeamLogo";
  * @param {boolean} props.loading - Schedule loading state
  * @param {string} props.error - Schedule error message
  * @param {object} [props.probablePitcher] - MLB only; { displayName, headshotUrl }
+ * @param {number} [props.score] - This team's score; renders at the row's far
+ *   right whenever present (live or final). Mobile parity: MatchupCard.tsx's
+ *   TeamRow scoreBox.
+ * @param {boolean} [props.isWinner] - True when the game is FINAL and this
+ *   team scored strictly more; accents the score.
  */
 function TeamRow({
   teamName,
@@ -42,7 +47,9 @@ function TeamRow({
   loading,
   error,
   probablePitcher,
-  asOfDate
+  asOfDate,
+  score,
+  isWinner
 }) {
   // resolveSportLeague returns null for unknown/missing enums so unsupported
   // sports don't silently render as an NCAA football route. Fall back to a
@@ -109,6 +116,11 @@ function TeamRow({
             )}
           </div>
         </div>
+        {score != null && (
+          <div className={`team-score${isWinner ? " team-score--winner" : ""}`}>
+            {score}
+          </div>
+        )}
       </div>
       {showSchedule && (
         loading ? (

--- a/src/UI/sd-ui/src/components/results/ResultsPage.css
+++ b/src/UI/sd-ui/src/components/results/ResultsPage.css
@@ -121,21 +121,26 @@
   transform: translateY(-1px);
 }
 
-.team-row {
+/* Scoped to .results-page: these generic class names (.team-row,
+   .team-name, .team-score) also exist in MatchupCard.css, and CRA css is
+   one global sheet - the bare selectors here were overriding the matchup
+   card's rules bundle-order-dependently (found via the winner-score accent
+   being stomped by the bare .team-score color). */
+.results-page .team-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   color: #c6cdd6;
   font-variant-numeric: tabular-nums;
 }
-.team-row.picked {
+.results-page .team-row.picked {
   color: #f4f4f5;
   font-weight: 600;
 }
-.team-name {
+.results-page .team-name {
   letter-spacing: 0.02em;
 }
-.team-score {
+.results-page .team-score {
   color: #e6e6e6;
 }
 


### PR DESCRIPTION
## What

Mobile's team rows show each team's score at the far right with the winner accented; web only showed the score in the FINAL strip below. Web now matches mobile.

- `TeamRow` renders the score at the row's far right whenever present — live (the SignalR merge already feeds `matchup.awayScore/homeScore`) or final.
- Winner rule mirrors mobile exactly: accent only when `STATUS_FINAL` **and** strictly higher score — ties accent neither; live games render both neutral. `1.6rem/700` with `tabular-nums`.

## CSS-leak fix (found during verification)

The winner accent was being stomped: `ResultsPage.css` declared **bare** `.team-score` / `.team-row` / `.team-name` — generic names that also exist in `MatchupCard.css`. CRA bundles all component CSS into one global sheet, so the bare selectors overrode the matchup card's rules bundle-order-dependently. All four selectors are now scoped under `.results-page`, with a comment explaining the hazard for the next generic class name.

## Validation

- Web tests 10/10, production build clean
- Matchup cards (winner accent, live-neutral) and the Results page (post-scoping) both verified visually by user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matchup cards now display team scores aligned consistently on the right.
  * Winning scores are highlighted for completed, non-tied games.
  * Live-game scores remain visually neutral.

* **Bug Fixes**
  * Scoped results-page styling to prevent unintended changes to matchup card layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->