### PR TITLE
feat(api,producer): payload hygiene projection + prior-season summary block

### DIFF
--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -483,9 +483,20 @@ logic is untouched by design.
    provider's data.
 2. ~~One endpoint vs compose~~ — DECIDED: one endpoint (implemented as
    above).
-3. Payload-hygiene projection (3e) first, or accept token growth and do it
-   later (proposed: first — PARTIALLY superseded: new history blocks are
-   born clean; the hygiene work now covers only the legacy fields).
+3. ~~Payload-hygiene projection (3e)~~ — **IMPLEMENTED 2026-08-08**
+   (`SerializePromptPayload` in the processor; the wire DTO is untouched
+   — hygiene is applied at serialization only, so no consumer risk):
+   omit-null (kills the ~28 null stat fields and null market fields on
+   old rows), string enums (`"Sport": "FootballNfl"`, O/U results as
+   words), top-level `AwaySpread` dropped (user: spread is ALWAYS
+   home-relative; the away value is a derived negation), `ContestId`
+   dropped, AND legacy CompetitionResults rows stripped of their five
+   per-row GUIDs (contest, both franchise-seasons, winner,
+   spread-winner) + per-row `AwaySpread` — winner/cover remain derivable
+   from slugs + scores + HomeSpread. Regression test: the entire payload
+   now contains EXACTLY the two live FranchiseSeasonIds and no other
+   GUID. Remaining prompt-side task: drop `AwaySpread` from the example
+   inputs during with-history authoring.
 4. Prompt authoring workflow for with-history-v1. Prompts stay blob-only
    (secret sauce, public repo — decided 2026-08-07); author against local
    gitignored working copies, upload to blob, PromptVersion tracks it.
@@ -503,3 +514,46 @@ logic is untouched by design.
    `sql/pgsql/_debug_preview_history.sql` (query 3), run per sport DB.
 3. Decisions 1–5 above.
 4. Design doc v2 with endpoint/DTO shapes → authorization → build.
+
+---
+
+## 6. Remaining work (consolidated 2026-08-08)
+
+Everything above through §3a/3b/3c/3e is SHIPPED. What's left, in
+recommended order (season opens ~Aug 30; goal is a defensible
+model/prompt choice before real generations start):
+
+1. **§3a prior-season block — IMPLEMENTED with one deferral**: final
+   record + prior-season FranchiseSeasonMetrics now flow (both-or-nothing
+   applied in API assembly; records always flow). DEFERRED: prior-season
+   final poll rank (NFL has no polls; NCAA final AP rank needs a
+   rankings-table join — add during NCAA-season tuning if the model
+   seems to need pedigree signal). GATE STILL OPEN: run the coverage
+   check (query 3 in `sql/pgsql/_debug_preview_history.sql`) per sport
+   DB — if 2025 FranchiseSeasonMetric rows are missing, a one-time
+   backfill is needed; until then the payload simply omits the block
+   (omit-null) and degrades honestly.
+2. **with-history prompt blob** (user authors; blob-only per policy).
+   Must teach: the metrics block (un-briefed since forever), HeadToHead
+   + prior-season blocks (incl. "history excludes preseason by
+   construction"), roster-churn discounting (NCAA > NFL), sport-aware
+   voice (no more "college football analyst" for NFL), updated example
+   inputs (no AwaySpread, string Sport, hygiene shape). New blob name =
+   provenance; selection logic gains the with-history variant.
+3. **Backtest harness MVP**: batch experiment enqueue ("every 2025
+   week-N game") + a scoring query joining MatchupPreviewPrompt captures
+   to Contest outcomes — SU accuracy, ATS accuracy, O/U accuracy, score
+   MAE, grouped by PromptVersion × Model. Mostly SQL over existing
+   tables; the lab already persists everything needed.
+4. **Model routing for experiments**: optional model override on
+   GenerateMatchupPreviewsCommand (capture rows already record Model) so
+   the harness compares prompt × model, not just prompts.
+   IProvideAiCommunication is single-bound today; see
+   ai-provider-routing-per-sport.md for prior art.
+
+Deliberately NOT doing now: Preview Lab UX polish (compare/diff views —
+curl-grade is fine for a single operator); NCAA-specific H2H tuning
+(sparse cross-season meetings are honest data); the Python
+metrics-service question (parked until previews flow — see memory);
+per-row odds provider selection (a different book's preview = a new
+run against that provider's data).

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -531,8 +531,9 @@ model/prompt choice before real generations start):
    seems to need pedigree signal). GATE STILL OPEN: run the coverage
    check (query 3 in `sql/pgsql/_debug_preview_history.sql`) per sport
    DB — if 2025 FranchiseSeasonMetric rows are missing, a one-time
-   backfill is needed; until then the payload simply omits the block
-   (omit-null) and degrades honestly.
+   backfill is needed; until then the prior-season RECORD still flows —
+   only the null `Metrics` property inside the block is omitted
+   (omit-null) — so the payload degrades honestly.
 2. **with-history prompt blob** (user authors; blob-only per policy).
    Must teach: the metrics block (un-briefed since forever), HeadToHead
    + prior-season blocks (incl. "history excludes preseason by

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -290,6 +290,17 @@ namespace SportsData.Api.Application.Previews
                 matchup.HeadToHead = historyResult.Value.HeadToHead;
                 matchup.AwayPriorSeasonGames = historyResult.Value.AwayPriorSeasonGames;
                 matchup.HomePriorSeasonGames = historyResult.Value.HomePriorSeasonGames;
+                matchup.AwayPriorSeason = historyResult.Value.AwayPriorSeason;
+                matchup.HomePriorSeason = historyResult.Value.HomePriorSeason;
+
+                // Same both-or-nothing rule as current-season metrics:
+                // asymmetric analytics would bias the model toward the
+                // covered team. Records keep flowing either way.
+                if (matchup.AwayPriorSeason?.Metrics is null || matchup.HomePriorSeason?.Metrics is null)
+                {
+                    if (matchup.AwayPriorSeason is not null) matchup.AwayPriorSeason.Metrics = null;
+                    if (matchup.HomePriorSeason is not null) matchup.HomePriorSeason.Metrics = null;
+                }
             }
             else
             {
@@ -349,7 +360,7 @@ namespace SportsData.Api.Application.Previews
 
             var promptData = await _promptProvider.GetPreviewInsightPromptAsync(hasStats);
 
-            var jsonInput = JsonSerializer.Serialize(matchup);
+            var jsonInput = SerializePromptPayload(matchup);
 
             var editorNote = rejectionNote != null
                 ? $"\n\nAdditional feedback from the editor:\n\"{rejectionNote}\""
@@ -364,6 +375,52 @@ namespace SportsData.Api.Application.Previews
                 jsonInput,
                 string.IsNullOrEmpty(editorNote) ? null : rejectionNote,
                 fullPrompt);
+        }
+
+        private static readonly JsonSerializerOptions PromptPayloadOptions = new()
+        {
+            // Hygiene projection (design doc §3.5/3e): every value in the
+            // payload should be usable by the model verbatim.
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        /// <summary>
+        /// The purpose-built prompt payload: the wire DTO serialized with
+        /// omit-null + string enums, minus fields the model cannot use —
+        /// ContestId (leaving exactly the two live FranchiseSeasonIds the
+        /// output contract needs) and AwaySpread (spread is ALWAYS
+        /// home-relative; the away value is a derived negation that invites
+        /// sign confusion).
+        /// </summary>
+        private static string SerializePromptPayload(MatchupForPreviewDto matchup)
+        {
+            var node = JsonSerializer.SerializeToNode(matchup, PromptPayloadOptions)!.AsObject();
+            node.Remove("ContestId");
+            node.Remove("AwaySpread");
+
+            // Legacy CompetitionResults rows carry five GUIDs each (contest,
+            // both franchise-seasons, winner, spread-winner) — per-season ids
+            // the model could echo into predictedStraightUpWinner — plus their
+            // own derived AwaySpread. Slugs + scores + HomeSpread remain, from
+            // which winner and cover are trivially derivable. After this walk
+            // the ONLY GUIDs in the payload are the two live Away/Home
+            // FranchiseSeasonIds the output contract requires.
+            foreach (var listName in new[] { "AwayCompetitionResults", "HomeCompetitionResults" })
+            {
+                if (node[listName] is not System.Text.Json.Nodes.JsonArray rows) continue;
+                foreach (var row in rows.OfType<System.Text.Json.Nodes.JsonObject>())
+                {
+                    row.Remove("ContestId");
+                    row.Remove("AwayFranchiseSeasonId");
+                    row.Remove("HomeFranchiseSeasonId");
+                    row.Remove("WinnerFranchiseSeasonId");
+                    row.Remove("SpreadWinnerFranchiseSeasonId");
+                    row.Remove("AwaySpread");
+                }
+            }
+
+            return node.ToJsonString();
         }
 
         private MatchupPreviewPrompt BuildCapture(

--- a/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
@@ -18,6 +18,36 @@ namespace SportsData.Core.Dtos.Canonical
         public List<PreviewGameResultDto> AwayPriorSeasonGames { get; set; } = [];
 
         public List<PreviewGameResultDto> HomePriorSeasonGames { get; set; } = [];
+
+        /// <summary>Prior-season summary (record + metrics); null when the franchise has no prior season.</summary>
+        public PreviewPriorSeasonSummaryDto? AwayPriorSeason { get; set; }
+
+        public PreviewPriorSeasonSummaryDto? HomePriorSeason { get; set; }
+    }
+
+    /// <summary>
+    /// A team's PRIOR season in summary: final record and the season-level
+    /// advanced metrics. The early-season statistical signal — current-season
+    /// stats/metrics are empty until several weeks in.
+    /// </summary>
+    public class PreviewPriorSeasonSummaryDto
+    {
+        public int SeasonYear { get; set; }
+
+        public int Wins { get; set; }
+
+        public int Losses { get; set; }
+
+        public int ConferenceWins { get; set; }
+
+        public int ConferenceLosses { get; set; }
+
+        /// <summary>
+        /// Prior-season FranchiseSeasonMetrics; null when not generated for
+        /// that season. The API applies the same both-or-nothing symmetry
+        /// rule as current-season metrics before the model sees them.
+        /// </summary>
+        public FranchiseSeasonMetricsDto? Metrics { get; set; }
     }
 
     /// <summary>

--- a/src/SportsData.Core/Dtos/Canonical/MatchupForPreviewDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/MatchupForPreviewDto.cs
@@ -68,6 +68,8 @@ namespace SportsData.Core.Dtos.Canonical
         public List<PreviewGameResultDto>? HeadToHead { get; set; }
         public List<PreviewGameResultDto>? AwayPriorSeasonGames { get; set; }
         public List<PreviewGameResultDto>? HomePriorSeasonGames { get; set; }
+        public PreviewPriorSeasonSummaryDto? AwayPriorSeason { get; set; }
+        public PreviewPriorSeasonSummaryDto? HomePriorSeason { get; set; }
 
         public string? Spread { get; set; }             // co."Details"
         public double? AwaySpread { get; set; }

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonMetricsById;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Sql;
 
@@ -23,15 +24,18 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
     private readonly TeamSportDataContext _dbContext;
     private readonly ProducerSqlQueryProvider _sqlProvider;
     private readonly IValidator<GetContestPreviewHistoryQuery> _validator;
+    private readonly IGetFranchiseSeasonMetricsByIdQueryHandler _metricsHandler;
 
     public GetContestPreviewHistoryQueryHandler(
         TeamSportDataContext dbContext,
         ProducerSqlQueryProvider sqlProvider,
-        IValidator<GetContestPreviewHistoryQuery> validator)
+        IValidator<GetContestPreviewHistoryQuery> validator,
+        IGetFranchiseSeasonMetricsByIdQueryHandler metricsHandler)
     {
         _dbContext = dbContext;
         _sqlProvider = sqlProvider;
         _validator = validator;
+        _metricsHandler = metricsHandler;
     }
 
     /// <summary>
@@ -83,6 +87,73 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                 .Where(x => x.Side == "Home").Cast<PreviewGameResultDto>().ToList()
         };
 
+        var target = await _dbContext.Contests
+            .AsNoTracking()
+            .Where(c => c.Id == query.ContestId)
+            .Select(c => new
+            {
+                c.SeasonYear,
+                c.AwayTeamFranchiseSeasonId,
+                c.HomeTeamFranchiseSeasonId
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (target is not null)
+        {
+            dto.AwayPriorSeason = await BuildPriorSeasonSummaryAsync(
+                target.AwayTeamFranchiseSeasonId, target.SeasonYear, cancellationToken);
+            dto.HomePriorSeason = await BuildPriorSeasonSummaryAsync(
+                target.HomeTeamFranchiseSeasonId, target.SeasonYear, cancellationToken);
+        }
+
         return new Success<ContestPreviewHistoryDto>(dto);
+    }
+
+    /// <summary>
+    /// Prior-season summary for one team: resolve the franchise's
+    /// SeasonYear-1 FranchiseSeason (cross-season identity via Franchise),
+    /// take its final record, and attach that season's metrics when they
+    /// exist. Null when the franchise has no prior season row.
+    /// </summary>
+    private async Task<PreviewPriorSeasonSummaryDto?> BuildPriorSeasonSummaryAsync(
+        Guid currentFranchiseSeasonId,
+        int targetSeasonYear,
+        CancellationToken cancellationToken)
+    {
+        var priorSeason = await _dbContext.FranchiseSeasons
+            .AsNoTracking()
+            .Where(current => current.Id == currentFranchiseSeasonId)
+            .SelectMany(current => _dbContext.FranchiseSeasons
+                .Where(prior => prior.FranchiseId == current.FranchiseId
+                             && prior.SeasonYear == targetSeasonYear - 1))
+            .Select(prior => new
+            {
+                prior.Id,
+                prior.SeasonYear,
+                prior.Wins,
+                prior.Losses,
+                prior.ConferenceWins,
+                prior.ConferenceLosses
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (priorSeason is null)
+            return null;
+
+        var metricsResult = await _metricsHandler.ExecuteAsync(
+            new GetFranchiseSeasonMetricsByIdQuery(priorSeason.Id), cancellationToken);
+
+        return new PreviewPriorSeasonSummaryDto
+        {
+            SeasonYear = priorSeason.SeasonYear,
+            Wins = priorSeason.Wins,
+            Losses = priorSeason.Losses,
+            ConferenceWins = priorSeason.ConferenceWins,
+            ConferenceLosses = priorSeason.ConferenceLosses,
+            // NotFound = metrics simply not generated for that season — the
+            // record still flows; the API's both-or-nothing rule handles
+            // asymmetry before the model sees anything.
+            Metrics = metricsResult.IsSuccess ? metricsResult.Value : null
+        };
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -96,6 +96,8 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 SeasonYear = 2025,
                 Wins = 8,
                 Losses = 10,
+                ConferenceWins = 5,
+                ConferenceLosses = 7,
                 Metrics = new FranchiseSeasonMetricsDto { GamesPlayed = 18, Ypp = 5.4m }
             },
             HomePriorSeason = new PreviewPriorSeasonSummaryDto
@@ -103,6 +105,8 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 SeasonYear = 2025,
                 Wins = 6,
                 Losses = 11,
+                ConferenceWins = 3,
+                ConferenceLosses = 9,
                 Metrics = new FranchiseSeasonMetricsDto { GamesPlayed = 17, Ypp = 4.9m }
             }
         };
@@ -204,6 +208,10 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             Assert.DoesNotContain(_contestId.ToString(), capture.PayloadJson);
             Assert.Contains("AwayPriorSeason", capture.PayloadJson);
             Assert.Contains("\"Wins\":8", capture.PayloadJson);
+            Assert.Contains("\"ConferenceWins\":5", capture.PayloadJson);
+            Assert.Contains("\"ConferenceLosses\":7", capture.PayloadJson);
+            Assert.Contains("\"ConferenceWins\":3", capture.PayloadJson);
+            Assert.Contains("\"ConferenceLosses\":9", capture.PayloadJson);
             Assert.Null(capture.EditorNote);
             Assert.True(capture.CharCount > PromptText.Length);
             Assert.Equal(capture.CharCount / 4, capture.EstTokens);
@@ -493,10 +501,14 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
 
             var awayPrior = payload.RootElement.GetProperty("AwayPriorSeason");
             Assert.Equal(8, awayPrior.GetProperty("Wins").GetInt32());
+            Assert.Equal(5, awayPrior.GetProperty("ConferenceWins").GetInt32());
+            Assert.Equal(7, awayPrior.GetProperty("ConferenceLosses").GetInt32());
             Assert.False(awayPrior.TryGetProperty("Metrics", out _)); // nulled -> omitted
 
             var homePrior = payload.RootElement.GetProperty("HomePriorSeason");
             Assert.Equal(6, homePrior.GetProperty("Wins").GetInt32());
+            Assert.Equal(3, homePrior.GetProperty("ConferenceWins").GetInt32());
+            Assert.Equal(9, homePrior.GetProperty("ConferenceLosses").GetInt32());
             Assert.False(homePrior.TryGetProperty("Metrics", out _));
         }
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -90,7 +90,21 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                     Winner = "Los Angeles Rams"
                 }
             ],
-            HomePriorSeasonGames = []
+            HomePriorSeasonGames = [],
+            AwayPriorSeason = new PreviewPriorSeasonSummaryDto
+            {
+                SeasonYear = 2025,
+                Wins = 8,
+                Losses = 10,
+                Metrics = new FranchiseSeasonMetricsDto { GamesPlayed = 18, Ypp = 5.4m }
+            },
+            HomePriorSeason = new PreviewPriorSeasonSummaryDto
+            {
+                SeasonYear = 2025,
+                Wins = 6,
+                Losses = 11,
+                Metrics = new FranchiseSeasonMetricsDto { GamesPlayed = 17, Ypp = 4.9m }
+            }
         };
 
         private void SetupPipeline(MatchupForPreviewDto matchup, Result<ContestPreviewHistoryDto>? history = null)
@@ -170,16 +184,26 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             Assert.Equal(PromptText, capture.PromptText);
             Assert.Contains("arizona-cardinals", capture.PayloadJson);
 
-            // Historical blocks flow into the payload, names only — the only
-            // GUIDs in the whole payload are the two live FranchiseSeasonIds
-            // (plus ContestId), never per-season ids from historical rows.
+            // Historical blocks flow into the payload, names only. After the
+            // hygiene projection the ONLY GUIDs in the whole payload are the
+            // two live FranchiseSeasonIds the output contract requires.
             Assert.Contains("HeadToHead", capture.PayloadJson);
             Assert.Contains("NFC Wild Card", capture.PayloadJson);
             Assert.Contains("ARI -6.5", capture.PayloadJson);
             var guidCount = System.Text.RegularExpressions.Regex.Matches(
                 capture.PayloadJson,
                 "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}").Count;
-            Assert.Equal(3, guidCount);
+            Assert.Equal(2, guidCount);
+
+            // Hygiene projection: string enums, omit-null, no derived
+            // away-relative spread, no ContestId — and the prior-season
+            // summaries ride in.
+            Assert.Contains("\"Sport\":\"FootballNfl\"", capture.PayloadJson);
+            Assert.DoesNotContain("AwayRank", capture.PayloadJson);      // null -> omitted
+            Assert.DoesNotContain("AwaySpread", capture.PayloadJson);
+            Assert.DoesNotContain(_contestId.ToString(), capture.PayloadJson);
+            Assert.Contains("AwayPriorSeason", capture.PayloadJson);
+            Assert.Contains("\"Wins\":8", capture.PayloadJson);
             Assert.Null(capture.EditorNote);
             Assert.True(capture.CharCount > PromptText.Length);
             Assert.Equal(capture.CharCount / 4, capture.EstTokens);
@@ -439,6 +463,41 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
 
             Assert.Equal("STATUS_SCHEDULED", payload.RootElement.GetProperty("Status").GetString());
             Assert.Equal("Scheduled", payload.RootElement.GetProperty("StatusDescription").GetString());
+        }
+
+        [Fact]
+        public async Task Capture_AppliesBothOrNothing_ToPriorSeasonMetrics()
+        {
+            // Arrange — away has prior metrics, home does not: asymmetric
+            // analytics would bias the model, so both must be nulled while
+            // the records keep flowing.
+            var history = BuildHistory();
+            history.HomePriorSeason!.Metrics = null;
+            SetupPipeline(BuildMatchup("STATUS_SCHEDULED"), new Success<ContestPreviewHistoryDto>(history));
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Capture
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            using var payload = System.Text.Json.JsonDocument.Parse(capture.PayloadJson);
+
+            var awayPrior = payload.RootElement.GetProperty("AwayPriorSeason");
+            Assert.Equal(8, awayPrior.GetProperty("Wins").GetInt32());
+            Assert.False(awayPrior.TryGetProperty("Metrics", out _)); // nulled -> omitted
+
+            var homePrior = payload.RootElement.GetProperty("HomePriorSeason");
+            Assert.Equal(6, homePrior.GetProperty("Wins").GetInt32());
+            Assert.False(homePrior.TryGetProperty("Metrics", out _));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Completes the preview payload data story ahead of with-history prompt authoring (`docs/metrics-modeling/matchup-preview-data-inputs.md` §3a + §3e; remaining work consolidated in new §6).

### Hygiene projection

`SerializePromptPayload` — applied **at serialization only**; the wire DTO is untouched, so zero consumer risk:

- **omit-null**: kills the ~28 always-null stat fields early-season and null market fields on pre-odds-era history rows
- **string enums**: `"Sport": "FootballNfl"`, O/U results as words
- **top-level `AwaySpread` dropped** (spread is ALWAYS home-relative; the away value is a derived negation that invites sign confusion) and `ContestId` dropped
- **legacy `CompetitionResults` rows stripped** of their five per-row GUIDs (contest, both franchise-seasons, winner, spread-winner) and per-row `AwaySpread` — winner/cover remain derivable from slugs + scores + `HomeSpread`

Regression test: the **entire payload now contains exactly the two live FranchiseSeasonIds and no other GUID** — the `predictedStraightUpWinner` echo trap is fully closed, including inside legacy rows.

### Prior-season summary (§3a)

- `ContestPreviewHistoryDto` gains `Away/HomePriorSeason`: final record (W-L, conference W-L) + prior-season `FranchiseSeasonMetrics`, resolved via Franchise → SeasonYear-1, reusing the existing `GetFranchiseSeasonMetricsByIdQueryHandler` via injection (not duplicated).
- API assembly applies the same **both-or-nothing** symmetry rule as current-season metrics: records always flow; analytics only when both teams have them (tested).
- Prior-season poll rank deferred with reasoning (NFL has no polls; NCAA needs a rankings join).
- Coverage gate documented: missing prior-season metric rows → block omits metrics (omit-null) and degrades honestly; backfill tracked in §6.

### Tests / verification

637 API + 530 Producer tests pass; full solution builds. Post-deploy: capture the HOF game — payload should be dramatically smaller (no null noise), `Sport` as a string, no `AwaySpread`/`ContestId`, exactly 2 GUIDs, and `AwayPriorSeason`/`HomePriorSeason` blocks with 2025 records (metrics presence depends on the prior-season coverage check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matchup previews now include each team’s prior-season record, conference record, season, and available metrics.
  * Historical preview data remains available when prior-season metrics are unavailable.

* **Improvements**
  * Preview payloads are streamlined by omitting empty values, redundant identifiers, contest details, and derived away-spread data.
  * Prior-season metrics are included consistently for both teams or omitted when incomplete.

* **Documentation**
  * Updated documentation to reflect completed payload improvements and remaining planned work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->