### PR TITLE
fix(mobile): picks page lands on the league's current week, not the latest

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -36,6 +36,24 @@ const EMPTY_PICKS: UserPick[] = [];
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
+// Latest week = last element of the ascending seasonWeeks list.
+const latestWeek = (l: { seasonWeeks?: number[] } | null | undefined) =>
+  l?.seasonWeeks?.length ? l.seasonWeeks[l.seasonWeeks.length - 1] : null;
+
+// Default landing week — web parity (PicksPage): the league's CURRENT week
+// when the server provides one and it exists in seasonWeeks; otherwise the
+// latest week. Landing on latest was the bug that dropped users into
+// preseason Week 4 when the league was in Week 2. Past-league summaries
+// carry no currentSeasonWeek, so they still land on latest — correct for a
+// finished season. Module scope: pure helpers, stable across renders, no
+// effect-dependency noise.
+const defaultWeek = (
+  l: { seasonWeeks?: number[]; currentSeasonWeek?: number | null } | null | undefined,
+) =>
+  l?.currentSeasonWeek != null && l.seasonWeeks?.includes(l.currentSeasonWeek)
+    ? l.currentSeasonWeek
+    : latestWeek(l);
+
 export default function PicksScreen() {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -100,22 +118,6 @@ export default function PicksScreen() {
   }, []);
   const [importOpen, setImportOpen] = useState(false);
 
-  // Latest week = last element of the ascending seasonWeeks list.
-  const latestWeek = (l: { seasonWeeks?: number[] } | null | undefined) =>
-    l?.seasonWeeks?.length ? l.seasonWeeks[l.seasonWeeks.length - 1] : null;
-
-  // Default landing week — web parity (PicksPage): the league's CURRENT
-  // week when the server provides one and it exists in seasonWeeks;
-  // otherwise the latest week. Landing on latest was the bug that dropped
-  // users into preseason Week 4 when the league was in Week 2. Past-league
-  // summaries carry no currentSeasonWeek, so they still land on latest —
-  // correct for a finished season.
-  const defaultWeek = (
-    l: { seasonWeeks?: number[]; currentSeasonWeek?: number | null } | null | undefined,
-  ) =>
-    l?.currentSeasonWeek != null && l.seasonWeeks?.includes(l.currentSeasonWeek)
-      ? l.currentSeasonWeek
-      : latestWeek(l);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize/target, not rerun on user selection
   useEffect(() => {
@@ -167,7 +169,8 @@ export default function PicksScreen() {
     refetchMe();
   }, [selectedLeague, seasonWeeks.length, refetchMe]);
 
-  // Snap to the latest week once the weeks actually arrive. The init effect
+  // Snap to the DEFAULT week (current, falling back to latest) once the
+  // weeks actually arrive. The init effect
   // above only runs on league/param change, so without this a heal-refetch
   // would land the data and still leave no week selected.
   useEffect(() => {

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -104,6 +104,19 @@ export default function PicksScreen() {
   const latestWeek = (l: { seasonWeeks?: number[] } | null | undefined) =>
     l?.seasonWeeks?.length ? l.seasonWeeks[l.seasonWeeks.length - 1] : null;
 
+  // Default landing week — web parity (PicksPage): the league's CURRENT
+  // week when the server provides one and it exists in seasonWeeks;
+  // otherwise the latest week. Landing on latest was the bug that dropped
+  // users into preseason Week 4 when the league was in Week 2. Past-league
+  // summaries carry no currentSeasonWeek, so they still land on latest —
+  // correct for a finished season.
+  const defaultWeek = (
+    l: { seasonWeeks?: number[]; currentSeasonWeek?: number | null } | null | undefined,
+  ) =>
+    l?.currentSeasonWeek != null && l.seasonWeeks?.includes(l.currentSeasonWeek)
+      ? l.currentSeasonWeek
+      : latestWeek(l);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize/target, not rerun on user selection
   useEffect(() => {
     // Deep-link param wins: an active league, or the on-demand past league.
@@ -111,12 +124,12 @@ export default function PicksScreen() {
       const active = leagues.find((l) => l.id === leagueIdParam);
       if (active) {
         setLeagueId(active.id);
-        setSelectedWeek(latestWeek(active));
+        setSelectedWeek(defaultWeek(active));
         return;
       }
       if (pastLeagueAsLeague && pastLeagueAsLeague.id === leagueIdParam) {
         setLeagueId(pastLeagueAsLeague.id);
-        setSelectedWeek(latestWeek(pastLeagueAsLeague));
+        setSelectedWeek(defaultWeek(pastLeagueAsLeague));
         return;
       }
       // Param is a past league still being fetched → wait rather than default to
@@ -128,7 +141,7 @@ export default function PicksScreen() {
     // Initialize once to the first active league.
     if (!leagueId && leagues.length > 0) {
       setLeagueId(leagues[0].id);
-      setSelectedWeek(latestWeek(leagues[0]));
+      setSelectedWeek(defaultWeek(leagues[0]));
     }
   }, [leagues, leagueIdParam, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
 
@@ -159,7 +172,7 @@ export default function PicksScreen() {
   // would land the data and still leave no week selected.
   useEffect(() => {
     if (selectedWeek !== null) return;
-    const week = latestWeek(selectedLeague);
+    const week = defaultWeek(selectedLeague);
     if (week !== null) setSelectedWeek(week);
   }, [selectedLeague, selectedWeek]);
 
@@ -169,7 +182,7 @@ export default function PicksScreen() {
       // Search selectableLeagues (active + viewed past) so switching to the past
       // league resolves its weeks instead of transiently clearing selectedWeek.
       const league = selectableLeagues.find((l) => l.id === id);
-      setSelectedWeek(latestWeek(league));
+      setSelectedWeek(defaultWeek(league));
     },
     [selectableLeagues],
   );

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -24,6 +24,13 @@ export interface League {
    * Custom-window leagues may contain a subset (e.g. [4]) rather than 1..N.
    */
   seasonWeeks?: number[];
+  /**
+   * The league's CURRENT week (server-computed from game dates). The picks
+   * page lands here by default — web parity: PicksPage prefers this over
+   * the latest week. Optional: older payloads and past-league summaries
+   * don't carry it, in which case latest-week is the fallback.
+   */
+  currentSeasonWeek?: number | null;
 }
 
 // ─── Probable Pitcher (MLB only) ─────────────────────────────────────────────


### PR DESCRIPTION
Tester-reported (and reproduced): joining the NFL preseason league — or tapping it on the mobile home page — landed on **Week 4** (the final week) while the league is in **Week 2**. Web behaves correctly.

## Root cause

`/user/me` leagues carry `currentSeasonWeek` (server-computed), and web's PicksPage prefers it with a `seasonWeeks.includes` validity check — but mobile's `League` type **omitted the field entirely**, and all five week-selection paths (deep-link init, past-league init, first-league default, weeks-arrived snap, league-change handler) used the *last element* of `seasonWeeks`.

## Fix

- `currentSeasonWeek?: number | null` added to the `League` type (documented).
- `defaultWeek()` helper with web's exact semantics — `currentSeasonWeek` when present **and** contained in `seasonWeeks`, else latest — feeds all five paths.
- `latestWeek` survives only as the internal fallback, which keeps past/deactivated leagues (whose summaries carry no `currentSeasonWeek`) landing on their final week — correct for a finished season.

## Ship path

JS-only — reaches closed-track testers via `eas update` immediately after merge; no build, no store review.

## Validation

`tsc --noEmit` clean; Jest 102/102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Picks now open to the league’s current season week when available.
  * Improved week selection for deep links, league switching, and refreshed league data.
  * Past leagues continue to default to their latest available week when no current week is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->