### PR TITLE
feat(metricbot,api): platform Sport vocabulary + backtest grader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,6 @@ docs/metrics-modeling/previews/
 
 # MetricBot runtime artifacts contain prod-derived data - never committed
 src/metrics-modeling/data/
+
+# MetricBot experiment/backtest results saved from Bruno - prod-derived
+docs/metrics-modeling/output/

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -391,7 +391,7 @@ Invoke-RestMethod -Uri http://localhost:8080/health
 
 # Dry-run experiment: no POST, returns run metadata only.
 $body = @{
-  sport             = "ncaaf"
+  sport             = "FootballNcaa"
   season_year       = 2026
   week              = 1
   prior_season_tail = 5
@@ -411,7 +411,7 @@ strips them when handing arguments to native executables:
 ```powershell
 curl.exe -X POST http://localhost:8080/run-week `
   -H "Content-Type: application/json" `
-  -d '{\"sport\":\"ncaaf\",\"season_year\":2026,\"week\":1,\"prior_season_tail\":5,\"dry_run\":true}'
+  -d '{\"sport\":\"FootballNcaa\",\"season_year\":2026,\"week\":1,\"prior_season_tail\":5,\"dry_run\":true}'
 ```
 
 ### Two gotchas

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -295,6 +295,28 @@ namespace SportsData.Api.Application.Admin
             return result.ToActionResult();
         }
 
+        /// <summary>
+        /// Backtest a historical week: predict it as-of (only information
+        /// available entering the week), then grade against final scores —
+        /// SU accuracy vs baselines, ATS with pushes excluded-and-counted,
+        /// model-vs-market margin MAE, Brier + calibration deciles. Never
+        /// publishes predictions.
+        ///
+        /// Example: POST /admin/metricbot/backtest
+        /// Body: { "sport": "FootballNcaa", "seasonYear": 2025, "week": 6,
+        ///         "priorSeasonTail": 5 }
+        /// </summary>
+        [HttpPost]
+        [Route("metricbot/backtest")]
+        public async Task<ActionResult<MetricBotBacktestResponse>> BacktestMetricBotWeek(
+            [FromBody] MetricBotBacktestRequest request,
+            [FromServices] IProvideMetricBot metricBot,
+            CancellationToken cancellationToken)
+        {
+            var result = await metricBot.BacktestAsync(request, cancellationToken);
+            return result.ToActionResult();
+        }
+
         [HttpGet]
         [Route("metricbot/health")]
         public async Task<IActionResult> GetMetricBotHealth(

--- a/src/SportsData.Api/Application/Jobs/MetricBotWeeklyJob.cs
+++ b/src/SportsData.Api/Application/Jobs/MetricBotWeeklyJob.cs
@@ -35,23 +35,23 @@ namespace SportsData.Api.Application.Jobs
             _logger = logger;
         }
 
-        /// <param name="sport">Platform Sport enum; mapped to MetricBot's vocabulary.</param>
+        /// <param name="sport">Platform Sport enum — MetricBot speaks the same vocabulary.</param>
         public async Task ExecuteAsync(Sport sport)
         {
-            var metricBotSport = MetricBotSports.FromSport(sport);
-            if (metricBotSport is null)
+            if (!MetricBotSports.IsSupported(sport))
             {
                 // Football-only models — a scheduling mistake should say so
                 // plainly rather than round-trip to a 422.
                 throw new InvalidOperationException(
-                    $"MetricBot has no model for {sport}; supported sports are FootballNcaa and FootballNfl.");
+                    $"MetricBot has no model for {sport}; supported sports are " +
+                    $"{Sport.FootballNcaa} and {Sport.FootballNfl}.");
             }
 
             _logger.LogInformation("MetricBotWeeklyJob starting. Sport: {Sport}", sport);
 
             var result = await _metricBot.RunWeekAsync(new MetricBotRunRequest
             {
-                Sport = metricBotSport,
+                Sport = sport,
                 PriorSeasonTail = PriorSeasonTail,
                 // Live run: no explicit week (MetricBot resolves the current
                 // one), publishes by default.

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -41,6 +41,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
+using SportsData.Core.Extensions;
 
 namespace SportsData.Core.DependencyInjection
 {
@@ -151,7 +152,9 @@ namespace SportsData.Core.DependencyInjection
             // it from the Hangfire pool (and, with role, Worker vs Ingest pods).
             connString = ApplyApplicationName(connString, applicationName, role, "Data");
 
-            Console.WriteLine($"PostgreSQL: {connString}");
+            // Redacted: this line ships to Seq, and an unredacted string
+            // would put the production DB password in the logs.
+            Console.WriteLine($"PostgreSQL: {connString.RedactCredentials()}");
 
             services.AddDbContext<T>((serviceProvider, options) =>
             {
@@ -308,7 +311,7 @@ namespace SportsData.Core.DependencyInjection
                 : 20;
 
 #if DEBUG
-            Console.WriteLine($"Hangfire ConnStr: {connString}");
+            Console.WriteLine($"Hangfire ConnStr: {connString.RedactCredentials()}");
 #endif
 
             services.AddHangfire(x =>

--- a/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
+++ b/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
@@ -38,14 +38,21 @@ namespace SportsData.Core.Extensions
             {
                 var builder = new NpgsqlConnectionStringBuilder(connectionString);
 
-                if (string.IsNullOrEmpty(builder.Password))
+                if (string.IsNullOrEmpty(builder.Password) &&
+                    string.IsNullOrEmpty(builder.SslPassword))
                 {
                     // Parsed and provably credential-free: preserve the
                     // original formatting exactly.
                     return connectionString;
                 }
 
-                builder.Password = Mask;
+                if (!string.IsNullOrEmpty(builder.Password))
+                    builder.Password = Mask;
+
+                // Client-certificate key passphrase — a credential too.
+                if (!string.IsNullOrEmpty(builder.SslPassword))
+                    builder.SslPassword = Mask;
+
                 return builder.ConnectionString;
             }
             catch (Exception)

--- a/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
+++ b/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 
 using Npgsql;
 
@@ -11,10 +12,23 @@ namespace SportsData.Core.Extensions
         private const string UnparseableMessage =
             "(connection string could not be parsed; redacted in full)";
 
+        // Key-presence probes against the RAW text. The builder cannot be
+        // the gate: duplicate aliases resolve last-wins and empty values
+        // are dropped from its collection, so "Password=secret;PWD=" looks
+        // credential-free to the builder while the secret still sits in
+        // the original string. These match KEYS only, never values.
+        private static readonly Regex PasswordKeyProbe = new(
+            @"(^|;)\s*(password|pwd|psw)\s*=",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex SslPasswordKeyProbe = new(
+            @"(^|;)\s*ssl\s*password\s*=",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         /// <summary>
         /// Masks credentials in a connection string so it can be logged.
         /// Everything operationally useful — host, port, database, pool
-        /// size, application name — survives; only the secret is replaced.
+        /// size, application name — survives; only secrets are replaced.
         /// </summary>
         /// <remarks>
         /// Startup logs ship to Seq, so an unredacted connection string
@@ -22,35 +36,38 @@ namespace SportsData.Core.Extensions
         /// log access (and in any log export or screenshot). Always call
         /// this before writing a connection string anywhere.
         ///
-        /// Parsing uses NpgsqlConnectionStringBuilder rather than a regex:
-        /// Npgsql accepts multiple password aliases (PWD, PSW) and quoted
-        /// values containing semicolons or doubled quotes — hand-rolled
-        /// matching leaks fragments on exactly those edges. If the string
-        /// cannot be parsed, nothing of it is returned: we cannot prove
-        /// which fragment is the secret.
+        /// Strategy: a raw-text probe decides whether credential keys are
+        /// present at all (verbatim passthrough only when provably none),
+        /// then NpgsqlConnectionStringBuilder re-renders the string with
+        /// the credential properties masked — the rebuild discards every
+        /// original occurrence, including duplicate aliases. A string that
+        /// has credential keys but cannot be parsed returns a fixed
+        /// message: we cannot prove which fragment is the secret.
         /// </remarks>
         public static string RedactCredentials(this string? connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
                 return string.Empty;
 
+            var hasPasswordKey = PasswordKeyProbe.IsMatch(connectionString);
+            var hasSslPasswordKey = SslPasswordKeyProbe.IsMatch(connectionString);
+
+            if (!hasPasswordKey && !hasSslPasswordKey)
+            {
+                // Provably credential-free: preserve the original
+                // formatting exactly.
+                return connectionString;
+            }
+
             try
             {
                 var builder = new NpgsqlConnectionStringBuilder(connectionString);
 
-                if (string.IsNullOrEmpty(builder.Password) &&
-                    string.IsNullOrEmpty(builder.SslPassword))
-                {
-                    // Parsed and provably credential-free: preserve the
-                    // original formatting exactly.
-                    return connectionString;
-                }
-
-                if (!string.IsNullOrEmpty(builder.Password))
+                if (hasPasswordKey)
                     builder.Password = Mask;
 
                 // Client-certificate key passphrase — a credential too.
-                if (!string.IsNullOrEmpty(builder.SslPassword))
+                if (hasSslPasswordKey)
                     builder.SslPassword = Mask;
 
                 return builder.ConnectionString;

--- a/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
+++ b/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
@@ -1,18 +1,15 @@
 using System;
-using System.Text.RegularExpressions;
+
+using Npgsql;
 
 namespace SportsData.Core.Extensions
 {
     public static class ConnectionStringExtensions
     {
-        // Npgsql accepts several spellings for the credential keys, and
-        // permits quoted values containing semicolons (Password='a;b' or
-        // "a;b") — the value alternation must consume a quoted value
-        // whole before falling back to "up to the next semicolon", or the
-        // tail of the password leaks past the mask.
-        private static readonly Regex SecretKeys = new(
-            @"\b(Password|Pwd)\s*=\s*('[^']*'|""[^""]*""|[^;]*)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private const string Mask = "***";
+
+        private const string UnparseableMessage =
+            "(connection string could not be parsed; redacted in full)";
 
         /// <summary>
         /// Masks credentials in a connection string so it can be logged.
@@ -24,17 +21,37 @@ namespace SportsData.Core.Extensions
         /// puts the production database password in front of anyone with
         /// log access (and in any log export or screenshot). Always call
         /// this before writing a connection string anywhere.
+        ///
+        /// Parsing uses NpgsqlConnectionStringBuilder rather than a regex:
+        /// Npgsql accepts multiple password aliases (PWD, PSW) and quoted
+        /// values containing semicolons or doubled quotes — hand-rolled
+        /// matching leaks fragments on exactly those edges. If the string
+        /// cannot be parsed, nothing of it is returned: we cannot prove
+        /// which fragment is the secret.
         /// </remarks>
         public static string RedactCredentials(this string? connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
                 return string.Empty;
 
-            return SecretKeys.Replace(connectionString, match =>
+            try
             {
-                var key = match.Value[..match.Value.IndexOf('=')].TrimEnd();
-                return $"{key}=***";
-            });
+                var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+                if (string.IsNullOrEmpty(builder.Password))
+                {
+                    // Parsed and provably credential-free: preserve the
+                    // original formatting exactly.
+                    return connectionString;
+                }
+
+                builder.Password = Mask;
+                return builder.ConnectionString;
+            }
+            catch (Exception)
+            {
+                return UnparseableMessage;
+            }
         }
     }
 }

--- a/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
+++ b/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
@@ -5,10 +5,13 @@ namespace SportsData.Core.Extensions
 {
     public static class ConnectionStringExtensions
     {
-        // Npgsql accepts several spellings for the credential keys; match
-        // them all, case-insensitively, up to the next ';' or end of string.
+        // Npgsql accepts several spellings for the credential keys, and
+        // permits quoted values containing semicolons (Password='a;b' or
+        // "a;b") — the value alternation must consume a quoted value
+        // whole before falling back to "up to the next semicolon", or the
+        // tail of the password leaks past the mask.
         private static readonly Regex SecretKeys = new(
-            @"\b(Password|Pwd)\s*=\s*[^;]*",
+            @"\b(Password|Pwd)\s*=\s*('[^']*'|""[^""]*""|[^;]*)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>

--- a/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
+++ b/src/SportsData.Core/Extensions/ConnectionStringExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace SportsData.Core.Extensions
+{
+    public static class ConnectionStringExtensions
+    {
+        // Npgsql accepts several spellings for the credential keys; match
+        // them all, case-insensitively, up to the next ';' or end of string.
+        private static readonly Regex SecretKeys = new(
+            @"\b(Password|Pwd)\s*=\s*[^;]*",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Masks credentials in a connection string so it can be logged.
+        /// Everything operationally useful — host, port, database, pool
+        /// size, application name — survives; only the secret is replaced.
+        /// </summary>
+        /// <remarks>
+        /// Startup logs ship to Seq, so an unredacted connection string
+        /// puts the production database password in front of anyone with
+        /// log access (and in any log export or screenshot). Always call
+        /// this before writing a connection string anywhere.
+        /// </remarks>
+        public static string RedactCredentials(this string? connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                return string.Empty;
+
+            return SecretKeys.Replace(connectionString, match =>
+            {
+                var key = match.Value[..match.Value.IndexOf('=')].TrimEnd();
+                return $"{key}=***";
+            });
+        }
+    }
+}

--- a/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
@@ -29,6 +29,10 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
             MetricBotRunRequest request,
             CancellationToken cancellationToken = default);
 
+        Task<Result<MetricBotBacktestResponse>> BacktestAsync(
+            MetricBotBacktestRequest request,
+            CancellationToken cancellationToken = default);
+
         Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default);
     }
 
@@ -146,6 +150,80 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
                 : value[..MaxUpstreamErrorChars] + "... (truncated)";
         }
 
+        public async Task<Result<MetricBotBacktestResponse>> BacktestAsync(
+            MetricBotBacktestRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (!MetricBotSports.IsSupported(request.Sport))
+            {
+                return new Failure<MetricBotBacktestResponse>(
+                    default!,
+                    ResultStatus.BadRequest,
+                    [new ValidationFailure(nameof(request.Sport),
+                        $"Unsupported sport '{request.Sport}'. MetricBot has football models only: " +
+                        $"{Sport.FootballNcaa} or {Sport.FootballNfl}.")]);
+            }
+
+            try
+            {
+                using var response = await _httpClient.PostAsJsonAsync(
+                    "backtest", request, JsonOptions, cancellationToken);
+
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var detail = Truncate(body);
+
+                    _logger.LogError(
+                        "MetricBot backtest failed. Status: {StatusCode}, Body: {Body}",
+                        response.StatusCode, detail);
+
+                    var status = response.StatusCode is System.Net.HttpStatusCode.BadRequest
+                                 or System.Net.HttpStatusCode.UnprocessableEntity
+                        ? ResultStatus.BadRequest
+                        : ResultStatus.Error;
+
+                    return new Failure<MetricBotBacktestResponse>(
+                        default!,
+                        status,
+                        [new ValidationFailure("MetricBot", $"MetricBot returned {(int)response.StatusCode}: {detail}")]);
+                }
+
+                var result = JsonSerializer.Deserialize<MetricBotBacktestResponse>(body, JsonOptions);
+
+                if (result is null)
+                {
+                    return new Failure<MetricBotBacktestResponse>(
+                        default!,
+                        ResultStatus.Error,
+                        [new ValidationFailure("MetricBot", "MetricBot returned an unreadable response")]);
+                }
+
+                return new Success<MetricBotBacktestResponse>(result);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogError(ex, "MetricBot backtest timed out");
+                return new Failure<MetricBotBacktestResponse>(
+                    default!,
+                    ResultStatus.Error,
+                    [new ValidationFailure("MetricBot", "MetricBot did not respond before the client timeout elapsed")]);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "MetricBot backtest request failed");
+                return new Failure<MetricBotBacktestResponse>(
+                    default!,
+                    ResultStatus.Error,
+                    [new ValidationFailure("MetricBot", $"MetricBot request failed: {ex.Message}")]);
+            }
+        }
+
         public async Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default)
         {
             // The typed client's 10-minute timeout exists for training runs;
@@ -226,5 +304,33 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
         /// shape belongs to the Python side and would drift.
         /// </summary>
         public object[]? Dtos { get; set; }
+    }
+
+    public class MetricBotBacktestRequest
+    {
+        public Sport Sport { get; set; } = Sport.FootballNcaa;
+        public int SeasonYear { get; set; }
+        public int Week { get; set; }
+        public int PriorSeasonTail { get; set; }
+    }
+
+    public class MetricBotBacktestResponse
+    {
+        public string ModelVersion { get; set; } = default!;
+        public Sport Sport { get; set; }
+        public int SeasonYear { get; set; }
+        public int Week { get; set; }
+        public int PriorSeasonTail { get; set; }
+        public int TrainingRows { get; set; }
+        public double InSampleMae { get; set; }
+        public double ResidualStd { get; set; }
+        public double ElapsedSeconds { get; set; }
+
+        /// <summary>
+        /// The grade report (su / ats / margin / calibration sections).
+        /// Deliberately opaque for the same reason as Dtos above — the
+        /// shape belongs to the Python grader.
+        /// </summary>
+        public object Grade { get; set; } = default!;
     }
 }

--- a/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/MetricBot/MetricBotClient.cs
@@ -47,7 +47,10 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            // Sport travels as its enum NAME ("FootballNcaa"): MetricBot
+            // speaks the platform's vocabulary, so there is no mapping.
+            Converters = { new JsonStringEnumConverter() }
         };
 
         public MetricBotClient(HttpClient httpClient, ILogger<MetricBotClient> logger)
@@ -66,7 +69,8 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
                     default!,
                     ResultStatus.BadRequest,
                     [new ValidationFailure(nameof(request.Sport),
-                        $"Unsupported sport '{request.Sport}'. MetricBot has football models only: 'ncaaf' or 'nfl'.")]);
+                        $"Unsupported sport '{request.Sport}'. MetricBot has football models only: " +
+                        $"{Sport.FootballNcaa} or {Sport.FootballNfl}.")]);
             }
 
             try
@@ -169,24 +173,18 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
 
     public static class MetricBotSports
     {
-        public const string Ncaaf = "ncaaf";
-        public const string Nfl = "nfl";
-
-        public static bool IsSupported(string? sport) => sport is Ncaaf or Nfl;
-
-        /// <summary>Maps the platform Sport enum to MetricBot's vocabulary; null when unsupported.</summary>
-        public static string? FromSport(Sport sport) => sport switch
-        {
-            Sport.FootballNcaa => Ncaaf,
-            Sport.FootballNfl => Nfl,
-            _ => null  // MetricBot has football models only
-        };
+        /// <summary>MetricBot has football models only.</summary>
+        public static bool IsSupported(Sport sport) =>
+            sport is Sport.FootballNcaa or Sport.FootballNfl;
     }
 
     public class MetricBotRunRequest
     {
-        /// <summary>"ncaaf" or "nfl" — MetricBot's own sport vocabulary.</summary>
-        public string Sport { get; set; } = MetricBotSports.Ncaaf;
+        /// <summary>
+        /// The platform Sport enum, sent as its name. MetricBot uses the
+        /// same vocabulary, so no translation happens anywhere.
+        /// </summary>
+        public Sport Sport { get; set; } = Sport.FootballNcaa;
 
         /// <summary>Explicit (season, week) = experiment; omit both for a live run.</summary>
         public int? SeasonYear { get; set; }
@@ -207,7 +205,7 @@ namespace SportsData.Core.Infrastructure.Clients.MetricBot
     public class MetricBotRunResponse
     {
         public string ModelVersion { get; set; } = default!;
-        public string Sport { get; set; } = default!;
+        public Sport Sport { get; set; }
 
         /// <summary>Always populated — live runs resolve it from the calendar.</summary>
         public int SeasonYear { get; set; }

--- a/src/metrics-modeling/README.md
+++ b/src/metrics-modeling/README.md
@@ -60,7 +60,30 @@ cd C:\Projects\sports-data\src\metrics-modeling
 
 # Deliberately publish an as-of run's predictions (rare; know why first)
 .venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2025 --week 6 --publish
+
+# ── BACKTEST (predict as-of + grade against final scores; never posts) ─
+
+# Grade a single historical week
+.venv\Scripts\python.exe -m metricbot backtest --sport FootballNcaa --season-year 2025 --week 6 --prior-season-tail 5
+
+# The tail experiment, graded: same week with and without
+.venv\Scripts\python.exe -m metricbot backtest --sport FootballNcaa --season-year 2025 --week 2 --prior-season-tail 5
+.venv\Scripts\python.exe -m metricbot backtest --sport FootballNcaa --season-year 2025 --week 2
+
+# Sweep and grade a season
+4..14 | ForEach-Object {
+  .venv\Scripts\python.exe -m metricbot backtest --sport FootballNcaa --season-year 2025 --week $_ --prior-season-tail 5
+}
 ```
+
+The grade report covers: SU accuracy vs always-home and
+favorite-by-spread baselines; ATS accuracy vs the 52.4% break-even
+(pushes excluded and counted); out-of-sample margin MAE/RMSE for the
+model AND for the spread itself on the same games (model vs market —
+the honest head-to-head); Brier scores; calibration deciles
+(predicted 70% should win ~70%). O/U is absent by design — the model
+predicts margin, not totals. In prod, the same report comes from
+`POST /admin/metricbot/backtest` (see Deployment below).
 
 Flag notes:
 

--- a/src/metrics-modeling/README.md
+++ b/src/metrics-modeling/README.md
@@ -177,7 +177,8 @@ C# and Python, no translation layer.
 ## Verification (first run)
 
 1. `.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2026 --week 1 --prior-season-tail 5 --dump-intermediate`
-   (works TODAY, pre-season: features come from 2025 tails)
+   (runs pre-season: with the tail flag, week-1 features come from the
+   prior season's final games, so no current-season data is required)
 2. Parity (mid-season, once 2026 metrics exist): run with and without
    `--legacy-extraction` for the same week and compare predictions —
    entering-week aggregates should match the live FranchiseSeasonMetric

--- a/src/metrics-modeling/README.md
+++ b/src/metrics-modeling/README.md
@@ -23,43 +23,43 @@ cd C:\Projects\sports-data\src\metrics-modeling
 # experiments (entering-week features, leak-free training).
 
 # Safest first contact: full pipeline, no POST, artifacts written to .\data
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --dry-run --dump-intermediate
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --dry-run --dump-intermediate
 
 # The real Tuesday-night run: predict the current NCAAFB week and publish.
 # In weeks 1-2 (little/no current-season data) add the tail or the slate
 # will be empty/thin:
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --prior-season-tail 5
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --prior-season-tail 5
 
 # Mid-season, once teams have games, the tail is optional:
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa
 
 # Same for the NFL week (its own database, same model)
-.venv\Scripts\python.exe -m metricbot run-week --sport nfl --prior-season-tail 5
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNfl --prior-season-tail 5
 
 # Something looks off? Re-run with artifacts + debug logging
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --dry-run --dump-intermediate --verbose
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --dry-run --dump-intermediate --verbose
 
 # ── AS-OF MODE (backtests / experiments — NEVER posts without --publish) ─
 
 # Backtest 2025 week 6 exactly as the model would have seen it
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 6 --dump-intermediate
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2025 --week 6 --dump-intermediate
 
 # Early-season experiment: week 2 with prior-season tail on...
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 2 --prior-season-tail 5 --dump-intermediate
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2025 --week 2 --prior-season-tail 5 --dump-intermediate
 
 # ...and the same week with it off, to compare
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 2 --dump-intermediate
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2025 --week 2 --dump-intermediate
 
 # NFL backtest
-.venv\Scripts\python.exe -m metricbot run-week --sport nfl --season-year 2025 --week 10 --dump-intermediate
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNfl --season-year 2025 --week 10 --dump-intermediate
 
 # Sweep a season's weeks (PowerShell loop; artifacts pile up in .\data)
 4..14 | ForEach-Object {
-  .venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week $_ --dump-intermediate
+  .venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2025 --week $_ --dump-intermediate
 }
 
 # Deliberately publish an as-of run's predictions (rare; know why first)
-.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2025 --week 6 --publish
+.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2025 --week 6 --publish
 ```
 
 Flag notes:
@@ -67,7 +67,8 @@ Flag notes:
 - `--dry-run` — everything except the POST; inspect logs/DTO counts first.
 - `--dump-intermediate` — writes CSV/JSON artifacts to `.\data`
   (gitignored — contains prod-derived data). As-of artifacts are named
-  `*_ncaaf_asof_2025_wk6_tail5.*`; live ones `*_ncaaf_week_N.*`.
+  `*_FootballNcaa_asof_2025_wk6_tail5.*`; live ones
+  `*_FootballNcaa_live_2026_wk1_tail5.*`.
 - Live mode has no week flag: `sql/detect_current_season_week.sql`
   resolves NOW to (season, week) — the open window, or the next upcoming
   non-preseason week.
@@ -132,8 +133,9 @@ either works. Never committed, repo is public:
 | `METRICBOT_ADMIN_TOKEN` | X-Admin-Token for the ingestion endpoint |
 | `METRICBOT_USER_ID` | optional GUID; defaults to the MetricBot synthetic user (`b210d677-…`) |
 
-The sport flag picks the database (`sdProducer.FootballNcaa` /
-`sdProducer.FootballNfl`).
+The sport flag takes the platform's Sport enum name (case-insensitive)
+and picks the matching database — deliberately ONE vocabulary across
+C# and Python, no translation layer.
 
 ## Layout
 
@@ -151,20 +153,20 @@ The sport flag picks the database (`sdProducer.FootballNcaa` /
 
 ## Verification (first run)
 
-1. `.venv\Scripts\python.exe -m metricbot run-week --sport ncaaf --season-year 2026 --week 1 --prior-season-tail 5 --dump-intermediate`
+1. `.venv\Scripts\python.exe -m metricbot run-week --sport FootballNcaa --season-year 2026 --week 1 --prior-season-tail 5 --dump-intermediate`
    (works TODAY, pre-season: features come from 2025 tails)
 2. Parity (mid-season, once 2026 metrics exist): run with and without
    `--legacy-extraction` for the same week and compare predictions —
    entering-week aggregates should match the live FranchiseSeasonMetric
    values; training deltas reflect the leak fixes, documented in the
    design doc.
-3. Live publish when happy: `run-week --sport ncaaf --prior-season-tail 5`.
+3. Live publish when happy: `run-week --sport FootballNcaa --prior-season-tail 5`.
 4. First as-of sanity check: pick a team you know in
-   `data\current_ncaaf_asof_2025_wk6_tail0.csv` — its feature values
+   `data\current_FootballNcaa_asof_2025_wk6_tail0.csv` — its feature values
    should reflect ONLY weeks 1–5 (they should NOT match the live
    `FranchiseSeasonMetric` row, which includes the full season).
 
-   .venv\Scripts\python.exe -m metricbot run-week --sport nfl --season-year 2026 --week 1 --prior-season-tail 5 --dump-intermediate
+   .venv\Scripts\python.exe -m metricbot run-week --sport FootballNfl --season-year 2026 --week 1 --prior-season-tail 5 --dump-intermediate
 
 ## Deployment (Phase B)
 
@@ -214,7 +216,7 @@ curl http://localhost:8080/health
 
 ```
 POST /admin/metricbot/run-week      (X-Admin-Token)
-{ "sport": "ncaaf", "seasonYear": 2025, "week": 6,
+{ "sport": "FootballNcaa", "seasonYear": 2025, "week": 6,
   "priorSeasonTail": 5, "includeDtos": true }
 ```
 

--- a/src/metrics-modeling/metricbot/__main__.py
+++ b/src/metrics-modeling/metricbot/__main__.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import sys
 
+from .config import normalize_sport
 from .pipeline import run_week
 
 
@@ -20,8 +21,10 @@ def main(argv: list[str] | None = None) -> int:
         "run-week",
         help="Extract current-week slate, train, predict SU + ATS, publish to the API.")
     run.add_argument(
-        "--sport", choices=["ncaaf", "nfl"], default="ncaaf",
-        help="Which football league's database to run against (default: ncaaf).")
+        "--sport", type=normalize_sport, default="FootballNcaa",
+        metavar="{FootballNcaa,FootballNfl}",
+        help="Platform Sport enum name (case-insensitive). "
+             "Default: FootballNcaa.")
     run.add_argument(
         "--dry-run", action="store_true",
         help="Do everything except the POST — inspect DTO counts/logs first.")

--- a/src/metrics-modeling/metricbot/__main__.py
+++ b/src/metrics-modeling/metricbot/__main__.py
@@ -7,7 +7,7 @@ import logging
 import sys
 
 from .config import normalize_sport
-from .pipeline import run_week
+from .pipeline import run_backtest, run_week
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -55,12 +55,48 @@ def main(argv: list[str] | None = None) -> int:
     run.add_argument(
         "--verbose", action="store_true", help="Debug-level logging.")
 
+    backtest = subparsers.add_parser(
+        "backtest",
+        help="Predict a historical week as-of, grade against final scores. "
+             "Never publishes.")
+    backtest.add_argument(
+        "--sport", type=normalize_sport, default="FootballNcaa",
+        metavar="{FootballNcaa,FootballNfl}",
+        help="Platform Sport enum name (case-insensitive).")
+    backtest.add_argument("--season-year", type=int, required=True)
+    backtest.add_argument("--week", type=int, required=True)
+    backtest.add_argument(
+        "--prior-season-tail", type=int, default=0, metavar="N",
+        help="Same top-up semantics as run-week — and an experiment axis: "
+             "grade a week with and without it and compare.")
+    backtest.add_argument(
+        "--dump-intermediate", action="store_true",
+        help="Write the prediction artifacts to ./data alongside the grade.")
+    backtest.add_argument(
+        "--verbose", action="store_true", help="Debug-level logging.")
+
     args = parser.parse_args(argv)
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
+
+    if args.command == "backtest":
+        try:
+            result = run_backtest(
+                sport=args.sport,
+                season_year=args.season_year,
+                week=args.week,
+                prior_tail=args.prior_season_tail,
+                dump_intermediate=args.dump_intermediate,
+            )
+            print()
+            print(result.format())
+            return 0
+        except Exception as ex:  # noqa: BLE001 — CLI boundary
+            logging.getLogger("metricbot").exception("Backtest failed: %s", ex)
+            return 1
 
     if args.command == "run-week":
         try:

--- a/src/metrics-modeling/metricbot/config.py
+++ b/src/metrics-modeling/metricbot/config.py
@@ -18,13 +18,32 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-# Databases are per-sport (per-sport RabbitMQ/DB split is load-bearing
-# platform-wide); football models cover both leagues with the same
-# feature set.
+# Sport values are the PLATFORM'S Sport enum names (SportsData.Core.
+# Common.Sport) — deliberately NOT a second vocabulary. Databases are
+# per-sport (the per-sport DB split is load-bearing platform-wide);
+# football models cover both leagues with the same feature set.
 SPORT_DATABASES = {
-    "ncaaf": "sdProducer.FootballNcaa",
-    "nfl": "sdProducer.FootballNfl",
+    "FootballNcaa": "sdProducer.FootballNcaa",
+    "FootballNfl": "sdProducer.FootballNfl",
 }
+
+SUPPORTED_SPORTS = tuple(SPORT_DATABASES)
+
+
+def normalize_sport(value: str) -> str:
+    """Resolve a sport argument to its canonical Sport-enum name.
+
+    Case-insensitive purely for CLI ergonomics — `--sport footballnfl`
+    works — but there is only ONE vocabulary, not an alias set.
+    """
+    if value is None:
+        raise SystemExit("A sport is required: " + ", ".join(SUPPORTED_SPORTS))
+    match = next((s for s in SUPPORTED_SPORTS if s.lower() == value.strip().lower()), None)
+    if match is None:
+        raise SystemExit(
+            f"Unknown sport '{value}'. MetricBot has football models only: "
+            + ", ".join(SUPPORTED_SPORTS))
+    return match
 
 # The synthetic MetricBot user the API attributes predictions to
 # (IsSynthetic = true; see design doc, Decision 6).
@@ -71,9 +90,7 @@ class Config:
 
     @staticmethod
     def load(sport: str) -> "Config":
-        if sport not in SPORT_DATABASES:
-            raise SystemExit(
-                f"Unknown sport '{sport}'. Supported: {', '.join(sorted(SPORT_DATABASES))}")
+        sport = normalize_sport(sport)
 
         file_values = _load_env_file()
 

--- a/src/metrics-modeling/metricbot/extract.py
+++ b/src/metrics-modeling/metricbot/extract.py
@@ -33,6 +33,7 @@ CURRENT_WEEK_SQL = SQL_DIR / "competition_metrics_current_week.sql"
 ASOF_TRAINING_SQL = SQL_DIR / "competition_metrics_asof_training.sql"
 ASOF_WEEK_SQL = SQL_DIR / "competition_metrics_asof_week.sql"
 DETECT_WEEK_SQL = SQL_DIR / "detect_current_season_week.sql"
+GRADING_SCORES_SQL = SQL_DIR / "grading_scores.sql"
 
 
 class ExtractionError(RuntimeError):
@@ -109,6 +110,13 @@ def extract_asof_week(config: Config, season_year: int, week: int, prior_tail: i
     recent prior-season (regular/post) games."""
     return _run_psql(config, ASOF_WEEK_SQL,
                      {"season_year": season_year, "week": week, "prior_tail": prior_tail})
+
+
+def extract_final_scores(config: Config, season_year: int, week: int) -> pd.DataFrame:
+    """Final scores for grading: the (season, week) slate's completed
+    games — ContestId, HomeScore, AwayScore."""
+    return _run_psql(config, GRADING_SCORES_SQL,
+                     {"season_year": season_year, "week": week})
 
 
 def detect_current_season_week(config: Config) -> tuple[int, int]:

--- a/src/metrics-modeling/metricbot/extract.py
+++ b/src/metrics-modeling/metricbot/extract.py
@@ -40,7 +40,10 @@ class ExtractionError(RuntimeError):
     pass
 
 
-def _run_psql(config: Config, sql_file: Path, variables: dict[str, int] | None = None) -> pd.DataFrame:
+def _run_psql(config: Config,
+              sql_file: Path,
+              variables: dict[str, int] | None = None,
+              allow_empty: bool = False) -> pd.DataFrame:
     if not sql_file.is_file():
         raise ExtractionError(f"SQL file not found: {sql_file}")
 
@@ -113,10 +116,13 @@ def extract_asof_week(config: Config, season_year: int, week: int, prior_tail: i
 
 
 def extract_final_scores(config: Config, season_year: int, week: int) -> pd.DataFrame:
-    """Final scores for grading: the (season, week) slate's completed
-    games — ContestId, HomeScore, AwayScore."""
+    """Final scores for grading: the (season, week) slate's FINALIZED
+    games — ContestId, HomeScore, AwayScore. Empty is a legitimate
+    result (backtesting a week nothing has finished in), and grade_week
+    turns it into an all-ungradeable report rather than an error."""
     return _run_psql(config, GRADING_SCORES_SQL,
-                     {"season_year": season_year, "week": week})
+                     {"season_year": season_year, "week": week},
+                     allow_empty=True)
 
 
 def detect_current_season_week(config: Config) -> tuple[int, int]:

--- a/src/metrics-modeling/metricbot/extract.py
+++ b/src/metrics-modeling/metricbot/extract.py
@@ -83,7 +83,7 @@ def _run_psql(config: Config,
             f"psql failed for {sql_file.name} (exit {result.returncode}):\n{result.stderr.strip()}")
 
     frame = pd.read_csv(io.StringIO(result.stdout))
-    if frame.empty:
+    if frame.empty and not allow_empty:
         raise ExtractionError(
             f"{sql_file.name} returned zero rows — is the season week window open "
             f"and are metrics generated for {config.pg_database}?")

--- a/src/metrics-modeling/metricbot/grading.py
+++ b/src/metrics-modeling/metricbot/grading.py
@@ -189,8 +189,7 @@ def format_report(report: GradeReport, header: str) -> str:
     r = report
     lines = [
         header,
-        f"  Contests: {r.week_contests} predicted, {r.graded} graded, "
-        f"{r.ungradeable} ungradeable",
+        f"  Contests: {r.week_contests} predicted, {r.graded} graded, {r.ungradeable} ungradeable",
     ]
     if r.su:
         su = r.su
@@ -198,7 +197,7 @@ def format_report(report: GradeReport, header: str) -> str:
         if su["accuracy"] is None:
             lines += [
                 "",
-                f"  STRAIGHT UP   n/a — no decided games"
+                "  STRAIGHT UP   n/a — no decided games"
                 + (f" ({su['ties_excluded']} ties excluded)" if su["ties_excluded"] else ""),
             ]
         else:

--- a/src/metrics-modeling/metricbot/grading.py
+++ b/src/metrics-modeling/metricbot/grading.py
@@ -1,0 +1,214 @@
+"""Grade a week's predictions against final scores.
+
+Pure pandas/numpy — no I/O — so every rule here is unit-testable offline.
+The rules follow the harness spec in
+docs/metrics-modeling/matchup-preview-data-inputs.md §6:
+
+- Accuracy is only meaningful as an edge over a baseline, so both SU
+  baselines (always-home, favorite-by-spread) ride along with the raw
+  number, and ATS carries the 52.4% break-even reference.
+- Pushes and ties are EXCLUDED from accuracy denominators and COUNTED
+  in the report — silently folding them either way biases the number.
+- Calibration is the point (the stated goal is "genuinely interesting
+  information", not beating Vegas): Brier scores plus decile buckets of
+  predicted-vs-realized frequency.
+- O/U is deliberately absent: the model predicts margin, not totals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+
+# ATS break-even at standard -110 juice; a fixed reference, not a baseline
+# computed from the data.
+ATS_BREAK_EVEN = 0.5238
+
+
+@dataclass
+class GradeReport:
+    week_contests: int          # predictions made
+    graded: int                 # had a final score to grade against
+    ungradeable: int            # no final score (cancelled late, not final)
+
+    su: dict = field(default_factory=dict)
+    ats: dict = field(default_factory=dict)
+    margin: dict = field(default_factory=dict)
+    calibration: list = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "week_contests": self.week_contests,
+            "graded": self.graded,
+            "ungradeable": self.ungradeable,
+            "su": self.su,
+            "ats": self.ats,
+            "margin": self.margin,
+            "calibration": self.calibration,
+        }
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    return round(numerator / denominator, 4) if denominator else None
+
+
+def grade_week(predictions: pd.DataFrame, scores: pd.DataFrame) -> GradeReport:
+    """predictions: the pipeline's per-contest frame (ContestId,
+    PredictedMargin, WinProbability, HomeCoverProbability, Spread).
+    scores: ContestId, HomeScore, AwayScore for the games that finished.
+    """
+    merged = predictions.merge(
+        scores, on="ContestId", how="left", suffixes=("", "Final"),
+        validate="one_to_one")
+
+    # The as-of slate emits literal NULL score columns; the merge brings
+    # the real ones in under *Final when the names collide.
+    home_col = "HomeScoreFinal" if "HomeScoreFinal" in merged.columns else "HomeScore"
+    away_col = "AwayScoreFinal" if "AwayScoreFinal" in merged.columns else "AwayScore"
+
+    graded = merged[merged[home_col].notna() & merged[away_col].notna()].copy()
+    graded["ActualMargin"] = graded[home_col].astype(float) - graded[away_col].astype(float)
+
+    report = GradeReport(
+        week_contests=len(merged),
+        graded=len(graded),
+        ungradeable=len(merged) - len(graded),
+    )
+    if len(graded) == 0:
+        return report
+
+    # ── Straight-up ──────────────────────────────────────────────────
+    decided = graded[graded["ActualMargin"] != 0].copy()
+    ties = len(graded) - len(decided)
+
+    actual_home_win = decided["ActualMargin"] > 0
+    picked_home = decided["WinProbability"] >= 0.5
+    su_correct = int((picked_home == actual_home_win).sum())
+
+    # Favorite-by-spread baseline: spread < 0 = home favored. Pick-em
+    # (0) and missing spreads drop out of this baseline's denominator.
+    with_spread = decided[decided["Spread"].notna() & (decided["Spread"] != 0)]
+    favorite_correct = int(
+        ((with_spread["Spread"] < 0) == (with_spread["ActualMargin"] > 0)).sum())
+
+    su_brier = float(np.mean(
+        (decided["WinProbability"] - actual_home_win.astype(float)) ** 2))
+    home_rate = float(actual_home_win.mean())
+    climatology_brier = float(np.mean(
+        (home_rate - actual_home_win.astype(float)) ** 2))
+
+    report.su = {
+        "decided": len(decided),
+        "ties_excluded": ties,
+        "correct": su_correct,
+        "accuracy": _ratio(su_correct, len(decided)),
+        "baseline_always_home": round(home_rate, 4) if len(decided) else None,
+        "baseline_favorite": {
+            "games_with_spread": len(with_spread),
+            "accuracy": _ratio(favorite_correct, len(with_spread)),
+        },
+        "brier": round(su_brier, 4),
+        "brier_climatology": round(climatology_brier, 4),
+    }
+
+    # ── Against the spread ───────────────────────────────────────────
+    spread_games = graded[graded["Spread"].notna()].copy()
+    no_spread = len(graded) - len(spread_games)
+
+    spread_games["CoverMargin"] = spread_games["ActualMargin"] + spread_games["Spread"]
+    pushes = int((spread_games["CoverMargin"] == 0).sum())
+    ats_decided = spread_games[spread_games["CoverMargin"] != 0]
+
+    actual_home_cover = ats_decided["CoverMargin"] > 0
+    picked_home_cover = ats_decided["HomeCoverProbability"] >= 0.5
+    ats_correct = int((picked_home_cover == actual_home_cover).sum())
+
+    ats_brier = float(np.mean(
+        (ats_decided["HomeCoverProbability"] - actual_home_cover.astype(float)) ** 2)) \
+        if len(ats_decided) else None
+
+    report.ats = {
+        "decided": len(ats_decided),
+        "pushes_excluded": pushes,
+        "no_spread_ungraded": no_spread,
+        "correct": ats_correct,
+        "accuracy": _ratio(ats_correct, len(ats_decided)),
+        "break_even_reference": ATS_BREAK_EVEN,
+        "brier": round(ats_brier, 4) if ats_brier is not None else None,
+    }
+
+    # ── Margin: the model vs the market on identical games ───────────
+    model_errors = (graded["PredictedMargin"] - graded["ActualMargin"]).abs()
+    market = spread_games.copy()
+    market_errors = (-market["Spread"] - market["ActualMargin"]).abs()
+
+    report.margin = {
+        "model_mae": round(float(model_errors.mean()), 2),
+        "model_rmse": round(float(np.sqrt((model_errors ** 2).mean())), 2),
+        # The spread AS a margin predictor, on the games that have one —
+        # the honest head-to-head with the market.
+        "market_mae": round(float(market_errors.mean()), 2) if len(market) else None,
+        "market_rmse": round(float(np.sqrt((market_errors ** 2).mean())), 2) if len(market) else None,
+        "market_games": len(market),
+    }
+
+    # ── Calibration deciles over P(home wins) ────────────────────────
+    buckets = pd.cut(decided["WinProbability"], bins=np.arange(0.0, 1.05, 0.1),
+                     include_lowest=True)
+    for interval, group in decided.groupby(buckets, observed=True):
+        if len(group) == 0:
+            continue
+        report.calibration.append({
+            "bucket": f"{interval.left:.1f}-{interval.right:.1f}",
+            "games": len(group),
+            "predicted": round(float(group["WinProbability"].mean()), 4),
+            "actual": round(float((group["ActualMargin"] > 0).mean()), 4),
+        })
+
+    return report
+
+
+def format_report(report: GradeReport, header: str) -> str:
+    """Human-readable rendering for the CLI; the service returns to_dict()."""
+    r = report
+    lines = [
+        header,
+        f"  Contests: {r.week_contests} predicted, {r.graded} graded, "
+        f"{r.ungradeable} ungradeable",
+    ]
+    if r.su:
+        su = r.su
+        fav = su["baseline_favorite"]
+        lines += [
+            "",
+            f"  STRAIGHT UP   {su['correct']}/{su['decided']}  "
+            f"({su['accuracy']:.1%})" if su['accuracy'] is not None else "  STRAIGHT UP   n/a",
+            f"    vs always-home {su['baseline_always_home']:.1%}"
+            + (f"  |  vs favorite {fav['accuracy']:.1%} ({fav['games_with_spread']} spread games)"
+               if fav["accuracy"] is not None else ""),
+            f"    Brier {su['brier']:.4f} (climatology {su['brier_climatology']:.4f}; lower is better)"
+            + (f"  |  {su['ties_excluded']} ties excluded" if su["ties_excluded"] else ""),
+        ]
+    if r.ats:
+        ats = r.ats
+        lines += [
+            "",
+            f"  ATS           {ats['correct']}/{ats['decided']}  "
+            f"({ats['accuracy']:.1%})" if ats['accuracy'] is not None else "  ATS           n/a",
+            f"    break-even {ATS_BREAK_EVEN:.1%}  |  {ats['pushes_excluded']} pushes excluded"
+            + (f"  |  {ats['no_spread_ungraded']} without a spread" if ats["no_spread_ungraded"] else "")
+            + (f"  |  Brier {ats['brier']:.4f}" if ats["brier"] is not None else ""),
+        ]
+    if r.margin:
+        m = r.margin
+        market = (f"  |  market (spread) MAE {m['market_mae']:.2f} on {m['market_games']}"
+                  if m["market_mae"] is not None else "")
+        lines += ["", f"  MARGIN        model MAE {m['model_mae']:.2f}, RMSE {m['model_rmse']:.2f}{market}"]
+    if r.calibration:
+        lines += ["", "  CALIBRATION (P(home win) decile: predicted -> actual, n)"]
+        for b in r.calibration:
+            lines.append(
+                f"    {b['bucket']}:  {b['predicted']:.2f} -> {b['actual']:.2f}   (n={b['games']})")
+    return "\n".join(lines)

--- a/src/metrics-modeling/metricbot/grading.py
+++ b/src/metrics-modeling/metricbot/grading.py
@@ -83,35 +83,49 @@ def grade_week(predictions: pd.DataFrame, scores: pd.DataFrame) -> GradeReport:
     decided = graded[graded["ActualMargin"] != 0].copy()
     ties = len(graded) - len(decided)
 
-    actual_home_win = decided["ActualMargin"] > 0
-    picked_home = decided["WinProbability"] >= 0.5
-    su_correct = int((picked_home == actual_home_win).sum())
+    if len(decided) == 0:
+        # Every graded game tied: means over empty frames are nan, and a
+        # nan Brier in the report reads as a number. Say "no data" instead.
+        report.su = {
+            "decided": 0,
+            "ties_excluded": ties,
+            "correct": 0,
+            "accuracy": None,
+            "baseline_always_home": None,
+            "baseline_favorite": {"games_with_spread": 0, "accuracy": None},
+            "brier": None,
+            "brier_climatology": None,
+        }
+    else:
+        actual_home_win = decided["ActualMargin"] > 0
+        picked_home = decided["WinProbability"] >= 0.5
+        su_correct = int((picked_home == actual_home_win).sum())
 
-    # Favorite-by-spread baseline: spread < 0 = home favored. Pick-em
-    # (0) and missing spreads drop out of this baseline's denominator.
-    with_spread = decided[decided["Spread"].notna() & (decided["Spread"] != 0)]
-    favorite_correct = int(
-        ((with_spread["Spread"] < 0) == (with_spread["ActualMargin"] > 0)).sum())
+        # Favorite-by-spread baseline: spread < 0 = home favored. Pick-em
+        # (0) and missing spreads drop out of this baseline's denominator.
+        with_spread = decided[decided["Spread"].notna() & (decided["Spread"] != 0)]
+        favorite_correct = int(
+            ((with_spread["Spread"] < 0) == (with_spread["ActualMargin"] > 0)).sum())
 
-    su_brier = float(np.mean(
-        (decided["WinProbability"] - actual_home_win.astype(float)) ** 2))
-    home_rate = float(actual_home_win.mean())
-    climatology_brier = float(np.mean(
-        (home_rate - actual_home_win.astype(float)) ** 2))
+        su_brier = float(np.mean(
+            (decided["WinProbability"] - actual_home_win.astype(float)) ** 2))
+        home_rate = float(actual_home_win.mean())
+        climatology_brier = float(np.mean(
+            (home_rate - actual_home_win.astype(float)) ** 2))
 
-    report.su = {
-        "decided": len(decided),
-        "ties_excluded": ties,
-        "correct": su_correct,
-        "accuracy": _ratio(su_correct, len(decided)),
-        "baseline_always_home": round(home_rate, 4) if len(decided) else None,
-        "baseline_favorite": {
-            "games_with_spread": len(with_spread),
-            "accuracy": _ratio(favorite_correct, len(with_spread)),
-        },
-        "brier": round(su_brier, 4),
-        "brier_climatology": round(climatology_brier, 4),
-    }
+        report.su = {
+            "decided": len(decided),
+            "ties_excluded": ties,
+            "correct": su_correct,
+            "accuracy": _ratio(su_correct, len(decided)),
+            "baseline_always_home": round(home_rate, 4),
+            "baseline_favorite": {
+                "games_with_spread": len(with_spread),
+                "accuracy": _ratio(favorite_correct, len(with_spread)),
+            },
+            "brier": round(su_brier, 4),
+            "brier_climatology": round(climatology_brier, 4),
+        }
 
     # ── Against the spread ───────────────────────────────────────────
     spread_games = graded[graded["Spread"].notna()].copy()
@@ -181,26 +195,34 @@ def format_report(report: GradeReport, header: str) -> str:
     if r.su:
         su = r.su
         fav = su["baseline_favorite"]
-        lines += [
-            "",
-            f"  STRAIGHT UP   {su['correct']}/{su['decided']}  "
-            f"({su['accuracy']:.1%})" if su['accuracy'] is not None else "  STRAIGHT UP   n/a",
-            f"    vs always-home {su['baseline_always_home']:.1%}"
-            + (f"  |  vs favorite {fav['accuracy']:.1%} ({fav['games_with_spread']} spread games)"
-               if fav["accuracy"] is not None else ""),
-            f"    Brier {su['brier']:.4f} (climatology {su['brier_climatology']:.4f}; lower is better)"
-            + (f"  |  {su['ties_excluded']} ties excluded" if su["ties_excluded"] else ""),
-        ]
+        if su["accuracy"] is None:
+            lines += [
+                "",
+                f"  STRAIGHT UP   n/a — no decided games"
+                + (f" ({su['ties_excluded']} ties excluded)" if su["ties_excluded"] else ""),
+            ]
+        else:
+            lines += [
+                "",
+                f"  STRAIGHT UP   {su['correct']}/{su['decided']}  ({su['accuracy']:.1%})",
+                f"    vs always-home {su['baseline_always_home']:.1%}"
+                + (f"  |  vs favorite {fav['accuracy']:.1%} ({fav['games_with_spread']} spread games)"
+                   if fav["accuracy"] is not None else ""),
+                f"    Brier {su['brier']:.4f} (climatology {su['brier_climatology']:.4f}; lower is better)"
+                + (f"  |  {su['ties_excluded']} ties excluded" if su["ties_excluded"] else ""),
+            ]
     if r.ats:
         ats = r.ats
-        lines += [
-            "",
-            f"  ATS           {ats['correct']}/{ats['decided']}  "
-            f"({ats['accuracy']:.1%})" if ats['accuracy'] is not None else "  ATS           n/a",
-            f"    break-even {ATS_BREAK_EVEN:.1%}  |  {ats['pushes_excluded']} pushes excluded"
-            + (f"  |  {ats['no_spread_ungraded']} without a spread" if ats["no_spread_ungraded"] else "")
-            + (f"  |  Brier {ats['brier']:.4f}" if ats["brier"] is not None else ""),
-        ]
+        if ats["accuracy"] is None:
+            lines += ["", "  ATS           n/a — no decided spread games"]
+        else:
+            lines += [
+                "",
+                f"  ATS           {ats['correct']}/{ats['decided']}  ({ats['accuracy']:.1%})",
+                f"    break-even {ATS_BREAK_EVEN:.1%}  |  {ats['pushes_excluded']} pushes excluded"
+                + (f"  |  {ats['no_spread_ungraded']} without a spread" if ats["no_spread_ungraded"] else "")
+                + (f"  |  Brier {ats['brier']:.4f}" if ats["brier"] is not None else ""),
+            ]
     if r.margin:
         m = r.margin
         market = (f"  |  market (spread) MAE {m['market_mae']:.2f} on {m['market_games']}"

--- a/src/metrics-modeling/metricbot/pipeline.py
+++ b/src/metrics-modeling/metricbot/pipeline.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 from . import MODEL_VERSION
 from .api import post_predictions
-from .config import Config
+from .config import Config, normalize_sport
 from .dtos import build_prediction_dtos
 from .extract import (detect_current_season_week, extract_asof_training,
                       extract_asof_week, extract_current_week, extract_training)
@@ -52,6 +52,7 @@ def run_week(sport: str,
              legacy_extraction: bool = False,
              return_result: bool = False) -> int | RunResult:
     started = datetime.now(timezone.utc)
+    sport = normalize_sport(sport)
     config = Config.load(sport)
 
     explicit_week = season_year is not None and week is not None

--- a/src/metrics-modeling/metricbot/pipeline.py
+++ b/src/metrics-modeling/metricbot/pipeline.py
@@ -20,7 +20,9 @@ from .api import post_predictions
 from .config import Config, normalize_sport
 from .dtos import build_prediction_dtos
 from .extract import (detect_current_season_week, extract_asof_training,
-                      extract_asof_week, extract_current_week, extract_training)
+                      extract_asof_week, extract_current_week,
+                      extract_final_scores, extract_training)
+from .grading import GradeReport, format_report, grade_week
 from .model import predict_ats, predict_straight_up
 
 logger = logging.getLogger("metricbot")
@@ -135,6 +137,77 @@ def run_week(sport: str,
             dtos=dtos,
         )
     return 0
+
+
+def run_backtest(sport: str,
+                 season_year: int,
+                 week: int,
+                 prior_tail: int = 0,
+                 dump_intermediate: bool = False) -> "BacktestResult":
+    """Predict a historical week as-of, then grade against final scores.
+
+    Never publishes — a backtest exists to be scored, not to overwrite
+    live deetsMeter data. The prediction path is EXACTLY run_week's
+    as-of mode (same extraction, same model); grading is a second
+    extraction (final scores) plus pure-pandas scoring.
+    """
+    started = datetime.now(timezone.utc)
+    sport = normalize_sport(sport)
+    config = Config.load(sport)
+
+    logger.info("MetricBot %s backtest starting. Sport: %s, %d wk%d (tail=%d)",
+                MODEL_VERSION, sport, season_year, week, prior_tail)
+
+    training = extract_asof_training(config, season_year, week)
+    current_week = extract_asof_week(config, season_year, week, prior_tail)
+    logger.info("Extracted %d training rows; %d contests for week %d",
+                len(training), len(current_week), week)
+
+    su = predict_straight_up(training, current_week)
+    predictions = predict_ats(su)
+
+    scores = extract_final_scores(config, season_year, week)
+    report = grade_week(predictions, scores)
+
+    if dump_intermediate:
+        label = f"{sport}_backtest_{season_year}_wk{week}_tail{prior_tail}"
+        _dump(training, current_week, predictions,
+              build_prediction_dtos(predictions), label)
+
+    elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+    logger.info("Backtest complete in %.1fs. SU %s, ATS %s, model MAE %s vs market %s",
+                elapsed, report.su.get("accuracy"), report.ats.get("accuracy"),
+                report.margin.get("model_mae"), report.margin.get("market_mae"))
+
+    return BacktestResult(
+        sport=sport,
+        season_year=season_year,
+        week=week,
+        prior_season_tail=prior_tail,
+        training_rows=su.training_rows,
+        in_sample_mae=su.mae,
+        residual_std=su.residual_std,
+        report=report,
+        elapsed_seconds=elapsed,
+    )
+
+
+@dataclass
+class BacktestResult:
+    sport: str
+    season_year: int
+    week: int
+    prior_season_tail: int
+    training_rows: int
+    in_sample_mae: float
+    residual_std: float
+    report: GradeReport
+    elapsed_seconds: float
+
+    def format(self) -> str:
+        header = (f"BACKTEST {self.sport} {self.season_year} week {self.week} "
+                  f"(tail={self.prior_season_tail}) — {MODEL_VERSION}")
+        return format_report(self.report, header)
 
 
 def _dump(training: pd.DataFrame,

--- a/src/metrics-modeling/metricbot/service.py
+++ b/src/metrics-modeling/metricbot/service.py
@@ -23,7 +23,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from . import MODEL_VERSION
-from .pipeline import RunResult, run_week
+from .pipeline import BacktestResult, RunResult, run_backtest, run_week
 
 logger = logging.getLogger("metricbot.service")
 
@@ -115,4 +115,57 @@ def post_run_week(request: RunWeekRequest) -> RunWeekResponse:
         published=result.published,
         elapsed_seconds=result.elapsed_seconds,
         dtos=result.dtos if request.include_dtos else None,
+    )
+
+
+class BacktestRequest(BaseModel):
+    sport: Literal["FootballNcaa", "FootballNfl"] = "FootballNcaa"
+    season_year: int = Field(ge=1990, le=2100)
+    week: int = Field(ge=1, le=25)
+    prior_season_tail: int = Field(default=0, ge=0, le=25)
+
+
+class BacktestResponse(BaseModel):
+    model_version: str
+    sport: str
+    season_year: int
+    week: int
+    prior_season_tail: int
+    training_rows: int
+    in_sample_mae: float
+    residual_std: float
+    elapsed_seconds: float
+    # grade_week's report: su / ats / margin / calibration sections.
+    grade: dict
+
+
+@app.post("/backtest", response_model=BacktestResponse)
+def post_backtest(request: BacktestRequest) -> BacktestResponse:
+    """Predict a historical week as-of, grade it against final scores.
+    Never publishes — backtests exist to be scored, not to overwrite
+    live deetsMeter data."""
+    try:
+        result: BacktestResult = run_backtest(
+            sport=request.sport,
+            season_year=request.season_year,
+            week=request.week,
+            prior_tail=request.prior_season_tail,
+        )
+    except SystemExit as ex:
+        raise HTTPException(status_code=400, detail=str(ex)) from ex
+    except Exception as ex:  # noqa: BLE001 — service boundary
+        logger.exception("backtest failed")
+        raise HTTPException(status_code=500, detail=f"{type(ex).__name__}: {ex}") from ex
+
+    return BacktestResponse(
+        model_version=MODEL_VERSION,
+        sport=result.sport,
+        season_year=result.season_year,
+        week=result.week,
+        prior_season_tail=result.prior_season_tail,
+        training_rows=result.training_rows,
+        in_sample_mae=result.in_sample_mae,
+        residual_std=result.residual_std,
+        elapsed_seconds=result.elapsed_seconds,
+        grade=result.report.to_dict(),
     )

--- a/src/metrics-modeling/metricbot/service.py
+++ b/src/metrics-modeling/metricbot/service.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import logging
 
+from typing import Literal
+
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
@@ -33,7 +35,9 @@ app = FastAPI(
 
 
 class RunWeekRequest(BaseModel):
-    sport: str = Field(default="ncaaf", pattern="^(ncaaf|nfl)$")
+    # The platform's Sport enum names — one vocabulary end to end, so
+    # the C# client sends Sport.ToString() with no translation layer.
+    sport: Literal["FootballNcaa", "FootballNfl"] = "FootballNcaa"
 
     # Explicit (season, week) = experiment/backtest; omit both for a live
     # run that auto-resolves the current week.

--- a/src/metrics-modeling/sql/grading_scores.sql
+++ b/src/metrics-modeling/sql/grading_scores.sql
@@ -16,5 +16,9 @@ LEFT JOIN public."SeasonPhase" sp ON sp."Id" = con."SeasonPhaseId"
 WHERE s."Year" = :season_year::int
   AND con."HomeScore" IS NOT NULL
   AND con."AwayScore" IS NOT NULL
+  -- Scores are written DURING live play (CompetitorScoreUpdated); only a
+  -- finalized contest's score is ground truth. Verified 2026-08-10:
+  -- 2023/2024 coverage is 100%, 2025 has a single unfinalized outlier.
+  AND con."FinalizedUtc" IS NOT NULL
   AND con."CancelledUtc" IS NULL
   AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1);

--- a/src/metrics-modeling/sql/grading_scores.sql
+++ b/src/metrics-modeling/sql/grading_scores.sql
@@ -1,0 +1,20 @@
+-- Final scores for grading a backtested week: the (season, week) slate's
+-- completed games. Same slate filters as the as-of extraction (preseason
+-- and cancelled games excluded) so the join back to predictions is
+-- one-to-one; contests that never finished simply don't appear here and
+-- are reported as ungradeable.
+--
+-- psql -v season_year=2025 -v week=6
+SELECT
+    con."Id" AS "ContestId",
+    con."HomeScore",
+    con."AwayScore"
+FROM public."Season" s
+JOIN public."SeasonWeek" sw ON sw."SeasonId" = s."Id" AND sw."Number" = :week::int
+JOIN public."Contest" con   ON con."SeasonWeekId" = sw."Id"
+LEFT JOIN public."SeasonPhase" sp ON sp."Id" = con."SeasonPhaseId"
+WHERE s."Year" = :season_year::int
+  AND con."HomeScore" IS NOT NULL
+  AND con."AwayScore" IS NOT NULL
+  AND con."CancelledUtc" IS NULL
+  AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1);

--- a/src/metrics-modeling/tests/test_grading.py
+++ b/src/metrics-modeling/tests/test_grading.py
@@ -3,8 +3,14 @@ calls out: pushes, ties, missing spreads, missing scores, baselines."""
 
 from __future__ import annotations
 
-import pandas as pd
+import subprocess
+from types import SimpleNamespace
 
+import pandas as pd
+import pytest
+
+from metricbot import extract
+from metricbot.config import Config
 from metricbot.grading import ATS_BREAK_EVEN, format_report, grade_week
 
 
@@ -188,3 +194,39 @@ def test_zero_completed_games_is_all_ungradeable():
 
     text = format_report(report, "BACKTEST empty")
     assert "0 graded" in text
+
+
+def _fake_config():
+    return Config(
+        pg_host="db.example.invalid", pg_user="u", pg_password="p",
+        pg_database="d", pg_port="5432",
+        api_base_url="http://api.example.invalid",
+        admin_token="t", metricbot_user_id="00000000-0000-0000-0000-000000000000")
+
+
+def test_extract_final_scores_allows_header_only_result(monkeypatch):
+    # psql --csv emits the header row even for zero-row results; a week
+    # nothing has finished in must come back as an empty frame, not an
+    # ExtractionError.
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(
+            returncode=0, stdout="ContestId,HomeScore,AwayScore\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    frame = extract.extract_final_scores(_fake_config(), 2026, 1)
+
+    assert frame.empty
+    assert list(frame.columns) == ["ContestId", "HomeScore", "AwayScore"]
+
+
+def test_extract_training_still_rejects_empty_results(monkeypatch):
+    # The default (allow_empty=False) behavior is unchanged: an empty
+    # training extraction is an error, not a silent no-op.
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="A,B\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(extract.ExtractionError, match="zero rows"):
+        extract.extract_training(_fake_config())

--- a/src/metrics-modeling/tests/test_grading.py
+++ b/src/metrics-modeling/tests/test_grading.py
@@ -1,0 +1,149 @@
+"""Offline tests for the grading rules — every edge the harness spec
+calls out: pushes, ties, missing spreads, missing scores, baselines."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from metricbot.grading import ATS_BREAK_EVEN, format_report, grade_week
+
+
+def _prediction(contest_id, p_home, p_cover, margin, spread):
+    return {
+        "ContestId": contest_id,
+        "PredictedMargin": margin,
+        "WinProbability": p_home,
+        "HomeCoverProbability": p_cover,
+        "Spread": spread,
+        # The as-of slate carries literal NULL score columns.
+        "HomeScore": None,
+        "AwayScore": None,
+    }
+
+
+def _score(contest_id, home, away):
+    return {"ContestId": contest_id, "HomeScore": home, "AwayScore": away}
+
+
+def test_su_and_ats_grading_with_baselines():
+    predictions = pd.DataFrame([
+        # Home favored (-7), model picks home, home wins by 10: SU hit, ATS hit.
+        _prediction("g1", 0.75, 0.60, 8.0, -7.0),
+        # Away favored (+3), model picks home, away wins by 7: SU miss;
+        # ATS: model picked away cover (0.30 < 0.5), away covered: hit.
+        _prediction("g2", 0.60, 0.30, 2.0, 3.0),
+        # Home favored (-3), model picks away, home wins by 1: SU miss;
+        # ATS: model picked away cover, cover margin 1-3 < 0, away covered: hit.
+        _prediction("g3", 0.40, 0.20, -2.0, -3.0),
+    ])
+    scores = pd.DataFrame([
+        _score("g1", 31, 21),
+        _score("g2", 14, 21),
+        _score("g3", 22, 21),
+    ])
+
+    report = grade_week(predictions, scores)
+
+    assert report.graded == 3 and report.ungradeable == 0
+    assert report.su["decided"] == 3
+    assert report.su["correct"] == 1
+    assert report.su["accuracy"] == round(1 / 3, 4)
+    # Home won g1 and g3: always-home baseline 2/3.
+    assert report.su["baseline_always_home"] == round(2 / 3, 4)
+    # Favorite: g1 home fav won (hit), g2 away fav won (hit), g3 home fav won (hit).
+    assert report.su["baseline_favorite"]["accuracy"] == 1.0
+    assert report.ats["decided"] == 3
+    assert report.ats["correct"] == 3
+    assert report.ats["break_even_reference"] == ATS_BREAK_EVEN
+
+
+def test_pushes_are_excluded_and_counted():
+    predictions = pd.DataFrame([
+        # Home -7, wins by exactly 7: PUSH.
+        _prediction("g1", 0.70, 0.55, 7.0, -7.0),
+        _prediction("g2", 0.70, 0.55, 7.0, -7.0),
+    ])
+    scores = pd.DataFrame([
+        _score("g1", 28, 21),   # margin 7, cover margin 0 -> push
+        _score("g2", 28, 14),   # margin 14 -> home covers
+    ])
+
+    report = grade_week(predictions, scores)
+
+    assert report.ats["pushes_excluded"] == 1
+    assert report.ats["decided"] == 1
+    assert report.ats["correct"] == 1
+    # The push still grades SU normally.
+    assert report.su["decided"] == 2
+
+
+def test_ties_missing_spreads_and_unplayed_games():
+    predictions = pd.DataFrame([
+        _prediction("tie", 0.55, 0.55, 1.0, -1.0),
+        _prediction("nospread", 0.80, 0.80, 14.0, None),
+        _prediction("unplayed", 0.60, 0.60, 3.0, -3.0),
+    ])
+    scores = pd.DataFrame([
+        _score("tie", 20, 20),
+        _score("nospread", 35, 10),
+        # "unplayed" absent: no final score.
+    ])
+
+    report = grade_week(predictions, scores)
+
+    assert report.ungradeable == 1
+    assert report.su["ties_excluded"] == 1
+    assert report.su["decided"] == 1          # only nospread decided
+    assert report.ats["no_spread_ungraded"] == 1
+    assert report.ats["decided"] == 1          # only the tie game had a spread
+    # Tie with spread -1: cover margin 0 + -1 = -1, away covered; model
+    # picked home cover (0.55): ATS miss.
+    assert report.ats["correct"] == 0
+
+
+def test_margin_model_vs_market():
+    predictions = pd.DataFrame([
+        # Model says home by 10, market says home by 7 (spread -7), actual 14.
+        _prediction("g1", 0.75, 0.60, 10.0, -7.0),
+    ])
+    scores = pd.DataFrame([_score("g1", 28, 14)])
+
+    report = grade_week(predictions, scores)
+
+    assert report.margin["model_mae"] == 4.0    # |10 - 14|
+    assert report.margin["market_mae"] == 7.0   # |-(-7) - 14|
+    assert report.margin["market_games"] == 1
+
+
+def test_calibration_buckets_predicted_vs_actual():
+    rows = (
+        [_prediction(f"hi{i}", 0.85, 0.5, 10.0, -7.0) for i in range(4)]
+        + [_prediction(f"lo{i}", 0.35, 0.5, -3.0, 3.0) for i in range(2)]
+    )
+    predictions = pd.DataFrame(rows)
+    scores = pd.DataFrame(
+        # 3 of 4 high-confidence homes win; both low-confidence homes lose.
+        [_score(f"hi{i}", 30, 20) for i in range(3)] + [_score("hi3", 17, 20)]
+        + [_score(f"lo{i}", 10, 24) for i in range(2)]
+    )
+
+    report = grade_week(predictions, scores)
+
+    by_bucket = {b["bucket"]: b for b in report.calibration}
+    assert by_bucket["0.8-0.9"]["games"] == 4
+    assert by_bucket["0.8-0.9"]["actual"] == 0.75
+    assert by_bucket["0.3-0.4"]["games"] == 2
+    assert by_bucket["0.3-0.4"]["actual"] == 0.0
+
+
+def test_format_report_renders_every_section():
+    predictions = pd.DataFrame([_prediction("g1", 0.75, 0.60, 8.0, -7.0)])
+    scores = pd.DataFrame([_score("g1", 31, 21)])
+
+    text = format_report(grade_week(predictions, scores), "BACKTEST test")
+
+    assert "STRAIGHT UP" in text
+    assert "ATS" in text
+    assert "MARGIN" in text
+    assert "CALIBRATION" in text
+    assert "break-even 52.4%" in text

--- a/src/metrics-modeling/tests/test_grading.py
+++ b/src/metrics-modeling/tests/test_grading.py
@@ -147,3 +147,44 @@ def test_format_report_renders_every_section():
     assert "MARGIN" in text
     assert "CALIBRATION" in text
     assert "break-even 52.4%" in text
+
+
+def test_all_ties_reports_no_data_instead_of_nan():
+    predictions = pd.DataFrame([
+        _prediction("t1", 0.60, 0.55, 2.0, -1.0),
+        _prediction("t2", 0.45, 0.40, -1.0, 2.0),
+    ])
+    scores = pd.DataFrame([_score("t1", 17, 17), _score("t2", 20, 20)])
+
+    report = grade_week(predictions, scores)
+
+    assert report.su["decided"] == 0
+    assert report.su["ties_excluded"] == 2
+    assert report.su["accuracy"] is None
+    assert report.su["brier"] is None
+    assert report.su["baseline_always_home"] is None
+
+    text = format_report(report, "BACKTEST all-ties")
+    assert "nan" not in text.lower()
+    assert "no decided games" in text
+
+
+def test_zero_completed_games_is_all_ungradeable():
+    # Backtesting a week nothing has finished in: the scores extraction
+    # legitimately returns an empty frame (allow_empty), and the report
+    # says so instead of erroring.
+    predictions = pd.DataFrame([
+        _prediction("g1", 0.70, 0.55, 7.0, -7.0),
+        _prediction("g2", 0.60, 0.45, 3.0, -3.0),
+    ])
+    scores = pd.DataFrame(columns=["ContestId", "HomeScore", "AwayScore"])
+
+    report = grade_week(predictions, scores)
+
+    assert report.week_contests == 2
+    assert report.graded == 0
+    assert report.ungradeable == 2
+    assert report.su == {} and report.ats == {} and report.margin == {}
+
+    text = format_report(report, "BACKTEST empty")
+    assert "0 graded" in text

--- a/src/metrics-modeling/tests/test_grading.py
+++ b/src/metrics-modeling/tests/test_grading.py
@@ -196,7 +196,7 @@ def test_zero_completed_games_is_all_ungradeable():
     assert "0 graded" in text
 
 
-def _fake_config():
+def _fake_config() -> Config:
     return Config(
         pg_host="db.example.invalid", pg_user="u", pg_password="p",
         pg_database="d", pg_port="5432",
@@ -208,7 +208,7 @@ def test_extract_final_scores_allows_header_only_result(monkeypatch):
     # psql --csv emits the header row even for zero-row results; a week
     # nothing has finished in must come back as an empty frame, not an
     # ExtractionError.
-    def fake_run(*args, **kwargs):
+    def fake_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
         return SimpleNamespace(
             returncode=0, stdout="ContestId,HomeScore,AwayScore\n", stderr="")
 
@@ -223,7 +223,7 @@ def test_extract_final_scores_allows_header_only_result(monkeypatch):
 def test_extract_training_still_rejects_empty_results(monkeypatch):
     # The default (allow_empty=False) behavior is unchanged: an empty
     # training extraction is an error, not a silent no-op.
-    def fake_run(*args, **kwargs):
+    def fake_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
         return SimpleNamespace(returncode=0, stdout="A,B\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)

--- a/src/metrics-modeling/tests/test_pipeline.py
+++ b/src/metrics-modeling/tests/test_pipeline.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pytest
 
 from metricbot import MODEL_VERSION
-from metricbot.config import Config
+from metricbot.config import Config, normalize_sport
 from metricbot.dtos import PICKTYPE_ATS, PICKTYPE_STRAIGHT_UP, build_prediction_dtos
 from metricbot.model import FEATURE_COLS, ModelError, predict_ats, predict_straight_up
 
@@ -95,6 +95,20 @@ def test_dtos_match_the_ingestion_contract():
 def test_config_rejects_unknown_sport():
     with pytest.raises(SystemExit):
         Config.load("cricket")
+
+
+def test_sport_vocabulary_matches_the_platform_enum():
+    # One vocabulary end to end: MetricBot speaks SportsData.Core.Common
+    # .Sport names, not an invented short form.
+    assert normalize_sport("FootballNcaa") == "FootballNcaa"
+    assert normalize_sport("FootballNfl") == "FootballNfl"
+    # Case-insensitive for CLI ergonomics only.
+    assert normalize_sport("footballnfl") == "FootballNfl"
+    # The old invented short forms are gone, not aliased.
+    with pytest.raises(SystemExit):
+        normalize_sport("ncaaf")
+    with pytest.raises(SystemExit):
+        normalize_sport("nfl")
 
 
 def test_env_file_parsing_tolerates_quotes_and_comments(tmp_path, monkeypatch):

--- a/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+
+using SportsData.Core.Extensions;
+
+using Xunit;
+
+namespace SportsData.Core.Tests.Unit.Extensions
+{
+    public class ConnectionStringExtensionsTests
+    {
+        [Fact]
+        public void RedactCredentials_MasksPassword_AndKeepsDiagnostics()
+        {
+            const string connString =
+                "Host=db.example.invalid;Port=5432;Username=example-user;Password=sup3r$ecret!!;" +
+                "Database=ExampleDb;Maximum Pool Size=5;Application Name=Example.Api.Data;";
+
+            var redacted = connString.RedactCredentials();
+
+            redacted.Should().NotContain("sup3r$ecret!!");
+            redacted.Should().Contain("Password=***");
+
+            // Everything an operator actually needs at startup survives.
+            redacted.Should().Contain("Host=db.example.invalid");
+            redacted.Should().Contain("Port=5432");
+            redacted.Should().Contain("Username=example-user");
+            redacted.Should().Contain("Database=ExampleDb");
+            redacted.Should().Contain("Maximum Pool Size=5");
+            redacted.Should().Contain("Application Name=Example.Api.Data");
+        }
+
+        [Theory]
+        [InlineData("Host=h;Password=secret;Database=d")]
+        [InlineData("Host=h;password=secret;Database=d")]
+        [InlineData("Host=h;PASSWORD=secret;Database=d")]
+        [InlineData("Host=h;Pwd=secret;Database=d")]
+        [InlineData("Host=h;Password = secret;Database=d")]
+        public void RedactCredentials_HandlesKeySpellingsAndCasing(string connString)
+        {
+            connString.RedactCredentials().Should().NotContain("secret");
+        }
+
+        [Fact]
+        public void RedactCredentials_MasksPasswordAtEndOfString()
+        {
+            "Host=h;Database=d;Password=secret".RedactCredentials()
+                .Should().Be("Host=h;Database=d;Password=***");
+        }
+
+        [Fact]
+        public void RedactCredentials_LeavesCredentialFreeStringsAlone()
+        {
+            const string connString = "Host=h;Port=5432;Database=d";
+            connString.RedactCredentials().Should().Be(connString);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void RedactCredentials_HandlesEmptyInput(string connString)
+        {
+            connString.RedactCredentials().Should().BeEmpty();
+        }
+    }
+}

--- a/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
@@ -55,6 +55,22 @@ namespace SportsData.Core.Tests.Unit.Extensions
             redacted.Should().Contain("Database=d");
         }
 
+        [Theory]
+        [InlineData("Host=h;Password=leaked-secret;PWD=;Database=d")]
+        [InlineData("Host=h;Password=leaked-secret;PSW=;Database=d")]
+        [InlineData("Host=h;SSL Password=leaked-secret;SSL Password=;Database=d")]
+        public void RedactCredentials_DuplicateAliasesCannotBlankTheirWayPastTheMask(string connString)
+        {
+            // Npgsql resolves duplicate keys last-wins, so a trailing empty
+            // alias makes the builder's FINAL value empty while the secret
+            // still sits in the original text — key presence, not final
+            // value, must gate the verbatim passthrough.
+            var redacted = connString.RedactCredentials();
+
+            redacted.Should().NotContain("leaked-secret");
+            redacted.Should().Contain("Database=d");
+        }
+
         [Fact]
         public void RedactCredentials_MasksSslPassword()
         {

--- a/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
@@ -12,12 +12,12 @@ namespace SportsData.Core.Tests.Unit.Extensions
         public void RedactCredentials_MasksPassword_AndKeepsDiagnostics()
         {
             const string connString =
-                "Host=db.example.invalid;Port=5432;Username=example-user;Password=sup3r$ecret!!;" +
+                "Host=db.example.invalid;Port=5432;Username=example-user;Password=fixture-password;" +
                 "Database=ExampleDb;Maximum Pool Size=5;Application Name=Example.Api.Data;";
 
             var redacted = connString.RedactCredentials();
 
-            redacted.Should().NotContain("sup3r$ecret!!");
+            redacted.Should().NotContain("fixture-password");
             redacted.Should().Contain("Password=***");
 
             // Everything an operator actually needs at startup survives.
@@ -38,6 +38,20 @@ namespace SportsData.Core.Tests.Unit.Extensions
         public void RedactCredentials_HandlesKeySpellingsAndCasing(string connString)
         {
             connString.RedactCredentials().Should().NotContain("secret");
+        }
+
+        [Theory]
+        [InlineData("Host=h;Password='first;second';Database=d")]
+        [InlineData("Host=h;Password=\"first;second\";Database=d")]
+        public void RedactCredentials_MasksQuotedValuesContainingSemicolons(string connString)
+        {
+            // Npgsql allows semicolons inside quoted values; a naive
+            // "up to the next semicolon" match would leak the tail.
+            var redacted = connString.RedactCredentials();
+
+            redacted.Should().NotContain("first");
+            redacted.Should().NotContain("second");
+            redacted.Should().Contain("Database=d");
         }
 
         [Fact]

--- a/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
@@ -56,6 +56,16 @@ namespace SportsData.Core.Tests.Unit.Extensions
         }
 
         [Fact]
+        public void RedactCredentials_MasksSslPassword()
+        {
+            // The client-certificate key passphrase is a credential too.
+            var redacted = "Host=h;SSL Password=cert-secret;Database=d".RedactCredentials();
+
+            redacted.Should().NotContain("cert-secret");
+            redacted.Should().Contain("Database=d");
+        }
+
+        [Fact]
         public void RedactCredentials_MasksDoubledQuotesInsideQuotedValue()
         {
             var redacted = "Host=h;Password='fragment''tail;x';Database=d".RedactCredentials();

--- a/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Extensions/ConnectionStringExtensionsTests.cs
@@ -34,6 +34,7 @@ namespace SportsData.Core.Tests.Unit.Extensions
         [InlineData("Host=h;password=secret;Database=d")]
         [InlineData("Host=h;PASSWORD=secret;Database=d")]
         [InlineData("Host=h;Pwd=secret;Database=d")]
+        [InlineData("Host=h;PSW=secret;Database=d")]
         [InlineData("Host=h;Password = secret;Database=d")]
         public void RedactCredentials_HandlesKeySpellingsAndCasing(string connString)
         {
@@ -52,6 +53,27 @@ namespace SportsData.Core.Tests.Unit.Extensions
             redacted.Should().NotContain("first");
             redacted.Should().NotContain("second");
             redacted.Should().Contain("Database=d");
+        }
+
+        [Fact]
+        public void RedactCredentials_MasksDoubledQuotesInsideQuotedValue()
+        {
+            var redacted = "Host=h;Password='fragment''tail;x';Database=d".RedactCredentials();
+
+            redacted.Should().NotContain("fragment");
+            redacted.Should().NotContain("tail");
+        }
+
+        [Fact]
+        public void RedactCredentials_UnparseableStringExposesNothing()
+        {
+            // Unclosed quote: parsing fails, and we cannot prove which
+            // fragment is the secret — so none of the input comes back.
+            var redacted = "Host=h;Password='fragment;Database=d".RedactCredentials();
+
+            redacted.Should().NotContain("fragment");
+            redacted.Should().NotContain("Host");
+            redacted.Should().Contain("redacted in full");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Two related changes to MetricBot, both surfaced by the first prod runs.

### 1. One sport vocabulary (fix)

MetricBot spoke `ncaaf`/`nfl` while the platform speaks `SportsData.Core.Common.Sport` — two vocabularies for one concept, with a C#-side mapping layer existing only to bridge a divergence the service itself introduced. Noticed immediately when hand-writing admin JSON.

MetricBot now speaks `FootballNcaa`/`FootballNfl` end to end:
- **Python**: `SPORT_DATABASES` keyed by enum names; `normalize_sport()` resolves case-insensitively (CLI ergonomics — one vocabulary, not an alias set; the old short forms are **rejected**, not mapped); the HTTP contract is a `Literal` so bad values 422 at the boundary.
- **C#**: `MetricBotRunRequest/Response.Sport` are the `Sport` enum serialized by name (`JsonStringEnumConverter`); the `FromSport()` mapping layer is deleted, leaving only an `IsSupported()` guard; `MetricBotWeeklyJob` passes its `Sport` straight through.

### 2. Backtest grader (feat)

The predictions have never been graded — MAE/residual-std are in-sample fit statistics, and `PickScoringJob` only scores live published picks. This adds the standalone grader the experiment workflow needs:

```
python -m metricbot backtest --sport FootballNcaa --season-year 2025 --week 6 --prior-season-tail 5
POST /backtest                      (service)
POST /admin/metricbot/backtest      (admin proxy — the Bruno path)
```

Re-runs the as-of prediction in memory (deterministic), pulls final scores for the slate, grades. **Never publishes.** Rules per the harness spec (matchup-preview-data-inputs §6):

- **SU**: accuracy reported *with* its baselines (always-home, favorite-by-spread) — raw accuracy is meaningless without the edge. Ties excluded-and-counted.
- **ATS**: pushes excluded-and-counted; 52.4% break-even reference; spreadless games counted as ungradeable.
- **Margin**: out-of-sample MAE/RMSE for the model **and for the spread itself** on the same games — the honest model-vs-market head-to-head.
- **Calibration**: Brier (with climatology reference) + P(home) deciles — calibration is the stated product goal.
- **O/U**: deliberately absent; the model predicts margin, not totals.

`grading.py` is pure pandas (no I/O), so every rule is offline-tested: pushes, ties, missing spreads, unplayed games, baseline arithmetic, bucket math.

Also: `docs/metrics-modeling/output/` gitignored (hand-saved prod-derived experiment results).

## Tests

15 Python (6 new grading + vocabulary coverage asserting `ncaaf`/`nfl` are rejected) + 660 API tests pass; full solution builds.

## Deploy note

Sport vocabulary is a breaking change to the service contract — API and MetricBot images should deploy together (both come from this PR's build; the auto-deploy checkboxes handle it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added historical football prediction backtesting through the API and command-line tools.
  * Added grading reports covering straight-up, ATS, margin, calibration, and error metrics.
  * Added canonical NCAA and NFL sport names with case-insensitive input.
  * Backtests now return detailed metrics and never publish results.
* **Bug Fixes**
  * Improved credential redaction for quoted, aliased, SSL, and malformed connection strings.
  * Backtests handle weeks without completed games gracefully.
* **Documentation**
  * Updated usage examples, API payloads, commands, and backtest guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->