### PR TITLE
chore(mobile): google-services.json with Play App Signing OAuth client

### DIFF
--- a/src/UI/sd-mobile/google-services.json
+++ b/src/UI/sd-mobile/google-services.json
@@ -14,6 +14,14 @@
       },
       "oauth_client": [
         {
+          "client_id": "812654295319-jieggvrf90ghpkvf4vapbg7m5hq2v2bd.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.sportdeets.mobile",
+            "certificate_hash": "a50d10f7a375ef0d3124a1417e241acbb5f24b92"
+          }
+        },
+        {
           "client_id": "812654295319-jsh0nbhh23mj3ndp5gmui7r9roa9tpiv.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {


### PR DESCRIPTION
Google Sign-In failed with `DEVELOPER_ERROR` on Play-installed builds: Play re-signs the app on delivery, so store installs carry the **Play App Signing certificate** rather than the upload keystore's — the #1 "worked in dev, broke in Play" gotcha called out in `docs/mobile/android-deployment.md`.

Fixed operationally today by registering the Play App Signing SHA-1/SHA-256 fingerprints in Firebase (the signature check is server-side — store installs signed in immediately, no rebuild, verified by the user on a closed-track install).

This PR bakes the refreshed `google-services.json` into the repo: a **strict superset** of the prior file — the existing upload-keystore OAuth client (`235aa78…`, why sideloads always worked) plus the new Play App Signing client (`a50d10f7…`, why store installs now work). Runtime behavior is already correct; this keeps the committed config truthful for future builds.

8 lines added, all one OAuth client block. (This file is intentionally committed — its contents are not secret.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android Google services configuration to support OAuth sign-in for the mobile app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->