### PR TITLE
fix(producer): metrics audit C1 + C2 — PointsPerDrive baseline, FieldPosDiff orientation

### DIFF
--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -80,8 +80,24 @@ snaps — and a later score in a NEW drive can be credited to the stale
 trip (e.g. trip at end of Q2, team receives the second-half kickoff
 and scores: the first-half trip is marked scored).
 
-**Fix**: also close the trip when THIS offense starts a new drive
-(DriveId change) or on period boundaries.
+**Fix — complete termination contract** (a trip, once open, closes on
+the FIRST of):
+1. The opposing offense takes a standing scrimmage snap (existing rule).
+2. THIS offense starts a NEW drive (DriveId change) — covers turnovers,
+   defensive scores, and kickoff-separated possessions in one rule,
+   since every one of those forces a new drive id.
+3. A half boundary (period 2→3) or end of regulation→OT transition —
+   possessions do not survive the half. (Q1→Q2 and Q3→Q4 do NOT
+   terminate: a drive legitimately spans those.)
+4. End of input (existing EOF close).
+Scoring credited to a trip counts only while that trip is open.
+Duplicate play events (same SequenceNumber) count once; missing events
+degrade to rule 1/2 whichever fires first.
+
+**Fixtures required**: trip → opponent snap; trip → turnover → own new
+drive later scores (stale-trip regression); trip open across Q1→Q2
+(must survive); trip open across the half (must close); trip ended by
+defensive TD; trip at EOF; duplicate-sequence play.
 
 ### H3. PenaltyYardsPerPlay attributes by possession, not by offender
 
@@ -90,34 +106,83 @@ possessing offense — so a defensive-offside against the OPPONENT during
 your drive counts as YOUR penalty yards, and your own defensive
 penalties are never counted. `Math.Abs` also erases direction.
 
-**Fix**: attribute by the penalized team if the data supports it; if
-not, rename/redefine the metric honestly ("penalty yards observed
-during own possessions") or drop it from the feature set.
+**Contract (data limitation verified 2026-08-13)**: ESPN's play
+document carries only the possessing/acting `Team` ref (→
+`StartFranchiseSeasonId`); there is NO structured penalized-team field
+— the offender exists only in free text. Therefore:
+- **DECIDED default (pending Randall veto): REMOVE PenaltyYardsPerPlay
+  from FEATURE_COLS and the preview payload.** A metric that cannot
+  attribute its subject is noise with a name. Text-parsing the offender
+  is rejected (fragile, unverifiable at scale).
+- The column may remain persisted as "penalty yards observed during
+  own possessions" ONLY if renamed to say so; otherwise stop computing
+  it. No `Math.Abs`: if it is ever reintroduced with real attribution,
+  yards are signed by beneficiary.
+- Fixtures on any reintroduction: offensive penalty on own drive,
+  defensive penalty on own drive, declined penalty (no yardage), and
+  NO-PLAY interaction.
 
 ## MEDIUM
 
-- **M1. TurnoverMarginPerDrive**: relies on play-type attribution
-  (`StartFranchiseSeasonId` on interception/fumble plays) that should
-  be verified empirically against box scores; likely misses
-  opponent-fumble-recovery play types. Denominator (own offensive
-  drives) is unusual but internally consistent.
-- **M2. TimePossRatio**: `(4 − period) * 900` goes negative in
-  overtime (period 5+), corrupting OT games' possession seconds; the
-  final play of each drive contributes zero elapsed time.
-- **M3. FgPctShrunk**: no shrinkage despite the name (a raw filtered
-  percentage), and zero attempts returns 0 — scoring a team with no
-  short-FG attempts as a 0% kicker. Should be null (SafeAvg-style) or
-  a shrunk prior.
-- **M4. NetPunt**: hardcoded `0m` TODO — a dead constant feature.
-  Harmless to models (zero variance) but misleading in payloads.
+Each medium finding now carries ONE deterministic target:
+
+- **M1. TurnoverMarginPerDrive — target: verified attribution or
+  exclusion.** Acceptance: a verification query comparing computed
+  turnovers-lost/gained against `CompetitionCompetitorStatistic` box
+  totals for ≥100 sampled 2025 games; ≥95% exact match → keep with the
+  play-type list extended to whatever the mismatches reveal (e.g.
+  opponent-fumble-recovery types); below → remove from FEATURE_COLS
+  until fixed. Fixture: a game with one INT each way + one lost fumble,
+  hand-counted.
+- **M2. TimePossRatio — target: OT contributes zero possession
+  seconds.** `secondsRemaining = Math.Max(0, 4 − period) * 900 + clock`
+  clamps OT periods to clock-only; since CFB/NFL OT possession time is
+  not meaningfully clocked in the data, OT plays contribute 0 elapsed
+  and the ratio is a REGULATION possession ratio (documented as such).
+  Last-play duration remains excluded (accepted approximation).
+  Fixture: an OT game whose ratio equals its regulation-only ratio and
+  is in [0,1].
+- **M3. FgPctShrunk — target: null when no qualifying attempts.**
+  The result is null (SafeAvg-carried, omitted from payloads) when a
+  team has zero ≤45yd attempts — never 0%. The shrinkage prior implied
+  by the name is DEFERRED to a future formula vintage; until then the
+  name stays (renaming is churn) with this doc as the honest record.
+  Fixtures: 0 attempts → null; 2/3 made → 0.6667.
+- **M4. NetPunt — target: removed from FEATURE_COLS and payloads.**
+  A hardcoded 0 is a dead constant to models and a lie in payloads.
+  The column may persist as null until punting stats are implemented
+  (likely from box-score data per franchise-season-week-metrics.md §5).
+  Fixture: payload serialization omits it.
+
+### H4. Lexicographic ordering of an ESPN string SequenceNumber
+(found implementing #624)
+
+`CompetitionPlayBase.SequenceNumber` is a STRING, and the handler
+orders plays with `OrderBy(p => p.SequenceNumber)` — lexicographic,
+where "10" sorts before "9". Every ordered computation (drive
+first/last plays, possession-time endpoints, red-zone trip scanning)
+is exposed if ESPN's values vary in digit count. #624's new
+PointsPerDrive orders numerically-with-fallback; the REST of the
+handler still sorts lexicographically.
+
+**Target**: one shared numeric-aware ordering helper used by every
+ordered computation in the handler; a verification query measuring how
+often numeric and lexicographic order actually disagree in prod data
+(if never, the fix is cheap insurance; if often, it re-ranks severity).
 
 ## Aggregation layer (`CalculateFranchiseSeasonMetricsCommandHandler`)
 
-- Plain unweighted mean of per-game ratios (average-of-ratios). This is
-  a documented, defensible choice — but note small-denominator games
-  (few snaps/drives) get equal weight with full games.
-- `SafeAvg` returns 0 (not null) when every game is null — known quirk,
-  formula-parity-locked into the as-of SQL; revisit deliberately.
+- Plain unweighted mean of per-game ratios (average-of-ratios).
+  **DECIDED: preserved unchanged in the recompute vintage** —
+  changing weighting mid-campaign would confound the formula fixes.
+  Small-denominator games keeping equal weight is accepted and
+  recorded. Fixture: 2-game aggregate equals the hand mean.
+- `SafeAvg` all-null → 0 quirk. **DECIDED: preserved in this vintage**
+  (formula-parity is locked into the as-of SQL; changing it means
+  changing two codebases in lockstep). Revisit with the weighting
+  question in a future vintage, as one deliberate change. Fixture:
+  all-null RZ inputs → 0 (current contract), asserted so any future
+  change is loud.
 - Delete+re-add identity churn on recompute — the same pattern
   #617 removed from the records processor; candidate for the same
   upsert treatment.
@@ -134,15 +199,52 @@ AND slates (v1.0/v1.1 both poisoned), (b) the LLM preview payload's
 stats + prior-season Metrics blocks (the model has been reading
 PPD ≈ 6.16 as fact), (c) any DeetsMeter/metric surface.
 
-## Recommended sequence
+## Recompute contract
 
-1. Fix C1 + C2 (and decide H1–H3) in
-   `CalculateCompetitionMetricsCommandHandler`; add
-   `MetricFormulaVersion` stamping; unit-test each formula against a
-   hand-computed fixture game (real play-by-play JSON, known answers).
-2. Recompute ALL CompetitionMetric + FranchiseSeasonMetric under the
-   fixed code (the audit-job idiom is the backfill mechanism) — one
-   vintage everywhere.
-3. Re-run the MetricBot acceptance sweep — pure model and market-prior
-   both re-graded on honest features. Only then resume model iteration
-   (v1.2: consistent as-of aggregate features on both sides).
+- **Identity**: natural key `(CompetitionId, FranchiseSeasonId)` for
+  CompetitionMetric; `(FranchiseSeasonId, Season)` for
+  FranchiseSeasonMetric. Verified 2026-08-13: NO code references
+  `CompetitionMetricId` as a foreign key — delete/re-add identity churn
+  breaks nothing today, but recompute handlers should still write
+  delete+insert in ONE SaveChanges (the current per-game handler uses
+  TWO — delete saved before insert — a crash between loses the rows;
+  same non-atomicity #617 removed from the records processor).
+- **Idempotency**: recompute of an unchanged competition under the same
+  formula version is a no-op in effect (identical values, new stamp
+  only if absent).
+- **Version stamp — ONE field, one name**: `FormulaVersion` (string,
+  e.g. "2026.08"), persisted on BOTH CompetitionMetric and
+  FranchiseSeasonMetric, bumped when EITHER the per-game formulas or
+  the aggregation change (they ship as one vintage; split fields buy
+  nothing and invite mismatched interpretation). Readers: the
+  verification gates below, the MetricBot harness (reports the vintage
+  it trained on), and any future drift check. The earlier
+  `AggregationVersion`/`MetricFormulaVersion` naming in
+  franchise-season-week-metrics.md is superseded by this single field.
+- **InputsHash**: populated at computation time as SHA-256 over the
+  ordered source-play identity list (EspnId + final scoreboard pair);
+  consumer contract: recompute may SKIP a competition whose stored
+  (InputsHash, FormulaVersion) both match — the cheap-idempotency path.
+  Until populated, recompute treats every row as stale (correct,
+  slower).
+
+## Recommended sequence (with gates)
+
+1. Fix C1 + C2 (#624) and land the H/M decisions above in
+   `CalculateCompetitionMetricsCommandHandler`, with the listed
+   fixtures. Add `FormulaVersion` + `InputsHash` stamping (migration).
+2. **Phase 1 recompute**: CompetitionMetric for every competition with
+   plays, oldest season first. GATE before phase 2: row count = 2 ×
+   competitions-with-plays; 100% stamped with the new FormulaVersion;
+   sanity bounds on FBS season means (PPD in [1.5, 3.5];
+   |mean FieldPosDiff| < 3; SuccessRate in [0.30, 0.55]). Any gate
+   failure halts the campaign — nothing downstream recomputes.
+3. **Phase 2 recompute**: FranchiseSeasonMetric strictly AFTER phase 1
+   passes (the season handler reads persisted CompetitionMetric rows —
+   ordering is load-bearing, not stylistic). GATE: per-season row
+   counts match franchise-seasons-with-metrics; spot parity checks vs
+   hand-aggregated samples; 100% version-stamped.
+4. Only after both gates: re-run the MetricBot acceptance sweep (pure
+   model and market-prior re-graded on honest features), regenerate any
+   payload-facing consumers, and resume model iteration (v1.2:
+   consistent as-of aggregate features on both sides).

--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -1,0 +1,148 @@
+# Competition Metrics Formula Audit
+
+Date: 2026-08-13
+Auditor: Claude (session with Randall), triggered by the MetricBot
+v1.1.1 acceptance failure — a −5.5pt systematic prediction bias traced
+through feature decomposition to the metric formulas themselves.
+Scope per Randall: **what the current code computes and what is wrong
+with it** — not archaeology about prior vintages.
+
+Audited chain: `FranchiseSeasonController.GenerateFranchiseSeasonMetrics`
+→ `EnqueueFranchiseSeasonMetricsGenerationCommandHandler` →
+`CalculateFranchiseSeasonMetricsCommandHandler` (season aggregation) and
+`CalculateCompetitionMetricsCommandHandler` (per-game formulas, where
+the values are born).
+
+## Empirical anchors (prod, 2026-08-13)
+
+- FBS per-game PointsPerDrive by season: 2022 = 1.31, 2023 = 1.81,
+  2024 = 1.43, **2025 = 5.93** (physically impossible; ~2.2–2.6 real).
+  Live `FranchiseSeasonMetric` 2025 average: 6.16. The 2025 rows came
+  from the current code below; the pre-2025 rows from an earlier
+  vintage — per scope, only the current behavior is judged.
+- FieldPosDiff per-game: home mean ≈ −37, away mean ≈ +37 (FBS-priced
+  subset); |FPD| ≈ 17 all-division. A real field-position edge cannot
+  be venue-signed.
+
+## CRITICAL
+
+### C1. PointsPerDrive — one-play drives credited with the whole scoreboard
+
+`CalculatePointsPerDrive` computes drive points as
+`score(lastPlay) − score(secondToLastPlay)`, and **when a drive has one
+play, the baseline is 0** — so a one-play drive is credited with the
+team's entire cumulative score at that moment. A kneel-down while
+leading 42–7 = +42 points on one drive. One-play drives are common
+(long TDs, kneels, end-of-half), and the error grows with the score,
+which is why season averages reach ~6.
+
+**Fix**: the baseline must be the score BEFORE the drive's first play —
+i.e. the score at the last play of the team's game-position predecessor
+(0 only at true game start). Compute per-drive points game-ordered, not
+within-drive-ordered.
+
+### C2. FieldPosDiff — differences a stadium-oriented coordinate
+
+`CalculateFieldPositionDiff` averages raw `CompetitionDrive.StartYardLine`
+for own vs opponent drives and subtracts. ESPN's yard line is a
+**fixed-orientation coordinate** (the same physical spot reads 30 for
+one team and 70 for the other), so the difference measures which side
+of the coordinate system each offense drives toward — producing the
+±37 venue-signed artifact. Downstream this silently encoded
+home-field itself into per-game training features (~16pts of implied
+signal) and then vanished in season aggregates, driving MetricBot
+v1.1's −5.5 bias.
+
+**Fix**: normalize each drive start to own-goal-relative field position
+(e.g. 100 − yards-to-endzone at the drive's first play, or orient
+StartYardLine by offense direction) before differencing.
+
+## HIGH
+
+### H1. Offensive-snap filter excludes disaster plays
+
+`IsOffensiveScrimmageType` includes Rush/Pass/Sack/Safety variants but
+**excludes interception plays and lost-fumble plays**. Those are
+offensive snaps with catastrophic outcomes; excluding them biases Ypp,
+SuccessRate, ExplosiveRate, and ThirdFourthRate upward for
+turnover-prone teams — the denominators skip exactly the worst plays.
+
+**Fix**: include `PassInterceptionReturn` (and interception-TD),
+`FumbleLost` (when the possessing offense is the team) as snaps with
+their actual yardage outcomes (typically ≤ 0 for the offense).
+
+### H2. Red-zone trip state survives possession changes it shouldn't
+
+Both RZ calculators end a trip only when the OTHER offense takes a
+standing scrimmage snap. A trip left open at a quarter/half boundary,
+or ended by a defensive score/kick, stays open until the opponent
+snaps — and a later score in a NEW drive can be credited to the stale
+trip (e.g. trip at end of Q2, team receives the second-half kickoff
+and scores: the first-half trip is marked scored).
+
+**Fix**: also close the trip when THIS offense starts a new drive
+(DriveId change) or on period boundaries.
+
+### H3. PenaltyYardsPerPlay attributes by possession, not by offender
+
+Penalty plays are attributed to `StartFranchiseSeasonId` — the
+possessing offense — so a defensive-offside against the OPPONENT during
+your drive counts as YOUR penalty yards, and your own defensive
+penalties are never counted. `Math.Abs` also erases direction.
+
+**Fix**: attribute by the penalized team if the data supports it; if
+not, rename/redefine the metric honestly ("penalty yards observed
+during own possessions") or drop it from the feature set.
+
+## MEDIUM
+
+- **M1. TurnoverMarginPerDrive**: relies on play-type attribution
+  (`StartFranchiseSeasonId` on interception/fumble plays) that should
+  be verified empirically against box scores; likely misses
+  opponent-fumble-recovery play types. Denominator (own offensive
+  drives) is unusual but internally consistent.
+- **M2. TimePossRatio**: `(4 − period) * 900` goes negative in
+  overtime (period 5+), corrupting OT games' possession seconds; the
+  final play of each drive contributes zero elapsed time.
+- **M3. FgPctShrunk**: no shrinkage despite the name (a raw filtered
+  percentage), and zero attempts returns 0 — scoring a team with no
+  short-FG attempts as a 0% kicker. Should be null (SafeAvg-style) or
+  a shrunk prior.
+- **M4. NetPunt**: hardcoded `0m` TODO — a dead constant feature.
+  Harmless to models (zero variance) but misleading in payloads.
+
+## Aggregation layer (`CalculateFranchiseSeasonMetricsCommandHandler`)
+
+- Plain unweighted mean of per-game ratios (average-of-ratios). This is
+  a documented, defensible choice — but note small-denominator games
+  (few snaps/drives) get equal weight with full games.
+- `SafeAvg` returns 0 (not null) when every game is null — known quirk,
+  formula-parity-locked into the as-of SQL; revisit deliberately.
+- Delete+re-add identity churn on recompute — the same pattern
+  #617 removed from the records processor; candidate for the same
+  upsert treatment.
+- `DateTime.UtcNow` used directly (house rule: `IDateTimeProvider`).
+- `InputsHash = null` at both persist sites and **no
+  AggregationVersion** — with formulas about to change, every recompute
+  MUST stamp a version or cross-vintage drift recurs invisibly
+  (see franchise-season-week-metrics.md provenance section).
+
+## Blast radius
+
+`CompetitionMetric` → `FranchiseSeasonMetric` → (a) MetricBot training
+AND slates (v1.0/v1.1 both poisoned), (b) the LLM preview payload's
+stats + prior-season Metrics blocks (the model has been reading
+PPD ≈ 6.16 as fact), (c) any DeetsMeter/metric surface.
+
+## Recommended sequence
+
+1. Fix C1 + C2 (and decide H1–H3) in
+   `CalculateCompetitionMetricsCommandHandler`; add
+   `MetricFormulaVersion` stamping; unit-test each formula against a
+   hand-computed fixture game (real play-by-play JSON, known answers).
+2. Recompute ALL CompetitionMetric + FranchiseSeasonMetric under the
+   fixed code (the audit-job idiom is the backfill mechanism) — one
+   vintage everywhere.
+3. Re-run the MetricBot acceptance sweep — pure model and market-prior
+   both re-graded on honest features. Only then resume model iteration
+   (v1.2: consistent as-of aggregate features on both sides).

--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -16,7 +16,10 @@ the values are born).
 ## Empirical anchors (prod, 2026-08-13)
 
 - FBS per-game PointsPerDrive by season: 2022 = 1.31, 2023 = 1.81,
-  2024 = 1.43, **2025 = 5.93** (physically impossible; ~2.2–2.6 real).
+  2024 = 1.43, **2025 = 5.93** — more than double the best FBS offense
+  in modern history (elite ≈ 3.5; league reality ≈ 2.2–2.6), i.e. far
+  outside any plausible range, and 3–4× the platform's own prior
+  seasons.
   Live `FranchiseSeasonMetric` 2025 average: 6.16. The 2025 rows came
   from the current code below; the pre-2025 rows from an earlier
   vintage — per scope, only the current behavior is judged.
@@ -36,10 +39,13 @@ leading 42–7 = +42 points on one drive. One-play drives are common
 (long TDs, kneels, end-of-half), and the error grows with the score,
 which is why season averages reach ~6.
 
-**Fix**: the baseline must be the score BEFORE the drive's first play —
-i.e. the score at the last play of the team's game-position predecessor
-(0 only at true game start). Compute per-drive points game-ordered, not
-within-drive-ordered.
+**Fix**: the baseline is the team's cumulative score immediately
+before the drive's first play **in global game order** — the last play
+by EITHER team preceding it (0 only at true game start). A same-team
+predecessor is not sufficient: a defensive score during the opponent's
+possession between two drives must be part of the baseline, or the
+next drive absorbs those points. (#624 implements exactly this: the
+baseline play is `ordered[driveFirstIndex − 1]` over ALL plays.)
 
 ### C2. FieldPosDiff — differences a stadium-oriented coordinate
 
@@ -67,9 +73,20 @@ offensive snaps with catastrophic outcomes; excluding them biases Ypp,
 SuccessRate, ExplosiveRate, and ThirdFourthRate upward for
 turnover-prone teams — the denominators skip exactly the worst plays.
 
-**Fix**: include `PassInterceptionReturn` (and interception-TD),
-`FumbleLost` (when the possessing offense is the team) as snaps with
-their actual yardage outcomes (typically ≤ 0 for the offense).
+**Fix (corrected 2026-08-13 — CR caught an error in the original
+guidance)**: interception play types keep the intercepted OFFENSE in
+`StartFranchiseSeasonId`, but `StatYardage` is the DEFENSIVE RETURN
+yardage — adding these types to the snap filter as-is would credit
+return yards to the offense. The correct contract:
+- Interception and lost-fumble plays join the DENOMINATOR of
+  Ypp/SuccessRate/ExplosiveRate/ThirdFourthRate as offensive snaps.
+- Their NUMERATOR contribution is fixed at 0 yards / not-a-success /
+  not-explosive — never `StatYardage`. (If per-type yardage semantics
+  are later verified to carry usable offense yardage for FumbleLost,
+  that is a separate, evidence-backed change.)
+- Fixtures: an interception play must increase snap count without
+  changing total yards; a 40-yard pick-six must not appear as a
+  40-yard offensive gain.
 
 ### H2. Red-zone trip state survives possession changes it shouldn't
 
@@ -230,7 +247,9 @@ PPD ≈ 6.16 as fact), (c) any DeetsMeter/metric surface.
 
 ## Recommended sequence (with gates)
 
-1. Fix C1 + C2 (#624) and land the H/M decisions above in
+1. Fix C1 + C2 (#624 — landed with hand-computed SYNTHETIC fixtures;
+   a real play-by-play fixture game with independently verified answers
+   remains follow-up coverage) and land the H/M decisions above in
    `CalculateCompetitionMetricsCommandHandler`, with the listed
    fixtures. Add `FormulaVersion` + `InputsHash` stamping (migration).
 2. **Phase 1 recompute**: CompetitionMetric for every competition with

--- a/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
@@ -100,7 +100,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             SuccessRate = CalculateSuccessRate(awayFranchiseSeasonId, plays),
             ExplosiveRate = CalculateExplosiveRate(awayFranchiseSeasonId, plays),
             ThirdFourthRate = CalculateThirdFourthConversionRate(awayFranchiseSeasonId, plays),
-            PointsPerDrive = CalculatePointsPerDrive(awayFranchiseSeasonId, plays, homeFranchiseSeasonId, awayFranchiseSeasonId),
+            PointsPerDrive = CalculatePointsPerDrive(awayFranchiseSeasonId, plays, homeFranchiseSeasonId),
             RzTdRate = CalculateRedZoneTdRate(awayFranchiseSeasonId, plays),
             RzScoreRate = CalculateRedZoneScoringRate(awayFranchiseSeasonId, plays),
             TimePossRatio = CalculateTimeOfPossessionRatio(awayFranchiseSeasonId, homeFranchiseSeasonId, plays),
@@ -108,7 +108,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             OppYpp = CalculateYpp(homeFranchiseSeasonId, plays),
             OppSuccessRate = CalculateSuccessRate(homeFranchiseSeasonId, plays),
             OppExplosiveRate = CalculateExplosiveRate(homeFranchiseSeasonId, plays),
-            OppPointsPerDrive = CalculatePointsPerDrive(homeFranchiseSeasonId, plays, homeFranchiseSeasonId, awayFranchiseSeasonId),
+            OppPointsPerDrive = CalculatePointsPerDrive(homeFranchiseSeasonId, plays, homeFranchiseSeasonId),
             OppThirdFourthRate = CalculateThirdFourthConversionRate(homeFranchiseSeasonId, plays),
             OppRzTdRate = CalculateRedZoneTdRate(homeFranchiseSeasonId, plays),
             OppScoreTdRate = CalculateRedZoneScoringRate(homeFranchiseSeasonId, plays),
@@ -132,7 +132,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             SuccessRate = CalculateSuccessRate(homeFranchiseSeasonId, plays),
             ExplosiveRate = CalculateExplosiveRate(homeFranchiseSeasonId, plays),
             ThirdFourthRate = CalculateThirdFourthConversionRate(homeFranchiseSeasonId, plays),
-            PointsPerDrive = CalculatePointsPerDrive(homeFranchiseSeasonId, plays, homeFranchiseSeasonId, awayFranchiseSeasonId),
+            PointsPerDrive = CalculatePointsPerDrive(homeFranchiseSeasonId, plays, homeFranchiseSeasonId),
             RzTdRate = CalculateRedZoneTdRate(homeFranchiseSeasonId, plays),
             RzScoreRate = CalculateRedZoneScoringRate(homeFranchiseSeasonId, plays),
             TimePossRatio = CalculateTimeOfPossessionRatio(homeFranchiseSeasonId, awayFranchiseSeasonId, plays),
@@ -140,7 +140,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             OppYpp = CalculateYpp(awayFranchiseSeasonId, plays),
             OppSuccessRate = CalculateSuccessRate(awayFranchiseSeasonId, plays),
             OppExplosiveRate = CalculateExplosiveRate(awayFranchiseSeasonId, plays),
-            OppPointsPerDrive = CalculatePointsPerDrive(awayFranchiseSeasonId, plays, homeFranchiseSeasonId, awayFranchiseSeasonId),
+            OppPointsPerDrive = CalculatePointsPerDrive(awayFranchiseSeasonId, plays, homeFranchiseSeasonId),
             OppThirdFourthRate = CalculateThirdFourthConversionRate(awayFranchiseSeasonId, plays),
             OppRzTdRate = CalculateRedZoneTdRate(awayFranchiseSeasonId, plays),
             OppScoreTdRate = CalculateRedZoneScoringRate(awayFranchiseSeasonId, plays),
@@ -224,20 +224,31 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     }
 
 
+    // AUDIT FIX (C2): the previous implementation differenced raw
+    // StartYardLine values — a STADIUM-oriented coordinate where the
+    // same physical spot reads 30 for one offense and 70 for the other.
+    // The result mostly measured coordinate orientation (systematic
+    // ±37 by venue), silently encoding home-field into per-game
+    // features. StartYardsToEndzone is orientation-free: field position
+    // = 100 − yards-to-endzone (own goal = 0, opponent goal = 100),
+    // comparable across both offenses.
     private static decimal CalculateFieldPositionDiff(
         Guid teamId,
         IReadOnlyCollection<CompetitionDrive> drives)
     {
-        var myDrives = drives.Where(d => d.StartFranchiseSeasonId == teamId && d.StartYardLine.HasValue).ToList();
-        var oppDrives = drives.Where(d => d.StartFranchiseSeasonId != teamId && d.StartYardLine.HasValue).ToList();
+        var myStarts = drives
+            .Where(d => d.StartFranchiseSeasonId == teamId && d.StartYardsToEndzone.HasValue)
+            .Select(d => 100m - d.StartYardsToEndzone!.Value)
+            .ToList();
+        var oppStarts = drives
+            .Where(d => d.StartFranchiseSeasonId != teamId && d.StartYardsToEndzone.HasValue)
+            .Select(d => 100m - d.StartYardsToEndzone!.Value)
+            .ToList();
 
-        if (!myDrives.Any() || !oppDrives.Any())
+        if (myStarts.Count == 0 || oppStarts.Count == 0)
             return 0m;
 
-        var myAvg = (decimal)myDrives.Average(d => d.StartYardLine!.Value);
-        var oppAvg = (decimal)oppDrives.Average(d => d.StartYardLine!.Value);
-
-        return Math.Round(myAvg - oppAvg, 2);
+        return Math.Round(myStarts.Average() - oppStarts.Average(), 2);
     }
 
     private static decimal CalculateTurnoverMarginPerDrive(
@@ -362,19 +373,45 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         return (decimal)conversions / snaps.Count;
     }
 
-    // PPD from plays only (ordered). We infer drives by contiguous offensive scrimmage snaps by the same offense.
-    // homeFsId / awayFsId are used to select the team's score on each play.
-    // PPD from plays only (ordered). We infer drives by contiguous offensive scrimmage snaps
-    // by the same offense. homeFsId/awayFsId are used to read the correct scoreboard.
+    // Points per drive from the cumulative scoreboard on plays.
+    //
+    // AUDIT FIX (C1): drive points = score at the drive's LAST play minus
+    // the score BEFORE the drive's FIRST play (the last play anywhere in
+    // the game preceding it; 0 only at true game start). The previous
+    // implementation used the drive's second-to-last play as the
+    // baseline — and for a ONE-PLAY drive that baseline degenerated to
+    // 0, crediting the drive with the team's entire cumulative score
+    // (a kneel-down while leading 42-7 booked +42), which inflated
+    // season PPD to physically impossible values (~6).
     private decimal CalculatePointsPerDrive(
         Guid franchiseSeasonId,
         List<FootballCompetitionPlay> plays,
-        Guid homeFsId,
-        Guid awayFsId)
+        Guid homeFsId)
     {
-        var drives = plays
-            .Where(p => p.DriveId != Guid.Empty && p.StartFranchiseSeasonId == franchiseSeasonId)
-            .GroupBy(p => p.DriveId)
+        int ScoreOf(FootballCompetitionPlay p) =>
+            franchiseSeasonId == homeFsId ? p.HomeScore : p.AwayScore;
+
+        // SequenceNumber is an ESPN STRING; lexicographic ordering breaks
+        // when digit counts differ ("10" < "9"). Order numerically when
+        // parseable, falling back to the raw string. Both the drive
+        // first/last selection and the baseline lookup use this SAME
+        // ordering, so they cannot disagree.
+        var ordered = plays
+            .Where(p => p.DriveId.HasValue && p.DriveId != Guid.Empty)
+            .OrderBy(p => long.TryParse(p.SequenceNumber, out var n) ? n : long.MaxValue)
+            .ThenBy(p => p.SequenceNumber, StringComparer.Ordinal)
+            .ToList();
+
+        var drives = ordered
+            .Where(p => p.StartFranchiseSeasonId == franchiseSeasonId)
+            .Select((p, _) => p)
+            .GroupBy(p => p.DriveId!.Value)
+            .Select(g => new
+            {
+                FirstIndex = ordered.IndexOf(g.First()),
+                Last = g.Last()
+            })
+            .OrderBy(d => d.FirstIndex)
             .ToList();
 
         if (drives.Count == 0) return 0m;
@@ -383,21 +420,16 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
 
         foreach (var drive in drives)
         {
-            // Use last play of the drive to infer final score for that possession
-            var lastPlay = drive.OrderBy(p => p.SequenceNumber).LastOrDefault();
-            if (lastPlay == null) continue;
+            var baseline = drive.FirstIndex > 0
+                ? ScoreOf(ordered[drive.FirstIndex - 1])
+                : 0;
 
-            var offensePoints = franchiseSeasonId == homeFsId
-                ? lastPlay.HomeScore
-                : lastPlay.AwayScore;
+            var drivePoints = ScoreOf(drive.Last) - baseline;
 
-            var previousPlay = drive.OrderBy(p => p.SequenceNumber).SkipLast(1).LastOrDefault();
-            var previousScore = previousPlay == null
-                ? 0
-                : (franchiseSeasonId == homeFsId ? previousPlay.HomeScore : previousPlay.AwayScore);
-
-            var drivePoints = offensePoints - previousScore;
-            if (drivePoints >= 0) totalPoints += drivePoints;
+            // A single possession is bounded by [0, 8] (TD + 2pt). The
+            // clamp guards scoreboard glitches in the source data rather
+            // than trusting them into the season average.
+            totalPoints += Math.Clamp(drivePoints, 0, 8);
         }
 
         return (decimal)totalPoints / drives.Count;

--- a/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
@@ -240,8 +240,12 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             .Where(d => d.StartFranchiseSeasonId == teamId && d.StartYardsToEndzone.HasValue)
             .Select(d => 100m - d.StartYardsToEndzone!.Value)
             .ToList();
+        // HasValue guard: for nullable Guid, null != teamId is TRUE — an
+        // unknown-offense drive would silently join the opponent average.
         var oppStarts = drives
-            .Where(d => d.StartFranchiseSeasonId != teamId && d.StartYardsToEndzone.HasValue)
+            .Where(d => d.StartFranchiseSeasonId.HasValue
+                     && d.StartFranchiseSeasonId != teamId
+                     && d.StartYardsToEndzone.HasValue)
             .Select(d => 100m - d.StartYardsToEndzone!.Value)
             .ToList();
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -267,7 +267,10 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
             await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
 
             var home = await FootballDataContext.CompetitionMetrics
-                .SingleAsync(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId);
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.PointsPerDrive })
+                .SingleAsync();
 
             home.PointsPerDrive.Should().Be(3.5m,
                 "TD drive (7) + kneel drive (0) over 2 drives — not the kneel inheriting the scoreboard");
@@ -288,15 +291,36 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
                 (homeOffense: true,  driveKey: 3, seq: "03", homeScore: 0, awayScore: 0, yte: 70),
                 (homeOffense: false, driveKey: 4, seq: "04", homeScore: 0, awayScore: 0, yte: 80));
 
+            // An unknown-offense drive (data gap) must be excluded from
+            // BOTH sides' averages, not silently counted as "opponent".
+            await FootballDataContext.Drives.AddAsync(new CompetitionDrive
+            {
+                Id = Guid.NewGuid(),
+                CompetitionId = competitionId,
+                StartFranchiseSeasonId = null,
+                StartYardsToEndzone = 1,
+                Description = "unknown offense",
+                SequenceNumber = "99",
+                Ordinal = 99
+            });
+            await FootballDataContext.SaveChangesAsync();
+
             var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
             await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
 
             var home = await FootballDataContext.CompetitionMetrics
-                .SingleAsync(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId);
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.FieldPosDiff })
+                .SingleAsync();
             var away = await FootballDataContext.CompetitionMetrics
-                .SingleAsync(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == awayId);
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == awayId)
+                .Select(m => new { m.FieldPosDiff })
+                .SingleAsync();
 
-            home.FieldPosDiff.Should().Be(10m, "home starts at own 30 vs away's own 20");
+            home.FieldPosDiff.Should().Be(10m,
+                "home starts at own 30 vs away's own 20 — and the unknown-offense drive is excluded from both sides");
             away.FieldPosDiff.Should().Be(-10m, "symmetric opposite of home");
         }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -244,6 +244,146 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
 
         private static string? _cachedJson; // Cache JSON across test instances
 
+        #region Audit regression fixtures (C1 / C2)
+
+        /// <summary>
+        /// AUDIT C1: a one-play drive must contribute the POINTS SCORED ON
+        /// THAT DRIVE, not the team's cumulative score. Fixture: home
+        /// scores a 2-play TD drive (0 -> 7), later takes a 1-play kneel
+        /// drive still leading 7-0. Correct PPD = (7 + 0) / 2 = 3.5; the
+        /// pre-fix code booked (7 + 7) / 2 = 7 (kneel credited with the
+        /// scoreboard).
+        /// </summary>
+        [Fact]
+        public async Task PointsPerDrive_OnePlayDrive_DoesNotInheritCumulativeScore()
+        {
+            var (competitionId, homeId, _) = await SeedSyntheticAsync(
+                (homeOffense: true,  driveKey: 1, seq: "01", homeScore: 0, awayScore: 0, yte: (int?)null),
+                (homeOffense: true,  driveKey: 1, seq: "02", homeScore: 7, awayScore: 0, yte: null),
+                (homeOffense: false, driveKey: 2, seq: "03", homeScore: 7, awayScore: 0, yte: null),
+                (homeOffense: true,  driveKey: 3, seq: "04", homeScore: 7, awayScore: 0, yte: null));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var home = await FootballDataContext.CompetitionMetrics
+                .SingleAsync(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId);
+
+            home.PointsPerDrive.Should().Be(3.5m,
+                "TD drive (7) + kneel drive (0) over 2 drives — not the kneel inheriting the scoreboard");
+        }
+
+        /// <summary>
+        /// AUDIT C2: FieldPosDiff must be computed from orientation-free
+        /// yards-to-endzone, not raw stadium-oriented yard lines. Fixture:
+        /// home drives start at own 30 (YTE 70), away drives at own 20
+        /// (YTE 80) — home diff = +10, away diff = -10, symmetric.
+        /// </summary>
+        [Fact]
+        public async Task FieldPosDiff_UsesOrientationFreeYardsToEndzone()
+        {
+            var (competitionId, homeId, awayId) = await SeedSyntheticAsync(
+                (homeOffense: true,  driveKey: 1, seq: "01", homeScore: 0, awayScore: 0, yte: (int?)70),
+                (homeOffense: false, driveKey: 2, seq: "02", homeScore: 0, awayScore: 0, yte: 80),
+                (homeOffense: true,  driveKey: 3, seq: "03", homeScore: 0, awayScore: 0, yte: 70),
+                (homeOffense: false, driveKey: 4, seq: "04", homeScore: 0, awayScore: 0, yte: 80));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var home = await FootballDataContext.CompetitionMetrics
+                .SingleAsync(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId);
+            var away = await FootballDataContext.CompetitionMetrics
+                .SingleAsync(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == awayId);
+
+            home.FieldPosDiff.Should().Be(10m, "home starts at own 30 vs away's own 20");
+            away.FieldPosDiff.Should().Be(-10m, "symmetric opposite of home");
+        }
+
+        /// <summary>
+        /// Minimal synthetic competition: one play per tuple, each play in
+        /// its own (or shared) drive. yte, when set, becomes the DRIVE's
+        /// StartYardsToEndzone (C2 input); scores are the cumulative
+        /// scoreboard (C1 input).
+        /// </summary>
+        private async Task<(Guid competitionId, Guid homeId, Guid awayId)> SeedSyntheticAsync(
+            params (bool homeOffense, int driveKey, string seq, int homeScore, int awayScore, int? yte)[] playSpecs)
+        {
+            var competitionId = Guid.NewGuid();
+            var homeId = Guid.NewGuid();
+            var awayId = Guid.NewGuid();
+
+            var homeFs = Fixture.Build<FranchiseSeason>()
+                .With(x => x.Id, homeId).With(x => x.FranchiseId, Guid.NewGuid())
+                .With(x => x.SeasonYear, 2025).Without(x => x.ExternalIds).Create();
+            var awayFs = Fixture.Build<FranchiseSeason>()
+                .With(x => x.Id, awayId).With(x => x.FranchiseId, Guid.NewGuid())
+                .With(x => x.SeasonYear, 2025).Without(x => x.ExternalIds).Create();
+            await FootballDataContext.FranchiseSeasons.AddRangeAsync(homeFs, awayFs);
+
+            var contest = Fixture.Build<FootballContest>()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.HomeTeamFranchiseSeasonId, homeId)
+                .With(x => x.AwayTeamFranchiseSeasonId, awayId)
+                .With(x => x.HomeTeamFranchiseSeason, homeFs)
+                .With(x => x.AwayTeamFranchiseSeason, awayFs)
+                .Without(x => x.Links).Without(x => x.ExternalIds).Without(x => x.Competitions)
+                .Create();
+            await FootballDataContext.Contests.AddAsync(contest);
+
+            var competition = Fixture.Build<FootballCompetition>()
+                .With(x => x.Id, competitionId)
+                .With(x => x.ContestId, contest.Id)
+                .With(x => x.Contest, contest)
+                .Without(x => x.Plays).Without(x => x.Drives)
+                .Without(x => x.Links).Without(x => x.ExternalIds)
+                .Create();
+            await FootballDataContext.Competitions.AddAsync(competition);
+
+            var driveIds = new Dictionary<int, Guid>();
+            var ordinal = 0;
+            foreach (var spec in playSpecs)
+            {
+                var offenseId = spec.homeOffense ? homeId : awayId;
+
+                if (!driveIds.TryGetValue(spec.driveKey, out var driveId))
+                {
+                    driveId = Guid.NewGuid();
+                    driveIds[spec.driveKey] = driveId;
+                    await FootballDataContext.Drives.AddAsync(new CompetitionDrive
+                    {
+                        Id = driveId,
+                        CompetitionId = competitionId,
+                        StartFranchiseSeasonId = offenseId,
+                        StartYardsToEndzone = spec.yte,
+                        Description = $"drive {spec.driveKey}",
+                        SequenceNumber = spec.driveKey.ToString("00"),
+                        Ordinal = ++ordinal
+                    });
+                }
+
+                await FootballDataContext.CompetitionPlays.AddAsync(new FootballCompetitionPlay
+                {
+                    Id = Guid.NewGuid(),
+                    CompetitionId = competitionId,
+                    DriveId = driveId,
+                    EspnId = spec.seq,
+                    SequenceNumber = spec.seq,
+                    TypeId = "5",
+                    Type = PlayType.Rush,
+                    Text = "synthetic",
+                    StartFranchiseSeasonId = offenseId,
+                    HomeScore = spec.homeScore,
+                    AwayScore = spec.awayScore
+                });
+            }
+
+            await FootballDataContext.SaveChangesAsync();
+            return (competitionId, homeId, awayId);
+        }
+
+        #endregion
+
         private async Task<(FootballCompetition competition, Guid homeTeamId, Guid awayTeamId)> SeedCompetitionWithRealGameDataAsync(Guid competitionId)
         {
             // Load JSON once and cache it


### PR DESCRIPTION
## Summary

The two CRITICAL findings from the metrics formula audit (#623), fixed with hand-computed regression fixtures. H1/H2 to follow in this PR or its sibling per review.

### C1 — PointsPerDrive

Drive points = score at the drive's last play **minus the score before the drive's first play** (the last preceding play anywhere in the game; 0 only at true game start). The old baseline — the drive's *second-to-last play* — degenerated to 0 for one-play drives, crediting a kneel-down while leading 42–7 with **+42 points**, which is the impossible ~6 PPD in prod. Per-drive points are clamped to [0, 8] (TD+2pt bound) against scoreboard glitches.

Also hardened: `SequenceNumber` is an ESPN **string**; the new code orders numerically when parseable so "10" can't sort before "9" (the rest of the handler still orders lexicographically — being added to the audit doc as a new finding).

### C2 — FieldPosDiff

Computed from orientation-free `StartYardsToEndzone` (field position = 100 − YTE) instead of raw stadium-oriented `StartYardLine` — which read the same physical spot as 30 for one offense and 70 for the other, producing the venue-signed ±37 artifact that smuggled home-field into per-game features (MetricBot v1.1's −5.5 bias).

## Tests

Two synthetic regression fixtures with hand-computed answers: the kneel-drive case (PPD = 3.5, pre-fix code booked 7.0) and the orientation case (+10/−10, symmetric). 6/6 handler tests pass; the 4 existing real-game tests are unchanged.

## Deploy note

Stored rows change **only on recompute** — this deploy fixes the formulas; the full one-vintage recompute campaign follows per the audit's recommended sequence (with formula version stamping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Points Per Drive to use drive-specific scoring, numeric play order, and globally ordered predecessor plays.
  * Prevented cumulative scores from affecting individual drives, including drives following defensive scores.
  * Corrected Field Position Differential to use orientation-independent field position values.
  * Included offensive interceptions and lost fumbles in rate calculations without awarding offensive yards or success.
  * Limited drive scoring values to a valid 0–8 point range.

* **Documentation**
  * Updated the competition-metrics audit with refined findings and remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->