### PR TITLE
feat(api,web): prompt capture, sandboxed model experiments, and admin Preview Lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,8 @@ bruno/**/.env
 src/UI/sd-mobile/dist/
 src/UI/sd-mobile/coverage/
 src/UI/sd-mobile/junit.xml
+
+# LLM prompts are proprietary (the 'secret sauce') and live in Azure Blob
+# storage ONLY - the repo is public. Local exports for analysis are fine;
+# they must never be committed.
+docs/metrics-modeling/prompts/

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -254,7 +254,7 @@ by the model verbatim. Structural choices worth noting:
 
 ---
 
-## 3.6 Prompt capture + persistence plan (2026-08-07, pre-implementation)
+## 3.6 Prompt capture + persistence (designed 2026-08-07, implemented in PR #601)
 
 Goal (user): run locally, trigger generation for one game from admin,
 and see EXACTLY what would be sent to the model — without burning
@@ -349,7 +349,8 @@ regeneration). Capture completion publishes a lightweight event through
 the same notification path. Retrieval is a companion
 `GET /admin/matchup/preview/{contestId}/captures` (list, newest first)
 returning payload + metadata, with the full prompt reconstructed
-(blob text + payload + editor note) so the admin sees exactly what the
+(persisted PromptText + PayloadJson + EditorNote — no blob round-trip,
+matching BuildCapture) so the admin sees exactly what the
 model would receive. The existing `/reset` endpoint stays untouched.
 
 **5. Always-on persistence** — the real generation path writes the same

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -1,0 +1,428 @@
+# Matchup Preview — Data Inputs (Capture + Historical Enrichment Design)
+
+Status: analysis + design, 2026-08-07. Captures exactly what the preview
+model received during the 2025-season alpha (and receives today), then
+proposes the historical-data enrichment for early-season quality. No
+implementation authorized yet.
+
+Relevant code: `MatchupPreviewProcessor` (SportsData.Api),
+`MatchupForPreviewDto` (SportsData.Core), `MatchupPreviewPromptProvider`,
+Producer's `GetMatchupForPreview` / `GetFranchiseSeasonPreviewStats` /
+`GetFranchiseSeasonMetricsByFranchiseSeasonId` /
+`GetFranchiseSeasonCompetitionResults`.
+
+---
+
+## 1. What the model receives today
+
+The processor serializes the ENTIRE enriched `MatchupForPreviewDto` as raw
+JSON and appends it to the prompt. Field census:
+
+**Game context:** Sport, SeasonYear, WeekNumber, ContestId, HeadLine,
+StartDateUtc, Status/StatusDescription, Venue/VenueCity/VenueState.
+
+**Per team (Away/Home):** FranchiseSeasonId, name, slug, rank (poll),
+ConferenceSlug, Wins/Losses, ConferenceWins/Losses, plus three enrichment
+blocks fetched by the processor:
+
+- **Stats** (`FranchiseSeasonModelStatsDto`): PointsPerGame, YardsPerGame,
+  Passing/RushingYardsPerGame, ThirdDownConvPct, RedZoneScoringPct,
+  TurnoverDifferential, PenaltiesPerGame, PenaltyYardsPerGame,
+  AvgYardsPerPlay, Sacks, Interceptions, FumblesLost, Takeaways.
+- **Metrics** (`FranchiseSeasonMetricsDto`): the advanced block — Ypp,
+  SuccessRate, ExplosiveRate, PointsPerDrive, ThirdFourthRate,
+  RzTdRate/RzScoreRate, TimePossRatio, the Opp* mirrors of all of those,
+  NetPunt, FgPctShrunk, FieldPosDiff, TurnoverMarginPerDrive,
+  PenaltyYardsPerPlay, PtsScored/Allowed Min/Max/Avg, GamesPlayed.
+  **Both-or-nothing rule:** if either team's metrics are missing, both are
+  nulled (asymmetric analytics would bias the model toward the covered
+  team).
+- **CompetitionResults** (`FranchiseSeasonCompetitionResultDto[]`): the
+  team's games this season — date, opponents (short/slug/rank), spread,
+  O/U, final scores, winner, spread-winner, O/U result.
+
+**Odds:** Spread (text), Away/HomeSpread, OverUnder, Over/UnderOdds — from
+the preferred odds provider (DraftKings).
+
+**Feedback loop:** if a prior preview for this contest was rejected, the
+rejection note is appended as "Additional feedback from the editor."
+
+**Prompt selection** (`MatchupPreviewPromptProvider`, Azure Blob container
+`prompts`): `hasStats` = BOTH teams have `RushingYardsPerGame` →
+`prediction-insights-with-stats-schedule.txt`; else
+`prediction-insights-v1.txt`. `PromptVersion` (blob name) is persisted on
+every generated preview — good provenance, keep it.
+
+**Model:** whatever `IProvideAiCommunication` is bound to (DeepSeek at
+present); model name persisted per preview. `UsedMetrics` flag records
+whether the metrics block survived the both-or-nothing rule.
+
+### Prompts — reviewed 2026-08-07 (NOT in source control, by design)
+
+The prompt texts are proprietary ("secret sauce") and live in the Azure
+Blob `prompts` container ONLY — this repo is public, so they are never
+committed. `docs/metrics-modeling/prompts/` is gitignored; local exports
+there are working copies for analysis. Blob inventory: 
+`prediction-insights-v1.txt`, `prediction-insights-with-stats.txt`
+(legacy variant, not referenced by the provider),
+`prediction-insights-with-stats-schedule.txt`, `game-recap-v1/v2.txt`.
+PromptVersion (blob name) persisted per preview remains the provenance
+mechanism; prompt edits happen against blob storage directly.
+
+**Findings from reading the active prompt
+(`with-stats-schedule`, 24-rule contract):**
+
+1. **It opens "You are a college football analyst"** — and since the
+   multi-sport unlock (#595) this same prompt generates NFL previews.
+   Sport-aware prompt voice (or neutral wording) is now a live gap, and
+   folds naturally into the with-history prompt authoring below.
+2. **The advanced Metrics block is un-briefed.** The processor ships
+   AwayMetrics/HomeMetrics, but the prompt documents only
+   AwayStats/HomeStats and CompetitionResults — the model receives ~30
+   advanced fields with no instruction. Either the with-history prompt
+   teaches them (preferred) or the payload drops them; today they are
+   tokens spent on unexplained data.
+3. Rules 21–24 already counteract spread-parroting and rank-overweight —
+   the prompt engineering anticipated the early-season signal problem;
+   the historical blocks give those rules material to work with.
+
+---
+
+## 2. The early-season problem (current behavior)
+
+Every enrichment block is keyed by the CURRENT season's FranchiseSeasonId:
+
+- Weeks 1–2: Stats are null → `hasStats` false → the no-stats prompt.
+  Metrics: GamesPlayed 0 or tiny samples (or absent → nulled).
+  CompetitionResults: empty or one game.
+- Net: an early-season preview reasons from **records (0-0), poll ranks,
+  venue, and the betting line** — the line being the only real signal.
+  The model is effectively paraphrasing the spread.
+- The problem decays but doesn't vanish: through roughly week 4, current-
+  season samples are noise-dominated (opponent quality unadjusted).
+
+---
+
+## 3. Historical enrichment design (build-upon proposal)
+
+Principle (user decision 2026-08-07): historical data flows to the model
+ALL season, not just early — the model weighs recency; we don't gate it.
+
+### 3a. Prior-season block (per team)
+
+Add `AwayPriorSeason` / `HomePriorSeason` to the preview payload:
+
+- Prior season's final record, conference record, final poll rank (if
+  any), and the full `FranchiseSeasonMetricsDto` for that season.
+- Resolution: current FranchiseSeasonId → Franchise → FranchiseSeason for
+  SeasonYear-1. New Producer query/endpoint (by franchiseId + year, or a
+  purpose-built "preview history" endpoint that returns the whole block).
+- Same both-or-nothing symmetry rule as current metrics.
+
+### 3b. Head-to-head history
+
+Last N (propose 5) meetings between the two franchises: date, scores,
+winner, and the spread result where available. Canonical query by
+franchise pair across seasons. High narrative value for the LLM ("X has
+won 4 straight in this series").
+
+### 3c. Recency bridge (late prior season form)
+
+The last ~5 games of the prior season per team (same
+`FranchiseSeasonCompetitionResultDto` shape) — "how did they finish?"
+matters more than season aggregates for early-current-season reads.
+
+### 3d. Roster-churn guardrail (prompt, not data)
+
+NCAA transfer portal / NFL free agency mean prior-season data describes a
+partially different team. The with-history prompt must instruct the model
+to discount historical signal accordingly (more heavily for NCAA). This
+is prompt text, not code.
+
+### 3e. Payload hygiene (recommended, separable)
+
+Today the raw wire DTO is serialized — GUIDs, slugs, $ref-ish fields the
+model can't use burn tokens and add noise. Propose a purpose-built prompt
+payload (projection of the DTO) so the prompt contract stops being
+coupled to wire-DTO churn. Doing this BEFORE adding historical blocks
+keeps the enlarged payload inside sane token budgets.
+
+### Prompt evolution
+
+New blob `prediction-insights-with-history-v1.txt` (naming keeps the
+PromptVersion provenance meaningful). Selection becomes: history present →
+with-history variant (which itself branches on hasStats internally or via
+two variants — decide during prompt authoring).
+
+---
+
+## 3.5 Proposed model payload structure (draft, 2026-08-07)
+
+Findings from prototyping the history queries
+(`sql/pgsql/_debug_contest.sql`, `_debug_preview_history.sql`, CAR/ARI
+test pair):
+
+- **Franchise-level join is the cross-season identity path.**
+  FranchiseSeasonIds change every year; Contest → FranchiseSeason →
+  Franchise resolves head-to-head across 2001–2025 cleanly.
+- **Playoff meetings surface in head-to-head** (e.g. the 2015 NFC
+  Championship, 49-15). Keep them — highest narrative value — but label
+  them: carry SeasonPhase name and EventNote per game.
+- **Spread/O-U context decays historically.** SpreadWinner is null and
+  OverUnder = 0 for roughly pre-2012 rows (and scattered later ones).
+  Historical ATS fields are OPTIONAL — omit when absent, never zero-fill.
+- **`Contest.OverUnder` is the RESULT enum (0 none / 1 Over / 2 Under),
+  not the line.** The line is not persisted on historical contests, so
+  historical O/U context is result-only.
+- **GUID trap:** historical Contest rows carry per-season
+  FranchiseSeasonIds. If serialized, the model can echo one into
+  `predictedStraightUpWinner` (the output contract demands a
+  FranchiseSeasonId). Rule: **exactly two GUIDs in the entire payload** —
+  the live Away/Home FranchiseSeasonIds. Every historical block is
+  names/labels only.
+
+Draft shape (also implements the 3e hygiene projection — this IS the
+purpose-built prompt payload, not the wire DTO):
+
+```jsonc
+{
+  "Sport": "FootballNfl",              // string enum; lets the prompt voice adapt per sport
+  "SeasonYear": 2026, "WeekNumber": 1,
+  "StartDateUtc": "...", "Venue": "...", "VenueCity": "...", "VenueState": "...",
+
+  "Away": "Carolina Panthers", "AwaySlug": "carolina-panthers",
+  "AwayFranchiseSeasonId": "<guid>",   // one of the only two GUIDs
+  "AwayRank": null,
+  "AwayRecord": { "Wins": 0, "Losses": 0, "ConfWins": 0, "ConfLosses": 0, "ConferenceSlug": "nfc-south" },
+  "AwayStats":   { /* FranchiseSeasonModelStatsDto — null weeks 1-2 */ },
+  "AwayMetrics": { /* FranchiseSeasonMetricsDto — both-or-nothing */ },
+  "AwaySeasonResults": [ /* current season, GameResult shape below */ ],
+  "AwayPriorSeason": {
+    "SeasonYear": 2025,
+    "Record": { "Wins": 0, "Losses": 0, "ConfWins": 0, "ConfLosses": 0 },
+    "FinalRank": null,
+    "Stats": { }, "Metrics": { },      // same shapes as current-season blocks
+    "LastFiveGames": [ /* GameResult */ ]   // the 3c recency bridge
+  },
+  // Home* mirrors all of the above
+
+  "HeadToHead": {
+    "GamesIncluded": 5,
+    "Games": [ /* GameResult, newest first */ ]
+  },
+
+  "Odds": { "Spread": "ARI -3", "AwaySpread": 3.0, "HomeSpread": -3.0,
+            "OverUnder": 44.5, "OverOdds": -110, "UnderOdds": -110 }
+}
+```
+
+**One unified `GameResult` shape** for all three lists (season results,
+prior-season last-five, head-to-head):
+
+```jsonc
+{
+  "Date": "2025-09-14", "SeasonYear": 2025,
+  "Phase": "Regular Season",           // SeasonPhase.Name; "Postseason" flags playoffs
+  "Home": "Arizona Cardinals", "Away": "Carolina Panthers",
+  "HomeScore": 27, "AwayScore": 22,
+  "Winner": "Arizona Cardinals",
+  "SpreadWinner": "Carolina Panthers", // omitted when unknown
+  "OverUnderResult": "Over",           // omitted when no line
+  "OpponentRank": null,                // season/recency lists only
+  "Note": "NFC Championship"           // EventNote; omitted when null
+}
+```
+
+Serialization rules: omit-null (no zero-fill, no `"SpreadWinner": null`
+noise), ISO dates, string enums over ints — every value should be usable
+by the model verbatim. Structural choices worth noting:
+
+- **Constant shape year-round** (user directive: history flows all
+  season). Week 1 and week 14 payloads differ only in which blocks are
+  populated — one prompt contract, no seasonal branching.
+- **PriorSeason.LastFiveGames replaces a free-floating "recent form"
+  list** — a cross-season "last 5" would overlap AwaySeasonResults
+  mid-season; scoping the bridge to the prior season keeps the two lists
+  disjoint by construction.
+- **No computed series summary** ("Arizona leads 3-2") — the model
+  derives it from 5 rows; computing it invites drift between summary and
+  rows.
+- Rough token cost: GameResult ≈ 40 tokens compact → H2H (5) + 2×5 prior
+  + 2×~17 season ≈ 2k tokens of game rows; the hygiene projection claws
+  back much of that from dropped GUIDs/wire noise.
+
+---
+
+## 3.6 Prompt capture + persistence plan (2026-08-07, pre-implementation)
+
+Goal (user): run locally, trigger generation for one game from admin,
+and see EXACTLY what would be sent to the model — without burning
+tokens. Then persist the data payload on every real generation (the
+thing we should have been saving all along — today only `PromptVersion`
+and `Model` survive; the serialized matchup JSON is gone the moment the
+call returns).
+
+### Where things stand in code
+
+- Single-game admin trigger EXISTS:
+  `POST /admin/matchup/preview/{contestId}/reset?sport=...` → enqueues
+  `GenerateMatchupPreviewsCommand` via Hangfire.
+- The processor composes `fullPrompt = promptText + "\n\n" + json(dto)
+  [+ editorNote]` inline at `MatchupPreviewProcessor.cs:109` — assembly
+  and LLM call are one code path, which is what makes capture easy to
+  add faithfully.
+
+### Storage decision: API's own Postgres, NOT Provider's IDocumentStore
+
+Considered: exposing Provider's Mongo `IDocumentStore` to API.
+Rejected, for the same reason API never touches Producer's database:
+the document store is Provider's PRIVATE persistence for third-party
+source documents; crossing that boundary couples API deploys/config to
+Provider infra and adds a Mongo connection + failure mode to API pods.
+Also mechanical: `IDocumentStore` is defined inside SportsData.Provider
+(`MongoDocumentService.cs`), not Core — using it would mean moving the
+interface or referencing Provider outright.
+
+The scale doesn't warrant a document store anyway: payloads are
+~10–30 KB of JSON, a few thousand per season (~60–100 MB/season).
+A `jsonb` column in API's Postgres is transactional with the preview
+row, joinable against `MatchupPreview`/contest for backtesting, and
+queryable ("captures where AwayMetrics was null").
+
+### Design
+
+**0. The overwrite hazard (drove the final shape).** The picks-page
+read is newest-non-rejected `MatchupPreview` per contest — so a testing
+run that wrote a preview row for a contest which already has one from a
+prior season would SHADOW the real preview instantly. Protection:
+experiment runs never write `MatchupPreview` at all; their results live
+on the capture row. (Real generation independently keeps its
+completed-contest skip.) This also removed any need to un-hide the
+admin approve/reject controls for completed games on the picks page —
+the Preview Lab replaces that path entirely.
+
+**1. Command mode** — `GenerateMatchupPreviewsCommand.Mode`:
+`Generate` (0, default — old serialized payloads keep working, same
+pattern as the Sport default), `Capture` (prompt persisted, no model
+call), `Experiment` (model called; raw response + model name +
+parse/validation problems recorded on the capture row; no
+MatchupPreview, no PreviewGenerated event). Capture and Experiment
+allow completed contests; Generate does not.
+
+**2. Processor refactor** — extract payload assembly (client fetches →
+both-or-nothing → hasStats → prompt selection → serialize → editor
+note) into one method returning the assembled prompt parts. Both paths
+(capture and real) use it — the capture is byte-identical to what
+generation would send, by construction. In capture mode: persist the
+capture row, SKIP the LLM call, the `MatchupPreview` row, and the
+`PreviewGenerated` event.
+
+**3. New entity `MatchupPreviewPrompt`** (API Postgres):
+
+| Field | Notes |
+|---|---|
+| Id, ContestId, Sport | |
+| MatchupPreviewId (nullable FK) | null for dry-run captures; set when a real generation wrote a preview |
+| PromptVersion | blob name, as today |
+| PayloadJson (jsonb) | the serialized matchup DTO — the data part |
+| EditorNote (nullable) | rejection-feedback text if it was appended |
+| CharCount, EstTokens | chars/4 estimate — pre-flight budget visibility |
+| Mode | Generate / Capture / Experiment |
+| Model, RawResponse, ResponseValidationErrors | model-call runs; RawResponse is deliberately `text` NOT `jsonb` — malformed responses are exactly the failures an experiment must record |
+| CreatedUtc, CorrelationId | |
+
+Store the DATA + prompt name, not the rendered instruction text:
+instructions are already versioned in blob (policy: edits get a new
+blob name, never in-place), and duplicating ~8 KB of secret sauce into
+thousands of rows adds nothing. Full prompt is reconstructable:
+blob(PromptVersion) + "\n\n" + PayloadJson + EditorNote.
+
+**4. Admin capture endpoint** — new
+`POST /admin/matchup/preview/{contestId}/capture?sport=...`, ASYNC via
+Hangfire, matching the established admin pattern (decision 2026-08-07:
+toast on submit → SignalR notification on completion, exactly like
+regeneration). Capture completion publishes a lightweight event through
+the same notification path. Retrieval is a companion
+`GET /admin/matchup/preview/{contestId}/captures` (list, newest first)
+returning payload + metadata, with the full prompt reconstructed
+(blob text + payload + editor note) so the admin sees exactly what the
+model would receive. The existing `/reset` endpoint stays untouched.
+
+**5. Always-on persistence** — the real generation path writes the same
+`MatchupPreviewPrompt` row (linked to the preview) in the same
+SaveChanges. From then on every preview carries its exact inputs —
+which is also the corpus for the 3.5 projection work: capture today's
+raw-DTO payloads, build the projection, diff.
+
+### Decisions (made 2026-08-07)
+
+1. **Capture mode ALLOWS completed contests.** Rationale goes beyond
+   local testing: completed games + captured payloads + actual outcomes
+   (already on Contest) form an EVAL HARNESS — replay a stored payload
+   against model X / prompt-variant Y and score the prediction against
+   reality. Expectation: different data shapes and instructions will
+   perform differently per model; this table is what makes that
+   measurable. (Real generation keeps its completed-contest skip.)
+2. **Async capture** via Hangfire + SignalR completion notification —
+   consistent with the existing admin regeneration UX (toast → SignalR).
+   Retrieval via the GET captures endpoint.
+3. **Keep forever.** The captures are the backtest corpus, not debug
+   debris.
+
+Eval-harness note (future, separate effort): a backtest run =
+`MatchupPreviewPrompt.PayloadJson` × {model, prompt blob} →
+prediction vs `Contest` final score / spread result. The capture table
+deliberately stores everything that run needs; the harness itself is
+not part of this build.
+
+### Admin UI — Preview Lab (built with the above, 2026-08-07)
+
+`/admin/preview-lab` (AdminRoute-gated): league selector + ContestId
+input (grab the GUID from the picks page), actions **Capture prompt**
+and **Run experiment**, list of captures per contest with mode badge,
+prompt version, model, est. tokens, expandable full-prompt / payload /
+raw-response blocks (copy buttons), and validation problems surfaced.
+SignalR `PreviewPromptCaptured` completion auto-refreshes the list.
+Endpoints: `POST .../capture`, `POST .../experiment`,
+`GET .../captures` on AdminController. The picks-page Matchup Preview
+logic is untouched by design.
+
+---
+
+## 4. Data availability (verified against the corpus work, 2026-08)
+
+- Play-by-play-derived metrics corpus: FBS NCAA 94–99.9% for 2008–2025;
+  NFL near-complete 2006–2025. Prior-season metrics for 2026 previews
+  (i.e. 2025 data) are in the strongest part of the corpus.
+- **Verify before build:** whether `FranchiseSeasonMetric` season
+  aggregates were actually GENERATED for prior seasons (the corpus work
+  confirmed CompetitionMetric coverage; the season-aggregate rows for
+  historical seasons need a count check per sport/season). If absent, a
+  one-time backfill job precedes 3a.
+- Head-to-head (3b) and prior-season results (3c) need only Contest
+  rows — coverage is effectively complete for both sports.
+
+---
+
+## 5. Open decisions
+
+1. N for head-to-head (proposed 5) and recency bridge (proposed 5 games).
+2. One combined Producer "preview history" endpoint vs. composing existing
+   per-piece endpoints (proposed: one endpoint — one HTTP hop, one place
+   to evolve).
+3. Payload-hygiene projection (3e) first, or accept token growth and do it
+   later (proposed: first).
+4. Prompt authoring workflow for with-history-v1. Prompts stay blob-only
+   (secret sauce, public repo — decided 2026-08-07); author against local
+   gitignored working copies, upload to blob, PromptVersion tracks it.
+5. Whether the DTO gains blocks (wire change through Producer client) or
+   the API composes history separately — follows from decision 2.
+
+## Sequencing
+
+1. ~~Prompt capture~~ — done 2026-08-07 (local working copies only;
+   blob remains source of truth).
+2. Verify prior-season FranchiseSeasonMetric row coverage — SQL ready in
+   `sql/pgsql/_debug_preview_history.sql` (query 3), run per sport DB.
+3. Decisions 1–5 above.
+4. Design doc v2 with endpoint/DTO shapes → authorization → build.

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -2,8 +2,9 @@
 
 Status: analysis + design, 2026-08-07. Captures exactly what the preview
 model received during the 2025-season alpha (and receives today), then
-proposes the historical-data enrichment for early-season quality. No
-implementation authorized yet.
+proposes the historical-data enrichment for early-season quality. The
+prompt-capture / experiment tooling (§3.6) is IMPLEMENTED (PR #601);
+only the historical enrichment (§3–3.5) remains unapproved.
 
 Relevant code: `MatchupPreviewProcessor` (SportsData.Api),
 `MatchupForPreviewDto` (SportsData.Core), `MatchupPreviewPromptProvider`,
@@ -324,6 +325,7 @@ capture row, SKIP the LLM call, the `MatchupPreview` row, and the
 | Id, ContestId, Sport | |
 | MatchupPreviewId (nullable FK) | null for dry-run captures; set when a real generation wrote a preview |
 | PromptVersion | blob name, as today |
+| PromptText | instruction text EXACTLY as sent — stored per capture because a blob can be edited in place, which would make version-based reconstruction lie (CR finding on #601) |
 | PayloadJson (jsonb) | the serialized matchup DTO — the data part |
 | EditorNote (nullable) | rejection-feedback text if it was appended |
 | CharCount, EstTokens | chars/4 estimate — pre-flight budget visibility |
@@ -331,11 +333,13 @@ capture row, SKIP the LLM call, the `MatchupPreview` row, and the
 | Model, RawResponse, ResponseValidationErrors | model-call runs; RawResponse is deliberately `text` NOT `jsonb` — malformed responses are exactly the failures an experiment must record |
 | CreatedUtc, CorrelationId | |
 
-Store the DATA + prompt name, not the rendered instruction text:
-instructions are already versioned in blob (policy: edits get a new
-blob name, never in-place), and duplicating ~8 KB of secret sauce into
-thousands of rows adds nothing. Full prompt is reconstructable:
-blob(PromptVersion) + "\n\n" + PayloadJson + EditorNote.
+Originally the plan stored only PromptVersion + payload and
+reconstructed via the blob — rejected during review: `ReloadPromptAsync`
+can replace a blob in place, so version-based reconstruction could show
+text that differs from what the model actually received. Each capture
+stores its instruction text; the DB is private, and ~10 KB per row at a
+few thousand rows/season is noise. Full prompt = PromptText + "\n\n" +
+PayloadJson + EditorNote, all from the row.
 
 **4. Admin capture endpoint** — new
 `POST /admin/matchup/preview/{contestId}/capture?sport=...`, ASYNC via

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -15,6 +15,7 @@ using SportsData.Api.Application.Admin.Queries.GetCompetitionsWithoutPlays;
 using SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests;
 using SportsData.Api.Application.Admin.Queries.GetMatchupForContest;
 using SportsData.Api.Application.Admin.Queries.GetMatchupPreview;
+using SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures;
 using SportsData.Api.Application.Admin.SignalRDebug;
 using SportsData.Api.Application.Admin.Commands.ReenrichContest;
 using SportsData.Api.Application.Previews;
@@ -132,6 +133,70 @@ namespace SportsData.Api.Application.Admin
             };
             _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
             return Accepted(new { cmd.CorrelationId });
+        }
+
+        /// <summary>
+        /// Dry run: assemble and persist the exact prompt payload for a
+        /// contest WITHOUT calling the model or writing a preview. Completed
+        /// contests are allowed (backtest capture). Completion is announced
+        /// via SignalR (PreviewPromptCaptured); retrieve results from the
+        /// captures endpoint below.
+        /// </summary>
+        [HttpPost]
+        [Route("matchup/preview/{contestId}/capture")]
+        public IActionResult CaptureContestPreviewPrompt(
+            [FromRoute] Guid contestId,
+            [FromQuery] Sport sport = Sport.FootballNcaa)
+        {
+            var cmd = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = contestId,
+                Sport = sport,
+                Mode = PreviewGenerationMode.Capture
+            };
+            _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
+            return Accepted(new { cmd.CorrelationId });
+        }
+
+        /// <summary>
+        /// Eval run: assemble the prompt, call the model, and store the raw
+        /// response on the capture row. NEVER writes a MatchupPreview — safe
+        /// to run against contests that already have a real preview from a
+        /// prior season (the picks page reads newest-non-rejected, so an
+        /// experimental preview row would shadow the real one). Completed
+        /// contests allowed. Completion announced via SignalR
+        /// (PreviewPromptCaptured).
+        /// </summary>
+        [HttpPost]
+        [Route("matchup/preview/{contestId}/experiment")]
+        public IActionResult RunContestPreviewExperiment(
+            [FromRoute] Guid contestId,
+            [FromQuery] Sport sport = Sport.FootballNcaa)
+        {
+            var cmd = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = contestId,
+                Sport = sport,
+                Mode = PreviewGenerationMode.Experiment
+            };
+            _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
+            return Accepted(new { cmd.CorrelationId });
+        }
+
+        /// <summary>
+        /// Persisted prompt captures for a contest, newest first — payload,
+        /// metadata, and the full rendered prompt exactly as the model would
+        /// receive it (instruction blob + payload + editor note).
+        /// </summary>
+        [HttpGet]
+        [Route("matchup/preview/{contestId}/captures")]
+        public async Task<ActionResult<List<MatchupPreviewCaptureDto>>> GetContestPreviewPromptCaptures(
+            [FromRoute] Guid contestId,
+            [FromServices] IGetMatchupPreviewCapturesQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(new GetMatchupPreviewCapturesQuery(contestId), cancellationToken);
+            return result.ToActionResult();
         }
 
         [HttpPost]

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQuery.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQuery.cs
@@ -1,0 +1,3 @@
+namespace SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures;
+
+public record GetMatchupPreviewCapturesQuery(Guid ContestId);

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryHandler.cs
@@ -1,0 +1,95 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Prompts;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures;
+
+public interface IGetMatchupPreviewCapturesQueryHandler
+{
+    Task<Result<List<MatchupPreviewCaptureDto>>> ExecuteAsync(GetMatchupPreviewCapturesQuery query, CancellationToken cancellationToken);
+}
+
+public class GetMatchupPreviewCapturesQueryHandler : IGetMatchupPreviewCapturesQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly MatchupPreviewPromptProvider _promptProvider;
+    private readonly ILogger<GetMatchupPreviewCapturesQueryHandler> _logger;
+
+    public GetMatchupPreviewCapturesQueryHandler(
+        AppDataContext dataContext,
+        MatchupPreviewPromptProvider promptProvider,
+        ILogger<GetMatchupPreviewCapturesQueryHandler> logger)
+    {
+        _dataContext = dataContext;
+        _promptProvider = promptProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<List<MatchupPreviewCaptureDto>>> ExecuteAsync(
+        GetMatchupPreviewCapturesQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (query.ContestId == Guid.Empty)
+        {
+            return new Failure<List<MatchupPreviewCaptureDto>>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(query.ContestId), "Contest ID cannot be empty")]);
+        }
+
+        try
+        {
+            var captures = await _dataContext.MatchupPreviewPrompts
+                .AsNoTracking()
+                .Where(x => x.ContestId == query.ContestId)
+                .OrderByDescending(x => x.CreatedUtc)
+                .Select(x => new MatchupPreviewCaptureDto
+                {
+                    Id = x.Id,
+                    ContestId = x.ContestId,
+                    Sport = x.Sport,
+                    MatchupPreviewId = x.MatchupPreviewId,
+                    PromptVersion = x.PromptVersion,
+                    PayloadJson = x.PayloadJson,
+                    EditorNote = x.EditorNote,
+                    CharCount = x.CharCount,
+                    EstTokens = x.EstTokens,
+                    Mode = x.Mode,
+                    Model = x.Model,
+                    RawResponse = x.RawResponse,
+                    ResponseValidationErrors = x.ResponseValidationErrors,
+                    CreatedUtc = x.CreatedUtc
+                })
+                .ToListAsync(cancellationToken);
+
+            // Zero captures is a normal empty state — return 200 + [] so a
+            // 404 from this route can only mean the endpoint isn't there.
+            foreach (var capture in captures)
+            {
+                // Reconstruct exactly what the processor renders:
+                // promptText + "\n\n" + payload [+ editor note]
+                var promptText = await _promptProvider.GetPromptTextByVersionAsync(capture.PromptVersion);
+
+                var editorNote = capture.EditorNote != null
+                    ? $"\n\nAdditional feedback from the editor:\n\"{capture.EditorNote}\""
+                    : string.Empty;
+
+                capture.FullPrompt = $"{promptText}\n\n{capture.PayloadJson}{editorNote}";
+            }
+
+            return new Success<List<MatchupPreviewCaptureDto>>(captures);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving prompt captures for contest {ContestId}", query.ContestId);
+            return new Failure<List<MatchupPreviewCaptureDto>>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure("Error", "An error occurred while retrieving prompt captures")]);
+        }
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryHandler.cs
@@ -1,9 +1,6 @@
-using FluentValidation.Results;
-
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Api.Infrastructure.Prompts;
 using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures;
@@ -16,16 +13,13 @@ public interface IGetMatchupPreviewCapturesQueryHandler
 public class GetMatchupPreviewCapturesQueryHandler : IGetMatchupPreviewCapturesQueryHandler
 {
     private readonly AppDataContext _dataContext;
-    private readonly MatchupPreviewPromptProvider _promptProvider;
     private readonly ILogger<GetMatchupPreviewCapturesQueryHandler> _logger;
 
     public GetMatchupPreviewCapturesQueryHandler(
         AppDataContext dataContext,
-        MatchupPreviewPromptProvider promptProvider,
         ILogger<GetMatchupPreviewCapturesQueryHandler> logger)
     {
         _dataContext = dataContext;
-        _promptProvider = promptProvider;
         _logger = logger;
     }
 
@@ -33,12 +27,15 @@ public class GetMatchupPreviewCapturesQueryHandler : IGetMatchupPreviewCapturesQ
         GetMatchupPreviewCapturesQuery query,
         CancellationToken cancellationToken)
     {
-        if (query.ContestId == Guid.Empty)
+        var validation = await new GetMatchupPreviewCapturesQueryValidator()
+            .ValidateAsync(query, cancellationToken);
+
+        if (!validation.IsValid)
         {
             return new Failure<List<MatchupPreviewCaptureDto>>(
                 default!,
                 ResultStatus.Validation,
-                [new ValidationFailure(nameof(query.ContestId), "Contest ID cannot be empty")]);
+                validation.Errors);
         }
 
         try
@@ -62,25 +59,18 @@ public class GetMatchupPreviewCapturesQueryHandler : IGetMatchupPreviewCapturesQ
                     Model = x.Model,
                     RawResponse = x.RawResponse,
                     ResponseValidationErrors = x.ResponseValidationErrors,
+                    // The instruction text is stored per capture, so this is
+                    // the EXACT model input — no blob round-trip, immune to
+                    // in-place blob edits after the fact.
+                    FullPrompt = x.EditorNote != null
+                        ? x.PromptText + "\n\n" + x.PayloadJson + "\n\nAdditional feedback from the editor:\n\"" + x.EditorNote + "\""
+                        : x.PromptText + "\n\n" + x.PayloadJson,
                     CreatedUtc = x.CreatedUtc
                 })
                 .ToListAsync(cancellationToken);
 
             // Zero captures is a normal empty state — return 200 + [] so a
             // 404 from this route can only mean the endpoint isn't there.
-            foreach (var capture in captures)
-            {
-                // Reconstruct exactly what the processor renders:
-                // promptText + "\n\n" + payload [+ editor note]
-                var promptText = await _promptProvider.GetPromptTextByVersionAsync(capture.PromptVersion);
-
-                var editorNote = capture.EditorNote != null
-                    ? $"\n\nAdditional feedback from the editor:\n\"{capture.EditorNote}\""
-                    : string.Empty;
-
-                capture.FullPrompt = $"{promptText}\n\n{capture.PayloadJson}{editorNote}";
-            }
-
             return new Success<List<MatchupPreviewCaptureDto>>(captures);
         }
         catch (Exception ex)
@@ -89,7 +79,7 @@ public class GetMatchupPreviewCapturesQueryHandler : IGetMatchupPreviewCapturesQ
             return new Failure<List<MatchupPreviewCaptureDto>>(
                 default!,
                 ResultStatus.Error,
-                [new ValidationFailure("Error", "An error occurred while retrieving prompt captures")]);
+                [new FluentValidation.Results.ValidationFailure("Error", "An error occurred while retrieving prompt captures")]);
         }
     }
 }

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryValidator.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures;
+
+public class GetMatchupPreviewCapturesQueryValidator : AbstractValidator<GetMatchupPreviewCapturesQuery>
+{
+    public GetMatchupPreviewCapturesQueryValidator()
+    {
+        RuleFor(x => x.ContestId)
+            .NotEmpty()
+            .WithMessage("Contest ID cannot be empty");
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/MatchupPreviewCaptureDto.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/MatchupPreviewCaptureDto.cs
@@ -1,0 +1,46 @@
+using SportsData.Api.Application.Previews;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures;
+
+public class MatchupPreviewCaptureDto
+{
+    public Guid Id { get; set; }
+
+    public Guid ContestId { get; set; }
+
+    public Sport Sport { get; set; }
+
+    /// <summary>Null for dry-run captures; set when a real generation produced a preview.</summary>
+    public Guid? MatchupPreviewId { get; set; }
+
+    public string PromptVersion { get; set; } = default!;
+
+    /// <summary>The serialized matchup DTO — the data part of the prompt.</summary>
+    public string PayloadJson { get; set; } = default!;
+
+    public string? EditorNote { get; set; }
+
+    /// <summary>
+    /// Exactly what the model would receive: instruction blob + payload +
+    /// editor note, reconstructed the same way the processor renders it.
+    /// </summary>
+    public string FullPrompt { get; set; } = default!;
+
+    public int CharCount { get; set; }
+
+    public int EstTokens { get; set; }
+
+    public PreviewGenerationMode Mode { get; set; }
+
+    /// <summary>Model name for runs that called the model (Generate/Experiment).</summary>
+    public string? Model { get; set; }
+
+    /// <summary>Raw model response (Generate/Experiment); may be malformed — that's the data.</summary>
+    public string? RawResponse { get; set; }
+
+    /// <summary>Parse/validation problems recorded on experiment runs; null = clean.</summary>
+    public string? ResponseValidationErrors { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+}

--- a/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
+++ b/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
@@ -13,5 +13,13 @@ public class GenerateMatchupPreviewsCommand
     /// </summary>
     public Sport Sport { get; set; } = Sport.FootballNcaa;
 
+    /// <summary>
+    /// Generate (default, prod), Capture (prompt only, no model call), or
+    /// Experiment (model call, result stored on the capture row, no
+    /// MatchupPreview written). Defaults to Generate so payloads serialized
+    /// before this property existed behave exactly as before.
+    /// </summary>
+    public PreviewGenerationMode Mode { get; set; } = PreviewGenerationMode.Generate;
+
     public Guid CorrelationId { get; set; } = Guid.NewGuid();
 }

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -56,6 +56,7 @@ namespace SportsData.Api.Application.Previews
         internal sealed record AssembledPrompt(
             MatchupForPreviewDto Matchup,
             string PromptName,
+            string InstructionText,
             string PayloadJson,
             string? EditorNote,
             string FullPrompt);
@@ -113,7 +114,7 @@ namespace SportsData.Api.Application.Previews
             {
                 await _eventBus.Publish(new PreviewPromptCaptured(
                     matchup.ContestId,
-                    $"{matchup.Home} @ {matchup.Away} prompt captured ({capture.EstTokens} est. tokens)",
+                    $"{matchup.Away} @ {matchup.Home} prompt captured ({capture.EstTokens} est. tokens)",
                     null,
                     matchup.Sport,
                     matchup.SeasonYear,
@@ -176,7 +177,7 @@ namespace SportsData.Api.Application.Previews
 
                 await _eventBus.Publish(new PreviewPromptCaptured(
                     matchup.ContestId,
-                    $"{matchup.Home} @ {matchup.Away} experiment completed ({capture.Model}{(capture.ResponseValidationErrors is null ? "" : ", with validation errors")})",
+                    $"{matchup.Away} @ {matchup.Home} experiment completed ({capture.Model}{(capture.ResponseValidationErrors is null ? "" : ", with validation errors")})",
                     null,
                     matchup.Sport,
                     matchup.SeasonYear,
@@ -259,7 +260,7 @@ namespace SportsData.Api.Application.Previews
 
             await _eventBus.Publish(new PreviewGenerated(
                 assembled.Matchup.ContestId,
-                $"{assembled.Matchup.Home} @ {assembled.Matchup.Away} preview generated",
+                $"{assembled.Matchup.Away} @ {assembled.Matchup.Home} preview generated",
                 null,
                 assembled.Matchup.Sport,
                 assembled.Matchup.SeasonYear,
@@ -316,6 +317,7 @@ namespace SportsData.Api.Application.Previews
             return new AssembledPrompt(
                 matchup,
                 promptData.PromptName,
+                promptData.PromptText,
                 jsonInput,
                 string.IsNullOrEmpty(editorNote) ? null : rejectionNote,
                 fullPrompt);
@@ -331,6 +333,7 @@ namespace SportsData.Api.Application.Previews
                 ContestId = command.ContestId,
                 Sport = command.Sport,
                 PromptVersion = assembled.PromptName,
+                PromptText = assembled.InstructionText,
                 PayloadJson = assembled.PayloadJson,
                 EditorNote = assembled.EditorNote,
                 CharCount = assembled.FullPrompt.Length,

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -6,6 +6,7 @@ using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Api.Infrastructure.Prompts;
 using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Previews;
 using SportsData.Core.Infrastructure.Clients.AI;
@@ -25,6 +26,7 @@ namespace SportsData.Api.Application.Previews
         private readonly IProvideAiCommunication _aiCommunication;
         private readonly MatchupPreviewPromptProvider _promptProvider;
         private readonly IEventBus _eventBus;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public MatchupPreviewProcessor(
             AppDataContext dataContext,
@@ -33,7 +35,8 @@ namespace SportsData.Api.Application.Previews
             IFranchiseClientFactory franchiseClientFactory,
             IProvideAiCommunication aiCommunication,
             MatchupPreviewPromptProvider promptProvider,
-            IEventBus eventBus)
+            IEventBus eventBus,
+            IDateTimeProvider dateTimeProvider)
         {
             _dataContext = dataContext;
             _logger = logger;
@@ -42,10 +45,27 @@ namespace SportsData.Api.Application.Previews
             _aiCommunication = aiCommunication;
             _promptProvider = promptProvider;
             _eventBus = eventBus;
+            _dateTimeProvider = dateTimeProvider;
         }
+
+        /// <summary>
+        /// Everything the model call needs, assembled by the single code path
+        /// shared by capture and generation — a capture is byte-identical to
+        /// what generation would send, by construction.
+        /// </summary>
+        internal sealed record AssembledPrompt(
+            MatchupForPreviewDto Matchup,
+            string PromptName,
+            string PayloadJson,
+            string? EditorNote,
+            string FullPrompt);
 
         public async Task Process(GenerateMatchupPreviewsCommand command)
         {
+            _logger.LogInformation(
+                "Preview processing started. ContestId: {ContestId}, Sport: {Sport}, Mode: {Mode}, CorrelationId: {CorrelationId}",
+                command.ContestId, command.Sport, command.Mode, command.CorrelationId);
+
             var rejectedPreview = await _dataContext.MatchupPreviews
                 .OrderByDescending(x => x.CreatedUtc)
                 .FirstOrDefaultAsync(x => x.ContestId == command.ContestId && x.RejectedUtc != null);
@@ -55,19 +75,208 @@ namespace SportsData.Api.Application.Previews
 
             if (matchup is null)
             {
+                // Surface WHY — this is the API -> Producer hop, and "not
+                // found" here usually means the wrong sport was requested or
+                // Producer for that sport is unreachable.
+                var failureDetail = previewResult is Failure<MatchupForPreviewDto> matchupFailure
+                    ? $"{matchupFailure.Status}: {string.Join(", ", matchupFailure.Errors.Select(x => x.ErrorMessage))}"
+                    : "no failure detail";
                 _logger.LogWarning(
-                    "Matchup not found for ContestId {ContestId}. Skipping preview generation.",
-                    command.ContestId);
+                    "Matchup could not be resolved for ContestId {ContestId} via {Sport} Producer ({FailureDetail}). Skipping.",
+                    command.ContestId, command.Sport, failureDetail);
                 return;
             }
 
-            if (ContestStatusValues.IsCompleted(matchup.Status))
+            // Capture/Experiment modes allow completed contests: replaying
+            // last season's games is the backtest case.
+            if (command.Mode == PreviewGenerationMode.Generate && ContestStatusValues.IsCompleted(matchup.Status))
             {
                 _logger.LogInformation("Skipping preview generation for completed contest {ContestId}. Status: {Status}", command.ContestId, matchup.Status);
                 return;
             }
 
-            var franchiseClient = _franchiseClientFactory.Resolve(command.Sport);
+            var assembled = await AssemblePromptAsync(matchup, command.Sport, rejectedPreview?.RejectionNote);
+
+            _logger.LogInformation(
+                "Prompt assembled for {ContestId}. PromptVersion: {PromptVersion}, CharCount: {CharCount}, UsedMetrics: {UsedMetrics}, AwayResults: {AwayResults}, HomeResults: {HomeResults}",
+                command.ContestId,
+                assembled.PromptName,
+                assembled.FullPrompt.Length,
+                assembled.Matchup.AwayMetrics != null,
+                assembled.Matchup.AwayCompetitionResults?.Count ?? 0,
+                assembled.Matchup.HomeCompetitionResults?.Count ?? 0);
+
+            var capture = BuildCapture(command, assembled);
+            await _dataContext.MatchupPreviewPrompts.AddAsync(capture);
+
+            if (command.Mode == PreviewGenerationMode.Capture)
+            {
+                await _eventBus.Publish(new PreviewPromptCaptured(
+                    matchup.ContestId,
+                    $"{matchup.Home} @ {matchup.Away} prompt captured ({capture.EstTokens} est. tokens)",
+                    null,
+                    matchup.Sport,
+                    matchup.SeasonYear,
+                    command.CorrelationId,
+                    CausationId.Api.MatchupPreviewProcessor));
+
+                await _dataContext.SaveChangesAsync();
+
+                _logger.LogInformation(
+                    "Prompt captured for {ContestId} without model call. CaptureId: {CaptureId}, EstTokens: {EstTokens}",
+                    matchup.ContestId, capture.Id, capture.EstTokens);
+                return;
+            }
+
+            var aiResponse = await _aiCommunication.GetResponseAsync(assembled.FullPrompt, CancellationToken.None);
+            var rawResponse = aiResponse.Value;
+
+            if (command.Mode == PreviewGenerationMode.Experiment)
+            {
+                // Sandboxed eval run: record everything — including failures —
+                // on the capture row. NEVER writes a MatchupPreview (an
+                // experimental row would shadow a prior season's real preview
+                // on the picks page) and never publishes PreviewGenerated.
+                capture.Model = _aiCommunication.GetModelName();
+                capture.RawResponse = string.IsNullOrWhiteSpace(rawResponse) ? null : rawResponse;
+
+                var problems = new List<string>();
+
+                if (!aiResponse.IsSuccess || string.IsNullOrWhiteSpace(rawResponse))
+                {
+                    problems.Add(aiResponse is Failure<string> aiFailure
+                        ? string.Join(", ", aiFailure.Errors.Select(x => x.ErrorMessage))
+                        : "AI request returned no content");
+                }
+                else
+                {
+                    var experimentParsed = TryParseResponse(rawResponse);
+                    if (experimentParsed is null)
+                    {
+                        problems.Add("Response could not be parsed by either deserialization strategy");
+                    }
+                    else
+                    {
+                        var experimentValidation = MatchupPreviewValidator.Validate(
+                            contestId: command.ContestId,
+                            homeScore: experimentParsed.HomeScore,
+                            awayScore: experimentParsed.AwayScore,
+                            homeSpread: assembled.Matchup.HomeSpread ?? 0,
+                            predictedStraightUpWinner: experimentParsed.PredictedStraightUpWinner,
+                            predictedSpreadWinner: experimentParsed.PredictedSpreadWinner,
+                            homeFranchiseSeasonId: assembled.Matchup.HomeFranchiseSeasonId,
+                            awayFranchiseSeasonId: assembled.Matchup.AwayFranchiseSeasonId);
+
+                        if (!experimentValidation.IsValid)
+                            problems.AddRange(experimentValidation.Errors);
+                    }
+                }
+
+                capture.ResponseValidationErrors = problems.Count > 0 ? string.Join("; ", problems) : null;
+
+                await _eventBus.Publish(new PreviewPromptCaptured(
+                    matchup.ContestId,
+                    $"{matchup.Home} @ {matchup.Away} experiment completed ({capture.Model}{(capture.ResponseValidationErrors is null ? "" : ", with validation errors")})",
+                    null,
+                    matchup.Sport,
+                    matchup.SeasonYear,
+                    command.CorrelationId,
+                    CausationId.Api.MatchupPreviewProcessor));
+
+                await _dataContext.SaveChangesAsync();
+
+                _logger.LogInformation("Experiment completed for {contestId}", matchup.ContestId);
+                return;
+            }
+
+            if (!aiResponse.IsSuccess || string.IsNullOrWhiteSpace(rawResponse))
+            {
+                var errorMsg = aiResponse is Failure<string> f
+                    ? string.Join(", ", f.Errors.Select(x => x.ErrorMessage))
+                    : "Unknown error";
+                _logger.LogError("AI request failed. Error: {Error}", errorMsg);
+                return;
+            }
+
+            var parsed = TryParseResponse(rawResponse);
+
+            // Exit if we still failed to parse anything
+            if (parsed is null)
+            {
+                _logger.LogError("Produced null after both deserialization strategies. Raw response: {Raw}", rawResponse);
+                return;
+            }
+
+            // Run semantic validation
+            var validation = MatchupPreviewValidator.Validate(
+                contestId: command.ContestId,
+                homeScore: parsed.HomeScore,
+                awayScore: parsed.AwayScore,
+                homeSpread: assembled.Matchup.HomeSpread ?? 0,
+                predictedStraightUpWinner: parsed.PredictedStraightUpWinner,
+                predictedSpreadWinner: parsed.PredictedSpreadWinner,
+                homeFranchiseSeasonId: assembled.Matchup.HomeFranchiseSeasonId,
+                awayFranchiseSeasonId: assembled.Matchup.AwayFranchiseSeasonId
+            );
+
+            if (!validation.IsValid)
+            {
+                _logger.LogError("Validation failed. Errors: {Errors}", validation.Errors);
+                return;
+            }
+
+            // We have a valid response (parsed + valid)
+            _logger.LogDebug("AI generated preview. {@Parsed}", parsed);
+
+            var preview = new MatchupPreview
+            {
+                Id = Guid.NewGuid(),
+                ContestId = command.ContestId,
+                Overview = parsed.Overview,
+                Analysis = parsed.Analysis,
+                Prediction = parsed.Prediction,
+                PredictedStraightUpWinner = parsed.PredictedStraightUpWinner,
+                PredictedSpreadWinner = parsed.PredictedSpreadWinner,
+                OverUnderPrediction = parsed.OverUnderPrediction == 1
+                    ? OverUnderPrediction.Over
+                    : OverUnderPrediction.Under,
+                AwayScore = parsed.AwayScore,
+                HomeScore = parsed.HomeScore,
+                Model = _aiCommunication.GetModelName(),
+                ValidationErrors = null,
+                CreatedUtc = _dateTimeProvider.UtcNow(),
+                CreatedBy = command.CorrelationId,
+                PromptVersion = assembled.PromptName,
+                IterationsRequired = 1,
+                UsedMetrics = assembled.Matchup.AwayMetrics != null
+            };
+
+            await _dataContext.MatchupPreviews.AddAsync(preview);
+
+            capture.MatchupPreviewId = preview.Id;
+            capture.Model = preview.Model;
+            capture.RawResponse = rawResponse;
+
+            await _eventBus.Publish(new PreviewGenerated(
+                assembled.Matchup.ContestId,
+                $"{assembled.Matchup.Home} @ {assembled.Matchup.Away} preview generated",
+                null,
+                assembled.Matchup.Sport,
+                assembled.Matchup.SeasonYear,
+                command.CorrelationId,
+                CausationId.Api.MatchupPreviewProcessor));
+
+            await _dataContext.SaveChangesAsync();
+
+            _logger.LogInformation("Preview generated for {contestId}", preview.ContestId);
+        }
+
+        private async Task<AssembledPrompt> AssemblePromptAsync(
+            MatchupForPreviewDto matchup,
+            Sport sport,
+            string? rejectionNote)
+        {
+            var franchiseClient = _franchiseClientFactory.Resolve(sport);
 
             matchup.AwayStats = await franchiseClient
                 .GetFranchiseSeasonPreviewStats(matchup.AwayFranchiseSeasonId);
@@ -98,31 +307,45 @@ namespace SportsData.Api.Application.Previews
 
             var jsonInput = JsonSerializer.Serialize(matchup);
 
-            MatchupPreviewResponse? parsed = null;
-            string? rawResponse = null;
-            List<string>? validationErrors = null;
-
-            var editorNote = rejectedPreview?.RejectionNote != null
-                ? $"\n\nAdditional feedback from the editor:\n\"{rejectedPreview.RejectionNote}\""
+            var editorNote = rejectionNote != null
+                ? $"\n\nAdditional feedback from the editor:\n\"{rejectionNote}\""
                 : string.Empty;
 
             var fullPrompt = $"{promptData.PromptText}\n\n{jsonInput}{editorNote}";
 
-            var aiResponse = await _aiCommunication.GetResponseAsync(fullPrompt, CancellationToken.None);
-            rawResponse = aiResponse.Value;
+            return new AssembledPrompt(
+                matchup,
+                promptData.PromptName,
+                jsonInput,
+                string.IsNullOrEmpty(editorNote) ? null : rejectionNote,
+                fullPrompt);
+        }
 
-            if (!aiResponse.IsSuccess || string.IsNullOrWhiteSpace(rawResponse))
+        private MatchupPreviewPrompt BuildCapture(
+            GenerateMatchupPreviewsCommand command,
+            AssembledPrompt assembled)
+        {
+            return new MatchupPreviewPrompt
             {
-                var errorMsg = aiResponse is Failure<string> f 
-                    ? string.Join(", ", f.Errors.Select(x => x.ErrorMessage)) 
-                    : "Unknown error";
-                _logger.LogError("AI request failed. Error: {Error}", errorMsg);
-                return;
-            }
+                Id = Guid.NewGuid(),
+                ContestId = command.ContestId,
+                Sport = command.Sport,
+                PromptVersion = assembled.PromptName,
+                PayloadJson = assembled.PayloadJson,
+                EditorNote = assembled.EditorNote,
+                CharCount = assembled.FullPrompt.Length,
+                EstTokens = assembled.FullPrompt.Length / 4,
+                Mode = command.Mode,
+                CreatedUtc = _dateTimeProvider.UtcNow(),
+                CreatedBy = command.CorrelationId
+            };
+        }
 
+        private MatchupPreviewResponse? TryParseResponse(string rawResponse)
+        {
             try
             {
-                parsed = JsonSerializer.Deserialize<MatchupPreviewResponse>(rawResponse, new JsonSerializerOptions
+                return JsonSerializer.Deserialize<MatchupPreviewResponse>(rawResponse, new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true
                 });
@@ -138,82 +361,14 @@ namespace SportsData.Api.Application.Previews
                         PropertyNameCaseInsensitive = true
                     });
 
-                    parsed = fallback?.ToV1();
+                    return fallback?.ToV1();
                 }
                 catch (JsonException fallbackEx)
                 {
                     _logger.LogError(fallbackEx, "V2 fallback deserialization also failed. Raw: {Raw}", rawResponse);
-                    return;
+                    return null;
                 }
             }
-
-            // Exit if we still failed to parse anything
-            if (parsed is null)
-            {
-                _logger.LogError("Produced null after both deserialization strategies. Raw response: {Raw}", rawResponse);
-                return;
-            }
-
-            // Run semantic validation
-            var validation = MatchupPreviewValidator.Validate(
-                contestId: command.ContestId,
-                homeScore: parsed.HomeScore,
-                awayScore: parsed.AwayScore,
-                homeSpread: matchup.HomeSpread ?? 0,
-                predictedStraightUpWinner: parsed.PredictedStraightUpWinner,
-                predictedSpreadWinner: parsed.PredictedSpreadWinner,
-                homeFranchiseSeasonId: matchup.HomeFranchiseSeasonId,
-                awayFranchiseSeasonId: matchup.AwayFranchiseSeasonId
-            );
-
-            validationErrors = validation.IsValid ? null : validation.Errors;
-
-            if (!validation.IsValid)
-            {
-                _logger.LogError("Validation failed. Errors: {Errors}", validation.Errors);
-                return;
-            }
-
-            // We have a valid response (parsed + valid)
-            _logger.LogDebug("AI generated preview. {@Parsed}", parsed);
-
-            var preview = new MatchupPreview
-            {
-                Id = Guid.NewGuid(),
-                ContestId = command.ContestId,
-                Overview = parsed.Overview,
-                Analysis = parsed.Analysis,
-                Prediction = parsed.Prediction,
-                PredictedStraightUpWinner = parsed.PredictedStraightUpWinner,
-                PredictedSpreadWinner = parsed.PredictedSpreadWinner,
-                OverUnderPrediction = parsed.OverUnderPrediction == 1
-                    ? OverUnderPrediction.Over
-                    : OverUnderPrediction.Under,
-                AwayScore = parsed.AwayScore,
-                HomeScore = parsed.HomeScore,
-                Model = _aiCommunication.GetModelName(),
-                ValidationErrors = null,
-                CreatedUtc = DateTime.UtcNow,
-                CreatedBy = command.CorrelationId,
-                PromptVersion = promptData.PromptName,
-                IterationsRequired = 1,
-                UsedMetrics = matchup.AwayMetrics != null
-            };
-
-            await _dataContext.MatchupPreviews.AddAsync(preview);
-
-            await _eventBus.Publish(new PreviewGenerated(
-                matchup.ContestId,
-                $"{matchup.Home} @ {matchup.Away} preview generated",
-                null,
-                matchup.Sport,
-                matchup.SeasonYear,
-                command.CorrelationId,
-                CausationId.Api.MatchupPreviewProcessor));
-
-            await _dataContext.SaveChangesAsync();
-
-            _logger.LogInformation("Preview generated for {contestId}", preview.ContestId);
         }
     }
 }

--- a/src/SportsData.Api/Application/Previews/PreviewGenerationMode.cs
+++ b/src/SportsData.Api/Application/Previews/PreviewGenerationMode.cs
@@ -1,0 +1,26 @@
+namespace SportsData.Api.Application.Previews;
+
+public enum PreviewGenerationMode
+{
+    /// <summary>
+    /// Production path: call the model and persist a MatchupPreview.
+    /// Skips completed contests. Default — Hangfire payloads serialized
+    /// before this enum existed deserialize to this value.
+    /// </summary>
+    Generate = 0,
+
+    /// <summary>
+    /// Dry run: assemble and persist the prompt payload only. No model
+    /// call, no MatchupPreview. Completed contests allowed.
+    /// </summary>
+    Capture = 1,
+
+    /// <summary>
+    /// Eval run: assemble, persist the payload, call the model, and store
+    /// the raw response on the capture row. NEVER writes a MatchupPreview —
+    /// the picks page reads newest-non-rejected per contest, so an
+    /// experimental preview row would shadow last season's real preview.
+    /// Completed contests allowed (that is the point).
+    /// </summary>
+    Experiment = 2
+}

--- a/src/SportsData.Api/Application/Previews/PreviewPromptCapturedHandler.cs
+++ b/src/SportsData.Api/Application/Previews/PreviewPromptCapturedHandler.cs
@@ -1,0 +1,33 @@
+using MassTransit;
+
+using Microsoft.AspNetCore.SignalR;
+
+using SportsData.Api.Infrastructure.Notifications;
+using SportsData.Core.Eventing.Events.Previews;
+
+namespace SportsData.Api.Application.Previews;
+
+public class PreviewPromptCapturedHandler : IConsumer<PreviewPromptCaptured>
+{
+    private readonly IHubContext<NotificationHub> _hubContext;
+
+    public PreviewPromptCapturedHandler(IHubContext<NotificationHub> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public async Task Consume(ConsumeContext<PreviewPromptCaptured> context)
+    {
+        var msg = context.Message;
+
+        await _hubContext.Clients
+            .All // ← same global broadcast as PreviewGenerated
+            .SendAsync(nameof(PreviewPromptCaptured), new
+            {
+                msg.ContestId,
+                msg.Message,
+                msg.CorrelationId,
+                msg.CausationId
+            });
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -228,6 +228,8 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetCompetitionsWithoutMetricsQueryHandler, GetCompetitionsWithoutMetricsQueryHandler>();
             services.AddScoped<SportsData.Api.Application.Admin.Queries.GetMatchupPreview.IGetMatchupPreviewQueryHandler,
                 SportsData.Api.Application.Admin.Queries.GetMatchupPreview.GetMatchupPreviewQueryHandler>();
+            services.AddScoped<SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures.IGetMatchupPreviewCapturesQueryHandler,
+                SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures.GetMatchupPreviewCapturesQueryHandler>();
             services.AddScoped<SportsData.Api.Application.Admin.Queries.GetMatchupForContest.IGetMatchupForContestQueryHandler,
                 SportsData.Api.Application.Admin.Queries.GetMatchupForContest.GetMatchupForContestQueryHandler>();
             services.AddScoped<SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests.IGetLeagueWeekContestsQueryHandler,

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -38,6 +38,8 @@ public class AppDataContext : DbContext
 
     public DbSet<MatchupPreview> MatchupPreviews { get; set; }
 
+    public DbSet<MatchupPreviewPrompt> MatchupPreviewPrompts { get; set; }
+
     public DbSet<Article> Articles { get; set; }
 
     public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
@@ -1,0 +1,98 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Api.Application.Previews;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// The exact data payload assembled for a matchup-preview LLM call —
+    /// captured on every real generation (linked to the resulting
+    /// <see cref="MatchupPreview"/>), on admin dry-run captures, and on
+    /// experiment runs (which also store the model's raw response here and
+    /// NEVER write a MatchupPreview — the picks page reads newest-non-
+    /// rejected per contest, so an experimental preview row would shadow a
+    /// prior season's real preview). The full prompt is reconstructable as
+    /// blob(PromptVersion) + "\n\n" + PayloadJson + EditorNote; instruction
+    /// text is never stored here. Rows are kept forever — they are the
+    /// backtest corpus (payload x model x prompt vs actual outcome).
+    /// </summary>
+    public class MatchupPreviewPrompt : CanonicalEntityBase<Guid>
+    {
+        public Guid ContestId { get; set; }
+
+        public Sport Sport { get; set; }
+
+        /// <summary>Set when a real generation persisted a preview; null for dry-run captures.</summary>
+        public Guid? MatchupPreviewId { get; set; }
+
+        public MatchupPreview? MatchupPreview { get; set; }
+
+        public required string PromptVersion { get; set; }
+
+        /// <summary>The serialized matchup DTO appended to the prompt — the data part.</summary>
+        public required string PayloadJson { get; set; }
+
+        /// <summary>Rejection-feedback text appended to the prompt, when present.</summary>
+        public string? EditorNote { get; set; }
+
+        /// <summary>Character count of the full rendered prompt (instructions + payload + note).</summary>
+        public int CharCount { get; set; }
+
+        /// <summary>Rough token estimate (chars / 4) for budget visibility.</summary>
+        public int EstTokens { get; set; }
+
+        public PreviewGenerationMode Mode { get; set; }
+
+        /// <summary>Model name, when the run called the model (Generate/Experiment).</summary>
+        public string? Model { get; set; }
+
+        /// <summary>
+        /// The model's raw response (Generate/Experiment runs). Deliberately
+        /// text, not jsonb — malformed responses are exactly the failures an
+        /// experiment needs to record.
+        /// </summary>
+        public string? RawResponse { get; set; }
+
+        /// <summary>Parse/validation problems recorded on experiment runs; null = clean.</summary>
+        public string? ResponseValidationErrors { get; set; }
+
+        public class EntityConfiguration : IEntityTypeConfiguration<MatchupPreviewPrompt>
+        {
+            public void Configure(EntityTypeBuilder<MatchupPreviewPrompt> builder)
+            {
+                builder.ToTable(nameof(MatchupPreviewPrompt));
+                builder.HasKey(x => x.Id);
+
+                builder.HasIndex(x => x.ContestId);
+
+                builder.HasOne(x => x.MatchupPreview)
+                    .WithMany()
+                    .HasForeignKey(x => x.MatchupPreviewId)
+                    .OnDelete(DeleteBehavior.SetNull);
+
+                builder.Property(x => x.Sport)
+                    .HasConversion<int>()
+                    .IsRequired();
+
+                builder.Property(x => x.PromptVersion).HasMaxLength(50);
+
+                builder.Property(x => x.PayloadJson)
+                    .HasColumnType("jsonb")
+                    .IsRequired();
+
+                builder.Property(x => x.EditorNote).HasMaxLength(512);
+
+                builder.Property(x => x.Mode)
+                    .HasConversion<int>()
+                    .IsRequired();
+
+                builder.Property(x => x.Model).HasMaxLength(50);
+
+                builder.Property(x => x.ResponseValidationErrors).HasMaxLength(1024);
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
@@ -14,10 +14,10 @@ namespace SportsData.Api.Infrastructure.Data.Entities
     /// experiment runs (which also store the model's raw response here and
     /// NEVER write a MatchupPreview — the picks page reads newest-non-
     /// rejected per contest, so an experimental preview row would shadow a
-    /// prior season's real preview). The full prompt is reconstructable as
-    /// blob(PromptVersion) + "\n\n" + PayloadJson + EditorNote; instruction
-    /// text is never stored here. Rows are kept forever — they are the
-    /// backtest corpus (payload x model x prompt vs actual outcome).
+    /// prior season's real preview). The full prompt is
+    /// PromptText + "\n\n" + PayloadJson + EditorNote, all stored here.
+    /// Rows are kept forever — they are the backtest corpus
+    /// (payload x model x prompt vs actual outcome).
     /// </summary>
     public class MatchupPreviewPrompt : CanonicalEntityBase<Guid>
     {
@@ -31,6 +31,13 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         public MatchupPreview? MatchupPreview { get; set; }
 
         public required string PromptVersion { get; set; }
+
+        /// <summary>
+        /// The instruction text EXACTLY as sent — stored per capture because
+        /// a blob can be edited in place (ReloadPromptAsync), which would
+        /// make version-based reconstruction lie about what the model saw.
+        /// </summary>
+        public required string PromptText { get; set; }
 
         /// <summary>The serialized matchup DTO appended to the prompt — the data part.</summary>
         public required string PayloadJson { get; set; }

--- a/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
+++ b/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
@@ -10,8 +10,6 @@ public class MatchupPreviewPromptProvider
     private Task<(string, string)>? _cachedPromptTask;
     private Task<(string, string)>? _cachedPromptWithStatsTask;
 
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Task<string>> _promptTextByVersion = new();
-
     private const string Container = "prompts";
 
     private const string Blob = "prediction-insights-v1.txt";
@@ -24,41 +22,24 @@ public class MatchupPreviewPromptProvider
 
     public Task<(string PromptText, string PromptName)> GetPreviewInsightPromptAsync(bool hasStats)
     {
-        if (hasStats)
-        {
-            if (_cachedPromptWithStatsTask != null)
-                return _cachedPromptWithStatsTask;
-        }
-        else
-        {
-            if (_cachedPromptTask != null)
-                return _cachedPromptTask;
-        }
-
+        // Evict faulted tasks so a transient blob failure doesn't poison the
+        // cache until process restart — every later call would receive the
+        // same faulted task and the whole preview pipeline stays down.
         lock (_lock)
         {
             if (hasStats)
             {
+                if (_cachedPromptWithStatsTask is { IsFaulted: true } or { IsCanceled: true })
+                    _cachedPromptWithStatsTask = null;
                 return _cachedPromptWithStatsTask ??= LoadPromptAsync(BlobWithStats);
             }
             else
             {
+                if (_cachedPromptTask is { IsFaulted: true } or { IsCanceled: true })
+                    _cachedPromptTask = null;
                 return _cachedPromptTask ??= LoadPromptAsync(Blob);
             }
         }
-    }
-
-    /// <summary>
-    /// Fetch prompt text by stored PromptVersion (blob name without
-    /// extension) — used to reconstruct the full prompt for persisted
-    /// captures, which may reference older blob versions than the two
-    /// active ones above.
-    /// </summary>
-    public Task<string> GetPromptTextByVersionAsync(string promptVersion)
-    {
-        return _promptTextByVersion.GetOrAdd(
-            promptVersion,
-            v => LoadPromptTextOnlyAsync($"{v}.txt"));
     }
 
     public async Task<string> ReloadPromptAsync(bool hasStats)

--- a/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
+++ b/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
@@ -10,6 +10,8 @@ public class MatchupPreviewPromptProvider
     private Task<(string, string)>? _cachedPromptTask;
     private Task<(string, string)>? _cachedPromptWithStatsTask;
 
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Task<string>> _promptTextByVersion = new();
+
     private const string Container = "prompts";
 
     private const string Blob = "prediction-insights-v1.txt";
@@ -44,6 +46,19 @@ public class MatchupPreviewPromptProvider
                 return _cachedPromptTask ??= LoadPromptAsync(Blob);
             }
         }
+    }
+
+    /// <summary>
+    /// Fetch prompt text by stored PromptVersion (blob name without
+    /// extension) — used to reconstruct the full prompt for persisted
+    /// captures, which may reference older blob versions than the two
+    /// active ones above.
+    /// </summary>
+    public Task<string> GetPromptTextByVersionAsync(string promptVersion)
+    {
+        return _promptTextByVersion.GetOrAdd(
+            promptVersion,
+            v => LoadPromptTextOnlyAsync($"{v}.txt"));
     }
 
     public async Task<string> ReloadPromptAsync(bool hasStats)

--- a/src/SportsData.Api/Migrations/20260807184840_AddMatchupPreviewPrompt.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260807184840_AddMatchupPreviewPrompt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260807184840_AddMatchupPreviewPrompt")]
+    partial class AddMatchupPreviewPrompt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260807184840_AddMatchupPreviewPrompt.cs
+++ b/src/SportsData.Api/Migrations/20260807184840_AddMatchupPreviewPrompt.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMatchupPreviewPrompt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MatchupPreviewPrompt",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContestId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Sport = table.Column<int>(type: "integer", nullable: false),
+                    MatchupPreviewId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PromptVersion = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    PayloadJson = table.Column<string>(type: "jsonb", nullable: false),
+                    EditorNote = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    CharCount = table.Column<int>(type: "integer", nullable: false),
+                    EstTokens = table.Column<int>(type: "integer", nullable: false),
+                    Mode = table.Column<int>(type: "integer", nullable: false),
+                    Model = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    RawResponse = table.Column<string>(type: "text", nullable: true),
+                    ResponseValidationErrors = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MatchupPreviewPrompt", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MatchupPreviewPrompt_MatchupPreview_MatchupPreviewId",
+                        column: x => x.MatchupPreviewId,
+                        principalTable: "MatchupPreview",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MatchupPreviewPrompt_ContestId",
+                table: "MatchupPreviewPrompt",
+                column: "ContestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MatchupPreviewPrompt_MatchupPreviewId",
+                table: "MatchupPreviewPrompt",
+                column: "MatchupPreviewId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MatchupPreviewPrompt");
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260807223016_AddPromptTextToMatchupPreviewPrompt.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260807223016_AddPromptTextToMatchupPreviewPrompt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260807223016_AddPromptTextToMatchupPreviewPrompt")]
+    partial class AddPromptTextToMatchupPreviewPrompt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260807223016_AddPromptTextToMatchupPreviewPrompt.cs
+++ b/src/SportsData.Api/Migrations/20260807223016_AddPromptTextToMatchupPreviewPrompt.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPromptTextToMatchupPreviewPrompt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PromptText",
+                table: "MatchupPreviewPrompt",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PromptText",
+                table: "MatchupPreviewPrompt");
+        }
+    }
+}

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -292,6 +292,7 @@ namespace SportsData.Api
                     typeof(PickemGroupsRequestedConsumer),
                     typeof(PickemGroupWeekMatchupsGeneratedHandler),
                     typeof(PreviewGeneratedHandler),
+                    typeof(PreviewPromptCapturedHandler),
                     typeof(SeasonPollWeekCreatedHandler),
                     typeof(UsersRequestedConsumer)
                 ]);

--- a/src/SportsData.Core/Eventing/Events/Previews/PreviewPromptCaptured.cs
+++ b/src/SportsData.Core/Eventing/Events/Previews/PreviewPromptCaptured.cs
@@ -1,0 +1,15 @@
+using System;
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Eventing.Events.Previews
+{
+    public record PreviewPromptCaptured(
+        Guid ContestId,
+        string Message,
+        Uri? Ref,
+        Sport Sport,
+        int? SeasonYear,
+        Guid CorrelationId,
+        Guid CausationId
+    ) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId);
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -23,7 +23,8 @@ public interface IProvideFranchises : IProvideHealthChecks
     Task<Result<GetFranchiseSeasonsResponse>> GetFranchiseSeasons(Guid franchiseId, CancellationToken cancellationToken = default);
     Task<Result<GetFranchiseSeasonByIdResponse>> GetFranchiseSeasonById(Guid franchiseId, int seasonYear, CancellationToken cancellationToken = default);
     Task<List<FranchiseSeasonMetricsDto>> GetFranchiseSeasonMetrics(int seasonYear, CancellationToken cancellationToken = default);
-    Task<FranchiseSeasonMetricsDto> GetFranchiseSeasonMetricsByFranchiseSeasonId(Guid franchiseSeasonId, CancellationToken cancellationToken = default);
+    /// <summary>Null when Producer has no metrics row for the franchise season (404) — normal missing data.</summary>
+    Task<FranchiseSeasonMetricsDto?> GetFranchiseSeasonMetricsByFranchiseSeasonId(Guid franchiseSeasonId, CancellationToken cancellationToken = default);
     Task<List<FranchiseSeasonPollDto>> GetFranchiseSeasonRankings(int seasonYear, CancellationToken cancellationToken = default);
     Task<TeamCardDto?> GetTeamCard(string slug, int seasonYear, CancellationToken cancellationToken = default);
     Task<Result<List<TeamCardScheduleItemDto>>> GetTeamFinalizedGames(string slug, int seasonYear, DateTime? asOfDate = null, CancellationToken cancellationToken = default);
@@ -118,12 +119,23 @@ public class FranchiseClient : ClientBase, IProvideFranchises
             cancellationToken);
     }
 
-    public async Task<FranchiseSeasonMetricsDto> GetFranchiseSeasonMetricsByFranchiseSeasonId(Guid franchiseSeasonId, CancellationToken cancellationToken = default)
+    public async Task<FranchiseSeasonMetricsDto?> GetFranchiseSeasonMetricsByFranchiseSeasonId(Guid franchiseSeasonId, CancellationToken cancellationToken = default)
     {
-        return await GetOrDefaultAsync(
-            $"franchise-seasons/id/{franchiseSeasonId}/metrics",
-            new FranchiseSeasonMetricsDto(),
-            cancellationToken);
+        // Producer 404s when no metrics row exists for the franchise season.
+        // That is normal missing data (early season, uncovered historical
+        // seasons), not an error — callers null-check for both-or-nothing
+        // handling. Other HTTP failures still throw so jobs retry.
+        try
+        {
+            return await GetOrDefaultAsync(
+                $"franchise-seasons/id/{franchiseSeasonId}/metrics",
+                new FranchiseSeasonMetricsDto(),
+                cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
     }
 
     public async Task<List<FranchiseSeasonPollDto>> GetFranchiseSeasonRankings(int seasonYear, CancellationToken cancellationToken = default)
@@ -194,18 +206,35 @@ public class FranchiseClient : ClientBase, IProvideFranchises
 
     public async Task<FranchiseSeasonModelStatsDto> GetFranchiseSeasonPreviewStats(Guid franchiseSeasonId, CancellationToken cancellationToken = default)
     {
-        return await GetOrDefaultAsync(
-            $"franchise-seasons/id/{franchiseSeasonId}/preview-stats",
-            new FranchiseSeasonModelStatsDto(),
-            cancellationToken);
+        // 404 = no stats yet (e.g. weeks 1-2) — empty DTO feeds the
+        // hasStats=false prompt path. Other failures still throw.
+        try
+        {
+            return await GetOrDefaultAsync(
+                $"franchise-seasons/id/{franchiseSeasonId}/preview-stats",
+                new FranchiseSeasonModelStatsDto(),
+                cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return new FranchiseSeasonModelStatsDto();
+        }
     }
 
     public async Task<List<FranchiseSeasonCompetitionResultDto>> GetFranchiseSeasonCompetitionResults(Guid franchiseSeasonId, CancellationToken cancellationToken = default)
     {
-        return await GetOrDefaultAsync(
-            $"franchise-seasons/id/{franchiseSeasonId}/competition-results",
-            new List<FranchiseSeasonCompetitionResultDto>(),
-            cancellationToken);
+        // 404 = no games recorded — empty list, not an error.
+        try
+        {
+            return await GetOrDefaultAsync(
+                $"franchise-seasons/id/{franchiseSeasonId}/competition-results",
+                new List<FranchiseSeasonCompetitionResultDto>(),
+                cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return [];
+        }
     }
 
     public async Task<List<ConferenceDivisionNameAndSlugDto>> GetConferenceNamesAndSlugs(int seasonYear, CancellationToken cancellationToken = default)

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -33,6 +33,7 @@ import ContestOverview from "./components/contests/ContestOverview";
 import AdminPage from "./components/admin/AdminPage";
 import AdminFootballPage from "./components/admin/AdminFootballPage";
 import AdminBaseballPage from "./components/admin/AdminBaseballPage";
+import AdminPreviewLabPage from "./components/admin/AdminPreviewLabPage";
 import AdminRoute from "./routes/AdminRoute";
 import SeasonOverview from "./components/season/SeasonOverview";
 
@@ -231,6 +232,14 @@ function MainApp() {
               element={
                 <AdminRoute>
                   <AdminBaseballPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/preview-lab"
+              element={
+                <AdminRoute>
+                  <AdminPreviewLabPage />
                 </AdminRoute>
               }
             />

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -16,6 +16,23 @@ const AdminApi = {
       `/admin/matchup/preview/${contestId}/reset${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
     ),
 
+  // Preview Lab (docs/metrics-modeling/matchup-preview-data-inputs.md §3.6).
+  // capture = persist the exact prompt payload without a model call;
+  // experiment = call the model but store the result on the capture row
+  // ONLY — never writes a MatchupPreview, so a prior season's real preview
+  // can't be shadowed on the picks page. Both allow completed contests and
+  // announce completion via SignalR (PreviewPromptCaptured).
+  capturePreviewPrompt: (contestId, sport) =>
+    apiClient.post(
+      `/admin/matchup/preview/${contestId}/capture${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+    ),
+  runPreviewExperiment: (contestId, sport) =>
+    apiClient.post(
+      `/admin/matchup/preview/${contestId}/experiment${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+    ),
+  getPreviewCaptures: (contestId) =>
+    apiClient.get(`/admin/matchup/preview/${contestId}/captures`),
+
   // Returns one MLB matchup in the same shape as the picks page so the
   // baseball SignalR debug page can render a real <MatchupCard /> for a
   // chosen contest. League-context fields (Predictions, AiWinner,

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -11,9 +11,11 @@ const AdminApi = {
   getCompetitionsWithoutMetrics: () =>
     apiClient.get('/admin/errors/competitions-without-metrics'),
   // sport: backend Sport enum name (e.g. "FootballNfl"); omitted = NCAA.
+  // contestId is encoded everywhere it enters the path — it comes from
+  // free-text admin inputs, and a stray ?/#// would change the request target.
   resetPreview: (contestId, sport) =>
     apiClient.post(
-      `/admin/matchup/preview/${contestId}/reset${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+      `/admin/matchup/preview/${encodeURIComponent(contestId)}/reset${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
     ),
 
   // Preview Lab (docs/metrics-modeling/matchup-preview-data-inputs.md §3.6).
@@ -24,14 +26,14 @@ const AdminApi = {
   // announce completion via SignalR (PreviewPromptCaptured).
   capturePreviewPrompt: (contestId, sport) =>
     apiClient.post(
-      `/admin/matchup/preview/${contestId}/capture${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+      `/admin/matchup/preview/${encodeURIComponent(contestId)}/capture${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
     ),
   runPreviewExperiment: (contestId, sport) =>
     apiClient.post(
-      `/admin/matchup/preview/${contestId}/experiment${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+      `/admin/matchup/preview/${encodeURIComponent(contestId)}/experiment${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
     ),
   getPreviewCaptures: (contestId) =>
-    apiClient.get(`/admin/matchup/preview/${contestId}/captures`),
+    apiClient.get(`/admin/matchup/preview/${encodeURIComponent(contestId)}/captures`),
 
   // Returns one MLB matchup in the same shape as the picks page so the
   // baseball SignalR debug page can render a real <MatchupCard /> for a

--- a/src/UI/sd-ui/src/components/admin/AdminPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.jsx
@@ -131,6 +131,11 @@ export default function AdminPage() {
       <AdminHeader />
 
       {/* SignalR debug cards moved to /admin/football and /admin/baseball. */}
+      <div style={{ display: 'flex', gap: 16, margin: '8px 0 16px' }}>
+        <a href="/admin/football">Football debug</a>
+        <a href="/admin/baseball">Baseball debug</a>
+        <a href="/admin/preview-lab">Preview Lab</a>
+      </div>
 
       <div className="admin-grid">
         <div className="admin-main">

--- a/src/UI/sd-ui/src/components/admin/AdminPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import './AdminPage.css';
 import apiWrapper from '../../api/apiWrapper';
 import AdminHeader from './AdminHeader';
@@ -132,9 +133,9 @@ export default function AdminPage() {
 
       {/* SignalR debug cards moved to /admin/football and /admin/baseball. */}
       <div style={{ display: 'flex', gap: 16, margin: '8px 0 16px' }}>
-        <a href="/admin/football">Football debug</a>
-        <a href="/admin/baseball">Baseball debug</a>
-        <a href="/admin/preview-lab">Preview Lab</a>
+        <Link to="/admin/football">Football debug</Link>
+        <Link to="/admin/baseball">Baseball debug</Link>
+        <Link to="/admin/preview-lab">Preview Lab</Link>
       </div>
 
       <div className="admin-grid">

--- a/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
@@ -1,0 +1,313 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import './AdminPage.css';
+import AdminHeader from './AdminHeader';
+import apiWrapper from '../../api/apiWrapper';
+import useSignalRClient from '../../hooks/useSignalRClient';
+import { useUserDto } from '../../contexts/UserContext';
+
+const CONTEST_ID_STORAGE_KEY = 'admin.previewlab.contestId';
+const LEAGUE_STORAGE_KEY = 'admin.previewlab.league';
+
+const LEAGUE_OPTIONS = [
+  { value: 'ncaa', label: 'NCAAFB', sport: 'FootballNcaa' },
+  { value: 'nfl', label: 'NFL', sport: 'FootballNfl' },
+];
+
+const MODE_LABELS = {
+  Generate: 'Generate',
+  Capture: 'Capture',
+  Experiment: 'Experiment',
+  0: 'Generate',
+  1: 'Capture',
+  2: 'Experiment',
+};
+
+/**
+ * Preview Lab — capture prompts and run sandboxed model experiments for a
+ * contest WITHOUT touching production previews. Experiment runs store
+ * their result on the capture row only; a MatchupPreview is never written,
+ * so a prior season's real preview cannot be shadowed on the picks page.
+ * Completed (historical) contests are explicitly allowed — that is the
+ * backtest workflow. Design: docs/metrics-modeling/
+ * matchup-preview-data-inputs.md §3.6.
+ */
+export default function AdminPreviewLabPage() {
+  const { userDto } = useUserDto();
+
+  const [league, setLeague] = useState(() => {
+    const stored = localStorage.getItem(LEAGUE_STORAGE_KEY);
+    return LEAGUE_OPTIONS.some(o => o.value === stored) ? stored : 'ncaa';
+  });
+  const [contestId, setContestId] = useState(
+    () => localStorage.getItem(CONTEST_ID_STORAGE_KEY) ?? ''
+  );
+  const [pendingId, setPendingId] = useState(contestId);
+  const [captures, setCaptures] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const leagueSport = useMemo(
+    () => LEAGUE_OPTIONS.find(o => o.value === league)?.sport ?? 'FootballNcaa',
+    [league]
+  );
+
+  const loadCaptures = useCallback(async (id) => {
+    if (!id) {
+      setCaptures([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await apiWrapper.Admin.getPreviewCaptures(id);
+      setCaptures(Array.isArray(res.data) ? res.data : []);
+    } catch (err) {
+      // 404 just means no captures yet — an empty lab, not an error.
+      if (err?.response?.status === 404) {
+        setCaptures([]);
+      } else {
+        toast.error(err?.message ?? 'Failed to load captures');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCaptures(contestId);
+  }, [contestId, loadCaptures]);
+
+  // Refresh the list when the async run completes for the contest we're
+  // looking at (SignalR payload is camelCase per the hub JSON options).
+  const handlePromptCaptured = useCallback(
+    (data) => {
+      if (!contestId || data?.contestId !== contestId) return;
+      toast.success(data?.message ?? 'Prompt capture completed');
+      loadCaptures(contestId);
+    },
+    [contestId, loadCaptures]
+  );
+
+  useSignalRClient({
+    userId: userDto?.id,
+    onPreviewPromptCaptured: handlePromptCaptured,
+  });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const trimmed = pendingId.trim();
+    if (trimmed) {
+      localStorage.setItem(CONTEST_ID_STORAGE_KEY, trimmed);
+    } else {
+      localStorage.removeItem(CONTEST_ID_STORAGE_KEY);
+    }
+    if (trimmed === contestId) {
+      // Same ID re-submitted — the state-keyed effect won't re-run, so
+      // fetch explicitly. "Load captures" should always mean a fetch.
+      loadCaptures(trimmed);
+    } else {
+      setContestId(trimmed);
+    }
+  };
+
+  const handleLeagueChange = (e) => {
+    const next = e.target.value;
+    setLeague(next);
+    localStorage.setItem(LEAGUE_STORAGE_KEY, next);
+  };
+
+  const runAction = async (action, queuedMessage) => {
+    if (!contestId) {
+      toast.error('Set a contest ID first.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await action(contestId, leagueSport);
+      toast.success(queuedMessage);
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.errors?.[0]?.errorMessage
+          ?? err.message
+          ?? 'Request failed'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="admin-page">
+      <AdminHeader />
+      <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+        <h2 style={{ marginBottom: 4 }}>Preview Lab</h2>
+        <p style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
+          Capture prompts and run sandboxed model experiments. Experiments
+          never write a MatchupPreview — existing previews (including last
+          season's) are untouched. Grab a contest ID from the picks page.
+        </p>
+
+        <form
+          onSubmit={handleSubmit}
+          style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '16px 0', flexWrap: 'wrap' }}
+        >
+          <label htmlFor="previewlab-league" style={{ fontWeight: 600 }}>League:</label>
+          <select
+            id="previewlab-league"
+            value={league}
+            onChange={handleLeagueChange}
+            style={{ padding: '6px 8px' }}
+          >
+            {LEAGUE_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+          <label htmlFor="previewlab-contest-id" style={{ fontWeight: 600 }}>Contest ID:</label>
+          <input
+            id="previewlab-contest-id"
+            type="text"
+            value={pendingId}
+            onChange={(e) => setPendingId(e.target.value)}
+            placeholder="paste a contest GUID"
+            style={{ flex: 1, padding: '6px 8px', minWidth: 240 }}
+          />
+          <button type="submit">Load captures</button>
+          <button
+            type="button"
+            disabled={submitting || !contestId}
+            onClick={() =>
+              runAction(
+                apiWrapper.Admin.capturePreviewPrompt,
+                'Capture queued — no tokens will be burned.'
+              )
+            }
+            title="Persist the exact prompt payload without calling the model"
+          >
+            Capture prompt
+          </button>
+          <button
+            type="button"
+            disabled={submitting || !contestId}
+            onClick={() =>
+              runAction(
+                apiWrapper.Admin.runPreviewExperiment,
+                'Experiment queued — result lands here, not on the picks page.'
+              )
+            }
+            title="Call the model; store the result on the capture row only"
+          >
+            Run experiment
+          </button>
+        </form>
+
+        {loading && <div>Loading captures…</div>}
+        {!loading && contestId && captures.length === 0 && (
+          <div style={{ color: 'var(--text-secondary)' }}>
+            No captures for this contest yet.
+          </div>
+        )}
+
+        {captures.map((c) => (
+          <CaptureCard key={c.id} capture={c} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CaptureCard({ capture }) {
+  const modeLabel = MODE_LABELS[capture.mode] ?? String(capture.mode);
+  const created = capture.createdUtc
+    ? new Date(capture.createdUtc).toLocaleString()
+    : '';
+
+  return (
+    <div
+      style={{
+        border: '1px solid var(--border-primary)',
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 16,
+        background: 'var(--table-stripe)',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'baseline', marginBottom: 8 }}>
+        <strong>{modeLabel}</strong>
+        <span>{capture.promptVersion}</span>
+        {capture.model && <span>model: {capture.model}</span>}
+        <span>{capture.estTokens?.toLocaleString()} est. tokens</span>
+        {capture.matchupPreviewId && <span>→ preview {capture.matchupPreviewId}</span>}
+        <span style={{ marginLeft: 'auto', color: 'var(--text-secondary)' }}>{created}</span>
+      </div>
+
+      {capture.responseValidationErrors && (
+        <div style={{ color: 'var(--color-danger, #c0392b)', marginBottom: 8 }}>
+          Validation: {capture.responseValidationErrors}
+        </div>
+      )}
+
+      {capture.editorNote && (
+        <div style={{ marginBottom: 8 }}>
+          Editor note: <em>{capture.editorNote}</em>
+        </div>
+      )}
+
+      <PromptBlock label="Full prompt (as the model receives it)" text={capture.fullPrompt} />
+      <PromptBlock label="Data payload (JSON)" text={capture.payloadJson} pretty />
+      {capture.rawResponse && (
+        <PromptBlock label="Model response" text={capture.rawResponse} pretty />
+      )}
+    </div>
+  );
+}
+
+function PromptBlock({ label, text, pretty = false }) {
+  if (!text) return null;
+
+  let display = text;
+  if (pretty) {
+    try {
+      display = JSON.stringify(JSON.parse(text), null, 2);
+    } catch {
+      // Malformed JSON (that's the data, for experiment failures) — show raw.
+    }
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success('Copied.');
+    } catch {
+      toast.error('Copy failed.');
+    }
+  };
+
+  return (
+    <details style={{ marginBottom: 8 }}>
+      <summary style={{ cursor: 'pointer', fontWeight: 600 }}>
+        {label}{' '}
+        <button
+          type="button"
+          onClick={(e) => { e.preventDefault(); handleCopy(); }}
+          style={{ marginLeft: 8, fontSize: '0.8rem' }}
+        >
+          Copy
+        </button>
+      </summary>
+      <pre
+        style={{
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          maxHeight: 420,
+          overflow: 'auto',
+          padding: 12,
+          border: '1px dashed var(--border-primary)',
+          borderRadius: 6,
+          fontSize: '0.85rem',
+        }}
+      >
+        {display}
+      </pre>
+    </details>
+  );
+}

--- a/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
@@ -60,7 +60,11 @@ export default function AdminPreviewLabPage() {
   const loadCaptures = useCallback(async (id) => {
     const seq = ++loadSeqRef.current;
     if (!id) {
+      // Clearing the contest ID invalidates any in-flight load (seq bump
+      // above), whose finally will therefore skip its setLoading(false) —
+      // clear it here so the page can't be stuck on "Loading captures…".
       setCaptures([]);
+      setLoading(false);
       return;
     }
     setLoading(true);

--- a/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import './AdminPage.css';
 import AdminHeader from './AdminHeader';
@@ -52,7 +52,13 @@ export default function AdminPreviewLabPage() {
     [league]
   );
 
+  // Request sequence token: concurrent loads are reachable (manual submit,
+  // contest switch, SignalR refresh) and an out-of-order response must not
+  // overwrite newer data — same discipline as AdminPage's cancelled flags.
+  const loadSeqRef = useRef(0);
+
   const loadCaptures = useCallback(async (id) => {
+    const seq = ++loadSeqRef.current;
     if (!id) {
       setCaptures([]);
       return;
@@ -60,8 +66,10 @@ export default function AdminPreviewLabPage() {
     setLoading(true);
     try {
       const res = await apiWrapper.Admin.getPreviewCaptures(id);
+      if (seq !== loadSeqRef.current) return; // stale response
       setCaptures(Array.isArray(res.data) ? res.data : []);
     } catch (err) {
+      if (seq !== loadSeqRef.current) return;
       // 404 just means no captures yet — an empty lab, not an error.
       if (err?.response?.status === 404) {
         setCaptures([]);
@@ -69,7 +77,7 @@ export default function AdminPreviewLabPage() {
         toast.error(err?.message ?? 'Failed to load captures');
       }
     } finally {
-      setLoading(false);
+      if (seq === loadSeqRef.current) setLoading(false);
     }
   }, []);
 
@@ -77,15 +85,24 @@ export default function AdminPreviewLabPage() {
     loadCaptures(contestId);
   }, [contestId, loadCaptures]);
 
+  // The SignalR callback reads contestId through a ref so its identity stays
+  // stable — a changing identity would tear down and renegotiate the hub
+  // connection on every contest switch (useSignalRClient keys its effect on
+  // the handler), and a completion landing in that window would be lost.
+  const contestIdRef = useRef(contestId);
+  contestIdRef.current = contestId;
+
   // Refresh the list when the async run completes for the contest we're
-  // looking at (SignalR payload is camelCase per the hub JSON options).
+  // looking at. SignalR payload is camelCase; server GUIDs arrive lowercase
+  // while the pasted ID may be uppercase — compare case-insensitively.
   const handlePromptCaptured = useCallback(
     (data) => {
-      if (!contestId || data?.contestId !== contestId) return;
+      const current = contestIdRef.current;
+      if (!current || data?.contestId?.toLowerCase() !== current.toLowerCase()) return;
       toast.success(data?.message ?? 'Prompt capture completed');
-      loadCaptures(contestId);
+      loadCaptures(current);
     },
-    [contestId, loadCaptures]
+    [loadCaptures]
   );
 
   useSignalRClient({
@@ -262,16 +279,19 @@ function CaptureCard({ capture }) {
 }
 
 function PromptBlock({ label, text, pretty = false }) {
-  if (!text) return null;
-
-  let display = text;
-  if (pretty) {
+  // Memoized: reformatting large JSON on every parent re-render is wasted
+  // work — recompute only when the text itself changes.
+  const display = useMemo(() => {
+    if (!text || !pretty) return text;
     try {
-      display = JSON.stringify(JSON.parse(text), null, 2);
+      return JSON.stringify(JSON.parse(text), null, 2);
     } catch {
       // Malformed JSON (that's the data, for experiment failures) — show raw.
+      return text;
     }
-  }
+  }, [text, pretty]);
+
+  if (!text) return null;
 
   const handleCopy = async () => {
     try {

--- a/src/UI/sd-ui/src/hooks/useSignalRClient.js
+++ b/src/UI/sd-ui/src/hooks/useSignalRClient.js
@@ -7,6 +7,7 @@ export default function useSignalRClient({
   userId,
   leagueId,
   onPreviewCompleted,
+  onPreviewPromptCaptured,
   onContestStatusChanged,
   onContestFinalized,
   onFootballPlayCompleted,
@@ -40,6 +41,12 @@ export default function useSignalRClient({
       .build();
 
     connection.on("PreviewGenerated", onPreviewCompleted);
+
+    // Preview Lab completions (capture / experiment runs) — admin-only
+    // consumers; broadcast is global like PreviewGenerated.
+    if (onPreviewPromptCaptured) {
+      connection.on("PreviewPromptCaptured", onPreviewPromptCaptured);
+    }
 
     // Lifecycle (Scheduled→InProgress→Final) — sport-neutral.
     if (onContestStatusChanged) {
@@ -86,6 +93,7 @@ export default function useSignalRClient({
     userId,
     leagueId,
     onPreviewCompleted,
+    onPreviewPromptCaptured,
     onContestStatusChanged,
     onContestFinalized,
     onFootballPlayCompleted,

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -117,6 +117,7 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             Assert.Null(capture.Model);
             Assert.Null(capture.RawResponse);
             Assert.Equal("prediction-insights-with-stats-schedule", capture.PromptVersion);
+            Assert.Equal(PromptText, capture.PromptText);
             Assert.Contains("arizona-cardinals", capture.PayloadJson);
             Assert.Null(capture.EditorNote);
             Assert.True(capture.CharCount > PromptText.Length);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -1,0 +1,339 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using SportsData.Api.Application.Previews;
+using SportsData.Api.Infrastructure.Prompts;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Previews;
+using SportsData.Core.Infrastructure.Blobs;
+using SportsData.Core.Infrastructure.Clients.AI;
+using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Infrastructure.Clients.Franchise;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Previews
+{
+    public class MatchupPreviewProcessorTests : ApiTestBase<MatchupPreviewProcessor>
+    {
+        private static readonly DateTime Now = new(2026, 8, 7, 12, 0, 0, DateTimeKind.Utc);
+
+        private const string PromptText = "PROMPT INSTRUCTIONS";
+
+        private readonly Guid _contestId = Guid.NewGuid();
+        private readonly Guid _homeFranchiseSeasonId = Guid.NewGuid();
+        private readonly Guid _awayFranchiseSeasonId = Guid.NewGuid();
+
+        private MatchupForPreviewDto BuildMatchup(string status) => new()
+        {
+            Sport = Sport.FootballNfl,
+            SeasonYear = 2025,
+            WeekNumber = 2,
+            ContestId = _contestId,
+            Status = status,
+            Venue = "State Farm Stadium",
+            VenueCity = "Glendale",
+            Home = "Arizona Cardinals",
+            HomeSlug = "arizona-cardinals",
+            HomeConferenceSlug = "nfc-west",
+            HomeFranchiseSeasonId = _homeFranchiseSeasonId,
+            Away = "Carolina Panthers",
+            AwaySlug = "carolina-panthers",
+            AwayConferenceSlug = "nfc-south",
+            AwayFranchiseSeasonId = _awayFranchiseSeasonId
+        };
+
+        private void SetupPipeline(MatchupForPreviewDto matchup)
+        {
+            var contestClient = new Mock<IProvideContests>();
+            contestClient
+                .Setup(x => x.GetMatchupForPreview(_contestId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<MatchupForPreviewDto>(matchup));
+
+            Mocker.GetMock<IContestClientFactory>()
+                .Setup(x => x.Resolve(It.IsAny<Sport>()))
+                .Returns(contestClient.Object);
+
+            var franchiseClient = new Mock<IProvideFranchises>();
+            franchiseClient
+                .Setup(x => x.GetFranchiseSeasonPreviewStats(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FranchiseSeasonModelStatsDto { RushingYardsPerGame = 150.0 });
+            franchiseClient
+                .Setup(x => x.GetFranchiseSeasonMetricsByFranchiseSeasonId(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((FranchiseSeasonMetricsDto?)null!);
+            franchiseClient
+                .Setup(x => x.GetFranchiseSeasonCompetitionResults(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([]);
+
+            Mocker.GetMock<IFranchiseClientFactory>()
+                .Setup(x => x.Resolve(It.IsAny<Sport>()))
+                .Returns(franchiseClient.Object);
+
+            // Real prompt provider backed by a mocked blob store — the
+            // provider class is concrete, so we feed it a real DI container.
+            var blobStorage = new Mock<IProvideBlobStorage>();
+            blobStorage
+                .Setup(x => x.GetFileContentsAsync("prompts", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PromptText);
+
+            var services = new ServiceCollection()
+                .AddSingleton(blobStorage.Object)
+                .BuildServiceProvider();
+
+            Mocker.Use(new MatchupPreviewPromptProvider(services));
+
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(x => x.UtcNow())
+                .Returns(Now);
+        }
+
+        [Fact]
+        public async Task CaptureOnly_PersistsCapture_WithoutModelCall_OrPreview()
+        {
+            // Arrange — completed contest: capture mode must still proceed
+            SetupPipeline(BuildMatchup("STATUS_FINAL"));
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Capture
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Equal(_contestId, capture.ContestId);
+            Assert.Equal(Sport.FootballNfl, capture.Sport);
+            Assert.Equal(PreviewGenerationMode.Capture, capture.Mode);
+            Assert.Null(capture.MatchupPreviewId);
+            Assert.Null(capture.Model);
+            Assert.Null(capture.RawResponse);
+            Assert.Equal("prediction-insights-with-stats-schedule", capture.PromptVersion);
+            Assert.Contains("arizona-cardinals", capture.PayloadJson);
+            Assert.Null(capture.EditorNote);
+            Assert.True(capture.CharCount > PromptText.Length);
+            Assert.Equal(capture.CharCount / 4, capture.EstTokens);
+            Assert.Equal(Now, capture.CreatedUtc);
+
+            Assert.Empty(DataContext.MatchupPreviews);
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            Mocker.GetMock<IEventBus>()
+                .Verify(x => x.Publish(It.IsAny<PreviewPromptCaptured>(), It.IsAny<CancellationToken>()), Times.Once);
+            Mocker.GetMock<IEventBus>()
+                .Verify(x => x.Publish(It.IsAny<PreviewGenerated>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task RealGeneration_PersistsCapture_LinkedToPreview()
+        {
+            // Arrange
+            SetupPipeline(BuildMatchup("STATUS_SCHEDULED"));
+
+            // No spread on the matchup -> validator treats it as pick'em, so
+            // the response must not name a spread winner.
+            var responseJson = $$"""
+                {
+                  "overview": "o",
+                  "analysis": "a",
+                  "prediction": "p",
+                  "predictedStraightUpWinner": "{{_homeFranchiseSeasonId}}",
+                  "predictedSpreadWinner": null,
+                  "overUnderPrediction": 2,
+                  "awayScore": 17,
+                  "homeScore": 27
+                }
+                """;
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(responseJson));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("test-model");
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            var preview = Assert.Single(DataContext.MatchupPreviews);
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+
+            Assert.Equal(preview.Id, capture.MatchupPreviewId);
+            Assert.Equal(PreviewGenerationMode.Generate, capture.Mode);
+            Assert.Equal(preview.PromptVersion, capture.PromptVersion);
+            Assert.Equal("test-model", capture.Model);
+            Assert.NotNull(capture.RawResponse);
+
+            // The model received exactly what was captured
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(
+                    $"{PromptText}\n\n{capture.PayloadJson}",
+                    It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task RealGeneration_SkipsCompletedContest_WithoutCapture()
+        {
+            // Arrange
+            SetupPipeline(BuildMatchup("STATUS_FINAL"));
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            Assert.Empty(DataContext.MatchupPreviewPrompts);
+            Assert.Empty(DataContext.MatchupPreviews);
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CaptureOnly_IncludesEditorNote_FromRejectedPreview()
+        {
+            // Arrange
+            SetupPipeline(BuildMatchup("STATUS_SCHEDULED"));
+
+            await DataContext.MatchupPreviews.AddAsync(new SportsData.Api.Infrastructure.Data.Entities.MatchupPreview
+            {
+                Id = Guid.NewGuid(),
+                ContestId = _contestId,
+                RejectedUtc = Now.AddDays(-1),
+                RejectionNote = "Too much spread parroting",
+                CreatedUtc = Now.AddDays(-1)
+            });
+            await DataContext.SaveChangesAsync();
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Capture
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Equal("Too much spread parroting", capture.EditorNote);
+        }
+
+        [Fact]
+        public async Task Experiment_OnCompletedContest_StoresResponse_WithoutWritingPreview()
+        {
+            // Arrange — completed contest with a valid model response: the
+            // core protection is that NO MatchupPreview row appears, so a
+            // prior season's real preview can never be shadowed.
+            SetupPipeline(BuildMatchup("STATUS_FINAL"));
+
+            var responseJson = $$"""
+                {
+                  "overview": "o",
+                  "analysis": "a",
+                  "prediction": "p",
+                  "predictedStraightUpWinner": "{{_homeFranchiseSeasonId}}",
+                  "predictedSpreadWinner": null,
+                  "overUnderPrediction": 2,
+                  "awayScore": 17,
+                  "homeScore": 27
+                }
+                """;
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(responseJson));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("experiment-model");
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Experiment
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            Assert.Empty(DataContext.MatchupPreviews);
+
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Equal(PreviewGenerationMode.Experiment, capture.Mode);
+            Assert.Null(capture.MatchupPreviewId);
+            Assert.Equal("experiment-model", capture.Model);
+            Assert.Equal(responseJson, capture.RawResponse);
+            Assert.Null(capture.ResponseValidationErrors);
+
+            Mocker.GetMock<IEventBus>()
+                .Verify(x => x.Publish(It.IsAny<PreviewPromptCaptured>(), It.IsAny<CancellationToken>()), Times.Once);
+            Mocker.GetMock<IEventBus>()
+                .Verify(x => x.Publish(It.IsAny<PreviewGenerated>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Experiment_WithMalformedResponse_RecordsProblems()
+        {
+            // Arrange
+            SetupPipeline(BuildMatchup("STATUS_FINAL"));
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>("this is not json"));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("experiment-model");
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Experiment
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — the failed response IS the data: persisted, flagged
+            Assert.Empty(DataContext.MatchupPreviews);
+
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Equal("this is not json", capture.RawResponse);
+            Assert.NotNull(capture.ResponseValidationErrors);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Full visibility into what the preview model receives — before tokens are burned — plus a safe path for testing models/prompts against historical games. Design doc: `docs/metrics-modeling/matchup-preview-data-inputs.md` (§3.5/§3.6).

### The core protection

The picks page reads the newest non-rejected `MatchupPreview` per contest — an experimental preview row for a game that already has a real preview from last season would shadow it instantly. **Experiment runs therefore never write a `MatchupPreview`** — their results live on the capture row only. Real generation independently keeps its completed-contest skip. Two independent walls between testing and production data.

### Backend

- `GenerateMatchupPreviewsCommand.Mode`: `Generate` (0, default — old Hangfire payloads deserialize unchanged), `Capture` (persist prompt payload, no model call), `Experiment` (model call; raw response + model + parse/validation problems stored on the capture row). Capture/Experiment allow completed contests (the backtest workflow).
- New `MatchupPreviewPrompt` table: jsonb payload, PromptVersion, editor note, char/token counts, mode, model, raw response (`text` deliberately, not jsonb — malformed model output is exactly the data an experiment must record), nullable SetNull FK to `MatchupPreview`. Every real generation now persists its exact inputs.
- `MatchupPreviewProcessor`: single shared prompt-assembly path for all modes (captures are byte-identical to real sends by construction), `IDateTimeProvider` instead of `DateTime.UtcNow`, step-by-step logging including the Producer failure detail that was previously swallowed.
- **Latent prod bug fixed** in `FranchiseClient`: `GetOrDefaultAsync` throws on any non-success despite its name, so a 404 from Producer's metrics/preview-stats/competition-results endpoints (= data simply doesn't exist) crashed the job into Hangfire's 10-retry loop and made the processor's both-or-nothing metrics handling unreachable. 404 now returns null/empty (existing `GetTeamCard` pattern); other statuses still throw so real failures still retry. Interface is now honestly `FranchiseSeasonMetricsDto?` — the only other caller already null-checked.
- Admin endpoints: `POST /admin/matchup/preview/{contestId}/capture`, `POST .../experiment`, `GET .../captures` (full prompt reconstructed from versioned blob + stored payload; zero captures = 200 + `[]`).
- `PreviewPromptCaptured` event + SignalR broadcast mirroring `PreviewGenerated`.

### Web

- `/admin/preview-lab` (AdminRoute): league + contest ID (grab from picks page), Capture prompt / Run experiment, captures list with expandable full-prompt/payload/response blocks, copy buttons, validation problems. SignalR completion toast auto-refreshes. Picks-page Matchup Preview logic untouched by design.
- Admin dashboard links to football/baseball debug pages + the lab.

### Tests / deploy

- 6 new processor tests (capture, experiment incl. malformed-response persistence, generate linkage, completed-contest matrix); 634 API + 10 web tests pass; production web build clean.
- EF migration `AddMatchupPreviewPrompt` — green-field CreateTable, no data-dependent constraints.
- Local E2E blocked at the Azurite prompt-blob fetch; validation happens in prod on the admin-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin Preview Lab for capturing matchup-preview prompts, running experiments, and reviewing stored prompts and model responses.
  * Added real-time updates when prompt captures are available.
  * Added support for Generate, Capture, and Experiment preview modes.
  * Added graceful handling for unavailable franchise and preview data.
  * Improved contest ID handling in admin preview actions.

* **Documentation**
  * Added design documentation covering matchup-preview inputs, prompt capture, historical enrichment, storage, and evaluation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->