### PR TITLE
feat(mobile): EAS Observe production performance metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ GitHub: github.com/jrandallsexton/sports-data-core
 - **Hosting**: Self-hosted Kubernetes on bare metal (NOT Azure Container Apps)
 - **Observability**: OpenTelemetry + Seq at `logging.sportdeets.com`. See `docs/seq-mcp.md` and `docs/seq-mcp-usage.md`.
 - **CI**: Azure Pipelines for .NET services (self-hosted agent pool `Default`, agent `Bender`), GitHub Actions for mobile app
-- **Mobile**: Expo SDK 55 / React Native 0.83.2 at `src/UI/sd-mobile`. Jest 29 required (Jest 30 incompatible with Expo 55).
+- **Mobile**: Expo SDK 55 / React Native 0.83.x (0.83.6 as of 2026-08) at `src/UI/sd-mobile`. Jest 29 required (Jest 30 incompatible with Expo 55).
 - **Web**: React at `src/UI/sd-ui`
 
 ## Key Patterns

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -14,7 +14,6 @@ import { useFonts } from 'expo-font';
 import { Poppins_400Regular, Poppins_700Bold_Italic } from '@expo-google-fonts/poppins';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { AppMetrics, AppMetricsRoot } from 'expo-observe';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import * as Notifications from 'expo-notifications';
 // Type-only import — erased at compile time. The runtime module is loaded via a
@@ -40,6 +39,23 @@ export {
   // Catch any errors thrown by the Layout component.
   ErrorBoundary,
 } from 'expo-router';
+
+// EAS Observe (expo-observe) calls requireNativeModule at module-init, so a
+// static import would crash any environment lacking the native module
+// (web bundle, Expo Go). Runtime-guarded require: absent module -> both
+// stay null and every usage below no-ops.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let AppMetrics: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let AppMetricsRoot: any = null;
+if (Platform.OS !== 'web') {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    ({ AppMetrics, AppMetricsRoot } = require('expo-observe'));
+  } catch {
+    // Native module unavailable (e.g. Expo Go) - run without metrics.
+  }
+}
 
 export const unstable_settings = {
   initialRouteName: '(tabs)',
@@ -196,10 +212,9 @@ function RootLayout() {
 // - Sentry: navigation breadcrumbs + root error boundary — outermost so it
 //   also captures anything the Observe wrapper throws.
 // - AppMetricsRoot (EAS Observe): production performance metrics (cold/warm
-//   start, time-to-interactive). Native-only — Observe supports
-//   Android/iOS; the web bundle skips the wrapper entirely.
-const MetricsWrappedRoot =
-  Platform.OS === 'web' ? RootLayout : AppMetricsRoot.wrap(RootLayout);
+//   start, time-to-interactive). Null when the native module is absent
+//   (web bundle, Expo Go) — see the guarded require above.
+const MetricsWrappedRoot = AppMetricsRoot ? AppMetricsRoot.wrap(RootLayout) : RootLayout;
 export default Sentry.wrap(MetricsWrappedRoot);
 
 /**
@@ -370,13 +385,14 @@ function RootLayoutNav() {
   // This is also the app's true time-to-interactive — the first frame the
   // user can actually see and touch — so EAS Observe's marker lives here.
   // Observe only records the FIRST call per session, so re-renders are
-  // harmless.
+  // harmless. Deliberately NOT gated on auth/AuthGuard's initial redirect:
+  // the splash-hide is a consistent measurement point, while auth settle
+  // varies with network conditions and would pollute the startup metric
+  // with backend latency.
   useEffect(() => {
     if (themeHydrated && textSizeHydrated) {
       SplashScreen.hideAsync();
-      if (Platform.OS !== 'web') {
-        AppMetrics.markInteractive();
-      }
+      AppMetrics?.markInteractive();
     }
   }, [themeHydrated, textSizeHydrated]);
 

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -14,6 +14,7 @@ import { useFonts } from 'expo-font';
 import { Poppins_400Regular, Poppins_700Bold_Italic } from '@expo-google-fonts/poppins';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
+import { AppMetrics, AppMetricsRoot } from 'expo-observe';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import * as Notifications from 'expo-notifications';
 // Type-only import — erased at compile time. The runtime module is loaded via a
@@ -191,9 +192,15 @@ function RootLayout() {
   );
 }
 
-// Wrap with Sentry so navigation transitions become breadcrumbs and the
-// root error boundary forwards into the SDK.
-export default Sentry.wrap(RootLayout);
+// Wrap order (outermost first):
+// - Sentry: navigation breadcrumbs + root error boundary — outermost so it
+//   also captures anything the Observe wrapper throws.
+// - AppMetricsRoot (EAS Observe): production performance metrics (cold/warm
+//   start, time-to-interactive). Native-only — Observe supports
+//   Android/iOS; the web bundle skips the wrapper entirely.
+const MetricsWrappedRoot =
+  Platform.OS === 'web' ? RootLayout : AppMetricsRoot.wrap(RootLayout);
+export default Sentry.wrap(MetricsWrappedRoot);
 
 /**
  * Native-only push notification receive + tap handling. Logs a privacy-safe
@@ -359,8 +366,18 @@ function RootLayoutNav() {
   // AsyncStorage. Keeps the splash visible through the full startup path
   // so the first painted pixels already reflect every stored preference
   // (no theme flash, no font-size flash on launch).
+  //
+  // This is also the app's true time-to-interactive — the first frame the
+  // user can actually see and touch — so EAS Observe's marker lives here.
+  // Observe only records the FIRST call per session, so re-renders are
+  // harmless.
   useEffect(() => {
-    if (themeHydrated && textSizeHydrated) SplashScreen.hideAsync();
+    if (themeHydrated && textSizeHydrated) {
+      SplashScreen.hideAsync();
+      if (Platform.OS !== 'web') {
+        AppMetrics.markInteractive();
+      }
+    }
   }, [themeHydrated, textSizeHydrated]);
 
   return (

--- a/src/UI/sd-mobile/package-lock.json
+++ b/src/UI/sd-mobile/package-lock.json
@@ -31,6 +31,7 @@
         "expo-linking": "~55.0.15",
         "expo-modules-core": "~55.0.25",
         "expo-notifications": "~55.0.23",
+        "expo-observe": "~0.2.4",
         "expo-router": "~55.0.14",
         "expo-screen-orientation": "~55.0.18",
         "expo-splash-screen": "~55.0.21",
@@ -6931,6 +6932,19 @@
         }
       }
     },
+    "node_modules/expo-app-metrics": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/expo-app-metrics/-/expo-app-metrics-0.2.4.tgz",
+      "integrity": "sha512-e/DNGk5HltgixpRVcH1yj61xmhGAEkVhBUMOKxGrTXe+mlVpm1/BPROES4WfVFwxanbSNlpUXKSorw58YzQgDw==",
+      "dependencies": {
+        "expo-updates-interface": "~55.1.6"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-apple-authentication": {
       "version": "55.0.13",
       "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-55.0.13.tgz",
@@ -7192,6 +7206,19 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-observe": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/expo-observe/-/expo-observe-0.2.4.tgz",
+      "integrity": "sha512-e8RIUQH0OX8K2W12EAm4wm2jMq6AByImMH0cNbqkAMOQufYlgARxNp4Hj4hjRZFr4/CHlD822ws6d/CsxhKfVA==",
+      "dependencies": {
+        "expo-app-metrics": "~0.2.4",
+        "expo-eas-client": "~55.0.5"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },

--- a/src/UI/sd-mobile/package.json
+++ b/src/UI/sd-mobile/package.json
@@ -61,6 +61,7 @@
     "expo-linking": "~55.0.15",
     "expo-modules-core": "~55.0.25",
     "expo-notifications": "~55.0.23",
+    "expo-observe": "~0.2.4",
     "expo-router": "~55.0.14",
     "expo-screen-orientation": "~55.0.18",
     "expo-splash-screen": "~55.0.21",


### PR DESCRIPTION
Adds `expo-observe` (~0.2.4, SDK 55) for cold/warm start and time-to-interactive telemetry — the observability niche neither Umami (web analytics) nor Sentry (crashes) covers, and the metric that matters most during the closed test: launch feel on real tester devices. Free tier covers the first 10k MAU.

- **Wrap order**: `Sentry.wrap(AppMetricsRoot.wrap(RootLayout))` — Sentry outermost so it also captures anything the Observe wrapper throws. The web bundle skips the wrapper entirely (Observe is Android/iOS only).
- **`AppMetrics.markInteractive()`** fires at the app's *true* time-to-interactive — the second splash gate (fonts + theme + text-size hydration), where the first touchable frame paints. Observe records only the first call per session, so effect re-runs are harmless.
- **Privacy**: anonymous per-install ID, no PII — fits the existing Play Data Safety declarations (Device or other IDs) without changes.
- `extra.eas.projectId` already present — no config changes.

Native module: ships in the next builds (iOS via TestFlight now; Android rides the next AAB cycle). Debug builds don't dispatch metrics.

Validated: `tsc --noEmit` clean, Jest 102/102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added app performance metrics on supported native platforms.
  * App readiness is recorded after theme and text-size preferences finish loading.
  * Metrics are safely disabled when unavailable or when using the web version.

* **Bug Fixes**
  * Improved splash-screen dismissal timing so it occurs after essential startup settings are applied.
  * Improved startup stability when optional monitoring features cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->