### PR TITLE
docs(metrics): first graded backtests, calibration autopsy, week-snapshots doc

### DIFF
--- a/docs/metrics-modeling/README.md
+++ b/docs/metrics-modeling/README.md
@@ -11,8 +11,9 @@ The two halves are deliberately kept in the same folder so design crosstalk (mod
 
 ## Active design
 
+- [franchise-season-week-metrics.md](./franchise-season-week-metrics.md) — discovery + design for per-SeasonWeek franchise metric snapshots, the point-in-time inputs StatBot regression testing requires. Documents the verified current pipeline (plays/drives → `CompetitionMetric` → `FranchiseSeasonMetric`), the retroactive-derivability insight that makes historical backfill possible without ESPN, and the open decisions. No implementation authorized yet.
 - [ai-provider-routing-per-sport.md](./ai-provider-routing-per-sport.md) — design for per-`(sport, division)` AI provider routing. DeepSeek stays for NCAAFB FBS and NFL (paid, audience matters). Ollama on Bender lights up for MLB and NCAAFB Division II (and any lower-tier divisions) where editorial accuracy isn't a release criterion. `OllamaClient` already exists; the work is wiring a sport-and-division-aware factory.
-- [metrics-microservice-deetsmeter.md](./metrics-microservice-deetsmeter.md) — design for promoting the prototype Python scripts into a cluster-hosted FastAPI service. Greenfield work; multiple open decisions before implementation begins.
+- [metrics-microservice-deetsmeter.md](./metrics-microservice-deetsmeter.md) — the MetricBot service: design plus implementation status. MVP Phases A+B are DEPLOYED (internal FastAPI service, Hangfire-scheduled weekly runs, admin-proxied on-demand/backtest runs); the doc also records the first graded 2025 backtests and the calibration autopsy. The full Q4 architecture (Producer metrics API, artifact storage) remains design.
 
 ## Background reference (DeepSeek era)
 

--- a/docs/metrics-modeling/franchise-season-week-metrics.md
+++ b/docs/metrics-modeling/franchise-season-week-metrics.md
@@ -112,12 +112,19 @@ Same metric columns as `FranchiseSeasonMetric`, plus:
 - `SeasonYear`, `SeasonType`, `WeekNumber` (and/or `SeasonWeekId`)
 - `GamesPlayed` (through the cutoff)
 - `ThroughUtc` — the actual cutoff instant used
-- `InputsHash` — hash of the contributing `CompetitionMetric` ids+hashes, so a
-  regression run can verify its SOURCE INPUTS are byte-identical to the
-  original. Scope limit: this detects source-row drift only; a change to
-  the aggregation formula itself leaves InputsHash unchanged. Pair it
-  with an `AggregationVersion` (bumped whenever
-  `ComputeFranchiseSeasonMetric` changes) for full replayability.
+- `InputsHash` — hash of the contributing `CompetitionMetric` rows.
+  REALITY CHECK (verified 2026-08-11): `CompetitionMetric.InputsHash`
+  exists as a column but `CalculateCompetitionMetricsCommandHandler`
+  writes it as null at both persist sites — there are no per-row hashes
+  to compose today. Until the handler populates a real hash of its
+  play/drive inputs, a snapshot InputsHash can only be built from
+  contributing row IDS (membership tracking: detects added/removed
+  source games, NOT value changes within them). Byte-identical source
+  verification requires populating CompetitionMetric.InputsHash first —
+  prerequisite Producer work for this design. Scope limit either way:
+  input hashing never detects aggregation-formula changes; pair with an
+  `AggregationVersion` (bumped whenever `ComputeFranchiseSeasonMetric`
+  changes) for full replayability.
 - Production wrinkle the snapshot must model or disclaim: MetricBot's
   early-season runs use a prior-season tail (production
   `MetricBotWeeklyJob` passes PriorSeasonTail=5 — each team's window is

--- a/docs/metrics-modeling/franchise-season-week-metrics.md
+++ b/docs/metrics-modeling/franchise-season-week-metrics.md
@@ -3,11 +3,17 @@
 Status: **discovery / design — snapshot table not authorized; the core
 insight is now IMPLEMENTED in query form** (2026-08-09): MetricBot's
 as-of extraction (`src/metrics-modeling/sql/competition_metrics_asof_*.sql`)
-computes entering-week aggregates on the fly from `CompetitionMetric`,
-exactly as §"The key insight" describes — formula-parity with
-`ComputeFranchiseSeasonMetric`, no new tables. A materialized
-`FranchiseSeasonWeekMetric` remains future work and this doc remains its
-design basis.
+computes point-in-time aggregates on the fly from `CompetitionMetric`,
+with formula-parity to `ComputeFranchiseSeasonMetric` and no new
+tables. **Cutoff semantics note:** the implementation uses
+ENTERING-week windows (`sw."Number" < :week` — "the state of the world
+before week N kicks off"), because its consumer predicts week N. This
+doc's proposal below uses `week <= N` ("after week N") for the
+materialized rows; the two are off-by-one views of the same derivation
+and the convention decision in "Open decisions" #1 remains open for the
+table. Any future `FranchiseSeasonWeekMetric` must pin ONE convention
+and document the mapping to the as-of queries. A materialized table
+remains future work and this doc remains its design basis.
 Date: 2026-07-29 (status updated 2026-08-11)
 Surfaces: SportsData.Producer (primary), SportsData.Api (preview provenance), football only
 
@@ -81,7 +87,9 @@ Two premises in the original framing don't match the code, and both are good new
 Because `CompetitionMetric` is per-game and persists, and contests map to weeks,
 **"metrics as of week N" is a pure function of data we already have**:
 
-> filter that team's `CompetitionMetric` rows to contests with week ≤ N,
+> filter that team's `CompetitionMetric` rows to contests with week ≤ N
+> (or `< N` for entering-week semantics — see the status note above;
+> MetricBot's shipped as-of queries use `< N`),
 > aggregate exactly as `ComputeFranchiseSeasonMetric` does today.
 
 Nothing needs to be captured going forward that isn't already captured. This
@@ -105,7 +113,19 @@ Same metric columns as `FranchiseSeasonMetric`, plus:
 - `GamesPlayed` (through the cutoff)
 - `ThroughUtc` — the actual cutoff instant used
 - `InputsHash` — hash of the contributing `CompetitionMetric` ids+hashes, so a
-  regression run can verify its inputs are byte-identical to the original
+  regression run can verify its SOURCE INPUTS are byte-identical to the
+  original. Scope limit: this detects source-row drift only; a change to
+  the aggregation formula itself leaves InputsHash unchanged. Pair it
+  with an `AggregationVersion` (bumped whenever
+  `ComputeFranchiseSeasonMetric` changes) for full replayability.
+- Production wrinkle the snapshot must model or disclaim: MetricBot's
+  early-season runs use a prior-season tail (production
+  `MetricBotWeeklyJob` passes PriorSeasonTail=5 — each team's window is
+  topped up with its most recent prior-season regular/post games until
+  it has 5 of its own). Plain week-N snapshot rows cannot reproduce
+  those runs; either model the tail rule (source-season provenance per
+  contributing game) or state that snapshots reproduce tail-less runs
+  only.
 - unique index `(FranchiseSeasonId, SeasonType, WeekNumber)`
 
 **Semantic decision needed:** does the week-N row mean *entering* week N (games
@@ -170,7 +190,9 @@ established chain. Two real roles:
 5. **Metric-formula versioning** — when a formula bug is fixed (e.g. NetPunt
    gets implemented), do historical snapshots get recomputed (corpus changes
    under the model) or frozen (corpus is stable but wrong)? `InputsHash` detects
-   the drift; policy for handling it is a product decision.
+   source-input drift only — formula changes require the
+   `AggregationVersion` field proposed in §1; policy for handling either
+   kind of drift is a product decision.
 6. **Postseason** — SeasonType handling: continuous week numbering or
    type-scoped; bowl/playoff games in season-to-date aggregates or excluded.
 7. **Scope** — football-only (both contexts are `FootballDataContext` today).
@@ -277,6 +299,35 @@ sourced) PBP there, and that season's floor is set by ESPN, not by us.
 `with_week_mapping` gaps → fixable on our side from `StartDateUtc` + the
 season-week calendar. (Table/column names should be sanity-checked against the
 live schema before running — written from the EF configurations, not psql.)
+
+### Coverage-query caveats (2026-08-11 review — apply before sizing)
+
+The recorded query and result tables above are kept as the historical
+record; a rerun for actual backfill sizing must address five
+limitations found in review:
+
+1. **Metrics without plays exist** (visible in the tables: 1999/2000
+   show `with_metrics = contests` with `with_plays = 0`).
+   `CalculateCompetitionMetricsCommandHandler` does not reject an empty
+   play collection, so a metric row is NOT proof of play-derived data.
+   Identify the provenance of pre-2001 metric rows before counting them
+   as regression corpus; until then the "backfills cleanly" reading
+   only holds for seasons where `with_plays ≈ with_metrics`.
+2. **Per-database execution, not a Sport predicate**: the two result
+   tables were produced by running the query separately against
+   `sdProducer.FootballNfl` and `sdProducer.FootballNcaa` (the
+   platform's per-sport database split) — that is why no `Sport` filter
+   appears. A rerun must preserve that execution model.
+3. **Inner join drops contest-only rows**: `contests` counts contests
+   having at least one Competition row (1:1 in practice, but a LEFT
+   JOIN or a renamed column would make the scope explicit).
+4. **No `FinalizedUtc` filter**: current-season rows (2026: 321
+   contests, zero plays/metrics — unplayed games) inflate denominators.
+   Sizing reruns should add `c."FinalizedUtc" IS NOT NULL` or report
+   the in-progress season separately.
+5. **`LIMIT 1` laterals count half-covered games**: one team's metric
+   row marks the competition covered; the entity is two rows per game.
+   Sizing reruns should require both franchise keys.
 
 ## Sizing (rough)
 

--- a/docs/metrics-modeling/franchise-season-week-metrics.md
+++ b/docs/metrics-modeling/franchise-season-week-metrics.md
@@ -1,0 +1,294 @@
+# Per-SeasonWeek Franchise Metrics: Point-in-Time Inputs for StatBot Regression Testing
+
+Status: **discovery / design — snapshot table not authorized; the core
+insight is now IMPLEMENTED in query form** (2026-08-09): MetricBot's
+as-of extraction (`src/metrics-modeling/sql/competition_metrics_asof_*.sql`)
+computes entering-week aggregates on the fly from `CompetitionMetric`,
+exactly as §"The key insight" describes — formula-parity with
+`ComputeFranchiseSeasonMetric`, no new tables. A materialized
+`FranchiseSeasonWeekMetric` remains future work and this doc remains its
+design basis.
+Date: 2026-07-29 (status updated 2026-08-11)
+Surfaces: SportsData.Producer (primary), SportsData.Api (preview provenance), football only
+
+## Problem
+
+StatBot outputs (DeetsMeter scores, matchup previews) cannot be regression-tested
+because their inputs are destroyed on every recompute. A preview generated before
+week 8 consumed the metrics as they stood after week 7 — but once week 8 games
+process, that state is gone. There is no way to ask "what did the model see?"
+
+The ask: capture franchise metrics on a per-SeasonWeek basis, calculate the
+rolling values, and store them, so any historical model run can be replayed
+against the exact inputs it had.
+
+## Current state (verified against source, 2026-07-29)
+
+The metric pipeline is entirely in-house, computed from play-by-play — **not**
+sourced from ESPN's season-stats documents:
+
+```
+ESPN plays/drives (immutable per game)
+  └─ FootballCompetitionPlay / CompetitionDrive
+       └─ CalculateCompetitionMetricsCommandHandler
+            └─ CompetitionMetric            ← 2 rows per game (one per team), PERSISTS
+                 └─ CalculateFranchiseSeasonMetricsCommandHandler
+                      └─ FranchiseSeasonMetric   ← 1 row per franchise-season, DELETE+REPLACE
+                           └─ MatchupPreviewProcessor (API, via FranchiseClient)
+                                └─ prompt → preview
+```
+
+Key facts, with sources:
+
+- **`CompetitionMetric`** (`Infrastructure/Data/Entities/Metrics/CompetitionMetric.cs`)
+  is per-competition per-team: YPP, success rate, explosive rate, points/drive,
+  3rd/4th conversion, RZ rates, possession ratio, the `Opp*` mirror set, and
+  ST/discipline fields. Carries `InputsHash` and `ComputedUtc`. Recomputed
+  delete+replace *per competition*, but a final game's plays don't change, so in
+  practice these rows are stable once a game is final.
+- **`FranchiseSeasonMetric`** (same folder) is the season-to-date aggregate.
+  **Unique index on `FranchiseSeasonId`** — structurally one row, no history.
+  `CalculateFranchiseSeasonMetricsCommandHandler` deletes and re-adds it from all
+  of that team's `CompetitionMetric` rows.
+- **Trigger** is the audit-job idiom: `FootballCompetitionMetricsAuditJob` sweeps
+  for competitions ≥3h past their date with no metrics and enqueues calculation.
+  Franchise-season aggregation is enqueued via `FranchiseSeasonController`.
+- **Previews consume the live row**: `MatchupPreviewProcessor.cs:79-82` pulls
+  current `FranchiseSeasonMetric` for both teams at generation time. A
+  `UsedMetrics` flag records *whether* metrics were available, not *which values*.
+- **Week mapping exists**: `ContestBase` has `SeasonYear`, `Week (int?)`, and
+  `SeasonWeekId → SeasonWeek`.
+- **Regression scaffolding partially exists**: `ModelRun` (name/version/params)
+  and `CompetitionModelOutput` (per-run per-competition per-team scores with
+  `ExplainerJson`) are already in the Metrics folder. What's missing is exactly
+  the point-in-time *inputs* side.
+
+### Corrections to the working assumptions
+
+Two premises in the original framing don't match the code, and both are good news:
+
+1. **"We get FranchiseSeasonMetric data from ESPN"** — no. ESPN's season-stats
+   document feeds `FranchiseSeasonStatistic` (a different entity). The metrics
+   that drive StatBot are computed in-house from plays/drives. We are not
+   dependent on capturing ESPN's weekly overwrites on a schedule; we own the
+   entire derivation.
+2. **"We get per-contest data via CompetitionCompetitorStatistic"** — that entity
+   exists (ESPN's per-game box score, category/stat tree), but it is **not in the
+   metric chain today**. Nothing reads it for metrics. See "Where it fits" below.
+
+## The key insight: snapshots are derivable retroactively
+
+Because `CompetitionMetric` is per-game and persists, and contests map to weeks,
+**"metrics as of week N" is a pure function of data we already have**:
+
+> filter that team's `CompetitionMetric` rows to contests with week ≤ N,
+> aggregate exactly as `ComputeFranchiseSeasonMetric` does today.
+
+Nothing needs to be captured going forward that isn't already captured. This
+means the entire historical corpus — NCAA seasons back through the historical
+sourcing effort — can be backfilled into per-week snapshots without touching
+ESPN. The regression-test dataset is as large as the play-by-play archive, not
+as large as "weeks since we started snapshotting."
+
+The one thing that is *not* reconstructible is what a **previously generated
+preview** actually saw (its inputs may predate correct week mapping, late plays,
+or metric-formula changes). Provenance has to be captured at generation time
+going forward; history before that is best-effort.
+
+## Proposed shape (for discussion, not authorized)
+
+### 1. `FranchiseSeasonWeekMetric` — the snapshot entity
+
+Same metric columns as `FranchiseSeasonMetric`, plus:
+
+- `SeasonYear`, `SeasonType`, `WeekNumber` (and/or `SeasonWeekId`)
+- `GamesPlayed` (through the cutoff)
+- `ThroughUtc` — the actual cutoff instant used
+- `InputsHash` — hash of the contributing `CompetitionMetric` ids+hashes, so a
+  regression run can verify its inputs are byte-identical to the original
+- unique index `(FranchiseSeasonId, SeasonType, WeekNumber)`
+
+**Semantic decision needed:** does the week-N row mean *entering* week N (games
+through N-1) or *after* week N (games through N)? Proposal: **after** — "the
+state of the world once week N completed" — because that's the input to
+anything generated during week N+1, and week 0/preseason falls out naturally as
+`GamesPlayed = 0`. But this must be pinned down before any row is written;
+it's the kind of off-by-one that poisons a regression corpus silently.
+
+### 2. Computation: parameterize, don't fork
+
+Extract the aggregation in `CalculateFranchiseSeasonMetricsCommandHandler.ComputeFranchiseSeasonMetric`
+so the same code produces both the live row (no cutoff) and any week snapshot
+(cutoff at week N). One formula, two callers — the live row and the snapshots
+can never drift from each other.
+
+### 3. Trigger: extend the audit-job idiom
+
+A `FranchiseSeasonWeekMetricsAuditJob` that finds `(franchiseSeason, week)`
+pairs whose week is complete but which lack a snapshot row, and enqueues
+computation. Self-healing, idempotent, and it **is** the backfill mechanism —
+pointed at 2024, it fills 2024. No separate one-shot backfill path to write and
+then throw away. Matches `FootballCompetitionMetricsAuditJob` exactly.
+
+"Week is complete" needs a definition (all contests in that SeasonWeek final?
+`SeasonWeek.EndDate` passed? both?) — open question below.
+
+### 4. Preview provenance (API side)
+
+When `MatchupPreviewProcessor` generates a preview, persist *which* inputs it
+saw — either the two `FranchiseSeasonWeekMetric` ids, or an inline JSON snapshot
+of the metric values on the preview record. Replaces the boolean `UsedMetrics`
+with something replayable. Without this, the snapshot table lets us reconstruct
+what a preview *should have* seen, but not prove what it *did* see.
+
+### 5. Where `CompetitionCompetitorStatistic` fits
+
+Not as the primary source — plays/drives already win on granularity and are the
+established chain. Two real roles:
+
+- **Cross-validation**: ESPN's box-score totals vs our play-derived numbers per
+  game. A cheap audit that catches play-ingestion gaps (missing plays understate
+  yardage silently; a box-score diff surfaces it).
+- **Gap-filling**: metrics not derivable from our play data. `NetPunt` is
+  literally `0m // TODO` in `CalculateCompetitionMetricsCommandHandler` today —
+  punting stats may be exactly what the box score provides cheaply.
+
+## Open decisions
+
+1. **Week-N semantics** — entering vs after (proposal: after; see §1).
+2. **"Week complete" definition** for the audit job — all contests final vs
+   week end-date passed vs both.
+3. **Bye weeks** — write a carry-forward row (identical values, `GamesPlayed`
+   unchanged) or no row? Carry-forward makes consumers dumber (every week has a
+   row); gaps make the table smaller and "played that week" explicit. Proposal:
+   carry-forward — regression harnesses joining "preview generated in week N"
+   to "snapshot N-1" shouldn't need bye-week special cases.
+4. **Rolling-value flavors** — season-to-date average only (what exists), or
+   also recency-weighted / last-3 forms? If multiple flavors are plausible, the
+   schema needs a discriminator (or a `ModelRun`-style versioning of the
+   aggregation itself) *now*, even if only one flavor ships first.
+5. **Metric-formula versioning** — when a formula bug is fixed (e.g. NetPunt
+   gets implemented), do historical snapshots get recomputed (corpus changes
+   under the model) or frozen (corpus is stable but wrong)? `InputsHash` detects
+   the drift; policy for handling it is a product decision.
+6. **Postseason** — SeasonType handling: continuous week numbering or
+   type-scoped; bowl/playoff games in season-to-date aggregates or excluded.
+7. **Scope** — football-only (both contexts are `FootballDataContext` today).
+   MLB's shape (162 games, no meaningful "week") suggests per-*date* snapshots
+   there eventually; out of scope here but worth not designing against.
+
+## Verify before trusting the backfill claim
+
+The retroactive-derivability claim is structural (verified from code); the
+**coverage** claim is empirical and unverified. The dataset is only as large as
+the play-by-play archive *actually is* — ESPN's PBP coverage thins with age,
+`CompetitionMetric` only exists where plays computed cleanly, and
+`Contest.Week`/`SeasonWeekId` are nullable. Run this against the football DB
+before sizing any backfill:
+
+```sql
+-- Per-season coverage: how much of the backfill corpus actually exists?
+SELECT
+    c."SeasonYear",
+    COUNT(DISTINCT c."Id")                                            AS contests,
+    COUNT(DISTINCT c."Id") FILTER (WHERE c."SeasonWeekId" IS NOT NULL) AS with_week_mapping,
+    COUNT(DISTINCT comp."Id")                                         AS competitions,
+    COUNT(DISTINCT p."CompetitionId")                                  AS with_plays,
+    COUNT(DISTINCT cm."CompetitionId")                                 AS with_metrics
+FROM "Contest" c
+JOIN "Competition" comp ON comp."ContestId" = c."Id"
+LEFT JOIN LATERAL (
+    SELECT fp."CompetitionId" FROM "FootballCompetitionPlay" fp
+    WHERE fp."CompetitionId" = comp."Id" LIMIT 1
+) p ON TRUE
+LEFT JOIN LATERAL (
+    SELECT m."CompetitionId" FROM "CompetitionMetric" m
+    WHERE m."CompetitionId" = comp."Id" LIMIT 1
+) cm ON TRUE
+GROUP BY c."SeasonYear"
+ORDER BY c."SeasonYear";
+```
+
+-- NFL Results --
+SeasonYear	contests	with_week_mapping	competitions	with_plays	with_metrics
+1999	248	248	248	0	248
+2000	324	324	324	0	324
+2001	323	323	323	286	323
+2002	333	333	333	267	333
+2003	333	333	333	290	333
+2004	333	333	333	267	333
+2005	333	333	333	266	333
+2006	332	332	332	332	332
+2007	332	332	332	331	332
+2008	332	332	332	332	332
+2009	332	332	332	331	332
+2010	332	332	332	332	332
+2011	332	332	332	331	332
+2012	332	332	332	330	332
+2013	332	332	332	309	332
+2014	333	333	333	327	333
+2015	332	332	332	332	332
+2016	332	332	332	331	332
+2017	333	333	333	317	333
+2018	332	332	332	332	332
+2019	332	332	332	332	332
+2020	334	334	334	269	334
+2021	334	334	334	333	334
+2022	334	334	334	333	334
+2023	334	334	334	334	334
+2024	334	334	334	334	334
+2025	334	334	334	334	334
+2026	321	321	321	0	0
+
+-- NCAAFB Results --
+SeasonYear	contests	with_week_mapping	competitions	with_plays	with_metrics
+1999	699	699	699	0	699
+2000	713	713	713	0	713
+2001	1498	1498	1498	456	1498
+2002	1505	1505	1505	31	1505
+2003	1526	1526	1526	484	1526
+2004	1428	1428	1428	475	1428
+2005	1438	1438	1438	597	1438
+2006	1535	1535	1535	692	1535
+2007	3495	3495	3495	866	3495
+2008	3587	3587	3587	1147	3587
+2009	3546	3546	3546	1232	3546
+2010	2276	2276	2276	211	2276
+2011	3616	3616	3616	1297	3616
+2012	3657	3657	3657	1318	3657
+2013	3772	3772	3772	1534	3772
+2014	3798	3798	3798	1472	3798
+2015	3748	3748	3748	1503	3748
+2016	3213	3213	3213	1117	3213
+2017	3699	3699	3699	1376	3699
+2018	3776	3776	3776	1441	3776
+2019	3791	3791	3791	1555	3791
+2020	2123	2123	2123	801	2123
+2021	3702	3702	3702	1408	3702
+2022	3724	3724	3724	1420	3724
+2023	3734	3734	3734	1519	3734
+2024	3802	3802	3802	1594	3802
+2025	3833	3833	3833	1679	3833
+2026	1481	1481	1481	0	0
+
+Reading it: `with_metrics ≈ competitions` in a season → that season backfills
+cleanly. `with_plays` well below `competitions` → ESPN never had (or we never
+sourced) PBP there, and that season's floor is set by ESPN, not by us.
+`with_week_mapping` gaps → fixable on our side from `StartDateUtc` + the
+season-week calendar. (Table/column names should be sanity-checked against the
+live schema before running — written from the EF configurations, not psql.)
+
+## Sizing (rough)
+
+Snapshot rows ≈ franchise-seasons × weeks ≈ (~800 NCAA + 32 NFL) × ~16 × years.
+For 25 years of NCAA history that's on the order of 300k rows of ~25 decimal
+columns — trivial for PostgreSQL, and dwarfed by the existing plays tables. The
+compute cost of a full backfill is bounded by the same aggregation the live path
+already runs, driven off indexed `CompetitionMetric` reads.
+
+## Out of scope
+
+- The prediction-model work itself (`metrics-microservice-deetsmeter.md`)
+- AI provider routing (`ai-provider-routing-per-sport.md`)
+- MLB / non-football metrics
+- Backfilling provenance for previews generated before provenance capture exists

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -376,22 +376,29 @@ Grader: `POST /admin/metricbot/backtest` (shipped #612). Weeks 4, 5, 6,
 8, 10; tail=0 per protocol (tail is an early-weeks-only question).
 1,439 graded games.
 
-| wk | SU | always-home | favorite (spread games) | ATS | model MAE | market MAE |
-|---|---|---|---|---|---|---|
-| 4 | 64.2% | 57.9% | 76.5% (98) | 50.5% | 19.60 | 11.47 |
-| 5 | 65.9% | 54.9% | 78.3% (106) | 44.3% | 17.47 | 10.22 |
-| 6 | 67.3% | 57.0% | 77.9% (95) | 45.3% | 17.53 | 11.22 |
-| 8 | 71.5% | 55.2% | 73.2% (108) | 50.9% | 16.63 | 12.20 |
-| 10 | 77.0% | 54.6% | 73.6% (110) | 45.5% | 15.43 | 12.44 |
+| wk | graded | SU | always-home | favorite (spread games) | ATS | model MAE | market MAE | Brier | climatology |
+|---|---|---|---|---|---|---|---|---|---|
+| 4 | 285 | 64.2% | 57.9% | 76.5% (98) | 50.5% (97) | 19.60 | 11.47 | 0.2378 | 0.2438 |
+| 5 | 264 | 65.9% | 54.9% | 78.3% (106) | 44.3% (106) | 17.47 | 10.22 | 0.2229 | 0.2476 |
+| 6 | 291 | 67.3% | 57.0% | 77.9% (95) | 45.3% (95) | 17.53 | 11.22 | 0.2146 | 0.2450 |
+| 8 | 295 | 71.5% | 55.2% | 73.2% (108) | 50.9% (108) | 16.63 | 12.20 | 0.1939 | 0.2472 |
+| 10 | 304 | 77.0% | 54.6% | 73.6% (110) | 45.5% (110) | 15.43 | 12.44 | 0.1598 | 0.2479 |
 
 Weighted: SU 69.4%, ATS 47.3% (n=516), model MAE 17.30 vs market 11.53.
-Brier beats climatology every week, dramatically by wk10 (0.160 vs
-0.248).
+Denominator note: favorite-baseline games (517) exceed ATS games (516)
+by one — a push, excluded from ATS grading per the harness rules but
+still SU-decided and so counted for the favorite baseline.
 
-**Conclusions:**
-- SU signal is real and GROWS with the season (aggregates stabilize) —
-  64% -> 77% by week 10. deetsMeter SU picks are defensible.
-- ATS: no edge, settled at this sample size. Frame as entertainment.
+**Conclusions (scope: five sampled weeks of one season, 2025 NCAAFB —
+observed results, not a multi-season generalization):**
+- SU accuracy rose monotonically across the sampled weeks — 64% (wk4)
+  -> 77% (wk10) — consistent with season-aggregate features
+  stabilizing as games accumulate. Brier beat climatology in every
+  sampled week (per-week values in the table). On this evidence,
+  deetsMeter SU picks are defensible; repeat over 2024 (and 2026 as it
+  arrives) before treating the trend as a law.
+- ATS: no observed edge — 47.3% weighted, below break-even in 4 of 5
+  weeks and never above 51%. Frame as entertainment.
 - Vegas beats the model by ~6 pts/game on margin, consistently.
   Consistent with the stated goal (calibration, not beating Vegas).
 - In-sample MAE 13.9 vs out-of-sample ~17.3: the honest gap; every
@@ -402,12 +409,16 @@ Two defects: 0.8–0.9 runs ~10pts hot (84.4% -> 74.9%, n=167), and
 0.0–0.1 is broken (5.6% -> 35.0% actual, n=40) while 0.9–1.0 is
 near-perfect (94.5% -> 94.3%).
 
-**Autopsy of the 0.0–0.1 bucket (40 games):** neutral-site theory
-REFUTED (2/40 off home venue, zero event notes). Root cause: **no
-opponent-strength adjustment in the features.** All metrics are raw
+**Autopsy of the 0.0–0.1 bucket (40 games):** the neutral-site theory
+is not supported — 2/40 games were off the home team's venue and none
+carried an event note (caveat: both signals depend on VenueId/EventNote
+completeness, which was not separately audited). Leading explanation,
+consistent with all the evidence: **no opponent-strength adjustment in
+the features.** All metrics are raw
 season averages; schedule-inflated stats are indistinguishable from
 real ones. Smoking guns: the model gave >=90% to LOWER-DIVISION road
-teams that then lost 47-14 (fcs @ fbs) and 35-9 (d2 @ fcs). Extreme
+teams that then lost 47-14 (fcs @ fbs) and 35-9 (d2 @ fcs) — hard to
+explain by any rival theory. Extreme
 away-favorite predictions concentrate the inflation failure because a
 90% road win requires stats overwhelming home field — inflated stats
 are exactly the kind that do. The asymmetry (0.9–1.0 fine) exists
@@ -423,12 +434,21 @@ variance.
    mismatches).
 2. MetricBot-v1.1: opponent-adjusted features (simple SOS — e.g.
    opponent-average-allowed versions of core metrics) and/or division
-   indicators from GroupSeasonMap (available at feature time). Bump
-   MODEL_VERSION; the grader measures whether it worked.
+   indicators from GroupSeasonMap. Bump MODEL_VERSION; the grader
+   measures whether it worked. Point-in-time caveat: GroupSeasonMap is
+   SEASON-scoped (a FranchiseSeason field), which is the right
+   granularity for division indicators — divisions don't change
+   mid-season — but the field is mutable if the hierarchy is ever
+   rebuilt/backfilled, so backtests assume the stored per-season value
+   reflects that season's actual membership. Acceptable for v1.1;
+   revisit if hierarchy rewrites become routine.
 3. Until v1.1: sub-10% home probabilities really mean ~1-in-3.
 4. Experiment results durable store (ExperimentRun tables) once the
-   report shape settles; hand-saved JSON in docs/metrics-modeling/
-   output/ (gitignored) until then.
+   report shape settles. Until then, hand-saved JSON in
+   docs/metrics-modeling/output/ (gitignored) is the interim record —
+   retention owner: the operator's local checkout (acceptable: every
+   backtest is deterministic and reproducible from the same request,
+   so lost artifacts are re-derivable, not lost evidence).
 
 ## Local container smoke test
 

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -370,6 +370,66 @@ Sibling design context:
 
 - `ai-provider-cutover-deepseek-to-ollama.md` (this folder) — the AI-side cutover plan, related but independent
 
+## First graded backtests — 2025 NCAAFB, five weeks (2026-08-10)
+
+Grader: `POST /admin/metricbot/backtest` (shipped #612). Weeks 4, 5, 6,
+8, 10; tail=0 per protocol (tail is an early-weeks-only question).
+1,439 graded games.
+
+| wk | SU | always-home | favorite (spread games) | ATS | model MAE | market MAE |
+|---|---|---|---|---|---|---|
+| 4 | 64.2% | 57.9% | 76.5% (98) | 50.5% | 19.60 | 11.47 |
+| 5 | 65.9% | 54.9% | 78.3% (106) | 44.3% | 17.47 | 10.22 |
+| 6 | 67.3% | 57.0% | 77.9% (95) | 45.3% | 17.53 | 11.22 |
+| 8 | 71.5% | 55.2% | 73.2% (108) | 50.9% | 16.63 | 12.20 |
+| 10 | 77.0% | 54.6% | 73.6% (110) | 45.5% | 15.43 | 12.44 |
+
+Weighted: SU 69.4%, ATS 47.3% (n=516), model MAE 17.30 vs market 11.53.
+Brier beats climatology every week, dramatically by wk10 (0.160 vs
+0.248).
+
+**Conclusions:**
+- SU signal is real and GROWS with the season (aggregates stabilize) —
+  64% -> 77% by week 10. deetsMeter SU picks are defensible.
+- ATS: no edge, settled at this sample size. Frame as entertainment.
+- Vegas beats the model by ~6 pts/game on margin, consistently.
+  Consistent with the stated goal (calibration, not beating Vegas).
+- In-sample MAE 13.9 vs out-of-sample ~17.3: the honest gap; every
+  prior 56-62% claim was measured with leaky features.
+
+**Pooled calibration (1,439 games):** buckets 0.1–0.8 healthy (±4pts).
+Two defects: 0.8–0.9 runs ~10pts hot (84.4% -> 74.9%, n=167), and
+0.0–0.1 is broken (5.6% -> 35.0% actual, n=40) while 0.9–1.0 is
+near-perfect (94.5% -> 94.3%).
+
+**Autopsy of the 0.0–0.1 bucket (40 games):** neutral-site theory
+REFUTED (2/40 off home venue, zero event notes). Root cause: **no
+opponent-strength adjustment in the features.** All metrics are raw
+season averages; schedule-inflated stats are indistinguishable from
+real ones. Smoking guns: the model gave >=90% to LOWER-DIVISION road
+teams that then lost 47-14 (fcs @ fbs) and 35-9 (d2 @ fcs). Extreme
+away-favorite predictions concentrate the inflation failure because a
+90% road win requires stats overwhelming home field — inflated stats
+are exactly the kind that do. The asymmetry (0.9–1.0 fine) exists
+because predicted HOME blowouts are mostly payday games where strong
+stats and home field agree. A global residual-std inflation CANNOT fix
+this (it would wreck the healthy 0.9–1.0 bucket); this is bias, not
+variance.
+
+**Agreed next steps (in order):**
+1. Grader enhancement: model SU accuracy restricted to the SAME spread
+   games as the favorite baseline — the current 69.4% vs 75.8%
+   comparison is apples-to-oranges (spreadless games are mostly easy
+   mismatches).
+2. MetricBot-v1.1: opponent-adjusted features (simple SOS — e.g.
+   opponent-average-allowed versions of core metrics) and/or division
+   indicators from GroupSeasonMap (available at feature time). Bump
+   MODEL_VERSION; the grader measures whether it worked.
+3. Until v1.1: sub-10% home probabilities really mean ~1-in-3.
+4. Experiment results durable store (ExperimentRun tables) once the
+   report shape settles; hand-saved JSON in docs/metrics-modeling/
+   output/ (gitignored) until then.
+
 ## Local container smoke test
 
 Docker's `--env-file` takes the same `KEY=VALUE` format as

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -444,11 +444,15 @@ variance.
    revisit if hierarchy rewrites become routine.
 3. Until v1.1: sub-10% home probabilities really mean ~1-in-3.
 4. Experiment results durable store (ExperimentRun tables) once the
-   report shape settles. Until then, hand-saved JSON in
-   docs/metrics-modeling/output/ (gitignored) is the interim record —
-   retention owner: the operator's local checkout (acceptable: every
-   backtest is deterministic and reproducible from the same request,
-   so lost artifacts are re-derivable, not lost evidence).
+   report shape settles. Until then the interim record is the HTTP
+   RESPONSE the operator saves by hand (e.g. from Bruno) into
+   docs/metrics-modeling/output/ (gitignored) — distinct from the CLI's
+   `--dump-intermediate`, which writes CSV/JSON artifacts to
+   `src/metrics-modeling/data/` (also gitignored; ephemeral when run in
+   the service container). Retention owner: the operator's local
+   checkout (acceptable: every backtest is deterministic and
+   reproducible from the same request, so lost artifacts are
+   re-derivable, not lost evidence).
 
 ## Local container smoke test
 


### PR DESCRIPTION
## Summary

Docs only — records the 2025 NCAAFB backtest campaign and its conclusions so they outlive the session that produced them.

### What the five graded weeks said (4/5/6/8/10, 1,439 games, tail=0)

| | Result | Reference |
|---|---|---|
| SU | 64.2% → **77.0%** (wk4→wk10), weighted 69.4% | always-home 57% |
| ATS | 47.3% weighted (n=516) — **no edge, settled** | break-even 52.4% |
| Margin | model MAE 17.30 | market 11.53 (~6 pts/game better) |
| Brier | beats climatology every week; 0.160 vs 0.248 by wk10 | |

### The calibration autopsy

Pooled calibration is healthy from 0.1–0.8; the 0.0–0.1 bucket is broken (5.6% predicted → 35.0% actual) while 0.9–1.0 is near-perfect. Autopsy of all 40 sub-10% games **refuted the neutral-site theory** (2/40) and identified the root cause: **no opponent-strength adjustment** — raw season averages can't distinguish schedule-inflated stats from real ones, and the model gave ≥90% to lower-division road teams that then lost 47–14 and 35–9. The asymmetry rules out a residual-std fix: this is bias, not variance.

### Agreed next steps (recorded in the doc)

1. Grader: model SU restricted to spread games (apples-to-apples vs the favorite baseline).
2. MetricBot-v1.1: SOS-adjusted features + `GroupSeasonMap` division indicators.
3. Interim: sub-10% home probabilities read as ~1-in-3.
4. Durable `ExperimentRun` store once the report shape settles.

### Also

- Adds `franchise-season-week-metrics.md` (the 2026-07-29 week-snapshots discovery doc) to the repo and README index — its "derivable retroactively" insight is now implemented in query form by the as-of extraction; the status header says so explicitly.
- README's deetsmeter line updated from "greenfield" to deployed reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for per-season-week franchise metrics, including historical coverage, aggregation, auditing, and future snapshot storage.
  * Documented initial 2025 NCAAFB backtest results covering straight-up, against-the-spread, calibration, and error metrics.
  * Recorded model limitations, including low-probability calibration issues and the need for opponent-strength adjustments.
  * Updated the metrics documentation index and MetricBot status details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->