### PR TITLE
feat(api,web): used-prompt immutability via MatchupPreview.PromptId FK; Prompt Manager UX

### DIFF
--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -598,13 +598,17 @@ model/prompt choice before real generations start):
    response, Contest holding ground truth (winner / spread winner / O/U
    result). To build:
    - **Model routing** (design sketched 2026-08-08, user thinking
-     aloud — mirrors the Prompt-entity pattern exactly): new
-     `ModelProvider` (name, credentials/config reference) and `Model`
-     entities in API's DB — provider FK, api model id string, display
-     name, **KnowledgeCutoffUtc** (makes contamination triage a QUERY:
-     the scoring join labels each experiment clean/contaminated by
-     comparing game StartDateUtc vs the model's cutoff — no doc
-     lookups), IsActive, IsDefault, cost metadata. `ModelId` on
+     aloud — mirrors the Prompt-entity pattern): new `ModelProvider`
+     (name, credentials/config reference) and `Model` entities in
+     API's DB. Model rows are IMMUTABLE identity records with a unique
+     (provider, api model id, revision) key: exact API identifier,
+     display name, release date, **KnowledgeCutoffUtc + its evidence
+     source and verification date** — the cutoff is a DECLARED
+     classification input from provider documentation, not proof a
+     game was unseen. The scoring join labels each experiment
+     lower-risk vs contaminated by comparing game StartDateUtc against
+     the declared cutoff — a triage query, not a verdict. IsActive,
+     IsDefault, cost metadata ride along. `ModelId` on
      GenerateMatchupPreviewsCommand routes generation through a
      multi-provider IProvideAiCommunication registration (single-bound
      to DeepSeek today; prior art in ai-provider-routing-per-sport.md).
@@ -612,20 +616,34 @@ model/prompt choice before real generations start):
      only — the UI runs on the default Model row, so the pre-season
      "single-model selection" is literally one IsDefault flag.
      `MatchupPreview` + capture rows gain ModelId FKs with the same
-     transition as PromptId (nullable → backfill from the existing
-     Model string → non-nullable).
+     transition as PromptId — with one rule: **backfill only
+     unambiguous Model-string matches; ambiguous rows stay unmapped
+     and are EXCLUDED from contamination-labeled scoring**, and new
+     experiment captures require the resolved identity before the FK
+     goes non-nullable.
    - **Batch runner**: enqueue experiments for every finalized game in a
      (season, week/league) range × models × prompts. Cost is trivial
      (~2k tokens/run; a 3-model × 2-prompt NFL season ≈ 3.5M tokens).
+     **Idempotent by construction**: each batch gets an ExperimentRunId
+     and rows are unique on (RunId, ContestId, ModelId, PromptId) —
+     reruns and provider retries cannot double-count; intentional
+     repeats are explicit replicate numbers, not duplicates.
    - **Scoring query**: captures → Contest, scoring a) straight-up
      winner, b) ATS winner, c) over/under, plus score MAE, grouped by
-     PromptVersion × Model — **always reported as EDGE OVER BASELINE,
-     never raw accuracy**. Baselines computed alongside: pick-the-
-     favorite SU (~66-67% NFL — a 62% model UNDERPERFORMS chalk),
-     home-ATS, always-Under. 52.4% ATS = break-even vs vig; one NFL
-     season (~285 games) has ~3% standard error, so ATS deltas need
-     both leagues and humility. Score MAE discriminates best at these
-     sample sizes.
+     PromptVersion × Model. **Persist the full tuple per group — raw
+     metric, baseline, edge, valid-sample count, excluded count, and
+     uncertainty** (edge-over-baseline is the headline, but absolutes
+     are retained: beating a weak baseline can still be unusable).
+     Denominators are defined up front: pushes/voids/ties and
+     missing-outcome rows are EXCLUDED and counted, not zeroed;
+     unparseable responses are excluded-and-counted (they already
+     carry ResponseValidationErrors). Baselines computed alongside:
+     pick-the-favorite SU (~66-67% NFL — a 62% model UNDERPERFORMS
+     chalk), home-ATS, always-Under. Break-even ATS is odds-derived
+     per row where odds exist (52.4% is only the standard -110
+     reference); one NFL season (~285 games) has ~3% standard error,
+     so ATS deltas need both leagues and humility. Score MAE
+     discriminates best at these sample sizes.
 
    **⚠️ THE MEMORIZATION GOTCHA (user-flagged, load-bearing):** every
    currently available model was trained through late-2025/2026, so
@@ -660,27 +678,45 @@ model/prompt choice before real generations start):
    prompt-refinement pool; current models join the stability/detector
    check. Example map (Claude fleet, user-supplied 2026-08-08) vs the
    2025 season (games Sep 2025 – Feb 2026):
-   | Model | Cutoff | 2025-season status |
+   | Model | Declared cutoff | 2025-season risk label |
    |---|---|---|
-   | Claude Sonnet 4.6 / Opus 4.6 | Aug 2025 | **CLEAN — entire season unseen; the gold backtest models** |
-   | Claude Haiku 4.5 | Jul 2025 | Clean (cheap floor) |
-   | Sonnet 5 / Fable 5 / Opus 4.8 / 4.7 | Jan 2026 | Sep–Dec contaminated; late playoffs ambiguous |
-   | Claude Opus 5 | May 2026 | Fully contaminated |
-   | Claude Opus 3 | Aug 2023 | Clean but 2 capability generations old — skip |
+   | Claude Sonnet 4.6 / Opus 4.6 | Aug 2025 | **Lower-risk — declared cutoff predates the season; preferred backtest models** |
+   | Claude Haiku 4.5 | Jul 2025 | Lower-risk (cheap floor) |
+   | Sonnet 5 / Fable 5 / Opus 4.8 / 4.7 | Jan 2026 | Higher-risk Sep–Dec; late playoffs ambiguous |
+   | Claude Opus 5 | May 2026 | Higher-risk, full season |
+   | Claude Opus 3 | Aug 2023 | Lower-risk but 2 capability generations old — skip |
 
-   **Sequencing (agreed):** (1) refine prompts on the CLEAN models —
-   full-2025 backtests there are absolutely trustworthy, upgrading the
-   earlier "backtests only rank prompts" rule; (2) transfer caveat:
-   prompt×model interaction is real — run finalists across the
-   contaminated/current models reading only STABILITY (valid,
-   well-calibrated output), not accuracy; (3) memorization detector for
-   contaminated models: EXACT-SCORE MATCH RATE vs actual finals — real
-   forecasters almost never nail exact scores; recall does — high rate
-   discounts that model's backtest; (4) pre-season single-model pick for
-   the UI is PROVISIONAL — clean-model backtests + stability/detector
-   reads decide the starting lineup; weeks 1–3 forward results (scored
-   live) can trigger a swap, since the production model is one default
-   away once routing exists. Rinse & repeat weekly.
+   Labels are RISK TIERS, not certainties: a pre-cutoff declaration
+   lowers direct-training risk but does not exclude provider-side
+   updates, retrieval, or benchmark leakage — and "Opus 3" style
+   family names are not concrete API identifiers. When the Model table
+   is built, each row records the exact API identifier, release date,
+   documented cutoff, evidence source, and verification date; forward
+   validation is required before any backtest result is treated as
+   forecasting evidence.
+
+   **Sequencing (agreed):** (1) refine prompts on the LOWER-RISK
+   models — full-2025 backtests there are the most trustworthy
+   comparisons available pre-season. Do NOT lean on higher-risk models
+   for prompt ranking: contamination is not uniform across prompts
+   (different wording/context can activate different memorized
+   associations, so a contaminated model can rank prompts by leakage
+   rather than forecasting quality); (2) transfer caveat: prompt×model
+   interaction is real — run finalists across the higher-risk/current
+   models reading only STABILITY (valid, well-calibrated output), not
+   accuracy; (3) memorization SCREEN for higher-risk models:
+   EXACT-SCORE MATCH RATE vs actual finals — a screening signal, not a
+   detector: a high rate is strong evidence of recall, but a low rate
+   does NOT prove memorization is absent; predeclare the decision rule
+   (e.g. exact-match rate vs the lower-risk models' own base rate as
+   the null) before discounting any model; (4) pre-season single-model
+   pick for the UI is PROVISIONAL — lower-risk-model backtests +
+   stability/screen reads decide the starting lineup. **Swap rule is
+   predeclared, not vibes**: early-season swaps trigger on
+   validity/stability failures (unparseable output, calibration
+   collapse), NOT on 1–3 weeks of accuracy — that sample is far too
+   noisy for ATS/O-U conclusions; accuracy-driven swaps wait for a
+   predeclared minimum sample. Rinse & repeat weekly.
 4. ~~Model routing~~ — folded into item 3.
 
 Deliberately NOT doing now: Preview Lab UX polish (compare/diff views —

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -571,6 +571,19 @@ model/prompt choice before real generations start):
    GameRecapPromptProvider deliberately untouched (still blob) — unify
    when recap work resumes.
 
+   **Follow-up (2026-08-08, deployed + seeded — 3 blobs imported):
+   used-prompt immutability.** `MatchupPreview.PromptId` (nullable Guid
+   FK → Prompt, Restrict delete; the processor stamps it on every new
+   generation). Transition plan: operator SQL backfills historical rows
+   from PromptVersion, THEN a later migration makes the column
+   non-nullable. Rule (enforced in UpdatePromptCommandHandler + shown in
+   the Prompt Manager as USED badges / read-only editor): **a prompt
+   whose Id appears in MatchupPreview.PromptId is IMMUTABLE — and
+   undeletable via the FK** — its text is provenance for real output;
+   iterate via "New version". Experiments (capture rows) do NOT freeze a
+   prompt — the lab iterates freely. Prompt Manager also gained explicit
+   Open / per-row New version actions.
+
 2. **with-history prompt blob** (user authors; blob-only per policy).
    Must teach: the metrics block (un-briefed since forever), HeadToHead
    + prior-season blocks (incl. "history excludes preseason by

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -591,16 +591,97 @@ model/prompt choice before real generations start):
    voice (no more "college football analyst" for NFL), updated example
    inputs (no AwaySpread, string Sport, hygiene shape). New blob name =
    provenance; selection logic gains the with-history variant.
-3. **Backtest harness MVP**: batch experiment enqueue ("every 2025
-   week-N game") + a scoring query joining MatchupPreviewPrompt captures
-   to Contest outcomes — SU accuracy, ATS accuracy, O/U accuracy, score
-   MAE, grouped by PromptVersion × Model. Mostly SQL over existing
-   tables; the lab already persists everything needed.
-4. **Model routing for experiments**: optional model override on
-   GenerateMatchupPreviewsCommand (capture rows already record Model) so
-   the harness compares prompt × model, not just prompts.
-   IProvideAiCommunication is single-bound today; see
-   ai-provider-routing-per-sport.md for prior art.
+3. **Backtest harness spec** (expanded 2026-08-08 from user's automated
+   multi-model experiment idea). Pieces already in place: sandboxed
+   Experiment mode (as-of filtered = pre-kickoff information state),
+   PromptId variant selection, captures recording model + prompt +
+   response, Contest holding ground truth (winner / spread winner / O/U
+   result). To build:
+   - **Model routing** (design sketched 2026-08-08, user thinking
+     aloud — mirrors the Prompt-entity pattern exactly): new
+     `ModelProvider` (name, credentials/config reference) and `Model`
+     entities in API's DB — provider FK, api model id string, display
+     name, **KnowledgeCutoffUtc** (makes contamination triage a QUERY:
+     the scoring join labels each experiment clean/contaminated by
+     comparing game StartDateUtc vs the model's cutoff — no doc
+     lookups), IsActive, IsDefault, cost metadata. `ModelId` on
+     GenerateMatchupPreviewsCommand routes generation through a
+     multi-provider IProvideAiCommunication registration (single-bound
+     to DeepSeek today; prior art in ai-provider-routing-per-sport.md).
+     Same guardrail as PromptId: override honored Capture/Experiment
+     only — the UI runs on the default Model row, so the pre-season
+     "single-model selection" is literally one IsDefault flag.
+     `MatchupPreview` + capture rows gain ModelId FKs with the same
+     transition as PromptId (nullable → backfill from the existing
+     Model string → non-nullable).
+   - **Batch runner**: enqueue experiments for every finalized game in a
+     (season, week/league) range × models × prompts. Cost is trivial
+     (~2k tokens/run; a 3-model × 2-prompt NFL season ≈ 3.5M tokens).
+   - **Scoring query**: captures → Contest, scoring a) straight-up
+     winner, b) ATS winner, c) over/under, plus score MAE, grouped by
+     PromptVersion × Model — **always reported as EDGE OVER BASELINE,
+     never raw accuracy**. Baselines computed alongside: pick-the-
+     favorite SU (~66-67% NFL — a 62% model UNDERPERFORMS chalk),
+     home-ATS, always-Under. 52.4% ATS = break-even vs vig; one NFL
+     season (~285 games) has ~3% standard error, so ATS deltas need
+     both leagues and humility. Score MAE discriminates best at these
+     sample sizes.
+
+   **⚠️ THE MEMORIZATION GOTCHA (user-flagged, load-bearing):** every
+   currently available model was trained through late-2025/2026, so
+   2025 results are plausibly IN the training data — the payload names
+   teams and dates, and a model can "predict" a memorized outcome.
+   A great backtest number is evidence of memorization before it is
+   evidence of forecasting. **Prompt-level mitigation ("do not use
+   prior knowledge of this game") does NOT work and must not be
+   trusted**: parametric knowledge is not a queryable store the model
+   can decline to consult — it is baked into the same weights doing the
+   reasoning, models cannot introspect which memories shaped an output,
+   and compliance claims are performance, not capability. Real
+   mitigations, strongest first:
+   1. **Forward-testing is the only clean eval**: run experiments
+      before each 2026 week, score after. Capture timestamps make this
+      free starting week 1.
+   2. Prefer models whose knowledge cutoff predates the tested games.
+   3. Use backtests mainly to rank PROMPTS within a model
+      (memorization contaminates all prompts of a model roughly
+      equally); rank MODELS via forward-tests.
+   4. (Partial, backtest-only) team pseudonymization in the payload
+      ("Team A/B") strips the lookup handle — but degrades the
+      program-identity signal prompts rely on, and history rows can
+      still fingerprint the matchup. Optional experiment variant, not
+      a default.
+
+   **Knowledge-cutoff triage — provider-agnostic protocol.** No
+   assumption that any provider's models are best for this reasoning
+   (user explicit: perhaps DeepSeek — unknown; the incumbent DeepSeek
+   is in the bake-off). Build the same map per candidate fleet
+   (DeepSeek, OpenAI, Google, ...): clean-for-2025 models join the
+   prompt-refinement pool; current models join the stability/detector
+   check. Example map (Claude fleet, user-supplied 2026-08-08) vs the
+   2025 season (games Sep 2025 – Feb 2026):
+   | Model | Cutoff | 2025-season status |
+   |---|---|---|
+   | Claude Sonnet 4.6 / Opus 4.6 | Aug 2025 | **CLEAN — entire season unseen; the gold backtest models** |
+   | Claude Haiku 4.5 | Jul 2025 | Clean (cheap floor) |
+   | Sonnet 5 / Fable 5 / Opus 4.8 / 4.7 | Jan 2026 | Sep–Dec contaminated; late playoffs ambiguous |
+   | Claude Opus 5 | May 2026 | Fully contaminated |
+   | Claude Opus 3 | Aug 2023 | Clean but 2 capability generations old — skip |
+
+   **Sequencing (agreed):** (1) refine prompts on the CLEAN models —
+   full-2025 backtests there are absolutely trustworthy, upgrading the
+   earlier "backtests only rank prompts" rule; (2) transfer caveat:
+   prompt×model interaction is real — run finalists across the
+   contaminated/current models reading only STABILITY (valid,
+   well-calibrated output), not accuracy; (3) memorization detector for
+   contaminated models: EXACT-SCORE MATCH RATE vs actual finals — real
+   forecasters almost never nail exact scores; recall does — high rate
+   discounts that model's backtest; (4) pre-season single-model pick for
+   the UI is PROVISIONAL — clean-model backtests + stability/detector
+   reads decide the starting lineup; weeks 1–3 forward results (scored
+   live) can trigger a swap, since the production model is one default
+   away once routing exists. Rinse & repeat weekly.
+4. ~~Model routing~~ — folded into item 3.
 
 Deliberately NOT doing now: Preview Lab UX polish (compare/diff views —
 curl-grade is fine for a single operator); NCAA-specific H2H tuning

--- a/src/SportsData.Api/Application/Admin/Prompts/GetPromptsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/GetPromptsQueryHandler.cs
@@ -17,6 +17,10 @@ public class PromptSummaryDto
     public bool IsDefault { get; set; }
     public string? Description { get; set; }
     public int TextLength { get; set; }
+
+    /// <summary>Real previews generated with this prompt. Non-zero = the prompt is immutable.</summary>
+    public int UsedByPreviewCount { get; set; }
+
     public DateTime CreatedUtc { get; set; }
 }
 
@@ -60,6 +64,7 @@ public class GetPromptsQueryHandler : IGetPromptsQueryHandler
                 IsDefault = p.IsDefault,
                 Description = p.Description,
                 TextLength = p.Text.Length,
+                UsedByPreviewCount = _dataContext.MatchupPreviews.Count(mp => mp.PromptId == p.Id),
                 CreatedUtc = p.CreatedUtc
             })
             .ToListAsync(cancellationToken);
@@ -93,6 +98,7 @@ public class GetPromptByIdQueryHandler : IGetPromptByIdQueryHandler
                 Description = p.Description,
                 TextLength = p.Text.Length,
                 Text = p.Text,
+                UsedByPreviewCount = _dataContext.MatchupPreviews.Count(mp => mp.PromptId == p.Id),
                 CreatedUtc = p.CreatedUtc
             })
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
@@ -73,6 +73,21 @@ public class UpdatePromptCommandHandler : IUpdatePromptCommandHandler
                 [new ValidationFailure(nameof(command.PromptId), "Prompt not found")]);
         }
 
+        // A prompt that generated real output is IMMUTABLE — its text is
+        // part of the provenance record for those previews. Experiments
+        // (capture rows) don't freeze a prompt; only MatchupPreview does.
+        var usedByPreviews = await _dataContext.MatchupPreviews
+            .AsNoTracking()
+            .AnyAsync(mp => mp.PromptId == command.PromptId, cancellationToken);
+
+        if (usedByPreviews)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(command.PromptId), "This prompt has generated real previews and is immutable — create a new version instead.")]);
+        }
+
         prompt.Text = command.Text.Replace("\r\n", "\n");
         prompt.Description = command.Description;
         prompt.ModifiedUtc = _dateTimeProvider.UtcNow();

--- a/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Prompts/UpdatePromptCommand.cs
@@ -76,6 +76,16 @@ public class UpdatePromptCommandHandler : IUpdatePromptCommandHandler
         // A prompt that generated real output is IMMUTABLE — its text is
         // part of the provenance record for those previews. Experiments
         // (capture rows) don't freeze a prompt; only MatchupPreview does.
+        //
+        // Known TOCTOU window (reviewed, accepted): a generation in flight
+        // can read the old text, this update can commit, and the preview
+        // can then persist referencing this PromptId. This check is a UX
+        // guardrail, NOT the provenance source of truth — every generation
+        // persists the EXACT text it sent on its capture row
+        // (MatchupPreviewPrompt.PromptText, linked to the preview), so
+        // provenance survives the race by construction. Serializing prompt
+        // updates against multi-minute generation runs would buy nothing
+        // the capture doesn't already guarantee.
         var usedByPreviews = await _dataContext.MatchupPreviews
             .AsNoTracking()
             .AnyAsync(mp => mp.PromptId == command.PromptId, cancellationToken);

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -258,6 +258,7 @@ namespace SportsData.Api.Application.Previews
                 ValidationErrors = null,
                 CreatedUtc = _dateTimeProvider.UtcNow(),
                 CreatedBy = command.CorrelationId,
+                PromptId = assembled.PromptId,
                 PromptVersion = assembled.PromptName,
                 IterationsRequired = 1,
                 UsedMetrics = assembled.Matchup.AwayMetrics != null

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
@@ -32,6 +32,17 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         public string? ValidationErrors { get; set; }
 
         public string? PromptVersion { get; set; }
+
+        /// <summary>
+        /// FK to the Prompt entity that generated this preview. Nullable
+        /// during the transition (historical rows are backfilled by
+        /// operator SQL, then the column goes non-nullable). Once a
+        /// prompt's Id appears here it is IMMUTABLE — edits are rejected;
+        /// create a new version instead.
+        /// </summary>
+        public Guid? PromptId { get; set; }
+
+        public Prompt? Prompt { get; set; }
         public DateTime? ApprovedUtc { get; set; }
 
         public DateTime? RejectedUtc { get; set; }
@@ -61,6 +72,15 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.Property(l => l.OverUnderPrediction)
                     .HasConversion<int>()
                     .IsRequired();
+
+                // Restrict: a prompt referenced by real output can never be
+                // deleted — it is part of the provenance record.
+                builder.HasOne(x => x.Prompt)
+                    .WithMany()
+                    .HasForeignKey(x => x.PromptId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                builder.HasIndex(x => x.PromptId);
             }
         }
     }

--- a/src/SportsData.Api/Migrations/20260808200156_AddMatchupPreviewPromptId.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260808200156_AddMatchupPreviewPromptId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260808200156_AddMatchupPreviewPromptId")]
+    partial class AddMatchupPreviewPromptId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260808200156_AddMatchupPreviewPromptId.cs
+++ b/src/SportsData.Api/Migrations/20260808200156_AddMatchupPreviewPromptId.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMatchupPreviewPromptId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PromptId",
+                table: "MatchupPreview",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MatchupPreview_PromptId",
+                table: "MatchupPreview",
+                column: "PromptId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MatchupPreview_Prompt_PromptId",
+                table: "MatchupPreview",
+                column: "PromptId",
+                principalTable: "Prompt",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MatchupPreview_Prompt_PromptId",
+                table: "MatchupPreview");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MatchupPreview_PromptId",
+                table: "MatchupPreview");
+
+            migrationBuilder.DropColumn(
+                name: "PromptId",
+                table: "MatchupPreview");
+        }
+    }
+}

--- a/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
@@ -21,6 +21,7 @@ const EMPTY_FORM = {
   isDefault: false,
   description: '',
   text: '',
+  usedByPreviewCount: 0,
 };
 
 /**
@@ -50,6 +51,8 @@ export default function AdminPromptsPage() {
     isDefault: false,
   });
 
+  const isImmutable = form.usedByPreviewCount > 0;
+
   const loadPrompts = useCallback(async () => {
     setLoading(true);
     try {
@@ -72,20 +75,42 @@ export default function AdminPromptsPage() {
     setForm(prefill);
   };
 
+  const fetchPrompt = async (promptId) => {
+    const res = await apiWrapper.Admin.getPrompt(promptId);
+    const p = res.data;
+    return {
+      name: p.name,
+      sport: p.sport ?? '',
+      withStats: p.withStats,
+      isDefault: p.isDefault,
+      description: p.description ?? '',
+      text: p.text,
+      usedByPreviewCount: p.usedByPreviewCount ?? 0,
+    };
+  };
+
   const handleSelect = async (promptId) => {
     try {
-      const res = await apiWrapper.Admin.getPrompt(promptId);
-      const p = res.data;
       setMode('edit');
       setSelectedId(promptId);
-      setForm({
-        name: p.name,
-        sport: p.sport ?? '',
-        withStats: p.withStats,
-        isDefault: p.isDefault,
-        description: p.description ?? '',
-        text: p.text,
+      setForm(await fetchPrompt(promptId));
+    } catch (err) {
+      toast.error(err?.message ?? 'Failed to load prompt');
+    }
+  };
+
+  // Per-row copy-as-new-version: loads the prompt and drops the editor
+  // straight into create mode with the same slot and text.
+  const handleNewVersionOf = async (promptId) => {
+    try {
+      const loaded = await fetchPrompt(promptId);
+      resetToCreate({
+        ...loaded,
+        name: `${loaded.name}-v`,
+        isDefault: false,
+        usedByPreviewCount: 0,
       });
+      toast('Editing a NEW version — give it a name and save.', { icon: '📝' });
     } catch (err) {
       toast.error(err?.message ?? 'Failed to load prompt');
     }
@@ -281,13 +306,23 @@ export default function AdminPromptsPage() {
                       {p.name}
                     </button>
                     {p.isDefault && <span style={{ color: 'var(--color-success, #27ae60)', fontSize: '0.8rem', fontWeight: 700 }}>DEFAULT</span>}
+                    {p.usedByPreviewCount > 0 && (
+                      <span
+                        style={{ color: 'var(--text-secondary)', fontSize: '0.8rem', fontWeight: 700 }}
+                        title={`Generated ${p.usedByPreviewCount} real preview(s) — text is immutable; create a new version to change it`}
+                      >
+                        USED ×{p.usedByPreviewCount}
+                      </span>
+                    )}
                   </div>
                   <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 4 }}>
                     <span>{sportLabel(p.sport)}</span>
                     <span>{p.withStats ? 'with stats' : 'no stats'}</span>
                     <span>{p.textLength?.toLocaleString()} chars</span>
                   </div>
-                  <div style={{ display: 'flex', gap: 8, marginTop: 6 }}>
+                  <div style={{ display: 'flex', gap: 8, marginTop: 6, flexWrap: 'wrap' }}>
+                    <button type="button" onClick={() => handleSelect(p.id)}>Open</button>
+                    <button type="button" onClick={() => handleNewVersionOf(p.id)}>New version</button>
                     {!p.isDefault && (
                       <button type="button" disabled={submitting} onClick={() => handleSetDefault(p.id)}>
                         Set default
@@ -304,7 +339,11 @@ export default function AdminPromptsPage() {
           <section>
             <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-                <strong>{mode === 'edit' ? `Editing: ${form.name}` : 'New prompt'}</strong>
+                <strong>
+                  {mode === 'edit'
+                    ? `${isImmutable ? 'Viewing (immutable)' : 'Editing'}: ${form.name}`
+                    : 'New prompt'}
+                </strong>
                 {mode === 'edit' && (
                   <>
                     <button type="button" onClick={handleNewVersionFrom}>New version from this</button>
@@ -312,6 +351,13 @@ export default function AdminPromptsPage() {
                   </>
                 )}
               </div>
+              {mode === 'edit' && isImmutable && (
+                <div style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+                  This prompt has generated {form.usedByPreviewCount} real
+                  preview(s) — its text is part of their provenance and cannot
+                  change. Use “New version from this” to iterate.
+                </div>
+              )}
 
               {mode === 'create' && (
                 <>
@@ -366,6 +412,7 @@ export default function AdminPromptsPage() {
 
               <textarea
                 aria-label="Prompt instruction text"
+                readOnly={mode === 'edit' && isImmutable}
                 value={form.text}
                 onChange={(e) => setForm(f => ({ ...f, text: e.target.value }))}
                 placeholder="prompt instruction text"
@@ -381,7 +428,7 @@ export default function AdminPromptsPage() {
               />
 
               <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                <button type="submit" disabled={submitting}>
+                <button type="submit" disabled={submitting || (mode === 'edit' && isImmutable)}>
                   {mode === 'edit' ? 'Save changes' : 'Create prompt'}
                 </button>
                 <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>

--- a/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
@@ -76,6 +76,10 @@ export default function AdminPromptsPage() {
   }, [loadPrompts]);
 
   const resetToCreate = (prefill = EMPTY_FORM) => {
+    // Invalidate any in-flight prompt load — without this, Cancel/New
+    // version during a slow load lets the late response overwrite the
+    // freshly reset editor.
+    promptLoadSeqRef.current += 1;
     setMode('create');
     setSelectedId(null);
     setForm(prefill);

--- a/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPromptsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import './AdminPage.css';
 import AdminHeader from './AdminHeader';
@@ -53,6 +53,12 @@ export default function AdminPromptsPage() {
 
   const isImmutable = form.usedByPreviewCount > 0;
 
+  // Request-generation token: two prompt loads can resolve out of order
+  // (double-click, slow network) and the stale response must not
+  // overwrite the editor for the newer selection — same discipline as
+  // the Preview Lab's loadCaptures.
+  const promptLoadSeqRef = useRef(0);
+
   const loadPrompts = useCallback(async () => {
     setLoading(true);
     try {
@@ -90,11 +96,15 @@ export default function AdminPromptsPage() {
   };
 
   const handleSelect = async (promptId) => {
+    const seq = ++promptLoadSeqRef.current;
     try {
+      const loaded = await fetchPrompt(promptId);
+      if (seq !== promptLoadSeqRef.current) return; // stale response
       setMode('edit');
       setSelectedId(promptId);
-      setForm(await fetchPrompt(promptId));
+      setForm(loaded);
     } catch (err) {
+      if (seq !== promptLoadSeqRef.current) return;
       toast.error(err?.message ?? 'Failed to load prompt');
     }
   };
@@ -102,8 +112,10 @@ export default function AdminPromptsPage() {
   // Per-row copy-as-new-version: loads the prompt and drops the editor
   // straight into create mode with the same slot and text.
   const handleNewVersionOf = async (promptId) => {
+    const seq = ++promptLoadSeqRef.current;
     try {
       const loaded = await fetchPrompt(promptId);
+      if (seq !== promptLoadSeqRef.current) return; // stale response
       resetToCreate({
         ...loaded,
         name: `${loaded.name}-v`,
@@ -112,6 +124,7 @@ export default function AdminPromptsPage() {
       });
       toast('Editing a NEW version — give it a name and save.', { icon: '📝' });
     } catch (err) {
+      if (seq !== promptLoadSeqRef.current) return;
       toast.error(err?.message ?? 'Failed to load prompt');
     }
   };

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Prompts/CreatePromptCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Prompts/CreatePromptCommandHandlerTests.cs
@@ -148,6 +148,50 @@ namespace SportsData.Api.Tests.Unit.Application.Admin.Prompts
         }
 
         [Fact]
+        public async Task Update_Rejected_WhenPromptGeneratedRealPreviews()
+        {
+            // Arrange — the prompt has produced actual output; its text is
+            // provenance and must be immutable.
+            var prompt = new Prompt { Id = Guid.NewGuid(), Name = "used-v1", WithStats = true, IsDefault = true, Text = "USED" };
+            await DataContext.Prompts.AddAsync(prompt);
+            await DataContext.MatchupPreviews.AddAsync(new MatchupPreview
+            {
+                Id = Guid.NewGuid(),
+                ContestId = Guid.NewGuid(),
+                PromptId = prompt.Id
+            });
+            await DataContext.SaveChangesAsync();
+
+            Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+            var sut = Mocker.CreateInstance<UpdatePromptCommandHandler>();
+
+            // Act
+            var result = await sut.ExecuteAsync(new UpdatePromptCommand
+            {
+                PromptId = prompt.Id,
+                Text = "CHANGED"
+            }, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Equal("USED", DataContext.Prompts.Single(p => p.Id == prompt.Id).Text);
+
+            // A prompt only used by EXPERIMENTS (capture rows) stays
+            // editable — only MatchupPreview freezes it.
+            var labOnly = new Prompt { Id = Guid.NewGuid(), Name = "lab-v1", WithStats = true, Text = "LAB" };
+            await DataContext.Prompts.AddAsync(labOnly);
+            await DataContext.SaveChangesAsync();
+
+            var labResult = await sut.ExecuteAsync(new UpdatePromptCommand
+            {
+                PromptId = labOnly.Id,
+                Text = "TUNED"
+            }, CancellationToken.None);
+
+            Assert.True(labResult.IsSuccess);
+        }
+
+        [Fact]
         public async Task ImportFromBlob_CreatesPrompt_WithBlobText()
         {
             Mocker.GetMock<IProvideBlobStorage>()

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -268,6 +268,9 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             var preview = Assert.Single(DataContext.MatchupPreviews);
             var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
 
+            // The preview records WHICH Prompt entity generated it — the FK
+            // that makes used prompts immutable.
+            Assert.Equal(DefaultPromptId, preview.PromptId);
             Assert.Equal(preview.Id, capture.MatchupPreviewId);
             Assert.Equal(PreviewGenerationMode.Generate, capture.Mode);
             Assert.Equal(preview.PromptVersion, capture.PromptVersion);


### PR DESCRIPTION
## Summary

A prompt that has generated real output is part of that output's provenance and must be immutable. This wires the enforcement end to end, per the agreed transition plan.

### Backend

- **`MatchupPreview.PromptId`** — nullable Guid FK → `Prompt` with **Restrict** delete (a used prompt can be neither edited nor deleted), indexed. Additive migration.
- The processor stamps `PromptId` on every **new** generation — operator SQL only needs to backfill historical rows (`PromptVersion` → `Prompt.Name` join; names are unique). A later migration makes the column non-nullable once the backfill lands.
- `UpdatePromptCommandHandler` rejects edits to any prompt whose Id appears in `MatchupPreview.PromptId`. **Correct through the transition**: pre-backfill rows have null `PromptId`, so nothing locks prematurely; each backfilled row extends the protection.
- Deliberate and tested both ways: **experiments (capture rows) do NOT freeze a prompt** — only real output does, so Preview Lab iteration stays free.
- Prompt DTOs gain `UsedByPreviewCount`.

### Web (Prompt Manager)

- Explicit **Open** + per-row **New version** actions (New version loads the prompt and enters create mode with slot + text prefilled, name suffixed for completion).
- **USED ×N** badges; opening a used prompt shows "Viewing (immutable)" with the reason, a read-only textarea, and disabled save — matching the API's enforcement, with "New version from this" as the forward path.

### Tests

653 API + 10 web pass; full solution builds. Coverage: immutability rejection, experiment-only prompts stay editable, processor stamps PromptId on generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Matchup previews now retain the prompt used to generate them.
  - Prompt Manager displays preview usage and marks prompts used by previews as immutable.
  - Added support for creating new prompt versions while preserving experiment editing.

- **Bug Fixes**
  - Prevented edits to prompts referenced by generated previews.

- **Documentation**
  - Documented prompt provenance, backfill behavior, and prompt immutability rules.
  - Expanded backtesting guidance to cover model routing, batch experiments, scoring baselines, contamination, memorization detection, and forward testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->