### PR TITLE
docs(metrics): sweep results + MetricBot-v1.1 design (market-prior, FBS scope)

### DIFF
--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -438,10 +438,10 @@ variance.
    weighted (n=922), rising to 80.4% by wk10 — confirming empirically
    that the overall 69.4% was propped up by easier unpriced matchups.
    These results led directly to the v1.1 design below.
-2. MetricBot-v1.1: opponent-adjusted features (simple SOS — e.g.
-   opponent-average-allowed versions of core metrics) and/or division
-   indicators from GroupSeasonMap. Bump MODEL_VERSION; the grader
-   measures whether it worked. Point-in-time caveat: GroupSeasonMap is
+2. ~~MetricBot-v1.1: opponent-adjusted features~~ SUPERSEDED
+   2026-08-11 by the v1.1 design section below: v1.1 is market-prior +
+   scope; opponent-adjusted features and division indicators moved to
+   v1.2 (one change per version so the grader can attribute). Point-in-time caveat: GroupSeasonMap is
    SEASON-scoped (a FranchiseSeason field), which is the right
    granularity for division indicators — divisions don't change
    mid-season — but the field is mutable if the hierarchy is ever
@@ -469,7 +469,14 @@ resolved same day):
 - NCAAFB: games with **at least one FBS participant** (payday games
   included — they appear in real pick'em slates). Filter:
   `split_part(FranchiseSeason.GroupSeasonMap,'|',3) = 'fbs'` on either
-  side.
+  side. Predicate note: existing consumers
+  (`GetCompletedFbsContestIds.sql`, `MatchupScheduleProcessor`) use
+  substring matching (`LIKE '%fbs%'` / case-insensitive contains);
+  v1.1 adopts segment-3 equality WITHIN MetricBot's SQL only — it is
+  stricter (immune to 'fbs' appearing in another path segment) and the
+  two agree on every current value. Existing consumers are
+  intentionally out of scope; harmonizing them on the segment predicate
+  is a separate cleanup candidate.
 - NFL: **every game.**
 - Matchup previews are UNAFFECTED and remain universal ("data-driven
   insights for every NCAAFB and NFL matchup") — previews are the LLM
@@ -483,14 +490,26 @@ resolved same day):
   invisible to box-score aggregates) at full strength instead of
   making 64 noisy features compete with it.
 - Unpriced games (a handful of FBS-participant games per season) fall
-  back to the existing pure-stats model, unchanged.
+  back to the existing pure-stats model, unchanged. Explicit contract:
+  priced games use the residual path (feature set decided at
+  implementation: the 64 stats columns, with Spread entering through
+  the prior term, not FEATURE_COLS); unpriced games use the 64-column
+  fallback and emit an SU prediction ONLY — no ATS DTO, since there is
+  no line to pick against. (Today's pipeline computes NaN cover
+  probabilities for spreadless rows and still builds ATS DTOs from
+  them — a latent defect v1.1 removes.)
 - ATS consequence: the cover probability becomes the model's measured
   DISAGREEMENT with the line. A correction model with nothing to say
   predicts ~0 residual, yielding ~50% ATS picks at low confidence —
   the truthful output given measured ATS of 47.3%, replacing today's
   false confidence.
-- SU consequence: same-games accuracy floors at the favorite baseline
-  (~76%) by construction; real signal in the correction lifts above.
+- SU consequence: the favorite baseline (~76%) becomes the natural
+  benchmark — a ZERO correction reproduces it exactly, but a trained
+  correction can flip favorite-side picks, so matching or beating the
+  baseline is a grader-verified outcome, not a construction guarantee.
+  The 2022+ backtest sweep is the acceptance test: v1.1 ships only if
+  same-games SU does not regress below the pure-stats v1.0 number and
+  ATS calibration improves.
 - Rejected alternatives: raw Spread in FEATURE_COLS (fillna(0) teaches
   the model that unpriced games are pick'ems, poisoning the mismatches
   it handles well); two fully separate models (doubles maintenance,
@@ -503,8 +522,14 @@ resolved same day):
   corpus. Adequate for a linear correction; rules out data-hungry
   approaches. Residual-model backtests are therefore 2022+ only.
 - Priced ≠ FBS: books price hundreds of FCS games (2025: 1,583 priced
-  total vs 932 FBS-participant; 922 of the 932 priced). The residual
-  model trains on priced games; the PRODUCT scope is FBS-participant.
+  total vs 932 FBS-participant; 922 of the 932 priced). DECIDED
+  training scope: the residual model trains on the INTERSECTION —
+  FBS-participant AND priced AND metrics (the ~3,540-game corpus in
+  the table above) — matching the product scope and keeping the
+  training distribution homogeneous. The ~660 priced-FCS games per
+  season are deliberately excluded: more rows, but they reintroduce
+  the cross-division mixing v1.2 exists to fix. Revisit if 3,540 rows
+  prove too thin (the grader will say so).
 - GroupSeasonMap: backfilled prod-wide 2026-08-11 (was 2025-only — an
   earlier run had only reached a local DB; 2026 was fully empty until
   then and is a pre-season onboarding dependency worth a checklist

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -429,11 +429,15 @@ variance.
 
 **Agreed next steps (in order):**
 1. ~~Grader enhancement: model SU accuracy restricted to the SAME
-   spread games as the favorite baseline~~ DONE (2026-08-11): the SU
-   report now carries `baseline_favorite.model_accuracy_same_games`
-   (the honest head-to-head) and a `spreadless` section (model accuracy
-   on unpriced games — tests the easy-mismatch claim). Re-run the
-   five-week sweep to fill in the real numbers.
+   spread games as the favorite baseline~~ DONE (2026-08-11), sweep
+   re-run same day. **Verdict: on market-priced games the favorite
+   baseline beats the model in every sampled week — weighted 75.8% vs
+   65.6% (n=517).** Per week (model/favorite): wk4 64.3/76.5, wk5
+   57.6/78.3, wk6 69.5/77.9, wk8 65.7/73.2, wk10 70.9/73.6 — the gap
+   narrows late but never closes. Spreadless games: model 71.5%
+   weighted (n=922), rising to 80.4% by wk10 — confirming empirically
+   that the overall 69.4% was propped up by easier unpriced matchups.
+   These results led directly to the v1.1 design below.
 2. MetricBot-v1.1: opponent-adjusted features (simple SOS — e.g.
    opponent-average-allowed versions of core metrics) and/or division
    indicators from GroupSeasonMap. Bump MODEL_VERSION; the grader
@@ -455,6 +459,66 @@ variance.
    checkout (acceptable: every backtest is deterministic and
    reproducible from the same request, so lost artifacts are
    re-derivable, not lost evidence).
+
+## MetricBot-v1.1 design (decided 2026-08-11)
+
+Decisions from the post-sweep review (decision owner: Randall; all
+resolved same day):
+
+**Scope — what deetsMeter covers:**
+- NCAAFB: games with **at least one FBS participant** (payday games
+  included — they appear in real pick'em slates). Filter:
+  `split_part(FranchiseSeason.GroupSeasonMap,'|',3) = 'fbs'` on either
+  side.
+- NFL: **every game.**
+- Matchup previews are UNAFFECTED and remain universal ("data-driven
+  insights for every NCAAFB and NFL matchup") — previews are the LLM
+  pipeline; MetricBot never touches them.
+
+**Architecture — market-prior with a residual model:**
+- The spread becomes an INPUT (decided: yes). For priced games,
+  `predicted_margin = -Spread + correction(features)` where the model
+  is trained to predict the RESIDUAL against the closing line. This
+  admits the market's information (injuries, weather, context —
+  invisible to box-score aggregates) at full strength instead of
+  making 64 noisy features compete with it.
+- Unpriced games (a handful of FBS-participant games per season) fall
+  back to the existing pure-stats model, unchanged.
+- ATS consequence: the cover probability becomes the model's measured
+  DISAGREEMENT with the line. A correction model with nothing to say
+  predicts ~0 residual, yielding ~50% ATS picks at low confidence —
+  the truthful output given measured ATS of 47.3%, replacing today's
+  false confidence.
+- SU consequence: same-games accuracy floors at the favorite baseline
+  (~76%) by construction; real signal in the correction lifts above.
+- Rejected alternatives: raw Spread in FEATURE_COLS (fillna(0) teaches
+  the model that unpriced games are pick'ems, poisoning the mismatches
+  it handles well); two fully separate models (doubles maintenance,
+  splits the corpus).
+
+**Corpus reality (verified against prod 2026-08-11):**
+- Odds exist from 2022 onward only. Residual-model training corpus =
+  FBS-participant + priced + metrics: 849 (2022) + 895 (2023) + 874
+  (2024) + 922 (2025) ≈ **3,540 NCAAFB games**, plus the NFL's own
+  corpus. Adequate for a linear correction; rules out data-hungry
+  approaches. Residual-model backtests are therefore 2022+ only.
+- Priced ≠ FBS: books price hundreds of FCS games (2025: 1,583 priced
+  total vs 932 FBS-participant; 922 of the 932 priced). The residual
+  model trains on priced games; the PRODUCT scope is FBS-participant.
+- GroupSeasonMap: backfilled prod-wide 2026-08-11 (was 2025-only — an
+  earlier run had only reached a local DB; 2026 was fully empty until
+  then and is a pre-season onboarding dependency worth a checklist
+  entry). Division labels: `fbs`, `fcs`, and `yy` (ESPN's abbreviation
+  for BOTH D2 and D3 — treat as one below-FCS bucket).
+
+**Sequencing (one change per version so the grader can attribute):**
+- v1.1: market-prior + scope filter. Bar: close the same-games gap
+  toward the 75.8% favorite baseline; grader unchanged (#614 already
+  measures everything needed).
+- v1.2: SOS-adjusted features + division indicators — matters MOST in
+  v1.1's world (the correction model and unpriced fallback are where
+  schedule-blindness still lives, including the broken 0.0-0.1
+  bucket).
 
 ## Local container smoke test
 

--- a/docs/metrics-modeling/metrics-microservice-deetsmeter.md
+++ b/docs/metrics-modeling/metrics-microservice-deetsmeter.md
@@ -498,6 +498,17 @@ resolved same day):
   no line to pick against. (Today's pipeline computes NaN cover
   probabilities for spreadless rows and still builds ATS DTOs from
   them — a latent defect v1.1 removes.)
+- **Canonical `is_priced` predicate (one definition, used everywhere):**
+  `is_priced := Spread IS NOT NULL`. A pick'em line (`Spread == 0`) IS
+  priced — it is a real market opinion (prior = 0 + correction), the
+  residual path applies, and an ATS pick is decidable (home covers iff
+  it wins). This one predicate gates the residual-vs-fallback split,
+  ATS DTO emission, and ATS grading. The favorite BASELINE's existing
+  `Spread != 0` exclusion is a different question — a pick'em has no
+  favorite to name — and stays as a baseline-only sub-rule, not a
+  pricing rule. (Current code is inconsistent on exactly this:
+  baseline excludes 0, ATS grading includes it, DTO emission ignores
+  the question — v1.1 unifies on the predicate above.)
 - ATS consequence: the cover probability becomes the model's measured
   DISAGREEMENT with the line. A correction model with nothing to say
   predicts ~0 residual, yielding ~50% ATS picks at low confidence —


### PR DESCRIPTION
## Summary

Docs only — records the spread-restricted SU sweep verdict and the full v1.1 design that came out of today's review.

### The sweep verdict (#614 grader)

On market-priced games the favorite baseline beats the model **in every sampled week** — weighted **75.8% vs 65.6%** (n=517), the gap narrowing by week 10 (73.6 vs 70.9) but never closing. Spreadless games: model 71.5% (n=922), 80.4% by wk10 — empirically confirming the overall 69.4% was propped up by easier unpriced matchups.

### The v1.1 design (all decisions resolved 2026-08-11)

- **Scope**: NCAAFB = at-least-one-FBS-participant; **NFL = every game**; matchup previews unaffected — they remain universal per the tagline.
- **Market-prior architecture**: the spread becomes an input via a *residual* model — `predicted_margin = −Spread + correction(features)` on priced games, pure-stats fallback for unpriced. ATS becomes the model's measured disagreement with the line (honest ~50% low-confidence picks when the correction has nothing to say). Rejected: raw `Spread` in FEATURE_COLS (fillna(0) poisons unpriced games) and two separate models.
- **Corpus reality** (verified against prod): odds exist 2022+ only → residual corpus ≈ 3,540 NCAAFB FBS-priced games + NFL's own; linear-only; residual backtests 2022+.
- **GroupSeasonMap**: backfilled prod-wide today (was 2025-only — the earlier run had only reached a local DB; 2026 was empty). Division labels: `fbs`, `fcs`, and `yy` (ESPN abbreviates both D2 and D3 as `yy`).
- **Sequencing**: v1.1 = market-prior + scope; v1.2 = SOS features. One change per version so the grader can attribute improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated backtesting conclusions with same-game and spreadless accuracy results.
  * Documented the MetricBot v1.1 design, including supported games, market-prior modeling, fallback handling for unpriced games, and omission of ATS predictions without a line.
  * Added corpus constraints, acceptance criteria, rejected alternatives, and plans for future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->