### PR TITLE
fix(producer): sourcing fan-out runs as a background job; 202 + correlation id

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -285,7 +285,7 @@ namespace SportsData.Api.Application.Admin
         /// </summary>
         [HttpPost]
         [Route("sourcing/franchise-seasons/{sport}/{seasonYear:int}")]
-        public async Task<ActionResult<bool>> RequestFranchiseSeasonSourcing(
+        public async Task<ActionResult<Guid>> RequestFranchiseSeasonSourcing(
             [FromRoute] Sport sport,
             [FromRoute] int seasonYear,
             [FromBody] FranchiseSeasonSourcingRequest request,

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -11,6 +11,7 @@ using SportsData.Core.Middleware.Health;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,8 +38,8 @@ public interface IProvideFranchises : IProvideHealthChecks
     Task<Result<TeamRosterDto>> GetTeamRoster(string slug, int seasonYear, CancellationToken cancellationToken = default);
     Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default);
     Task<Result<bool>> UpdateLogoDarkBg(Guid logoId, bool isForDarkBg, string logoType, CancellationToken cancellationToken = default);
-    /// <summary>Fan out ESPN sourcing for every FranchiseSeason in the year, optionally narrowed to specific child document types.</summary>
-    Task<Result<bool>> RequestFranchiseSeasonSourcing(int seasonYear, FranchiseSeasonSourcingRequest request, CancellationToken cancellationToken = default);
+    /// <summary>Fan out ESPN sourcing for every FranchiseSeason in the year, optionally narrowed to specific child document types. Returns the batch correlation id (the Seq handle).</summary>
+    Task<Result<Guid>> RequestFranchiseSeasonSourcing(int seasonYear, FranchiseSeasonSourcingRequest request, CancellationToken cancellationToken = default);
 }
 
 public class FranchiseClient : ClientBase, IProvideFranchises
@@ -113,16 +114,54 @@ public class FranchiseClient : ClientBase, IProvideFranchises
             cancellationToken);
     }
 
-    public async Task<Result<bool>> RequestFranchiseSeasonSourcing(
+    public async Task<Result<Guid>> RequestFranchiseSeasonSourcing(
         int seasonYear,
         FranchiseSeasonSourcingRequest request,
         CancellationToken cancellationToken = default)
     {
-        return await PostWithResultAsync(
-            $"franchise-seasons/seasonYear/{seasonYear}/source",
-            request,
-            nameof(RequestFranchiseSeasonSourcing),
-            cancellationToken);
+        // Producer answers 202 with the batch correlation id — the
+        // operator's Seq handle for the whole fan-out. It must survive the
+        // round-trip, so this parses the body rather than using the
+        // body-discarding PostWithResultAsync helper.
+        try
+        {
+            var content = new StringContent(request.ToJson(), Encoding.UTF8, "application/json");
+            using var response = await HttpClient.PostAsync(
+                $"franchise-seasons/seasonYear/{seasonYear}/source", content, cancellationToken);
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return new Failure<Guid>(
+                    default,
+                    ResultStatus.Error,
+                    [new ValidationFailure(nameof(RequestFranchiseSeasonSourcing),
+                        $"Producer returned {(int)response.StatusCode}: {body}")]);
+            }
+
+            // Body is the bare guid as JSON ("\"<guid>\"").
+            if (!Guid.TryParse(body.Trim().Trim('"'), out var correlationId))
+            {
+                // A 2xx without a parseable id means the contract broke —
+                // surface it rather than handing back an empty Seq handle.
+                return new Failure<Guid>(
+                    default,
+                    ResultStatus.Error,
+                    [new ValidationFailure(nameof(RequestFranchiseSeasonSourcing),
+                        $"Producer accepted the request but returned an unparseable correlation id: '{body}'")]);
+            }
+
+            return new Success<Guid>(correlationId, ResultStatus.Accepted);
+        }
+        catch (Exception ex)
+        {
+            return new Failure<Guid>(
+                default,
+                ResultStatus.Error,
+                [new ValidationFailure(nameof(RequestFranchiseSeasonSourcing),
+                    $"RequestFranchiseSeasonSourcing failed: {ex.Message}")]);
+        }
     }
 
     public async Task<List<FranchiseSeasonMetricsDto>> GetFranchiseSeasonMetrics(int seasonYear, CancellationToken cancellationToken = default)

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -154,6 +154,13 @@ public class FranchiseClient : ClientBase, IProvideFranchises
 
             return new Success<Guid>(correlationId, ResultStatus.Accepted);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller aborted — propagate rather than reporting a Producer
+            // failure for something the client chose to stop. (Same
+            // contract as MetricBotClient.)
+            throw;
+        }
         catch (Exception ex)
         {
             return new Failure<Guid>(

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommand.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using SportsData.Core.Common;
@@ -10,4 +11,5 @@ namespace SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranc
 public record RequestFranchiseSeasonSourcingCommand(
     int SeasonYear,
     Sport Sport,
-    List<DocumentType>? IncludeLinkedDocumentTypes = null);
+    List<DocumentType>? IncludeLinkedDocumentTypes = null,
+    Guid? CorrelationId = null);

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/RequestFranchiseSeasonSourcing/RequestFranchiseSeasonSourcingCommandHandler.cs
@@ -79,7 +79,11 @@ public class RequestFranchiseSeasonSourcingCommandHandler : IRequestFranchiseSea
             return new Success<Guid>(Guid.Empty, ResultStatus.NotFound);
         }
 
-        var correlationId = Guid.NewGuid();
+        // The controller enqueues this handler as a background job and
+        // returns 202 with the correlation id BEFORE the fan-out runs — the
+        // id must therefore be minted by the caller and passed in, so the
+        // operator's Seq handle matches what the endpoint returned.
+        var correlationId = command.CorrelationId ?? Guid.NewGuid();
         var requested = 0;
         var skipped = 0;
         var failed = 0;

--- a/src/SportsData.Producer/Application/FranchiseSeasons/FranchiseSeasonController.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/FranchiseSeasonController.cs
@@ -5,6 +5,7 @@ using SportsData.Core.DependencyInjection;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.Clients.Franchise;
+using SportsData.Core.Processing;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonEnrichment;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.EnqueueFranchiseSeasonMetricsGeneration;
 using SportsData.Producer.Application.FranchiseSeasons.Commands.RequestFranchiseSeasonSourcing;
@@ -53,22 +54,34 @@ public class FranchiseSeasonController : ControllerBase
     /// those child document types (e.g. [TeamSeasonRecord] to re-source
     /// W/L records across a season without re-cascading everything).
     /// </summary>
+    /// <remarks>
+    /// Returns 202 immediately: the fan-out publishes one broker message
+    /// per franchise (~800 for NCAAFB) and comfortably outlives any HTTP
+    /// timeout, so it runs as a background job. The returned correlation
+    /// id is the Seq handle for the whole batch. Validation failures
+    /// (implausible season year) surface in the job's logs, matching the
+    /// contest finalize/enrich enqueue endpoints.
+    /// </remarks>
     [HttpPost("seasonYear/{seasonYear}/source")]
-    public async Task<ActionResult<Guid>> RequestFranchiseSeasonSourcing(
+    public ActionResult<Guid> RequestFranchiseSeasonSourcing(
         [FromRoute] int seasonYear,
         [FromBody] FranchiseSeasonSourcingRequest request,
-        [FromServices] IRequestFranchiseSeasonSourcingCommandHandler handler,
-        [FromServices] IAppMode appMode,
-        CancellationToken cancellationToken)
+        [FromServices] IProvideBackgroundJobs backgroundJobProvider,
+        [FromServices] IAppMode appMode)
     {
+        var correlationId = Guid.NewGuid();
+
         var command = new RequestFranchiseSeasonSourcingCommand(
             seasonYear,
             appMode.CurrentSport,
-            request.IncludeLinkedDocumentTypes);
+            request.IncludeLinkedDocumentTypes,
+            correlationId);
 
-        var result = await handler.ExecuteAsync(command, cancellationToken);
+        backgroundJobProvider.Enqueue<IRequestFranchiseSeasonSourcingCommandHandler>(
+            h => h.ExecuteAsync(command, CancellationToken.None));
 
-        return result.ToActionResult();
+        return Accepted(correlationId);
+
     }
 
     [HttpPost("seasonYear/{seasonYear}/metrics/generate")]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/RequestFranchiseSeasonSourcingCommandHandlerTests.cs
@@ -166,6 +166,28 @@ public class RequestFranchiseSeasonSourcingCommandHandlerTests
             Times.Exactly(2));
     }
 
+    [Fact]
+    public async Task SuppliedCorrelationId_IsUsedOnEveryPublishedEvent()
+    {
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/1");
+        await SeedFranchiseSeasonAsync("http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2026/teams/2");
+
+        // The controller mints the id, returns it in the 202, and enqueues
+        // the handler — the operator's Seq handle must match the response.
+        var suppliedId = Guid.NewGuid();
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestFranchiseSeasonSourcingCommand(
+                SeasonYear, Sport.FootballNfl, null, suppliedId));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e => e.CorrelationId == suppliedId),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
     private sealed class NoopDisposable : IDisposable
     {
         public void Dispose() { }


### PR DESCRIPTION
## Summary

First real run of #618's endpoint timed out: the handler publishes one broker message per franchise (~800 for NCAAFB) **synchronously** before the controller returns, blowing past the API client's 100-second HttpClient limit while Producer kept working. Diagnosed by the operator; fix follows the established contest finalize/enrich idiom:

- Controller mints the correlation id, enqueues `IRequestFranchiseSeasonSourcingCommandHandler` via `IProvideBackgroundJobs`, and returns **202 Accepted with the id immediately** — the id is the operator's Seq handle, so it must be minted before the fan-out, not inside it.
- `RequestFranchiseSeasonSourcingCommand` carries the nullable `CorrelationId` (handler falls back to minting its own for other callers).
- `FranchiseClient` now parses the 202 body into `Result<Guid>` — the previous `PostWithResultAsync` discarded the body, which would have reduced the Bruno response to `true` and lost the Seq handle.
- Validation failures (implausible year) surface in the job's logs, matching the precedent endpoints.

## Tests

New handler test: a supplied correlation id is used on every published `DocumentRequested`. 8/8 sourcing tests; clean-checkout verification: full solution builds (0 errors), 660 API + 532 Producer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Franchise-season sourcing now runs in the background, allowing requests to return immediately with an HTTP 202 response.
  - Each request receives a correlation ID for tracking progress across related processing events.
  - Supplied correlation IDs are preserved throughout processing.

- **Bug Fixes**
  - Improved handling and reporting of sourcing request failures, including unsuccessful responses, communication errors, and invalid responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->