### PR TITLE
feat(producer,api): narrowed franchise-season re-sourcing for the records backfill

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -34,6 +34,7 @@ using SportsData.Core.Eventing.Events.Contests.Baseball;
 using SportsData.Core.Eventing.Events.Contests.Football;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Infrastructure.Clients.Franchise;
 using SportsData.Core.Infrastructure.Clients.MetricBot;
 using SportsData.Core.Processing;
 
@@ -270,6 +271,30 @@ namespace SportsData.Api.Application.Admin
             CancellationToken cancellationToken)
         {
             var result = await handler.ExecuteAsync(promptId, cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
+        /// Fan out ESPN sourcing for every FranchiseSeason in a season year,
+        /// optionally narrowed to specific child document types. Producer is
+        /// not publicly reachable; this proxy is the operator's entry point.
+        ///
+        /// Example: POST /admin/sourcing/franchise-seasons/FootballNcaa/2025
+        /// Body: { "includeLinkedDocumentTypes": ["TeamSeasonRecord"] }
+        /// (empty body object {} = the historical full cascade)
+        /// </summary>
+        [HttpPost]
+        [Route("sourcing/franchise-seasons/{sport}/{seasonYear:int}")]
+        public async Task<ActionResult<bool>> RequestFranchiseSeasonSourcing(
+            [FromRoute] Sport sport,
+            [FromRoute] int seasonYear,
+            [FromBody] FranchiseSeasonSourcingRequest request,
+            [FromServices] IFranchiseClientFactory franchiseClientFactory,
+            CancellationToken cancellationToken)
+        {
+            var client = franchiseClientFactory.Resolve(sport);
+            var result = await client.RequestFranchiseSeasonSourcing(
+                seasonYear, request, cancellationToken);
             return result.ToActionResult();
         }
 

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -37,6 +37,8 @@ public interface IProvideFranchises : IProvideHealthChecks
     Task<Result<TeamRosterDto>> GetTeamRoster(string slug, int seasonYear, CancellationToken cancellationToken = default);
     Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default);
     Task<Result<bool>> UpdateLogoDarkBg(Guid logoId, bool isForDarkBg, string logoType, CancellationToken cancellationToken = default);
+    /// <summary>Fan out ESPN sourcing for every FranchiseSeason in the year, optionally narrowed to specific child document types.</summary>
+    Task<Result<bool>> RequestFranchiseSeasonSourcing(int seasonYear, FranchiseSeasonSourcingRequest request, CancellationToken cancellationToken = default);
 }
 
 public class FranchiseClient : ClientBase, IProvideFranchises
@@ -108,6 +110,18 @@ public class FranchiseClient : ClientBase, IProvideFranchises
             new GetFranchiseSeasonByIdResponse(null),
             "FranchiseSeason",
             ResultStatus.NotFound,
+            cancellationToken);
+    }
+
+    public async Task<Result<bool>> RequestFranchiseSeasonSourcing(
+        int seasonYear,
+        FranchiseSeasonSourcingRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        return await PostWithResultAsync(
+            $"franchise-seasons/seasonYear/{seasonYear}/source",
+            request,
+            nameof(RequestFranchiseSeasonSourcing),
             cancellationToken);
     }
 

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseSeasonSourcingRequest.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseSeasonSourcingRequest.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Core.Infrastructure.Clients.Franchise;
+
+/// <summary>
+/// Optional narrowing for a franchise-season sourcing request. Null/empty
+/// IncludeLinkedDocumentTypes preserves the historical behavior: the full
+/// TeamSeason child cascade (logos, records, ranks, stats, events, ...).
+/// A populated list restricts the TeamSeason processor to spawning only
+/// the listed child document types — e.g. [TeamSeasonRecord] re-sources
+/// W/L records across a season without re-cascading everything else.
+/// </summary>
+public class FranchiseSeasonSourcingRequest
+{
+    public List<DocumentType>? IncludeLinkedDocumentTypes { get; set; }
+}

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommand.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommand.cs
@@ -1,5 +1,13 @@
+using System.Collections.Generic;
+
 using SportsData.Core.Common;
 
 namespace SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
 
-public record RequestFranchiseSeasonSourcingCommand(int SeasonYear, Sport Sport);
+/// <param name="IncludeLinkedDocumentTypes">Null/empty = full TeamSeason
+/// child cascade (historical behavior); populated = the TeamSeason
+/// processor spawns only the listed child document types.</param>
+public record RequestFranchiseSeasonSourcingCommand(
+    int SeasonYear,
+    Sport Sport,
+    List<DocumentType>? IncludeLinkedDocumentTypes = null);

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
@@ -23,7 +23,7 @@ public interface IRequestFranchiseSeasonSourcingCommandHandler
 /// NFL 2026 schedule). Provider fetches each TeamSeason document from ESPN and
 /// publishes DocumentCreated; TeamSeasonDocumentProcessor takes it from there.
 ///
-/// IncludeLinkedDocumentTypes is DELIBERATELY omitted: null means "spawn
+/// IncludeLinkedDocumentTypes defaults to null: null means "spawn
 /// everything" (see DocumentProcessorBase.ShouldSpawn), so the full document
 /// tree — events/schedule included — cascades from each team season. The
 /// filter also PROPAGATES to children, so narrowing it here (e.g. to Event
@@ -124,7 +124,8 @@ public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSea
                         DocumentType: DocumentType.TeamSeason,
                         SourceDataProvider: SourceDataProvider.Espn,
                         CorrelationId: correlationId,
-                        CausationId: CausationId.Producer.FranchiseSeasonService
+                        CausationId: CausationId.Producer.FranchiseSeasonService,
+                        IncludeLinkedDocumentTypes: command.IncludeLinkedDocumentTypes
                     ), cancellationToken);
 
                     requested++;

--- a/src/SportsData.Producer/Application/FranchiseSeasons/FranchiseSeasonController.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/FranchiseSeasonController.cs
@@ -4,6 +4,7 @@ using SportsData.Core.Common;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Franchise;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonEnrichment;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonMetricsGeneration;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
@@ -45,20 +46,25 @@ public class FranchiseSeasonController : ControllerBase
 
     /// <summary>
     /// Requests ESPN sourcing for every FranchiseSeason in the season year:
-    /// one DocumentRequested (TeamSeason) per franchise, full cascade — the
-    /// linked-document filter is deliberately omitted so events (the
-    /// schedule), rosters, and the rest of the tree source along with it.
+    /// one DocumentRequested (TeamSeason) per franchise. The body's
+    /// IncludeLinkedDocumentTypes narrows the child cascade — null/empty
+    /// preserves the historical full cascade (events, rosters, the whole
+    /// tree); a populated list makes the TeamSeason processor spawn only
+    /// those child document types (e.g. [TeamSeasonRecord] to re-source
+    /// W/L records across a season without re-cascading everything).
     /// </summary>
     [HttpPost("seasonYear/{seasonYear}/source")]
     public async Task<ActionResult<Guid>> RequestFranchiseSeasonSourcing(
         [FromRoute] int seasonYear,
+        [FromBody] FranchiseSeasonSourcingRequest request,
         [FromServices] IRequestFranchiseSeasonSourcingCommandHandler handler,
         [FromServices] IAppMode appMode,
         CancellationToken cancellationToken)
     {
         var command = new RequestFranchiseSeasonSourcingCommand(
             seasonYear,
-            appMode.CurrentSport);
+            appMode.CurrentSport,
+            request.IncludeLinkedDocumentTypes);
 
         var result = await handler.ExecuteAsync(command, cancellationToken);
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
@@ -140,6 +140,32 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
             .Verify(x => x.Use(DeliveryMode.Direct), Times.Once);
     }
 
+    [Fact]
+    public async Task NarrowedRequest_ThreadsFilterIntoEveryDocumentRequested()
+    {
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/1");
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/2");
+
+        // The records backfill case: narrow the TeamSeason cascade to
+        // FranchiseSeasonRecord child documents only.
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(
+                SeasonYear,
+                Sport.FootballNfl,
+                [DocumentType.TeamSeasonRecord]));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e =>
+                    e.DocumentType == DocumentType.TeamSeason &&
+                    e.IncludeLinkedDocumentTypes != null &&
+                    e.IncludeLinkedDocumentTypes.Count == 1 &&
+                    e.IncludeLinkedDocumentTypes.Contains(DocumentType.TeamSeasonRecord)),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
     private sealed class NoopDisposable : IDisposable
     {
         public void Dispose() { }


### PR DESCRIPTION
## Summary

The FranchiseSeasonRecord backfill (NCAAFB 2025 missing entirely; all seasons refreshed post-dedup, both sports) needs per-season sourcing that spawns **only** record child documents — the existing endpoint always ran the full TeamSeason cascade.

The narrowing mechanism already existed end to end (`DocumentRequested.IncludeLinkedDocumentTypes` → Provider → `DocumentCreated` → `ProcessDocumentCommand` → `ShouldSpawn`, same path the contest-refresh cascade uses). This PR exposes it at the sourcing entry point and gives it a public door:

- **Producer**: `RequestFranchiseSeasonSourcing` accepts `FranchiseSeasonSourcingRequest` (null/empty list = the historical full cascade, byte-for-byte unchanged behavior); the handler threads the filter into every fanned-out `DocumentRequested`.
- **Core**: shared request DTO + `FranchiseClient.RequestFranchiseSeasonSourcing` (enums serialize as numbers via `ToJson`, which Producer binds natively — zero MVC config changes).
- **API**: `POST /admin/sourcing/franchise-seasons/{sport}/{seasonYear}` (admin-token gated) proxies via `IFranchiseClientFactory` — Producer is internal-only; this is the operator's Bruno entry point.

## Operator flow (per sport, per season)

```
POST /admin/sourcing/franchise-seasons/FootballNcaa/2025
{ "includeLinkedDocumentTypes": ["TeamSeasonRecord"] }
```

## Verified against the Provider path

Historical seasons serve from Mongo, but cache **misses still fetch** — the never-sourced NCAAFB 2025 record documents get pulled fresh from ESPN. Already-cached documents republish (outside the known ~90-min suppression window) and land in #617's upsert as quiet no-ops. Run seasons ≥90 minutes apart if repeating one.

## Tests

New handler test asserts the filter is threaded into every published `DocumentRequested`; the existing full-cascade test still pins null-filter behavior. 7/7 sourcing tests; full solution builds; 660 API tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an administrative endpoint for requesting franchise-season data sourcing by sport and season.
  * Requests can optionally limit processing to selected linked document types.
  * Existing behavior remains unchanged when no document-type filter is provided.
  * Franchise-season sourcing now supports consistent filtering throughout the request workflow.

* **Tests**
  * Added coverage confirming selected document types are applied to each requested team-season record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->