### PR TITLE
fix(api,producer): close the SUT answer leak; enrich history rows with market context

### DIFF
--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -394,13 +394,15 @@ the model the answer; every such result is invalid as an eval signal.
 In-season real generation never hits this (completed-contest skip =
 generation is always pre-game), so this is an EXPERIMENT-MODE problem.
 
-**Required before the eval harness is trusted:** as-of filtering during
-assembly for Experiment mode — exclude from both CompetitionResults
-lists any game with `StartDateUtc >= target.StartDateUtc` (which
-removes the target itself and later games), and mask
-`Status`/`StatusDescription` to a pre-game value. This recreates the
-information state the model would have had before kickoff. Not yet
-implemented.
+**FIXED (2026-08-08, follow-up PR):** assembly now applies the as-of
+rule to both CompetitionResults lists in ALL modes — no game with
+`StartDateUtc >= target.StartDateUtc` reaches the payload (a no-op for
+pre-game generation, so captures stay byte-identical to real sends) —
+and Capture/Experiment runs on completed contests mask
+`Status`/`StatusDescription` to Scheduled, recreating the pre-kickoff
+information state. Eval numbers from the lab are trustworthy from this
+point. (Same PR: history SQL emits `Franchise.DisplayName` so
+historical rows string-match the live team names exactly.)
 
 Other confirmations from the same capture (§3.5 hygiene case, now
 quantified): 28 serialized null stat fields across the two teams,
@@ -469,6 +471,16 @@ logic is untouched by design.
    the payload's only GUIDs remain ContestId + the two live
    FranchiseSeasonIds (regression-tested). 3a (prior-season
    record/metrics block) still pending.
+
+   **Expanded 2026-08-08 (user PoC):** every historical row also carries
+   MARKET CONTEXT — Spread details text, home-relative HomeSpread +
+   HomeSpreadOpen (line movement), OverUnder + OverUnderOpen, Over/Under
+   odds — via the preferred-provider odds lateral, using the live
+   payload's exact vocabulary so one shape reads everywhere. Null for
+   pre-odds-era games (~pre-2022): result-only context degrades
+   honestly. ProviderName deliberately excluded (provenance, not
+   signal); alternate-provider previews are just a new run against that
+   provider's data.
 2. ~~One endpoint vs compose~~ — DECIDED: one endpoint (implemented as
    above).
 3. Payload-hygiene projection (3e) first, or accept token growth and do it

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -96,7 +96,7 @@ namespace SportsData.Api.Application.Previews
                 return;
             }
 
-            var assembled = await AssemblePromptAsync(matchup, command.Sport, rejectedPreview?.RejectionNote);
+            var assembled = await AssemblePromptAsync(matchup, command.Sport, command.Mode, rejectedPreview?.RejectionNote);
 
             _logger.LogInformation(
                 "Prompt assembled for {ContestId}. PromptVersion: {PromptVersion}, CharCount: {CharCount}, UsedMetrics: {UsedMetrics}, AwayResults: {AwayResults}, HomeResults: {HomeResults}",
@@ -275,6 +275,7 @@ namespace SportsData.Api.Application.Previews
         private async Task<AssembledPrompt> AssemblePromptAsync(
             MatchupForPreviewDto matchup,
             Sport sport,
+            PreviewGenerationMode mode,
             string? rejectionNote)
         {
             // Historical context (last 5 H2H + prior-season last 5, preview-
@@ -320,6 +321,28 @@ namespace SportsData.Api.Application.Previews
                 .GetFranchiseSeasonCompetitionResults(matchup.AwayFranchiseSeasonId);
             matchup.HomeCompetitionResults = await franchiseClient
                 .GetFranchiseSeasonCompetitionResults(matchup.HomeFranchiseSeasonId);
+
+            // As-of rule: the payload must never contain any game starting on
+            // or after the target. For a completed target (capture/experiment
+            // on a historical game) the raw CompetitionResults include the
+            // TARGET ITSELF — final score, winner, spread winner: the answer.
+            // For a pre-game target this is a no-op (those games haven't been
+            // played), so applying it uniformly keeps captures byte-identical
+            // to what real generation sends.
+            matchup.AwayCompetitionResults = matchup.AwayCompetitionResults?
+                .Where(r => r.StartDateUtc < matchup.StartDateUtc).ToList();
+            matchup.HomeCompetitionResults = matchup.HomeCompetitionResults?
+                .Where(r => r.StartDateUtc < matchup.StartDateUtc).ToList();
+
+            // Status masking: a completed target's STATUS_FINAL/"Final" also
+            // leaks that the game is over. Recreate the pre-game information
+            // state for capture/experiment runs; Generate never reaches here
+            // for completed contests, so live behavior is untouched.
+            if (mode != PreviewGenerationMode.Generate && ContestStatusValues.IsCompleted(matchup.Status))
+            {
+                matchup.Status = ContestStatusValues.ScheduledRaw;
+                matchup.StatusDescription = "Scheduled";
+            }
 
             var hasStats = (matchup.AwayStats.RushingYardsPerGame.HasValue &&
                             matchup.HomeStats.RushingYardsPerGame.HasValue);

--- a/src/SportsData.Core/Common/ContestStatus.cs
+++ b/src/SportsData.Core/Common/ContestStatus.cs
@@ -25,6 +25,7 @@ namespace SportsData.Core.Common
         // string comparison.
         public const string FinalRaw = "STATUS_FINAL";
         public const string CompletedRaw = "STATUS_COMPLETED";
+        public const string ScheduledRaw = "STATUS_SCHEDULED";
 
         // ── Legacy PascalCase enum-name forms ────────────────────────────────
         // What the wire used to ship pre-dual-field PR (via the

--- a/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
@@ -55,6 +55,27 @@ namespace SportsData.Core.Dtos.Canonical
         /// <summary>Team that covered; null when no spread data exists (common pre-2012).</summary>
         public string? SpreadWinner { get; set; }
 
+        // Market context for the historical game — same vocabulary as the
+        // live matchup payload so the model reads one shape everywhere.
+        // All null for pre-odds-era games (~pre-2022): result-only context.
+
+        /// <summary>Line details text (e.g. "ARI -6.5") — self-documents the favorite.</summary>
+        public string? Spread { get; set; }
+
+        /// <summary>Closing/current spread, home-relative (negative = home favored).</summary>
+        public double? HomeSpread { get; set; }
+
+        /// <summary>Opening spread, home-relative — with HomeSpread exposes line movement.</summary>
+        public double? HomeSpreadOpen { get; set; }
+
+        public double? OverUnder { get; set; }
+
+        public double? OverUnderOpen { get; set; }
+
+        public double? OverOdds { get; set; }
+
+        public double? UnderOdds { get; set; }
+
         /// <summary>"Over" / "Under"; null when no total was recorded.</summary>
         public string? OverUnderResult { get; set; }
     }

--- a/src/SportsData.Producer/Infrastructure/Sql/GetContestHeadToHeadResults.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetContestHeadToHeadResults.sql
@@ -23,23 +23,44 @@ SELECT
     c."SeasonYear",
     sp."Name" AS "Phase",
     c."EventNote" AS "Note",
-    fHome."Name" AS "HomeTeam",
-    fAway."Name" AS "AwayTeam",
+    fHome."DisplayName" AS "HomeTeam",
+    fAway."DisplayName" AS "AwayTeam",
     c."HomeScore",
     c."AwayScore",
     CASE
-        WHEN c."WinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
-        WHEN c."WinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+        WHEN c."WinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."DisplayName"
+        WHEN c."WinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."DisplayName"
         ELSE NULL
     END AS "Winner",
     CASE
-        WHEN c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
-        WHEN c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+        WHEN c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."DisplayName"
+        WHEN c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."DisplayName"
         ELSE NULL
     END AS "SpreadWinner",
+    -- Market context (preferred-provider lateral, same vocabulary as the
+    -- live matchup payload: Spread = details text e.g. "ARI -6.5",
+    -- HomeSpread home-relative). Open values expose line movement.
+    -- NULL for pre-odds-era games (~pre-2022) — result-only context there.
+    co."Details" AS "Spread",
+    co."Spread" AS "HomeSpread",
+    cto."SpreadPointsOpen" AS "HomeSpreadOpen",
+    co."OverUnder" AS "OverUnder",
+    co."TotalPointsOpen" AS "OverUnderOpen",
+    co."OverOdds" AS "OverOdds",
+    co."UnderOdds" AS "UnderOdds",
     CASE c."OverUnder" WHEN 1 THEN 'Over' WHEN 2 THEN 'Under' ELSE NULL END AS "OverUnderResult"
 FROM target t
 INNER JOIN public."Contest" c ON c."Id" <> t."Id"
+INNER JOIN public."Competition" comp ON comp."ContestId" = c."Id"
+LEFT JOIN LATERAL (
+    SELECT *
+    FROM public."CompetitionOdds"
+    WHERE "CompetitionId" = comp."Id"
+      AND "ProviderId" IN ('{PreferredOddsProviderId}', '{FallbackOddsProviderId}')
+    ORDER BY CASE WHEN "ProviderId" = '{PreferredOddsProviderId}' THEN 1 ELSE 2 END
+    LIMIT 1
+) co ON TRUE
+LEFT JOIN public."CompetitionTeamOdds" cto ON cto."CompetitionOddsId" = co."Id" AND cto."Side" = 'Home'
 INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
 INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
 INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"

--- a/src/SportsData.Producer/Infrastructure/Sql/GetContestPriorSeasonResults.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetContestPriorSeasonResults.sql
@@ -29,22 +29,41 @@ CROSS JOIN LATERAL (
         c."SeasonYear",
         sp."Name" AS "Phase",
         c."EventNote" AS "Note",
-        fHome."Name" AS "HomeTeam",
-        fAway."Name" AS "AwayTeam",
+        fHome."DisplayName" AS "HomeTeam",
+        fAway."DisplayName" AS "AwayTeam",
         c."HomeScore",
         c."AwayScore",
         CASE
-            WHEN c."WinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
-            WHEN c."WinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+            WHEN c."WinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."DisplayName"
+            WHEN c."WinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."DisplayName"
             ELSE NULL
         END AS "Winner",
         CASE
-            WHEN c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."Name"
-            WHEN c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."Name"
+            WHEN c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."DisplayName"
+            WHEN c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."DisplayName"
             ELSE NULL
         END AS "SpreadWinner",
+        -- Market context — same shape as head-to-head rows (one uniform
+        -- GameResult vocabulary for the model). NULL pre-odds-era.
+        co."Details" AS "Spread",
+        co."Spread" AS "HomeSpread",
+        cto."SpreadPointsOpen" AS "HomeSpreadOpen",
+        co."OverUnder" AS "OverUnder",
+        co."TotalPointsOpen" AS "OverUnderOpen",
+        co."OverOdds" AS "OverOdds",
+        co."UnderOdds" AS "UnderOdds",
         CASE c."OverUnder" WHEN 1 THEN 'Over' WHEN 2 THEN 'Under' ELSE NULL END AS "OverUnderResult"
     FROM public."Contest" c
+    INNER JOIN public."Competition" comp ON comp."ContestId" = c."Id"
+    LEFT JOIN LATERAL (
+        SELECT *
+        FROM public."CompetitionOdds"
+        WHERE "CompetitionId" = comp."Id"
+          AND "ProviderId" IN ('{PreferredOddsProviderId}', '{FallbackOddsProviderId}')
+        ORDER BY CASE WHEN "ProviderId" = '{PreferredOddsProviderId}' THEN 1 ELSE 2 END
+        LIMIT 1
+    ) co ON TRUE
+    LEFT JOIN public."CompetitionTeamOdds" cto ON cto."CompetitionOddsId" = co."Id" AND cto."Side" = 'Home'
     INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
     INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
     INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -27,12 +27,15 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
         private readonly Guid _homeFranchiseSeasonId = Guid.NewGuid();
         private readonly Guid _awayFranchiseSeasonId = Guid.NewGuid();
 
+        private static readonly DateTime TargetStartUtc = new(2026, 8, 7, 0, 0, 0, DateTimeKind.Utc);
+
         private MatchupForPreviewDto BuildMatchup(string status) => new()
         {
             Sport = Sport.FootballNfl,
             SeasonYear = 2025,
             WeekNumber = 2,
             ContestId = _contestId,
+            StartDateUtc = TargetStartUtc,
             Status = status,
             Venue = "State Farm Stadium",
             VenueCity = "Glendale",
@@ -61,6 +64,13 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                     AwayScore = 22,
                     Winner = "Arizona Cardinals",
                     SpreadWinner = "Carolina Panthers",
+                    Spread = "ARI -6.5",
+                    HomeSpread = -6.5,
+                    HomeSpreadOpen = -6.5,
+                    OverUnder = 45.5,
+                    OverUnderOpen = 45.5,
+                    OverOdds = -105,
+                    UnderOdds = -115,
                     OverUnderResult = "Over"
                 }
             ],
@@ -164,6 +174,7 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             // (plus ContestId), never per-season ids from historical rows.
             Assert.Contains("HeadToHead", capture.PayloadJson);
             Assert.Contains("NFC Wild Card", capture.PayloadJson);
+            Assert.Contains("ARI -6.5", capture.PayloadJson);
             var guidCount = System.Text.RegularExpressions.Regex.Matches(
                 capture.PayloadJson,
                 "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}").Count;
@@ -351,6 +362,78 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 .Verify(x => x.Publish(It.IsAny<PreviewPromptCaptured>(), It.IsAny<CancellationToken>()), Times.Once);
             Mocker.GetMock<IEventBus>()
                 .Verify(x => x.Publish(It.IsAny<PreviewGenerated>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Capture_OnCompletedContest_ExcludesTargetGameAndMasksStatus()
+        {
+            // Arrange — the raw CompetitionResults for a completed target
+            // contain the TARGET GAME ITSELF (the answer) plus an earlier
+            // game. Only the earlier game may reach the payload, and the
+            // completed status must read as pre-game.
+            SetupPipeline(BuildMatchup("STATUS_FINAL"));
+
+            var targetRow = new FranchiseSeasonCompetitionResultDto
+            {
+                ContestId = _contestId,
+                StartDateUtc = TargetStartUtc,
+                AwaySlug = "carolina-panthers",
+                HomeSlug = "arizona-cardinals",
+                AwayShort = "CAR",
+                HomeShort = "ARI",
+                AwayScore = 33,
+                HomeScore = 30
+            };
+            var earlierRow = new FranchiseSeasonCompetitionResultDto
+            {
+                ContestId = Guid.NewGuid(),
+                StartDateUtc = TargetStartUtc.AddDays(-210),
+                AwaySlug = "carolina-panthers",
+                HomeSlug = "tampa-bay-buccaneers",
+                AwayShort = "CAR",
+                HomeShort = "TB",
+                AwayScore = 14,
+                HomeScore = 16
+            };
+
+            var franchiseClient = new Mock<IProvideFranchises>();
+            franchiseClient
+                .Setup(x => x.GetFranchiseSeasonPreviewStats(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FranchiseSeasonModelStatsDto { RushingYardsPerGame = 150.0 });
+            franchiseClient
+                .Setup(x => x.GetFranchiseSeasonMetricsByFranchiseSeasonId(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((FranchiseSeasonMetricsDto?)null!);
+            franchiseClient
+                .Setup(x => x.GetFranchiseSeasonCompetitionResults(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([targetRow, earlierRow]);
+            Mocker.GetMock<IFranchiseClientFactory>()
+                .Setup(x => x.Resolve(It.IsAny<Sport>()))
+                .Returns(franchiseClient.Object);
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Capture
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — the answer is gone, the earlier game survives, and the
+            // status reads pre-game.
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+
+            using var payload = System.Text.Json.JsonDocument.Parse(capture.PayloadJson);
+            var awayResults = payload.RootElement.GetProperty("AwayCompetitionResults");
+            Assert.Equal(1, awayResults.GetArrayLength());
+            Assert.Equal("tampa-bay-buccaneers", awayResults[0].GetProperty("HomeSlug").GetString());
+            Assert.DoesNotContain(_contestId.ToString(), awayResults.GetRawText());
+
+            Assert.DoesNotContain("STATUS_FINAL", capture.PayloadJson);
+            Assert.Contains("STATUS_SCHEDULED", capture.PayloadJson);
         }
 
         [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -37,6 +37,7 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             ContestId = _contestId,
             StartDateUtc = TargetStartUtc,
             Status = status,
+            StatusDescription = status == "STATUS_FINAL" ? "Final" : "Scheduled",
             Venue = "State Farm Stadium",
             VenueCity = "Glendale",
             Home = "Arizona Cardinals",
@@ -427,13 +428,17 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
 
             using var payload = System.Text.Json.JsonDocument.Parse(capture.PayloadJson);
-            var awayResults = payload.RootElement.GetProperty("AwayCompetitionResults");
-            Assert.Equal(1, awayResults.GetArrayLength());
-            Assert.Equal("tampa-bay-buccaneers", awayResults[0].GetProperty("HomeSlug").GetString());
-            Assert.DoesNotContain(_contestId.ToString(), awayResults.GetRawText());
 
-            Assert.DoesNotContain("STATUS_FINAL", capture.PayloadJson);
-            Assert.Contains("STATUS_SCHEDULED", capture.PayloadJson);
+            foreach (var listName in new[] { "AwayCompetitionResults", "HomeCompetitionResults" })
+            {
+                var results = payload.RootElement.GetProperty(listName);
+                Assert.Equal(1, results.GetArrayLength());
+                Assert.Equal("tampa-bay-buccaneers", results[0].GetProperty("HomeSlug").GetString());
+                Assert.DoesNotContain(_contestId.ToString(), results.GetRawText());
+            }
+
+            Assert.Equal("STATUS_SCHEDULED", payload.RootElement.GetProperty("Status").GetString());
+            Assert.Equal("Scheduled", payload.RootElement.GetProperty("StatusDescription").GetString());
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Three linked changes to preview payload assembly, all found/validated via Preview Lab captures of the Hall of Fame Game (`docs/metrics-modeling/matchup-preview-data-inputs.md` tracks each):

### 1. SUT answer leak — CLOSED

The raw `CompetitionResults` for a completed target contest contained **the target game itself** (final score, winner, spread winner) plus `Status: STATUS_FINAL` — handing any experiment on a historical game the answer it was asked to predict.

- **As-of rule, all modes**: no game with `StartDateUtc >= target's` reaches either results list. A no-op for pre-game generation, so captures remain byte-identical to real sends.
- **Status masking, Capture/Experiment only**: completed targets read `STATUS_SCHEDULED`/"Scheduled" — the payload recreates the pre-kickoff information state. Generate is untouched (it never runs on completed contests). New `ScheduledRaw` constant on `ContestStatusValues`.

Eval numbers from the Preview Lab are trustworthy after this ships.

### 2. DisplayName in history rows

The history SQL selected `Franchise."Name"` — the nickname ("Panthers"). Rows now emit `DisplayName` ("Carolina Panthers"), string-matching the live team names in the payload exactly.

### 3. Market context on every historical row

Per-row odds via the same preferred-provider lateral as `GetMatchupByContestId.sql` (placeholder-substituted provider ids), in the live payload's exact vocabulary: `Spread` details text ("ARI -6.5"), home-relative `HomeSpread` + `HomeSpreadOpen` (line movement), `OverUnder` + `OverUnderOpen`, `OverOdds`/`UnderOdds`. Null for pre-odds-era games (~pre-2022) — result-only context degrades honestly. `ProviderName` deliberately excluded (provenance, not signal). Uniform across head-to-head and both prior-season lists — one GameResult shape for the model everywhere. The model can now read "ARI was favored by 6.5 in this building last September and won by only 5" straight off a row.

### Tests / verification

- New end-to-end test: a completed target's own row is filtered out of results, an earlier game survives, and status reads pre-game. History sample carries a real market line asserted into the payload.
- 636 API tests pass; the SQL provider's fail-fast placeholder validation covers the new laterals; full solution builds.
- Post-deploy check: capture the HOF game again — results lists show only pre-HOF games, status reads Scheduled, and H2H rows carry full team names + market lines for 2022+ meetings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matchup previews now include historical market context, including spreads, totals, line movement, and over/under odds when available.
  * Historical team results now use consistent display names matching live data.
* **Bug Fixes**
  * Preview data excludes games occurring at or after the target matchup time.
  * Completed contests in capture and experiment previews are presented as scheduled to prevent outcome leakage.
  * Games from before odds tracking began safely show unavailable market values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->