### PR TITLE
fix(ci): add MetricBot to the auto deploy workflow

### DIFF
--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -156,13 +156,15 @@ jobs:
         id: metricbot_tag
         run: |
           set -euo pipefail
+          # `|| true`: under pipefail a no-match grep exits 1 and would kill
+          # the step before the explicit check below could report why.
           LATEST_TAG=$(az acr repository show-tags \
             --name sportdeets \
             --repository sportsdatametricbot \
             --orderby time_desc \
             --output tsv \
             | grep -E '^[0-9]+$' \
-            | head -n 1)
+            | head -n 1 || true)
           if [ -z "$LATEST_TAG" ]; then
             echo "::error::No numeric tags found for sportsdatametricbot"
             exit 1

--- a/.github/workflows/deploy-services-prod-auto.yml
+++ b/.github/workflows/deploy-services-prod-auto.yml
@@ -36,6 +36,17 @@ on:
         required: false
         type: boolean
         default: false
+      deploy_metricbot:
+        description: 'Deploy MetricBot with latest tag'
+        required: false
+        type: boolean
+        default: false
+
+# Shares the group with deploy-services-prod.yml: both workflows commit
+# and push sports-data-config, so their pushes must not race.
+concurrency:
+  group: sports-data-config-prod-update
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -139,6 +150,25 @@ jobs:
           fi
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           echo "Latest Notification tag: $LATEST_TAG"
+
+      - name: Get latest MetricBot tag from ACR
+        if: ${{ inputs.deploy_metricbot }}
+        id: metricbot_tag
+        run: |
+          set -euo pipefail
+          LATEST_TAG=$(az acr repository show-tags \
+            --name sportdeets \
+            --repository sportsdatametricbot \
+            --orderby time_desc \
+            --output tsv \
+            | grep -E '^[0-9]+$' \
+            | head -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::No numeric tags found for sportsdatametricbot"
+            exit 1
+          fi
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Latest MetricBot tag: $LATEST_TAG"
 
       - name: Checkout sports-data-config repo
         uses: actions/checkout@v5
@@ -249,8 +279,36 @@ jobs:
           fi
           echo "Updated Notification to tag: ${{ steps.notification_tag.outputs.tag }}"
 
+      - name: Update MetricBot image tag
+        if: ${{ inputs.deploy_metricbot && steps.metricbot_tag.outputs.tag != '' }}
+        working-directory: sports-data-config
+        env:
+          # Via env, never interpolated into the script body — this job
+          # holds GH_PAT for the config repo.
+          METRICBOT_TAG: ${{ steps.metricbot_tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PATCH=app/overlays/04_prod/metricbot-patch.yaml
+          if [ ! -f "$PATCH" ]; then
+            echo "::error::$PATCH not found"
+            exit 1
+          fi
+
+          IMAGE="sportdeets.azurecr.io/sportsdatametricbot:${METRICBOT_TAG}"
+          # Anchored to the metricbot image line so unrelated images in
+          # the patch can never be rewritten.
+          sed -i "s|image: sportdeets.azurecr.io/sportsdatametricbot:.*|image: ${IMAGE}|g" "$PATCH"
+
+          if ! grep -q "image: ${IMAGE}" "$PATCH"; then
+            echo "::error::Failed to set MetricBot image to ${IMAGE} in $PATCH"
+            exit 1
+          fi
+          echo "Updated MetricBot to tag: ${METRICBOT_TAG}"
+
       - name: Commit and push changes
         working-directory: sports-data-config
+        env:
+          METRICBOT_TAG_SAFE: ${{ steps.metricbot_tag.outputs.tag }}
         run: |
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "actions@github.com"
@@ -267,6 +325,7 @@ jobs:
             [ "${{ inputs.deploy_ui }}" == "true" ] && COMMIT_MSG="$COMMIT_MSG UI=${{ steps.ui_tag.outputs.tag }}"
             [ "${{ inputs.deploy_jobs_dashboard }}" == "true" ] && [ -n "${{ steps.jobs_dashboard_tag.outputs.tag }}" ] && COMMIT_MSG="$COMMIT_MSG JobsDashboard=${{ steps.jobs_dashboard_tag.outputs.tag }}"
             [ "${{ inputs.deploy_notification }}" == "true" ] && [ -n "${{ steps.notification_tag.outputs.tag }}" ] && COMMIT_MSG="$COMMIT_MSG Notification=${{ steps.notification_tag.outputs.tag }}"
+            [ "${{ inputs.deploy_metricbot }}" == "true" ] && [ -n "${METRICBOT_TAG_SAFE:-}" ] && COMMIT_MSG="$COMMIT_MSG MetricBot=${METRICBOT_TAG_SAFE}"
             
             git commit -m "$COMMIT_MSG"
             git push


### PR DESCRIPTION
## Summary

The **auto** workflow is the one used day to day (the manual one requires typing an image tag), but #609 only wired `metricbot_tag` into the manual workflow — so MetricBot had no deploy checkbox where it matters.

- `deploy_metricbot` input + ACR latest-numeric-tag lookup for `sportsdatametricbot`, mirroring the other services.
- Patch-update step: tag passed via step `env` (this job holds `GH_PAT` for sports-data-config), `sed` anchored to the `sportsdatametricbot` image line, and the result asserted — a failed edit errors instead of silently redeploying the previous tag.
- Commit-message entry for MetricBot.
- **`concurrency` group shared with `deploy-services-prod.yml`** — both workflows commit and push sports-data-config, so the group added in #609 only actually serializes them if both files declare it.

Other services' steps deliberately untouched.

Note: the initial MetricBot deploy (tag 5984) was already applied by hand to sports-data-config; this makes subsequent deploys a checkbox like everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to deploy MetricBot independently during production deployments.
  * Automatically selects and applies the latest available MetricBot image version.
* **Reliability**
  * Validates deployment configuration before applying updates.
  * Confirms the MetricBot image was updated successfully.
  * Prevents concurrent production configuration updates from conflicting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->