### PR TITLE
feat(api): MatchupPreview.PromptId non-nullable; drop PromptVersion

### DIFF
--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -725,3 +725,43 @@ curl-grade is fine for a single operator); NCAA-specific H2H tuning
 metrics-service question (parked until previews flow — see memory);
 per-row odds provider selection (a different book's preview = a new
 run against that provider's data).
+
+---
+
+## 7. Target architecture: the model predicts, the LLM explains (2026-08-08)
+
+**Goal framing (user, explicit):** this is NOT about beating Vegas.
+The bar is "given enough data, can we produce genuinely interesting,
+honest information for users (and for us)?" Success = CALIBRATION and
+consistency, not edge. The scoring harness (§6) remains fully valuable
+under this framing — as quality control, not alpha-hunting; market
+lines are context to reason against, not a benchmark to promise
+victory over.
+
+**The shape:**
+1. **Stats model predicts** (Python, over the play-by-play metrics
+   corpus): win probability, projected spread, projected total, top
+   factor contributions. Outputs are TINY (~15 numbers) — the corpus
+   never enters the payload, only conclusions do. New `ModelProjection`
+   payload block, same both-or-nothing hygiene as metrics.
+2. **LLM explains** — ONE generation pass, fully conditioned on
+   everything including the projection. No draft-then-revise loop:
+   revision loops reconcile disagreements created by withholding data
+   from the first pass (user's own conclusion), and they double cost
+   while inviting hedge-mush.
+3. **Critic validates** — a cheap second model reads the finished
+   preview against the payload: does the narrative contradict the
+   data? On failure it emits a note into the EXISTING rejection-note →
+   regenerate machinery (#601). The human editor loop generalizes to an
+   automated editor; human review is reserved for taste.
+
+**Dependency (user: "sooner than later"):** the Python track unparks
+(its parking trigger — previews flowing — is met). Two workstreams:
+(a) in-season metrics cadence — weekly FranchiseSeasonMetric refresh
+feeding the with-stats path and future prior-season blocks (needed
+regardless); (b) the projection model itself (new build) — inputs from
+the corpus, outputs = the ModelProjection contract above. The
+CronJob-vs-service decision from the parked note gets made as part of
+(a). RAG/vectors: NOT needed for structured data (SQL payload assembly
+IS exact retrieval); revisit only if unstructured sources (injury
+news, beat coverage) get added to payloads someday.

--- a/src/SportsData.Api/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandler.cs
@@ -56,6 +56,18 @@ public class UpsertMatchupPreviewCommandHandler : IUpsertMatchupPreviewCommandHa
                     [new ValidationFailure(nameof(command.JsonContent), "Invalid preview content")]);
             }
 
+            // PromptId is a non-nullable FK — a manual upsert without one
+            // (or with an unknown one) would otherwise die as an opaque
+            // database FK violation at save.
+            if (preview.PromptId == Guid.Empty ||
+                !await _dataContext.Prompts.AsNoTracking().AnyAsync(p => p.Id == preview.PromptId, cancellationToken))
+            {
+                return new Failure<Guid>(
+                    default,
+                    ResultStatus.Validation,
+                    [new ValidationFailure(nameof(MatchupPreview.PromptId), "Preview JSON must reference an existing Prompt via promptId (see GET /admin/prompts)")]);
+            }
+
             // Wrap in the DbContext execution strategy: EnableRetryOnFailure is configured
             // globally for Npgsql (see Core/DependencyInjection/ServiceRegistration.cs),
             // and raw BeginTransactionAsync under a retry strategy throws at runtime unless

--- a/src/SportsData.Api/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandler.cs
@@ -38,7 +38,7 @@ public class UpsertMatchupPreviewCommandHandler : IUpsertMatchupPreviewCommandHa
         if (!validationResult.IsValid)
         {
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.Validation,
                 validationResult.Errors);
         }
@@ -51,7 +51,7 @@ public class UpsertMatchupPreviewCommandHandler : IUpsertMatchupPreviewCommandHa
             {
                 _logger.LogWarning("Invalid preview content provided");
                 return new Failure<Guid>(
-                    default,
+                    default!,
                     ResultStatus.Validation,
                     [new ValidationFailure(nameof(command.JsonContent), "Invalid preview content")]);
             }
@@ -63,7 +63,7 @@ public class UpsertMatchupPreviewCommandHandler : IUpsertMatchupPreviewCommandHa
                 !await _dataContext.Prompts.AsNoTracking().AnyAsync(p => p.Id == preview.PromptId, cancellationToken))
             {
                 return new Failure<Guid>(
-                    default,
+                    default!,
                     ResultStatus.Validation,
                     [new ValidationFailure(nameof(MatchupPreview.PromptId), "Preview JSON must reference an existing Prompt via promptId (see GET /admin/prompts)")]);
             }
@@ -100,7 +100,7 @@ public class UpsertMatchupPreviewCommandHandler : IUpsertMatchupPreviewCommandHa
         {
             _logger.LogError(ex, "Error upserting matchup preview");
             return new Failure<Guid>(
-                default,
+                default!,
                 ResultStatus.Error,
                 [new ValidationFailure("Error", "An error occurred while upserting the matchup preview")]);
         }

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -259,7 +259,6 @@ namespace SportsData.Api.Application.Previews
                 CreatedUtc = _dateTimeProvider.UtcNow(),
                 CreatedBy = command.CorrelationId,
                 PromptId = assembled.PromptId,
-                PromptVersion = assembled.PromptName,
                 IterationsRequired = 1,
                 UsedMetrics = assembled.Matchup.AwayMetrics != null
             };

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
@@ -31,16 +31,15 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public string? ValidationErrors { get; set; }
 
-        public string? PromptVersion { get; set; }
-
         /// <summary>
-        /// FK to the Prompt entity that generated this preview. Nullable
-        /// during the transition (historical rows are backfilled by
-        /// operator SQL, then the column goes non-nullable). Once a
+        /// FK to the Prompt entity that generated this preview (transition
+        /// complete 2026-08-08: historical rows backfilled from the old
+        /// PromptVersion string, column non-nullable, PromptVersion
+        /// dropped — the name now lives on the Prompt row). Once a
         /// prompt's Id appears here it is IMMUTABLE — edits are rejected;
         /// create a new version instead.
         /// </summary>
-        public Guid? PromptId { get; set; }
+        public Guid PromptId { get; set; }
 
         public Prompt? Prompt { get; set; }
         public DateTime? ApprovedUtc { get; set; }
@@ -64,7 +63,6 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.Property(x => x.Prediction).HasMaxLength(768);
 
                 builder.Property(x => x.Model).HasMaxLength(50);
-                builder.Property(x => x.PromptVersion).HasMaxLength(50);
 
                 builder.Property(x => x.ValidationErrors).HasMaxLength(1024);
                 builder.Property(x => x.RejectionNote).HasMaxLength(512);

--- a/src/SportsData.Api/Migrations/20260808215827_MatchupPreviewPromptIdNonNullDropPromptVersion.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260808215827_MatchupPreviewPromptIdNonNullDropPromptVersion.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260808215827_MatchupPreviewPromptIdNonNullDropPromptVersion")]
+    partial class MatchupPreviewPromptIdNonNullDropPromptVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260808215827_MatchupPreviewPromptIdNonNullDropPromptVersion.cs
+++ b/src/SportsData.Api/Migrations/20260808215827_MatchupPreviewPromptIdNonNullDropPromptVersion.cs
@@ -11,6 +11,20 @@ namespace SportsData.Api.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Idempotent safety net for environments where the operator
+            // backfill never ran (e.g. local dev DBs with legacy preview
+            // rows): map PromptVersion -> Prompt.Name (names are unique).
+            // Prod is a no-op — zero null rows, verified pre-merge. Any row
+            // that still has no match fails the SET NOT NULL below loudly,
+            // by design. Must run BEFORE PromptVersion is dropped.
+            migrationBuilder.Sql("""
+                UPDATE "MatchupPreview" mp
+                SET "PromptId" = p."Id"
+                FROM "Prompt" p
+                WHERE mp."PromptId" IS NULL
+                  AND mp."PromptVersion" = p."Name";
+                """);
+
             migrationBuilder.DropColumn(
                 name: "PromptVersion",
                 table: "MatchupPreview");
@@ -43,6 +57,16 @@ namespace SportsData.Api.Migrations
                 type: "character varying(50)",
                 maxLength: 50,
                 nullable: true);
+
+            // Repopulate the recreated column from the Prompt row so a
+            // rollback is not lossy (LEFT guards names > 50 chars, the
+            // column's own limit).
+            migrationBuilder.Sql("""
+                UPDATE "MatchupPreview" mp
+                SET "PromptVersion" = LEFT(p."Name", 50)
+                FROM "Prompt" p
+                WHERE p."Id" = mp."PromptId";
+                """);
         }
     }
 }

--- a/src/SportsData.Api/Migrations/20260808215827_MatchupPreviewPromptIdNonNullDropPromptVersion.cs
+++ b/src/SportsData.Api/Migrations/20260808215827_MatchupPreviewPromptIdNonNullDropPromptVersion.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MatchupPreviewPromptIdNonNullDropPromptVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PromptVersion",
+                table: "MatchupPreview");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "PromptId",
+                table: "MatchupPreview",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "PromptId",
+                table: "MatchupPreview",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PromptVersion",
+                table: "MatchupPreview",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandlerTests.cs
@@ -51,6 +51,20 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
         failure.Errors.Should().NotBeEmpty();
     }
 
+    private async Task<Prompt> SeedPromptAsync()
+    {
+        var prompt = new Prompt
+        {
+            Id = Guid.NewGuid(),
+            Name = $"test-prompt-{Guid.NewGuid():N}",
+            WithStats = false,
+            Text = "TEST PROMPT"
+        };
+        await DataContext.Prompts.AddAsync(prompt);
+        await DataContext.SaveChangesAsync();
+        return prompt;
+    }
+
     [Fact]
     public async Task ExecuteAsync_ShouldCreateNewPreview_WhenNoExistingPreviewExists()
     {
@@ -58,13 +72,14 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
         var contestId = Guid.NewGuid();
         var previewId = Guid.NewGuid();
         var userId = Guid.NewGuid();
-        
+        var prompt = await SeedPromptAsync();
+
         // Create JSON with camelCase for deserialization (matches FromJson DefaultOptions)
         var json = $$"""
         {
             "id": "{{previewId}}",
             "contestId": "{{contestId}}",
-            "promptVersion": "v1.0",
+            "promptId": "{{prompt.Id}}",
             "overview": "Test overview",
             "analysis": "Test analysis",
             "prediction": "Test prediction",
@@ -102,11 +117,12 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
         var existingPreviewId = Guid.NewGuid();
         var userId = Guid.NewGuid();
         
+        var prompt = await SeedPromptAsync();
         var existingPreview = new MatchupPreview
         {
             Id = existingPreviewId,
             ContestId = contestId,
-            PromptVersion = "v1.0",
+            PromptId = prompt.Id,
             Overview = "Old overview",
             CreatedUtc = DateTime.UtcNow.AddDays(-1),
             CreatedBy = userId
@@ -115,12 +131,13 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
         await DataContext.MatchupPreviews.AddAsync(existingPreview);
         await DataContext.SaveChangesAsync();
 
+        var newPrompt = await SeedPromptAsync();
         var newPreviewId = Guid.NewGuid();
         var json = $$"""
         {
             "id": "{{newPreviewId}}",
             "contestId": "{{contestId}}",
-            "promptVersion": "v2.0",
+            "promptId": "{{newPrompt.Id}}",
             "overview": "New overview",
             "analysis": "New analysis",
             "createdUtc": "{{DateTime.UtcNow:O}}",
@@ -146,25 +163,57 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
         var newSaved = await DataContext.MatchupPreviews.FindAsync(newPreviewId);
         newSaved.Should().NotBeNull();
         newSaved!.Overview.Should().Be("New overview");
-        newSaved.PromptVersion.Should().Be("v2.0");
+        newSaved.PromptId.Should().Be(newPrompt.Id);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnValidationError_WhenPromptIdMissingOrUnknown()
+    {
+        // Arrange — non-nullable FK: an upsert without a valid promptId must
+        // fail with a clear validation message, not an opaque FK violation.
+        var json = $$"""
+        {
+            "id": "{{Guid.NewGuid()}}",
+            "contestId": "{{Guid.NewGuid()}}",
+            "promptId": "{{Guid.NewGuid()}}",
+            "overview": "No such prompt",
+            "createdUtc": "{{DateTime.UtcNow:O}}",
+            "createdBy": "{{Guid.NewGuid()}}"
+        }
+        """;
+
+        var handler = Mocker.CreateInstance<UpsertMatchupPreviewCommandHandler>();
+
+        // Act
+        var result = await handler.ExecuteAsync(new UpsertMatchupPreviewCommand(json), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Validation);
+        ((Failure<Guid>)result).Errors.Should().Contain(e => e.PropertyName == nameof(MatchupPreview.PromptId));
     }
 
     [Fact]
     public async Task ExecuteAsync_ShouldReturnError_WhenSaveChangesFails()
     {
-        // Arrange
+        // Arrange — prompt seeded BEFORE disposal so the PromptId check
+        // passes and the failure surfaces at save, per the test's intent.
         var contestId = Guid.NewGuid();
+        var prompt = await SeedPromptAsync();
         var preview = new MatchupPreview
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            PromptVersion = "v1.0",
+            PromptId = prompt.Id,
             Overview = "Test overview",
             CreatedUtc = DateTime.UtcNow,
             CreatedBy = Guid.NewGuid()
         };
 
-        var json = System.Text.Json.JsonSerializer.Serialize(preview);
+        // ToJson mirrors the handler's FromJson conventions (camelCase) —
+        // raw PascalCase Serialize would leave PromptId unbound and trip
+        // the validation before the save this test targets.
+        var json = SportsData.Core.Extensions.JsonExtensions.ToJson(preview);
         var command = new UpsertMatchupPreviewCommand(json);
 
         // Dispose the context to cause save to fail

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Commands/UpsertMatchupPreview/UpsertMatchupPreviewCommandHandlerTests.cs
@@ -11,6 +11,10 @@ namespace SportsData.Api.Tests.Unit.Application.Admin.Commands.UpsertMatchupPrev
 
 public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchupPreviewCommandHandler>
 {
+    // Fixed test clock per the no-DateTime.UtcNow rule — fixtures stay
+    // deterministic.
+    private static readonly DateTime FixedUtc = new(2026, 8, 8, 12, 0, 0, DateTimeKind.Utc);
+
     public UpsertMatchupPreviewCommandHandlerTests()
     {
         // Register validator
@@ -86,7 +90,7 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
             "predictedStraightUpWinner": "{{Guid.NewGuid()}}",
             "predictedSpreadWinner": "{{Guid.NewGuid()}}",
             "overUnderPrediction": 1,
-            "createdUtc": "{{DateTime.UtcNow:O}}",
+            "createdUtc": "{{FixedUtc:O}}",
             "createdBy": "{{userId}}"
         }
         """;
@@ -124,7 +128,7 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
             ContestId = contestId,
             PromptId = prompt.Id,
             Overview = "Old overview",
-            CreatedUtc = DateTime.UtcNow.AddDays(-1),
+            CreatedUtc = FixedUtc.AddDays(-1),
             CreatedBy = userId
         };
 
@@ -140,7 +144,7 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
             "promptId": "{{newPrompt.Id}}",
             "overview": "New overview",
             "analysis": "New analysis",
-            "createdUtc": "{{DateTime.UtcNow:O}}",
+            "createdUtc": "{{FixedUtc:O}}",
             "createdBy": "{{userId}}"
         }
         """;
@@ -177,7 +181,7 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
             "contestId": "{{Guid.NewGuid()}}",
             "promptId": "{{Guid.NewGuid()}}",
             "overview": "No such prompt",
-            "createdUtc": "{{DateTime.UtcNow:O}}",
+            "createdUtc": "{{FixedUtc:O}}",
             "createdBy": "{{Guid.NewGuid()}}"
         }
         """;
@@ -206,7 +210,7 @@ public class UpsertMatchupPreviewCommandHandlerTests : ApiTestBase<UpsertMatchup
             ContestId = contestId,
             PromptId = prompt.Id,
             Overview = "Test overview",
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = FixedUtc,
             CreatedBy = Guid.NewGuid()
         };
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Queries/GetMatchupPreview/GetMatchupPreviewQueryHandlerTests.cs
@@ -55,7 +55,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            PromptVersion = "v1.0",
+            PromptId = Guid.NewGuid(),
             Overview = "Test preview content",
             PredictedStraightUpWinner = Guid.NewGuid(),
             PredictedSpreadWinner = Guid.NewGuid(),
@@ -90,7 +90,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            PromptVersion = "v1.0",
+            PromptId = Guid.NewGuid(),
             Overview = "First preview",
             PredictedStraightUpWinner = Guid.NewGuid(),
             PredictedSpreadWinner = Guid.NewGuid(),
@@ -103,7 +103,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         {
             Id = Guid.NewGuid(),
             ContestId = contestId,
-            PromptVersion = "v2.0",
+            PromptId = Guid.NewGuid(),
             Overview = "Second preview",
             PredictedStraightUpWinner = Guid.NewGuid(),
             PredictedSpreadWinner = Guid.NewGuid(),
@@ -131,7 +131,7 @@ public class GetMatchupPreviewQueryHandlerTests : ApiTestBase<GetMatchupPreviewQ
         var returnedPreview = json.FromJson<MatchupPreview>();
         returnedPreview.Should().NotBeNull();
         returnedPreview!.Id.Should().Be(preview1.Id);
-        returnedPreview.PromptVersion.Should().Be("v1.0");
+        returnedPreview.PromptId.Should().NotBe(Guid.Empty);
         returnedPreview.Overview.Should().Be("First preview");
         returnedPreview.OverUnderPrediction.Should().Be(OverUnderPrediction.Over);
     }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -273,7 +273,7 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             Assert.Equal(DefaultPromptId, preview.PromptId);
             Assert.Equal(preview.Id, capture.MatchupPreviewId);
             Assert.Equal(PreviewGenerationMode.Generate, capture.Mode);
-            Assert.Equal(preview.PromptVersion, capture.PromptVersion);
+            Assert.Equal(preview.PromptId, capture.PromptId);
             Assert.Equal("test-model", capture.Model);
             Assert.NotNull(capture.RawResponse);
 
@@ -628,7 +628,7 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                     It.IsAny<CancellationToken>()), Times.Once);
 
             var preview = Assert.Single(DataContext.MatchupPreviews);
-            Assert.Equal("prediction-insights-with-stats-schedule", preview.PromptVersion);
+            Assert.Equal(DefaultPromptId, preview.PromptId);
         }
 
         [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -318,6 +318,7 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             {
                 Id = Guid.NewGuid(),
                 ContestId = _contestId,
+                PromptId = DefaultPromptId,
                 RejectedUtc = Now.AddDays(-1),
                 RejectionNote = "Too much spread parroting",
                 CreatedUtc = Now.AddDays(-1)


### PR DESCRIPTION
## Summary

Completes the prompt-provenance transition — operator backfill of all historical `MatchupPreview` rows confirmed complete.

- **`PromptId` → non-nullable** (migration fails loudly if any row escaped the backfill, rather than masking it with a default). **`PromptVersion` dropped** — the human-readable name lives on the `Prompt` row now. The capture table keeps *its* `PromptVersion` (blob-era captures have no Prompt entity to point at).
- Processor no longer writes `PromptVersion` on previews (it stopped needing to the moment the FK existed).
- **Manual admin upsert hardened**: `UpsertMatchupPreview` validates the preview JSON references an existing Prompt — a clear validation message instead of an opaque FK violation at save. New test covers missing/unknown promptId.
- Test fixes: upsert fixtures seed Prompt rows and carry `promptId`; the disposed-context test serializes via `ToJson` (FromJson's camelCase mirror) — raw PascalCase `Serialize` left `PromptId` unbound and tripped the new validation before the save that test targets.
- Doc rides along: §7 target architecture ("the model predicts, the LLM explains, the critic validates"; goal framing = calibration, not edge; Python track unparked).

## Tests

654 API tests pass; full solution builds. Migration is AlterColumn + DropColumn — run against the backfilled prod table only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matchup previews now require a valid prompt reference, improving traceability of generated content.
  * Added a target workflow for statistical projections, narrative generation, and automated validation.

* **Bug Fixes**
  * Invalid or missing prompt references now return a clear validation error.

* **Documentation**
  * Documented the planned metrics refresh and projection-model workflow for matchup previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->