### PR TITLE
feat(api,web): multi-sport matchup previews; hide admin preview actions for completed games

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -117,11 +117,18 @@ namespace SportsData.Api.Application.Admin
 
         [HttpPost]
         [Route("matchup/preview/{contestId}/reset")]
-        public IActionResult ResetContestPreview([FromRoute] Guid contestId)
+        public IActionResult ResetContestPreview(
+            [FromRoute] Guid contestId,
+            // Sport enum name (e.g. "FootballNfl"); omitted = NCAA for
+            // backward compatibility. The processor validates by resolving
+            // the contest against this sport's canonical client — a wrong
+            // sport 404s there and is logged as a skip.
+            [FromQuery] Sport sport = Sport.FootballNcaa)
         {
             var cmd = new GenerateMatchupPreviewsCommand
             {
-                ContestId = contestId
+                ContestId = contestId,
+                Sport = sport
             };
             _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
             return Accepted(new { cmd.CorrelationId });

--- a/src/SportsData.Api/Application/Jobs/MatchupPreviewGenerator.cs
+++ b/src/SportsData.Api/Application/Jobs/MatchupPreviewGenerator.cs
@@ -27,17 +27,47 @@ namespace SportsData.Api.Application.Jobs
             _backgroundJobProvider = backgroundJobProvider;
         }
 
+        /// <summary>
+        /// Sports the preview pipeline can currently serve. The prompt blobs
+        /// are football-generic; baseball (and future sports) stay excluded
+        /// until a sport-appropriate prompt exists, even if active leagues
+        /// for them appear.
+        /// </summary>
+        private static readonly Sport[] SupportedSports =
+        [
+            Sport.FootballNcaa,
+            Sport.FootballNfl
+        ];
+
         public async Task ExecuteAsync()
         {
+            // Sports come from ACTIVE leagues, not a hardcoded list — a sport
+            // with no leagues generates nothing, and a new sport onboards
+            // itself the day its first league exists (subject to
+            // SupportedSports above).
+            var activeSports = await _dataContext.PickemGroups
+                .AsNoTracking()
+                .Where(g => g.DeactivatedUtc == null)
+                .Select(g => g.Sport)
+                .Distinct()
+                .ToListAsync();
+
+            foreach (var sport in activeSports.Where(SupportedSports.Contains))
+            {
+                await GenerateForSportAsync(sport);
+            }
+        }
+
+        private async Task GenerateForSportAsync(Sport sport)
+        {
             // Get all matchups for the current week
-            // TODO: multi-sport
-            var matchupsResult = await _contestClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa).GetMatchupsForCurrentWeek();
-            if (!matchupsResult.IsSuccess) { _logger.LogWarning("Failed to retrieve matchups from Producer."); return; }
+            var matchupsResult = await _contestClientFactory.Resolve(sport).GetMatchupsForCurrentWeek();
+            if (!matchupsResult.IsSuccess) { _logger.LogWarning("Failed to retrieve matchups from Producer for {Sport}.", sport); return; }
             var matchups = matchupsResult.Value;
 
             if (matchups is null || !matchups.Any())
             {
-                _logger.LogWarning("No matchups found for the current week; skipping preview generation");
+                _logger.LogWarning("No matchups found for the current week ({Sport}); skipping preview generation", sport);
                 return;
             }
 
@@ -85,7 +115,8 @@ namespace SportsData.Api.Application.Jobs
             {
                 var cmd = new GenerateMatchupPreviewsCommand
                 {
-                    ContestId = contestId
+                    ContestId = contestId,
+                    Sport = sport
                 };
 
                 // TODO: Replace with prioritized queue via Service Bus
@@ -97,7 +128,7 @@ namespace SportsData.Api.Application.Jobs
                 return previews.TryGetValue(contestId, out var errors) && string.IsNullOrWhiteSpace(errors);
             }
 
-            _logger.LogInformation("Enqueued {LeagueCount} league matchups for preview generation.", leagueMatchupCount);
+            _logger.LogInformation("Enqueued {LeagueCount} league matchups for preview generation ({Sport}).", leagueMatchupCount, sport);
         }
 
     }

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupMatchupAddedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupMatchupAddedHandler.cs
@@ -54,7 +54,8 @@ namespace SportsData.Api.Application.PickemGroups
             // Enqueue preview generation job
             var cmd = new GenerateMatchupPreviewsCommand
             {
-                ContestId = @event.ContestId
+                ContestId = @event.ContestId,
+                Sport = @event.Sport
             };
 
             _backgroundJobProvider.Enqueue<MatchupPreviewProcessor>(p => p.Process(cmd));

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
@@ -104,7 +104,8 @@ namespace SportsData.Api.Application.PickemGroups
             {
                 var cmd = new GenerateMatchupPreviewsCommand()
                 {
-                    ContestId = contestId
+                    ContestId = contestId,
+                    Sport = @event.Sport
                 };
 
                 _backgroundJobProvider.Enqueue<MatchupPreviewProcessor>(p => p.Process(cmd));

--- a/src/SportsData.Api/Application/Previews/Commands/RejectMatchupPreviewCommand.cs
+++ b/src/SportsData.Api/Application/Previews/Commands/RejectMatchupPreviewCommand.cs
@@ -1,11 +1,18 @@
 using System.Text.Json.Serialization;
 
+using SportsData.Core.Common;
+
 namespace SportsData.Api.Application.Previews.Commands;
 
 public class RejectMatchupPreviewCommand
 {
     [JsonPropertyName("previewId")]
     public Guid PreviewId { get; set; }
+
+    /// <summary>Sport for the regeneration enqueued after rejection.
+    /// Defaults to NCAA for callers that omit it.</summary>
+    [JsonPropertyName("sport")]
+    public Sport Sport { get; set; } = Sport.FootballNcaa;
 
     [JsonPropertyName("contestId")]
     public Guid ContestId { get; set; }

--- a/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
+++ b/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
@@ -1,8 +1,17 @@
-﻿namespace SportsData.Api.Application.Previews;
+﻿using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Previews;
 
 public class GenerateMatchupPreviewsCommand
 {
     public Guid ContestId { get; set; }
+
+    /// <summary>
+    /// Which sport's canonical clients resolve this contest. Defaults to
+    /// FootballNcaa so any payload serialized before this property existed
+    /// (or a caller that omits it) behaves exactly as before.
+    /// </summary>
+    public Sport Sport { get; set; } = Sport.FootballNcaa;
 
     public Guid CorrelationId { get; set; } = Guid.NewGuid();
 }

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -50,8 +50,7 @@ namespace SportsData.Api.Application.Previews
                 .OrderByDescending(x => x.CreatedUtc)
                 .FirstOrDefaultAsync(x => x.ContestId == command.ContestId && x.RejectedUtc != null);
 
-            // TODO: multi-sport
-            var previewResult = await _contestClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa).GetMatchupForPreview(command.ContestId);
+            var previewResult = await _contestClientFactory.Resolve(command.Sport).GetMatchupForPreview(command.ContestId);
             var matchup = previewResult.IsSuccess ? previewResult.Value : null;
 
             if (matchup is null)
@@ -68,8 +67,7 @@ namespace SportsData.Api.Application.Previews
                 return;
             }
 
-            // TODO: Support multiple sports - currently hardcoded to FootballNcaa
-            var franchiseClient = _franchiseClientFactory.Resolve(Sport.FootballNcaa);
+            var franchiseClient = _franchiseClientFactory.Resolve(command.Sport);
 
             matchup.AwayStats = await franchiseClient
                 .GetFranchiseSeasonPreviewStats(matchup.AwayFranchiseSeasonId);

--- a/src/SportsData.Api/Application/Previews/PreviewController.cs
+++ b/src/SportsData.Api/Application/Previews/PreviewController.cs
@@ -63,7 +63,8 @@ namespace SportsData.Api.Application.Previews
 
             var cmd = new GenerateMatchupPreviewsCommand
             {
-                ContestId = command.ContestId
+                ContestId = command.ContestId,
+                Sport = command.Sport
             };
 
             _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/GenerateLeagueWeekPreviews/GenerateLeagueWeekPreviewsCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/GenerateLeagueWeekPreviews/GenerateLeagueWeekPreviewsCommandHandler.cs
@@ -70,7 +70,8 @@ public class GenerateLeagueWeekPreviewsCommandHandler : IGenerateLeagueWeekPrevi
 
             var cmd = new GenerateMatchupPreviewsCommand
             {
-                ContestId = contestId
+                ContestId = contestId,
+                Sport = league.Sport
             };
             _backgroundJobProvider.Enqueue<MatchupPreviewProcessor>(p => p.Process(cmd));
             enqueuedCount++;

--- a/src/SportsData.Api/Application/UI/Matchups/Dtos/MatchupPreviewDto.cs
+++ b/src/SportsData.Api/Application/UI/Matchups/Dtos/MatchupPreviewDto.cs
@@ -23,4 +23,12 @@ public class MatchupPreviewDto
     public string? VegasImpliedScore { get; set; }
 
     public DateTime GeneratedUtc { get; set; }
+
+    /// <summary>
+    /// True when the contest this preview describes has finished
+    /// (canonical status STATUS_FINAL). The admin approve/reject
+    /// affordances are pointless after the game is played — clients hide
+    /// them when this is set.
+    /// </summary>
+    public bool IsContestCompleted { get; set; }
 }

--- a/src/SportsData.Api/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandler.cs
@@ -64,7 +64,7 @@ public class GetMatchupPreviewQueryHandler : IGetMatchupPreviewQueryHandler
                 (m, g) => (Sport?)g.Sport)
             .FirstOrDefaultAsync(cancellationToken) ?? Sport.FootballNcaa;
 
-        var previewResult = await _contestClientFactory.Resolve(sport).GetMatchupForPreview(query.ContestId);
+        var previewResult = await _contestClientFactory.Resolve(sport).GetMatchupForPreview(query.ContestId, cancellationToken);
         var canonical = previewResult.IsSuccess ? previewResult.Value : null;
 
         if (canonical is null)

--- a/src/SportsData.Api/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandler.cs
@@ -50,8 +50,21 @@ public class GetMatchupPreviewQueryHandler : IGetMatchupPreviewQueryHandler
                 [new ValidationFailure(nameof(query.ContestId), "Matchup preview not found")]);
         }
 
-        // TODO: multi-sport
-        var previewResult = await _contestClientFactory.Resolve(SportsData.Core.Common.Sport.FootballNcaa).GetMatchupForPreview(query.ContestId);
+        // Derive the sport server-side from the contest's league — every
+        // previewed contest is in a PickemGroup by construction (previews
+        // are generated off group events / league weeks). Falls back to
+        // NCAA for any orphan so legacy behavior is preserved.
+        var sport = await _dbContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => m.ContestId == query.ContestId)
+            .Join(
+                _dbContext.PickemGroups,
+                m => m.GroupId,
+                g => g.Id,
+                (m, g) => (Sport?)g.Sport)
+            .FirstOrDefaultAsync(cancellationToken) ?? Sport.FootballNcaa;
+
+        var previewResult = await _contestClientFactory.Resolve(sport).GetMatchupForPreview(query.ContestId);
         var canonical = previewResult.IsSuccess ? previewResult.Value : null;
 
         if (canonical is null)
@@ -87,7 +100,11 @@ public class GetMatchupPreviewQueryHandler : IGetMatchupPreviewQueryHandler
             AwayScore = preview.AwayScore,
             HomeScore = preview.HomeScore,
             VegasImpliedScore = implied,
-            GeneratedUtc = preview.CreatedUtc
+            GeneratedUtc = preview.CreatedUtc,
+            // Canonical status is authoritative — approve/reject is
+            // meaningless once the game has been played, so clients hide
+            // those admin affordances when this is true.
+            IsContestCompleted = canonical.Status == "STATUS_FINAL"
         };
 
         return new Success<MatchupPreviewDto>(result);

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -10,8 +10,11 @@ const AdminApi = {
     apiClient.get('/admin/errors/competitions-without-drives'),
   getCompetitionsWithoutMetrics: () =>
     apiClient.get('/admin/errors/competitions-without-metrics'),
-  resetPreview: (contestId) =>
-    apiClient.post(`/admin/matchup/preview/${contestId}/reset`),
+  // sport: backend Sport enum name (e.g. "FootballNfl"); omitted = NCAA.
+  resetPreview: (contestId, sport) =>
+    apiClient.post(
+      `/admin/matchup/preview/${contestId}/reset${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+    ),
 
   // Returns one MLB matchup in the same shape as the picks page so the
   // baseball SignalR debug page can render a real <MatchupCard /> for a

--- a/src/UI/sd-ui/src/api/matchupsApi.js
+++ b/src/UI/sd-ui/src/api/matchupsApi.js
@@ -8,9 +8,10 @@ const MatchupsApi = {
     ),
   getPreviewByContestId: (contestId) =>
     apiClient.get(`/ui/matchup/${encodeURIComponent(contestId)}/preview`),
-  resetPreviewByContestId: (contestId) =>
+  // sport: backend Sport enum name (e.g. "FootballNfl"); omitted = NCAA.
+  resetPreviewByContestId: (contestId, sport) =>
     apiClient.post(
-      `/admin/matchup/preview/${encodeURIComponent(contestId)}/reset`
+      `/admin/matchup/preview/${encodeURIComponent(contestId)}/reset${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
     )
 };
 

--- a/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
+++ b/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
@@ -121,7 +121,10 @@ function InsightDialog({
           )}
         </div>
 
-        {isAdmin && !loading && (
+        {/* Approve/reject is meaningless once the game has been played —
+            isContestCompleted is server-authoritative (canonical
+            STATUS_FINAL) off the preview DTO. */}
+        {isAdmin && !loading && !matchup.isContestCompleted && (
           <div className="admin-controls">
             <textarea
               className="admin-rejection-note"

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -628,10 +628,15 @@ function PicksPage() {
   }
 
   async function handleViewInsight(matchup) {
-    // If no preview available and user is admin, trigger preview generation
+    // If no preview available and user is admin, trigger preview generation —
+    // but never for a completed game (generating a "preview" of a played
+    // game is as meaningless as approving one; same rule as InsightDialog's
+    // hidden approve/reject). Completed + no preview = nothing to generate
+    // AND nothing to fetch, so no-op rather than falling through to a 404.
     if (!matchup.isPreviewAvailable && userDto?.isAdmin) {
+      if (matchup.status === 'STATUS_FINAL') return;
       try {
-        await apiWrapper.Admin.resetPreview(matchup.contestId);
+        await apiWrapper.Admin.resetPreview(matchup.contestId, leagueSport);
         toast.success("Preview generation initiated. Please refresh in a moment.");
       } catch (error) {
         console.error("Error resetting preview:", error);
@@ -667,7 +672,10 @@ function PicksPage() {
         awayScore: preview.awayScore,
         homeScore: preview.homeScore,
         vegasImpliedScore: preview.vegasImpliedScore,
-        generatedUtc: preview.generatedUtc
+        generatedUtc: preview.generatedUtc,
+        // Server-authoritative: hides the admin approve/reject block for
+        // completed games (see InsightDialog).
+        isContestCompleted: preview.isContestCompleted
       }));
     } catch (error) {
       console.error("Error fetching insight preview:", error);
@@ -688,6 +696,9 @@ function PicksPage() {
         PreviewId,
         ContestId,
         RejectionNote,
+        // Regeneration after rejection resolves canonical data for THIS
+        // league's sport (backend Sport enum name).
+        Sport: leagueSport,
       });
       toast.success("Preview rejection sent.");
     } catch (error) {

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandlerTests.cs
@@ -15,6 +15,12 @@ namespace SportsData.Api.Tests.Unit.Application.UI.Matchups.Queries.GetMatchupPr
 
 public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQueryHandler>
 {
+    // Deterministic clock for all seeded timestamps (repo rule: no direct
+    // DateTime.UtcNow). The handler itself takes no IDateTimeProvider, so a
+    // fixed constant - the same pattern as LeagueInvitationTests - is the
+    // minimal compliant form.
+    private static readonly DateTime Now = new(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc);
+
     private readonly Mock<IProvideContests> _contestClientMock = new();
 
     public GetMatchupPreviewQueryHandlerTests()
@@ -48,7 +54,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Now,
             Overview = "Test overview",
             Analysis = "Test analysis",
             Prediction = "Test prediction"
@@ -83,7 +89,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Now,
             Overview = "Test overview",
             Analysis = "Test analysis",
             Prediction = "Test prediction",
@@ -151,7 +157,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Now,
             Overview = "Test overview",
             Analysis = "Test analysis",
             Prediction = "Test prediction"
@@ -208,7 +214,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
             TiebreakerType = TiebreakerType.TotalPoints,
             TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
             SeasonYear = 2026,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Now,
             CreatedBy = commissionerId
         });
         await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
@@ -217,17 +223,17 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
             GroupId = groupId,
             SeasonWeekId = Guid.NewGuid(),
             ContestId = contestId,
-            StartDateUtc = DateTime.UtcNow.AddDays(3),
+            StartDateUtc = Now.AddDays(3),
             SeasonYear = 2026,
             SeasonWeek = 1,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Now,
             CreatedBy = commissionerId
         });
         await DataContext.MatchupPreviews.AddAsync(new MatchupPreview
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Now,
             Overview = "Test overview",
             Analysis = "Test analysis",
             Prediction = "Test prediction"

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Matchups/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandlerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 
 using Moq;
 
+using SportsData.Api.Application.Common.Enums;
 using SportsData.Api.Application.UI.Matchups.Queries.GetMatchupPreview;
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
@@ -130,6 +131,135 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         result.Value.AtsWinner.Should().Be("Home Team");
         result.Value.AwayScore.Should().Be(24);
         result.Value.HomeScore.Should().Be(21);
+        // No canonical status seeded -> not completed.
+        result.Value.IsContestCompleted.Should().BeFalse();
+    }
+
+    // IsContestCompleted derives from the canonical status — the admin
+    // approve/reject affordances hide once the game has been played.
+    [Theory]
+    [InlineData("STATUS_FINAL", true)]
+    [InlineData("STATUS_SCHEDULED", false)]
+    [InlineData("STATUS_IN_PROGRESS", false)]
+    [InlineData(null, false)]
+    public async Task ExecuteAsync_SetsIsContestCompleted_FromCanonicalStatus(
+        string? canonicalStatus, bool expected)
+    {
+        // Arrange
+        var contestId = Guid.NewGuid();
+        var preview = new MatchupPreview
+        {
+            Id = Guid.NewGuid(),
+            ContestId = contestId,
+            CreatedUtc = DateTime.UtcNow,
+            Overview = "Test overview",
+            Analysis = "Test analysis",
+            Prediction = "Test prediction"
+        };
+        await DataContext.MatchupPreviews.AddAsync(preview);
+        await DataContext.SaveChangesAsync();
+
+        var canonicalData = new MatchupForPreviewDto
+        {
+            ContestId = contestId,
+            Status = canonicalStatus,
+            Away = "Away Team",
+            Home = "Home Team",
+            AwaySlug = "away-team",
+            HomeSlug = "home-team",
+            AwayConferenceSlug = "conf-a",
+            HomeConferenceSlug = "conf-b",
+            Venue = "Stadium",
+            VenueCity = "City"
+        };
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupForPreview(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupForPreviewDto>(canonicalData));
+
+        var sut = Mocker.CreateInstance<GetMatchupPreviewQueryHandler>();
+        var query = new GetMatchupPreviewQuery { ContestId = contestId };
+
+        // Act
+        var result = await sut.ExecuteAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsContestCompleted.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ResolvesSportFromContestsLeague()
+    {
+        // Arrange — the contest belongs to an NFL league, so the canonical
+        // client must be resolved for FootballNfl, not the NCAA fallback.
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var commissionerId = Guid.NewGuid();
+
+        await DataContext.PickemGroups.AddAsync(new PickemGroup
+        {
+            Id = groupId,
+            Name = "NFL League",
+            CommissionerUserId = commissionerId,
+            Sport = Sport.FootballNfl,
+            League = League.NFL,
+            PickType = PickType.StraightUp,
+            TiebreakerType = TiebreakerType.TotalPoints,
+            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
+            SeasonYear = 2026,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = commissionerId
+        });
+        await DataContext.PickemGroupMatchups.AddAsync(new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            GroupId = groupId,
+            SeasonWeekId = Guid.NewGuid(),
+            ContestId = contestId,
+            StartDateUtc = DateTime.UtcNow.AddDays(3),
+            SeasonYear = 2026,
+            SeasonWeek = 1,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = commissionerId
+        });
+        await DataContext.MatchupPreviews.AddAsync(new MatchupPreview
+        {
+            Id = Guid.NewGuid(),
+            ContestId = contestId,
+            CreatedUtc = DateTime.UtcNow,
+            Overview = "Test overview",
+            Analysis = "Test analysis",
+            Prediction = "Test prediction"
+        });
+        await DataContext.SaveChangesAsync();
+
+        _contestClientMock
+            .Setup(x => x.GetMatchupForPreview(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupForPreviewDto>(new MatchupForPreviewDto
+            {
+                ContestId = contestId,
+                Away = "Away Team",
+                Home = "Home Team",
+                AwaySlug = "away-team",
+                HomeSlug = "home-team",
+                AwayConferenceSlug = "conf-a",
+                HomeConferenceSlug = "conf-b",
+                Venue = "Stadium",
+                VenueCity = "City"
+            }));
+
+        var sut = Mocker.CreateInstance<GetMatchupPreviewQueryHandler>();
+
+        // Act
+        var result = await sut.ExecuteAsync(new GetMatchupPreviewQuery { ContestId = contestId });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IContestClientFactory>()
+            .Verify(x => x.Resolve(Sport.FootballNfl), Times.Once);
+        Mocker.GetMock<IContestClientFactory>()
+            .Verify(x => x.Resolve(Sport.FootballNcaa), Times.Never);
     }
 }
 


### PR DESCRIPTION
## Completed-contest gating

- **`MatchupPreviewDto.IsContestCompleted`** — derived in the read handler from the canonical status (`STATUS_FINAL`) it already fetches; server-authoritative.
- `InsightDialog` hides the entire admin approve/reject block for completed games. `PicksPage` threads the flag through the preview merge, and the admin generate-on-click for a final game with no preview is now a clean no-op (nested guard — never falls through to a 404 fetch).

## Multi-sport de-hardcoding (the StatBot NCAA hardcode)

- **`GenerateMatchupPreviewsCommand` gains `Sport`** (default `FootballNcaa` — any caller or payload that omits it behaves exactly as before).
- **Processor** resolves both factories (contest + franchise) from `command.Sport`; both TODOs gone.
- **Producers:**
  - Event handlers pass the event's `Sport` (already on the wire)
  - `GenerateLeagueWeekPreviews` passes `league.Sport`
  - The weekly job **derives its sport list from active leagues** (`distinct Sport where DeactivatedUtc is null`) ∩ `SupportedSports [FootballNcaa, FootballNfl]` — prompts are football-generic, so baseball stays excluded until a sport-appropriate prompt exists; new sports onboard themselves the day their first league exists
  - Admin reset takes `?sport=` (UI passes `leagueSport`); validation = the processor's canonical resolve (wrong sport 404s → logged skip)
  - Reject-regenerate carries `Sport` on `RejectMatchupPreviewCommand`
- **Read handler derives sport server-side** from `PickemGroupMatchup → PickemGroup.Sport` (NCAA fallback for orphans) — no client trust on a GET, and the `IsContestCompleted` derivation is multi-sport for free.

## Tests

Completed-status theory (FINAL / scheduled / in-progress / null) + NFL sport-derivation test (`Resolve(FootballNfl)` verified once, NCAA never).

## Deployment note

First NFL previews may be metric-less (the both-or-nothing branch) until NFL franchise-season metrics generation runs — the no-stats prompt handles that gracefully.

## Validation

- API 628/628, build zero warnings
- Web tests 10/10, production build clean
- Reviewed staged by user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matchup previews now support multiple sports, including sport-specific generation and data retrieval.
  * Administrators can select a sport when resetting or regenerating contest previews.
  * Preview details now indicate whether a contest is completed.

* **Bug Fixes**
  * Admin approval and rejection controls are hidden for completed contests.
  * Preview regeneration now preserves the contest’s sport.
  * NFL contests use the correct sport data instead of defaulting to NCAA football.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->