### PR TITLE
feat(metricbot,api): MetricBot service — as-of pipeline, FastAPI, Hangfire scheduling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,10 @@ README.md
 !.git/config
 !.git/packed-refs
 !.git/refs/heads/**
+
+# MetricBot: both builds use the repo root as context, so keep local
+# prod-derived artifacts and the workstation venv out of the daemon.
+src/metrics-modeling/data
+src/metrics-modeling/.venv
+**/__pycache__
+**/*.pyc

--- a/.github/workflows/deploy-services-prod.yml
+++ b/.github/workflows/deploy-services-prod.yml
@@ -31,6 +31,13 @@ on:
         required: false
         type: string
 
+# Both this workflow and deploy-services-prod-auto.yml commit and push
+# sports-data-config. Serialize them so concurrent runs cannot race the
+# push or drop a distinct pending image bump.
+concurrency:
+  group: sports-data-config-prod-update
+  cancel-in-progress: false
+
 jobs:
   update-tags:
     runs-on: ubuntu-latest
@@ -144,21 +151,40 @@ jobs:
       - name: Update MetricBot image tag
         if: ${{ inputs.metricbot_tag != '' }}
         working-directory: sports-data-config
+        env:
+          # Via env, never interpolated into the script body: this job
+          # checks out sports-data-config with GH_PAT, so a crafted input
+          # interpolated into shell would run with deploy credentials.
+          METRICBOT_TAG: ${{ inputs.metricbot_tag }}
         run: |
-          TAG='${{ inputs.metricbot_tag }}'
-          if ! [[ "$TAG" =~ ^[0-9]+$ ]]; then
+          set -euo pipefail
+          if ! [[ "$METRICBOT_TAG" =~ ^[0-9]+$ ]]; then
             echo "::error::metricbot_tag must be a numeric build tag"
             exit 1
           fi
-          # Update or add image to metricbot-patch.yaml
-          if grep -q "image:" app/overlays/04_prod/metricbot-patch.yaml; then
-            sed -i "s|image: .*|image: sportdeets.azurecr.io/sportsdatametricbot:${TAG}|g" app/overlays/04_prod/metricbot-patch.yaml
-          else
-            sed -i '/- name: metricbot/a\        image: sportdeets.azurecr.io/sportsdatametricbot:'"$TAG" app/overlays/04_prod/metricbot-patch.yaml
+
+          PATCH=app/overlays/04_prod/metricbot-patch.yaml
+          if [ ! -f "$PATCH" ]; then
+            echo "::error::$PATCH not found"
+            exit 1
           fi
-          echo "Updated MetricBot to tag: $TAG"
+
+          IMAGE="sportdeets.azurecr.io/sportsdatametricbot:${METRICBOT_TAG}"
+          # Anchored to the metricbot container block so the edit cannot
+          # rewrite unrelated image lines.
+          sed -i "s|image: sportdeets.azurecr.io/sportsdatametricbot:.*|image: ${IMAGE}|g" "$PATCH"
+
+          if ! grep -q "image: ${IMAGE}" "$PATCH"; then
+            echo "::error::Failed to set MetricBot image to ${IMAGE} in $PATCH"
+            exit 1
+          fi
+          echo "Updated MetricBot to tag: ${METRICBOT_TAG}"
       - name: Commit and push changes
         working-directory: sports-data-config
+        env:
+          # Passed via env (not interpolated into the script) so a crafted
+          # input cannot execute during commit-message construction.
+          METRICBOT_TAG_SAFE: ${{ inputs.metricbot_tag }}
         run: |
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "actions@github.com"
@@ -174,7 +200,7 @@ jobs:
             [ -n "${{ inputs.provider_tag }}" ] && COMMIT_MSG="$COMMIT_MSG Provider=${{ inputs.provider_tag }}"
             [ -n "${{ inputs.jobs_dashboard_tag }}" ] && COMMIT_MSG="$COMMIT_MSG JobsDashboard=${{ inputs.jobs_dashboard_tag }}"
             [ -n "${{ inputs.notification_tag }}" ] && COMMIT_MSG="$COMMIT_MSG Notification=${{ inputs.notification_tag }}"
-            [ -n "${{ inputs.metricbot_tag }}" ] && COMMIT_MSG="$COMMIT_MSG MetricBot=${{ inputs.metricbot_tag }}"
+            [ -n "${METRICBOT_TAG_SAFE:-}" ] && COMMIT_MSG="$COMMIT_MSG MetricBot=${METRICBOT_TAG_SAFE}"
             
             git commit -m "$COMMIT_MSG"
             git push

--- a/.github/workflows/deploy-services-prod.yml
+++ b/.github/workflows/deploy-services-prod.yml
@@ -26,6 +26,10 @@ on:
         description: 'Notification image tag (e.g., 1351)'
         required: false
         type: string
+      metricbot_tag:
+        description: 'MetricBot image tag (e.g., 1352)'
+        required: false
+        type: string
 
 jobs:
   update-tags:
@@ -136,6 +140,23 @@ jobs:
           fi
           echo "Updated Notification to tag: $TAG"
 
+
+      - name: Update MetricBot image tag
+        if: ${{ inputs.metricbot_tag != '' }}
+        working-directory: sports-data-config
+        run: |
+          TAG='${{ inputs.metricbot_tag }}'
+          if ! [[ "$TAG" =~ ^[0-9]+$ ]]; then
+            echo "::error::metricbot_tag must be a numeric build tag"
+            exit 1
+          fi
+          # Update or add image to metricbot-patch.yaml
+          if grep -q "image:" app/overlays/04_prod/metricbot-patch.yaml; then
+            sed -i "s|image: .*|image: sportdeets.azurecr.io/sportsdatametricbot:${TAG}|g" app/overlays/04_prod/metricbot-patch.yaml
+          else
+            sed -i '/- name: metricbot/a\        image: sportdeets.azurecr.io/sportsdatametricbot:'"$TAG" app/overlays/04_prod/metricbot-patch.yaml
+          fi
+          echo "Updated MetricBot to tag: $TAG"
       - name: Commit and push changes
         working-directory: sports-data-config
         run: |
@@ -153,6 +174,7 @@ jobs:
             [ -n "${{ inputs.provider_tag }}" ] && COMMIT_MSG="$COMMIT_MSG Provider=${{ inputs.provider_tag }}"
             [ -n "${{ inputs.jobs_dashboard_tag }}" ] && COMMIT_MSG="$COMMIT_MSG JobsDashboard=${{ inputs.jobs_dashboard_tag }}"
             [ -n "${{ inputs.notification_tag }}" ] && COMMIT_MSG="$COMMIT_MSG Notification=${{ inputs.notification_tag }}"
+            [ -n "${{ inputs.metricbot_tag }}" ] && COMMIT_MSG="$COMMIT_MSG MetricBot=${{ inputs.metricbot_tag }}"
             
             git commit -m "$COMMIT_MSG"
             git push

--- a/.gitignore
+++ b/.gitignore
@@ -449,3 +449,6 @@ docs/metrics-modeling/prompts/
 
 # Preview Lab exports (capture.txt contains full prompt instruction text)
 docs/metrics-modeling/previews/
+
+# MetricBot runtime artifacts contain prod-derived data - never committed
+src/metrics-modeling/data/

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -369,3 +369,41 @@ Production code (existing):
 Sibling design context:
 
 - `ai-provider-cutover-deepseek-to-ollama.md` (this folder) — the AI-side cutover plan, related but independent
+
+## Random
+
+Docker's --env-file takes exactly the KEY=VALUE format your _metricbot.env already is, so you point at it directly:
+
+  cd C:\Projects\sports-data
+  docker build -f src/metrics-modeling/Dockerfile -t sportsdatametricbot:local .
+
+  docker run --rm -p 8080:8080 --env-file "D:\Dropbox\Code\sports-data-provision\_secrets\_metricbot.env" sportsdatametricbot:local
+
+  Then in another terminal:
+
+  curl http://localhost:8080/health
+
+  # a dry-run experiment (no POST, returns the metadata)
+  curl -X POST http://localhost:8080/run-week -H "Content-Type: application/json" -d '{\"sport\":\"ncaaf\",\"season_year\":2026,\"week\":1,\"prior_season_tail\":5}'
+
+  Two gotchas that will bite otherwise:
+
+  1. Docker's --env-file does not strip quotes — unlike my config parser. If you wrote METRICBOT_PG_HOST="somehost", Docker passes the quote characters as part
+  of the value and the connection fails. Unquote the values in that file (the CLI works either way, so unquoted is strictly safer).
+  2. localhost inside a container is the container. If METRICBOT_PG_HOST or METRICBOT_API_BASE_URL point at localhost, override them for the container run —
+  Docker Desktop exposes the host as host.docker.internal:
+
+  docker run --rm -p 8080:8080 `
+    --env-file "D:\Dropbox\Code\sports-data-provision\_secrets\_metricbot.env" `
+    -e METRICBOT_API_BASE_URL=http://host.docker.internal:5262 `
+    sportsdatametricbot:local
+
+  (Flags after --env-file win, so that's the clean way to patch just the host-relative values. Your prod Postgres host is presumably a real hostname already, so
+  it likely needs no override.)
+
+  $body = @{ sport = "ncaaf"; season_year = 2026; week = 1; prior_season_tail = 5 } | ConvertTo-Json
+  Invoke-RestMethod -Uri http://localhost:8080/run-week -Method Post -ContentType "application/json" -Body $body
+
+  curl.exe -X POST http://localhost:8080/run-week -H "Content-Type: application/json" -d '{\"sport\":\"ncaaf\",\"season_year\":2026,\"week\":1,\"prior_season_tail\":5}'
+
+  $body = @{ sport = "ncaaf"; season_year = 2026; week = 1; prior_season_tail = 5 } | ConvertTo-Json Invoke-RestMethod -Uri http://localhost:8080/run-week -Method Post -ContentType "application/json" -Body $body

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -370,40 +370,70 @@ Sibling design context:
 
 - `ai-provider-cutover-deepseek-to-ollama.md` (this folder) — the AI-side cutover plan, related but independent
 
-## Random
+## Local container smoke test
 
-Docker's --env-file takes exactly the KEY=VALUE format your _metricbot.env already is, so you point at it directly:
+Docker's `--env-file` takes the same `KEY=VALUE` format as
+`_metricbot.env`, so it can be pointed at directly.
 
-  cd C:\Projects\sports-data
-  docker build -f src/metrics-modeling/Dockerfile -t sportsdatametricbot:local .
+```powershell
+cd C:\Projects\sports-data
+docker build -f src/metrics-modeling/Dockerfile -t sportsdatametricbot:local .
 
-  docker run --rm -p 8080:8080 --env-file "D:\Dropbox\Code\sports-data-provision\_secrets\_metricbot.env" sportsdatametricbot:local
+docker run --rm -p 8080:8080 `
+  --env-file "D:\Dropbox\Code\sports-data-provision\_secrets\_metricbot.env" `
+  sportsdatametricbot:local
+```
 
-  Then in another terminal:
+Then from another terminal:
 
-  curl http://localhost:8080/health
+```powershell
+Invoke-RestMethod -Uri http://localhost:8080/health
 
-  # a dry-run experiment (no POST, returns the metadata)
-  curl -X POST http://localhost:8080/run-week -H "Content-Type: application/json" -d '{\"sport\":\"ncaaf\",\"season_year\":2026,\"week\":1,\"prior_season_tail\":5}'
+# Dry-run experiment: no POST, returns run metadata only.
+$body = @{
+  sport             = "ncaaf"
+  season_year       = 2026
+  week              = 1
+  prior_season_tail = 5
+  dry_run           = $true
+  publish           = $false
+} | ConvertTo-Json
 
-  Two gotchas that will bite otherwise:
+Invoke-RestMethod -Uri http://localhost:8080/run-week `
+  -Method Post -ContentType "application/json" -Body $body
+```
 
-  1. Docker's --env-file does not strip quotes — unlike my config parser. If you wrote METRICBOT_PG_HOST="somehost", Docker passes the quote characters as part
-  of the value and the connection fails. Unquote the values in that file (the CLI works either way, so unquoted is strictly safer).
-  2. localhost inside a container is the container. If METRICBOT_PG_HOST or METRICBOT_API_BASE_URL point at localhost, override them for the container run —
-  Docker Desktop exposes the host as host.docker.internal:
+`Invoke-RestMethod` is the reliable form on Windows PowerShell 5.1. The
+`curl` alias resolves to `Invoke-WebRequest` (different parameters), and
+even `curl.exe` needs backslash-escaped inner quotes because PS 5.1
+strips them when handing arguments to native executables:
 
-  docker run --rm -p 8080:8080 `
-    --env-file "D:\Dropbox\Code\sports-data-provision\_secrets\_metricbot.env" `
-    -e METRICBOT_API_BASE_URL=http://host.docker.internal:5262 `
-    sportsdatametricbot:local
+```powershell
+curl.exe -X POST http://localhost:8080/run-week `
+  -H "Content-Type: application/json" `
+  -d '{\"sport\":\"ncaaf\",\"season_year\":2026,\"week\":1,\"prior_season_tail\":5,\"dry_run\":true}'
+```
 
-  (Flags after --env-file win, so that's the clean way to patch just the host-relative values. Your prod Postgres host is presumably a real hostname already, so
-  it likely needs no override.)
+### Two gotchas
 
-  $body = @{ sport = "ncaaf"; season_year = 2026; week = 1; prior_season_tail = 5 } | ConvertTo-Json
-  Invoke-RestMethod -Uri http://localhost:8080/run-week -Method Post -ContentType "application/json" -Body $body
+1. **`--env-file` does not strip quotes** — unlike MetricBot's own config
+   parser. `METRICBOT_PG_HOST="somehost"` reaches the process with the
+   quote characters included and the connection fails. Keep the values
+   unquoted (the CLI accepts either).
+2. **`localhost` inside a container is the container.** If
+   `METRICBOT_PG_HOST` or `METRICBOT_API_BASE_URL` point at `localhost`,
+   override them for the container run — Docker Desktop exposes the host
+   as `host.docker.internal`. Flags after `--env-file` win, so only the
+   host-relative values need patching:
 
-  curl.exe -X POST http://localhost:8080/run-week -H "Content-Type: application/json" -d '{\"sport\":\"ncaaf\",\"season_year\":2026,\"week\":1,\"prior_season_tail\":5}'
+```powershell
+docker run --rm -p 8080:8080 `
+  --env-file "D:\Dropbox\Code\sports-data-provision\_secrets\_metricbot.env" `
+  -e METRICBOT_PG_HOST=host.docker.internal `
+  -e METRICBOT_API_BASE_URL=http://host.docker.internal:5262 `
+  sportsdatametricbot:local
+```
 
-  $body = @{ sport = "ncaaf"; season_year = 2026; week = 1; prior_season_tail = 5 } | ConvertTo-Json Invoke-RestMethod -Uri http://localhost:8080/run-week -Method Post -ContentType "application/json" -Body $body
+Neither applies in-cluster: the `metricbot-secrets` values are the real
+Postgres host and the internal API service address, both resolvable from
+any pod.

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -34,6 +34,7 @@ using SportsData.Core.Eventing.Events.Contests.Baseball;
 using SportsData.Core.Eventing.Events.Contests.Football;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Infrastructure.Clients.MetricBot;
 using SportsData.Core.Processing;
 
 namespace SportsData.Api.Application.Admin
@@ -270,6 +271,38 @@ namespace SportsData.Api.Application.Admin
         {
             var result = await handler.ExecuteAsync(promptId, cancellationToken);
             return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Trigger a MetricBot prediction run (deetsMeter). Omit
+        /// seasonYear/week for a live run of the current week; supply both
+        /// for an experiment/backtest, which never publishes unless
+        /// publish=true. MetricBot is internal-only, so this proxy is the
+        /// on-demand entry point — the weekly schedule is a Hangfire job.
+        ///
+        /// Example: POST /admin/metricbot/run-week
+        /// Body: { "sport": "ncaaf", "seasonYear": 2025, "week": 6,
+        ///         "priorSeasonTail": 5, "includeDtos": true }
+        /// </summary>
+        [HttpPost]
+        [Route("metricbot/run-week")]
+        public async Task<ActionResult<MetricBotRunResponse>> RunMetricBotWeek(
+            [FromBody] MetricBotRunRequest request,
+            [FromServices] IProvideMetricBot metricBot,
+            CancellationToken cancellationToken)
+        {
+            var result = await metricBot.RunWeekAsync(request, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        [HttpGet]
+        [Route("metricbot/health")]
+        public async Task<IActionResult> GetMetricBotHealth(
+            [FromServices] IProvideMetricBot metricBot,
+            CancellationToken cancellationToken)
+        {
+            var healthy = await metricBot.IsHealthyAsync(cancellationToken);
+            return healthy ? Ok(new { status = "healthy" }) : StatusCode(503, new { status = "unreachable" });
         }
 
         /// <summary>

--- a/src/SportsData.Api/Application/Jobs/MetricBotWeeklyJob.cs
+++ b/src/SportsData.Api/Application/Jobs/MetricBotWeeklyJob.cs
@@ -35,14 +35,23 @@ namespace SportsData.Api.Application.Jobs
             _logger = logger;
         }
 
-        /// <param name="sport">MetricBot's sport vocabulary: "ncaaf" or "nfl".</param>
-        public async Task ExecuteAsync(string sport)
+        /// <param name="sport">Platform Sport enum; mapped to MetricBot's vocabulary.</param>
+        public async Task ExecuteAsync(Sport sport)
         {
+            var metricBotSport = MetricBotSports.FromSport(sport);
+            if (metricBotSport is null)
+            {
+                // Football-only models — a scheduling mistake should say so
+                // plainly rather than round-trip to a 422.
+                throw new InvalidOperationException(
+                    $"MetricBot has no model for {sport}; supported sports are FootballNcaa and FootballNfl.");
+            }
+
             _logger.LogInformation("MetricBotWeeklyJob starting. Sport: {Sport}", sport);
 
             var result = await _metricBot.RunWeekAsync(new MetricBotRunRequest
             {
-                Sport = sport,
+                Sport = metricBotSport,
                 PriorSeasonTail = PriorSeasonTail,
                 // Live run: no explicit week (MetricBot resolves the current
                 // one), publishes by default.

--- a/src/SportsData.Api/Application/Jobs/MetricBotWeeklyJob.cs
+++ b/src/SportsData.Api/Application/Jobs/MetricBotWeeklyJob.cs
@@ -1,0 +1,72 @@
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.MetricBot;
+
+namespace SportsData.Api.Application.Jobs
+{
+    /// <summary>
+    /// Weekly deetsMeter prediction run. Hangfire owns the schedule (and
+    /// the manual-trigger button in the jobs dashboard) while MetricBot —
+    /// the internal Python service — does the work and POSTs its
+    /// predictions back to the API's ingestion endpoint.
+    ///
+    /// Chosen over a bare K8s CronJob precisely for the dashboard:
+    /// on-demand and parameterized runs are the experiment workflow, and
+    /// a CronJob offers neither. Design:
+    /// docs/metrics-modeling/metrics-microservice-deetsmeter.md.
+    /// </summary>
+    public class MetricBotWeeklyJob
+    {
+        private readonly IProvideMetricBot _metricBot;
+        private readonly ILogger<MetricBotWeeklyJob> _logger;
+
+        /// <summary>
+        /// Early-season weeks have little or no current-season data, so the
+        /// feature windows are topped up with each team's last N
+        /// prior-season games. Harmless later in the season: the top-up
+        /// retires itself once a team has N games of its own.
+        /// </summary>
+        private const int PriorSeasonTail = 5;
+
+        public MetricBotWeeklyJob(
+            IProvideMetricBot metricBot,
+            ILogger<MetricBotWeeklyJob> logger)
+        {
+            _metricBot = metricBot;
+            _logger = logger;
+        }
+
+        /// <param name="sport">MetricBot's sport vocabulary: "ncaaf" or "nfl".</param>
+        public async Task ExecuteAsync(string sport)
+        {
+            _logger.LogInformation("MetricBotWeeklyJob starting. Sport: {Sport}", sport);
+
+            var result = await _metricBot.RunWeekAsync(new MetricBotRunRequest
+            {
+                Sport = sport,
+                PriorSeasonTail = PriorSeasonTail,
+                // Live run: no explicit week (MetricBot resolves the current
+                // one), publishes by default.
+            });
+
+            if (!result.IsSuccess || result.Value is null)
+            {
+                var errors = result is Failure<MetricBotRunResponse> failure
+                    ? string.Join(", ", failure.Errors.Select(e => e.ErrorMessage))
+                    : "unknown error";
+
+                // Throw so Hangfire records a failed job (visible in the
+                // dashboard, retried per its policy) rather than a silent
+                // success — this is the season's weekly deliverable.
+                throw new InvalidOperationException($"MetricBot run failed for {sport}: {errors}");
+            }
+
+            var run = result.Value;
+            _logger.LogInformation(
+                "MetricBotWeeklyJob complete. Sport: {Sport}, Season: {Season}, Week: {Week}, " +
+                "Contests: {Contests}, TrainingRows: {TrainingRows}, MAE: {Mae:F2}, " +
+                "ResidualStd: {ResidualStd:F2}, Published: {Published}, Elapsed: {Elapsed:F1}s",
+                sport, run.SeasonYear, run.Week, run.Contests, run.TrainingRows,
+                run.Mae, run.ResidualStd, run.Published, run.ElapsedSeconds);
+        }
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -341,6 +341,7 @@ namespace SportsData.Api.DependencyInjection
 
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<MatchupPreviewGenerator>();
+            services.AddScoped<MetricBotWeeklyJob>();
             services.AddScoped<MatchupScheduler>();
             // Scoped: resolves prompts from AppDataContext (text lives in the DB).
             services.AddScoped<IMatchupPreviewPromptProvider, MatchupPreviewPromptProvider>();
@@ -443,6 +444,23 @@ namespace SportsData.Api.DependencyInjection
                 nameof(MatchupPreviewGenerator),
                 job => job.ExecuteAsync(),
                 Cron.Weekly);
+
+            // deetsMeter predictions via the MetricBot service. Scheduled
+            // ahead of each league's slate lock: NCAAFB games start
+            // Thursday, NFL on Thursday too but its week rolls later, so
+            // NCAA runs Tuesday 03:00 UTC and NFL Wednesday 03:00 UTC.
+            // Hangfire (not a K8s CronJob) so the dashboard's manual
+            // trigger covers ad-hoc reruns; parameterized experiment runs
+            // go through POST /admin/metricbot/run-week instead.
+            recurringJobManager.AddOrUpdate<MetricBotWeeklyJob>(
+                "MetricBotWeekly-FootballNcaa",
+                job => job.ExecuteAsync("ncaaf"),
+                "0 3 * * 2");
+
+            recurringJobManager.AddOrUpdate<MetricBotWeeklyJob>(
+                "MetricBotWeekly-FootballNfl",
+                job => job.ExecuteAsync("nfl"),
+                "0 3 * * 3");
 
             // Daily primary trigger. Can't be event-driven — matchups must
             // be generated BEFORE games happen. Daily is sufficient since

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -454,12 +454,12 @@ namespace SportsData.Api.DependencyInjection
             // go through POST /admin/metricbot/run-week instead.
             recurringJobManager.AddOrUpdate<MetricBotWeeklyJob>(
                 "MetricBotWeekly-FootballNcaa",
-                job => job.ExecuteAsync("ncaaf"),
+                job => job.ExecuteAsync(Sport.FootballNcaa),
                 "0 3 * * 2");
 
             recurringJobManager.AddOrUpdate<MetricBotWeeklyJob>(
                 "MetricBotWeekly-FootballNfl",
-                job => job.ExecuteAsync("nfl"),
+                job => job.ExecuteAsync(Sport.FootballNfl),
                 "0 3 * * 3");
 
             // Daily primary trigger. Can't be event-driven — matchups must

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -24,6 +24,7 @@ using SportsData.Core.Common;
 using SportsData.Core.Config;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Infrastructure.Clients.AI;
+using SportsData.Core.Infrastructure.Clients.MetricBot;
 using SportsData.Core.Middleware.Health;
 using SportsData.Core.Processing;
 
@@ -227,6 +228,22 @@ namespace SportsData.Api
             });
 
             services.AddScoped<IProvideAiCommunication>(sp => sp.GetRequiredService<DeepSeekClient>());
+
+            // MetricBot (internal Python service; deetsMeter predictions).
+            // Hangfire owns the weekly schedule + manual triggers; this
+            // client is how the API reaches it. Base URL is cluster-internal
+            // DNS in prod, localhost in dev.
+            var metricBotBaseUrl = config["CommonConfig:MetricBot:BaseUrl"];
+            services.AddHttpClient<IProvideMetricBot, MetricBotClient>(client =>
+            {
+                client.BaseAddress = new Uri(
+                    string.IsNullOrWhiteSpace(metricBotBaseUrl)
+                        ? "http://metricbot:8080/"
+                        : metricBotBaseUrl.EndsWith('/') ? metricBotBaseUrl : metricBotBaseUrl + "/");
+                // Runs are seconds, but a cold container + full training
+                // extraction can be slower; keep headroom.
+                client.Timeout = TimeSpan.FromMinutes(10);
+            });
             /* End AI */
 
             // Per-pool sizing. Two distinct pools live on this pod:

--- a/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
@@ -37,6 +37,13 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
         private readonly HttpClient _httpClient;
         private readonly ILogger<MetricBotClient> _logger;
 
+        /// <summary>
+        /// Upstream failures can carry a full FastAPI traceback or an
+        /// ingress HTML error page; that text reaches both the log and the
+        /// admin caller, so cap it.
+        /// </summary>
+        private const int MaxUpstreamErrorChars = 500;
+
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -53,6 +60,15 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
             MetricBotRunRequest request,
             CancellationToken cancellationToken = default)
         {
+            if (!MetricBotSports.IsSupported(request.Sport))
+            {
+                return new Failure<MetricBotRunResponse>(
+                    default!,
+                    ResultStatus.BadRequest,
+                    [new ValidationFailure(nameof(request.Sport),
+                        $"Unsupported sport '{request.Sport}'. MetricBot has football models only: 'ncaaf' or 'nfl'.")]);
+            }
+
             try
             {
                 using var response = await _httpClient.PostAsJsonAsync(
@@ -62,16 +78,23 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
 
                 if (!response.IsSuccessStatusCode)
                 {
+                    var detail = Truncate(body);
+
                     _logger.LogError(
                         "MetricBot run-week failed. Status: {StatusCode}, Body: {Body}",
-                        response.StatusCode, body);
+                        response.StatusCode, detail);
+
+                    // 422 is FastAPI's request-validation status — a caller
+                    // problem, not a server fault, so surface it as one.
+                    var status = response.StatusCode is System.Net.HttpStatusCode.BadRequest
+                                 or System.Net.HttpStatusCode.UnprocessableEntity
+                        ? ResultStatus.BadRequest
+                        : ResultStatus.Error;
 
                     return new Failure<MetricBotRunResponse>(
                         default!,
-                        response.StatusCode == System.Net.HttpStatusCode.BadRequest
-                            ? ResultStatus.BadRequest
-                            : ResultStatus.Error,
-                        [new ValidationFailure("MetricBot", $"MetricBot returned {(int)response.StatusCode}: {body}")]);
+                        status,
+                        [new ValidationFailure("MetricBot", $"MetricBot returned {(int)response.StatusCode}: {detail}")]);
                 }
 
                 var result = JsonSerializer.Deserialize<MetricBotRunResponse>(body, JsonOptions);
@@ -86,6 +109,21 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
 
                 return new Success<MetricBotRunResponse>(result);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller aborted — propagate rather than reporting a server
+                // fault for something the client chose to stop.
+                throw;
+            }
+            catch (TaskCanceledException ex)
+            {
+                // Not caller-requested: HttpClient.Timeout elapsed.
+                _logger.LogError(ex, "MetricBot run-week timed out");
+                return new Failure<MetricBotRunResponse>(
+                    default!,
+                    ResultStatus.Error,
+                    [new ValidationFailure("MetricBot", "MetricBot did not respond before the client timeout elapsed")]);
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "MetricBot run-week request failed");
@@ -96,12 +134,30 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
             }
         }
 
+        private static string Truncate(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return string.Empty;
+            return value.Length <= MaxUpstreamErrorChars
+                ? value
+                : value[..MaxUpstreamErrorChars] + "... (truncated)";
+        }
+
         public async Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default)
         {
+            // The typed client's 10-minute timeout exists for training runs;
+            // a liveness probe must fail fast instead of holding a request
+            // thread while MetricBot is unreachable.
+            using var probeTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            probeTimeout.CancelAfter(TimeSpan.FromSeconds(5));
+
             try
             {
-                using var response = await _httpClient.GetAsync("health", cancellationToken);
+                using var response = await _httpClient.GetAsync("health", probeTimeout.Token);
                 return response.IsSuccessStatusCode;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -111,10 +167,26 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
         }
     }
 
+    public static class MetricBotSports
+    {
+        public const string Ncaaf = "ncaaf";
+        public const string Nfl = "nfl";
+
+        public static bool IsSupported(string? sport) => sport is Ncaaf or Nfl;
+
+        /// <summary>Maps the platform Sport enum to MetricBot's vocabulary; null when unsupported.</summary>
+        public static string? FromSport(Sport sport) => sport switch
+        {
+            Sport.FootballNcaa => Ncaaf,
+            Sport.FootballNfl => Nfl,
+            _ => null  // MetricBot has football models only
+        };
+    }
+
     public class MetricBotRunRequest
     {
         /// <summary>"ncaaf" or "nfl" — MetricBot's own sport vocabulary.</summary>
-        public string Sport { get; set; } = "ncaaf";
+        public string Sport { get; set; } = MetricBotSports.Ncaaf;
 
         /// <summary>Explicit (season, week) = experiment; omit both for a live run.</summary>
         public int? SeasonYear { get; set; }
@@ -136,7 +208,10 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
     {
         public string ModelVersion { get; set; } = default!;
         public string Sport { get; set; } = default!;
-        public int? SeasonYear { get; set; }
+
+        /// <summary>Always populated — live runs resolve it from the calendar.</summary>
+        public int SeasonYear { get; set; }
+
         public int Week { get; set; }
         public int PriorSeasonTail { get; set; }
         public int TrainingRows { get; set; }
@@ -145,6 +220,13 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
         public double ResidualStd { get; set; }
         public bool Published { get; set; }
         public double ElapsedSeconds { get; set; }
+
+        /// <summary>
+        /// Deliberately opaque (deserializes to JsonElement[]): these are
+        /// MetricBot's own prediction DTOs, echoed back only when
+        /// IncludeDtos is set. Do NOT replace with a typed model — the
+        /// shape belongs to the Python side and would drift.
+        /// </summary>
         public object[]? Dtos { get; set; }
     }
 }

--- a/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentValidation.Results;
+
+using Microsoft.Extensions.Logging;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Infrastructure.Clients.MetricBot
+{
+    /// <summary>
+    /// Typed client for the MetricBot service (Python/FastAPI, internal —
+    /// no public ingress). Design:
+    /// docs/metrics-modeling/metrics-microservice-deetsmeter.md.
+    ///
+    /// MetricBot itself POSTs its predictions to the API's existing
+    /// ingestion endpoint; this client only triggers runs and reads back
+    /// run metadata.
+    /// </summary>
+    public interface IProvideMetricBot
+    {
+        Task<Result<MetricBotRunResponse>> RunWeekAsync(
+            MetricBotRunRequest request,
+            CancellationToken cancellationToken = default);
+
+        Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default);
+    }
+
+    public class MetricBotClient : IProvideMetricBot
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<MetricBotClient> _logger;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public MetricBotClient(HttpClient httpClient, ILogger<MetricBotClient> logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+        }
+
+        public async Task<Result<MetricBotRunResponse>> RunWeekAsync(
+            MetricBotRunRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using var response = await _httpClient.PostAsJsonAsync(
+                    "run-week", request, JsonOptions, cancellationToken);
+
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError(
+                        "MetricBot run-week failed. Status: {StatusCode}, Body: {Body}",
+                        response.StatusCode, body);
+
+                    return new Failure<MetricBotRunResponse>(
+                        default!,
+                        response.StatusCode == System.Net.HttpStatusCode.BadRequest
+                            ? ResultStatus.BadRequest
+                            : ResultStatus.Error,
+                        [new ValidationFailure("MetricBot", $"MetricBot returned {(int)response.StatusCode}: {body}")]);
+                }
+
+                var result = JsonSerializer.Deserialize<MetricBotRunResponse>(body, JsonOptions);
+
+                if (result is null)
+                {
+                    return new Failure<MetricBotRunResponse>(
+                        default!,
+                        ResultStatus.Error,
+                        [new ValidationFailure("MetricBot", "MetricBot returned an unreadable response")]);
+                }
+
+                return new Success<MetricBotRunResponse>(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "MetricBot run-week request failed");
+                return new Failure<MetricBotRunResponse>(
+                    default!,
+                    ResultStatus.Error,
+                    [new ValidationFailure("MetricBot", $"MetricBot request failed: {ex.Message}")]);
+            }
+        }
+
+        public async Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using var response = await _httpClient.GetAsync("health", cancellationToken);
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "MetricBot health check failed");
+                return false;
+            }
+        }
+    }
+
+    public class MetricBotRunRequest
+    {
+        /// <summary>"ncaaf" or "nfl" — MetricBot's own sport vocabulary.</summary>
+        public string Sport { get; set; } = "ncaaf";
+
+        /// <summary>Explicit (season, week) = experiment; omit both for a live run.</summary>
+        public int? SeasonYear { get; set; }
+
+        public int? Week { get; set; }
+
+        /// <summary>Top up thin early-week feature windows with prior-season games.</summary>
+        public int PriorSeasonTail { get; set; }
+
+        /// <summary>Explicit-week runs never publish unless this is true.</summary>
+        public bool Publish { get; set; }
+
+        public bool DryRun { get; set; }
+
+        public bool IncludeDtos { get; set; }
+    }
+
+    public class MetricBotRunResponse
+    {
+        public string ModelVersion { get; set; } = default!;
+        public string Sport { get; set; } = default!;
+        public int? SeasonYear { get; set; }
+        public int Week { get; set; }
+        public int PriorSeasonTail { get; set; }
+        public int TrainingRows { get; set; }
+        public int Contests { get; set; }
+        public double Mae { get; set; }
+        public double ResidualStd { get; set; }
+        public bool Published { get; set; }
+        public double ElapsedSeconds { get; set; }
+        public object[]? Dtos { get; set; }
+    }
+}

--- a/src/metrics-modeling/Dockerfile
+++ b/src/metrics-modeling/Dockerfile
@@ -5,12 +5,16 @@
 # services' pipelines:
 #   docker build -f src/metrics-modeling/Dockerfile -t metricbot:local .
 
-FROM python:3.12-slim-bookworm
+# Pinned to a patch release (not the floating 3.12-slim tag) so a rebuild
+# of the same commit produces the same runtime. Bump deliberately.
+FROM python:3.12.11-slim-bookworm
 
 # psql is the extraction tool (deliberate: no Python DB driver — see
 # metricbot/extract.py). curl is for container-level health checks.
+# postgresql-client-15 pins the Debian bookworm major so security patches
+# still flow while a rebuild cannot silently jump major versions.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-client curl \
+    && apt-get install -y --no-install-recommends postgresql-client-15 curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/src/metrics-modeling/Dockerfile
+++ b/src/metrics-modeling/Dockerfile
@@ -1,0 +1,41 @@
+# MetricBot — deetsMeter prediction pipeline (internal service).
+# Design: docs/metrics-modeling/metrics-microservice-deetsmeter.md
+#
+# Build from the REPO ROOT so the build context matches the other
+# services' pipelines:
+#   docker build -f src/metrics-modeling/Dockerfile -t metricbot:local .
+
+FROM python:3.12-slim-bookworm
+
+# psql is the extraction tool (deliberate: no Python DB driver — see
+# metricbot/extract.py). curl is for container-level health checks.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Dependencies first so layer caching survives source edits.
+COPY src/metrics-modeling/requirements.txt ./requirements.txt
+COPY src/metrics-modeling/requirements-service.txt ./requirements-service.txt
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-service.txt
+
+COPY src/metrics-modeling/metricbot ./metricbot
+COPY src/metrics-modeling/sql ./sql
+
+# Non-root, matching the platform's container posture.
+RUN useradd --create-home --uid 10001 metricbot \
+    && chown -R metricbot:metricbot /app
+USER metricbot
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -fsS http://localhost:8080/health || exit 1
+
+# Single worker: runs are short, and the LinearRegression fit is
+# CPU-bound — concurrency comes from replicas, not threads.
+CMD ["uvicorn", "metricbot.service:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "1"]

--- a/src/metrics-modeling/README.md
+++ b/src/metrics-modeling/README.md
@@ -1,0 +1,222 @@
+# MetricBot — deetsMeter prediction pipeline
+
+Season-launch MVP Phase A (design:
+`docs/metrics-modeling/metrics-microservice-deetsmeter.md`). One command
+replaces the old `Generate-Predictions.ps1` + inter-stage CSVs + manual
+Postman POST.
+
+All commands below assume you are in this directory
+(`C:\Projects\sports-data\src\metrics-modeling`) and use the venv's
+python directly — no activation needed:
+
+```powershell
+cd C:\Projects\sports-data\src\metrics-modeling
+.venv\Scripts\python.exe -m metricbot run-week --help
+```
+
+## Cookbook
+
+```powershell
+# ── LIVE MODE (the weekly production run) ────────────────────────────
+# Live mode auto-resolves NOW -> (season, week) — current open window or
+# the next upcoming week — and uses the SAME as-of extraction as
+# experiments (entering-week features, leak-free training).
+
+# Safest first contact: full pipeline, no POST, artifacts written to .\data
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --dry-run --dump-intermediate
+
+# The real Tuesday-night run: predict the current NCAAFB week and publish.
+# In weeks 1-2 (little/no current-season data) add the tail or the slate
+# will be empty/thin:
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --prior-season-tail 5
+
+# Mid-season, once teams have games, the tail is optional:
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf
+
+# Same for the NFL week (its own database, same model)
+.venv\Scripts\python.exe -m metricbot run-week --sport nfl --prior-season-tail 5
+
+# Something looks off? Re-run with artifacts + debug logging
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --dry-run --dump-intermediate --verbose
+
+# ── AS-OF MODE (backtests / experiments — NEVER posts without --publish) ─
+
+# Backtest 2025 week 6 exactly as the model would have seen it
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 6 --dump-intermediate
+
+# Early-season experiment: week 2 with prior-season tail on...
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 2 --prior-season-tail 5 --dump-intermediate
+
+# ...and the same week with it off, to compare
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 2 --dump-intermediate
+
+# NFL backtest
+.venv\Scripts\python.exe -m metricbot run-week --sport nfl --season-year 2025 --week 10 --dump-intermediate
+
+# Sweep a season's weeks (PowerShell loop; artifacts pile up in .\data)
+4..14 | ForEach-Object {
+  .venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week $_ --dump-intermediate
+}
+
+# Deliberately publish an as-of run's predictions (rare; know why first)
+.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 6 --publish
+```
+
+Flag notes:
+
+- `--dry-run` — everything except the POST; inspect logs/DTO counts first.
+- `--dump-intermediate` — writes CSV/JSON artifacts to `.\data`
+  (gitignored — contains prod-derived data). As-of artifacts are named
+  `*_ncaaf_asof_2025_wk6_tail5.*`; live ones `*_ncaaf_week_N.*`.
+- Live mode has no week flag: `sql/detect_current_season_week.sql`
+  resolves NOW to (season, week) — the open window, or the next upcoming
+  non-preseason week.
+- `--legacy-extraction` runs the original prototype SQL (live
+  FranchiseSeasonMetric joins + leaky training) for parity comparison
+  only. It cannot run before metrics exist for the season.
+
+## As-of mode semantics (Option B, full as-of — decided 2026-08-09)
+
+Predicts a historical week using ONLY information available entering it:
+
+- **Slate features**: entering-week aggregates computed from per-game
+  `CompetitionMetric` rows (weeks < N), formula-parity with the live
+  `ComputeFranchiseSeasonMetric` (including its SafeAvg→0 quirk).
+- **Training set**: all completed games strictly before
+  (season-year, week) — prior seasons fully, target season weeks < N,
+  later seasons never. The 12 Pts/Margin columns are ENTERING-GAME
+  windows per team (the live flow leaks these from the current
+  FranchiseSeason row — a known finding this mode corrects).
+- **Preseason excluded everywhere** (system-testing data, never signal).
+- `--prior-season-tail N`: tops up thin early-week windows with the
+  team's most recent N prior-season (regular/post) games — an
+  experiment axis; run early weeks with and without it and compare.
+- **As-of runs NEVER post** to the predictions endpoint unless
+  `--publish` is passed — a backtest must not touch live deetsMeter
+  data.
+
+Expect as-of accuracy to differ from the prototype's 56–62% backtests:
+those numbers were computed with leaky features. Lower-but-honest is
+the correct outcome, not a regression.
+
+## Setup
+
+```powershell
+python -m venv .venv
+.venv\Scripts\pip install -r requirements.txt
+```
+
+`psql` must be on PATH (extraction shells out to it — no Python DB
+driver by design; the Phase B container installs postgresql-client).
+
+Tests (offline — no DB, no network):
+
+```powershell
+.venv\Scripts\pip install -r requirements-dev.txt
+.venv\Scripts\python.exe -m pytest tests\ -q
+```
+
+## Configuration
+
+Environment variables, or a `_metricbot.env` (plain KEY=VALUE lines;
+leading underscore per the secrets-file convention; quotes around values
+optional) placed BESIDE the existing `_common-variables.ps1` —
+`SPORTDEETS_SECRETS_PATH` may point at that file or its directory;
+either works. Never committed, repo is public:
+
+| Variable | Purpose |
+|---|---|
+| `METRICBOT_PG_HOST` / `METRICBOT_PG_PORT` | Producer Postgres (port defaults 5432) |
+| `METRICBOT_PG_USER` / `METRICBOT_PG_PASSWORD` | credentials |
+| `METRICBOT_API_BASE_URL` | API base — same base the web app's API client uses; the CLI appends `/admin/ai-predictions/{userId}` |
+| `METRICBOT_ADMIN_TOKEN` | X-Admin-Token for the ingestion endpoint |
+| `METRICBOT_USER_ID` | optional GUID; defaults to the MetricBot synthetic user (`b210d677-…`) |
+
+The sport flag picks the database (`sdProducer.FootballNcaa` /
+`sdProducer.FootballNfl`).
+
+## Layout
+
+- `metricbot/` — the pipeline package (extract → model → dtos → api →
+  pipeline). Math is ported VERBATIM from the prototype scripts; any
+  intentional math change bumps `MODEL_VERSION` in `__init__.py`.
+- `sql/` — extraction queries. The two `competition_metrics_*.sql` files
+  are unchanged from the prototype (the spec); the two `*_asof_*.sql`
+  files take `psql -v` variables (a client-runnable copy of the as-of
+  week query with inlined params lives at
+  `sql/pgsql/competition_metrics_asof_week.sql` in the repo root).
+- Legacy prototype scripts (`predict_*.py`, `Generate-Predictions.ps1`,
+  etc.) remain untouched for output-parity comparison; delete them once
+  the CLI has produced matching output for a real week.
+
+## Verification (first run)
+
+1. `.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2026 --week 1 --prior-season-tail 5 --dump-intermediate`
+   (works TODAY, pre-season: features come from 2025 tails)
+2. Parity (mid-season, once 2026 metrics exist): run with and without
+   `--legacy-extraction` for the same week and compare predictions —
+   entering-week aggregates should match the live FranchiseSeasonMetric
+   values; training deltas reflect the leak fixes, documented in the
+   design doc.
+3. Live publish when happy: `run-week --sport ncaaf --prior-season-tail 5`.
+4. First as-of sanity check: pick a team you know in
+   `data\current_ncaaf_asof_2025_wk6_tail0.csv` — its feature values
+   should reflect ONLY weeks 1–5 (they should NOT match the live
+   `FranchiseSeasonMetric` row, which includes the full season).
+
+   .venv\Scripts\python.exe -m metricbot run-week --sport nfl --season-year 2026 --week 1 --prior-season-tail 5 --dump-intermediate
+
+## Deployment (Phase B)
+
+MetricBot runs as an **internal** service — no public ingress, same
+posture as Producer/Provider. The API's **Hangfire** owns scheduling and
+manual triggering; MetricBot is a stateless executor.
+
+```
+Hangfire (API pod)                    MetricBot (this service)
+  MetricBotWeekly-FootballNcaa  ──┐
+    cron: Tue 03:00 UTC           │   POST /run-week  →  extract → train
+  MetricBotWeekly-FootballNfl   ──┤                       → predict → POST
+    cron: Wed 03:00 UTC           │                         predictions back
+                                  │                         to the API
+POST /admin/metricbot/run-week  ──┘   (admin-token gated proxy; the
+  {sport, seasonYear?, week?,          on-demand + experiment entry point)
+   priorSeasonTail, publish,
+   includeDtos}
+```
+
+Why Hangfire instead of a K8s CronJob: the jobs dashboard already gives
+manual re-triggering, run history, and failure visibility — and a
+CronJob cannot take parameters, which is the entire experiment
+workflow.
+
+### Image
+
+```powershell
+# from the repo root (build context = repo root)
+docker build -f src/metrics-modeling/Dockerfile -t sportsdatametricbot:local .
+docker run --rm -p 8080:8080 --env-file <your env file> sportsdatametricbot:local
+curl http://localhost:8080/health
+```
+
+### Cluster
+
+- Manifests: `app/base/apps/metricbot/` in **sports-data-config**;
+  prod overlay patch `app/overlays/04_prod/metricbot-patch.yaml`.
+- Secret `metricbot-secrets` (namespace `default`) with keys:
+  `pg-host`, `pg-port`, `pg-user`, `pg-password`, `api-base-url`,
+  `admin-token`.
+- API config key `CommonConfig:MetricBot:BaseUrl` →
+  `http://metricbot:8080/` (defaults to that if unset).
+- Deploy workflow input: `metricbot_tag`.
+
+### Ad-hoc / experiment runs in prod
+
+```
+POST /admin/metricbot/run-week      (X-Admin-Token)
+{ "sport": "ncaaf", "seasonYear": 2025, "week": 6,
+  "priorSeasonTail": 5, "includeDtos": true }
+```
+
+Explicit `seasonYear`/`week` never publishes unless `"publish": true` —
+the same guard as the CLI. Omit both for a live run of the current week.

--- a/src/metrics-modeling/azure-pipelines.yml
+++ b/src/metrics-modeling/azure-pipelines.yml
@@ -1,0 +1,84 @@
+# MetricBot (deetsMeter prediction service) — Python, so this pipeline
+# does NOT use the .NET templates the other services share.
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - 'src/metrics-modeling/*'
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - 'src/metrics-modeling/*'
+
+pool:
+  name: Default
+  demands:
+    - Agent.Name -equals Bender
+
+resources:
+  - repo: self
+
+variables:
+  dockerRegistryServiceConnection: '805d6790-3b89-43f4-8551-f1a6b1c8f2f0'
+  imageRepository: 'sportsdatametricbot'
+  containerRegistry: 'sportdeets.azurecr.io'
+  dockerfilePath: '$(Build.SourcesDirectory)/src/metrics-modeling/Dockerfile'
+  # The Dockerfile COPYs from src/metrics-modeling/... so the build
+  # context must be the repo root, not the Dockerfile's directory.
+  dockerBuildContext: '$(Build.SourcesDirectory)'
+  tag: '$(Build.BuildId)'
+  pythonVersion: '3.12'
+
+stages:
+- stage: BuildAndTest
+  displayName: "Build & Test: MetricBot"
+  jobs:
+    - job: BuildAndTest
+      displayName: BuildAndTest
+      steps:
+        - task: UsePythonVersion@0
+          displayName: 'Use Python $(pythonVersion)'
+          inputs:
+            versionSpec: '$(pythonVersion)'
+            addToPath: true
+
+        - script: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt -r requirements-service.txt -r requirements-dev.txt
+          workingDirectory: '$(Build.SourcesDirectory)/src/metrics-modeling'
+          displayName: 'Install dependencies'
+
+        - script: |
+            python -m pytest tests/ -q
+          workingDirectory: '$(Build.SourcesDirectory)/src/metrics-modeling'
+          displayName: 'Run unit tests'
+
+        - script: |
+            python -c "import metricbot.service; print('service imports cleanly')"
+          workingDirectory: '$(Build.SourcesDirectory)/src/metrics-modeling'
+          displayName: 'Verify service module loads'
+
+- stage: BuildImagePushACR
+  displayName: Build Image & Push to ACR
+  dependsOn: BuildAndTest
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  jobs:
+  - job: BuildImage
+    displayName: 'Build and Push Image'
+    steps:
+    - task: Docker@2
+      displayName: Build and push an image to container registry
+      inputs:
+        command: buildAndPush
+        repository: $(imageRepository)
+        dockerfile: $(dockerfilePath)
+        buildContext: $(dockerBuildContext)
+        containerRegistry: $(dockerRegistryServiceConnection)
+        tags: |
+          $(tag)

--- a/src/metrics-modeling/metricbot/__init__.py
+++ b/src/metrics-modeling/metricbot/__init__.py
@@ -1,0 +1,17 @@
+"""MetricBot — the deetsMeter prediction pipeline as a single CLI.
+
+Season-launch MVP Phase A (docs/metrics-modeling/metrics-microservice-deetsmeter.md):
+replaces Generate-Predictions.ps1 + inter-stage CSVs + the manual Postman
+POST with one entry point:
+
+    python -m metricbot run-week [--sport ncaaf|nfl] [--dry-run] [--dump-intermediate]
+
+Math is ported verbatim from the prototype scripts (predict_straightup.py,
+predict_ats.py, generate_contest_prediction_dtos.py) — the goal is
+output parity, not model improvement.
+"""
+
+__version__ = "1.0.0"
+
+# Stamped on every prediction row; bump when the MATH changes, not the plumbing.
+MODEL_VERSION = "MetricBot-v1.0.0"

--- a/src/metrics-modeling/metricbot/__main__.py
+++ b/src/metrics-modeling/metricbot/__main__.py
@@ -72,7 +72,9 @@ def main(argv: list[str] | None = None) -> int:
                 legacy_extraction=args.legacy_extraction,
             )
         except Exception as ex:  # noqa: BLE001 — CLI boundary: fail loudly, exit nonzero
-            logging.getLogger("metricbot").error("Pipeline failed: %s", ex)
+            # .exception() so the traceback lands too: this is the only
+            # diagnostic artifact for a scheduled weekly run.
+            logging.getLogger("metricbot").exception("Pipeline failed: %s", ex)
             return 1
 
     return 2

--- a/src/metrics-modeling/metricbot/__main__.py
+++ b/src/metrics-modeling/metricbot/__main__.py
@@ -1,0 +1,82 @@
+"""CLI entry point: python -m metricbot run-week [options]"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from .pipeline import run_week
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="metricbot",
+        description="MetricBot prediction pipeline (deetsMeter). One command replaces "
+                    "Generate-Predictions.ps1 + CSV shuffling + the Postman POST.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run = subparsers.add_parser(
+        "run-week",
+        help="Extract current-week slate, train, predict SU + ATS, publish to the API.")
+    run.add_argument(
+        "--sport", choices=["ncaaf", "nfl"], default="ncaaf",
+        help="Which football league's database to run against (default: ncaaf).")
+    run.add_argument(
+        "--dry-run", action="store_true",
+        help="Do everything except the POST — inspect DTO counts/logs first.")
+    run.add_argument(
+        "--dump-intermediate", action="store_true",
+        help="Write prototype-equivalent CSV/JSON artifacts to ./data for debugging.")
+    run.add_argument(
+        "--season-year", type=int, default=None,
+        help="AS-OF mode (with --week): backtest a historical week using only "
+             "data available entering it. As-of runs never POST unless --publish.")
+    run.add_argument(
+        "--week", type=int, default=None,
+        help="AS-OF mode (with --season-year): the week whose slate to predict.")
+    run.add_argument(
+        "--prior-season-tail", type=int, default=0, metavar="N",
+        help="Top up thin early-week feature windows with the team's most recent "
+             "N prior-season (regular/post) games. Works in live AND as-of runs "
+             "(essential for weeks 1-2 when no current-season games exist). "
+             "Default 0 = off.")
+    run.add_argument(
+        "--publish", action="store_true",
+        help="Allow an explicit --season-year/--week run to POST predictions "
+             "(default: explicit-week runs never post; live runs post normally).")
+    run.add_argument(
+        "--legacy-extraction", action="store_true",
+        help="Use the original prototype SQL (live FranchiseSeasonMetric joins, "
+             "leaky training) — parity comparison only.")
+    run.add_argument(
+        "--verbose", action="store_true", help="Debug-level logging.")
+
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    if args.command == "run-week":
+        try:
+            return run_week(
+                sport=args.sport,
+                dry_run=args.dry_run,
+                dump_intermediate=args.dump_intermediate,
+                season_year=args.season_year,
+                week=args.week,
+                prior_tail=args.prior_season_tail,
+                publish=args.publish,
+                legacy_extraction=args.legacy_extraction,
+            )
+        except Exception as ex:  # noqa: BLE001 — CLI boundary: fail loudly, exit nonzero
+            logging.getLogger("metricbot").error("Pipeline failed: %s", ex)
+            return 1
+
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/metrics-modeling/metricbot/api.py
+++ b/src/metrics-modeling/metricbot/api.py
@@ -1,0 +1,42 @@
+"""POST predictions to the API — replaces the manual Postman step.
+
+Stdlib urllib on purpose: the venv has no HTTP client and this is one
+JSON POST. The endpoint is the existing admin ingestion route,
+authenticated with the admin token header (AdminApiToken filter).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+from .config import Config
+
+
+class PublishError(RuntimeError):
+    pass
+
+
+def post_predictions(config: Config, dtos: list[dict], timeout_seconds: int = 60) -> str:
+    url = f"{config.api_base_url}/admin/ai-predictions/{config.metricbot_user_id}"
+
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(dtos).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Admin-Token": config.admin_token,
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return f"{response.status}: {body[:500]}"
+    except urllib.error.HTTPError as ex:
+        detail = ex.read().decode("utf-8", errors="replace")[:1000]
+        raise PublishError(f"API returned {ex.code} for {url}: {detail}") from ex
+    except urllib.error.URLError as ex:
+        raise PublishError(f"Could not reach {url}: {ex.reason}") from ex

--- a/src/metrics-modeling/metricbot/api.py
+++ b/src/metrics-modeling/metricbot/api.py
@@ -8,10 +8,18 @@ authenticated with the admin token header (AdminApiToken filter).
 from __future__ import annotations
 
 import json
+import logging
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from .config import Config
+
+logger = logging.getLogger("metricbot.api")
+
+# urlopen honours file:/ftp: too — a misconfigured base URL would then
+# silently change the destination instead of failing. Restrict it.
+ALLOWED_SCHEMES = ("https", "http")
 
 
 class PublishError(RuntimeError):
@@ -20,6 +28,20 @@ class PublishError(RuntimeError):
 
 def post_predictions(config: Config, dtos: list[dict], timeout_seconds: int = 60) -> str:
     url = f"{config.api_base_url}/admin/ai-predictions/{config.metricbot_user_id}"
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ALLOWED_SCHEMES:
+        raise PublishError(
+            f"METRICBOT_API_BASE_URL must use https (or http for in-cluster/"
+            f"local targets); got scheme '{parsed.scheme}'.")
+    if parsed.scheme == "http" and parsed.hostname not in ("localhost", "127.0.0.1", "::1"):
+        # In-cluster traffic is http by design (same as every other
+        # service-to-service call); flag it so a mistyped public URL that
+        # would ship the admin token in cleartext is visible in the logs.
+        logger.warning(
+            "Posting predictions over plaintext http to %s — expected for "
+            "in-cluster service DNS, wrong for any public endpoint.",
+            parsed.hostname)
 
     request = urllib.request.Request(
         url,

--- a/src/metrics-modeling/metricbot/config.py
+++ b/src/metrics-modeling/metricbot/config.py
@@ -1,0 +1,97 @@
+"""Configuration for the MetricBot pipeline.
+
+Resolution order per setting:
+1. Environment variable (METRICBOT_*)
+2. Optional key=value file `_metricbot.env` beside the existing
+   `_common-variables.ps1` (same secrets directory the PowerShell flow
+   already uses, but a plain env-file format Python can read — no
+   PowerShell parsing)
+
+Nothing here is ever committed: the repo is public and these are prod
+credentials. In Phase B (K3s CronJob) the same variables arrive as
+Kubernetes secrets.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+# Databases are per-sport (per-sport RabbitMQ/DB split is load-bearing
+# platform-wide); football models cover both leagues with the same
+# feature set.
+SPORT_DATABASES = {
+    "ncaaf": "sdProducer.FootballNcaa",
+    "nfl": "sdProducer.FootballNfl",
+}
+
+# The synthetic MetricBot user the API attributes predictions to
+# (IsSynthetic = true; see design doc, Decision 6).
+DEFAULT_METRICBOT_USER_ID = "b210d677-19c3-4f26-ac4b-b2cc7ad58c44"
+
+
+def _load_env_file() -> dict[str, str]:
+    secrets_path = os.environ.get("SPORTDEETS_SECRETS_PATH")
+    if not secrets_path:
+        return {}
+    # SPORTDEETS_SECRETS_PATH historically points at the PowerShell
+    # variables FILE (_common-variables.ps1); _metricbot.env lives beside
+    # it (leading underscore = the secrets-file naming convention).
+    # Accept either the file or its directory.
+    base = Path(secrets_path)
+    secrets_dir = base.parent if base.suffix else base
+    env_path = secrets_dir / "_metricbot.env"
+    if not env_path.is_file():
+        return {}
+    values: dict[str, str] = {}
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        value = value.strip()
+        # Tolerate optional surrounding quotes (standard .env convention).
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        values[key.strip()] = value
+    return values
+
+
+@dataclass(frozen=True)
+class Config:
+    pg_host: str
+    pg_user: str
+    pg_password: str
+    pg_database: str
+    pg_port: str
+    api_base_url: str
+    admin_token: str
+    metricbot_user_id: str
+
+    @staticmethod
+    def load(sport: str) -> "Config":
+        if sport not in SPORT_DATABASES:
+            raise SystemExit(
+                f"Unknown sport '{sport}'. Supported: {', '.join(sorted(SPORT_DATABASES))}")
+
+        file_values = _load_env_file()
+
+        def get(name: str, default: str | None = None) -> str:
+            value = os.environ.get(name) or file_values.get(name) or default
+            if value is None:
+                raise SystemExit(
+                    f"Missing required setting {name}. Set it as an environment "
+                    f"variable or in _metricbot.env beside your secrets file")
+            return value
+
+        return Config(
+            pg_host=get("METRICBOT_PG_HOST"),
+            pg_user=get("METRICBOT_PG_USER"),
+            pg_password=get("METRICBOT_PG_PASSWORD"),
+            pg_database=SPORT_DATABASES[sport],
+            pg_port=get("METRICBOT_PG_PORT", "5432"),
+            api_base_url=get("METRICBOT_API_BASE_URL").rstrip("/"),
+            admin_token=get("METRICBOT_ADMIN_TOKEN"),
+            metricbot_user_id=get("METRICBOT_USER_ID", DEFAULT_METRICBOT_USER_ID),
+        )

--- a/src/metrics-modeling/metricbot/dtos.py
+++ b/src/metrics-modeling/metricbot/dtos.py
@@ -1,0 +1,37 @@
+"""Prediction DTO assembly — ported from generate_contest_prediction_dtos.py.
+
+Both prediction types are expressed HOME-team-relative (WinnerFranchiseSeasonId
+is always the home team; the probability is the home team's) for
+consistency with the deetsMeter UI's rendering convention.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+PICKTYPE_STRAIGHT_UP = 1
+PICKTYPE_ATS = 2
+
+
+def build_prediction_dtos(predictions: pd.DataFrame) -> list[dict]:
+    records: list[dict] = []
+
+    for _, row in predictions.iterrows():
+        records.append({
+            "ContestId": row["ContestId"],
+            "WinnerFranchiseSeasonId": row["HomeFranchiseSeasonId"],
+            "WinProbability": round(float(row["WinProbability"]), 4),
+            "PredictionType": PICKTYPE_STRAIGHT_UP,
+            "ModelVersion": row["ModelVersion"],
+        })
+
+    for _, row in predictions.iterrows():
+        records.append({
+            "ContestId": row["ContestId"],
+            "WinnerFranchiseSeasonId": row["HomeFranchiseSeasonId"],
+            "WinProbability": round(float(row["HomeCoverProbability"]), 4),
+            "PredictionType": PICKTYPE_ATS,
+            "ModelVersion": row["ModelVersion"],
+        })
+
+    return records

--- a/src/metrics-modeling/metricbot/extract.py
+++ b/src/metrics-modeling/metricbot/extract.py
@@ -1,0 +1,112 @@
+"""Data extraction via psql (the pipeline's only external tool).
+
+Deliberately shells out to psql rather than adding a Postgres driver:
+the operator box already has psql (the PowerShell flow required it), the
+venv stays unchanged, and the Phase B container just installs
+postgresql-client. Swap for psycopg later if a driver earns its way in.
+
+The SQL files in ./sql are UNCHANGED from the prototype — they are the
+spec. competition_metrics_current_week.sql self-detects the current week
+via its own CTE, so no week parameter exists anywhere in extraction.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+from .config import Config
+
+SQL_DIR = Path(__file__).resolve().parent.parent / "sql"
+
+TRAINING_SQL = SQL_DIR / "competition_metrics_training.sql"
+CURRENT_WEEK_SQL = SQL_DIR / "competition_metrics_current_week.sql"
+ASOF_TRAINING_SQL = SQL_DIR / "competition_metrics_asof_training.sql"
+ASOF_WEEK_SQL = SQL_DIR / "competition_metrics_asof_week.sql"
+DETECT_WEEK_SQL = SQL_DIR / "detect_current_season_week.sql"
+
+
+class ExtractionError(RuntimeError):
+    pass
+
+
+def _run_psql(config: Config, sql_file: Path, variables: dict[str, int] | None = None) -> pd.DataFrame:
+    if not sql_file.is_file():
+        raise ExtractionError(f"SQL file not found: {sql_file}")
+
+    env = os.environ.copy()
+    env["PGPASSWORD"] = config.pg_password
+
+    args = [
+        "psql",
+        "-h", config.pg_host,
+        "-p", config.pg_port,
+        "-U", config.pg_user,
+        "-d", config.pg_database,
+        "-f", str(sql_file),
+        "--csv",
+        "-v", "ON_ERROR_STOP=1",
+    ]
+    for name, value in (variables or {}).items():
+        args += ["-v", f"{name}={int(value)}"]  # int() — nothing user-shaped reaches psql
+
+    result = subprocess.run(
+        args,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    if result.returncode != 0:
+        raise ExtractionError(
+            f"psql failed for {sql_file.name} (exit {result.returncode}):\n{result.stderr.strip()}")
+
+    frame = pd.read_csv(io.StringIO(result.stdout))
+    if frame.empty:
+        raise ExtractionError(
+            f"{sql_file.name} returned zero rows — is the season week window open "
+            f"and are metrics generated for {config.pg_database}?")
+    return frame
+
+
+def extract_training(config: Config) -> pd.DataFrame:
+    """Completed games with scores/winner + both teams' season metrics."""
+    return _run_psql(config, TRAINING_SQL)
+
+
+def extract_current_week(config: Config) -> pd.DataFrame:
+    """The current week's unplayed slate (self-detected by the SQL)."""
+    return _run_psql(config, CURRENT_WEEK_SQL)
+
+
+def extract_asof_training(config: Config, season_year: int, week: int) -> pd.DataFrame:
+    """Option-B as-of training set: strictly before (season, week); the 12
+    Pts/Margin columns are ENTERING-GAME windows, not live season rows."""
+    return _run_psql(config, ASOF_TRAINING_SQL,
+                     {"season_year": season_year, "week": week})
+
+
+def extract_asof_week(config: Config, season_year: int, week: int, prior_tail: int) -> pd.DataFrame:
+    """The (season, week) slate with features computed entering that week;
+    prior_tail > 0 tops up thin early-week windows with the team's most
+    recent prior-season (regular/post) games."""
+    return _run_psql(config, ASOF_WEEK_SQL,
+                     {"season_year": season_year, "week": week, "prior_tail": prior_tail})
+
+
+def detect_current_season_week(config: Config) -> tuple[int, int]:
+    """Resolve NOW to (season_year, week) for live runs — the current open
+    week window, or the next upcoming non-preseason week."""
+    try:
+        frame = _run_psql(config, DETECT_WEEK_SQL)
+    except ExtractionError as ex:
+        raise ExtractionError(
+            "Could not resolve the current season week — no open or upcoming "
+            "week window found. For off-season/system-testing runs pass "
+            "--season-year and --week explicitly.") from ex
+    return int(frame["SeasonYear"].iloc[0]), int(frame["WeekNumber"].iloc[0])

--- a/src/metrics-modeling/metricbot/extract.py
+++ b/src/metrics-modeling/metricbot/extract.py
@@ -23,6 +23,11 @@ from .config import Config
 
 SQL_DIR = Path(__file__).resolve().parent.parent / "sql"
 
+# A blocked connection or runaway query must not pin a service worker
+# forever. Full-corpus training extraction runs in seconds; 10 minutes is
+# generous headroom before we call it stuck.
+PSQL_TIMEOUT_SECONDS = 600
+
 TRAINING_SQL = SQL_DIR / "competition_metrics_training.sql"
 CURRENT_WEEK_SQL = SQL_DIR / "competition_metrics_current_week.sql"
 ASOF_TRAINING_SQL = SQL_DIR / "competition_metrics_asof_training.sql"
@@ -54,13 +59,20 @@ def _run_psql(config: Config, sql_file: Path, variables: dict[str, int] | None =
     for name, value in (variables or {}).items():
         args += ["-v", f"{name}={int(value)}"]  # int() — nothing user-shaped reaches psql
 
-    result = subprocess.run(
-        args,
-        env=env,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
+    try:
+        result = subprocess.run(
+            args,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=PSQL_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as ex:
+        raise ExtractionError(
+            f"psql exceeded {PSQL_TIMEOUT_SECONDS}s running {sql_file.name} — "
+            f"database unreachable or query stuck.") from ex
 
     if result.returncode != 0:
         raise ExtractionError(

--- a/src/metrics-modeling/metricbot/model.py
+++ b/src/metrics-modeling/metricbot/model.py
@@ -45,6 +45,10 @@ FEATURE_COLS = [
 ]
 
 
+class ModelError(RuntimeError):
+    """Training data cannot support a usable model."""
+
+
 @dataclass
 class SuResult:
     predictions: pd.DataFrame  # ContestId, Home/AwayFranchiseSeasonId, PredictedMargin, WinProbability, ...
@@ -59,6 +63,20 @@ def predict_straight_up(training: pd.DataFrame, current_week: pd.DataFrame) -> S
     train = training[training["Winner"].isin(["HOME", "AWAY"])].copy()
     train["Margin"] = train["HomeScore"] - train["AwayScore"]
 
+    # Degenerate inputs would produce confident-looking nonsense: an
+    # underdetermined fit (more features than games) interpolates its
+    # training data exactly, driving residual_std to 0 — and a 0 scale is
+    # not a valid normal distribution, so every probability would come
+    # back as 0 or 1 and clipping would merely disguise it.
+    if len(train) == 0:
+        raise ModelError(
+            "No completed games with a decided winner in the training window — "
+            "nothing to train on. For early-season runs, use --prior-season-tail.")
+    if len(train) <= len(FEATURE_COLS):
+        raise ModelError(
+            f"Training window has {len(train)} decided games for {len(FEATURE_COLS)} "
+            f"features — underdetermined. Widen the window or use --prior-season-tail.")
+
     x_train = train[FEATURE_COLS].fillna(0)
     y_train = train["Margin"]
 
@@ -68,6 +86,11 @@ def predict_straight_up(training: pd.DataFrame, current_week: pd.DataFrame) -> S
     residuals = y_train - model.predict(x_train)
     residual_std = float(np.std(residuals))
     mae = float(np.mean(np.abs(residuals)))
+
+    if not np.isfinite(residual_std) or residual_std <= 0:
+        raise ModelError(
+            f"Residual standard deviation is {residual_std} — the fit is degenerate, "
+            f"so win probabilities would be meaningless.")
 
     predictions = current_week.copy()
     x_predict = predictions[FEATURE_COLS].fillna(0)

--- a/src/metrics-modeling/metricbot/model.py
+++ b/src/metrics-modeling/metricbot/model.py
@@ -1,0 +1,104 @@
+"""SU + ATS math, ported VERBATIM from the prototype scripts.
+
+Sources of truth: predict_straightup.py, predict_ats.py. Any intentional
+change to this math must bump MODEL_VERSION in __init__.py. The
+prototype's combine step (concat train + current week, then filter to
+completed games) is preserved semantically: filtering on
+Winner in {HOME, AWAY} excludes the score-less current-week rows, so
+training input is identical either way.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+from sklearn.linear_model import LinearRegression
+
+from . import MODEL_VERSION
+
+# The 64 features from predict_straightup.py — order preserved.
+FEATURE_COLS = [
+    'HomeYpp', 'HomeSuccessRate', 'HomeExplosiveRate', 'HomePointsPerDrive',
+    'HomeThirdFourthRate', 'HomeRzTdRate', 'HomeRzScoreRate', 'HomeTimePossRatio',
+    'HomeOppYpp', 'HomeOppSuccessRate', 'HomeOppExplosiveRate', 'HomeOppPointsPerDrive',
+    'HomeOppThirdFourthRate', 'HomeOppRzTdRate', 'HomeOppScoreTdRate',
+    'HomeNetPunt', 'HomeFgPctShrunk', 'HomeFieldPosDiff', 'HomeTurnoverMarginPerDrive',
+    'HomePenaltyYardsPerPlay',
+    'HomePtsScoredAvg', 'HomePtsScoredMin', 'HomePtsScoredMax',
+    'HomePtsAllowedAvg', 'HomePtsAllowedMin', 'HomePtsAllowedMax',
+    'HomeMarginWinAvg', 'HomeMarginWinMin', 'HomeMarginWinMax',
+    'HomeMarginLossAvg', 'HomeMarginLossMin', 'HomeMarginLossMax',
+
+    'AwayYpp', 'AwaySuccessRate', 'AwayExplosiveRate', 'AwayPointsPerDrive',
+    'AwayThirdFourthRate', 'AwayRzTdRate', 'AwayRzScoreRate', 'AwayTimePossRatio',
+    'AwayOppYpp', 'AwayOppSuccessRate', 'AwayOppExplosiveRate', 'AwayOppPointsPerDrive',
+    'AwayOppThirdFourthRate', 'AwayOppRzTdRate', 'AwayOppScoreTdRate',
+    'AwayNetPunt', 'AwayFgPctShrunk', 'AwayFieldPosDiff', 'AwayTurnoverMarginPerDrive',
+    'AwayPenaltyYardsPerPlay',
+    'AwayPtsScoredAvg', 'AwayPtsScoredMin', 'AwayPtsScoredMax',
+    'AwayPtsAllowedAvg', 'AwayPtsAllowedMin', 'AwayPtsAllowedMax',
+    'AwayMarginWinAvg', 'AwayMarginWinMin', 'AwayMarginWinMax',
+    'AwayMarginLossAvg', 'AwayMarginLossMin', 'AwayMarginLossMax'
+]
+
+
+@dataclass
+class SuResult:
+    predictions: pd.DataFrame  # ContestId, Home/AwayFranchiseSeasonId, PredictedMargin, WinProbability, ...
+    mae: float
+    residual_std: float
+    training_rows: int
+
+
+def predict_straight_up(training: pd.DataFrame, current_week: pd.DataFrame) -> SuResult:
+    """LinearRegression on point margin (home − away); win probability is
+    the normal-tail P(margin > 0) using the residual std."""
+    train = training[training["Winner"].isin(["HOME", "AWAY"])].copy()
+    train["Margin"] = train["HomeScore"] - train["AwayScore"]
+
+    x_train = train[FEATURE_COLS].fillna(0)
+    y_train = train["Margin"]
+
+    model = LinearRegression()
+    model.fit(x_train, y_train)
+
+    residuals = y_train - model.predict(x_train)
+    residual_std = float(np.std(residuals))
+    mae = float(np.mean(np.abs(residuals)))
+
+    predictions = current_week.copy()
+    x_predict = predictions[FEATURE_COLS].fillna(0)
+    predictions["PredictedMargin"] = model.predict(x_predict)
+    predictions["WinProbability"] = norm.sf(
+        0, loc=predictions["PredictedMargin"], scale=residual_std)
+    predictions["WinProbability"] = predictions["WinProbability"].clip(0.01, 0.99)
+    predictions["PredictedLabel"] = (predictions["WinProbability"] > 0.5).astype(int)
+    predictions["ModelVersion"] = MODEL_VERSION
+    predictions["ResidualStd"] = residual_std
+
+    return SuResult(
+        predictions=predictions,
+        mae=mae,
+        residual_std=residual_std,
+        training_rows=len(train),
+    )
+
+
+def predict_ats(su: SuResult) -> pd.DataFrame:
+    """P(home covers) = P(margin + spread > 0) under the same residual
+    distribution. Spread is home-relative (negative = home favored)."""
+    predictions = su.predictions.copy()
+
+    margin_vs_spread = predictions["PredictedMargin"] + predictions["Spread"]
+    predictions["HomeCoverProbability"] = norm.sf(
+        0, loc=margin_vs_spread, scale=su.residual_std).clip(0.01, 0.99)
+    predictions["AwayCoverProbability"] = norm.sf(
+        0, loc=-margin_vs_spread, scale=su.residual_std).clip(0.01, 0.99)
+    predictions["AtsPredictedLabel"] = (
+        predictions["HomeCoverProbability"] > predictions["AwayCoverProbability"]
+    ).astype(int)
+
+    return predictions

--- a/src/metrics-modeling/metricbot/pipeline.py
+++ b/src/metrics-modeling/metricbot/pipeline.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -141,6 +142,10 @@ def _dump(training: pd.DataFrame,
           dtos: list[dict],
           stamp: str) -> None:
     """Write the prototype-equivalent artifacts for debugging."""
+    # Stamp is built from CLI/HTTP inputs — allow only filename-safe
+    # characters so it can never escape DATA_DIR (CodeQL: path injection).
+    stamp = re.sub(r"[^A-Za-z0-9_.-]", "_", stamp)[:120]
+
     DATA_DIR.mkdir(exist_ok=True)
 
     training.to_csv(DATA_DIR / f"training_{stamp}.csv", index=False)

--- a/src/metrics-modeling/metricbot/pipeline.py
+++ b/src/metrics-modeling/metricbot/pipeline.py
@@ -1,0 +1,152 @@
+"""The run-week orchestration: extract → train → predict SU → predict ATS
+→ build DTOs → POST. State stays in memory on the happy path;
+--dump-intermediate writes the same CSV/JSON artifacts the prototype
+produced, for debugging parity.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from . import MODEL_VERSION
+from .api import post_predictions
+from .config import Config
+from .dtos import build_prediction_dtos
+from .extract import (detect_current_season_week, extract_asof_training,
+                      extract_asof_week, extract_current_week, extract_training)
+from .model import predict_ats, predict_straight_up
+
+logger = logging.getLogger("metricbot")
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+@dataclass
+class RunResult:
+    """Structured outcome — the HTTP service returns this; the CLI ignores it."""
+    season_year: int | None
+    week: int
+    training_rows: int
+    contests: int
+    mae: float
+    residual_std: float
+    published: bool
+    elapsed_seconds: float
+    dtos: list[dict]
+
+
+def run_week(sport: str,
+             dry_run: bool,
+             dump_intermediate: bool,
+             season_year: int | None = None,
+             week: int | None = None,
+             prior_tail: int = 0,
+             publish: bool = False,
+             legacy_extraction: bool = False,
+             return_result: bool = False) -> int | RunResult:
+    started = datetime.now(timezone.utc)
+    config = Config.load(sport)
+
+    explicit_week = season_year is not None and week is not None
+    if (season_year is None) != (week is None):
+        raise SystemExit("--season-year and --week must be provided together.")
+
+    # Explicit-week runs are EXPERIMENTS: they never publish unless
+    # --publish is explicit — a backtest must not overwrite live
+    # deetsMeter predictions. Live (auto-detected) runs publish normally.
+    effective_dry_run = dry_run or (explicit_week and not publish)
+
+    # Live runs resolve NOW -> (season, week) and use the SAME as-of
+    # extraction as experiments: entering-week features (identical to the
+    # live aggregates mid-season, and the only thing that works in weeks
+    # 1-2 when FranchiseSeasonMetric is empty), leak-free training, and
+    # prior-season tail support. The legacy extraction remains available
+    # behind --legacy-extraction for parity comparison only.
+    if not explicit_week and not legacy_extraction:
+        season_year, week = detect_current_season_week(config)
+
+    mode = ("legacy-live" if legacy_extraction
+            else f"{'as-of' if explicit_week else 'live'} {season_year} wk{week} (tail={prior_tail})")
+    logger.info("MetricBot %s run-week starting. Sport: %s, Database: %s, Mode: %s, DryRun: %s",
+                MODEL_VERSION, sport, config.pg_database, mode, effective_dry_run)
+
+    # ── Extract ──────────────────────────────────────────────────────
+    if legacy_extraction:
+        from .extract import detect_week_number
+        training = extract_training(config)
+        current_week = extract_current_week(config)
+        week_number = detect_week_number(current_week)
+    else:
+        training = extract_asof_training(config, season_year, week)
+        current_week = extract_asof_week(config, season_year, week, prior_tail)
+        week_number = week
+    logger.info("Extracted %d training rows; %d contests for week %d",
+                len(training), len(current_week), week_number)
+
+    # ── Model ────────────────────────────────────────────────────────
+    su = predict_straight_up(training, current_week)
+    logger.info("SU model: %d completed games trained, MAE %.2f pts, residual std %.2f pts",
+                su.training_rows, su.mae, su.residual_std)
+
+    predictions = predict_ats(su)
+    logger.info("Predictions computed for %d contests", len(predictions))
+
+    # ── DTOs ─────────────────────────────────────────────────────────
+    dtos = build_prediction_dtos(predictions)
+    logger.info("Built %d prediction DTOs (%d SU + %d ATS)",
+                len(dtos), len(predictions), len(predictions))
+
+    if dump_intermediate:
+        label = (f"{sport}_legacy_week_{week_number}" if legacy_extraction
+                 else f"{sport}_{'asof' if explicit_week else 'live'}_{season_year}_wk{week_number}_tail{prior_tail}")
+        _dump(training, current_week, predictions, dtos, label)
+
+    # ── Publish ──────────────────────────────────────────────────────
+    if effective_dry_run:
+        reason = "DRY RUN" if dry_run else "EXPLICIT-WEEK RUN (pass --publish to override)"
+        logger.info("%s — skipping POST. %d DTOs ready for %s/admin/ai-predictions/%s",
+                    reason, len(dtos), config.api_base_url, config.metricbot_user_id)
+    else:
+        response = post_predictions(config, dtos)
+        logger.info("Published predictions. API response: %s", response)
+
+    elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+    logger.info("MetricBot run-week complete in %.1fs. Sport: %s, Week: %d, Contests: %d",
+                elapsed, sport, week_number, len(predictions))
+
+    if return_result:
+        return RunResult(
+            season_year=season_year,
+            week=week_number,
+            training_rows=su.training_rows,
+            contests=len(predictions),
+            mae=su.mae,
+            residual_std=su.residual_std,
+            published=not effective_dry_run,
+            elapsed_seconds=elapsed,
+            dtos=dtos,
+        )
+    return 0
+
+
+def _dump(training: pd.DataFrame,
+          current_week: pd.DataFrame,
+          predictions: pd.DataFrame,
+          dtos: list[dict],
+          stamp: str) -> None:
+    """Write the prototype-equivalent artifacts for debugging."""
+    DATA_DIR.mkdir(exist_ok=True)
+
+    training.to_csv(DATA_DIR / f"training_{stamp}.csv", index=False)
+    current_week.to_csv(DATA_DIR / f"current_{stamp}.csv", index=False)
+    predictions.to_csv(DATA_DIR / f"predictions_{stamp}.csv", index=False)
+    (DATA_DIR / f"contest_predictions_{stamp}.json").write_text(
+        json.dumps(dtos, indent=2), encoding="utf-8")
+
+    logger.info("Intermediate artifacts written to %s (*_%s.*)", DATA_DIR, stamp)

--- a/src/metrics-modeling/metricbot/service.py
+++ b/src/metrics-modeling/metricbot/service.py
@@ -1,0 +1,112 @@
+"""FastAPI wrapper — the same run_week() the CLI calls, over HTTP.
+
+Deployment shape (Phase B, revised 2026-08-09): metricbot runs as an
+INTERNAL service (no public ingress, same posture as Producer/Provider).
+The API's Hangfire owns scheduling and manual triggering, so this service
+stays a thin, stateless executor:
+
+    POST /run-week   → run the pipeline, return DTOs + run metadata
+    GET  /health     → liveness/readiness
+
+Runs are seconds, so /run-week is synchronous and returns its results on
+the wire — which also keeps experiment artifacts out of an ephemeral
+container's filesystem.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from . import MODEL_VERSION
+from .pipeline import RunResult, run_week
+
+logger = logging.getLogger("metricbot.service")
+
+app = FastAPI(
+    title="MetricBot",
+    version=MODEL_VERSION,
+    description="deetsMeter prediction pipeline (internal service).",
+)
+
+
+class RunWeekRequest(BaseModel):
+    sport: str = Field(default="ncaaf", pattern="^(ncaaf|nfl)$")
+
+    # Explicit (season, week) = experiment/backtest; omit both for a live
+    # run that auto-resolves the current week.
+    season_year: int | None = Field(default=None, ge=1990, le=2100)
+    week: int | None = Field(default=None, ge=1, le=25)
+
+    prior_season_tail: int = Field(default=0, ge=0, le=25)
+
+    # Explicit-week runs never publish unless this is true; live runs
+    # publish unless dry_run is true. Same guard as the CLI.
+    publish: bool = False
+    dry_run: bool = False
+
+    # Return the prediction DTOs in the response body (experiments want
+    # them; the weekly job doesn't need the payload back).
+    include_dtos: bool = False
+
+
+class RunWeekResponse(BaseModel):
+    model_version: str
+    sport: str
+    season_year: int | None
+    week: int
+    prior_season_tail: int
+    training_rows: int
+    contests: int
+    mae: float
+    residual_std: float
+    published: bool
+    elapsed_seconds: float
+    dtos: list[dict] | None = None
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "healthy", "modelVersion": MODEL_VERSION}
+
+
+@app.post("/run-week", response_model=RunWeekResponse)
+def post_run_week(request: RunWeekRequest) -> RunWeekResponse:
+    if (request.season_year is None) != (request.week is None):
+        raise HTTPException(
+            status_code=400,
+            detail="season_year and week must be provided together (or both omitted for a live run).")
+
+    try:
+        result: RunResult = run_week(
+            sport=request.sport,
+            dry_run=request.dry_run,
+            dump_intermediate=False,  # containers are ephemeral; results ride the response
+            season_year=request.season_year,
+            week=request.week,
+            prior_tail=request.prior_season_tail,
+            publish=request.publish,
+            return_result=True,
+        )
+    except SystemExit as ex:  # config/validation failures raise SystemExit
+        raise HTTPException(status_code=400, detail=str(ex)) from ex
+    except Exception as ex:  # noqa: BLE001 — service boundary
+        logger.exception("run-week failed")
+        raise HTTPException(status_code=500, detail=f"{type(ex).__name__}: {ex}") from ex
+
+    return RunWeekResponse(
+        model_version=MODEL_VERSION,
+        sport=request.sport,
+        season_year=result.season_year,
+        week=result.week,
+        prior_season_tail=request.prior_season_tail,
+        training_rows=result.training_rows,
+        contests=result.contests,
+        mae=result.mae,
+        residual_std=result.residual_std,
+        published=result.published,
+        elapsed_seconds=result.elapsed_seconds,
+        dtos=result.dtos if request.include_dtos else None,
+    )

--- a/src/metrics-modeling/metricbot/service.py
+++ b/src/metrics-modeling/metricbot/service.py
@@ -55,7 +55,9 @@ class RunWeekRequest(BaseModel):
 class RunWeekResponse(BaseModel):
     model_version: str
     sport: str
-    season_year: int | None
+    # Always resolved: live runs detect it from the calendar, explicit
+    # runs supply it.
+    season_year: int
     week: int
     prior_season_tail: int
     training_rows: int

--- a/src/metrics-modeling/requirements-dev.txt
+++ b/src/metrics-modeling/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Test-only dependencies (CI + local `pytest` runs).
+pytest==8.4.2

--- a/src/metrics-modeling/requirements-service.txt
+++ b/src/metrics-modeling/requirements-service.txt
@@ -1,0 +1,6 @@
+# HTTP service layer only — the CLI needs none of this.
+# Kept separate so a local venv can run the pipeline without pulling in
+# a web stack (requirements.txt stays the model/data pins).
+fastapi==0.118.0
+uvicorn[standard]==0.37.0
+pydantic==2.11.9

--- a/src/metrics-modeling/requirements.txt
+++ b/src/metrics-modeling/requirements.txt
@@ -1,0 +1,8 @@
+# MetricBot pipeline — pinned to the versions in the working .venv
+# (python -m venv .venv && pip install -r requirements.txt)
+# psql (PostgreSQL client tools) must be on PATH — extraction shells out
+# to it deliberately; no Python DB driver required.
+numpy==2.3.4
+pandas==2.3.3
+scikit-learn==1.7.2
+scipy==1.16.2

--- a/src/metrics-modeling/sql/competition_metrics_asof_training.sql
+++ b/src/metrics-modeling/sql/competition_metrics_asof_training.sql
@@ -1,0 +1,143 @@
+-- AS-OF training extraction (Option B, full as-of): completed games
+-- STRICTLY BEFORE (:season_year, :week) — prior seasons fully, the
+-- target season only weeks < :week, later seasons never.
+--
+-- Feature semantics preserved from the prototype: each game's OWN
+-- per-game CompetitionMetric rows (immutable, inherently point-in-time).
+-- The 12 Pts/Margin columns — which the live flow leaks from the
+-- CURRENT FranchiseSeason row — are computed here as ENTERING-GAME
+-- windows (that team's completed games earlier in the SAME season, by
+-- kickoff time). Week-1 training rows have NULL windows (the pipeline
+-- fillna(0)s, as the prototype always did for missing values).
+--
+-- Preseason excluded everywhere (policy 2026-08-08) — note the live
+-- training SQL has no phase filter, so NFL preseason games with metrics
+-- leak into live training; flagged in the design doc.
+--
+-- psql -v season_year=2025 -v week=6
+WITH params AS (
+    SELECT :season_year::int AS season_year,
+           :week::int        AS week
+),
+
+-- One row per (team-perspective, completed non-preseason game) across
+-- all seasons up to the cutoff, with entering-game score windows.
+team_games AS (
+    SELECT
+        con."Id"  AS contest_id,
+        fs."Id"   AS franchise_season_id,
+        con."StartDateUtc" AS start_date_utc,
+        CASE WHEN con."HomeTeamFranchiseSeasonId" = fs."Id" THEN con."HomeScore" ELSE con."AwayScore" END AS own_score,
+        CASE WHEN con."HomeTeamFranchiseSeasonId" = fs."Id" THEN con."AwayScore" ELSE con."HomeScore" END AS opp_score
+    FROM params p
+    JOIN public."Contest" con      ON con."HomeScore" IS NOT NULL AND con."AwayScore" IS NOT NULL
+    JOIN public."SeasonWeek" sw    ON sw."Id" = con."SeasonWeekId"
+    JOIN public."Season" s         ON s."Id" = sw."SeasonId"
+    LEFT JOIN public."SeasonPhase" sp ON sp."Id" = con."SeasonPhaseId"
+    JOIN public."FranchiseSeason" fs
+        ON fs."Id" IN (con."HomeTeamFranchiseSeasonId", con."AwayTeamFranchiseSeasonId")
+    WHERE con."CancelledUtc" IS NULL
+      AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+      AND (s."Year" < p.season_year OR (s."Year" = p.season_year AND sw."Number" < p.week))
+),
+
+entering AS (
+    SELECT
+        contest_id,
+        franchise_season_id,
+        AVG(own_score) OVER w AS pts_scored_avg,
+        MIN(own_score) OVER w AS pts_scored_min,
+        MAX(own_score) OVER w AS pts_scored_max,
+        AVG(opp_score) OVER w AS pts_allowed_avg,
+        MIN(opp_score) OVER w AS pts_allowed_min,
+        MAX(opp_score) OVER w AS pts_allowed_max,
+        AVG(CASE WHEN own_score > opp_score THEN own_score - opp_score END) OVER w AS margin_win_avg,
+        MIN(CASE WHEN own_score > opp_score THEN own_score - opp_score END) OVER w AS margin_win_min,
+        MAX(CASE WHEN own_score > opp_score THEN own_score - opp_score END) OVER w AS margin_win_max,
+        AVG(CASE WHEN own_score < opp_score THEN opp_score - own_score END) OVER w AS margin_loss_avg,
+        MIN(CASE WHEN own_score < opp_score THEN opp_score - own_score END) OVER w AS margin_loss_min,
+        MAX(CASE WHEN own_score < opp_score THEN opp_score - own_score END) OVER w AS margin_loss_max
+    FROM team_games
+    WINDOW w AS (
+        PARTITION BY franchise_season_id
+        ORDER BY start_date_utc
+        ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+    )
+)
+
+SELECT
+    con."Id" AS "ContestId",
+    comp."Id" AS "CompetitionId",
+    sw."Number" AS "WeekNumber",
+    con."HomeTeamFranchiseSeasonId",
+    con."AwayTeamFranchiseSeasonId",
+
+    cm_home."FranchiseSeasonId" AS "HomeFranchiseSeasonId",
+    cm_home."Ypp" AS "HomeYpp", cm_home."SuccessRate" AS "HomeSuccessRate",
+    cm_home."ExplosiveRate" AS "HomeExplosiveRate", cm_home."PointsPerDrive" AS "HomePointsPerDrive",
+    cm_home."ThirdFourthRate" AS "HomeThirdFourthRate", cm_home."RzTdRate" AS "HomeRzTdRate",
+    cm_home."RzScoreRate" AS "HomeRzScoreRate", cm_home."TimePossRatio" AS "HomeTimePossRatio",
+    cm_home."OppYpp" AS "HomeOppYpp", cm_home."OppSuccessRate" AS "HomeOppSuccessRate",
+    cm_home."OppExplosiveRate" AS "HomeOppExplosiveRate", cm_home."OppPointsPerDrive" AS "HomeOppPointsPerDrive",
+    cm_home."OppThirdFourthRate" AS "HomeOppThirdFourthRate", cm_home."OppRzTdRate" AS "HomeOppRzTdRate",
+    cm_home."OppScoreTdRate" AS "HomeOppScoreTdRate", cm_home."NetPunt" AS "HomeNetPunt",
+    cm_home."FgPctShrunk" AS "HomeFgPctShrunk", cm_home."FieldPosDiff" AS "HomeFieldPosDiff",
+    cm_home."TurnoverMarginPerDrive" AS "HomeTurnoverMarginPerDrive",
+    cm_home."PenaltyYardsPerPlay" AS "HomePenaltyYardsPerPlay",
+
+    eh.pts_scored_avg  AS "HomePtsScoredAvg",  eh.pts_scored_min  AS "HomePtsScoredMin",  eh.pts_scored_max  AS "HomePtsScoredMax",
+    eh.pts_allowed_avg AS "HomePtsAllowedAvg", eh.pts_allowed_min AS "HomePtsAllowedMin", eh.pts_allowed_max AS "HomePtsAllowedMax",
+    eh.margin_win_avg  AS "HomeMarginWinAvg",  eh.margin_win_min  AS "HomeMarginWinMin",  eh.margin_win_max  AS "HomeMarginWinMax",
+    eh.margin_loss_avg AS "HomeMarginLossAvg", eh.margin_loss_min AS "HomeMarginLossMin", eh.margin_loss_max AS "HomeMarginLossMax",
+
+    cm_away."FranchiseSeasonId" AS "AwayFranchiseSeasonId",
+    cm_away."Ypp" AS "AwayYpp", cm_away."SuccessRate" AS "AwaySuccessRate",
+    cm_away."ExplosiveRate" AS "AwayExplosiveRate", cm_away."PointsPerDrive" AS "AwayPointsPerDrive",
+    cm_away."ThirdFourthRate" AS "AwayThirdFourthRate", cm_away."RzTdRate" AS "AwayRzTdRate",
+    cm_away."RzScoreRate" AS "AwayRzScoreRate", cm_away."TimePossRatio" AS "AwayTimePossRatio",
+    cm_away."OppYpp" AS "AwayOppYpp", cm_away."OppSuccessRate" AS "AwayOppSuccessRate",
+    cm_away."OppExplosiveRate" AS "AwayOppExplosiveRate", cm_away."OppPointsPerDrive" AS "AwayOppPointsPerDrive",
+    cm_away."OppThirdFourthRate" AS "AwayOppThirdFourthRate", cm_away."OppRzTdRate" AS "AwayOppRzTdRate",
+    cm_away."OppScoreTdRate" AS "AwayOppScoreTdRate", cm_away."NetPunt" AS "AwayNetPunt",
+    cm_away."FgPctShrunk" AS "AwayFgPctShrunk", cm_away."FieldPosDiff" AS "AwayFieldPosDiff",
+    cm_away."TurnoverMarginPerDrive" AS "AwayTurnoverMarginPerDrive",
+    cm_away."PenaltyYardsPerPlay" AS "AwayPenaltyYardsPerPlay",
+
+    ea.pts_scored_avg  AS "AwayPtsScoredAvg",  ea.pts_scored_min  AS "AwayPtsScoredMin",  ea.pts_scored_max  AS "AwayPtsScoredMax",
+    ea.pts_allowed_avg AS "AwayPtsAllowedAvg", ea.pts_allowed_min AS "AwayPtsAllowedMin", ea.pts_allowed_max AS "AwayPtsAllowedMax",
+    ea.margin_win_avg  AS "AwayMarginWinAvg",  ea.margin_win_min  AS "AwayMarginWinMin",  ea.margin_win_max  AS "AwayMarginWinMax",
+    ea.margin_loss_avg AS "AwayMarginLossAvg", ea.margin_loss_min AS "AwayMarginLossMin", ea.margin_loss_max AS "AwayMarginLossMax",
+
+    con."HomeScore",
+    con."AwayScore",
+    CASE
+        WHEN con."HomeScore" > con."AwayScore" THEN 'HOME'
+        WHEN con."AwayScore" > con."HomeScore" THEN 'AWAY'
+        ELSE 'TIE'
+    END AS "Winner",
+    odds."Spread"
+
+FROM params p
+JOIN public."Contest" con      ON con."HomeScore" IS NOT NULL AND con."AwayScore" IS NOT NULL
+JOIN public."SeasonWeek" sw    ON sw."Id" = con."SeasonWeekId"
+JOIN public."Season" s         ON s."Id" = sw."SeasonId"
+LEFT JOIN public."SeasonPhase" sp ON sp."Id" = con."SeasonPhaseId"
+JOIN public."Competition" comp ON comp."ContestId" = con."Id"
+JOIN public."CompetitionMetric" cm_home
+    ON cm_home."CompetitionId" = comp."Id" AND cm_home."FranchiseSeasonId" = con."HomeTeamFranchiseSeasonId"
+JOIN public."CompetitionMetric" cm_away
+    ON cm_away."CompetitionId" = comp."Id" AND cm_away."FranchiseSeasonId" = con."AwayTeamFranchiseSeasonId"
+JOIN entering eh ON eh.contest_id = con."Id" AND eh.franchise_season_id = con."HomeTeamFranchiseSeasonId"
+JOIN entering ea ON ea.contest_id = con."Id" AND ea.franchise_season_id = con."AwayTeamFranchiseSeasonId"
+LEFT JOIN LATERAL (
+  SELECT *
+  FROM public."CompetitionOdds"
+  WHERE "CompetitionId" = comp."Id"
+    AND "ProviderId" IN ('58', '100')
+  ORDER BY CASE WHEN "ProviderId" = '58' THEN 1 ELSE 2 END
+  LIMIT 1
+) odds ON TRUE
+WHERE con."CancelledUtc" IS NULL
+  AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+  AND (s."Year" < p.season_year OR (s."Year" = p.season_year AND sw."Number" < p.week))
+ORDER BY s."Year", sw."Number";

--- a/src/metrics-modeling/sql/competition_metrics_asof_week.sql
+++ b/src/metrics-modeling/sql/competition_metrics_asof_week.sql
@@ -1,0 +1,206 @@
+-- AS-OF slate extraction for backtests: the week-:week slate of season
+-- :season_year with features computed ENTERING that week — aggregates of
+-- CompetitionMetric rows from completed games in weeks < :week only.
+-- Formula parity with ComputeFranchiseSeasonMetric (unweighted AVG per
+-- game; RZ SafeAvg fields COALESCE to 0 when all-null, matching the C#
+-- DefaultIfEmpty().Average() quirk). Pts/Margin columns aggregate from
+-- Contest scores under the same cutoff.
+--
+-- :prior_tail (0 = off): top-up semantics — when a team has played fewer
+-- than :prior_tail current-season games before the cutoff, its window is
+-- supplemented with its most recent prior-season games (regular/post
+-- season only; preseason is system-testing data, never signal) up to a
+-- floor of :prior_tail total games where available.
+--
+-- psql -v season_year=2025 -v week=6 -v prior_tail=5
+WITH params AS (
+    SELECT :season_year::int AS season_year,
+           :week::int        AS week,
+           :prior_tail::int  AS prior_tail
+),
+
+-- One row per (team-perspective, completed game) for the CURRENT season
+-- before the cutoff week. Carries the game's CompetitionMetric and the
+-- team-relative scores.
+current_team_games AS (
+    SELECT
+        fs."Id"            AS franchise_season_id,
+        fs."FranchiseId"   AS franchise_id,
+        con."StartDateUtc" AS start_date_utc,
+        cm.*,
+        CASE WHEN con."HomeTeamFranchiseSeasonId" = fs."Id" THEN con."HomeScore" ELSE con."AwayScore" END AS own_score,
+        CASE WHEN con."HomeTeamFranchiseSeasonId" = fs."Id" THEN con."AwayScore" ELSE con."HomeScore" END AS opp_score
+    FROM params p
+    JOIN public."Season" s          ON s."Year" = p.season_year
+    JOIN public."SeasonWeek" sw     ON sw."SeasonId" = s."Id" AND sw."Number" < p.week
+    JOIN public."Contest" con       ON con."SeasonWeekId" = sw."Id"
+    JOIN public."Competition" comp  ON comp."ContestId" = con."Id"
+    LEFT JOIN public."SeasonPhase" sp ON sp."Id" = con."SeasonPhaseId"
+    JOIN public."FranchiseSeason" fs
+        ON fs."Id" IN (con."HomeTeamFranchiseSeasonId", con."AwayTeamFranchiseSeasonId")
+    JOIN public."CompetitionMetric" cm
+        ON cm."CompetitionId" = comp."Id" AND cm."FranchiseSeasonId" = fs."Id"
+    WHERE con."HomeScore" IS NOT NULL AND con."AwayScore" IS NOT NULL
+      AND con."CancelledUtc" IS NULL
+      AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)  -- preseason excluded (policy 2026-08-08)
+),
+
+current_counts AS (
+    SELECT franchise_season_id, COUNT(*) AS games_played
+    FROM current_team_games
+    GROUP BY franchise_season_id
+),
+
+-- Prior-season (season_year - 1) team-games for the SAME franchises,
+-- keyed to the CURRENT season's FranchiseSeasonId, newest first.
+prior_team_games_ranked AS (
+    SELECT
+        fs_now."Id"        AS franchise_season_id,
+        fs_prev."FranchiseId" AS franchise_id,
+        con."StartDateUtc" AS start_date_utc,
+        cm.*,
+        CASE WHEN con."HomeTeamFranchiseSeasonId" = fs_prev."Id" THEN con."HomeScore" ELSE con."AwayScore" END AS own_score,
+        CASE WHEN con."HomeTeamFranchiseSeasonId" = fs_prev."Id" THEN con."AwayScore" ELSE con."HomeScore" END AS opp_score,
+        ROW_NUMBER() OVER (PARTITION BY fs_now."Id" ORDER BY con."StartDateUtc" DESC) AS recency_rank
+    FROM params p
+    JOIN public."FranchiseSeason" fs_now  ON fs_now."SeasonYear" = p.season_year
+    JOIN public."FranchiseSeason" fs_prev ON fs_prev."FranchiseId" = fs_now."FranchiseId"
+                                         AND fs_prev."SeasonYear" = p.season_year - 1
+    JOIN public."Contest" con
+        ON fs_prev."Id" IN (con."HomeTeamFranchiseSeasonId", con."AwayTeamFranchiseSeasonId")
+    JOIN public."Competition" comp  ON comp."ContestId" = con."Id"
+    LEFT JOIN public."SeasonPhase" sp ON sp."Id" = con."SeasonPhaseId"
+    JOIN public."CompetitionMetric" cm
+        ON cm."CompetitionId" = comp."Id" AND cm."FranchiseSeasonId" = fs_prev."Id"
+    WHERE p.prior_tail > 0
+      AND con."HomeScore" IS NOT NULL AND con."AwayScore" IS NOT NULL
+      AND con."CancelledUtc" IS NULL
+      AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+),
+
+-- Top-up: prior games admitted only up to (prior_tail - current games).
+window_games AS (
+    SELECT franchise_season_id, start_date_utc, own_score, opp_score,
+           "Ypp", "SuccessRate", "ExplosiveRate", "PointsPerDrive", "ThirdFourthRate",
+           "RzTdRate", "RzScoreRate", "TimePossRatio",
+           "OppYpp", "OppSuccessRate", "OppExplosiveRate", "OppPointsPerDrive",
+           "OppThirdFourthRate", "OppRzTdRate", "OppScoreTdRate",
+           "NetPunt", "FgPctShrunk", "FieldPosDiff", "TurnoverMarginPerDrive", "PenaltyYardsPerPlay"
+    FROM current_team_games
+
+    UNION ALL
+
+    SELECT ptg.franchise_season_id, ptg.start_date_utc, ptg.own_score, ptg.opp_score,
+           ptg."Ypp", ptg."SuccessRate", ptg."ExplosiveRate", ptg."PointsPerDrive", ptg."ThirdFourthRate",
+           ptg."RzTdRate", ptg."RzScoreRate", ptg."TimePossRatio",
+           ptg."OppYpp", ptg."OppSuccessRate", ptg."OppExplosiveRate", ptg."OppPointsPerDrive",
+           ptg."OppThirdFourthRate", ptg."OppRzTdRate", ptg."OppScoreTdRate",
+           ptg."NetPunt", ptg."FgPctShrunk", ptg."FieldPosDiff", ptg."TurnoverMarginPerDrive", ptg."PenaltyYardsPerPlay"
+    FROM prior_team_games_ranked ptg
+    CROSS JOIN params p
+    LEFT JOIN current_counts cc ON cc.franchise_season_id = ptg.franchise_season_id
+    WHERE ptg.recency_rank <= GREATEST(p.prior_tail - COALESCE(cc.games_played, 0), 0)
+),
+
+-- Entering-week aggregates, formula-parity with ComputeFranchiseSeasonMetric.
+asof AS (
+    SELECT
+        franchise_season_id,
+        AVG("Ypp")                     AS "Ypp",
+        AVG("SuccessRate")             AS "SuccessRate",
+        AVG("ExplosiveRate")           AS "ExplosiveRate",
+        AVG("PointsPerDrive")          AS "PointsPerDrive",
+        AVG("ThirdFourthRate")         AS "ThirdFourthRate",
+        COALESCE(AVG("RzTdRate"), 0)   AS "RzTdRate",       -- SafeAvg quirk
+        COALESCE(AVG("RzScoreRate"), 0) AS "RzScoreRate",   -- SafeAvg quirk
+        AVG("TimePossRatio")           AS "TimePossRatio",
+        AVG("OppYpp")                  AS "OppYpp",
+        AVG("OppSuccessRate")          AS "OppSuccessRate",
+        AVG("OppExplosiveRate")        AS "OppExplosiveRate",
+        AVG("OppPointsPerDrive")       AS "OppPointsPerDrive",
+        AVG("OppThirdFourthRate")      AS "OppThirdFourthRate",
+        COALESCE(AVG("OppRzTdRate"), 0)    AS "OppRzTdRate",    -- SafeAvg quirk
+        COALESCE(AVG("OppScoreTdRate"), 0) AS "OppScoreTdRate", -- SafeAvg quirk
+        AVG("NetPunt")                 AS "NetPunt",
+        AVG("FgPctShrunk")             AS "FgPctShrunk",
+        AVG("FieldPosDiff")            AS "FieldPosDiff",
+        AVG("TurnoverMarginPerDrive")  AS "TurnoverMarginPerDrive",
+        AVG("PenaltyYardsPerPlay")     AS "PenaltyYardsPerPlay",
+        AVG(own_score)                 AS "PtsScoredAvg",
+        MIN(own_score)                 AS "PtsScoredMin",
+        MAX(own_score)                 AS "PtsScoredMax",
+        AVG(opp_score)                 AS "PtsAllowedAvg",
+        MIN(opp_score)                 AS "PtsAllowedMin",
+        MAX(opp_score)                 AS "PtsAllowedMax",
+        AVG(CASE WHEN own_score > opp_score THEN own_score - opp_score END) AS "MarginWinAvg",
+        MIN(CASE WHEN own_score > opp_score THEN own_score - opp_score END) AS "MarginWinMin",
+        MAX(CASE WHEN own_score > opp_score THEN own_score - opp_score END) AS "MarginWinMax",
+        AVG(CASE WHEN own_score < opp_score THEN opp_score - own_score END) AS "MarginLossAvg",
+        MIN(CASE WHEN own_score < opp_score THEN opp_score - own_score END) AS "MarginLossMin",
+        MAX(CASE WHEN own_score < opp_score THEN opp_score - own_score END) AS "MarginLossMax"
+    FROM window_games
+    GROUP BY franchise_season_id
+)
+
+SELECT
+    con."Id" AS "ContestId",
+    comp."Id" AS "CompetitionId",
+    sw."Number" AS "WeekNumber",
+    con."HomeTeamFranchiseSeasonId",
+    con."AwayTeamFranchiseSeasonId",
+
+    con."HomeTeamFranchiseSeasonId" AS "HomeFranchiseSeasonId",
+    h."Ypp" AS "HomeYpp", h."SuccessRate" AS "HomeSuccessRate", h."ExplosiveRate" AS "HomeExplosiveRate",
+    h."PointsPerDrive" AS "HomePointsPerDrive", h."ThirdFourthRate" AS "HomeThirdFourthRate",
+    h."RzTdRate" AS "HomeRzTdRate", h."RzScoreRate" AS "HomeRzScoreRate", h."TimePossRatio" AS "HomeTimePossRatio",
+    h."OppYpp" AS "HomeOppYpp", h."OppSuccessRate" AS "HomeOppSuccessRate", h."OppExplosiveRate" AS "HomeOppExplosiveRate",
+    h."OppPointsPerDrive" AS "HomeOppPointsPerDrive", h."OppThirdFourthRate" AS "HomeOppThirdFourthRate",
+    h."OppRzTdRate" AS "HomeOppRzTdRate", h."OppScoreTdRate" AS "HomeOppScoreTdRate",
+    h."NetPunt" AS "HomeNetPunt", h."FgPctShrunk" AS "HomeFgPctShrunk", h."FieldPosDiff" AS "HomeFieldPosDiff",
+    h."TurnoverMarginPerDrive" AS "HomeTurnoverMarginPerDrive", h."PenaltyYardsPerPlay" AS "HomePenaltyYardsPerPlay",
+    h."PtsScoredAvg" AS "HomePtsScoredAvg", h."PtsScoredMin" AS "HomePtsScoredMin", h."PtsScoredMax" AS "HomePtsScoredMax",
+    h."PtsAllowedAvg" AS "HomePtsAllowedAvg", h."PtsAllowedMin" AS "HomePtsAllowedMin", h."PtsAllowedMax" AS "HomePtsAllowedMax",
+    h."MarginWinAvg" AS "HomeMarginWinAvg", h."MarginWinMin" AS "HomeMarginWinMin", h."MarginWinMax" AS "HomeMarginWinMax",
+    h."MarginLossAvg" AS "HomeMarginLossAvg", h."MarginLossMin" AS "HomeMarginLossMin", h."MarginLossMax" AS "HomeMarginLossMax",
+
+    con."AwayTeamFranchiseSeasonId" AS "AwayFranchiseSeasonId",
+    a."Ypp" AS "AwayYpp", a."SuccessRate" AS "AwaySuccessRate", a."ExplosiveRate" AS "AwayExplosiveRate",
+    a."PointsPerDrive" AS "AwayPointsPerDrive", a."ThirdFourthRate" AS "AwayThirdFourthRate",
+    a."RzTdRate" AS "AwayRzTdRate", a."RzScoreRate" AS "AwayRzScoreRate", a."TimePossRatio" AS "AwayTimePossRatio",
+    a."OppYpp" AS "AwayOppYpp", a."OppSuccessRate" AS "AwayOppSuccessRate", a."OppExplosiveRate" AS "AwayOppExplosiveRate",
+    a."OppPointsPerDrive" AS "AwayOppPointsPerDrive", a."OppThirdFourthRate" AS "AwayOppThirdFourthRate",
+    a."OppRzTdRate" AS "AwayOppRzTdRate", a."OppScoreTdRate" AS "AwayOppScoreTdRate",
+    a."NetPunt" AS "AwayNetPunt", a."FgPctShrunk" AS "AwayFgPctShrunk", a."FieldPosDiff" AS "AwayFieldPosDiff",
+    a."TurnoverMarginPerDrive" AS "AwayTurnoverMarginPerDrive", a."PenaltyYardsPerPlay" AS "AwayPenaltyYardsPerPlay",
+    a."PtsScoredAvg" AS "AwayPtsScoredAvg", a."PtsScoredMin" AS "AwayPtsScoredMin", a."PtsScoredMax" AS "AwayPtsScoredMax",
+    a."PtsAllowedAvg" AS "AwayPtsAllowedAvg", a."PtsAllowedMin" AS "AwayPtsAllowedMin", a."PtsAllowedMax" AS "AwayPtsAllowedMax",
+    a."MarginWinAvg" AS "AwayMarginWinAvg", a."MarginWinMin" AS "AwayMarginWinMin", a."MarginWinMax" AS "AwayMarginWinMax",
+    a."MarginLossAvg" AS "AwayMarginLossAvg", a."MarginLossMin" AS "AwayMarginLossMin", a."MarginLossMax" AS "AwayMarginLossMax",
+
+    -- Scores stay NULL: the harness scores against Contest ground truth
+    -- AFTER prediction; the pipeline must never see them here.
+    NULL AS "HomeScore",
+    NULL AS "AwayScore",
+    NULL AS "Winner",
+
+    odds."Spread"
+
+FROM params p
+JOIN public."Season" s         ON s."Year" = p.season_year
+JOIN public."SeasonWeek" sw    ON sw."SeasonId" = s."Id" AND sw."Number" = p.week
+JOIN public."Contest" con      ON con."SeasonWeekId" = sw."Id"
+JOIN public."Competition" comp ON comp."ContestId" = con."Id"
+LEFT JOIN public."SeasonPhase" sp ON sp."Id" = con."SeasonPhaseId"
+JOIN asof h ON h.franchise_season_id = con."HomeTeamFranchiseSeasonId"
+JOIN asof a ON a.franchise_season_id = con."AwayTeamFranchiseSeasonId"
+LEFT JOIN LATERAL (
+  SELECT *
+  FROM public."CompetitionOdds"
+  WHERE "CompetitionId" = comp."Id"
+    AND "ProviderId" IN ('58', '100')
+  ORDER BY CASE WHEN "ProviderId" = '58' THEN 1 ELSE 2 END
+  LIMIT 1
+) odds ON TRUE
+WHERE con."CancelledUtc" IS NULL
+  AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+ORDER BY con."StartDateUtc";

--- a/src/metrics-modeling/sql/detect_current_season_week.sql
+++ b/src/metrics-modeling/sql/detect_current_season_week.sql
@@ -1,0 +1,19 @@
+-- Resolve "now" to (SeasonYear, WeekNumber) for live runs. Prefers the
+-- week window containing NOW(); falls back to the NEXT upcoming week so
+-- a run a few days before the window opens (e.g. the Tuesday before
+-- kickoff week) still resolves. Preseason weeks excluded (policy).
+WITH candidates AS (
+    SELECT s."Year" AS "SeasonYear",
+           sw."Number" AS "WeekNumber",
+           sw."StartDate",
+           CASE WHEN sw."StartDate" <= NOW() AND sw."EndDate" > NOW() THEN 0 ELSE 1 END AS pref
+    FROM public."Season" s
+    JOIN public."SeasonWeek" sw ON sw."SeasonId" = s."Id"
+    JOIN public."SeasonPhase" sp ON sp."Id" = sw."SeasonPhaseId"
+    WHERE sp."TypeCode" <> 1
+      AND sw."EndDate" > NOW()
+)
+SELECT "SeasonYear", "WeekNumber"
+FROM candidates
+ORDER BY pref, "StartDate"
+LIMIT 1;

--- a/src/metrics-modeling/tests/test_pipeline.py
+++ b/src/metrics-modeling/tests/test_pipeline.py
@@ -15,7 +15,7 @@ import pytest
 from metricbot import MODEL_VERSION
 from metricbot.config import Config
 from metricbot.dtos import PICKTYPE_ATS, PICKTYPE_STRAIGHT_UP, build_prediction_dtos
-from metricbot.model import FEATURE_COLS, predict_ats, predict_straight_up
+from metricbot.model import FEATURE_COLS, ModelError, predict_ats, predict_straight_up
 
 
 def _frame(rows: int, completed: bool, seed: int = 42) -> pd.DataFrame:
@@ -117,3 +117,18 @@ def test_env_file_parsing_tolerates_quotes_and_comments(tmp_path, monkeypatch):
     assert values["METRICBOT_PG_HOST"] == "db.example.com"
     assert values["METRICBOT_PG_USER"] == "bob"
     assert values["METRICBOT_PG_PASSWORD"] == "p@ss=word"
+
+
+def test_empty_training_window_is_rejected():
+    # Early-season without a prior-season tail: no decided games at all.
+    empty = _frame(0, completed=True)
+    with pytest.raises(ModelError, match="nothing to train on"):
+        predict_straight_up(empty, _frame(3, completed=False))
+
+
+def test_underdetermined_training_window_is_rejected():
+    # Fewer decided games than features would interpolate exactly,
+    # collapsing residual_std to 0 and making probabilities meaningless.
+    too_few = _frame(len(FEATURE_COLS) - 1, completed=True)
+    with pytest.raises(ModelError, match="underdetermined"):
+        predict_straight_up(too_few, _frame(3, completed=False))

--- a/src/metrics-modeling/tests/test_pipeline.py
+++ b/src/metrics-modeling/tests/test_pipeline.py
@@ -1,0 +1,119 @@
+"""Offline tests — no database, no network.
+
+Covers the pieces that can drift silently: the model math's contracts,
+the DTO shape the API ingestion endpoint expects, and config parsing.
+Extraction is deliberately untested here (it shells to psql against a
+real database; that's integration territory).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from metricbot import MODEL_VERSION
+from metricbot.config import Config
+from metricbot.dtos import PICKTYPE_ATS, PICKTYPE_STRAIGHT_UP, build_prediction_dtos
+from metricbot.model import FEATURE_COLS, predict_ats, predict_straight_up
+
+
+def _frame(rows: int, completed: bool, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    data = {col: rng.normal(size=rows) for col in FEATURE_COLS}
+    data["ContestId"] = [f"contest-{i}" for i in range(rows)]
+    data["HomeFranchiseSeasonId"] = [f"home-{i}" for i in range(rows)]
+    data["AwayFranchiseSeasonId"] = [f"away-{i}" for i in range(rows)]
+    data["Spread"] = rng.normal(scale=7, size=rows).round(1)
+
+    if completed:
+        home = rng.integers(0, 50, rows)
+        away = rng.integers(0, 50, rows)
+        data["HomeScore"] = home
+        data["AwayScore"] = away
+        data["Winner"] = ["HOME" if h >= a else "AWAY" for h, a in zip(home, away)]
+    else:
+        data["HomeScore"] = [None] * rows
+        data["AwayScore"] = [None] * rows
+        data["Winner"] = [None] * rows
+
+    return pd.DataFrame(data)
+
+
+def test_straight_up_trains_only_on_decided_games():
+    training = _frame(200, completed=True)
+    # Slate rows carry no Winner and must never enter training.
+    training = pd.concat([training, _frame(5, completed=False)], ignore_index=True)
+
+    result = predict_straight_up(training, _frame(5, completed=False))
+
+    assert result.training_rows == 200
+    assert result.residual_std > 0
+    assert result.mae > 0
+    assert len(result.predictions) == 5
+
+
+def test_win_probabilities_are_clipped_and_directional():
+    su = predict_straight_up(_frame(200, completed=True), _frame(20, completed=False))
+    probs = su.predictions["WinProbability"]
+
+    assert probs.between(0.01, 0.99).all()
+    # P(home wins) must move with the predicted margin.
+    ordered = su.predictions.sort_values("PredictedMargin")
+    assert ordered["WinProbability"].is_monotonic_increasing
+
+
+def test_ats_probabilities_complement_and_respect_spread():
+    su = predict_straight_up(_frame(200, completed=True), _frame(20, completed=False))
+    predictions = predict_ats(su)
+
+    total = predictions["HomeCoverProbability"] + predictions["AwayCoverProbability"]
+    # Complementary up to the 0.01/0.99 clipping.
+    assert ((total - 1.0).abs() < 0.02).all()
+    assert predictions["AtsPredictedLabel"].isin([0, 1]).all()
+
+
+def test_dtos_match_the_ingestion_contract():
+    su = predict_straight_up(_frame(200, completed=True), _frame(7, completed=False))
+    dtos = build_prediction_dtos(predict_ats(su))
+
+    assert len(dtos) == 14  # SU + ATS per contest
+    assert {d["PredictionType"] for d in dtos} == {PICKTYPE_STRAIGHT_UP, PICKTYPE_ATS}
+
+    for dto in dtos:
+        # Exactly the keys ContestPredictionDto binds.
+        assert set(dto) == {
+            "ContestId", "WinnerFranchiseSeasonId", "WinProbability",
+            "PredictionType", "ModelVersion",
+        }
+        assert dto["ModelVersion"] == MODEL_VERSION
+        assert 0.01 <= dto["WinProbability"] <= 0.99
+        # Both prediction types are expressed home-relative for the UI.
+        assert dto["WinnerFranchiseSeasonId"].startswith("home-")
+
+
+def test_config_rejects_unknown_sport():
+    with pytest.raises(SystemExit):
+        Config.load("cricket")
+
+
+def test_env_file_parsing_tolerates_quotes_and_comments(tmp_path, monkeypatch):
+    secrets = tmp_path / "_metricbot.env"
+    secrets.write_text(
+        "# comment line\n"
+        'METRICBOT_PG_HOST="db.example.com"\n'
+        "METRICBOT_PG_USER=bob\n"
+        "METRICBOT_PG_PASSWORD='p@ss=word'\n"
+        "\n",
+        encoding="utf-8",
+    )
+    # SPORTDEETS_SECRETS_PATH may point at the PowerShell secrets FILE,
+    # not its directory — the loader handles both.
+    monkeypatch.setenv("SPORTDEETS_SECRETS_PATH", str(tmp_path / "_common-variables.ps1"))
+
+    from metricbot import config as config_module
+
+    values = config_module._load_env_file()
+    assert values["METRICBOT_PG_HOST"] == "db.example.com"
+    assert values["METRICBOT_PG_USER"] == "bob"
+    assert values["METRICBOT_PG_PASSWORD"] == "p@ss=word"


### PR DESCRIPTION
## Summary

Replaces the operator-orchestrated PowerShell + CSV + Postman deetsMeter workflow with a service the platform runs itself. Design: `docs/metrics-modeling/metrics-microservice-deetsmeter.md` (MVP Phases A+B; **Phase B revised** from the CronJob plan — see below).

### Phase A — the pipeline as a package

One entry point replaces five manual steps:

```
python -m metricbot run-week [--sport ncaaf|nfl] [--dry-run] [--dump-intermediate]
```

Extract → train → SU → ATS → DTOs → POST, in memory. **Math ported verbatim** from the prototype scripts (`MODEL_VERSION` bumps only when the math changes). Extraction shells to `psql` using the existing SQL (no new deps); publishing replaces the Postman step against the existing `/admin/ai-predictions/{userId}` endpoint.

### As-of mode — the experiment capability (Option B, full as-of)

`--season-year Y --week N [--prior-season-tail K]` predicts a historical week using **only information available entering it**: slate features aggregated on the fly from per-game `CompetitionMetric` rows (weeks < N), formula-parity with `ComputeFranchiseSeasonMetric` including its SafeAvg→0 quirk; training capped strictly before (Y, N) with **entering-game** Pts/Margin windows. `--prior-season-tail` tops up thin early-week windows with a team's most recent K prior-season games (top-up semantics — it retires itself as real games accumulate) and doubles as an experiment axis. **Explicit-week runs never publish without `--publish`.**

**Live mode now uses the same extraction**, with (season, week) resolved from the calendar — which is the only thing that works in weeks 1–2 when `FranchiseSeasonMetric` is empty. The live path literally could not run for 2026 before this. The prototype SQL survives behind `--legacy-extraction` for parity comparison.

**Two live-flow bugs this surfaced and corrects:** training leaked current-season-end Pts/Margin values onto historical games, and had no preseason filter (NFL preseason games entered training, violating the preseason-is-never-signal policy). Expect honest as-of accuracy **below** the prototype's leaky 56–62% backtests — that's the leak being removed, not a regression.

### Phase B — deployment (revised)

A K8s CronJob cannot take parameters and has no trigger UI, but on-demand parameterized runs **are** the experiment workflow. Instead:

- MetricBot ships as a thin **internal** FastAPI service (`POST /run-week`, `GET /health`; no public ingress). Runs are seconds and return DTOs + metadata (MAE, residual std, counts) on the wire, so nothing depends on an ephemeral container's filesystem.
- **The API's Hangfire owns scheduling**: `MetricBotWeekly-FootballNcaa` (Tue 03:00 UTC) and `-FootballNfl` (Wed 03:00 UTC) — giving the jobs dashboard's manual trigger, run history, and failure visibility for free. This answers the design doc's own open question ("Hangfire trigger or k8s CronJob; pick one") in favor of Hangfire.
- Ad-hoc/experiment runs: `POST /admin/metricbot/run-week` (admin-gated proxy → typed `MetricBotClient`), plus `/admin/metricbot/health`.
- Dockerfile (python:3.12-slim + postgresql-client, non-root, healthcheck), requirements split (model pins / service / dev), and `azure-pipelines.yml` (pytest + import check → Docker buildAndPush with repo-root build context). `metricbot_tag` input added to the deploy workflow.

### Tests

6 offline Python tests (training excludes undecided games; probability clipping + monotonicity; ATS complementarity; DTO contract matching `ContestPredictionDto` exactly; config validation; env parsing). 660 API tests still pass; full solution builds. Locally verified end to end: the CLI produced 2026 week-1 predictions (193 contests, 60k training rows, MAE 13.9) and the container's `/health` + `/run-week` responded correctly.

### Deploy prerequisites (not in this PR)

1. Create the `metricbot-secrets` K8s secret (`pg-host`, `pg-port`, `pg-user`, `pg-password`, `api-base-url`, `admin-token`).
2. K8s manifests live in **sports-data-config** (`app/base/apps/metricbot/` + prod overlay patch) and get pushed **after** this merges and the image builds — same ordering as the daemon work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MetricBot weekly football predictions, including straight-up and against-the-spread results.
  * Added health monitoring and on-demand weekly runs through the admin API.
  * Added automated weekly processing for NCAA football and NFL.
  * Added optional publishing, historical/as-of analysis, and dry-run capabilities.
  * Added containerized HTTP service and command-line operation.

* **Documentation**
  * Added setup, local Docker usage, configuration, execution, and troubleshooting guidance.

* **Deployment**
  * Added automated testing, image publishing, configurable production image tags, and serialized production updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->