### PR TITLE
fix(api,web): league ordering by StartsOn; admin-gate Map; Locker Room rename

### DIFF
--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -72,7 +72,10 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                     // Newest-first so a just-created league lands at the top of
                     // YourLeaguesCard on the next /me fetch — matches the
                     // commissioner's mental model coming out of the create flow.
-                    .OrderByDescending(m => m.Group.CreatedUtc)
+                    // StartsOn is null for FullSeason leagues, and Postgres sorts DESC
+                    // with NULLS FIRST - coalesce so undated leagues sink below
+                    // dated ones instead of pinning to the top of Your Leagues.
+                    .OrderByDescending(m => m.Group.StartsOn ?? DateTime.MinValue)
                     .Select(m => new UserDto.UserLeagueMembership
                     {
                         Id = m.Group.Id,

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -167,7 +167,16 @@ function MainApp() {
             <Route path="/picks/:leagueId/weeks/:week" element={<PicksPage />} />
             <Route path="/warroom" element={<WarRoomPage />} />
             <Route path="/leaderboard" element={<LeaderboardPage />} />
-            <Route path="/map" element={<GameMap />} />
+            {/* Admin-only until launch-ready — the nav link is hidden for
+                non-admins too (Navigation.jsx). */}
+            <Route
+              path="/map"
+              element={
+                <AdminRoute>
+                  <GameMap />
+                </AdminRoute>
+              }
+            />
             <Route path="/messageboard" element={<MessageBoardPage />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route

--- a/src/UI/sd-ui/src/components/gallery/Gallery.jsx
+++ b/src/UI/sd-ui/src/components/gallery/Gallery.jsx
@@ -72,7 +72,7 @@ function Gallery() {
       src: '/media/Screenshot 2025-10-30 181706.png',
       type: 'image',
       alt: 'Screenshot 10',
-      title: 'Message Board'
+      title: 'Locker Room'
     },
     {
       src: '/media/Screenshot 2025-10-30 181717.png',

--- a/src/UI/sd-ui/src/components/home/SystemNews.jsx
+++ b/src/UI/sd-ui/src/components/home/SystemNews.jsx
@@ -33,7 +33,7 @@ function SystemNews() {
           AI-powered matchup previews{" "}
           <em>(hint: look between the pick buttons)</em>
         </li>
-        <li>Group-based smack talk threads aka: Messageboards</li>
+        <li>The Locker Room: group-based smack talk threads</li>
         <li>
           Picks can be submitted individually instead of all at once{" "}
           <em>(ahem, you know who you are, someWebsite!)</em>

--- a/src/UI/sd-ui/src/components/layout/Navigation.jsx
+++ b/src/UI/sd-ui/src/components/layout/Navigation.jsx
@@ -13,9 +13,16 @@ import {
   FaMapMarkedAlt
 } from "react-icons/fa";
 import Wordmark from '../brand/Wordmark';
+import { useUserDto } from '../../contexts/UserContext';
 import './Navigation.css';
 
 function Navigation({ isSideNav, onToggle, onSignOut }) {
+  // Game Map is admin-only until the feature is launch-ready — hidden from
+  // regular users in BOTH nav variants (the /app/map route is AdminRoute-
+  // gated too, so a typed URL bounces).
+  const { userDto } = useUserDto();
+  const isAdmin = userDto?.isAdmin === true;
+
   // Auto-close menu on mobile when navigation link is clicked
   const handleNavLinkClick = () => {
     // Only auto-close on mobile/small screens when in side nav mode
@@ -48,13 +55,15 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
               <FaTrophy className="nav-icon" />
               <span>Leaderboard</span>
             </NavLink>
-            <NavLink to="/app/map" className="nav-link" onClick={handleNavLinkClick}>
-              <FaMapMarkedAlt className="nav-icon" />
-              <span>Game Map</span>
-            </NavLink>
+            {isAdmin && (
+              <NavLink to="/app/map" className="nav-link" onClick={handleNavLinkClick}>
+                <FaMapMarkedAlt className="nav-icon" />
+                <span>Game Map</span>
+              </NavLink>
+            )}
             <NavLink to="/app/messageboard" className="nav-link" onClick={handleNavLinkClick}>
               <FaComments className="nav-icon" />
-              <span>Message Board</span>
+              <span>Locker Room</span>
             </NavLink>
             <NavLink to="/app/settings" className="nav-link" onClick={handleNavLinkClick}>
               <FaCog className="nav-icon" />
@@ -120,16 +129,18 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
                   <span>Leaderboard</span>
                 </NavLink>
               </td>
-              <td>
-                <NavLink to="/app/map" className="nav-link">
-                  <FaMapMarkedAlt className="nav-icon" />
-                  <span>Map</span>
-                </NavLink>
-              </td>
+              {isAdmin && (
+                <td>
+                  <NavLink to="/app/map" className="nav-link">
+                    <FaMapMarkedAlt className="nav-icon" />
+                    <span>Map</span>
+                  </NavLink>
+                </td>
+              )}
               <td>
                 <NavLink to="/app/messageboard" className="nav-link">
                   <FaComments className="nav-icon" />
-                  <span>Message Board</span>
+                  <span>Locker Room</span>
                 </NavLink>
               </td>
             </tr>


### PR DESCRIPTION
Three polish items:

## Your Leagues ordering (`GetMeQueryHandler`)

Orders by `Group.StartsOn` desc (was `CreatedUtc` desc, which buried in-season leagues under recently-created test leagues). `StartsOn` is **null for FullSeason leagues** and Postgres sorts `DESC` with NULLS FIRST — coalesced to `DateTime.MinValue` so undated leagues sink below dated ones instead of pinning to the top.

## Game Map admin-gated

Not launch-ready; hidden from non-admins in **both** nav variants (side + top), and `/app/map` wrapped in the existing `AdminRoute` so a typed URL bounces — hiding isn't just cosmetic.

## "Message Board" → "Locker Room"

Renamed everywhere users see it (nav ×2, gallery card, SystemNews blurb). Parallels "War Room," sports-native, and names what the feature is for. The `/app/messageboard` route and internal component/API names are deliberately unchanged — no broken links, no churn. Mobile-parity + UGC-compliance requirements are captured in `docs/mobile/locker-room-mobile-parity.md` (kept local, not in this PR).

## Validation

- API build zero warnings; GetMe tests 8/8
- Web tests 10/10; production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Game Map access is now limited to administrators in navigation and routing.
  - League listings are ordered by group start date, with upcoming or recently started groups shown first.

- **UI Updates**
  - “Message Board” has been renamed to “Locker Room” across navigation, media details, and system news.
  - Game Map links are displayed only to administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->