### PR TITLE
feat(producer): football finalization backstop + daemon patch auto-bump

### DIFF
--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -173,7 +173,7 @@ jobs:
           # Daemon patches are present per-sport once that sport's daemon Deployment ships in sports-data-config
           # (MLB only as of PR B in the contest-finalization-reconcile-backstop workstream).
           # Must stay in sync with deploy-services-prod.yml.
-          for patch in producer-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
+          for patch in producer-patch.yaml producer-ncaa-daemon-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-daemon-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
             FILE="app/overlays/04_prod/$patch"
             if [ ! -f "$FILE" ]; then
               echo "::error::Missing producer patch file: $FILE"

--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -170,8 +170,9 @@ jobs:
             exit 1
           fi
           # Update all producer role patch files (worker, ingest, api, daemon) for NCAA, NFL, and MLB.
-          # Daemon patches are present per-sport once that sport's daemon Deployment ships in sports-data-config
-          # (MLB only as of PR B in the contest-finalization-reconcile-backstop workstream).
+          # Daemon patches exist for ALL THREE sports as of 2026-08-06 (football
+          # daemons shipped for NFL preseason; sports-data-config commit 7a71f5e).
+          # The missing-file guard below fails the deploy if any is absent.
           # Must stay in sync with deploy-services-prod.yml.
           for patch in producer-patch.yaml producer-ncaa-daemon-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-daemon-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
             FILE="app/overlays/04_prod/$patch"

--- a/.github/workflows/deploy-services-prod.yml
+++ b/.github/workflows/deploy-services-prod.yml
@@ -63,7 +63,7 @@ jobs:
           # Daemon patches are present per-sport once that sport's daemon Deployment ships in sports-data-config
           # (MLB only as of PR B in the contest-finalization-reconcile-backstop workstream).
           # Must stay in sync with deploy-services-prod-auto.yml.
-          for patch in producer-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
+          for patch in producer-patch.yaml producer-ncaa-daemon-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-daemon-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
             FILE="app/overlays/04_prod/$patch"
             if [ ! -f "$FILE" ]; then
               echo "::error::Missing producer patch file: $FILE"

--- a/.github/workflows/deploy-services-prod.yml
+++ b/.github/workflows/deploy-services-prod.yml
@@ -60,8 +60,9 @@ jobs:
             exit 1
           fi
           # Update all producer role patch files (worker, ingest, api, daemon) for NCAA, NFL, and MLB.
-          # Daemon patches are present per-sport once that sport's daemon Deployment ships in sports-data-config
-          # (MLB only as of PR B in the contest-finalization-reconcile-backstop workstream).
+          # Daemon patches exist for ALL THREE sports as of 2026-08-06 (football
+          # daemons shipped for NFL preseason; sports-data-config commit 7a71f5e).
+          # The missing-file guard below fails the deploy if any is absent.
           # Must stay in sync with deploy-services-prod-auto.yml.
           for patch in producer-patch.yaml producer-ncaa-daemon-patch.yaml producer-ingest-patch.yaml producer-api-patch.yaml producer-nfl-patch.yaml producer-nfl-daemon-patch.yaml producer-nfl-ingest-patch.yaml producer-nfl-api-patch.yaml producer-mlb-patch.yaml producer-mlb-ingest-patch.yaml producer-mlb-api-patch.yaml producer-mlb-daemon-patch.yaml; do
             FILE="app/overlays/04_prod/$patch"

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -246,13 +246,17 @@ namespace SportsData.Producer.DependencyInjection
             // FinalizationReconcileJob: durable backstop that recovers stranded
             // CompetitionStream rows when the streamer fails to publish ContestCompleted
             // (KEDA scale-down mid-game, OOM, 5h MaxStreamDuration). Same closed-generic
-            // pattern as ContestEnrichmentJob; only MLB is wired up initially per the
-            // sequencing in docs/contest-finalization-reconcile-backstop.md. Football
-            // joins when its Daemon Deployments ship pre-season.
+            // pattern as ContestEnrichmentJob; see
+            // docs/contest-finalization-reconcile-backstop.md. Football joined
+            // 2026-08-06 alongside its Daemon Deployments (NFL preseason).
             switch (mode)
             {
                 case Sport.BaseballMlb:
                     services.AddScoped<IFinalizationReconcileJob, FinalizationReconcileJob<BaseballDataContext>>();
+                    break;
+                case Sport.FootballNcaa:
+                case Sport.FootballNfl:
+                    services.AddScoped<IFinalizationReconcileJob, FinalizationReconcileJob<FootballDataContext>>();
                     break;
             }
 
@@ -452,13 +456,19 @@ namespace SportsData.Producer.DependencyInjection
                     nameof(CompetitionStreamScheduler),
                     job => job.Execute(),
                     "0 7 * * *"); // Daily at 07:00 UTC
+            }
 
+            if (mode is Sport.FootballNcaa or Sport.FootballNfl or Sport.BaseballMlb)
+            {
                 // FinalizationReconcileJob — durable backstop. Every 15 minutes
                 // it sweeps for CompetitionStream rows whose streamer process
                 // died before publishing ContestCompleted, re-checks ESPN status,
                 // and publishes the finalization events if the game is now FINAL.
                 // [Queue("daemon")] on IFinalizationReconcileJob.ExecuteAsync
-                // routes the trigger to the daemon queue.
+                // routes the trigger to the daemon queue. Football joined
+                // 2026-08-06 alongside its Daemon Deployments (each sport's
+                // Producer has its own Hangfire storage, so the shared job id
+                // cannot collide across sports).
                 recurringJobManager.AddOrUpdate<IFinalizationReconcileJob>(
                     "FinalizationReconcileJob",
                     job => job.ExecuteAsync(CancellationToken.None),


### PR DESCRIPTION
Companion to the sports-data-config change shipping NFL/NCAA **Daemon Deployments** — the *"Football joins when its Daemon Deployments ship pre-season"* step from ServiceRegistration's own comments. NFL preseason starts tonight; zero `CompetitionStream` rows for football was the symptom (MLB streams fine because only its daemon existed).

## Changes

- **`FinalizationReconcileJob` for football** — registered for `FootballNcaa`/`FootballNfl` on `FootballDataContext`, **and** its recurring 15-minute schedule extended from the MLB-only block to all three sports. The registration alone would never have fired: the `AddOrUpdate` was also MLB-gated. (Each sport's Producer has its own Hangfire storage, so the shared job id can't collide across sports.)
- **Both deploy workflows** gain `producer-nfl-daemon-patch.yaml` + `producer-ncaa-daemon-patch.yaml` in their producer patch loops, so image auto-bumps cover the new daemons from their first post-merge deploy.

## Sequencing

Streaming itself (`CompetitionStreamScheduler` + `FootballCompetitionStreamer`) has been registered for football since the role split — only the pods were missing. The config-repo daemons run on the current image (`:5856`) and stream tonight; this PR's backstop rides the next image bump. Operational note: football's stream scheduler cron is Sundays 07:00 UTC, so the first run gets triggered manually via the Hangfire dashboard after the daemons come up.

## Validation

Producer build zero warnings; 530 tests passed (18 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled finalization reconciliation for NCAA and NFL football data.
  * Added recurring reconciliation jobs for supported football modes.

* **Bug Fixes**
  * Improved producer deployments to update NCAA, NFL, and MLB daemon patches consistently.
  * Deployments now continue to validate that required sport-specific patch files are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->