### PR TITLE
feat(api,web): ModelProvider + Model entities, admin endpoints, Model Manager (harness PR A)

### DIFF
--- a/docs/metrics-modeling/llm-training-dates.md
+++ b/docs/metrics-modeling/llm-training-dates.md
@@ -1,0 +1,104 @@
+# LLM Model Registry — knowledge cutoffs vs the 2025 season
+
+Seed data for the coming `ModelProvider`/`Model` tables (design:
+`matchup-preview-data-inputs.md` §6). Compiled 2026-08-08 from provider
+documentation and cross-checked aggregators; every row needs
+re-verification against the provider's own docs when entered into the
+Model table (that is what the EvidenceSource/VerifiedUtc columns are
+for). Risk labels are relative to the 2025 season: NCAA week 0/1 =
+Aug 23 – Sep 1, 2025; NFL kickoff Sep 4, 2025; Super Bowl Feb 8, 2026.
+
+**Cutoff semantics matter:** contamination cares about the TRAINING
+data cutoff, not the "reliable knowledge" date some providers also
+publish. Where the two differ, the LATER (training) date governs the
+risk label. Any model run with server-side retrieval/search enabled
+(e.g. Grok's Web/X search) is contaminated regardless of cutoff —
+backtests must disable retrieval tools.
+
+## Anthropic (user-supplied from provider docs, 2026-08-08)
+
+| Model | API id | Released | Training cutoff | 2025-season risk |
+|---|---|---|---|---|
+| Claude Opus 5 | claude-opus-5 | 2026 | May 2026 | Higher — full season |
+| Claude Sonnet 5 | claude-sonnet-5 | 2026 | Jan 2026 | Higher — Sep–Dec |
+| Claude Fable 5 | claude-fable-5 | Jun 2026 | Jan 2026 | Higher — Sep–Dec |
+| Claude Opus 4.8 | claude-opus-4-8 | May 2026 | Jan 2026 | Higher — Sep–Dec |
+| Claude Opus 4.7 | claude-opus-4-7 | Apr 2026 | Jan 2026 | Higher — Sep–Dec |
+| Claude Sonnet 4.6 | claude-sonnet-4-6 | Jan 2026 | Aug 2025 ⚠️ | Lower (NFL + NCAA wk2+) — **VERIFY** |
+| Claude Opus 4.6 | claude-opus-4-6 | 2025 | Aug 2025 | Lower (NFL + NCAA wk2+) |
+| Claude Haiku 4.5 | claude-haiku-4-5 | Oct 2025 | Jul 2025 | Lower — full season (cheap floor) |
+| Claude Opus 3 | (family label — resolve exact id) | 2024 | Aug 2023 | Lower but 2 generations old — skip |
+
+⚠️ **Sonnet 4.6 discrepancy (load-bearing — resolve before trusting):**
+one cross-check source claims training data through Jan 2026 with only
+"reliable knowledge" at Aug 2025. If TRAINING ran to Jan 2026, Sonnet
+4.6 flips to higher-risk and Opus 4.6 deserves the same scrutiny.
+Verify against docs.anthropic.com before using either as a
+lower-risk backtest model.
+
+## OpenAI
+
+| Model | API id | Released | Training cutoff | 2025-season risk |
+|---|---|---|---|---|
+| GPT-5.5 / 5.5 Pro | gpt-5.5 / gpt-5.5-pro | Apr 2026 | Dec 1, 2025 | Higher — Sep–Nov |
+| GPT-5.4 / 5.4 Pro | gpt-5.4 / gpt-5.4-pro | Mar 2026 | Aug 31, 2025 | Lower for NFL + NCAA wk2+; NCAA wk0/1 INSIDE cutoff |
+| GPT-5.2 | gpt-5.2 | Dec 2025 | Aug 31, 2025 | Same as 5.4 |
+| GPT-4o | gpt-4o | May 2024 | Oct 2023 | Lower — full season (older capability) |
+
+Note the Aug 31, 2025 cutoffs: NCAA week 0/1 (Aug 23–31) sits INSIDE
+training for 5.4/5.2 — exactly why per-game
+`StartDateUtc >= Model.KnowledgeCutoffUtc` comparison beats per-season
+labels; the scoring query handles this boundary automatically.
+
+## Google
+
+| Model | API id | Released | Training cutoff | 2025-season risk |
+|---|---|---|---|---|
+| Gemini 3.5 Pro / Flash | gemini-3.5-pro / -flash | May 2026 | Jan 2025 ⚠️ conflicting claims (one source says Jan 2026) | Lower if Jan 2025 — **VERIFY via model card** |
+| Gemini 3.1 Pro | gemini-3.1-pro-preview | Feb 2026 | Jan 2025 | Lower — full season, current capability |
+| Gemini 2.5 Pro | gemini-2.5-pro | Mar 2025 | Jan 2025 | Lower — full season |
+
+If Jan 2025 holds for the 3.x line, Google offers the rare combo:
+CURRENT capability + lower-risk for the whole 2025 season.
+
+## DeepSeek (incumbent — provider does NOT publish cutoffs)
+
+| Model | API id | Released | Training cutoff | 2025-season risk |
+|---|---|---|---|---|
+| DeepSeek V4-Pro / V4-Flash | (per API docs) | Apr 2026 | UNPUBLISHED | Treat as higher — unknown = worst case |
+| DeepSeek V3 / R1 | deepseek-chat / deepseek-reasoner (verify) | Dec 2024 / Jan 2025 | ~Jul 2024 (inferred, unofficial) | Lower — full season, but undocumented |
+
+Action item: confirm which DeepSeek model id the current
+IProvideAiCommunication binding actually calls — that determines the
+incumbent's own risk label.
+
+## xAI
+
+| Model | API id | Released | Training cutoff | 2025-season risk |
+|---|---|---|---|---|
+| Grok 4.5 | (per docs.x.ai) | 2026 | Feb 1, 2026 | Higher — full season |
+| Grok 4.3 | (per docs.x.ai) | 2025/26 | Dec 2025 | Higher — Sep–Nov |
+
+Grok's server-side Web/X search MUST be disabled for any backtest run.
+
+## Others (cross-checked aggregator, Tier-2 confidence)
+
+| Model | Cutoff | 2025-season risk |
+|---|---|---|
+| Qwen 3 Max | Jun 30, 2025 | Lower — full season |
+| Kimi K2.6 | Apr 2025 | Lower — full season, current (Apr 2026) release |
+| Kimi K2 0905 | Dec 2024 | Lower — full season |
+| MiniMax M2.5 | Jan 2025 | Lower — full season |
+| MiniMax M3 | Jan 2026 | Higher — Sep–Dec |
+
+## The lower-risk backtest pool (pending the flagged verifications)
+
+Full-season lower-risk candidates with modern capability: Gemini
+3.1/3.5 line (if Jan 2025 verifies), Claude Haiku 4.5, Qwen 3 Max,
+Kimi K2.6, MiniMax M2.5, DeepSeek V3/R1 (undocumented caveat), GPT-4o
+(older). Near-full-season (NFL + NCAA wk2+): Claude Sonnet/Opus 4.6
+(pending the training-cutoff verification), GPT-5.4/5.2.
+
+Sources: user-supplied Anthropic list; metehan.ai LLM cutoff registry
+(2026-07-04); ai.google.dev changelog; docs.x.ai; DeepSeek V4 coverage
+(morphllm/codersera); HaoooWang/llm-knowledge-cutoff-dates.

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -621,6 +621,23 @@ model/prompt choice before real generations start):
      and are EXCLUDED from contamination-labeled scoring**, and new
      experiment captures require the resolved identity before the FK
      goes non-nullable.
+
+     **Provider strategy — DECIDED 2026-08-08: first-party clients
+     only.** Keep the existing DeepSeek client; add sibling
+     IProvideAiCommunication implementations for Anthropic, OpenAI, and
+     Google, resolved by a factory keyed off the Model row's provider —
+     the platform's established typed-client/factory idiom. Evaluated
+     and passed: **OpenRouter** (unified API, pass-through pricing —
+     but puts a third party in the prompt path, and provider routing
+     blurs open-weight model identity/quantization; acceptable
+     mitigations existed but first-party wins on IP-path and exact
+     identity; can be added later as just another ModelProvider row +
+     client if the long tail — Qwen/Kimi/MiniMax/xAI — ever earns its
+     way in) and **Ollama Cloud** (open-weight only — no
+     Claude/GPT/Gemini; per-tier model-count caps fight matrix sweeps;
+     subscription economics invert for bursty batch usage). The four
+     first-party fleets contain a sufficient lower-risk pool per
+     llm-training-dates.md.
    - **Batch runner**: enqueue experiments for every finalized game in a
      (season, week/league) range × models × prompts. Cost is trivial
      (~2k tokens/run; a 3-model × 2-prompt NFL season ≈ 3.5M tokens).

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -273,6 +273,102 @@ namespace SportsData.Api.Application.Admin
         }
 
         /// <summary>
+        /// Create an LLM provider row (pairs with a code-side client via
+        /// Kind — credentials live in AppConfig, never the DB).
+        /// </summary>
+        [HttpPost]
+        [Route("model-providers")]
+        public async Task<ActionResult<Guid>> CreateModelProvider(
+            [FromBody] Application.Admin.Models.CreateModelProviderCommand command,
+            [FromServices] Application.Admin.Models.ICreateModelProviderCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(command, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        [HttpGet]
+        [Route("model-providers")]
+        public async Task<ActionResult<List<Application.Admin.Models.ModelProviderDto>>> GetModelProviders(
+            [FromServices] Application.Admin.Models.IGetModelProvidersQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Create a model identity record (seed data:
+        /// docs/metrics-modeling/llm-training-dates.md). IsDefault=true
+        /// makes it THE production model.
+        /// </summary>
+        [HttpPost]
+        [Route("models")]
+        public async Task<ActionResult<Guid>> CreateModel(
+            [FromBody] Application.Admin.Models.CreateModelCommand command,
+            [FromServices] Application.Admin.Models.ICreateModelCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(command, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        [HttpGet]
+        [Route("models")]
+        public async Task<ActionResult<List<Application.Admin.Models.ModelDto>>> GetModels(
+            [FromServices] Application.Admin.Models.IGetModelsQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(cancellationToken);
+            return result.ToActionResult();
+        }
+
+        [HttpGet]
+        [Route("models/{modelId}")]
+        public async Task<ActionResult<Application.Admin.Models.ModelDto>> GetModelById(
+            [FromRoute] Guid modelId,
+            [FromServices] Application.Admin.Models.IGetModelByIdQueryHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(modelId, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Edit a model's metadata (cutoff verification, costs, IsActive).
+        /// Identity fields (Name, ApiModelId, provider) are immutable — a
+        /// different API identifier is a different model.
+        /// </summary>
+        [HttpPut]
+        [Route("models/{modelId}")]
+        public async Task<ActionResult<Guid>> UpdateModel(
+            [FromRoute] Guid modelId,
+            [FromBody] Application.Admin.Models.UpdateModelCommand command,
+            [FromServices] Application.Admin.Models.IUpdateModelCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            command.ModelId = modelId;
+            var result = await handler.ExecuteAsync(command, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Make a model THE production default (single global slot).
+        /// Effective next generation run — the pre-season model selection,
+        /// and any in-season swap, is this call.
+        /// </summary>
+        [HttpPost]
+        [Route("models/{modelId}/set-default")]
+        public async Task<ActionResult<Guid>> SetDefaultModel(
+            [FromRoute] Guid modelId,
+            [FromServices] Application.Admin.Models.ISetDefaultModelCommandHandler handler,
+            CancellationToken cancellationToken)
+        {
+            var result = await handler.ExecuteAsync(modelId, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
         /// Persisted prompt captures for a contest, newest first — payload,
         /// metadata, and the full rendered prompt exactly as the model would
         /// receive it (instruction blob + payload + editor note).

--- a/src/SportsData.Api/Application/Admin/Models/CreateModelCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Models/CreateModelCommand.cs
@@ -1,0 +1,161 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Models;
+
+public class CreateModelCommand
+{
+    public Guid ModelProviderId { get; set; }
+
+    /// <summary>Display name (unique), e.g. "Claude Haiku 4.5".</summary>
+    public required string Name { get; set; }
+
+    /// <summary>Exact API identifier, e.g. "claude-haiku-4-5".</summary>
+    public required string ApiModelId { get; set; }
+
+    public DateTime? ReleaseDate { get; set; }
+
+    /// <summary>Declared TRAINING cutoff; null = provider does not publish (treated higher-risk).</summary>
+    public DateTime? KnowledgeCutoffUtc { get; set; }
+
+    public string? CutoffEvidence { get; set; }
+
+    public DateTime? CutoffVerifiedUtc { get; set; }
+
+    public decimal? InputCostPerMTok { get; set; }
+
+    public decimal? OutputCostPerMTok { get; set; }
+
+    /// <summary>Make this THE production model; clears the previous default.</summary>
+    public bool IsDefault { get; set; }
+}
+
+public class CreateModelCommandValidator : AbstractValidator<CreateModelCommand>
+{
+    public CreateModelCommandValidator()
+    {
+        RuleFor(x => x.ModelProviderId).NotEmpty();
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.ApiModelId).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.CutoffEvidence).MaximumLength(512);
+    }
+}
+
+public interface ICreateModelCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(CreateModelCommand command, CancellationToken cancellationToken);
+}
+
+public class CreateModelCommandHandler : ICreateModelCommandHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogger<CreateModelCommandHandler> _logger;
+
+    public CreateModelCommandHandler(
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider,
+        ILogger<CreateModelCommandHandler> logger)
+    {
+        _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(CreateModelCommand command, CancellationToken cancellationToken)
+    {
+        var validation = await new CreateModelCommandValidator().ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+        }
+
+        var providerExists = await _dataContext.ModelProviders
+            .AsNoTracking()
+            .AnyAsync(p => p.Id == command.ModelProviderId, cancellationToken);
+
+        if (!providerExists)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.ModelProviderId), "Model provider not found — create it first (POST /admin/model-providers)")]);
+        }
+
+        var name = command.Name.Trim();
+        var apiModelId = command.ApiModelId.Trim();
+
+        var duplicate = await _dataContext.Models
+            .AsNoTracking()
+            .AnyAsync(m => m.Name == name
+                        || (m.ModelProviderId == command.ModelProviderId && m.ApiModelId == apiModelId),
+                cancellationToken);
+
+        if (duplicate)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.Name), $"A model with this name or (provider, api id) already exists.")]);
+        }
+
+        if (command.IsDefault)
+        {
+            var currentDefaults = await _dataContext.Models
+                .Where(m => m.IsDefault)
+                .ToListAsync(cancellationToken);
+
+            foreach (var existing in currentDefaults)
+            {
+                existing.IsDefault = false;
+                existing.ModifiedUtc = _dateTimeProvider.UtcNow();
+            }
+        }
+
+        var model = new Model
+        {
+            Id = Guid.NewGuid(),
+            ModelProviderId = command.ModelProviderId,
+            Name = name,
+            ApiModelId = apiModelId,
+            ReleaseDate = command.ReleaseDate,
+            KnowledgeCutoffUtc = command.KnowledgeCutoffUtc,
+            CutoffEvidence = command.CutoffEvidence,
+            CutoffVerifiedUtc = command.CutoffVerifiedUtc,
+            InputCostPerMTok = command.InputCostPerMTok,
+            OutputCostPerMTok = command.OutputCostPerMTok,
+            IsDefault = command.IsDefault,
+            CreatedUtc = _dateTimeProvider.UtcNow()
+        };
+
+        await _dataContext.Models.AddAsync(model, cancellationToken);
+
+        try
+        {
+            // Clear-old-default + insert commit in ONE SaveChanges; the
+            // partial unique index turns a concurrent race into a
+            // constraint violation here.
+            await _dataContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (command.IsDefault)
+        {
+            _logger.LogWarning(ex, "Concurrent default-model change detected while creating model {ModelId}.", model.Id);
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(command.IsDefault), "The default model changed concurrently — reload and retry.")]);
+        }
+
+        _logger.LogInformation(
+            "Model created. Id: {ModelId}, Provider: {ProviderId}, IsDefault: {IsDefault}, Cutoff: {Cutoff}",
+            model.Id, model.ModelProviderId, model.IsDefault, model.KnowledgeCutoffUtc);
+
+        return new Success<Guid>(model.Id);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Models/GetModelsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Models/GetModelsQueryHandler.cs
@@ -1,0 +1,124 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Models;
+
+public class ModelDto
+{
+    public Guid Id { get; set; }
+    public Guid ModelProviderId { get; set; }
+    public string ProviderName { get; set; } = default!;
+    public ModelProviderKind ProviderKind { get; set; }
+    public string Name { get; set; } = default!;
+    public string ApiModelId { get; set; } = default!;
+    public DateTime? ReleaseDate { get; set; }
+    public DateTime? KnowledgeCutoffUtc { get; set; }
+    public string? CutoffEvidence { get; set; }
+    public DateTime? CutoffVerifiedUtc { get; set; }
+    public decimal? InputCostPerMTok { get; set; }
+    public decimal? OutputCostPerMTok { get; set; }
+    public bool IsActive { get; set; }
+    public bool IsDefault { get; set; }
+    public DateTime CreatedUtc { get; set; }
+}
+
+public interface IGetModelsQueryHandler
+{
+    Task<Result<List<ModelDto>>> ExecuteAsync(CancellationToken cancellationToken);
+}
+
+public interface IGetModelByIdQueryHandler
+{
+    Task<Result<ModelDto>> ExecuteAsync(Guid modelId, CancellationToken cancellationToken);
+}
+
+public class GetModelsQueryHandler : IGetModelsQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+
+    public GetModelsQueryHandler(AppDataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<List<ModelDto>>> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var models = await _dataContext.Models
+            .AsNoTracking()
+            .OrderByDescending(m => m.IsDefault)
+            .ThenBy(m => m.ModelProvider!.Name)
+            .ThenBy(m => m.Name)
+            .Select(m => new ModelDto
+            {
+                Id = m.Id,
+                ModelProviderId = m.ModelProviderId,
+                ProviderName = m.ModelProvider!.Name,
+                ProviderKind = m.ModelProvider.Kind,
+                Name = m.Name,
+                ApiModelId = m.ApiModelId,
+                ReleaseDate = m.ReleaseDate,
+                KnowledgeCutoffUtc = m.KnowledgeCutoffUtc,
+                CutoffEvidence = m.CutoffEvidence,
+                CutoffVerifiedUtc = m.CutoffVerifiedUtc,
+                InputCostPerMTok = m.InputCostPerMTok,
+                OutputCostPerMTok = m.OutputCostPerMTok,
+                IsActive = m.IsActive,
+                IsDefault = m.IsDefault,
+                CreatedUtc = m.CreatedUtc
+            })
+            .ToListAsync(cancellationToken);
+
+        return new Success<List<ModelDto>>(models);
+    }
+}
+
+public class GetModelByIdQueryHandler : IGetModelByIdQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+
+    public GetModelByIdQueryHandler(AppDataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<ModelDto>> ExecuteAsync(Guid modelId, CancellationToken cancellationToken)
+    {
+        var model = await _dataContext.Models
+            .AsNoTracking()
+            .Where(m => m.Id == modelId)
+            .Select(m => new ModelDto
+            {
+                Id = m.Id,
+                ModelProviderId = m.ModelProviderId,
+                ProviderName = m.ModelProvider!.Name,
+                ProviderKind = m.ModelProvider.Kind,
+                Name = m.Name,
+                ApiModelId = m.ApiModelId,
+                ReleaseDate = m.ReleaseDate,
+                KnowledgeCutoffUtc = m.KnowledgeCutoffUtc,
+                CutoffEvidence = m.CutoffEvidence,
+                CutoffVerifiedUtc = m.CutoffVerifiedUtc,
+                InputCostPerMTok = m.InputCostPerMTok,
+                OutputCostPerMTok = m.OutputCostPerMTok,
+                IsActive = m.IsActive,
+                IsDefault = m.IsDefault,
+                CreatedUtc = m.CreatedUtc
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (model is null)
+        {
+            return new Failure<ModelDto>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(modelId), "Model not found")]);
+        }
+
+        return new Success<ModelDto>(model);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Models/ModelProviderAdmin.cs
+++ b/src/SportsData.Api/Application/Admin/Models/ModelProviderAdmin.cs
@@ -1,0 +1,138 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Models;
+
+public class CreateModelProviderCommand
+{
+    /// <summary>Display name (unique), e.g. "Anthropic".</summary>
+    public required string Name { get; set; }
+
+    /// <summary>Maps the row to its client implementation (DeepSeek/Anthropic/OpenAi/Google).</summary>
+    public ModelProviderKind Kind { get; set; }
+
+    public string? Description { get; set; }
+}
+
+public class CreateModelProviderCommandValidator : AbstractValidator<CreateModelProviderCommand>
+{
+    public CreateModelProviderCommandValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Kind).IsInEnum();
+        RuleFor(x => x.Description).MaximumLength(256);
+    }
+}
+
+public interface ICreateModelProviderCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(CreateModelProviderCommand command, CancellationToken cancellationToken);
+}
+
+public class CreateModelProviderCommandHandler : ICreateModelProviderCommandHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogger<CreateModelProviderCommandHandler> _logger;
+
+    public CreateModelProviderCommandHandler(
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider,
+        ILogger<CreateModelProviderCommandHandler> logger)
+    {
+        _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(CreateModelProviderCommand command, CancellationToken cancellationToken)
+    {
+        var validation = await new CreateModelProviderCommandValidator().ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+        }
+
+        var name = command.Name.Trim();
+
+        var nameTaken = await _dataContext.ModelProviders
+            .AsNoTracking()
+            .AnyAsync(p => p.Name == name, cancellationToken);
+
+        if (nameTaken)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.Name), $"A provider named '{name}' already exists.")]);
+        }
+
+        var provider = new ModelProvider
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Kind = command.Kind,
+            Description = command.Description,
+            CreatedUtc = _dateTimeProvider.UtcNow()
+        };
+
+        await _dataContext.ModelProviders.AddAsync(provider, cancellationToken);
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "ModelProvider created. Id: {ProviderId}, Kind: {Kind}",
+            provider.Id, provider.Kind);
+
+        return new Success<Guid>(provider.Id);
+    }
+}
+
+public class ModelProviderDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public ModelProviderKind Kind { get; set; }
+    public string? Description { get; set; }
+    public bool IsActive { get; set; }
+    public int ModelCount { get; set; }
+}
+
+public interface IGetModelProvidersQueryHandler
+{
+    Task<Result<List<ModelProviderDto>>> ExecuteAsync(CancellationToken cancellationToken);
+}
+
+public class GetModelProvidersQueryHandler : IGetModelProvidersQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+
+    public GetModelProvidersQueryHandler(AppDataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<List<ModelProviderDto>>> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var providers = await _dataContext.ModelProviders
+            .AsNoTracking()
+            .OrderBy(p => p.Name)
+            .Select(p => new ModelProviderDto
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Kind = p.Kind,
+                Description = p.Description,
+                IsActive = p.IsActive,
+                ModelCount = p.Models.Count
+            })
+            .ToListAsync(cancellationToken);
+
+        return new Success<List<ModelProviderDto>>(providers);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Models/UpdateModelCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Models/UpdateModelCommand.cs
@@ -1,0 +1,186 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Models;
+
+/// <summary>
+/// Edits a model's METADATA — cutoff (verification updates are the main
+/// use), evidence, costs, release date, IsActive. Identity fields
+/// (Name, ApiModelId, ModelProviderId) are deliberately immutable: a
+/// different API identifier is a different model, full stop.
+/// </summary>
+public class UpdateModelCommand
+{
+    public Guid ModelId { get; set; }
+
+    public DateTime? ReleaseDate { get; set; }
+
+    public DateTime? KnowledgeCutoffUtc { get; set; }
+
+    public string? CutoffEvidence { get; set; }
+
+    public DateTime? CutoffVerifiedUtc { get; set; }
+
+    public decimal? InputCostPerMTok { get; set; }
+
+    public decimal? OutputCostPerMTok { get; set; }
+
+    public bool IsActive { get; set; } = true;
+}
+
+public class UpdateModelCommandValidator : AbstractValidator<UpdateModelCommand>
+{
+    public UpdateModelCommandValidator()
+    {
+        RuleFor(x => x.ModelId).NotEmpty();
+        RuleFor(x => x.CutoffEvidence).MaximumLength(512);
+    }
+}
+
+public interface IUpdateModelCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(UpdateModelCommand command, CancellationToken cancellationToken);
+}
+
+public class UpdateModelCommandHandler : IUpdateModelCommandHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogger<UpdateModelCommandHandler> _logger;
+
+    public UpdateModelCommandHandler(
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider,
+        ILogger<UpdateModelCommandHandler> logger)
+    {
+        _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(UpdateModelCommand command, CancellationToken cancellationToken)
+    {
+        var validation = await new UpdateModelCommandValidator().ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+        }
+
+        var model = await _dataContext.Models
+            .FirstOrDefaultAsync(m => m.Id == command.ModelId, cancellationToken);
+
+        if (model is null)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(command.ModelId), "Model not found")]);
+        }
+
+        model.ReleaseDate = command.ReleaseDate;
+        model.KnowledgeCutoffUtc = command.KnowledgeCutoffUtc;
+        model.CutoffEvidence = command.CutoffEvidence;
+        model.CutoffVerifiedUtc = command.CutoffVerifiedUtc;
+        model.InputCostPerMTok = command.InputCostPerMTok;
+        model.OutputCostPerMTok = command.OutputCostPerMTok;
+        model.IsActive = command.IsActive;
+        model.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Model updated. Id: {ModelId}, Cutoff: {Cutoff}, VerifiedUtc: {VerifiedUtc}, IsActive: {IsActive}",
+            model.Id, model.KnowledgeCutoffUtc, model.CutoffVerifiedUtc, model.IsActive);
+
+        return new Success<Guid>(model.Id);
+    }
+}
+
+public interface ISetDefaultModelCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(Guid modelId, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Makes a model THE production default (single global slot), clearing
+/// the previous default. Effective on the next generation run — the
+/// pre-season model selection, and any in-season swap, is this call.
+/// </summary>
+public class SetDefaultModelCommandHandler : ISetDefaultModelCommandHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ILogger<SetDefaultModelCommandHandler> _logger;
+
+    public SetDefaultModelCommandHandler(
+        AppDataContext dataContext,
+        IDateTimeProvider dateTimeProvider,
+        ILogger<SetDefaultModelCommandHandler> logger)
+    {
+        _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(Guid modelId, CancellationToken cancellationToken)
+    {
+        var model = await _dataContext.Models
+            .FirstOrDefaultAsync(m => m.Id == modelId, cancellationToken);
+
+        if (model is null)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.NotFound,
+                [new ValidationFailure(nameof(modelId), "Model not found")]);
+        }
+
+        if (!model.IsActive)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(modelId), "An inactive model cannot be the production default")]);
+        }
+
+        if (!model.IsDefault)
+        {
+            var currentDefaults = await _dataContext.Models
+                .Where(m => m.Id != model.Id && m.IsDefault)
+                .ToListAsync(cancellationToken);
+
+            foreach (var existing in currentDefaults)
+            {
+                existing.IsDefault = false;
+                existing.ModifiedUtc = _dateTimeProvider.UtcNow();
+            }
+
+            model.IsDefault = true;
+            model.ModifiedUtc = _dateTimeProvider.UtcNow();
+
+            try
+            {
+                await _dataContext.SaveChangesAsync(cancellationToken);
+            }
+            catch (DbUpdateException ex)
+            {
+                _logger.LogWarning(ex, "Concurrent default-model change detected while promoting model {ModelId}.", model.Id);
+                return new Failure<Guid>(
+                    default!,
+                    ResultStatus.BadRequest,
+                    [new ValidationFailure(nameof(modelId), "The default model changed concurrently — reload and retry.")]);
+            }
+
+            _logger.LogInformation(
+                "Model {ModelId} ('{Name}') is now the production default; {Cleared} previous default(s) cleared.",
+                model.Id, model.Name, currentDefaults.Count);
+        }
+
+        return new Success<Guid>(model.Id);
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -350,6 +350,13 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<Application.Admin.Prompts.IGetPromptByIdQueryHandler, Application.Admin.Prompts.GetPromptByIdQueryHandler>();
             services.AddScoped<Application.Admin.Prompts.IUpdatePromptCommandHandler, Application.Admin.Prompts.UpdatePromptCommandHandler>();
             services.AddScoped<Application.Admin.Prompts.ISetDefaultPromptCommandHandler, Application.Admin.Prompts.SetDefaultPromptCommandHandler>();
+            services.AddScoped<Application.Admin.Models.ICreateModelProviderCommandHandler, Application.Admin.Models.CreateModelProviderCommandHandler>();
+            services.AddScoped<Application.Admin.Models.IGetModelProvidersQueryHandler, Application.Admin.Models.GetModelProvidersQueryHandler>();
+            services.AddScoped<Application.Admin.Models.ICreateModelCommandHandler, Application.Admin.Models.CreateModelCommandHandler>();
+            services.AddScoped<Application.Admin.Models.IGetModelsQueryHandler, Application.Admin.Models.GetModelsQueryHandler>();
+            services.AddScoped<Application.Admin.Models.IGetModelByIdQueryHandler, Application.Admin.Models.GetModelByIdQueryHandler>();
+            services.AddScoped<Application.Admin.Models.IUpdateModelCommandHandler, Application.Admin.Models.UpdateModelCommandHandler>();
+            services.AddScoped<Application.Admin.Models.ISetDefaultModelCommandHandler, Application.Admin.Models.SetDefaultModelCommandHandler>();
             services.AddSingleton<GameRecapPromptProvider>();
             services.AddScoped<PickScoringJob>();
             services.AddScoped<LeagueWeekScoringJob>();

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -42,6 +42,10 @@ public class AppDataContext : DbContext
 
     public DbSet<Prompt> Prompts { get; set; }
 
+    public DbSet<ModelProvider> ModelProviders { get; set; }
+
+    public DbSet<Model> Models { get; set; }
+
     public DbSet<Article> Articles { get; set; }
 
     public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();

--- a/src/SportsData.Api/Infrastructure/Data/Entities/Model.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/Model.cs
@@ -1,0 +1,99 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// An LLM model identity record (design:
+    /// docs/metrics-modeling/matchup-preview-data-inputs.md §6; seed data:
+    /// docs/metrics-modeling/llm-training-dates.md). The knowledge cutoff
+    /// is a DECLARED classification input from provider documentation —
+    /// not proof a game was unseen — which is why the evidence source and
+    /// verification date ride alongside it. The scoring harness labels
+    /// each experiment lower-risk vs higher-risk by comparing the game's
+    /// StartDateUtc against <see cref="KnowledgeCutoffUtc"/>.
+    /// IsDefault marks the single model powering production generation —
+    /// the pre-season "model selection" is literally this flag.
+    /// </summary>
+    public class Model : CanonicalEntityBase<Guid>
+    {
+        public Guid ModelProviderId { get; set; }
+
+        public ModelProvider? ModelProvider { get; set; }
+
+        /// <summary>Display name (unique), e.g. "Claude Haiku 4.5".</summary>
+        public required string Name { get; set; }
+
+        /// <summary>Exact API identifier sent on the wire, e.g. "claude-haiku-4-5".</summary>
+        public required string ApiModelId { get; set; }
+
+        public DateTime? ReleaseDate { get; set; }
+
+        /// <summary>
+        /// Declared TRAINING-data cutoff (the later of any published
+        /// "training" vs "reliable knowledge" dates — training exposure is
+        /// what contamination risk cares about). Null = provider does not
+        /// publish (e.g. DeepSeek) — the harness treats unknown as
+        /// higher-risk.
+        /// </summary>
+        public DateTime? KnowledgeCutoffUtc { get; set; }
+
+        /// <summary>Where the cutoff claim comes from (doc URL / note).</summary>
+        public string? CutoffEvidence { get; set; }
+
+        /// <summary>When the cutoff was last verified against provider docs.</summary>
+        public DateTime? CutoffVerifiedUtc { get; set; }
+
+        /// <summary>Cost metadata (USD per million tokens); informational.</summary>
+        public decimal? InputCostPerMTok { get; set; }
+
+        public decimal? OutputCostPerMTok { get; set; }
+
+        public bool IsActive { get; set; } = true;
+
+        /// <summary>The single model powering production generation.</summary>
+        public bool IsDefault { get; set; }
+
+        /// <summary>PostgreSQL xmin concurrency token — operator-edited via the management UI.</summary>
+        public uint RowVersion { get; set; }
+
+        public class EntityConfiguration : IEntityTypeConfiguration<Model>
+        {
+            public void Configure(EntityTypeBuilder<Model> builder)
+            {
+                builder.ToTable(nameof(Model));
+                builder.HasKey(x => x.Id);
+
+                builder.HasOne(x => x.ModelProvider)
+                    .WithMany(p => p.Models)
+                    .HasForeignKey(x => x.ModelProviderId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                builder.Property(x => x.Name).HasMaxLength(100).IsRequired();
+                builder.HasIndex(x => x.Name).IsUnique();
+
+                builder.Property(x => x.ApiModelId).HasMaxLength(100).IsRequired();
+                builder.HasIndex(x => new { x.ModelProviderId, x.ApiModelId }).IsUnique();
+
+                builder.Property(x => x.CutoffEvidence).HasMaxLength(512);
+
+                builder.Property(x => x.InputCostPerMTok).HasPrecision(10, 4);
+                builder.Property(x => x.OutputCostPerMTok).HasPrecision(10, 4);
+
+                builder.Property(x => x.RowVersion)
+                    .HasColumnName("xmin")
+                    .HasColumnType("xid")
+                    .IsRowVersion();
+
+                // ONE production default across all models, enforced at the
+                // database (same discipline as Prompt default slots).
+                builder.HasIndex(x => x.IsDefault)
+                    .IsUnique()
+                    .HasFilter("\"IsDefault\"")
+                    .HasDatabaseName("IX_Model_SingleDefault");
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Infrastructure/Data/Entities/ModelProvider.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/ModelProvider.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// An LLM provider fleet (DeepSeek, Anthropic, OpenAI, Google —
+    /// first-party clients only, per the 2026-08-08 decision; OpenRouter
+    /// and Ollama Cloud evaluated and passed, see
+    /// docs/metrics-modeling/matchup-preview-data-inputs.md §6).
+    /// A provider row pairs with a code-side IProvideAiCommunication
+    /// implementation resolved via <see cref="Kind"/> — adding a provider
+    /// means a new client anyway, so the enum being code-bound is honest.
+    /// Credentials live in AppConfig, never here.
+    /// </summary>
+    public class ModelProvider : CanonicalEntityBase<Guid>
+    {
+        public required string Name { get; set; }
+
+        /// <summary>Maps the row to its client implementation in the factory.</summary>
+        public ModelProviderKind Kind { get; set; }
+
+        public string? Description { get; set; }
+
+        public bool IsActive { get; set; } = true;
+
+        public ICollection<Model> Models { get; set; } = [];
+
+        public class EntityConfiguration : IEntityTypeConfiguration<ModelProvider>
+        {
+            public void Configure(EntityTypeBuilder<ModelProvider> builder)
+            {
+                builder.ToTable(nameof(ModelProvider));
+                builder.HasKey(x => x.Id);
+
+                builder.Property(x => x.Name).HasMaxLength(100).IsRequired();
+                builder.HasIndex(x => x.Name).IsUnique();
+
+                builder.Property(x => x.Kind)
+                    .HasConversion<int>()
+                    .IsRequired();
+
+                builder.Property(x => x.Description).HasMaxLength(256);
+            }
+        }
+    }
+
+    public enum ModelProviderKind
+    {
+        DeepSeek = 0,
+        Anthropic = 1,
+        OpenAi = 2,
+        Google = 3
+    }
+}

--- a/src/SportsData.Api/Migrations/20260808224729_AddModelAndModelProvider.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260808224729_AddModelAndModelProvider.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260808224729_AddModelAndModelProvider")]
+    partial class AddModelAndModelProvider
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260808224729_AddModelAndModelProvider.cs
+++ b/src/SportsData.Api/Migrations/20260808224729_AddModelAndModelProvider.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddModelAndModelProvider : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ModelProvider",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Kind = table.Column<int>(type: "integer", nullable: false),
+                    Description = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ModelProvider", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Model",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModelProviderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    ApiModelId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    ReleaseDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    KnowledgeCutoffUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CutoffEvidence = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    CutoffVerifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    InputCostPerMTok = table.Column<decimal>(type: "numeric(10,4)", precision: 10, scale: 4, nullable: true),
+                    OutputCostPerMTok = table.Column<decimal>(type: "numeric(10,4)", precision: 10, scale: 4, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    IsDefault = table.Column<bool>(type: "boolean", nullable: false),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Model", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Model_ModelProvider_ModelProviderId",
+                        column: x => x.ModelProviderId,
+                        principalTable: "ModelProvider",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Model_ModelProviderId_ApiModelId",
+                table: "Model",
+                columns: new[] { "ModelProviderId", "ApiModelId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Model_Name",
+                table: "Model",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Model_SingleDefault",
+                table: "Model",
+                column: "IsDefault",
+                unique: true,
+                filter: "\"IsDefault\"");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelProvider_Name",
+                table: "ModelProvider",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Model");
+
+            migrationBuilder.DropTable(
+                name: "ModelProvider");
+        }
+    }
+}

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -35,6 +35,7 @@ import AdminFootballPage from "./components/admin/AdminFootballPage";
 import AdminBaseballPage from "./components/admin/AdminBaseballPage";
 import AdminPreviewLabPage from "./components/admin/AdminPreviewLabPage";
 import AdminPromptsPage from "./components/admin/AdminPromptsPage";
+import AdminModelsPage from "./components/admin/AdminModelsPage";
 import AdminRoute from "./routes/AdminRoute";
 import SeasonOverview from "./components/season/SeasonOverview";
 
@@ -249,6 +250,14 @@ function MainApp() {
               element={
                 <AdminRoute>
                   <AdminPromptsPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/models"
+              element={
+                <AdminRoute>
+                  <AdminModelsPage />
                 </AdminRoute>
               }
             />

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -54,6 +54,20 @@ const AdminApi = {
     apiClient.post(`/admin/prompts/${encodeURIComponent(promptId)}/set-default`),
   importPromptFromBlob: (body) => apiClient.post('/admin/prompts/import-blob', body),
 
+  // Model management (provider fleets + model identity records driving
+  // the experiment harness and production routing; seed data in
+  // docs/metrics-modeling/llm-training-dates.md). Identity fields are
+  // immutable after creation; set-default flips THE production model.
+  getModelProviders: () => apiClient.get('/admin/model-providers'),
+  createModelProvider: (body) => apiClient.post('/admin/model-providers', body),
+  getModels: () => apiClient.get('/admin/models'),
+  getModel: (modelId) => apiClient.get(`/admin/models/${encodeURIComponent(modelId)}`),
+  createModel: (body) => apiClient.post('/admin/models', body),
+  updateModel: (modelId, body) =>
+    apiClient.put(`/admin/models/${encodeURIComponent(modelId)}`, body),
+  setDefaultModel: (modelId) =>
+    apiClient.post(`/admin/models/${encodeURIComponent(modelId)}/set-default`),
+
   // Returns one MLB matchup in the same shape as the picks page so the
   // baseball SignalR debug page can render a real <MatchupCard /> for a
   // chosen contest. League-context fields (Predictions, AiWinner,

--- a/src/UI/sd-ui/src/components/admin/AdminModelsPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelsPage.jsx
@@ -1,0 +1,414 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import './AdminPage.css';
+import AdminHeader from './AdminHeader';
+import apiWrapper from '../../api/apiWrapper';
+
+const PROVIDER_KINDS = [
+  { value: 'DeepSeek', label: 'DeepSeek' },
+  { value: 'Anthropic', label: 'Anthropic' },
+  { value: 'OpenAi', label: 'OpenAI' },
+  { value: 'Google', label: 'Google' },
+];
+
+// 2025 season window for the risk chip (see llm-training-dates.md):
+// NCAA wk0 Aug 23, 2025 -> Super Bowl Feb 8, 2026. A cutoff BEFORE the
+// window start is lower-risk for the whole season; inside the window is
+// partial; after (or unpublished) is higher-risk.
+const SEASON_START = new Date('2025-08-23T00:00:00Z');
+const SEASON_END = new Date('2026-02-09T00:00:00Z');
+
+function riskFor2025(cutoffUtc) {
+  if (!cutoffUtc) return { label: 'UNPUBLISHED — treat higher-risk', color: 'var(--color-danger, #c0392b)' };
+  const cutoff = new Date(cutoffUtc);
+  if (cutoff < SEASON_START) return { label: 'LOWER-RISK (full 2025 season)', color: 'var(--color-success, #27ae60)' };
+  if (cutoff < SEASON_END) return { label: 'PARTIAL — games before cutoff contaminated', color: 'var(--color-warning, #e67e22)' };
+  return { label: 'HIGHER-RISK (full 2025 season in training)', color: 'var(--color-danger, #c0392b)' };
+}
+
+const EMPTY_FORM = {
+  modelProviderId: '',
+  name: '',
+  apiModelId: '',
+  releaseDate: '',
+  knowledgeCutoffUtc: '',
+  cutoffEvidence: '',
+  cutoffVerifiedUtc: '',
+  inputCostPerMTok: '',
+  outputCostPerMTok: '',
+  isDefault: false,
+  isActive: true,
+};
+
+const toDateInput = (iso) => (iso ? iso.substring(0, 10) : '');
+const fromDateInput = (v) => (v ? `${v}T00:00:00Z` : null);
+
+/**
+ * Model Manager — providers + model identity records that drive the
+ * experiment harness and production routing. Cutoffs are DECLARED
+ * classification inputs (verify + record evidence); the risk chip
+ * compares them against the 2025-season window client-side, and the
+ * scoring harness does the same per-game server-side. The DEFAULT badge
+ * marks THE production model — pre-season selection and in-season swaps
+ * are one Set-default click.
+ */
+export default function AdminModelsPage() {
+  const [providers, setProviders] = useState([]);
+  const [models, setModels] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [mode, setMode] = useState('create'); // create | edit
+  const [selectedId, setSelectedId] = useState(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [newProvider, setNewProvider] = useState({ name: '', kind: 'DeepSeek', description: '' });
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [prov, mods] = await Promise.all([
+        apiWrapper.Admin.getModelProviders(),
+        apiWrapper.Admin.getModels(),
+      ]);
+      setProviders(Array.isArray(prov.data) ? prov.data : []);
+      setModels(Array.isArray(mods.data) ? mods.data : []);
+    } catch (err) {
+      toast.error(err?.message ?? 'Failed to load models');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  const resetToCreate = () => {
+    setMode('create');
+    setSelectedId(null);
+    setForm(EMPTY_FORM);
+  };
+
+  const handleSelect = (m) => {
+    setMode('edit');
+    setSelectedId(m.id);
+    setForm({
+      modelProviderId: m.modelProviderId,
+      name: m.name,
+      apiModelId: m.apiModelId,
+      releaseDate: toDateInput(m.releaseDate),
+      knowledgeCutoffUtc: toDateInput(m.knowledgeCutoffUtc),
+      cutoffEvidence: m.cutoffEvidence ?? '',
+      cutoffVerifiedUtc: toDateInput(m.cutoffVerifiedUtc),
+      inputCostPerMTok: m.inputCostPerMTok ?? '',
+      outputCostPerMTok: m.outputCostPerMTok ?? '',
+      isDefault: m.isDefault,
+      isActive: m.isActive,
+    });
+  };
+
+  const handleCreateProvider = async () => {
+    if (!newProvider.name.trim()) {
+      toast.error('Provider name is required.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await apiWrapper.Admin.createModelProvider({
+        name: newProvider.name.trim(),
+        kind: newProvider.kind,
+        description: newProvider.description || null,
+      });
+      toast.success('Provider created.');
+      setNewProvider({ name: '', kind: 'DeepSeek', description: '' });
+      loadAll();
+    } catch (err) {
+      toast.error(err?.response?.data?.errors?.[0]?.errorMessage ?? err.message ?? 'Create failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      if (mode === 'edit') {
+        await apiWrapper.Admin.updateModel(selectedId, {
+          releaseDate: fromDateInput(form.releaseDate),
+          knowledgeCutoffUtc: fromDateInput(form.knowledgeCutoffUtc),
+          cutoffEvidence: form.cutoffEvidence || null,
+          cutoffVerifiedUtc: fromDateInput(form.cutoffVerifiedUtc),
+          inputCostPerMTok: form.inputCostPerMTok === '' ? null : Number(form.inputCostPerMTok),
+          outputCostPerMTok: form.outputCostPerMTok === '' ? null : Number(form.outputCostPerMTok),
+          isActive: form.isActive,
+        });
+        toast.success('Model updated.');
+      } else {
+        if (!form.modelProviderId || !form.name.trim() || !form.apiModelId.trim()) {
+          toast.error('Provider, name, and API model id are required.');
+          return;
+        }
+        await apiWrapper.Admin.createModel({
+          modelProviderId: form.modelProviderId,
+          name: form.name.trim(),
+          apiModelId: form.apiModelId.trim(),
+          releaseDate: fromDateInput(form.releaseDate),
+          knowledgeCutoffUtc: fromDateInput(form.knowledgeCutoffUtc),
+          cutoffEvidence: form.cutoffEvidence || null,
+          cutoffVerifiedUtc: fromDateInput(form.cutoffVerifiedUtc),
+          inputCostPerMTok: form.inputCostPerMTok === '' ? null : Number(form.inputCostPerMTok),
+          outputCostPerMTok: form.outputCostPerMTok === '' ? null : Number(form.outputCostPerMTok),
+          isDefault: form.isDefault,
+        });
+        toast.success('Model created.');
+        resetToCreate();
+      }
+      loadAll();
+    } catch (err) {
+      toast.error(err?.response?.data?.errors?.[0]?.errorMessage ?? err.message ?? 'Save failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSetDefault = async (modelId) => {
+    setSubmitting(true);
+    try {
+      await apiWrapper.Admin.setDefaultModel(modelId);
+      toast.success('Production default flipped — effective on the next run.');
+      loadAll();
+    } catch (err) {
+      toast.error(err?.response?.data?.errors?.[0]?.errorMessage ?? err.message ?? 'Set default failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCopyId = async (modelId) => {
+    try {
+      await navigator.clipboard.writeText(modelId);
+      toast.success('Model ID copied.');
+    } catch {
+      toast.error('Copy failed.');
+    }
+  };
+
+  return (
+    <div className="admin-page">
+      <AdminHeader />
+      <div style={{ maxWidth: 1200, margin: '0 auto' }}>
+        <h2 style={{ marginBottom: 4 }}>Model Manager</h2>
+        <p style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
+          Provider fleets and model identity records for the experiment
+          harness. Cutoffs are declared, not proven — verify and record
+          evidence. Seed data: docs/metrics-modeling/llm-training-dates.md.
+        </p>
+
+        <details style={{ marginBottom: 16 }}>
+          <summary style={{ cursor: 'pointer', fontWeight: 600 }}>
+            Providers ({providers.length})
+          </summary>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '10px 0' }}>
+            {providers.map(p => (
+              <div key={p.id} style={{ fontSize: '0.9rem' }}>
+                <strong>{p.name}</strong> — {p.kind} · {p.modelCount} model(s)
+              </div>
+            ))}
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+              <input
+                type="text"
+                aria-label="New provider name"
+                value={newProvider.name}
+                onChange={(e) => setNewProvider(f => ({ ...f, name: e.target.value }))}
+                placeholder="provider name (e.g. Anthropic)"
+                style={{ padding: '6px 8px' }}
+              />
+              <select
+                aria-label="Provider kind (client implementation)"
+                value={newProvider.kind}
+                onChange={(e) => setNewProvider(f => ({ ...f, kind: e.target.value }))}
+                style={{ padding: '6px 8px' }}
+              >
+                {PROVIDER_KINDS.map(k => (
+                  <option key={k.value} value={k.value}>{k.label}</option>
+                ))}
+              </select>
+              <button type="button" disabled={submitting} onClick={handleCreateProvider}>
+                Add provider
+              </button>
+            </div>
+          </div>
+        </details>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(360px, 1.1fr) minmax(380px, 1fr)', gap: 20, alignItems: 'start' }}>
+          {/* Left: the registry */}
+          <section>
+            {loading && <div>Loading models…</div>}
+            {!loading && models.length === 0 && (
+              <div style={{ color: 'var(--text-secondary)' }}>
+                No models yet — add a provider above, then create models
+                from the registry doc.
+              </div>
+            )}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {models.map((m) => {
+                const risk = riskFor2025(m.knowledgeCutoffUtc);
+                return (
+                  <div
+                    key={m.id}
+                    style={{
+                      border: '1px solid var(--border-primary)',
+                      borderLeft: m.isDefault ? '4px solid var(--color-success, #27ae60)' : '1px solid var(--border-primary)',
+                      borderRadius: 6,
+                      padding: 10,
+                      opacity: m.isActive ? 1 : 0.55,
+                      background: selectedId === m.id ? 'var(--table-stripe)' : 'transparent',
+                    }}
+                  >
+                    <div style={{ display: 'flex', gap: 8, alignItems: 'baseline', flexWrap: 'wrap' }}>
+                      <strong>{m.name}</strong>
+                      <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>{m.providerName}</span>
+                      {m.isDefault && <span style={{ color: 'var(--color-success, #27ae60)', fontSize: '0.8rem', fontWeight: 700 }}>PRODUCTION DEFAULT</span>}
+                      {!m.isActive && <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-secondary)' }}>INACTIVE</span>}
+                    </div>
+                    <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', marginTop: 4, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                      <span>{m.apiModelId}</span>
+                      <span>cutoff: {m.knowledgeCutoffUtc ? m.knowledgeCutoffUtc.substring(0, 10) : '—'}</span>
+                      <span>{m.cutoffVerifiedUtc ? `verified ${m.cutoffVerifiedUtc.substring(0, 10)}` : 'UNVERIFIED'}</span>
+                    </div>
+                    <div style={{ fontSize: '0.8rem', fontWeight: 700, color: risk.color, marginTop: 4 }}>
+                      {risk.label}
+                    </div>
+                    <div style={{ display: 'flex', gap: 8, marginTop: 6, flexWrap: 'wrap' }}>
+                      <button type="button" onClick={() => handleSelect(m)}>Open</button>
+                      {!m.isDefault && m.isActive && (
+                        <button type="button" disabled={submitting} onClick={() => handleSetDefault(m.id)}>
+                          Set default
+                        </button>
+                      )}
+                      <button type="button" onClick={() => handleCopyId(m.id)}>Copy ID</button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Right: the editor */}
+          <section>
+            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                <strong>{mode === 'edit' ? `Editing metadata: ${form.name}` : 'New model'}</strong>
+                {mode === 'edit' && (
+                  <button type="button" onClick={resetToCreate}>Cancel</button>
+                )}
+              </div>
+              {mode === 'edit' && (
+                <div style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+                  Identity (name, API id, provider) is immutable — a
+                  different API identifier is a different model.
+                </div>
+              )}
+
+              {mode === 'create' && (
+                <>
+                  <select
+                    aria-label="Provider"
+                    value={form.modelProviderId}
+                    onChange={(e) => setForm(f => ({ ...f, modelProviderId: e.target.value }))}
+                    style={{ padding: '6px 8px' }}
+                  >
+                    <option value="">— provider —</option>
+                    {providers.map(p => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    aria-label="Model display name"
+                    value={form.name}
+                    onChange={(e) => setForm(f => ({ ...f, name: e.target.value }))}
+                    placeholder="display name (e.g. Claude Haiku 4.5)"
+                    style={{ padding: '6px 8px' }}
+                  />
+                  <input
+                    type="text"
+                    aria-label="API model id"
+                    value={form.apiModelId}
+                    onChange={(e) => setForm(f => ({ ...f, apiModelId: e.target.value }))}
+                    placeholder="exact API id (e.g. claude-haiku-4-5)"
+                    style={{ padding: '6px 8px', fontFamily: 'monospace' }}
+                  />
+                </>
+              )}
+
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+                <label style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: '0.9rem' }}>
+                  released
+                  <input type="date" aria-label="Release date" value={form.releaseDate}
+                    onChange={(e) => setForm(f => ({ ...f, releaseDate: e.target.value }))} />
+                </label>
+                <label style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: '0.9rem' }}>
+                  training cutoff
+                  <input type="date" aria-label="Knowledge cutoff" value={form.knowledgeCutoffUtc}
+                    onChange={(e) => setForm(f => ({ ...f, knowledgeCutoffUtc: e.target.value }))} />
+                </label>
+                <label style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: '0.9rem' }}>
+                  verified
+                  <input type="date" aria-label="Cutoff verified date" value={form.cutoffVerifiedUtc}
+                    onChange={(e) => setForm(f => ({ ...f, cutoffVerifiedUtc: e.target.value }))} />
+                </label>
+              </div>
+
+              <input
+                type="text"
+                aria-label="Cutoff evidence"
+                value={form.cutoffEvidence}
+                onChange={(e) => setForm(f => ({ ...f, cutoffEvidence: e.target.value }))}
+                placeholder="cutoff evidence (doc URL / note)"
+                style={{ padding: '6px 8px' }}
+              />
+
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+                <label style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: '0.9rem' }}>
+                  $/MTok in
+                  <input type="number" step="0.0001" min="0" aria-label="Input cost per million tokens"
+                    value={form.inputCostPerMTok}
+                    onChange={(e) => setForm(f => ({ ...f, inputCostPerMTok: e.target.value }))}
+                    style={{ width: 100, padding: '4px 6px' }} />
+                </label>
+                <label style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: '0.9rem' }}>
+                  $/MTok out
+                  <input type="number" step="0.0001" min="0" aria-label="Output cost per million tokens"
+                    value={form.outputCostPerMTok}
+                    onChange={(e) => setForm(f => ({ ...f, outputCostPerMTok: e.target.value }))}
+                    style={{ width: 100, padding: '4px 6px' }} />
+                </label>
+                {mode === 'create' ? (
+                  <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    <input type="checkbox" checked={form.isDefault}
+                      onChange={(e) => setForm(f => ({ ...f, isDefault: e.target.checked }))} />
+                    make production default
+                  </label>
+                ) : (
+                  <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    <input type="checkbox" checked={form.isActive}
+                      onChange={(e) => setForm(f => ({ ...f, isActive: e.target.checked }))} />
+                    active
+                  </label>
+                )}
+              </div>
+
+              <div>
+                <button type="submit" disabled={submitting}>
+                  {mode === 'edit' ? 'Save metadata' : 'Create model'}
+                </button>
+              </div>
+            </form>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/UI/sd-ui/src/components/admin/AdminPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.jsx
@@ -137,6 +137,7 @@ export default function AdminPage() {
         <Link to="/admin/baseball">Baseball debug</Link>
         <Link to="/admin/preview-lab">Preview Lab</Link>
         <Link to="/admin/prompts">Prompt Manager</Link>
+        <Link to="/admin/models">Model Manager</Link>
       </div>
 
       <div className="admin-grid">

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Models/ModelAdminHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/Models/ModelAdminHandlerTests.cs
@@ -1,0 +1,176 @@
+using Moq;
+
+using SportsData.Api.Application.Admin.Models;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Admin.Models
+{
+    public class ModelAdminHandlerTests : ApiTestBase<CreateModelCommandHandler>
+    {
+        private static readonly DateTime Now = new(2026, 8, 8, 12, 0, 0, DateTimeKind.Utc);
+
+        public ModelAdminHandlerTests()
+        {
+            Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+        }
+
+        private async Task<ModelProvider> SeedProviderAsync(string name = "Anthropic", ModelProviderKind kind = ModelProviderKind.Anthropic)
+        {
+            var provider = new ModelProvider { Id = Guid.NewGuid(), Name = name, Kind = kind };
+            await DataContext.ModelProviders.AddAsync(provider);
+            await DataContext.SaveChangesAsync();
+            return provider;
+        }
+
+        [Fact]
+        public async Task CreateModel_RequiresExistingProvider()
+        {
+            var sut = Mocker.CreateInstance<CreateModelCommandHandler>();
+
+            var result = await sut.ExecuteAsync(new CreateModelCommand
+            {
+                ModelProviderId = Guid.NewGuid(),
+                Name = "Claude Haiku 4.5",
+                ApiModelId = "claude-haiku-4-5"
+            }, CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Empty(DataContext.Models);
+        }
+
+        [Fact]
+        public async Task CreateModel_WithDefault_FlipsPreviousDefault()
+        {
+            var provider = await SeedProviderAsync();
+            var incumbent = new Model
+            {
+                Id = Guid.NewGuid(),
+                ModelProviderId = provider.Id,
+                Name = "DeepSeek V3",
+                ApiModelId = "deepseek-chat",
+                IsDefault = true
+            };
+            await DataContext.Models.AddAsync(incumbent);
+            await DataContext.SaveChangesAsync();
+
+            var sut = Mocker.CreateInstance<CreateModelCommandHandler>();
+
+            var result = await sut.ExecuteAsync(new CreateModelCommand
+            {
+                ModelProviderId = provider.Id,
+                Name = "Claude Haiku 4.5",
+                ApiModelId = "claude-haiku-4-5",
+                KnowledgeCutoffUtc = new DateTime(2025, 7, 31, 0, 0, 0, DateTimeKind.Utc),
+                IsDefault = true
+            }, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            var defaults = DataContext.Models.Where(m => m.IsDefault).ToList();
+            var single = Assert.Single(defaults);
+            Assert.Equal("Claude Haiku 4.5", single.Name);
+            Assert.False(DataContext.Models.Single(m => m.Id == incumbent.Id).IsDefault);
+        }
+
+        [Fact]
+        public async Task CreateModel_RejectsDuplicateApiIdWithinProvider()
+        {
+            var provider = await SeedProviderAsync();
+            await DataContext.Models.AddAsync(new Model
+            {
+                Id = Guid.NewGuid(),
+                ModelProviderId = provider.Id,
+                Name = "Claude Haiku 4.5",
+                ApiModelId = "claude-haiku-4-5"
+            });
+            await DataContext.SaveChangesAsync();
+
+            var sut = Mocker.CreateInstance<CreateModelCommandHandler>();
+
+            var result = await sut.ExecuteAsync(new CreateModelCommand
+            {
+                ModelProviderId = provider.Id,
+                Name = "Haiku 4.5 (dupe)",
+                ApiModelId = "claude-haiku-4-5"
+            }, CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Single(DataContext.Models);
+        }
+
+        [Fact]
+        public async Task UpdateModel_EditsMetadata_NotIdentity()
+        {
+            var provider = await SeedProviderAsync();
+            var model = new Model
+            {
+                Id = Guid.NewGuid(),
+                ModelProviderId = provider.Id,
+                Name = "Claude Sonnet 4.6",
+                ApiModelId = "claude-sonnet-4-6"
+            };
+            await DataContext.Models.AddAsync(model);
+            await DataContext.SaveChangesAsync();
+
+            var sut = Mocker.CreateInstance<UpdateModelCommandHandler>();
+
+            var result = await sut.ExecuteAsync(new UpdateModelCommand
+            {
+                ModelId = model.Id,
+                KnowledgeCutoffUtc = new DateTime(2025, 8, 31, 0, 0, 0, DateTimeKind.Utc),
+                CutoffEvidence = "docs.anthropic.com — resolved training-vs-reliable discrepancy",
+                CutoffVerifiedUtc = Now,
+                IsActive = true
+            }, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            var updated = DataContext.Models.Single(m => m.Id == model.Id);
+            Assert.Equal(new DateTime(2025, 8, 31, 0, 0, 0, DateTimeKind.Utc), updated.KnowledgeCutoffUtc);
+            Assert.Equal(Now, updated.CutoffVerifiedUtc);
+            // Identity untouched
+            Assert.Equal("Claude Sonnet 4.6", updated.Name);
+            Assert.Equal("claude-sonnet-4-6", updated.ApiModelId);
+        }
+
+        [Fact]
+        public async Task SetDefaultModel_FlipsSingleGlobalSlot_AndRejectsInactive()
+        {
+            var provider = await SeedProviderAsync();
+            var current = new Model { Id = Guid.NewGuid(), ModelProviderId = provider.Id, Name = "A", ApiModelId = "a", IsDefault = true };
+            var challenger = new Model { Id = Guid.NewGuid(), ModelProviderId = provider.Id, Name = "B", ApiModelId = "b" };
+            var inactive = new Model { Id = Guid.NewGuid(), ModelProviderId = provider.Id, Name = "C", ApiModelId = "c", IsActive = false };
+            await DataContext.Models.AddRangeAsync(current, challenger, inactive);
+            await DataContext.SaveChangesAsync();
+
+            var sut = Mocker.CreateInstance<SetDefaultModelCommandHandler>();
+
+            // Inactive model cannot become the production default
+            var rejected = await sut.ExecuteAsync(inactive.Id, CancellationToken.None);
+            Assert.False(rejected.IsSuccess);
+
+            // Promotion flips the single global slot
+            var promoted = await sut.ExecuteAsync(challenger.Id, CancellationToken.None);
+            Assert.True(promoted.IsSuccess);
+            var single = Assert.Single(DataContext.Models.Where(m => m.IsDefault).ToList());
+            Assert.Equal(challenger.Id, single.Id);
+        }
+
+        [Fact]
+        public async Task CreateProvider_RejectsDuplicateName()
+        {
+            await SeedProviderAsync("Anthropic");
+            var sut = Mocker.CreateInstance<CreateModelProviderCommandHandler>();
+
+            var result = await sut.ExecuteAsync(new CreateModelProviderCommand
+            {
+                Name = "Anthropic",
+                Kind = ModelProviderKind.Anthropic
+            }, CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Single(DataContext.ModelProviders);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First half of the experiment-harness metadata (design: `docs/metrics-modeling/matchup-preview-data-inputs.md` §6). Provider strategy decided and recorded: **first-party clients only** — DeepSeek (incumbent) + Anthropic/OpenAI/Google arriving in PR B; OpenRouter and Ollama Cloud evaluated and passed (reasons in the doc: third-party prompt path + open-weight identity blur; open-weight-only catalog + tier caps respectively).

### Entities

- **`ModelProvider`**: Name (unique), `Kind` enum mapping the row to its code-side `IProvideAiCommunication` client — a new provider requires a client anyway, so the code-bound enum is honest. Credentials live in AppConfig, never the DB.
- **`Model`**: immutable identity record — provider FK (Restrict), unique Name, unique (provider, ApiModelId), ReleaseDate, **`KnowledgeCutoffUtc` + `CutoffEvidence` + `CutoffVerifiedUtc`** (cutoffs are *declared* classification inputs, not proof — the harness compares game `StartDateUtc` vs cutoff per game), cost metadata, IsActive, IsDefault, xmin.
- **One production default across all models**, DB-enforced via partial unique index — the pre-season model selection and any in-season swap is one flag flip, race-safe (constraint violation → "changed concurrently" Result).

### Endpoints + UI

Admin CRUD mirroring the Prompt set: create/list providers; create/list/get models; `PUT` metadata-only (identity immutable — a different API id **is** a different model); set-default (rejects inactive). Model Manager at `/admin/models`: registry with PRODUCTION DEFAULT badge, **live 2025-season risk chip** computed from the cutoff (lower-risk / partial / higher-risk-or-unpublished), UNVERIFIED indicator, and a create-vs-metadata editor matching the API contract. The cutoff-verification workflow lives here.

### Riding along

`docs/metrics-modeling/llm-training-dates.md` — the researched seed-data registry (four fleets + others, with two flagged verifications including the load-bearing Sonnet 4.6 training-vs-reliable discrepancy) — and the provider-strategy decision in the design doc.

### Not in this PR (PR B)

Anthropic/OpenAI/Google clients, provider-keyed factory, `ModelId` routing on the command, capture/preview stamping.

### Tests

660 API + 10 web pass; 6 new handler tests (provider-required, default flip, duplicate rejection, metadata-vs-identity immutability, single-slot promotion + inactive rejection); green-field migration (two CreateTables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)