### PR TITLE
feat(metricbot): grade model SU on the same games as the favorite baseline

### DIFF
--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -428,10 +428,12 @@ this (it would wreck the healthy 0.9–1.0 bucket); this is bias, not
 variance.
 
 **Agreed next steps (in order):**
-1. Grader enhancement: model SU accuracy restricted to the SAME spread
-   games as the favorite baseline — the current 69.4% vs 75.8%
-   comparison is apples-to-oranges (spreadless games are mostly easy
-   mismatches).
+1. ~~Grader enhancement: model SU accuracy restricted to the SAME
+   spread games as the favorite baseline~~ DONE (2026-08-11): the SU
+   report now carries `baseline_favorite.model_accuracy_same_games`
+   (the honest head-to-head) and a `spreadless` section (model accuracy
+   on unpriced games — tests the easy-mismatch claim). Re-run the
+   five-week sweep to fill in the real numbers.
 2. MetricBot-v1.1: opponent-adjusted features (simple SOS — e.g.
    opponent-average-allowed versions of core metrics) and/or division
    indicators from GroupSeasonMap. Bump MODEL_VERSION; the grader

--- a/src/metrics-modeling/metricbot/grading.py
+++ b/src/metrics-modeling/metricbot/grading.py
@@ -92,20 +92,36 @@ def grade_week(predictions: pd.DataFrame, scores: pd.DataFrame) -> GradeReport:
             "correct": 0,
             "accuracy": None,
             "baseline_always_home": None,
-            "baseline_favorite": {"games_with_spread": 0, "accuracy": None},
+            "baseline_favorite": {
+                "games_with_spread": 0,
+                "accuracy": None,
+                "model_accuracy_same_games": None,
+            },
+            "spreadless": {"games": 0, "model_accuracy": None},
             "brier": None,
             "brier_climatology": None,
         }
     else:
         actual_home_win = decided["ActualMargin"] > 0
         picked_home = decided["WinProbability"] >= 0.5
-        su_correct = int((picked_home == actual_home_win).sum())
+        su_hits = picked_home == actual_home_win
+        su_correct = int(su_hits.sum())
 
         # Favorite-by-spread baseline: spread < 0 = home favored. Pick-em
         # (0) and missing spreads drop out of this baseline's denominator.
-        with_spread = decided[decided["Spread"].notna() & (decided["Spread"] != 0)]
+        has_line = decided["Spread"].notna() & (decided["Spread"] != 0)
+        with_spread = decided[has_line]
         favorite_correct = int(
             ((with_spread["Spread"] < 0) == (with_spread["ActualMargin"] > 0)).sum())
+
+        # The apples-to-apples number: the model graded on the SAME games
+        # the favorite baseline uses. Overall accuracy mixes in spreadless
+        # games (mostly lopsided FCS matchups where blowout-picking is
+        # easy), so model-overall vs favorite-on-spread-games flatters
+        # neither comparison; this does.
+        model_on_spread_correct = int(su_hits[has_line].sum())
+        spreadless = decided[~has_line]
+        model_spreadless_correct = int(su_hits[~has_line].sum())
 
         su_brier = float(np.mean(
             (decided["WinProbability"] - actual_home_win.astype(float)) ** 2))
@@ -122,6 +138,11 @@ def grade_week(predictions: pd.DataFrame, scores: pd.DataFrame) -> GradeReport:
             "baseline_favorite": {
                 "games_with_spread": len(with_spread),
                 "accuracy": _ratio(favorite_correct, len(with_spread)),
+                "model_accuracy_same_games": _ratio(model_on_spread_correct, len(with_spread)),
+            },
+            "spreadless": {
+                "games": len(spreadless),
+                "model_accuracy": _ratio(model_spreadless_correct, len(spreadless)),
             },
             "brier": round(su_brier, 4),
             "brier_climatology": round(climatology_brier, 4),
@@ -204,12 +225,21 @@ def format_report(report: GradeReport, header: str) -> str:
             lines += [
                 "",
                 f"  STRAIGHT UP   {su['correct']}/{su['decided']}  ({su['accuracy']:.1%})",
-                f"    vs always-home {su['baseline_always_home']:.1%}"
-                + (f"  |  vs favorite {fav['accuracy']:.1%} ({fav['games_with_spread']} spread games)"
-                   if fav["accuracy"] is not None else ""),
-                f"    Brier {su['brier']:.4f} (climatology {su['brier_climatology']:.4f}; lower is better)"
-                + (f"  |  {su['ties_excluded']} ties excluded" if su["ties_excluded"] else ""),
+                f"    vs always-home {su['baseline_always_home']:.1%}",
             ]
+            if fav["accuracy"] is not None:
+                # Same-games comparison — the honest model-vs-favorite line.
+                lines.append(
+                    f"    on the {fav['games_with_spread']} spread games: "
+                    f"model {fav['model_accuracy_same_games']:.1%} vs favorite {fav['accuracy']:.1%}")
+            spreadless = su.get("spreadless", {})
+            if spreadless.get("model_accuracy") is not None:
+                lines.append(
+                    f"    on the {spreadless['games']} spreadless games: "
+                    f"model {spreadless['model_accuracy']:.1%}")
+            lines.append(
+                f"    Brier {su['brier']:.4f} (climatology {su['brier_climatology']:.4f}; lower is better)"
+                + (f"  |  {su['ties_excluded']} ties excluded" if su["ties_excluded"] else ""))
     if r.ats:
         ats = r.ats
         if ats["accuracy"] is None:

--- a/src/metrics-modeling/tests/test_grading.py
+++ b/src/metrics-modeling/tests/test_grading.py
@@ -58,6 +58,10 @@ def test_su_and_ats_grading_with_baselines():
     assert report.su["baseline_always_home"] == round(2 / 3, 4)
     # Favorite: g1 home fav won (hit), g2 away fav won (hit), g3 home fav won (hit).
     assert report.su["baseline_favorite"]["accuracy"] == 1.0
+    # Same-games model accuracy: all three games have spreads, so it
+    # equals overall accuracy here (1/3); no spreadless games.
+    assert report.su["baseline_favorite"]["model_accuracy_same_games"] == round(1 / 3, 4)
+    assert report.su["spreadless"] == {"games": 0, "model_accuracy": None}
     assert report.ats["decided"] == 3
     assert report.ats["correct"] == 3
     assert report.ats["break_even_reference"] == ATS_BREAK_EVEN
@@ -230,3 +234,34 @@ def test_extract_training_still_rejects_empty_results(monkeypatch):
 
     with pytest.raises(extract.ExtractionError, match="zero rows"):
         extract.extract_training(_fake_config())
+
+
+def test_spread_restricted_su_separates_model_from_easy_spreadless_games():
+    predictions = pd.DataFrame([
+        # Two spread games: model splits them (one hit, one miss).
+        _prediction("s1", 0.70, 0.55, 7.0, -7.0),    # home wins: hit
+        _prediction("s2", 0.70, 0.55, 7.0, -7.0),    # away wins: miss
+        # Two spreadless mismatches: model nails both.
+        _prediction("e1", 0.95, 0.5, 30.0, None),    # home blowout: hit
+        _prediction("e2", 0.05, 0.5, -30.0, None),   # away blowout: hit
+    ])
+    scores = pd.DataFrame([
+        _score("s1", 28, 14),
+        _score("s2", 14, 28),
+        _score("e1", 55, 3),
+        _score("e2", 0, 45),
+    ])
+
+    report = grade_week(predictions, scores)
+
+    # Overall 3/4 is flattered by the easy games; the same-games number
+    # tells the honest story: 1/2 on games the market actually priced.
+    assert report.su["accuracy"] == 0.75
+    fav = report.su["baseline_favorite"]
+    assert fav["games_with_spread"] == 2
+    assert fav["model_accuracy_same_games"] == 0.5
+    assert report.su["spreadless"] == {"games": 2, "model_accuracy": 1.0}
+
+    text = format_report(report, "BACKTEST split")
+    assert "model 50.0% vs favorite" in text
+    assert "spreadless games: model 100.0%" in text


### PR DESCRIPTION
## Summary

Agreed next-step #1 from the backtest findings (#613): the report compared model-overall SU (all decided games) against the favorite baseline (spread games only) — apples-to-oranges, since spreadless games are mostly lopsided matchups where blowout-picking is easy.

The SU section now carries:

- **`baseline_favorite.model_accuracy_same_games`** — the model graded on *exactly* the games the favorite baseline uses. The honest head-to-head.
- **`spreadless` {games, model_accuracy}** — the complement, which also tests the "spreadless games are easy" claim empirically instead of assuming it.

Formatter renders both:

```
STRAIGHT UP   196/291  (67.4%)
  vs always-home 57.0%
  on the 95 spread games: model 71.6% vs favorite 77.9%   <- the new line
  on the 196 spreadless games: model 65.3%
```

(numbers illustrative — the five-week sweep gets re-run after merge to fill in the real ones)

Report shape is additive: the service passes the grade dict through and the C# `Grade` property is opaque by design, so nothing else changes. All-ties branch carries the new fields as `None`.

## Tests

New test proves the split matters: a slate where overall 75% hides a 50% same-games reality. 20 Python tests pass.

Design doc next-step #1 marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)