### PR TITLE
feat(api,producer): historical blocks in preview payloads - head-to-head and prior-season form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -446,3 +446,6 @@ src/UI/sd-mobile/junit.xml
 # storage ONLY - the repo is public. Local exports for analysis are fine;
 # they must never be committed.
 docs/metrics-modeling/prompts/
+
+# Preview Lab exports (capture.txt contains full prompt instruction text)
+docs/metrics-modeling/previews/

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -380,6 +380,52 @@ prediction vs `Contest` final score / spread result. The capture table
 deliberately stores everything that run needs; the harness itself is
 not part of this build.
 
+### ⚠️ First prod capture finding (2026-08-08): the answer leaks into
+### completed-game payloads
+
+Captured the Hall of Fame Game (completed) via the lab. The payload's
+`Away/HomeCompetitionResults` contain **the target game itself** — same
+ContestId, final score 33-30, `WinnerFranchiseSeasonId`,
+`SpreadWinnerFranchiseSeasonId`, `OverUnderResult` — plus
+`Status: "STATUS_FINAL"`. An experiment against any completed game hands
+the model the answer; every such result is invalid as an eval signal.
+In-season real generation never hits this (completed-contest skip =
+generation is always pre-game), so this is an EXPERIMENT-MODE problem.
+
+**Required before the eval harness is trusted:** as-of filtering during
+assembly for Experiment mode — exclude from both CompetitionResults
+lists any game with `StartDateUtc >= target.StartDateUtc` (which
+removes the target itself and later games), and mask
+`Status`/`StatusDescription` to a pre-game value. This recreates the
+information state the model would have had before kickoff. Not yet
+implemented.
+
+Other confirmations from the same capture (§3.5 hygiene case, now
+quantified): 28 serialized null stat fields across the two teams,
+`"Sport": 3` as a bare int the prompt can't interpret (user 2026-08-08:
+resolve — string enums in the projection), six-decimal odds
+(`34.500000`), and the same result row duplicated verbatim in both
+teams' lists. And the no-stats path selected `prediction-insights-v1`,
+which never documents CompetitionResults — the model received schedule
+data the v1 prompt gives no guidance on.
+
+**POLICY — NFL preseason is system-testing data ONLY** (user decision
+2026-08-08). A finalized preseason game DOES flow into current-season
+CompetitionResults — but preseason is a proving ground for the roster
+bubble (final 53-man cuts land Aug 30); outcomes say nothing about the
+September team. Decision: preseason results are **excluded, not
+labeled** — they NEVER appear in matchup-preview payloads (season
+results, recency bridge, head-to-head — note the Hall of Fame Game
+itself is a preseason "meeting" and must not count in CAR/ARI H2H) and
+NEVER contribute to anything metrics-based, including the Python
+scripts that power the DeetsMeter. Their only value is exercising the
+live pipeline before the season.
+
+Scoping note for the build: filter at the preview/metrics CONSUMPTION
+layer (SeasonPhase on the game), not blanket at Producer's
+competition-results endpoint — user-facing schedule surfaces (team
+cards) legitimately show preseason games.
+
 ### Admin UI — Preview Lab (built with the above, 2026-08-07)
 
 `/admin/preview-lab` (AdminRoute-gated): league selector + ContestId
@@ -411,17 +457,29 @@ logic is untouched by design.
 
 ## 5. Open decisions
 
-1. N for head-to-head (proposed 5) and recency bridge (proposed 5 games).
-2. One combined Producer "preview history" endpoint vs. composing existing
-   per-piece endpoints (proposed: one endpoint — one HTTP hop, one place
-   to evolve).
+1. ~~N for head-to-head and recency bridge~~ — DECIDED 2026-08-08: 5 and
+   5 (defaults on `GetContestPreviewHistoryQuery`). **Implemented**: 3b
+   (head-to-head) + 3c (recency bridge) shipped as
+   `GET /contests/{contestId}/preview-history` with preview-safe
+   semantics in the SQL (finalized/non-cancelled, preseason excluded per
+   policy, as-of `< target.StartDateUtc` so the target never leaks into
+   its own history). New blocks use the names-only GameResult shape —
+   the payload's only GUIDs remain ContestId + the two live
+   FranchiseSeasonIds (regression-tested). 3a (prior-season
+   record/metrics block) still pending.
+2. ~~One endpoint vs compose~~ — DECIDED: one endpoint (implemented as
+   above).
 3. Payload-hygiene projection (3e) first, or accept token growth and do it
-   later (proposed: first).
+   later (proposed: first — PARTIALLY superseded: new history blocks are
+   born clean; the hygiene work now covers only the legacy fields).
 4. Prompt authoring workflow for with-history-v1. Prompts stay blob-only
    (secret sauce, public repo — decided 2026-08-07); author against local
    gitignored working copies, upload to blob, PromptVersion tracks it.
-5. Whether the DTO gains blocks (wire change through Producer client) or
-   the API composes history separately — follows from decision 2.
+5. ~~DTO gains blocks vs API composes~~ — DECIDED: `MatchupForPreviewDto`
+   gained nullable HeadToHead / AwayPriorSeasonGames /
+   HomePriorSeasonGames; the API's assembly populates them from the
+   preview-history endpoint with graceful degradation (history fetch
+   failure logs and proceeds without blocks — never fails generation).
 
 ## Sequencing
 

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -178,9 +178,12 @@ test pair):
 - **GUID trap:** historical Contest rows carry per-season
   FranchiseSeasonIds. If serialized, the model can echo one into
   `predictedStraightUpWinner` (the output contract demands a
-  FranchiseSeasonId). Rule: **exactly two GUIDs in the entire payload** —
-  the live Away/Home FranchiseSeasonIds. Every historical block is
-  names/labels only.
+  FranchiseSeasonId). Rule: **historical blocks contribute ZERO GUIDs**
+  (names/labels only — implemented and regression-tested in the
+  preview-history PR). Today's raw payload therefore carries exactly
+  three GUIDs: ContestId plus the two live Away/Home
+  FranchiseSeasonIds. The 3e projection below drops ContestId (the
+  model has no use for it), landing on two.
 
 Draft shape (also implements the 3e hygiene projection — this IS the
 purpose-built prompt payload, not the wire DTO):
@@ -380,8 +383,7 @@ prediction vs `Contest` final score / spread result. The capture table
 deliberately stores everything that run needs; the harness itself is
 not part of this build.
 
-### ⚠️ First prod capture finding (2026-08-08): the answer leaks into
-### completed-game payloads
+### ⚠️ First prod capture finding (2026-08-08): the answer leaks into completed-game payloads
 
 Captured the Hall of Fame Game (completed) via the lab. The payload's
 `Away/HomeCompetitionResults` contain **the target game itself** — same

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -277,6 +277,26 @@ namespace SportsData.Api.Application.Previews
             Sport sport,
             string? rejectionNote)
         {
+            // Historical context (last 5 H2H + prior-season last 5, preview-
+            // safe semantics baked into Producer's queries). Degrades
+            // gracefully: a failed fetch logs and the preview proceeds
+            // without history rather than failing the job.
+            var historyResult = await _contestClientFactory.Resolve(sport)
+                .GetContestPreviewHistory(matchup.ContestId);
+
+            if (historyResult.IsSuccess && historyResult.Value is not null)
+            {
+                matchup.HeadToHead = historyResult.Value.HeadToHead;
+                matchup.AwayPriorSeasonGames = historyResult.Value.AwayPriorSeasonGames;
+                matchup.HomePriorSeasonGames = historyResult.Value.HomePriorSeasonGames;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Preview history unavailable for {ContestId}; proceeding without historical blocks.",
+                    matchup.ContestId);
+            }
+
             var franchiseClient = _franchiseClientFactory.Resolve(sport);
 
             matchup.AwayStats = await franchiseClient

--- a/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
@@ -24,8 +24,9 @@ namespace SportsData.Core.Dtos.Canonical
     /// One historical game, expressed entirely in team NAMES — deliberately
     /// no GUIDs. The preview prompt's output contract asks the model to
     /// echo a FranchiseSeasonId for its predicted winner; historical rows
-    /// carry per-season ids that a model could echo by mistake, so the only
-    /// two GUIDs in the entire preview payload are the live Away/Home
+    /// carry per-season ids that a model could echo by mistake. Historical
+    /// blocks therefore contribute ZERO GUIDs to the payload — its only
+    /// GUIDs are the ContestId and the two live Away/Home
     /// FranchiseSeasonIds.
     /// </summary>
     public class PreviewGameResultDto

--- a/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Core.Dtos.Canonical
+{
+    /// <summary>
+    /// Historical context for a matchup preview: recent head-to-head
+    /// meetings plus each team's late-prior-season form. Assembled by
+    /// Producer with preview-safe semantics baked in: preseason games
+    /// excluded (system-testing data only), finalized/non-cancelled games
+    /// only, and as-of filtering (no meeting on/after the target contest's
+    /// start — the target can never leak into its own history).
+    /// </summary>
+    public class ContestPreviewHistoryDto
+    {
+        public List<PreviewGameResultDto> HeadToHead { get; set; } = [];
+
+        public List<PreviewGameResultDto> AwayPriorSeasonGames { get; set; } = [];
+
+        public List<PreviewGameResultDto> HomePriorSeasonGames { get; set; } = [];
+    }
+
+    /// <summary>
+    /// One historical game, expressed entirely in team NAMES — deliberately
+    /// no GUIDs. The preview prompt's output contract asks the model to
+    /// echo a FranchiseSeasonId for its predicted winner; historical rows
+    /// carry per-season ids that a model could echo by mistake, so the only
+    /// two GUIDs in the entire preview payload are the live Away/Home
+    /// FranchiseSeasonIds.
+    /// </summary>
+    public class PreviewGameResultDto
+    {
+        public DateTime GameDate { get; set; }
+
+        public int SeasonYear { get; set; }
+
+        /// <summary>Season phase name (e.g. "Regular Season", "Postseason"); null on old rows.</summary>
+        public string? Phase { get; set; }
+
+        /// <summary>Event note when present (e.g. "NFC Championship").</summary>
+        public string? Note { get; set; }
+
+        public string HomeTeam { get; set; } = default!;
+
+        public string AwayTeam { get; set; } = default!;
+
+        public int? HomeScore { get; set; }
+
+        public int? AwayScore { get; set; }
+
+        /// <summary>Winning team name; null for a tie.</summary>
+        public string? Winner { get; set; }
+
+        /// <summary>Team that covered; null when no spread data exists (common pre-2012).</summary>
+        public string? SpreadWinner { get; set; }
+
+        /// <summary>"Over" / "Under"; null when no total was recorded.</summary>
+        public string? OverUnderResult { get; set; }
+    }
+}

--- a/src/SportsData.Core/Dtos/Canonical/MatchupForPreviewDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/MatchupForPreviewDto.cs
@@ -57,6 +57,18 @@ namespace SportsData.Core.Dtos.Canonical
         public FranchiseSeasonMetricsDto? HomeMetrics { get; set; }
         public List<FranchiseSeasonCompetitionResultDto>? HomeCompetitionResults { get; set; }
 
+        /// <summary>
+        /// Historical blocks (docs/metrics-modeling/matchup-preview-data-inputs.md
+        /// §3b/3c): last 5 head-to-head meetings and each team's last 5
+        /// prior-season games. Names-only rows (no GUIDs — the model must
+        /// only ever echo the two live FranchiseSeasonIds above). Populated
+        /// by the API's preview assembly; null when history fetch fails
+        /// (graceful degradation).
+        /// </summary>
+        public List<PreviewGameResultDto>? HeadToHead { get; set; }
+        public List<PreviewGameResultDto>? AwayPriorSeasonGames { get; set; }
+        public List<PreviewGameResultDto>? HomePriorSeasonGames { get; set; }
+
         public string? Spread { get; set; }             // co."Details"
         public double? AwaySpread { get; set; }
         public double? HomeSpread { get; set; }

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
@@ -97,6 +97,7 @@ public interface IProvideContests : IProvideHealthChecks
     Task<Result<Matchup>> GetMatchupByContestId(Guid contestId, CancellationToken ct = default);
     Task<Result<List<LeagueMatchupDto>>> GetMatchupsByContestIds(List<Guid> contestIds, MarkDirection direction, CancellationToken ct = default);
     Task<Result<MatchupForPreviewDto>> GetMatchupForPreview(Guid contestId, CancellationToken ct = default);
+    Task<Result<ContestPreviewHistoryDto>> GetContestPreviewHistory(Guid contestId, CancellationToken ct = default);
     Task<Result<Dictionary<Guid, MatchupForPreviewDto>>> GetMatchupsForPreviewBatch(List<Guid> contestIds, CancellationToken ct = default);
     Task<Result<MatchupResult>> GetMatchupResult(Guid contestId, CancellationToken ct = default);
     Task<Result<List<ContestResultDto>>> GetContestResultsByContestIds(List<Guid> contestIds, CancellationToken ct = default);
@@ -414,6 +415,17 @@ public class ContestClient : ClientBase, IProvideContests
         return await GetAsync<MatchupForPreviewDto>(
             $"contests/{contestId}/matchup-preview",
             default!, "Matchup preview", ResultStatus.NotFound, ct);
+    }
+
+    public async Task<Result<ContestPreviewHistoryDto>> GetContestPreviewHistory(Guid contestId, CancellationToken ct = default)
+    {
+        if (contestId == Guid.Empty)
+            return new Failure<ContestPreviewHistoryDto>(default!, ResultStatus.BadRequest,
+                [new ValidationFailure("contestId", "Contest ID cannot be empty")]);
+
+        return await GetAsync<ContestPreviewHistoryDto>(
+            $"contests/{contestId}/preview-history",
+            default!, "Contest preview history", ResultStatus.NotFound, ct);
     }
 
     public async Task<Result<Dictionary<Guid, MatchupForPreviewDto>>> GetMatchupsForPreviewBatch(List<Guid> contestIds, CancellationToken ct = default)

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -497,6 +497,23 @@ namespace SportsData.Producer.Application.Contests
             return result.ToActionResult();
         }
 
+        /// <summary>
+        /// Historical context for a matchup preview: last N head-to-head
+        /// meetings between the two franchises (cross-season) and each
+        /// team's last N games of the prior season. Preview-safe semantics
+        /// baked into the queries: finalized/non-cancelled only, preseason
+        /// excluded, and no game on/after the target's start date.
+        /// </summary>
+        [HttpGet("{contestId}/preview-history")]
+        public async Task<ActionResult<ContestPreviewHistoryDto>> GetContestPreviewHistory(
+            [FromRoute] Guid contestId,
+            [FromServices] Queries.Matchups.GetContestPreviewHistory.IGetContestPreviewHistoryQueryHandler handler,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await handler.ExecuteAsync(new Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQuery(contestId), cancellationToken);
+            return result.ToActionResult();
+        }
+
         [HttpPost("matchups/previews")]
         public async Task<ActionResult<Dictionary<Guid, MatchupForPreviewDto>>> GetMatchupsForPreviewBatch(
             [FromBody] Guid[] contestIds,

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQuery.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQuery.cs
@@ -1,0 +1,12 @@
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
+
+/// <summary>
+/// Historical context for a matchup preview: last N head-to-head meetings
+/// (franchise-level, cross-season) and each team's last N games of the
+/// prior season. Defaults of 5/5 per the design doc
+/// (docs/metrics-modeling/matchup-preview-data-inputs.md §3b/3c).
+/// </summary>
+public record GetContestPreviewHistoryQuery(
+    Guid ContestId,
+    int MeetingCount = 5,
+    int RecentGameCount = 5);

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -1,5 +1,7 @@
 using Dapper;
 
+using FluentValidation;
+
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
@@ -20,13 +22,16 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
 {
     private readonly TeamSportDataContext _dbContext;
     private readonly ProducerSqlQueryProvider _sqlProvider;
+    private readonly IValidator<GetContestPreviewHistoryQuery> _validator;
 
     public GetContestPreviewHistoryQueryHandler(
         TeamSportDataContext dbContext,
-        ProducerSqlQueryProvider sqlProvider)
+        ProducerSqlQueryProvider sqlProvider,
+        IValidator<GetContestPreviewHistoryQuery> validator)
     {
         _dbContext = dbContext;
         _sqlProvider = sqlProvider;
+        _validator = validator;
     }
 
     /// <summary>
@@ -42,6 +47,15 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
         GetContestPreviewHistoryQuery query,
         CancellationToken cancellationToken = default)
     {
+        var validationResult = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return new Failure<ContestPreviewHistoryDto>(
+                default!,
+                ResultStatus.Validation,
+                validationResult.Errors);
+        }
+
         var connection = _dbContext.Database.GetDbConnection();
 
         var headToHead = (await connection.QueryAsync<PreviewGameResultDto>(

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -1,0 +1,74 @@
+using Dapper;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Sql;
+
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
+
+public interface IGetContestPreviewHistoryQueryHandler
+{
+    Task<Result<ContestPreviewHistoryDto>> ExecuteAsync(
+        GetContestPreviewHistoryQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQueryHandler
+{
+    private readonly TeamSportDataContext _dbContext;
+    private readonly ProducerSqlQueryProvider _sqlProvider;
+
+    public GetContestPreviewHistoryQueryHandler(
+        TeamSportDataContext dbContext,
+        ProducerSqlQueryProvider sqlProvider)
+    {
+        _dbContext = dbContext;
+        _sqlProvider = sqlProvider;
+    }
+
+    /// <summary>
+    /// Dapper row for the prior-season query: a PreviewGameResultDto plus
+    /// which TARGET team (Away/Home) the row belongs to.
+    /// </summary>
+    private class PriorSeasonRow : PreviewGameResultDto
+    {
+        public string Side { get; set; } = default!;
+    }
+
+    public async Task<Result<ContestPreviewHistoryDto>> ExecuteAsync(
+        GetContestPreviewHistoryQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = _dbContext.Database.GetDbConnection();
+
+        var headToHead = (await connection.QueryAsync<PreviewGameResultDto>(
+            new CommandDefinition(
+                _sqlProvider.GetContestHeadToHeadResults(),
+                new { query.ContestId, Count = query.MeetingCount },
+                cancellationToken: cancellationToken))).ToList();
+
+        var priorSeasonRows = (await connection.QueryAsync<PriorSeasonRow>(
+            new CommandDefinition(
+                _sqlProvider.GetContestPriorSeasonResults(),
+                new { query.ContestId, Count = query.RecentGameCount },
+                cancellationToken: cancellationToken))).ToList();
+
+        // An unknown contest yields empty lists everywhere (the target CTE
+        // matches nothing) — an empty history is a normal state for a
+        // first-ever meeting, so no NotFound here; the caller degrades
+        // gracefully either way.
+        var dto = new ContestPreviewHistoryDto
+        {
+            HeadToHead = headToHead,
+            AwayPriorSeasonGames = priorSeasonRows
+                .Where(x => x.Side == "Away").Cast<PreviewGameResultDto>().ToList(),
+            HomePriorSeasonGames = priorSeasonRows
+                .Where(x => x.Side == "Home").Cast<PreviewGameResultDto>().ToList()
+        };
+
+        return new Success<ContestPreviewHistoryDto>(dto);
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
+
+public class GetContestPreviewHistoryQueryValidator : AbstractValidator<GetContestPreviewHistoryQuery>
+{
+    public GetContestPreviewHistoryQueryValidator()
+    {
+        RuleFor(x => x.ContestId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("ContestId must be provided");
+
+        RuleFor(x => x.MeetingCount)
+            .InclusiveBetween(1, 25)
+            .WithMessage("MeetingCount must be between 1 and 25");
+
+        RuleFor(x => x.RecentGameCount)
+            .InclusiveBetween(1, 25)
+            .WithMessage("RecentGameCount must be between 1 and 25");
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -371,6 +371,8 @@ namespace SportsData.Producer.DependencyInjection
                 Application.Contests.Queries.GetGameDates.GetGameDatesQueryHandler>();
             services.AddScoped<IGetMatchupsByContestIdsQueryHandler, GetMatchupsByContestIdsQueryHandler>();
             services.AddScoped<IGetMatchupForPreviewQueryHandler, GetMatchupForPreviewQueryHandler>();
+            services.AddScoped<Application.Contests.Queries.Matchups.GetContestPreviewHistory.IGetContestPreviewHistoryQueryHandler,
+                Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQueryHandler>();
             services.AddScoped<IGetMatchupResultQueryHandler, GetMatchupResultQueryHandler>();
             services.AddScoped<IGetContestResultsByContestIdsQueryHandler, GetContestResultsByContestIdsQueryHandler>();
             services.AddScoped<IGetFinalizedContestIdsQueryHandler, GetFinalizedContestIdsQueryHandler>();

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -373,6 +373,8 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IGetMatchupForPreviewQueryHandler, GetMatchupForPreviewQueryHandler>();
             services.AddScoped<Application.Contests.Queries.Matchups.GetContestPreviewHistory.IGetContestPreviewHistoryQueryHandler,
                 Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQueryHandler>();
+            services.AddScoped<IValidator<Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQuery>,
+                Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQueryValidator>();
             services.AddScoped<IGetMatchupResultQueryHandler, GetMatchupResultQueryHandler>();
             services.AddScoped<IGetContestResultsByContestIdsQueryHandler, GetContestResultsByContestIdsQueryHandler>();
             services.AddScoped<IGetFinalizedContestIdsQueryHandler, GetFinalizedContestIdsQueryHandler>();

--- a/src/SportsData.Producer/Infrastructure/Sql/GetContestHeadToHeadResults.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetContestHeadToHeadResults.sql
@@ -1,0 +1,55 @@
+-- Last @Count head-to-head meetings between the target contest's two
+-- FRANCHISES (cross-season identity via Franchise, since FranchiseSeasonIds
+-- change yearly). Preview-safe by construction:
+--   * finalized, non-cancelled games only
+--   * as-of: strictly before the target's start (the target contest can
+--     never leak into its own history — see the answer-leak finding in
+--     docs/metrics-modeling/matchup-preview-data-inputs.md)
+--   * preseason excluded (SeasonPhase.TypeCode 1) — system-testing data
+--     only, per policy 2026-08-08. NULL phase (old rows) is kept.
+WITH target AS (
+    SELECT
+        c."Id",
+        c."StartDateUtc",
+        fsAway."FranchiseId" AS "AwayFranchiseId",
+        fsHome."FranchiseId" AS "HomeFranchiseId"
+    FROM public."Contest" c
+    INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+    INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+    WHERE c."Id" = @ContestId
+)
+SELECT
+    c."StartDateUtc" AS "GameDate",
+    c."SeasonYear",
+    sp."Name" AS "Phase",
+    c."EventNote" AS "Note",
+    fHome."Name" AS "HomeTeam",
+    fAway."Name" AS "AwayTeam",
+    c."HomeScore",
+    c."AwayScore",
+    CASE
+        WHEN c."WinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
+        WHEN c."WinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+        ELSE NULL
+    END AS "Winner",
+    CASE
+        WHEN c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
+        WHEN c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+        ELSE NULL
+    END AS "SpreadWinner",
+    CASE c."OverUnder" WHEN 1 THEN 'Over' WHEN 2 THEN 'Under' ELSE NULL END AS "OverUnderResult"
+FROM target t
+INNER JOIN public."Contest" c ON c."Id" <> t."Id"
+INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
+INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
+LEFT JOIN public."SeasonPhase" sp ON sp."Id" = c."SeasonPhaseId"
+WHERE ((fHome."Id" = t."HomeFranchiseId" AND fAway."Id" = t."AwayFranchiseId")
+    OR (fHome."Id" = t."AwayFranchiseId" AND fAway."Id" = t."HomeFranchiseId"))
+  AND c."FinalizedUtc" IS NOT NULL
+  AND c."CancelledUtc" IS NULL
+  AND c."StartDateUtc" < t."StartDateUtc"
+  AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+ORDER BY c."StartDateUtc" DESC
+LIMIT @Count

--- a/src/SportsData.Producer/Infrastructure/Sql/GetContestPriorSeasonResults.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetContestPriorSeasonResults.sql
@@ -1,0 +1,61 @@
+-- Recency bridge: each target-contest team's last @Count games of the
+-- PRIOR season ("how did they finish?"), resolved by Franchise so the
+-- season boundary is crossed correctly. "Side" says which target team the
+-- row belongs to (Away/Home relative to the TARGET contest, not the
+-- historical game). Same preview-safe semantics as head-to-head:
+-- finalized + non-cancelled only, preseason excluded (TypeCode 1; NULL
+-- phase kept), and inherently as-of (prior season only).
+WITH target AS (
+    SELECT
+        c."Id",
+        c."SeasonYear",
+        fsAway."FranchiseId" AS "AwayFranchiseId",
+        fsHome."FranchiseId" AS "HomeFranchiseId"
+    FROM public."Contest" c
+    INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+    INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+    WHERE c."Id" = @ContestId
+),
+sides AS (
+    SELECT t."AwayFranchiseId" AS "FranchiseId", CAST('Away' AS text) AS "Side", t."SeasonYear" FROM target t
+    UNION ALL
+    SELECT t."HomeFranchiseId", 'Home', t."SeasonYear" FROM target t
+)
+SELECT s."Side", g.*
+FROM sides s
+CROSS JOIN LATERAL (
+    SELECT
+        c."StartDateUtc" AS "GameDate",
+        c."SeasonYear",
+        sp."Name" AS "Phase",
+        c."EventNote" AS "Note",
+        fHome."Name" AS "HomeTeam",
+        fAway."Name" AS "AwayTeam",
+        c."HomeScore",
+        c."AwayScore",
+        CASE
+            WHEN c."WinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
+            WHEN c."WinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+            ELSE NULL
+        END AS "Winner",
+        CASE
+            WHEN c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
+            WHEN c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+            ELSE NULL
+        END AS "SpreadWinner",
+        CASE c."OverUnder" WHEN 1 THEN 'Over' WHEN 2 THEN 'Under' ELSE NULL END AS "OverUnderResult"
+    FROM public."Contest" c
+    INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+    INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
+    INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+    INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
+    LEFT JOIN public."SeasonPhase" sp ON sp."Id" = c."SeasonPhaseId"
+    WHERE (fsAway."FranchiseId" = s."FranchiseId" OR fsHome."FranchiseId" = s."FranchiseId")
+      AND c."SeasonYear" = s."SeasonYear" - 1
+      AND c."FinalizedUtc" IS NOT NULL
+      AND c."CancelledUtc" IS NULL
+      AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+    ORDER BY c."StartDateUtc" DESC
+    LIMIT @Count
+) g
+ORDER BY s."Side", g."GameDate" DESC

--- a/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
+++ b/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
@@ -18,6 +18,8 @@ public class ProducerSqlQueryProvider
         "GetGameDates.sql",
         "GetMatchupByContestId.sql",
         "GetRankingsByPollByWeek.sql",
+        "GetContestHeadToHeadResults.sql",
+        "GetContestPriorSeasonResults.sql",
         "GetFranchiseSeasonCompetitionResults.sql",
         "GetFranchiseSeasonPreviewStats.sql",
         "GetFranchiseSeasonStatistics.sql",
@@ -98,6 +100,10 @@ public class ProducerSqlQueryProvider
     public string GetMatchupByContestId() => Get("GetMatchupByContestId.sql");
 
     public string GetRankingsByPollByWeek() => Get("GetRankingsByPollByWeek.sql");
+
+    public string GetContestHeadToHeadResults() => Get("GetContestHeadToHeadResults.sql");
+
+    public string GetContestPriorSeasonResults() => Get("GetContestPriorSeasonResults.sql");
 
     public string GetFranchiseSeasonCompetitionResults() => Get("GetFranchiseSeasonCompetitionResults.sql");
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -46,12 +46,51 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             AwayFranchiseSeasonId = _awayFranchiseSeasonId
         };
 
-        private void SetupPipeline(MatchupForPreviewDto matchup)
+        private static ContestPreviewHistoryDto BuildHistory() => new()
+        {
+            HeadToHead =
+            [
+                new PreviewGameResultDto
+                {
+                    GameDate = new DateTime(2025, 9, 14, 16, 5, 0, DateTimeKind.Utc),
+                    SeasonYear = 2025,
+                    Phase = "Regular Season",
+                    HomeTeam = "Arizona Cardinals",
+                    AwayTeam = "Carolina Panthers",
+                    HomeScore = 27,
+                    AwayScore = 22,
+                    Winner = "Arizona Cardinals",
+                    SpreadWinner = "Carolina Panthers",
+                    OverUnderResult = "Over"
+                }
+            ],
+            AwayPriorSeasonGames =
+            [
+                new PreviewGameResultDto
+                {
+                    GameDate = new DateTime(2026, 1, 10, 21, 30, 0, DateTimeKind.Utc),
+                    SeasonYear = 2025,
+                    Phase = "Postseason",
+                    Note = "NFC Wild Card",
+                    HomeTeam = "Carolina Panthers",
+                    AwayTeam = "Los Angeles Rams",
+                    HomeScore = 31,
+                    AwayScore = 34,
+                    Winner = "Los Angeles Rams"
+                }
+            ],
+            HomePriorSeasonGames = []
+        };
+
+        private void SetupPipeline(MatchupForPreviewDto matchup, Result<ContestPreviewHistoryDto>? history = null)
         {
             var contestClient = new Mock<IProvideContests>();
             contestClient
                 .Setup(x => x.GetMatchupForPreview(_contestId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<MatchupForPreviewDto>(matchup));
+            contestClient
+                .Setup(x => x.GetContestPreviewHistory(_contestId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(history ?? new Success<ContestPreviewHistoryDto>(BuildHistory()));
 
             Mocker.GetMock<IContestClientFactory>()
                 .Setup(x => x.Resolve(It.IsAny<Sport>()))
@@ -119,6 +158,16 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             Assert.Equal("prediction-insights-with-stats-schedule", capture.PromptVersion);
             Assert.Equal(PromptText, capture.PromptText);
             Assert.Contains("arizona-cardinals", capture.PayloadJson);
+
+            // Historical blocks flow into the payload, names only — the only
+            // GUIDs in the whole payload are the two live FranchiseSeasonIds
+            // (plus ContestId), never per-season ids from historical rows.
+            Assert.Contains("HeadToHead", capture.PayloadJson);
+            Assert.Contains("NFC Wild Card", capture.PayloadJson);
+            var guidCount = System.Text.RegularExpressions.Regex.Matches(
+                capture.PayloadJson,
+                "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}").Count;
+            Assert.Equal(3, guidCount);
             Assert.Null(capture.EditorNote);
             Assert.True(capture.CharCount > PromptText.Length);
             Assert.Equal(capture.CharCount / 4, capture.EstTokens);
@@ -302,6 +351,35 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 .Verify(x => x.Publish(It.IsAny<PreviewPromptCaptured>(), It.IsAny<CancellationToken>()), Times.Once);
             Mocker.GetMock<IEventBus>()
                 .Verify(x => x.Publish(It.IsAny<PreviewGenerated>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Capture_ProceedsWithoutHistory_WhenHistoryFetchFails()
+        {
+            // Arrange — history endpoint down: preview assembly must degrade
+            // gracefully, not fail the job.
+            SetupPipeline(
+                BuildMatchup("STATUS_SCHEDULED"),
+                new Failure<ContestPreviewHistoryDto>(
+                    default!,
+                    ResultStatus.Error,
+                    [new FluentValidation.Results.ValidationFailure("history", "unavailable")]));
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Capture
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.DoesNotContain("NFC Wild Card", capture.PayloadJson);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

First historical-enrichment data for matchup previews (design: `docs/metrics-modeling/matchup-preview-data-inputs.md` §3b/3c): **last 5 head-to-head meetings** between the two franchises and **each team's last 5 prior-season games** now flow into every preview payload — capture, experiment, and real generation identically.

### Producer

- New `GET /contests/{contestId}/preview-history` → `ContestPreviewHistoryDto` (HeadToHead, Away/HomePriorSeasonGames), one HTTP hop.
- Two embedded SQL queries (existing Dapper pattern). H2H resolves cross-season franchise identity via Contest → FranchiseSeason → Franchise; prior-season form via `SeasonYear - 1`.
- **Preview-safe semantics baked into the SQL:**
  - finalized + non-cancelled games only
  - as-of filtering (`StartDateUtc < target's`) — a contest can never appear in its own history (the answer-leak class of bug found in the first prod capture)
  - **preseason excluded** (`SeasonPhase.TypeCode 1`) per policy: NFL preseason is system-testing data, never signal — the Hall of Fame Game must not count as a CAR/ARI meeting. NULL-phase legacy rows kept. MLB spring training excluded by the same check when baseball previews arrive.

### Core

- `PreviewGameResultDto`: names-only rows — string phase, "Over"/"Under" as words, EventNote for playoff labels, winner/spread-winner as team names. **Zero GUIDs in historical rows**: the prompt's output contract asks the model to echo a FranchiseSeasonId for its predicted winner, and per-season ids from history could be echoed by mistake. A regression test asserts the whole payload contains exactly 3 GUIDs (ContestId + the two live FranchiseSeasonIds).

### API

- `MatchupForPreviewDto` gains the three nullable blocks; `MatchupPreviewProcessor` fetches history inside the shared assembly path. Graceful degradation: a failed history fetch logs and proceeds — never fails a generation.

### Tests / verification

- 635 API + 530 Producer tests pass; full solution builds.
- Post-deploy check via the Preview Lab: capture the Hall of Fame Game — `HeadToHead` should be topped by the 2025-09-14 CAR @ ARI regular-season meeting (NOT the HOF game itself) with five 2025 games per team in the prior-season blocks.

Out of scope (per the design doc): §3a prior-season record/metrics block, the with-history prompt blob, experiment-mode as-of filtering for the LEGACY CompetitionResults blocks (that answer leak remains and is tracked in the doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added contest preview history with recent head-to-head meetings and each team’s prior-season games.
  - Preview data can include historical scores, winners, and betting outcomes when available.
  - Added configurable history retrieval, defaulting to five entries per category.
  - Added a preview-history API endpoint for retrieving historical matchup details.
- **Bug Fixes**
  - Prevented completed-game outcomes from appearing in in-progress preview evaluations.
  - Excluded preseason games from preview and metrics calculations while retaining them in schedules.
  - Preview generation now continues when historical data is unavailable.
- **Documentation**
  - Documented preview filtering and historical data behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->