### PR TITLE
fix(producer): preview current-season records from per-game snapshots

### DIFF
--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreview.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreview.sql
@@ -11,13 +11,13 @@ SELECT
   fsAway."Id" AS "AwayFranchiseSeasonId", fAway."DisplayName" AS "Away",
   fAway."Slug" AS "AwaySlug", fsrdAway."Current" AS "AwayRank",
   gsAway."Slug" AS "AwayConferenceSlug", gsAwayParent."Slug" AS "AwayParentConferenceSlug",
-  fsAway."Wins" AS "AwayWins", fsAway."Losses" AS "AwayLosses",
-  fsAway."ConferenceWins" AS "AwayConferenceWins", fsAway."ConferenceLosses" AS "AwayConferenceLosses",
+  COALESCE(enterAway."Wins", 0) AS "AwayWins", COALESCE(enterAway."Losses", 0) AS "AwayLosses",
+  COALESCE(enterAway."ConferenceWins", 0) AS "AwayConferenceWins", COALESCE(enterAway."ConferenceLosses", 0) AS "AwayConferenceLosses",
   fsHome."Id" AS "HomeFranchiseSeasonId", fHome."DisplayName" AS "Home",
   fHome."Slug" AS "HomeSlug", fsrdHome."Current" AS "HomeRank",
   gsHome."Slug" AS "HomeConferenceSlug", gsHomeParent."Slug" AS "HomeParentConferenceSlug",
-  fsHome."Wins" AS "HomeWins", fsHome."Losses" AS "HomeLosses",
-  fsHome."ConferenceWins" AS "HomeConferenceWins", fsHome."ConferenceLosses" AS "HomeConferenceLosses",
+  COALESCE(enterHome."Wins", 0) AS "HomeWins", COALESCE(enterHome."Losses", 0) AS "HomeLosses",
+  COALESCE(enterHome."ConferenceWins", 0) AS "HomeConferenceWins", COALESCE(enterHome."ConferenceLosses", 0) AS "HomeConferenceLosses",
   co."Details" AS "Spread", (co."Spread" * -1) AS "AwaySpread",
   co."Spread" AS "HomeSpread", co."OverUnder", co."OverOdds", co."UnderOdds"
 FROM public."Contest" c
@@ -59,4 +59,55 @@ LEFT JOIN LATERAL (
   ORDER BY rsw."StartDate" DESC LIMIT 1
 ) fsrHome ON TRUE
 LEFT JOIN public."FranchiseSeasonRankingDetail" fsrdHome ON fsrdHome."FranchiseSeasonRankingId" = fsrHome."Id"
+
+-- Entering record for the away team: taken from the most recent
+-- completed game's CompetitionCompetitorRecord (ESPN snapshots each
+-- team's record ON every game document) — point-in-time by
+-- construction, and the CURRENT record for an upcoming contest. The
+-- FranchiseSeason Wins/Losses denorm columns are abandoned (never
+-- populated for NFL, inconsistent for NCAAFB — see #617); same proven
+-- lateral as GetMatchupsByContestIds.
+LEFT JOIN LATERAL (
+  SELECT
+    split_part(tot."Summary", '-', 1)::int  AS "Wins",
+    split_part(tot."Summary", '-', 2)::int  AS "Losses",
+    split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
+    split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
+  FROM public."CompetitionCompetitor" prev_cc
+  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
+  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionCompetitorRecord" tot
+    ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+  LEFT JOIN public."CompetitionCompetitorRecord" conf
+    ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
+  WHERE prev_cc."FranchiseSeasonId" = fsAway."Id"
+    AND prev_ct."StartDateUtc" < c."StartDateUtc"
+  ORDER BY prev_ct."StartDateUtc" DESC
+  LIMIT 1
+) enterAway ON TRUE
+-- Entering record for the home team: taken from the most recent
+-- completed game's CompetitionCompetitorRecord (ESPN snapshots each
+-- team's record ON every game document) — point-in-time by
+-- construction, and the CURRENT record for an upcoming contest. The
+-- FranchiseSeason Wins/Losses denorm columns are abandoned (never
+-- populated for NFL, inconsistent for NCAAFB — see #617); same proven
+-- lateral as GetMatchupsByContestIds.
+LEFT JOIN LATERAL (
+  SELECT
+    split_part(tot."Summary", '-', 1)::int  AS "Wins",
+    split_part(tot."Summary", '-', 2)::int  AS "Losses",
+    split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
+    split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
+  FROM public."CompetitionCompetitor" prev_cc
+  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
+  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionCompetitorRecord" tot
+    ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+  LEFT JOIN public."CompetitionCompetitorRecord" conf
+    ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
+  WHERE prev_cc."FranchiseSeasonId" = fsHome."Id"
+    AND prev_ct."StartDateUtc" < c."StartDateUtc"
+  ORDER BY prev_ct."StartDateUtc" DESC
+  LIMIT 1
+) enterHome ON TRUE
 WHERE c."Id" = @ContestId

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreview.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreview.sql
@@ -77,12 +77,23 @@ LEFT JOIN LATERAL (
   FROM public."CompetitionCompetitor" prev_cc
   INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
   INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionStatus" prev_cs ON prev_cs."CompetitionId" = prev_comp."Id"
+  LEFT JOIN public."SeasonPhase" prev_sp ON prev_sp."Id" = prev_ct."SeasonPhaseId"
   INNER JOIN public."CompetitionCompetitorRecord" tot
     ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
   LEFT JOIN public."CompetitionCompetitorRecord" conf
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
   WHERE prev_cc."FranchiseSeasonId" = fsAway."Id"
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
+    -- Preview-safe semantics, same as every other preview query: only
+    -- FINALIZED, non-cancelled games anchor the record...
+    AND prev_cs."StatusTypeName" = 'STATUS_FINAL'
+    AND prev_ct."CancelledUtc" IS NULL
+    -- ...and never a PRESEASON game (policy: preseason is system-testing,
+    -- never signal) — without this, an NFL week-1 preview would anchor on
+    -- the team's last preseason game and show preseason W/L as the
+    -- current record.
+    AND (prev_sp."TypeCode" IS NULL OR prev_sp."TypeCode" <> 1)
   ORDER BY prev_ct."StartDateUtc" DESC
   LIMIT 1
 ) enterAway ON TRUE
@@ -102,12 +113,23 @@ LEFT JOIN LATERAL (
   FROM public."CompetitionCompetitor" prev_cc
   INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
   INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionStatus" prev_cs ON prev_cs."CompetitionId" = prev_comp."Id"
+  LEFT JOIN public."SeasonPhase" prev_sp ON prev_sp."Id" = prev_ct."SeasonPhaseId"
   INNER JOIN public."CompetitionCompetitorRecord" tot
     ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
   LEFT JOIN public."CompetitionCompetitorRecord" conf
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
   WHERE prev_cc."FranchiseSeasonId" = fsHome."Id"
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
+    -- Preview-safe semantics, same as every other preview query: only
+    -- FINALIZED, non-cancelled games anchor the record...
+    AND prev_cs."StatusTypeName" = 'STATUS_FINAL'
+    AND prev_ct."CancelledUtc" IS NULL
+    -- ...and never a PRESEASON game (policy: preseason is system-testing,
+    -- never signal) — without this, an NFL week-1 preview would anchor on
+    -- the team's last preseason game and show preseason W/L as the
+    -- current record.
+    AND (prev_sp."TypeCode" IS NULL OR prev_sp."TypeCode" <> 1)
   ORDER BY prev_ct."StartDateUtc" DESC
   LIMIT 1
 ) enterHome ON TRUE

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreviewBatch.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreviewBatch.sql
@@ -11,13 +11,13 @@ SELECT
   fsAway."Id" AS "AwayFranchiseSeasonId", fAway."DisplayName" AS "Away",
   fAway."Slug" AS "AwaySlug", fsrdAway."Current" AS "AwayRank",
   gsAway."Slug" AS "AwayConferenceSlug", gsAwayParent."Slug" AS "AwayParentConferenceSlug",
-  fsAway."Wins" AS "AwayWins", fsAway."Losses" AS "AwayLosses",
-  fsAway."ConferenceWins" AS "AwayConferenceWins", fsAway."ConferenceLosses" AS "AwayConferenceLosses",
+  COALESCE(enterAway."Wins", 0) AS "AwayWins", COALESCE(enterAway."Losses", 0) AS "AwayLosses",
+  COALESCE(enterAway."ConferenceWins", 0) AS "AwayConferenceWins", COALESCE(enterAway."ConferenceLosses", 0) AS "AwayConferenceLosses",
   fsHome."Id" AS "HomeFranchiseSeasonId", fHome."DisplayName" AS "Home",
   fHome."Slug" AS "HomeSlug", fsrdHome."Current" AS "HomeRank",
   gsHome."Slug" AS "HomeConferenceSlug", gsHomeParent."Slug" AS "HomeParentConferenceSlug",
-  fsHome."Wins" AS "HomeWins", fsHome."Losses" AS "HomeLosses",
-  fsHome."ConferenceWins" AS "HomeConferenceWins", fsHome."ConferenceLosses" AS "HomeConferenceLosses",
+  COALESCE(enterHome."Wins", 0) AS "HomeWins", COALESCE(enterHome."Losses", 0) AS "HomeLosses",
+  COALESCE(enterHome."ConferenceWins", 0) AS "HomeConferenceWins", COALESCE(enterHome."ConferenceLosses", 0) AS "HomeConferenceLosses",
   co."Details" AS "Spread", (co."Spread" * -1) AS "AwaySpread",
   co."Spread" AS "HomeSpread", co."OverUnder", co."OverOdds", co."UnderOdds"
 FROM public."Contest" c
@@ -59,4 +59,55 @@ LEFT JOIN LATERAL (
   ORDER BY rsw."StartDate" DESC LIMIT 1
 ) fsrHome ON TRUE
 LEFT JOIN public."FranchiseSeasonRankingDetail" fsrdHome ON fsrdHome."FranchiseSeasonRankingId" = fsrHome."Id"
+
+-- Entering record for the away team: taken from the most recent
+-- completed game's CompetitionCompetitorRecord (ESPN snapshots each
+-- team's record ON every game document) — point-in-time by
+-- construction, and the CURRENT record for an upcoming contest. The
+-- FranchiseSeason Wins/Losses denorm columns are abandoned (never
+-- populated for NFL, inconsistent for NCAAFB — see #617); same proven
+-- lateral as GetMatchupsByContestIds.
+LEFT JOIN LATERAL (
+  SELECT
+    split_part(tot."Summary", '-', 1)::int  AS "Wins",
+    split_part(tot."Summary", '-', 2)::int  AS "Losses",
+    split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
+    split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
+  FROM public."CompetitionCompetitor" prev_cc
+  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
+  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionCompetitorRecord" tot
+    ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+  LEFT JOIN public."CompetitionCompetitorRecord" conf
+    ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
+  WHERE prev_cc."FranchiseSeasonId" = fsAway."Id"
+    AND prev_ct."StartDateUtc" < c."StartDateUtc"
+  ORDER BY prev_ct."StartDateUtc" DESC
+  LIMIT 1
+) enterAway ON TRUE
+-- Entering record for the home team: taken from the most recent
+-- completed game's CompetitionCompetitorRecord (ESPN snapshots each
+-- team's record ON every game document) — point-in-time by
+-- construction, and the CURRENT record for an upcoming contest. The
+-- FranchiseSeason Wins/Losses denorm columns are abandoned (never
+-- populated for NFL, inconsistent for NCAAFB — see #617); same proven
+-- lateral as GetMatchupsByContestIds.
+LEFT JOIN LATERAL (
+  SELECT
+    split_part(tot."Summary", '-', 1)::int  AS "Wins",
+    split_part(tot."Summary", '-', 2)::int  AS "Losses",
+    split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
+    split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
+  FROM public."CompetitionCompetitor" prev_cc
+  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
+  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionCompetitorRecord" tot
+    ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
+  LEFT JOIN public."CompetitionCompetitorRecord" conf
+    ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
+  WHERE prev_cc."FranchiseSeasonId" = fsHome."Id"
+    AND prev_ct."StartDateUtc" < c."StartDateUtc"
+  ORDER BY prev_ct."StartDateUtc" DESC
+  LIMIT 1
+) enterHome ON TRUE
 WHERE c."Id" = ANY(@ContestIds)

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreviewBatch.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupForPreviewBatch.sql
@@ -77,12 +77,23 @@ LEFT JOIN LATERAL (
   FROM public."CompetitionCompetitor" prev_cc
   INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
   INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionStatus" prev_cs ON prev_cs."CompetitionId" = prev_comp."Id"
+  LEFT JOIN public."SeasonPhase" prev_sp ON prev_sp."Id" = prev_ct."SeasonPhaseId"
   INNER JOIN public."CompetitionCompetitorRecord" tot
     ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
   LEFT JOIN public."CompetitionCompetitorRecord" conf
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
   WHERE prev_cc."FranchiseSeasonId" = fsAway."Id"
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
+    -- Preview-safe semantics, same as every other preview query: only
+    -- FINALIZED, non-cancelled games anchor the record...
+    AND prev_cs."StatusTypeName" = 'STATUS_FINAL'
+    AND prev_ct."CancelledUtc" IS NULL
+    -- ...and never a PRESEASON game (policy: preseason is system-testing,
+    -- never signal) — without this, an NFL week-1 preview would anchor on
+    -- the team's last preseason game and show preseason W/L as the
+    -- current record.
+    AND (prev_sp."TypeCode" IS NULL OR prev_sp."TypeCode" <> 1)
   ORDER BY prev_ct."StartDateUtc" DESC
   LIMIT 1
 ) enterAway ON TRUE
@@ -102,12 +113,23 @@ LEFT JOIN LATERAL (
   FROM public."CompetitionCompetitor" prev_cc
   INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
   INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  INNER JOIN public."CompetitionStatus" prev_cs ON prev_cs."CompetitionId" = prev_comp."Id"
+  LEFT JOIN public."SeasonPhase" prev_sp ON prev_sp."Id" = prev_ct."SeasonPhaseId"
   INNER JOIN public."CompetitionCompetitorRecord" tot
     ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
   LEFT JOIN public."CompetitionCompetitorRecord" conf
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
   WHERE prev_cc."FranchiseSeasonId" = fsHome."Id"
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
+    -- Preview-safe semantics, same as every other preview query: only
+    -- FINALIZED, non-cancelled games anchor the record...
+    AND prev_cs."StatusTypeName" = 'STATUS_FINAL'
+    AND prev_ct."CancelledUtc" IS NULL
+    -- ...and never a PRESEASON game (policy: preseason is system-testing,
+    -- never signal) — without this, an NFL week-1 preview would anchor on
+    -- the team's last preseason game and show preseason W/L as the
+    -- current record.
+    AND (prev_sp."TypeCode" IS NULL OR prev_sp."TypeCode" <> 1)
   ORDER BY prev_ct."StartDateUtc" DESC
   LIMIT 1
 ) enterHome ON TRUE


### PR DESCRIPTION
## Summary

Task queued from the #621 review trace: the preview queries read current-season `HomeWins`/`AwayWins` (+conference) from the **abandoned `FranchiseSeason` denorm columns** — the same columns #617 stopped trusting for prior seasons. Right now they're harmlessly 0-0 (season not started); from week 1 onward they'd be wrong all season, feeding the LLM a false current record for every game.

## The fix — a better source than planned

The league query (`GetMatchupsByContestIds`) already solved this with a source better than the `FranchiseSeasonRecord` approach I'd planned: **`CompetitionCompetitorRecord`** — ESPN snapshots each team's record on *every game document*. The lateral takes the record from the team's most recent completed game:

- **Point-in-time by construction** — no denorm maintenance, no drift, no in-season re-sourcing dependency.
- **Correct for upcoming games** — the latest completed game's record *is* the current record.
- **Correct for week 1** — no prior game → 0-0, which is the true entering record.

Both preview queries (`GetMatchupForPreview` + `Batch`) now use the identical proven lateral. Coverage verified against prod: 668 total-type rows for NFL 2025 = 334 games × 2 competitors — complete.

## Deliberately deferred

Five other readers of the denorm columns (`GetMatchupByContestId`, `ForCurrentWeek`, `ForSeasonWeek`, `GetPollByTypeAndSeason`, `GetRankingsByPollByWeek`) are league/rankings **UI** surfaces — audited and flagged, but their fix deserves its own change with UI verification rather than riding a pre-kickoff preview fix.

## Tests

Solution builds; 660 API tests pass (embedded SQL — behavior verified at the source-data level; the payload shape is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Matchup previews now show each team’s most recent prior overall and conference records.
  - Records are calculated relative to the matchup date for more accurate “entering” statistics.
  - Missing record data now displays as zero instead of appearing blank or incorrect.
  - Updated both individual and batch matchup preview results for consistent statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->