### PR TITLE
feat(api,web): prompts as first-class DB entities; Guid overrides in the Preview Lab

### DIFF
--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -534,6 +534,43 @@ model/prompt choice before real generations start):
    backfill is needed; until then the prior-season RECORD still flows —
    only the null `Metrics` property inside the block is omitted
    (omit-null) — so the payload degrades honestly.
+1a. **Prompt provider refactor — IMPLEMENTED 2026-08-08** (the
+   "refactor prompt providers" whiteboard item; revised same day per
+   user decisions: prompts are Guid-identified DB ENTITIES, text
+   included). New `Prompt` table in API's Postgres (private — the
+   secret-sauce policy holds): Id, Name (unique; becomes PromptVersion
+   on captures), Type (MatchupPreview / future GameRecap), Sport
+   (null = any), WithStats, IsDefault, Description, Text. The DB
+   storing text removes Azure blob storage from the preview pipeline
+   entirely — no Azurite for local dev (the exact blocker from the
+   first E2E attempt), and the coming prompt-management UI is plain
+   CRUD. Text formatting in Postgres is a non-issue (proven by
+   MatchupPreviewPrompt.PromptText since #601); CRLF normalized to LF
+   on create for deterministic diffs.
+
+   `IMatchupPreviewPromptProvider` resolution: (1) explicit `PromptId`
+   (Guid) → that row; unknown id or wrong Type fails loudly, never
+   falls back; honored in Capture/Experiment ONLY — Generate always
+   resolves the default, so an experiment override can never leak into
+   production previews. (2) Default for the (Sport, WithStats) slot —
+   sport-specific outranks Sport=null; flipping defaults takes effect
+   next run, no deploy. No caching (scoped indexed read; the blob-era
+   fault-eviction machinery is gone).
+
+   Captures now stamp PromptId (Guid) alongside PromptVersion + text.
+   Admin endpoints: POST /admin/prompts (create; IsDefault flips the
+   slot), POST /admin/prompts/import-blob (ONE-TIME seeding from the
+   legacy container), GET /admin/prompts (+ /{id}). Preview Lab's
+   Prompt ID input takes the Guid.
+
+   **DEPLOY GATE: seed before the next preview cycle** — the provider
+   is DB-only; with no default rows, generation fails with an explicit
+   message. Seed via import-blob: `prediction-insights-v1` (WithStats
+   false, IsDefault true) and `prediction-insights-with-stats-schedule`
+   (WithStats true, IsDefault true), both Sport=null.
+   GameRecapPromptProvider deliberately untouched (still blob) — unify
+   when recap work resumes.
+
 2. **with-history prompt blob** (user authors; blob-only per policy).
    Must teach: the metrics block (un-briefed since forever), HeadToHead
    + prior-season blocks (incl. "history excludes preseason by

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -241,6 +241,38 @@ namespace SportsData.Api.Application.Admin
         }
 
         /// <summary>
+        /// Edit a prompt's Text/Description. Name and slot (Sport,
+        /// WithStats) are immutable — a different slot is a new version.
+        /// </summary>
+        [HttpPut]
+        [Route("prompts/{promptId}")]
+        public async Task<ActionResult<Guid>> UpdatePrompt(
+            [FromRoute] Guid promptId,
+            [FromBody] Application.Admin.Prompts.UpdatePromptCommand command,
+            [FromServices] Application.Admin.Prompts.IUpdatePromptCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            command.PromptId = promptId;
+            var result = await handler.ExecuteAsync(command, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Make a prompt the default for its own (Sport, WithStats) slot;
+        /// clears the slot's previous default. Effective next run.
+        /// </summary>
+        [HttpPost]
+        [Route("prompts/{promptId}/set-default")]
+        public async Task<ActionResult<Guid>> SetDefaultPrompt(
+            [FromRoute] Guid promptId,
+            [FromServices] Application.Admin.Prompts.ISetDefaultPromptCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(promptId, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
         /// Persisted prompt captures for a contest, newest first — payload,
         /// metadata, and the full rendered prompt exactly as the model would
         /// receive it (instruction blob + payload + editor note).

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -146,13 +146,17 @@ namespace SportsData.Api.Application.Admin
         [Route("matchup/preview/{contestId}/capture")]
         public IActionResult CaptureContestPreviewPrompt(
             [FromRoute] Guid contestId,
-            [FromQuery] Sport sport = Sport.FootballNcaa)
+            [FromQuery] Sport sport = Sport.FootballNcaa,
+            // Prompt entity Guid — model binding rejects malformed values
+            // with a 400 before anything reaches Hangfire.
+            [FromQuery] Guid? promptId = null)
         {
             var cmd = new GenerateMatchupPreviewsCommand
             {
                 ContestId = contestId,
                 Sport = sport,
-                Mode = PreviewGenerationMode.Capture
+                Mode = PreviewGenerationMode.Capture,
+                PromptId = promptId
             };
             _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
             return Accepted(new { cmd.CorrelationId });
@@ -171,16 +175,69 @@ namespace SportsData.Api.Application.Admin
         [Route("matchup/preview/{contestId}/experiment")]
         public IActionResult RunContestPreviewExperiment(
             [FromRoute] Guid contestId,
-            [FromQuery] Sport sport = Sport.FootballNcaa)
+            [FromQuery] Sport sport = Sport.FootballNcaa,
+            [FromQuery] Guid? promptId = null)
         {
             var cmd = new GenerateMatchupPreviewsCommand
             {
                 ContestId = contestId,
                 Sport = sport,
-                Mode = PreviewGenerationMode.Experiment
+                Mode = PreviewGenerationMode.Experiment,
+                PromptId = promptId
             };
             _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
             return Accepted(new { cmd.CorrelationId });
+        }
+
+        /// <summary>
+        /// Create a prompt (text lives in the DB — the repo is public, the
+        /// DB is not). IsDefault=true flips the (Sport, WithStats) slot.
+        /// </summary>
+        [HttpPost]
+        [Route("prompts")]
+        public async Task<ActionResult<Guid>> CreatePrompt(
+            [FromBody] Application.Admin.Prompts.CreatePromptCommand command,
+            [FromServices] Application.Admin.Prompts.ICreatePromptCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(command, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// One-time seeding: import a legacy prompt blob from the "prompts"
+        /// container into the Prompt table.
+        /// </summary>
+        [HttpPost]
+        [Route("prompts/import-blob")]
+        public async Task<ActionResult<Guid>> ImportPromptFromBlob(
+            [FromBody] Application.Admin.Prompts.ImportPromptFromBlobCommand command,
+            [FromServices] Application.Admin.Prompts.IImportPromptFromBlobCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(command, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        [HttpGet]
+        [Route("prompts")]
+        public async Task<ActionResult<List<Application.Admin.Prompts.PromptSummaryDto>>> GetPrompts(
+            [FromServices] Application.Admin.Prompts.IGetPromptsQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(cancellationToken);
+            return result.ToActionResult();
+        }
+
+        [HttpGet]
+        [Route("prompts/{promptId}")]
+        public async Task<ActionResult<Application.Admin.Prompts.PromptDetailDto>> GetPromptById(
+            [FromRoute] Guid promptId,
+            [FromServices] Application.Admin.Prompts.IGetPromptByIdQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(promptId, cancellationToken);
+            return result.ToActionResult();
         }
 
         /// <summary>

--- a/src/SportsData.Api/Application/Admin/Prompts/CreatePromptCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/CreatePromptCommand.cs
@@ -1,0 +1,40 @@
+using FluentValidation;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Prompts;
+
+public class CreatePromptCommand
+{
+    /// <summary>Human-readable version name (unique) — becomes PromptVersion on captures.</summary>
+    public required string Name { get; set; }
+
+    /// <summary>Null = applies to any sport.</summary>
+    public Sport? Sport { get; set; }
+
+    public bool WithStats { get; set; }
+
+    /// <summary>Make this the active prompt for its (Sport, WithStats) slot; clears the previous default.</summary>
+    public bool IsDefault { get; set; }
+
+    public string? Description { get; set; }
+
+    public required string Text { get; set; }
+}
+
+public class CreatePromptCommandValidator : AbstractValidator<CreatePromptCommand>
+{
+    public CreatePromptCommandValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(100);
+
+        RuleFor(x => x.Text)
+            .NotEmpty()
+            .WithMessage("Prompt text cannot be empty");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(256);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Prompts/CreatePromptCommandHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/CreatePromptCommandHandler.cs
@@ -34,7 +34,7 @@ public class CreatePromptCommandHandler : ICreatePromptCommandHandler
         var validation = await new CreatePromptCommandValidator().ValidateAsync(command, cancellationToken);
         if (!validation.IsValid)
         {
-            return new Failure<Guid>(default, ResultStatus.Validation, validation.Errors);
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
         }
 
         var name = command.Name.Trim();
@@ -46,7 +46,7 @@ public class CreatePromptCommandHandler : ICreatePromptCommandHandler
         if (nameTaken)
         {
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.Validation,
                 [new ValidationFailure(nameof(command.Name), $"A prompt named '{name}' already exists. Prompt names are immutable provenance — create a new version name instead.")]);
         }
@@ -86,11 +86,26 @@ public class CreatePromptCommandHandler : ICreatePromptCommandHandler
         };
 
         await _dataContext.Prompts.AddAsync(prompt, cancellationToken);
-        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            // Clear-old-default + insert commit in ONE SaveChanges (single
+            // transaction); the partial unique indexes on default slots turn
+            // a concurrent race into a constraint violation here.
+            await _dataContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (command.IsDefault)
+        {
+            _logger.LogWarning(ex, "Concurrent default-slot change detected while creating prompt {PromptId}.", prompt.Id);
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(command.IsDefault), "The slot's default changed concurrently — reload and retry.")]);
+        }
 
         _logger.LogInformation(
             "Prompt created. Id: {PromptId}, Name: {Name}, Sport: {Sport}, WithStats: {WithStats}, IsDefault: {IsDefault}, Length: {Length}",
-            prompt.Id, prompt.Name, prompt.Sport, prompt.WithStats, prompt.IsDefault, prompt.Text.Length);
+            prompt.Id, LogSanitizer.Clean(prompt.Name), prompt.Sport, prompt.WithStats, prompt.IsDefault, prompt.Text.Length);
 
         return new Success<Guid>(prompt.Id);
     }

--- a/src/SportsData.Api/Application/Admin/Prompts/CreatePromptCommandHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/CreatePromptCommandHandler.cs
@@ -1,0 +1,97 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Prompts;
+
+public interface ICreatePromptCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(CreatePromptCommand command, CancellationToken cancellationToken);
+}
+
+public class CreatePromptCommandHandler : ICreatePromptCommandHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogger<CreatePromptCommandHandler> _logger;
+
+    public CreatePromptCommandHandler(
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider,
+        ILogger<CreatePromptCommandHandler> logger)
+    {
+        _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(CreatePromptCommand command, CancellationToken cancellationToken)
+    {
+        var validation = await new CreatePromptCommandValidator().ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default, ResultStatus.Validation, validation.Errors);
+        }
+
+        var name = command.Name.Trim();
+
+        var nameTaken = await _dataContext.Prompts
+            .AsNoTracking()
+            .AnyAsync(p => p.Name == name, cancellationToken);
+
+        if (nameTaken)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.Name), $"A prompt named '{name}' already exists. Prompt names are immutable provenance — create a new version name instead.")]);
+        }
+
+        if (command.IsDefault)
+        {
+            // At most one default per (Type, Sport, WithStats) slot. Note:
+            // a sport-specific default coexists with the any-sport default
+            // by design (resolution prefers sport-specific).
+            var currentDefaults = await _dataContext.Prompts
+                .Where(p => p.Type == PromptType.MatchupPreview
+                         && p.IsDefault
+                         && p.WithStats == command.WithStats
+                         && p.Sport == command.Sport)
+                .ToListAsync(cancellationToken);
+
+            foreach (var existing in currentDefaults)
+            {
+                existing.IsDefault = false;
+                existing.ModifiedUtc = _dateTimeProvider.UtcNow();
+            }
+        }
+
+        var prompt = new Prompt
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Type = PromptType.MatchupPreview,
+            Sport = command.Sport,
+            WithStats = command.WithStats,
+            IsDefault = command.IsDefault,
+            Description = command.Description,
+            // Normalize line endings so identical text hashes/diffs the same
+            // regardless of the editor it was pasted from.
+            Text = command.Text.Replace("\r\n", "\n"),
+            CreatedUtc = _dateTimeProvider.UtcNow()
+        };
+
+        await _dataContext.Prompts.AddAsync(prompt, cancellationToken);
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Prompt created. Id: {PromptId}, Name: {Name}, Sport: {Sport}, WithStats: {WithStats}, IsDefault: {IsDefault}, Length: {Length}",
+            prompt.Id, prompt.Name, prompt.Sport, prompt.WithStats, prompt.IsDefault, prompt.Text.Length);
+
+        return new Success<Guid>(prompt.Id);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Prompts/GetPromptsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/GetPromptsQueryHandler.cs
@@ -1,0 +1,110 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Prompts;
+
+/// <summary>List row — metadata only; fetch a single prompt for the text.</summary>
+public class PromptSummaryDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public PromptType Type { get; set; }
+    public Sport? Sport { get; set; }
+    public bool WithStats { get; set; }
+    public bool IsDefault { get; set; }
+    public string? Description { get; set; }
+    public int TextLength { get; set; }
+    public DateTime CreatedUtc { get; set; }
+}
+
+public class PromptDetailDto : PromptSummaryDto
+{
+    public string Text { get; set; } = default!;
+}
+
+public interface IGetPromptsQueryHandler
+{
+    Task<Result<List<PromptSummaryDto>>> ExecuteAsync(CancellationToken cancellationToken);
+}
+
+public interface IGetPromptByIdQueryHandler
+{
+    Task<Result<PromptDetailDto>> ExecuteAsync(Guid promptId, CancellationToken cancellationToken);
+}
+
+public class GetPromptsQueryHandler : IGetPromptsQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+
+    public GetPromptsQueryHandler(AppDataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<List<PromptSummaryDto>>> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var prompts = await _dataContext.Prompts
+            .AsNoTracking()
+            .OrderByDescending(p => p.IsDefault)
+            .ThenBy(p => p.Name)
+            .Select(p => new PromptSummaryDto
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Type = p.Type,
+                Sport = p.Sport,
+                WithStats = p.WithStats,
+                IsDefault = p.IsDefault,
+                Description = p.Description,
+                TextLength = p.Text.Length,
+                CreatedUtc = p.CreatedUtc
+            })
+            .ToListAsync(cancellationToken);
+
+        return new Success<List<PromptSummaryDto>>(prompts);
+    }
+}
+
+public class GetPromptByIdQueryHandler : IGetPromptByIdQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+
+    public GetPromptByIdQueryHandler(AppDataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<PromptDetailDto>> ExecuteAsync(Guid promptId, CancellationToken cancellationToken)
+    {
+        var prompt = await _dataContext.Prompts
+            .AsNoTracking()
+            .Where(p => p.Id == promptId)
+            .Select(p => new PromptDetailDto
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Type = p.Type,
+                Sport = p.Sport,
+                WithStats = p.WithStats,
+                IsDefault = p.IsDefault,
+                Description = p.Description,
+                TextLength = p.Text.Length,
+                Text = p.Text,
+                CreatedUtc = p.CreatedUtc
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (prompt is null)
+        {
+            return new Failure<PromptDetailDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new FluentValidation.Results.ValidationFailure(nameof(promptId), "Prompt not found")]);
+        }
+
+        return new Success<PromptDetailDto>(prompt);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Prompts/ImportPromptFromBlobCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/ImportPromptFromBlobCommand.cs
@@ -51,6 +51,14 @@ public class ImportPromptFromBlobCommandHandler : IImportPromptFromBlobCommandHa
     public async Task<Result<Guid>> ExecuteAsync(ImportPromptFromBlobCommand command, CancellationToken cancellationToken)
     {
         var blobName = command.BlobName.Trim();
+        if (string.IsNullOrWhiteSpace(blobName))
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.BadRequest,
+                [new FluentValidation.Results.ValidationFailure(nameof(command.BlobName), "Blob name cannot be empty")]);
+        }
+
         if (!blobName.EndsWith(".txt", StringComparison.OrdinalIgnoreCase))
             blobName += ".txt";
 
@@ -58,7 +66,7 @@ public class ImportPromptFromBlobCommandHandler : IImportPromptFromBlobCommandHa
 
         _logger.LogInformation(
             "Importing prompt blob {BlobName} ({Length} chars) into the Prompt table.",
-            blobName, text.Length);
+            LogSanitizer.Clean(blobName), text.Length);
 
         return await _createHandler.ExecuteAsync(new CreatePromptCommand
         {

--- a/src/SportsData.Api/Application/Admin/Prompts/ImportPromptFromBlobCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/ImportPromptFromBlobCommand.cs
@@ -1,0 +1,73 @@
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Blobs;
+
+namespace SportsData.Api.Application.Admin.Prompts;
+
+/// <summary>
+/// One-time seeding path: pull a legacy prompt blob out of the "prompts"
+/// container and create the Prompt entity from it. After the blobs are
+/// imported, blob storage is out of the preview pipeline entirely.
+/// </summary>
+public class ImportPromptFromBlobCommand
+{
+    /// <summary>Blob name, with or without the .txt extension.</summary>
+    public required string BlobName { get; set; }
+
+    /// <summary>Prompt name; defaults to the blob name without extension (the legacy PromptVersion value).</summary>
+    public string? Name { get; set; }
+
+    public Sport? Sport { get; set; }
+
+    public bool WithStats { get; set; }
+
+    public bool IsDefault { get; set; }
+
+    public string? Description { get; set; }
+}
+
+public interface IImportPromptFromBlobCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(ImportPromptFromBlobCommand command, CancellationToken cancellationToken);
+}
+
+public class ImportPromptFromBlobCommandHandler : IImportPromptFromBlobCommandHandler
+{
+    private const string Container = "prompts";
+
+    private readonly IProvideBlobStorage _blobStorage;
+    private readonly ICreatePromptCommandHandler _createHandler;
+    private readonly ILogger<ImportPromptFromBlobCommandHandler> _logger;
+
+    public ImportPromptFromBlobCommandHandler(
+        IProvideBlobStorage blobStorage,
+        ICreatePromptCommandHandler createHandler,
+        ILogger<ImportPromptFromBlobCommandHandler> logger)
+    {
+        _blobStorage = blobStorage;
+        _createHandler = createHandler;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(ImportPromptFromBlobCommand command, CancellationToken cancellationToken)
+    {
+        var blobName = command.BlobName.Trim();
+        if (!blobName.EndsWith(".txt", StringComparison.OrdinalIgnoreCase))
+            blobName += ".txt";
+
+        var text = await _blobStorage.GetFileContentsAsync(Container, blobName, cancellationToken);
+
+        _logger.LogInformation(
+            "Importing prompt blob {BlobName} ({Length} chars) into the Prompt table.",
+            blobName, text.Length);
+
+        return await _createHandler.ExecuteAsync(new CreatePromptCommand
+        {
+            Name = command.Name?.Trim() ?? Path.GetFileNameWithoutExtension(blobName),
+            Sport = command.Sport,
+            WithStats = command.WithStats,
+            IsDefault = command.IsDefault,
+            Description = command.Description ?? $"Imported from blob '{blobName}'",
+            Text = text
+        }, cancellationToken);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Prompts/LogSanitizer.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/LogSanitizer.cs
@@ -1,0 +1,15 @@
+namespace SportsData.Api.Application.Admin.Prompts;
+
+/// <summary>
+/// Strips control characters (CR/LF included) from operator-supplied
+/// strings before they reach log templates — prevents log-entry forging
+/// (CodeQL: log entries created from user input).
+/// </summary>
+public static class LogSanitizer
+{
+    public static string Clean(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return new string(value.Where(c => !char.IsControl(c)).ToArray());
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Prompts/SetDefaultPromptCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/SetDefaultPromptCommand.cs
@@ -1,0 +1,77 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Prompts;
+
+public interface ISetDefaultPromptCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(Guid promptId, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Makes a prompt the default for ITS OWN (Type, Sport, WithStats) slot,
+/// clearing the slot's previous default. Takes effect on the next
+/// generation run — no deploy.
+/// </summary>
+public class SetDefaultPromptCommandHandler : ISetDefaultPromptCommandHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogger<SetDefaultPromptCommandHandler> _logger;
+
+    public SetDefaultPromptCommandHandler(
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider,
+        ILogger<SetDefaultPromptCommandHandler> logger)
+    {
+        _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(Guid promptId, CancellationToken cancellationToken)
+    {
+        var prompt = await _dataContext.Prompts
+            .FirstOrDefaultAsync(p => p.Id == promptId, cancellationToken);
+
+        if (prompt is null)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(promptId), "Prompt not found")]);
+        }
+
+        if (!prompt.IsDefault)
+        {
+            var currentDefaults = await _dataContext.Prompts
+                .Where(p => p.Id != prompt.Id
+                         && p.Type == prompt.Type
+                         && p.IsDefault
+                         && p.WithStats == prompt.WithStats
+                         && p.Sport == prompt.Sport)
+                .ToListAsync(cancellationToken);
+
+            foreach (var existing in currentDefaults)
+            {
+                existing.IsDefault = false;
+                existing.ModifiedUtc = _dateTimeProvider.UtcNow();
+            }
+
+            prompt.IsDefault = true;
+            prompt.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+            await _dataContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "Prompt {PromptId} ('{Name}') is now the default for slot (Sport: {Sport}, WithStats: {WithStats}); {Cleared} previous default(s) cleared.",
+                prompt.Id, prompt.Name, prompt.Sport, prompt.WithStats, currentDefaults.Count);
+        }
+
+        return new Success<Guid>(prompt.Id);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Prompts/SetDefaultPromptCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/SetDefaultPromptCommand.cs
@@ -41,7 +41,7 @@ public class SetDefaultPromptCommandHandler : ISetDefaultPromptCommandHandler
         if (prompt is null)
         {
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.NotFound,
                 [new ValidationFailure(nameof(promptId), "Prompt not found")]);
         }
@@ -65,11 +65,25 @@ public class SetDefaultPromptCommandHandler : ISetDefaultPromptCommandHandler
             prompt.IsDefault = true;
             prompt.ModifiedUtc = _dateTimeProvider.UtcNow();
 
-            await _dataContext.SaveChangesAsync(cancellationToken);
+            try
+            {
+                // Clear + promote commit in ONE SaveChanges (single
+                // transaction); the partial unique indexes turn a concurrent
+                // promotion race into a constraint violation here.
+                await _dataContext.SaveChangesAsync(cancellationToken);
+            }
+            catch (DbUpdateException ex)
+            {
+                _logger.LogWarning(ex, "Concurrent default-slot change detected while promoting prompt {PromptId}.", prompt.Id);
+                return new Failure<Guid>(
+                    default!,
+                    ResultStatus.BadRequest,
+                    [new ValidationFailure(nameof(promptId), "The slot's default changed concurrently — reload and retry.")]);
+            }
 
             _logger.LogInformation(
                 "Prompt {PromptId} ('{Name}') is now the default for slot (Sport: {Sport}, WithStats: {WithStats}); {Cleared} previous default(s) cleared.",
-                prompt.Id, prompt.Name, prompt.Sport, prompt.WithStats, currentDefaults.Count);
+                prompt.Id, LogSanitizer.Clean(prompt.Name), prompt.Sport, prompt.WithStats, currentDefaults.Count);
         }
 
         return new Success<Guid>(prompt.Id);

--- a/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
@@ -1,0 +1,88 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Prompts;
+
+/// <summary>
+/// Edits a prompt's Text and/or Description. Name and slot
+/// (Sport, WithStats) are deliberately immutable — a prompt's identity
+/// never silently changes meaning; a different slot is a NEW version.
+/// Captures store the exact text sent, so editing never rewrites history.
+/// </summary>
+public class UpdatePromptCommand
+{
+    public Guid PromptId { get; set; }
+
+    public string? Description { get; set; }
+
+    public required string Text { get; set; }
+}
+
+public class UpdatePromptCommandValidator : AbstractValidator<UpdatePromptCommand>
+{
+    public UpdatePromptCommandValidator()
+    {
+        RuleFor(x => x.PromptId).NotEmpty();
+        RuleFor(x => x.Text).NotEmpty().WithMessage("Prompt text cannot be empty");
+        RuleFor(x => x.Description).MaximumLength(256);
+    }
+}
+
+public interface IUpdatePromptCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(UpdatePromptCommand command, CancellationToken cancellationToken);
+}
+
+public class UpdatePromptCommandHandler : IUpdatePromptCommandHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogger<UpdatePromptCommandHandler> _logger;
+
+    public UpdatePromptCommandHandler(
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider,
+        ILogger<UpdatePromptCommandHandler> logger)
+    {
+        _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(UpdatePromptCommand command, CancellationToken cancellationToken)
+    {
+        var validation = await new UpdatePromptCommandValidator().ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default, ResultStatus.Validation, validation.Errors);
+        }
+
+        var prompt = await _dataContext.Prompts
+            .FirstOrDefaultAsync(p => p.Id == command.PromptId, cancellationToken);
+
+        if (prompt is null)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(command.PromptId), "Prompt not found")]);
+        }
+
+        prompt.Text = command.Text.Replace("\r\n", "\n");
+        prompt.Description = command.Description;
+        prompt.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Prompt updated. Id: {PromptId}, Name: {Name}, Length: {Length}",
+            prompt.Id, prompt.Name, prompt.Text.Length);
+
+        return new Success<Guid>(prompt.Id);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
@@ -59,7 +59,7 @@ public class UpdatePromptCommandHandler : IUpdatePromptCommandHandler
         var validation = await new UpdatePromptCommandValidator().ValidateAsync(command, cancellationToken);
         if (!validation.IsValid)
         {
-            return new Failure<Guid>(default, ResultStatus.Validation, validation.Errors);
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
         }
 
         var prompt = await _dataContext.Prompts
@@ -68,7 +68,7 @@ public class UpdatePromptCommandHandler : IUpdatePromptCommandHandler
         if (prompt is null)
         {
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.NotFound,
                 [new ValidationFailure(nameof(command.PromptId), "Prompt not found")]);
         }
@@ -81,7 +81,7 @@ public class UpdatePromptCommandHandler : IUpdatePromptCommandHandler
 
         _logger.LogInformation(
             "Prompt updated. Id: {PromptId}, Name: {Name}, Length: {Length}",
-            prompt.Id, prompt.Name, prompt.Text.Length);
+            prompt.Id, LogSanitizer.Clean(prompt.Name), prompt.Text.Length);
 
         return new Success<Guid>(prompt.Id);
     }

--- a/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
+++ b/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
@@ -21,5 +21,13 @@ public class GenerateMatchupPreviewsCommand
     /// </summary>
     public PreviewGenerationMode Mode { get; set; } = PreviewGenerationMode.Generate;
 
+    /// <summary>
+    /// Explicit Prompt entity override for Preview Lab runs — honored in
+    /// Capture/Experiment modes only; Generate always uses the resolved
+    /// default so an experiment override can never leak into production
+    /// previews. Null = sport/variant default resolution.
+    /// </summary>
+    public Guid? PromptId { get; set; }
+
     public Guid CorrelationId { get; set; } = Guid.NewGuid();
 }

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -24,7 +24,7 @@ namespace SportsData.Api.Application.Previews
         private readonly IContestClientFactory _contestClientFactory;
         private readonly IFranchiseClientFactory _franchiseClientFactory;
         private readonly IProvideAiCommunication _aiCommunication;
-        private readonly MatchupPreviewPromptProvider _promptProvider;
+        private readonly IMatchupPreviewPromptProvider _promptProvider;
         private readonly IEventBus _eventBus;
         private readonly IDateTimeProvider _dateTimeProvider;
 
@@ -34,7 +34,7 @@ namespace SportsData.Api.Application.Previews
             IContestClientFactory contestClientFactory,
             IFranchiseClientFactory franchiseClientFactory,
             IProvideAiCommunication aiCommunication,
-            MatchupPreviewPromptProvider promptProvider,
+            IMatchupPreviewPromptProvider promptProvider,
             IEventBus eventBus,
             IDateTimeProvider dateTimeProvider)
         {
@@ -55,6 +55,7 @@ namespace SportsData.Api.Application.Previews
         /// </summary>
         internal sealed record AssembledPrompt(
             MatchupForPreviewDto Matchup,
+            Guid PromptId,
             string PromptName,
             string InstructionText,
             string PayloadJson,
@@ -96,7 +97,17 @@ namespace SportsData.Api.Application.Previews
                 return;
             }
 
-            var assembled = await AssemblePromptAsync(matchup, command.Sport, command.Mode, rejectedPreview?.RejectionNote);
+            if (command.PromptId is not null && command.Mode == PreviewGenerationMode.Generate)
+            {
+                // Guard rail: an experiment prompt override must never leak
+                // into production previews.
+                _logger.LogWarning(
+                    "PromptId {PromptId} ignored for Generate mode on {ContestId} — overrides are Capture/Experiment only.",
+                    command.PromptId, command.ContestId);
+            }
+
+            var assembled = await AssemblePromptAsync(matchup, command.Sport, command.Mode, rejectedPreview?.RejectionNote,
+                command.Mode == PreviewGenerationMode.Generate ? null : command.PromptId);
 
             _logger.LogInformation(
                 "Prompt assembled for {ContestId}. PromptVersion: {PromptVersion}, CharCount: {CharCount}, UsedMetrics: {UsedMetrics}, AwayResults: {AwayResults}, HomeResults: {HomeResults}",
@@ -276,7 +287,8 @@ namespace SportsData.Api.Application.Previews
             MatchupForPreviewDto matchup,
             Sport sport,
             PreviewGenerationMode mode,
-            string? rejectionNote)
+            string? rejectionNote,
+            Guid? promptId = null)
         {
             // Historical context (last 5 H2H + prior-season last 5, preview-
             // safe semantics baked into Producer's queries). Degrades
@@ -358,7 +370,8 @@ namespace SportsData.Api.Application.Previews
             var hasStats = (matchup.AwayStats.RushingYardsPerGame.HasValue &&
                             matchup.HomeStats.RushingYardsPerGame.HasValue);
 
-            var promptData = await _promptProvider.GetPreviewInsightPromptAsync(hasStats);
+            var promptData = await _promptProvider.GetPromptAsync(
+                new PreviewPromptRequest(sport, hasStats, promptId));
 
             var jsonInput = SerializePromptPayload(matchup);
 
@@ -370,6 +383,7 @@ namespace SportsData.Api.Application.Previews
 
             return new AssembledPrompt(
                 matchup,
+                promptData.PromptId,
                 promptData.PromptName,
                 promptData.PromptText,
                 jsonInput,
@@ -432,6 +446,7 @@ namespace SportsData.Api.Application.Previews
                 Id = Guid.NewGuid(),
                 ContestId = command.ContestId,
                 Sport = command.Sport,
+                PromptId = assembled.PromptId,
                 PromptVersion = assembled.PromptName,
                 PromptText = assembled.InstructionText,
                 PayloadJson = assembled.PayloadJson,

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -342,7 +342,12 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<MatchupPreviewGenerator>();
             services.AddScoped<MatchupScheduler>();
-            services.AddSingleton<MatchupPreviewPromptProvider>();
+            // Scoped: resolves prompts from AppDataContext (text lives in the DB).
+            services.AddScoped<IMatchupPreviewPromptProvider, MatchupPreviewPromptProvider>();
+            services.AddScoped<Application.Admin.Prompts.ICreatePromptCommandHandler, Application.Admin.Prompts.CreatePromptCommandHandler>();
+            services.AddScoped<Application.Admin.Prompts.IImportPromptFromBlobCommandHandler, Application.Admin.Prompts.ImportPromptFromBlobCommandHandler>();
+            services.AddScoped<Application.Admin.Prompts.IGetPromptsQueryHandler, Application.Admin.Prompts.GetPromptsQueryHandler>();
+            services.AddScoped<Application.Admin.Prompts.IGetPromptByIdQueryHandler, Application.Admin.Prompts.GetPromptByIdQueryHandler>();
             services.AddSingleton<GameRecapPromptProvider>();
             services.AddScoped<PickScoringJob>();
             services.AddScoped<LeagueWeekScoringJob>();

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -348,6 +348,8 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<Application.Admin.Prompts.IImportPromptFromBlobCommandHandler, Application.Admin.Prompts.ImportPromptFromBlobCommandHandler>();
             services.AddScoped<Application.Admin.Prompts.IGetPromptsQueryHandler, Application.Admin.Prompts.GetPromptsQueryHandler>();
             services.AddScoped<Application.Admin.Prompts.IGetPromptByIdQueryHandler, Application.Admin.Prompts.GetPromptByIdQueryHandler>();
+            services.AddScoped<Application.Admin.Prompts.IUpdatePromptCommandHandler, Application.Admin.Prompts.UpdatePromptCommandHandler>();
+            services.AddScoped<Application.Admin.Prompts.ISetDefaultPromptCommandHandler, Application.Admin.Prompts.SetDefaultPromptCommandHandler>();
             services.AddSingleton<GameRecapPromptProvider>();
             services.AddScoped<PickScoringJob>();
             services.AddScoped<LeagueWeekScoringJob>();

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -40,6 +40,8 @@ public class AppDataContext : DbContext
 
     public DbSet<MatchupPreviewPrompt> MatchupPreviewPrompts { get; set; }
 
+    public DbSet<Prompt> Prompts { get; set; }
+
     public DbSet<Article> Articles { get; set; }
 
     public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
@@ -33,6 +33,14 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         public required string PromptVersion { get; set; }
 
         /// <summary>
+        /// The Prompt entity that supplied the instructions; null for
+        /// captures from the blob era. Deliberately no FK — prompts may be
+        /// deleted by the management UI, and the capture's PromptText is the
+        /// provenance record either way.
+        /// </summary>
+        public Guid? PromptId { get; set; }
+
+        /// <summary>
         /// The instruction text EXACTLY as sent — stored per capture because
         /// a blob can be edited in place (ReloadPromptAsync), which would
         /// make version-based reconstruction lie about what the model saw.

--- a/src/SportsData.Api/Infrastructure/Data/Entities/Prompt.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/Prompt.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// A prompt as a first-class entity: Guid identity, metadata, and the
+    /// instruction TEXT itself. The database is private (the repo is
+    /// public), so text lives here — no blob round-trip, no Azurite for
+    /// local dev. The legacy blob container remains only as a one-time
+    /// import source (and for game recaps until they unify onto this).
+    ///
+    /// Default resolution slot = (Type, Sport, WithStats): the provider
+    /// picks the IsDefault row for the slot, preferring sport-specific over
+    /// Sport=null (any sport). Handler logic keeps at most one default per
+    /// slot. Captures store the exact text sent regardless, so editing a
+    /// prompt row never rewrites history.
+    /// </summary>
+    public class Prompt : CanonicalEntityBase<Guid>
+    {
+        /// <summary>Human-readable version name (e.g. "prediction-insights-v1") — becomes PromptVersion on captures.</summary>
+        public required string Name { get; set; }
+
+        public PromptType Type { get; set; } = PromptType.MatchupPreview;
+
+        /// <summary>Null = applies to any sport; a sport-specific default outranks it.</summary>
+        public Sport? Sport { get; set; }
+
+        /// <summary>Which stats-variant slot this prompt serves (mirrors the hasStats selection).</summary>
+        public bool WithStats { get; set; }
+
+        /// <summary>The active prompt for its (Type, Sport, WithStats) slot.</summary>
+        public bool IsDefault { get; set; }
+
+        /// <summary>Optional operator note for the management UI.</summary>
+        public string? Description { get; set; }
+
+        /// <summary>The full instruction text.</summary>
+        public required string Text { get; set; }
+
+        public class EntityConfiguration : IEntityTypeConfiguration<Prompt>
+        {
+            public void Configure(EntityTypeBuilder<Prompt> builder)
+            {
+                builder.ToTable(nameof(Prompt));
+                builder.HasKey(x => x.Id);
+
+                builder.Property(x => x.Name).HasMaxLength(100).IsRequired();
+                builder.HasIndex(x => x.Name).IsUnique();
+
+                builder.Property(x => x.Type)
+                    .HasConversion<int>()
+                    .IsRequired();
+
+                builder.Property(x => x.Sport)
+                    .HasConversion<int?>();
+
+                builder.Property(x => x.Description).HasMaxLength(256);
+
+                builder.Property(x => x.Text).IsRequired();
+
+                // Default lookups: slot scan is tiny, but index the flag for
+                // the management UI's "what's live" view.
+                builder.HasIndex(x => new { x.Type, x.IsDefault });
+            }
+        }
+    }
+
+    public enum PromptType
+    {
+        MatchupPreview = 0,
+
+        /// <summary>Not yet served from the DB — game recaps still load from blob; unify later.</summary>
+        GameRecap = 1
+    }
+}

--- a/src/SportsData.Api/Infrastructure/Data/Entities/Prompt.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/Prompt.cs
@@ -41,6 +41,9 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         /// <summary>The full instruction text.</summary>
         public required string Text { get; set; }
 
+        /// <summary>PostgreSQL xmin concurrency token — prompts are operator-edited via the management UI.</summary>
+        public uint RowVersion { get; set; }
+
         public class EntityConfiguration : IEntityTypeConfiguration<Prompt>
         {
             public void Configure(EntityTypeBuilder<Prompt> builder)
@@ -62,9 +65,25 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
                 builder.Property(x => x.Text).IsRequired();
 
-                // Default lookups: slot scan is tiny, but index the flag for
-                // the management UI's "what's live" view.
-                builder.HasIndex(x => new { x.Type, x.IsDefault });
+                builder.Property(x => x.RowVersion)
+                    .HasColumnName("xmin")
+                    .HasColumnType("xid")
+                    .IsRowVersion();
+
+                // One default per (Type, Sport, WithStats) slot, enforced at
+                // the database so concurrent create/set-default requests
+                // cannot race two defaults into one slot. Postgres treats
+                // NULLs as distinct in unique indexes, so the any-sport slot
+                // (Sport IS NULL) needs its own partial index.
+                builder.HasIndex(x => new { x.Type, x.Sport, x.WithStats })
+                    .IsUnique()
+                    .HasFilter("\"IsDefault\" AND \"Sport\" IS NOT NULL")
+                    .HasDatabaseName("IX_Prompt_DefaultSlot_Sport");
+
+                builder.HasIndex(x => new { x.Type, x.WithStats })
+                    .IsUnique()
+                    .HasFilter("\"IsDefault\" AND \"Sport\" IS NULL")
+                    .HasDatabaseName("IX_Prompt_DefaultSlot_AnySport");
             }
         }
     }

--- a/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
+++ b/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
@@ -60,15 +60,17 @@ public class MatchupPreviewPromptProvider : IMatchupPreviewPromptProvider
         {
             var prompt = await _dataContext.Prompts
                 .AsNoTracking()
-                .FirstOrDefaultAsync(p => p.Id == promptId, cancellationToken)
+                .Where(p => p.Id == promptId)
+                .Select(p => new { p.Id, p.Name, p.Text, p.Type })
+                .FirstOrDefaultAsync(cancellationToken)
                 ?? throw new InvalidOperationException(
                     $"Prompt {promptId} does not exist. Experiment overrides fail loudly rather than falling back to a default.");
 
             if (prompt.Type != PromptType.MatchupPreview)
                 throw new InvalidOperationException(
-                    $"Prompt {promptId} ('{prompt.Name}') is a {prompt.Type} prompt, not a MatchupPreview prompt.");
+                    $"Prompt {promptId} is a {prompt.Type} prompt, not a MatchupPreview prompt.");
 
-            return new PreviewPrompt(prompt.Id!, prompt.Text, prompt.Name);
+            return new PreviewPrompt(prompt.Id, prompt.Text, prompt.Name);
         }
 
         var resolved = await _dataContext.Prompts
@@ -78,11 +80,12 @@ public class MatchupPreviewPromptProvider : IMatchupPreviewPromptProvider
                      && p.WithStats == request.HasStats
                      && (p.Sport == request.Sport || p.Sport == null))
             .OrderByDescending(p => p.Sport != null) // sport-specific outranks any-sport
+            .Select(p => new PreviewPrompt(p.Id, p.Text, p.Name))
             .FirstOrDefaultAsync(cancellationToken)
             ?? throw new InvalidOperationException(
                 $"No default matchup-preview prompt configured for Sport={request.Sport}, WithStats={request.HasStats}. " +
                 "Seed one via POST /admin/prompts or POST /admin/prompts/import-blob.");
 
-        return new PreviewPrompt(resolved.Id!, resolved.Text, resolved.Name);
+        return resolved;
     }
 }

--- a/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
+++ b/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
@@ -1,79 +1,88 @@
-﻿using SportsData.Core.Infrastructure.Blobs;
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
 
 namespace SportsData.Api.Infrastructure.Prompts;
 
-public class MatchupPreviewPromptProvider
+/// <summary>
+/// What the preview pipeline needs to resolve prompt instructions.
+/// </summary>
+/// <param name="Sport">Drives sport-specific default resolution.</param>
+/// <param name="HasStats">Selects the with-stats vs no-stats default slot.</param>
+/// <param name="PromptId">
+/// Explicit Prompt entity override for Preview Lab experiments — when set,
+/// default resolution is bypassed entirely.
+/// </param>
+public sealed record PreviewPromptRequest(Sport Sport, bool HasStats, Guid? PromptId = null);
+
+public sealed record PreviewPrompt(Guid PromptId, string PromptText, string PromptName);
+
+public interface IMatchupPreviewPromptProvider
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly object _lock = new();
+    /// <summary>
+    /// Resolve prompt instructions. Throws when an explicit PromptId does
+    /// not exist (an operator typo must fail loudly, never silently fall
+    /// back to a default) or when no default is configured for the slot.
+    /// </summary>
+    Task<PreviewPrompt> GetPromptAsync(PreviewPromptRequest request, CancellationToken cancellationToken = default);
+}
 
-    private Task<(string, string)>? _cachedPromptTask;
-    private Task<(string, string)>? _cachedPromptWithStatsTask;
+/// <summary>
+/// Database-backed prompt resolution. Prompt text lives in the (private)
+/// API database as first-class Prompt entities — no blob storage, no
+/// Azurite for local dev, and the coming management UI is plain CRUD.
+///
+/// Resolution order:
+/// 1. Explicit <c>PromptId</c> → that Prompt row (must be a MatchupPreview
+///    prompt), no fallback.
+/// 2. Default for the slot (Type=MatchupPreview, WithStats, Sport):
+///    a sport-specific default outranks a Sport=null (any-sport) default.
+///    Creating/flipping defaults takes effect on the next run — no deploy.
+///
+/// No caching: a scoped indexed read per generation is noise, and its
+/// absence removes the fault-eviction/staleness machinery the blob era
+/// needed.
+/// </summary>
+public class MatchupPreviewPromptProvider : IMatchupPreviewPromptProvider
+{
+    private readonly AppDataContext _dataContext;
 
-    private const string Container = "prompts";
-
-    private const string Blob = "prediction-insights-v1.txt";
-    private const string BlobWithStats = "prediction-insights-with-stats-schedule.txt";
-
-    public MatchupPreviewPromptProvider(IServiceProvider serviceProvider)
+    public MatchupPreviewPromptProvider(AppDataContext dataContext)
     {
-        _serviceProvider = serviceProvider;
+        _dataContext = dataContext;
     }
 
-    public Task<(string PromptText, string PromptName)> GetPreviewInsightPromptAsync(bool hasStats)
+    public async Task<PreviewPrompt> GetPromptAsync(PreviewPromptRequest request, CancellationToken cancellationToken = default)
     {
-        // Evict faulted tasks so a transient blob failure doesn't poison the
-        // cache until process restart — every later call would receive the
-        // same faulted task and the whole preview pipeline stays down.
-        lock (_lock)
+        if (request.PromptId is { } promptId)
         {
-            if (hasStats)
-            {
-                if (_cachedPromptWithStatsTask is { IsFaulted: true } or { IsCanceled: true })
-                    _cachedPromptWithStatsTask = null;
-                return _cachedPromptWithStatsTask ??= LoadPromptAsync(BlobWithStats);
-            }
-            else
-            {
-                if (_cachedPromptTask is { IsFaulted: true } or { IsCanceled: true })
-                    _cachedPromptTask = null;
-                return _cachedPromptTask ??= LoadPromptAsync(Blob);
-            }
-        }
-    }
+            var prompt = await _dataContext.Prompts
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Id == promptId, cancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"Prompt {promptId} does not exist. Experiment overrides fail loudly rather than falling back to a default.");
 
-    public async Task<string> ReloadPromptAsync(bool hasStats)
-    {
-        var blobName = hasStats ? BlobWithStats : Blob;
-        var newPrompt = await LoadPromptTextOnlyAsync(blobName);
+            if (prompt.Type != PromptType.MatchupPreview)
+                throw new InvalidOperationException(
+                    $"Prompt {promptId} ('{prompt.Name}') is a {prompt.Type} prompt, not a MatchupPreview prompt.");
 
-        lock (_lock)
-        {
-            if (hasStats)
-                _cachedPromptWithStatsTask = Task.FromResult((newPrompt, Path.GetFileNameWithoutExtension(blobName)));
-            else
-                _cachedPromptTask = Task.FromResult((newPrompt, Path.GetFileNameWithoutExtension(blobName)));
+            return new PreviewPrompt(prompt.Id!, prompt.Text, prompt.Name);
         }
 
-        return newPrompt;
-    }
+        var resolved = await _dataContext.Prompts
+            .AsNoTracking()
+            .Where(p => p.Type == PromptType.MatchupPreview
+                     && p.IsDefault
+                     && p.WithStats == request.HasStats
+                     && (p.Sport == request.Sport || p.Sport == null))
+            .OrderByDescending(p => p.Sport != null) // sport-specific outranks any-sport
+            .FirstOrDefaultAsync(cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"No default matchup-preview prompt configured for Sport={request.Sport}, WithStats={request.HasStats}. " +
+                "Seed one via POST /admin/prompts or POST /admin/prompts/import-blob.");
 
-    private async Task<(string, string)> LoadPromptAsync(string blobName, bool forceReload = false)
-    {
-        using var scope = _serviceProvider.CreateScope();
-        var blobStorage = scope.ServiceProvider.GetRequiredService<IProvideBlobStorage>();
-
-        var promptText = await blobStorage.GetFileContentsAsync(Container, blobName);
-        var promptName = Path.GetFileNameWithoutExtension(blobName);
-
-        return (promptText, promptName);
-    }
-
-    private async Task<string> LoadPromptTextOnlyAsync(string blobName)
-    {
-        using var scope = _serviceProvider.CreateScope();
-        var blobStorage = scope.ServiceProvider.GetRequiredService<IProvideBlobStorage>();
-
-        return await blobStorage.GetFileContentsAsync(Container, blobName);
+        return new PreviewPrompt(resolved.Id!, resolved.Text, resolved.Name);
     }
 }

--- a/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
+++ b/src/SportsData.Api/Infrastructure/Prompts/MatchupPreviewPromptProvider.cs
@@ -64,7 +64,7 @@ public class MatchupPreviewPromptProvider : IMatchupPreviewPromptProvider
                 .Select(p => new { p.Id, p.Name, p.Text, p.Type })
                 .FirstOrDefaultAsync(cancellationToken)
                 ?? throw new InvalidOperationException(
-                    $"Prompt {promptId} does not exist. Experiment overrides fail loudly rather than falling back to a default.");
+                    $"Prompt {promptId} does not exist. Explicit prompt overrides fail loudly rather than falling back to a default.");
 
             if (prompt.Type != PromptType.MatchupPreview)
                 throw new InvalidOperationException(

--- a/src/SportsData.Api/Migrations/20260808135010_AddPromptEntity.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260808135010_AddPromptEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260808135010_AddPromptEntity")]
+    partial class AddPromptEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260808135010_AddPromptEntity.cs
+++ b/src/SportsData.Api/Migrations/20260808135010_AddPromptEntity.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPromptEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PromptId",
+                table: "MatchupPreviewPrompt",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Prompt",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Sport = table.Column<int>(type: "integer", nullable: true),
+                    WithStats = table.Column<bool>(type: "boolean", nullable: false),
+                    IsDefault = table.Column<bool>(type: "boolean", nullable: false),
+                    Description = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Text = table.Column<string>(type: "text", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Prompt", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Prompt_Name",
+                table: "Prompt",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Prompt_Type_IsDefault",
+                table: "Prompt",
+                columns: new[] { "Type", "IsDefault" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Prompt");
+
+            migrationBuilder.DropColumn(
+                name: "PromptId",
+                table: "MatchupPreviewPrompt");
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260808142037_AddPromptEntity.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260808142037_AddPromptEntity.Designer.cs
@@ -12,7 +12,7 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    [Migration("20260808135010_AddPromptEntity")]
+    [Migration("20260808142037_AddPromptEntity")]
     partial class AddPromptEntity
     {
         /// <inheritdoc />
@@ -1453,6 +1453,12 @@ namespace SportsData.Api.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
+                    b.Property<uint>("RowVersion")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
+
                     b.Property<int?>("Sport")
                         .HasColumnType("integer");
 
@@ -1471,7 +1477,15 @@ namespace SportsData.Api.Migrations
                     b.HasIndex("Name")
                         .IsUnique();
 
-                    b.HasIndex("Type", "IsDefault");
+                    b.HasIndex("Type", "WithStats")
+                        .IsUnique()
+                        .HasDatabaseName("IX_Prompt_DefaultSlot_AnySport")
+                        .HasFilter("\"IsDefault\" AND \"Sport\" IS NULL");
+
+                    b.HasIndex("Type", "Sport", "WithStats")
+                        .IsUnique()
+                        .HasDatabaseName("IX_Prompt_DefaultSlot_Sport")
+                        .HasFilter("\"IsDefault\" AND \"Sport\" IS NOT NULL");
 
                     b.ToTable("Prompt", (string)null);
                 });

--- a/src/SportsData.Api/Migrations/20260808142037_AddPromptEntity.cs
+++ b/src/SportsData.Api/Migrations/20260808142037_AddPromptEntity.cs
@@ -29,6 +29,7 @@ namespace SportsData.Api.Migrations
                     IsDefault = table.Column<bool>(type: "boolean", nullable: false),
                     Description = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
                     Text = table.Column<string>(type: "text", nullable: false),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false),
                     CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
                     CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
@@ -40,15 +41,24 @@ namespace SportsData.Api.Migrations
                 });
 
             migrationBuilder.CreateIndex(
+                name: "IX_Prompt_DefaultSlot_AnySport",
+                table: "Prompt",
+                columns: new[] { "Type", "WithStats" },
+                unique: true,
+                filter: "\"IsDefault\" AND \"Sport\" IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Prompt_DefaultSlot_Sport",
+                table: "Prompt",
+                columns: new[] { "Type", "Sport", "WithStats" },
+                unique: true,
+                filter: "\"IsDefault\" AND \"Sport\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Prompt_Name",
                 table: "Prompt",
                 column: "Name",
                 unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Prompt_Type_IsDefault",
-                table: "Prompt",
-                columns: new[] { "Type", "IsDefault" });
         }
 
         /// <inheritdoc />

--- a/src/SportsData.Api/Migrations/AppDataContextModelSnapshot.cs
+++ b/src/SportsData.Api/Migrations/AppDataContextModelSnapshot.cs
@@ -1450,6 +1450,12 @@ namespace SportsData.Api.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
+                    b.Property<uint>("RowVersion")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
+
                     b.Property<int?>("Sport")
                         .HasColumnType("integer");
 
@@ -1468,7 +1474,15 @@ namespace SportsData.Api.Migrations
                     b.HasIndex("Name")
                         .IsUnique();
 
-                    b.HasIndex("Type", "IsDefault");
+                    b.HasIndex("Type", "WithStats")
+                        .IsUnique()
+                        .HasDatabaseName("IX_Prompt_DefaultSlot_AnySport")
+                        .HasFilter("\"IsDefault\" AND \"Sport\" IS NULL");
+
+                    b.HasIndex("Type", "Sport", "WithStats")
+                        .IsUnique()
+                        .HasDatabaseName("IX_Prompt_DefaultSlot_Sport")
+                        .HasFilter("\"IsDefault\" AND \"Sport\" IS NOT NULL");
 
                     b.ToTable("Prompt", (string)null);
                 });

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -34,6 +34,7 @@ import AdminPage from "./components/admin/AdminPage";
 import AdminFootballPage from "./components/admin/AdminFootballPage";
 import AdminBaseballPage from "./components/admin/AdminBaseballPage";
 import AdminPreviewLabPage from "./components/admin/AdminPreviewLabPage";
+import AdminPromptsPage from "./components/admin/AdminPromptsPage";
 import AdminRoute from "./routes/AdminRoute";
 import SeasonOverview from "./components/season/SeasonOverview";
 
@@ -240,6 +241,14 @@ function MainApp() {
               element={
                 <AdminRoute>
                   <AdminPreviewLabPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/prompts"
+              element={
+                <AdminRoute>
+                  <AdminPromptsPage />
                 </AdminRoute>
               }
             />

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -42,6 +42,18 @@ const AdminApi = {
   getPreviewCaptures: (contestId) =>
     apiClient.get(`/admin/matchup/preview/${encodeURIComponent(contestId)}/captures`),
 
+  // Prompt management (per-sport-league prompt entities; text lives in
+  // the API database). Name and slot (sport, withStats) are immutable —
+  // a different slot means creating a new version.
+  getPrompts: () => apiClient.get('/admin/prompts'),
+  getPrompt: (promptId) => apiClient.get(`/admin/prompts/${encodeURIComponent(promptId)}`),
+  createPrompt: (body) => apiClient.post('/admin/prompts', body),
+  updatePrompt: (promptId, body) =>
+    apiClient.put(`/admin/prompts/${encodeURIComponent(promptId)}`, body),
+  setDefaultPrompt: (promptId) =>
+    apiClient.post(`/admin/prompts/${encodeURIComponent(promptId)}/set-default`),
+  importPromptFromBlob: (body) => apiClient.post('/admin/prompts/import-blob', body),
+
   // Returns one MLB matchup in the same shape as the picks page so the
   // baseball SignalR debug page can render a real <MatchupCard /> for a
   // chosen contest. League-context fields (Predictions, AiWinner,

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -24,13 +24,20 @@ const AdminApi = {
   // ONLY — never writes a MatchupPreview, so a prior season's real preview
   // can't be shadowed on the picks page. Both allow completed contests and
   // announce completion via SignalR (PreviewPromptCaptured).
-  capturePreviewPrompt: (contestId, sport) =>
+  // promptId (optional): explicit prompt blob override (name without
+  // extension) for prompt-variant experiments. Server validates shape and
+  // fails the run loudly if the blob doesn't exist.
+  capturePreviewPrompt: (contestId, sport, promptId) =>
     apiClient.post(
-      `/admin/matchup/preview/${encodeURIComponent(contestId)}/capture${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+      `/admin/matchup/preview/${encodeURIComponent(contestId)}/capture`,
+      null,
+      { params: { ...(sport ? { sport } : {}), ...(promptId ? { promptId } : {}) } }
     ),
-  runPreviewExperiment: (contestId, sport) =>
+  runPreviewExperiment: (contestId, sport, promptId) =>
     apiClient.post(
-      `/admin/matchup/preview/${encodeURIComponent(contestId)}/experiment${sport ? `?sport=${encodeURIComponent(sport)}` : ""}`
+      `/admin/matchup/preview/${encodeURIComponent(contestId)}/experiment`,
+      null,
+      { params: { ...(sport ? { sport } : {}), ...(promptId ? { promptId } : {}) } }
     ),
   getPreviewCaptures: (contestId) =>
     apiClient.get(`/admin/matchup/preview/${encodeURIComponent(contestId)}/captures`),

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -24,9 +24,9 @@ const AdminApi = {
   // ONLY — never writes a MatchupPreview, so a prior season's real preview
   // can't be shadowed on the picks page. Both allow completed contests and
   // announce completion via SignalR (PreviewPromptCaptured).
-  // promptId (optional): explicit prompt blob override (name without
-  // extension) for prompt-variant experiments. Server validates shape and
-  // fails the run loudly if the blob doesn't exist.
+  // promptId (optional): Prompt entity GUID selecting a specific prompt
+  // version from the API database for this run. An unknown id fails the
+  // run loudly rather than silently using the slot default.
   capturePreviewPrompt: (contestId, sport, promptId) =>
     apiClient.post(
       `/admin/matchup/preview/${encodeURIComponent(contestId)}/capture`,

--- a/src/UI/sd-ui/src/components/admin/AdminPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.jsx
@@ -136,6 +136,7 @@ export default function AdminPage() {
         <Link to="/admin/football">Football debug</Link>
         <Link to="/admin/baseball">Baseball debug</Link>
         <Link to="/admin/preview-lab">Preview Lab</Link>
+        <Link to="/admin/prompts">Prompt Manager</Link>
       </div>
 
       <div className="admin-grid">

--- a/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPreviewLabPage.jsx
@@ -8,6 +8,7 @@ import { useUserDto } from '../../contexts/UserContext';
 
 const CONTEST_ID_STORAGE_KEY = 'admin.previewlab.contestId';
 const LEAGUE_STORAGE_KEY = 'admin.previewlab.league';
+const PROMPT_ID_STORAGE_KEY = 'admin.previewlab.promptId';
 
 const LEAGUE_OPTIONS = [
   { value: 'ncaa', label: 'NCAAFB', sport: 'FootballNcaa' },
@@ -43,6 +44,9 @@ export default function AdminPreviewLabPage() {
     () => localStorage.getItem(CONTEST_ID_STORAGE_KEY) ?? ''
   );
   const [pendingId, setPendingId] = useState(contestId);
+  const [promptId, setPromptId] = useState(
+    () => localStorage.getItem(PROMPT_ID_STORAGE_KEY) ?? ''
+  );
   const [captures, setCaptures] = useState([]);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -137,6 +141,16 @@ export default function AdminPreviewLabPage() {
     localStorage.setItem(LEAGUE_STORAGE_KEY, next);
   };
 
+  const handlePromptIdChange = (e) => {
+    const next = e.target.value;
+    setPromptId(next);
+    if (next.trim()) {
+      localStorage.setItem(PROMPT_ID_STORAGE_KEY, next);
+    } else {
+      localStorage.removeItem(PROMPT_ID_STORAGE_KEY);
+    }
+  };
+
   const runAction = async (action, queuedMessage) => {
     if (!contestId) {
       toast.error('Set a contest ID first.');
@@ -144,11 +158,12 @@ export default function AdminPreviewLabPage() {
     }
     setSubmitting(true);
     try {
-      await action(contestId, leagueSport);
+      await action(contestId, leagueSport, promptId.trim() || undefined);
       toast.success(queuedMessage);
     } catch (err) {
       toast.error(
         err?.response?.data?.errors?.[0]?.errorMessage
+          ?? err?.response?.data
           ?? err.message
           ?? 'Request failed'
       );
@@ -193,6 +208,16 @@ export default function AdminPreviewLabPage() {
             style={{ flex: 1, padding: '6px 8px', minWidth: 240 }}
           />
           <button type="submit">Load captures</button>
+          <label htmlFor="previewlab-prompt-id" style={{ fontWeight: 600 }}>Prompt ID:</label>
+          <input
+            id="previewlab-prompt-id"
+            type="text"
+            value={promptId}
+            onChange={handlePromptIdChange}
+            placeholder="optional — Prompt GUID from GET /admin/prompts"
+            title="Explicit Prompt entity override for this run (Guid). Blank = the sport/variant default. An unknown id fails the run rather than silently using a default."
+            style={{ flex: 1, padding: '6px 8px', minWidth: 240 }}
+          />
           <button
             type="button"
             disabled={submitting || !contestId}

--- a/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
@@ -1,0 +1,317 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import './AdminPage.css';
+import AdminHeader from './AdminHeader';
+import apiWrapper from '../../api/apiWrapper';
+
+const SPORT_OPTIONS = [
+  { value: '', label: 'Any sport' },
+  { value: 'FootballNcaa', label: 'NCAAFB' },
+  { value: 'FootballNfl', label: 'NFL' },
+  { value: 'BaseballMlb', label: 'MLB' },
+];
+
+const sportLabel = (sport) =>
+  SPORT_OPTIONS.find(o => o.value === (sport ?? ''))?.label ?? String(sport);
+
+const EMPTY_FORM = {
+  name: '',
+  sport: '',
+  withStats: false,
+  isDefault: false,
+  description: '',
+  text: '',
+};
+
+/**
+ * Prompt Manager — CRUD over the per-sport-league Prompt entities that
+ * drive matchup-preview generation (e.g. an NCAAFB prompt that discusses
+ * AP/CFP rankings vs an NFL prompt that never mentions them). Name and
+ * slot (sport, withStats) are immutable after creation; "New version
+ * from this" is the replace workflow, and Set default flips which
+ * version is live for a slot — effective next run, no deploy. Prompt
+ * text lives in the API database only (the repo is public; the DB is
+ * not) — treat it as the secret sauce it is.
+ */
+export default function AdminPromptsPage() {
+  const [prompts, setPrompts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Editor state: mode 'create' (form holds everything) or 'edit'
+  // (selected prompt id; only description/text are editable).
+  const [mode, setMode] = useState('create');
+  const [selectedId, setSelectedId] = useState(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+
+  const loadPrompts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiWrapper.Admin.getPrompts();
+      setPrompts(Array.isArray(res.data) ? res.data : []);
+    } catch (err) {
+      toast.error(err?.message ?? 'Failed to load prompts');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPrompts();
+  }, [loadPrompts]);
+
+  const resetToCreate = (prefill = EMPTY_FORM) => {
+    setMode('create');
+    setSelectedId(null);
+    setForm(prefill);
+  };
+
+  const handleSelect = async (promptId) => {
+    try {
+      const res = await apiWrapper.Admin.getPrompt(promptId);
+      const p = res.data;
+      setMode('edit');
+      setSelectedId(promptId);
+      setForm({
+        name: p.name,
+        sport: p.sport ?? '',
+        withStats: p.withStats,
+        isDefault: p.isDefault,
+        description: p.description ?? '',
+        text: p.text,
+      });
+    } catch (err) {
+      toast.error(err?.message ?? 'Failed to load prompt');
+    }
+  };
+
+  const handleNewVersionFrom = () => {
+    // Replace workflow: same slot and text, new name; operator edits then
+    // creates (optionally as the new default).
+    resetToCreate({
+      ...form,
+      name: `${form.name}-v`,
+      isDefault: false,
+    });
+    toast('Editing a NEW version — give it a name and save.', { icon: '📝' });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.text.trim()) {
+      toast.error('Prompt text cannot be empty.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      if (mode === 'edit') {
+        await apiWrapper.Admin.updatePrompt(selectedId, {
+          description: form.description || null,
+          text: form.text,
+        });
+        toast.success('Prompt updated.');
+      } else {
+        if (!form.name.trim()) {
+          toast.error('Name is required.');
+          return;
+        }
+        await apiWrapper.Admin.createPrompt({
+          name: form.name.trim(),
+          sport: form.sport || null,
+          withStats: form.withStats,
+          isDefault: form.isDefault,
+          description: form.description || null,
+          text: form.text,
+        });
+        toast.success('Prompt created.');
+        resetToCreate();
+      }
+      loadPrompts();
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.errors?.[0]?.errorMessage
+          ?? err.message
+          ?? 'Save failed'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSetDefault = async (promptId) => {
+    setSubmitting(true);
+    try {
+      await apiWrapper.Admin.setDefaultPrompt(promptId);
+      toast.success('Default flipped — effective on the next run.');
+      loadPrompts();
+      if (selectedId === promptId) setForm(f => ({ ...f, isDefault: true }));
+    } catch (err) {
+      toast.error(err?.message ?? 'Set default failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCopyId = async (promptId) => {
+    try {
+      await navigator.clipboard.writeText(promptId);
+      toast.success('Prompt ID copied — paste it into the Preview Lab.');
+    } catch {
+      toast.error('Copy failed.');
+    }
+  };
+
+  return (
+    <div className="admin-page">
+      <AdminHeader />
+      <div style={{ maxWidth: 1200, margin: '0 auto' }}>
+        <h2 style={{ marginBottom: 4 }}>Prompt Manager</h2>
+        <p style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
+          Per-sport-league prompts for preview generation. Name and slot are
+          immutable — use “New version from this” to replace, and “Set
+          default” to flip what's live (next run, no deploy). Copy an ID
+          into the Preview Lab to experiment before promoting.
+        </p>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(320px, 1fr) minmax(420px, 1.4fr)', gap: 20, alignItems: 'start' }}>
+          {/* Left: the registry */}
+          <section>
+            {loading && <div>Loading prompts…</div>}
+            {!loading && prompts.length === 0 && (
+              <div style={{ color: 'var(--text-secondary)' }}>
+                No prompts yet — create one, or seed from the legacy blobs
+                via POST /admin/prompts/import-blob.
+              </div>
+            )}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {prompts.map((p) => (
+                <div
+                  key={p.id}
+                  style={{
+                    border: '1px solid var(--border-primary)',
+                    borderLeft: p.isDefault ? '4px solid var(--color-success, #27ae60)' : '1px solid var(--border-primary)',
+                    borderRadius: 6,
+                    padding: 10,
+                    background: selectedId === p.id ? 'var(--table-stripe)' : 'transparent',
+                  }}
+                >
+                  <div style={{ display: 'flex', gap: 8, alignItems: 'baseline', flexWrap: 'wrap' }}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(p.id)}
+                      style={{ fontWeight: 600, background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--text-primary)' }}
+                      title="Open in the editor"
+                    >
+                      {p.name}
+                    </button>
+                    {p.isDefault && <span style={{ color: 'var(--color-success, #27ae60)', fontSize: '0.8rem', fontWeight: 700 }}>DEFAULT</span>}
+                  </div>
+                  <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 4 }}>
+                    <span>{sportLabel(p.sport)}</span>
+                    <span>{p.withStats ? 'with stats' : 'no stats'}</span>
+                    <span>{p.textLength?.toLocaleString()} chars</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8, marginTop: 6 }}>
+                    {!p.isDefault && (
+                      <button type="button" disabled={submitting} onClick={() => handleSetDefault(p.id)}>
+                        Set default
+                      </button>
+                    )}
+                    <button type="button" onClick={() => handleCopyId(p.id)}>Copy ID</button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Right: the editor */}
+          <section>
+            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                <strong>{mode === 'edit' ? `Editing: ${form.name}` : 'New prompt'}</strong>
+                {mode === 'edit' && (
+                  <>
+                    <button type="button" onClick={handleNewVersionFrom}>New version from this</button>
+                    <button type="button" onClick={() => resetToCreate()}>Cancel</button>
+                  </>
+                )}
+              </div>
+
+              {mode === 'create' && (
+                <>
+                  <input
+                    type="text"
+                    value={form.name}
+                    onChange={(e) => setForm(f => ({ ...f, name: e.target.value }))}
+                    placeholder="name (immutable, unique — e.g. prediction-insights-nfl-v2)"
+                    style={{ padding: '6px 8px' }}
+                  />
+                  <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <select
+                      value={form.sport}
+                      onChange={(e) => setForm(f => ({ ...f, sport: e.target.value }))}
+                      style={{ padding: '6px 8px' }}
+                      title="Sport/league scope — a sport-specific default outranks the any-sport default"
+                    >
+                      {SPORT_OPTIONS.map(o => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                    <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                      <input
+                        type="checkbox"
+                        checked={form.withStats}
+                        onChange={(e) => setForm(f => ({ ...f, withStats: e.target.checked }))}
+                      />
+                      with-stats variant
+                    </label>
+                    <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                      <input
+                        type="checkbox"
+                        checked={form.isDefault}
+                        onChange={(e) => setForm(f => ({ ...f, isDefault: e.target.checked }))}
+                      />
+                      make default for its slot
+                    </label>
+                  </div>
+                </>
+              )}
+
+              <input
+                type="text"
+                value={form.description}
+                onChange={(e) => setForm(f => ({ ...f, description: e.target.value }))}
+                placeholder="description (optional operator note)"
+                style={{ padding: '6px 8px' }}
+              />
+
+              <textarea
+                value={form.text}
+                onChange={(e) => setForm(f => ({ ...f, text: e.target.value }))}
+                placeholder="prompt instruction text"
+                rows={24}
+                spellCheck={false}
+                style={{
+                  fontFamily: 'monospace',
+                  fontSize: '0.85rem',
+                  padding: 10,
+                  whiteSpace: 'pre',
+                  overflowX: 'auto',
+                }}
+              />
+
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <button type="submit" disabled={submitting}>
+                  {mode === 'edit' ? 'Save changes' : 'Create prompt'}
+                </button>
+                <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+                  {form.text.length.toLocaleString()} chars (~{Math.round(form.text.length / 4).toLocaleString()} tokens)
+                </span>
+              </div>
+            </form>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
@@ -43,6 +43,12 @@ export default function AdminPromptsPage() {
   const [mode, setMode] = useState('create');
   const [selectedId, setSelectedId] = useState(null);
   const [form, setForm] = useState(EMPTY_FORM);
+  const [importForm, setImportForm] = useState({
+    blobName: '',
+    sport: '',
+    withStats: false,
+    isDefault: false,
+  });
 
   const loadPrompts = useCallback(async () => {
     setLoading(true);
@@ -152,6 +158,29 @@ export default function AdminPromptsPage() {
     }
   };
 
+  const handleImport = async () => {
+    setSubmitting(true);
+    try {
+      await apiWrapper.Admin.importPromptFromBlob({
+        blobName: importForm.blobName.trim(),
+        sport: importForm.sport || null,
+        withStats: importForm.withStats,
+        isDefault: importForm.isDefault,
+      });
+      toast.success('Imported.');
+      setImportForm(f => ({ ...f, blobName: '' }));
+      loadPrompts();
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.errors?.[0]?.errorMessage
+          ?? err.message
+          ?? 'Import failed'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const handleCopyId = async (promptId) => {
     try {
       await navigator.clipboard.writeText(promptId);
@@ -180,9 +209,56 @@ export default function AdminPromptsPage() {
             {!loading && prompts.length === 0 && (
               <div style={{ color: 'var(--text-secondary)' }}>
                 No prompts yet — create one, or seed from the legacy blobs
-                via POST /admin/prompts/import-blob.
+                below.
               </div>
             )}
+
+            <details style={{ marginBottom: 12 }}>
+              <summary style={{ cursor: 'pointer', fontWeight: 600 }}>
+                Import from legacy blob
+              </summary>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '10px 0' }}>
+                <input
+                  type="text"
+                  aria-label="Blob name"
+                  value={importForm.blobName}
+                  onChange={(e) => setImportForm(f => ({ ...f, blobName: e.target.value }))}
+                  placeholder="blob name — e.g. prediction-insights-v1"
+                  style={{ padding: '6px 8px' }}
+                />
+                <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <select
+                    aria-label="Sport scope for imported prompt"
+                    value={importForm.sport}
+                    onChange={(e) => setImportForm(f => ({ ...f, sport: e.target.value }))}
+                    style={{ padding: '6px 8px' }}
+                  >
+                    {SPORT_OPTIONS.map(o => (
+                      <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+                  </select>
+                  <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={importForm.withStats}
+                      onChange={(e) => setImportForm(f => ({ ...f, withStats: e.target.checked }))}
+                    />
+                    with-stats variant
+                  </label>
+                  <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    <input
+                      type="checkbox"
+                      checked={importForm.isDefault}
+                      onChange={(e) => setImportForm(f => ({ ...f, isDefault: e.target.checked }))}
+                    />
+                    make default
+                  </label>
+                  <button type="button" disabled={submitting || !importForm.blobName.trim()} onClick={handleImport}>
+                    Import
+                  </button>
+                </div>
+              </div>
+            </details>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {prompts.map((p) => (
                 <div
@@ -241,6 +317,7 @@ export default function AdminPromptsPage() {
                 <>
                   <input
                     type="text"
+                    aria-label="Prompt name"
                     value={form.name}
                     onChange={(e) => setForm(f => ({ ...f, name: e.target.value }))}
                     placeholder="name (immutable, unique — e.g. prediction-insights-nfl-v2)"
@@ -248,6 +325,7 @@ export default function AdminPromptsPage() {
                   />
                   <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
                     <select
+                      aria-label="Sport scope"
                       value={form.sport}
                       onChange={(e) => setForm(f => ({ ...f, sport: e.target.value }))}
                       style={{ padding: '6px 8px' }}
@@ -279,6 +357,7 @@ export default function AdminPromptsPage() {
 
               <input
                 type="text"
+                aria-label="Description"
                 value={form.description}
                 onChange={(e) => setForm(f => ({ ...f, description: e.target.value }))}
                 placeholder="description (optional operator note)"
@@ -286,6 +365,7 @@ export default function AdminPromptsPage() {
               />
 
               <textarea
+                aria-label="Prompt instruction text"
                 value={form.text}
                 onChange={(e) => setForm(f => ({ ...f, text: e.target.value }))}
                 placeholder="prompt instruction text"

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Prompts/CreatePromptCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Prompts/CreatePromptCommandHandlerTests.cs
@@ -1,0 +1,125 @@
+using Moq;
+
+using SportsData.Api.Application.Admin.Prompts;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Blobs;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Admin.Prompts
+{
+    public class CreatePromptCommandHandlerTests : ApiTestBase<CreatePromptCommandHandler>
+    {
+        private static readonly DateTime Now = new(2026, 8, 8, 12, 0, 0, DateTimeKind.Utc);
+
+        private CreatePromptCommandHandler BuildSut()
+        {
+            Mocker.GetMock<IDateTimeProvider>()
+                .Setup(x => x.UtcNow())
+                .Returns(Now);
+            return Mocker.CreateInstance<CreatePromptCommandHandler>();
+        }
+
+        [Fact]
+        public async Task Create_SetsDefault_AndFlipsPreviousDefaultInSlot()
+        {
+            // Arrange — an existing default in the same (Sport=null, WithStats) slot
+            await DataContext.Prompts.AddAsync(new Prompt
+            {
+                Id = Guid.NewGuid(),
+                Name = "prediction-insights-v1",
+                Sport = null,
+                WithStats = false,
+                IsDefault = true,
+                Text = "OLD"
+            });
+            // Different slot — must be untouched
+            var withStatsDefault = new Prompt
+            {
+                Id = Guid.NewGuid(),
+                Name = "with-stats",
+                Sport = null,
+                WithStats = true,
+                IsDefault = true,
+                Text = "STATS"
+            };
+            await DataContext.Prompts.AddAsync(withStatsDefault);
+            await DataContext.SaveChangesAsync();
+
+            var sut = BuildSut();
+
+            // Act
+            var result = await sut.ExecuteAsync(new CreatePromptCommand
+            {
+                Name = "prediction-insights-v2",
+                Sport = null,
+                WithStats = false,
+                IsDefault = true,
+                Text = "NEW\r\nLINE"
+            }, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+
+            var slotDefaults = DataContext.Prompts
+                .Where(p => p.WithStats == false && p.IsDefault).ToList();
+            var newDefault = Assert.Single(slotDefaults);
+            Assert.Equal("prediction-insights-v2", newDefault.Name);
+            Assert.Equal("NEW\nLINE", newDefault.Text); // CRLF normalized to LF
+
+            Assert.True(DataContext.Prompts.Single(p => p.Id == withStatsDefault.Id).IsDefault);
+        }
+
+        [Fact]
+        public async Task Create_RejectsDuplicateName()
+        {
+            await DataContext.Prompts.AddAsync(new Prompt
+            {
+                Id = Guid.NewGuid(),
+                Name = "prediction-insights-v1",
+                WithStats = false,
+                Text = "EXISTING"
+            });
+            await DataContext.SaveChangesAsync();
+
+            var sut = BuildSut();
+
+            var result = await sut.ExecuteAsync(new CreatePromptCommand
+            {
+                Name = "prediction-insights-v1",
+                WithStats = true,
+                Text = "OTHER"
+            }, CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Single(DataContext.Prompts);
+        }
+
+        [Fact]
+        public async Task ImportFromBlob_CreatesPrompt_WithBlobText()
+        {
+            Mocker.GetMock<IProvideBlobStorage>()
+                .Setup(x => x.GetFileContentsAsync("prompts", "prediction-insights-v1.txt", It.IsAny<CancellationToken>()))
+                .ReturnsAsync("BLOB TEXT");
+
+            Mocker.Use<ICreatePromptCommandHandler>(BuildSut());
+            var importer = Mocker.CreateInstance<ImportPromptFromBlobCommandHandler>();
+
+            var result = await importer.ExecuteAsync(new ImportPromptFromBlobCommand
+            {
+                BlobName = "prediction-insights-v1", // extension optional
+                Sport = null,
+                WithStats = false,
+                IsDefault = true
+            }, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+
+            var prompt = Assert.Single(DataContext.Prompts);
+            Assert.Equal("prediction-insights-v1", prompt.Name); // legacy PromptVersion value
+            Assert.Equal("BLOB TEXT", prompt.Text);
+            Assert.True(prompt.IsDefault);
+        }
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Prompts/CreatePromptCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Prompts/CreatePromptCommandHandlerTests.cs
@@ -97,6 +97,57 @@ namespace SportsData.Api.Tests.Unit.Application.Admin.Prompts
         }
 
         [Fact]
+        public async Task SetDefault_FlipsOnlyItsOwnSlot()
+        {
+            // Arrange — two slots, each with a default; a challenger in slot 1
+            var oldDefault = new Prompt { Id = Guid.NewGuid(), Name = "v1", Sport = Sport.FootballNfl, WithStats = false, IsDefault = true, Text = "OLD" };
+            var challenger = new Prompt { Id = Guid.NewGuid(), Name = "v2", Sport = Sport.FootballNfl, WithStats = false, IsDefault = false, Text = "NEW" };
+            var otherSlot = new Prompt { Id = Guid.NewGuid(), Name = "any-sport", Sport = null, WithStats = false, IsDefault = true, Text = "ANY" };
+            await DataContext.Prompts.AddRangeAsync(oldDefault, challenger, otherSlot);
+            await DataContext.SaveChangesAsync();
+
+            Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+            var sut = Mocker.CreateInstance<SetDefaultPromptCommandHandler>();
+
+            // Act
+            var result = await sut.ExecuteAsync(challenger.Id, CancellationToken.None);
+
+            // Assert — slot (FootballNfl, false) flipped; any-sport slot untouched
+            Assert.True(result.IsSuccess);
+            Assert.True(DataContext.Prompts.Single(p => p.Id == challenger.Id).IsDefault);
+            Assert.False(DataContext.Prompts.Single(p => p.Id == oldDefault.Id).IsDefault);
+            Assert.True(DataContext.Prompts.Single(p => p.Id == otherSlot.Id).IsDefault);
+        }
+
+        [Fact]
+        public async Task Update_EditsTextAndDescription_Only()
+        {
+            var prompt = new Prompt { Id = Guid.NewGuid(), Name = "v1", Sport = Sport.FootballNcaa, WithStats = true, IsDefault = true, Text = "OLD" };
+            await DataContext.Prompts.AddAsync(prompt);
+            await DataContext.SaveChangesAsync();
+
+            Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+            var sut = Mocker.CreateInstance<UpdatePromptCommandHandler>();
+
+            var result = await sut.ExecuteAsync(new UpdatePromptCommand
+            {
+                PromptId = prompt.Id,
+                Description = "tuned",
+                Text = "NEW\r\nTEXT"
+            }, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            var updated = DataContext.Prompts.Single(p => p.Id == prompt.Id);
+            Assert.Equal("NEW\nTEXT", updated.Text); // CRLF normalized
+            Assert.Equal("tuned", updated.Description);
+            // Identity and slot untouched
+            Assert.Equal("v1", updated.Name);
+            Assert.Equal(Sport.FootballNcaa, updated.Sport);
+            Assert.True(updated.WithStats);
+            Assert.True(updated.IsDefault);
+        }
+
+        [Fact]
         public async Task ImportFromBlob_CreatesPrompt_WithBlobText()
         {
             Mocker.GetMock<IProvideBlobStorage>()

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-
 using Moq;
 
 using SportsData.Api.Application.Previews;
@@ -8,7 +6,6 @@ using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Previews;
-using SportsData.Core.Infrastructure.Blobs;
 using SportsData.Core.Infrastructure.Clients.AI;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Infrastructure.Clients.Franchise;
@@ -22,6 +19,8 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
         private static readonly DateTime Now = new(2026, 8, 7, 12, 0, 0, DateTimeKind.Utc);
 
         private const string PromptText = "PROMPT INSTRUCTIONS";
+
+        private static readonly Guid DefaultPromptId = Guid.NewGuid();
 
         private readonly Guid _contestId = Guid.NewGuid();
         private readonly Guid _homeFranchiseSeasonId = Guid.NewGuid();
@@ -140,18 +139,16 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 .Setup(x => x.Resolve(It.IsAny<Sport>()))
                 .Returns(franchiseClient.Object);
 
-            // Real prompt provider backed by a mocked blob store — the
-            // provider class is concrete, so we feed it a real DI container.
-            var blobStorage = new Mock<IProvideBlobStorage>();
-            blobStorage
-                .Setup(x => x.GetFileContentsAsync("prompts", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(PromptText);
-
-            var services = new ServiceCollection()
-                .AddSingleton(blobStorage.Object)
-                .BuildServiceProvider();
-
-            Mocker.Use(new MatchupPreviewPromptProvider(services));
+            // The provider echoes the request so tests can assert both the
+            // default-variant selection and PromptId overrides.
+            Mocker.GetMock<IMatchupPreviewPromptProvider>()
+                .Setup(x => x.GetPromptAsync(It.IsAny<PreviewPromptRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PreviewPromptRequest r, CancellationToken _) => new PreviewPrompt(
+                    r.PromptId ?? DefaultPromptId,
+                    PromptText,
+                    r.PromptId is not null
+                        ? "override-prompt"
+                        : (r.HasStats ? "prediction-insights-with-stats-schedule" : "prediction-insights-v1")));
 
             Mocker.GetMock<IDateTimeProvider>()
                 .Setup(x => x.UtcNow())
@@ -539,6 +536,96 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             // Assert
             var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
             Assert.DoesNotContain("NFC Wild Card", capture.PayloadJson);
+        }
+
+        [Fact]
+        public async Task Experiment_WithPromptId_UsesOverrideAndRecordsIt()
+        {
+            // Arrange
+            SetupPipeline(BuildMatchup("STATUS_FINAL"));
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>("not json — irrelevant here"));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("experiment-model");
+
+            var overridePromptId = Guid.NewGuid();
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Experiment,
+                PromptId = overridePromptId
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — the override reached the provider, and the capture
+            // records BOTH the Prompt entity id and its name for provenance.
+            Mocker.GetMock<IMatchupPreviewPromptProvider>()
+                .Verify(x => x.GetPromptAsync(
+                    It.Is<PreviewPromptRequest>(r => r.PromptId == overridePromptId),
+                    It.IsAny<CancellationToken>()), Times.Once);
+
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Equal(overridePromptId, capture.PromptId);
+            Assert.Equal("override-prompt", capture.PromptVersion);
+        }
+
+        [Fact]
+        public async Task Generate_IgnoresPromptId()
+        {
+            // Arrange — an experiment override must never leak into a real
+            // generation; the provider must be asked for the DEFAULT prompt.
+            SetupPipeline(BuildMatchup("STATUS_SCHEDULED"));
+
+            var responseJson = $$"""
+                {
+                  "overview": "o",
+                  "analysis": "a",
+                  "prediction": "p",
+                  "predictedStraightUpWinner": "{{_homeFranchiseSeasonId}}",
+                  "predictedSpreadWinner": null,
+                  "overUnderPrediction": 2,
+                  "awayScore": 17,
+                  "homeScore": 27
+                }
+                """;
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(responseJson));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("test-model");
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Generate,
+                PromptId = Guid.NewGuid() // rogue override — must be ignored
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            Mocker.GetMock<IMatchupPreviewPromptProvider>()
+                .Verify(x => x.GetPromptAsync(
+                    It.Is<PreviewPromptRequest>(r => r.PromptId == null),
+                    It.IsAny<CancellationToken>()), Times.Once);
+
+            var preview = Assert.Single(DataContext.MatchupPreviews);
+            Assert.Equal("prediction-insights-with-stats-schedule", preview.PromptVersion);
         }
 
         [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Infrastructure/Prompts/MatchupPreviewPromptProviderTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Infrastructure/Prompts/MatchupPreviewPromptProviderTests.cs
@@ -1,0 +1,140 @@
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Api.Infrastructure.Prompts;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Infrastructure.Prompts
+{
+    public class MatchupPreviewPromptProviderTests : ApiTestBase<MatchupPreviewPromptProvider>
+    {
+        private MatchupPreviewPromptProvider BuildProvider() => new(DataContext);
+
+        private async Task<Prompt> AddPromptAsync(
+            string name,
+            Sport? sport,
+            bool withStats,
+            bool isDefault,
+            string text,
+            PromptType type = PromptType.MatchupPreview)
+        {
+            var prompt = new Prompt
+            {
+                Id = Guid.NewGuid(),
+                Name = name,
+                Type = type,
+                Sport = sport,
+                WithStats = withStats,
+                IsDefault = isDefault,
+                Text = text
+            };
+            await DataContext.Prompts.AddAsync(prompt);
+            await DataContext.SaveChangesAsync();
+            return prompt;
+        }
+
+        [Fact]
+        public async Task ResolvesAnySportDefault_WhenNoSportSpecificExists()
+        {
+            await AddPromptAsync("prediction-insights-v1", sport: null, withStats: false, isDefault: true, "GENERIC");
+
+            var prompt = await BuildProvider().GetPromptAsync(
+                new PreviewPromptRequest(Sport.FootballNfl, HasStats: false));
+
+            Assert.Equal("GENERIC", prompt.PromptText);
+            Assert.Equal("prediction-insights-v1", prompt.PromptName);
+        }
+
+        [Fact]
+        public async Task PrefersSportSpecificDefault_OverAnySport()
+        {
+            await AddPromptAsync("prediction-insights-v1", sport: null, withStats: false, isDefault: true, "GENERIC");
+            await AddPromptAsync("prediction-insights-v1-nfl", Sport.FootballNfl, withStats: false, isDefault: true, "NFL VOICE");
+
+            var nfl = await BuildProvider().GetPromptAsync(
+                new PreviewPromptRequest(Sport.FootballNfl, HasStats: false));
+            Assert.Equal("NFL VOICE", nfl.PromptText);
+
+            // Other sports still get the any-sport default.
+            var ncaa = await BuildProvider().GetPromptAsync(
+                new PreviewPromptRequest(Sport.FootballNcaa, HasStats: false));
+            Assert.Equal("GENERIC", ncaa.PromptText);
+        }
+
+        [Fact]
+        public async Task ResolvesTheCorrectStatsSlot()
+        {
+            await AddPromptAsync("no-stats", sport: null, withStats: false, isDefault: true, "NO STATS");
+            await AddPromptAsync("with-stats", sport: null, withStats: true, isDefault: true, "WITH STATS");
+
+            var withStats = await BuildProvider().GetPromptAsync(
+                new PreviewPromptRequest(Sport.FootballNfl, HasStats: true));
+            Assert.Equal("WITH STATS", withStats.PromptText);
+
+            var noStats = await BuildProvider().GetPromptAsync(
+                new PreviewPromptRequest(Sport.FootballNfl, HasStats: false));
+            Assert.Equal("NO STATS", noStats.PromptText);
+        }
+
+        [Fact]
+        public async Task IgnoresNonDefaultPrompts_ForSlotResolution()
+        {
+            await AddPromptAsync("old-version", sport: null, withStats: false, isDefault: false, "OLD");
+            await AddPromptAsync("current", sport: null, withStats: false, isDefault: true, "CURRENT");
+
+            var prompt = await BuildProvider().GetPromptAsync(
+                new PreviewPromptRequest(Sport.FootballNfl, HasStats: false));
+
+            Assert.Equal("CURRENT", prompt.PromptText);
+        }
+
+        [Fact]
+        public async Task Throws_WhenNoDefaultConfigured()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                BuildProvider().GetPromptAsync(
+                    new PreviewPromptRequest(Sport.FootballNfl, HasStats: true)));
+
+            Assert.Contains("No default matchup-preview prompt", ex.Message);
+        }
+
+        [Fact]
+        public async Task PromptIdOverride_BypassesDefaultResolution()
+        {
+            await AddPromptAsync("the-default", sport: null, withStats: true, isDefault: true, "DEFAULT");
+            var experimental = await AddPromptAsync("with-history-v1", sport: null, withStats: true, isDefault: false, "EXPERIMENTAL");
+
+            var prompt = await BuildProvider().GetPromptAsync(
+                new PreviewPromptRequest(Sport.FootballNfl, HasStats: true, PromptId: experimental.Id));
+
+            Assert.Equal("EXPERIMENTAL", prompt.PromptText);
+            Assert.Equal("with-history-v1", prompt.PromptName);
+            Assert.Equal(experimental.Id, prompt.PromptId);
+        }
+
+        [Fact]
+        public async Task PromptIdOverride_Throws_WhenPromptMissing()
+        {
+            // An operator typo must fail loudly, never silently fall back.
+            await AddPromptAsync("the-default", sport: null, withStats: true, isDefault: true, "DEFAULT");
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                BuildProvider().GetPromptAsync(
+                    new PreviewPromptRequest(Sport.FootballNfl, HasStats: true, PromptId: Guid.NewGuid())));
+
+            Assert.Contains("does not exist", ex.Message);
+        }
+
+        [Fact]
+        public async Task PromptIdOverride_Throws_ForWrongPromptType()
+        {
+            var recap = await AddPromptAsync("game-recap-v2", sport: null, withStats: false, isDefault: false, "RECAP", PromptType.GameRecap);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                BuildProvider().GetPromptAsync(
+                    new PreviewPromptRequest(Sport.FootballNfl, HasStats: false, PromptId: recap.Id)));
+
+            Assert.Contains("GameRecap", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The 'refactor prompt providers' whiteboard item: prompts become **Guid-identified entities in API's Postgres with the text stored in the database**, removing Azure blob storage from the preview pipeline entirely (no Azurite for local dev). The DB is private, so the prompts-never-in-source-control policy holds unchanged.

### Prompt entity

`Id`, `Name` (unique — becomes PromptVersion on captures), `Type` (MatchupPreview; GameRecap reserved — recap provider untouched until unified), `Sport` (nullable = any; the Sport enum is league-granular — `FootballNcaa` vs `FootballNfl` — so per-league prompts like an NCAAFB ranking-aware voice are exactly a Sport-scoped row), `WithStats`, `IsDefault`, `Description`, `Text`. CRLF→LF normalization on create. Captures gain `PromptId` (nullable, no FK — the capture's stored text is the provenance record even if a prompt row is deleted).

### Provider rewrite

One scoped indexed read; the blob-era caching/fault-eviction/404-probe machinery is deleted.

- Explicit `PromptId` → that row; unknown id or wrong Type **fails loudly** — an experiment must never silently run a default prompt.
- Otherwise: the `IsDefault` row for the (Sport, WithStats) slot, sport-specific outranking Sport=null. Flipping defaults takes effect on the next run — no deploy.
- `PromptId` honored in **Capture/Experiment only**; Generate always resolves the default so an experiment override cannot leak into production previews (tested).

### Admin endpoints (management-UI precursors)

- `POST /admin/prompts` — create; `IsDefault` atomically flips the slot's previous default; duplicate names rejected (names are provenance)
- `POST /admin/prompts/import-blob` — one-time seeding from the legacy container
- `GET /admin/prompts` (metadata only) + `GET /admin/prompts/{promptId}`
- Preview Lab Prompt ID input takes the Guid; endpoints take `Guid? promptId`

### ⚠️ Deploy gate

The provider is **DB-only, no blob fallback** (by explicit decision — remove the Azure complexity). **Seed before the next preview cycle** via import-blob: `prediction-insights-v1` (WithStats=false, IsDefault=true) and `prediction-insights-with-stats-schedule` (WithStats=true, IsDefault=true), both Sport=null. Until seeded, generation fails with an explicit message pointing at these endpoints.

### Tests

650 API + 10 web pass; full solution builds. Migration is additive (CreateTable + nullable AddColumn). Provider tests cover sport-specific precedence, slot separation, loud-failure paths; handler tests cover default-slot flip, duplicate-name rejection, CRLF normalization, blob import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin Prompt Manager for creating, editing, importing, listing, and selecting default matchup-preview prompts.
  * Added sport- and statistics-aware default prompt selection.
  * Preview capture and experiments can optionally use a specified prompt.
  * Preview captures now retain the selected prompt identifier.
  * Added a Prompt ID field to the Preview Lab, with saved selections.

* **Bug Fixes**
  * Invalid or unavailable prompt selections now return clear failures instead of silently proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->