### PR TITLE
fix(producer): H1/H2 metrics formula fixes — turnover snaps and red-zone trip termination

### DIFF
--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -88,11 +88,15 @@ return yards to the offense. The correct contract:
   changing total yards; a 40-yard pick-six must not appear as a
   40-yard offensive gain.
 
-**Implemented** (fix/metrics-h1-h2): `IsTurnoverType` added; those
-types join `IsOffensiveScrimmageType`; a `Yardage(play)` accessor
-returns 0 for turnover types and feeds every numerator (Ypp,
-success/explosive checks, first-down-by-yardage). Both fixtures above
-are in the test suite.
+**Implemented** (fix/metrics-h1-h2): `IsTurnoverType` added
+(PassInterceptionReturn, InterceptionReturnTouchdown, FumbleLost,
+FumbleReturnTouchdown); those types join `IsOffensiveScrimmageType`;
+a `Yardage(play)` accessor returns 0 for turnover types and feeds
+every numerator (Ypp, success/explosive checks,
+first-down-by-yardage). Fixtures cover the snap-count/zero-yard
+contract, a 95-yard pick-six (InterceptionReturnTouchdown), a 60-yard
+fumble-return TD, and a third-down interception as a failed
+conversion attempt.
 
 ### H2. Red-zone trip state survives possession changes it shouldn't
 
@@ -109,9 +113,9 @@ the FIRST of):
 2. THIS offense starts a NEW drive (DriveId change) — covers turnovers,
    defensive scores, and kickoff-separated possessions in one rule,
    since every one of those forces a new drive id.
-3. A half boundary (period 2→3) or end of regulation→OT transition —
-   possessions do not survive the half. (Q1→Q2 and Q3→Q4 do NOT
-   terminate: a drive legitimately spans those.)
+3. A half boundary (period 2→3), the regulation→OT transition, or any
+   OT→OT break — possessions do not survive those. (Q1→Q2 and Q3→Q4
+   do NOT terminate: a drive legitimately spans those.)
 4. End of input (existing EOF close).
 Scoring credited to a trip counts only while that trip is open.
 Duplicate play events (same SequenceNumber) count once; missing events
@@ -124,12 +128,16 @@ defensive TD; trip at EOF; duplicate-sequence play.
 
 **Implemented** (fix/metrics-h1-h2): both rates now delegate to one
 shared `CountRedZoneTrips` state machine implementing rules 1–4
-verbatim (half bucket: period ≤2 / ≤4 / OT; own-new-DriveId close
-evaluated before a fresh trip can start on the same play; adjacent
-duplicate SequenceNumber skipped). Trip-ended-by-defensive-TD is
-covered by rule 2 (the defensive score forces a new drive id) and by
-rule 1 now catching opponent interception snaps via the widened H1
-type set. Fixture battery is in the test suite.
+verbatim (period buckets: Q1–Q2 = 1, Q3–Q4 = 2, then EVERY overtime
+period is its own bucket; own-new-DriveId close evaluated before a
+fresh trip can start on the same play; adjacent duplicate
+SequenceNumber skipped — the machine is idempotent under adjacent
+replays by construction, so the guard documents the contract rather
+than fixing a reachable defect). Fixtures cover: opponent standing
+snap; stale trip across own new drive; Q1→Q2 survival; half-boundary
+close on a same-DriveId glitch; OT→OT close; red-zone pick-six
+(defensive TD ends the trip scoreless); trip open at EOF counts as
+scoreless; FG-vs-TD predicate split with duplicate events present.
 
 ### H3. PenaltyYardsPerPlay attributes by possession, not by offender
 

--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -88,6 +88,12 @@ return yards to the offense. The correct contract:
   changing total yards; a 40-yard pick-six must not appear as a
   40-yard offensive gain.
 
+**Implemented** (fix/metrics-h1-h2): `IsTurnoverType` added; those
+types join `IsOffensiveScrimmageType`; a `Yardage(play)` accessor
+returns 0 for turnover types and feeds every numerator (Ypp,
+success/explosive checks, first-down-by-yardage). Both fixtures above
+are in the test suite.
+
 ### H2. Red-zone trip state survives possession changes it shouldn't
 
 Both RZ calculators end a trip only when the OTHER offense takes a
@@ -115,6 +121,15 @@ degrade to rule 1/2 whichever fires first.
 drive later scores (stale-trip regression); trip open across Q1→Q2
 (must survive); trip open across the half (must close); trip ended by
 defensive TD; trip at EOF; duplicate-sequence play.
+
+**Implemented** (fix/metrics-h1-h2): both rates now delegate to one
+shared `CountRedZoneTrips` state machine implementing rules 1–4
+verbatim (half bucket: period ≤2 / ≤4 / OT; own-new-DriveId close
+evaluated before a fresh trip can start on the same play; adjacent
+duplicate SequenceNumber skipped). Trip-ended-by-defensive-TD is
+covered by rule 2 (the defensive score forces a new drive id) and by
+rule 1 now catching opponent interception snaps via the widened H1
+type set. Fixture battery is in the test suite.
 
 ### H3. PenaltyYardsPerPlay attributes by possession, not by offender
 

--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -210,6 +210,17 @@ ordered computation in the handler; a verification query measuring how
 often numeric and lexicographic order actually disagree in prod data
 (if never, the fix is cheap insurance; if often, it re-ranks severity).
 
+**Implemented** (fix/metrics-h1-h2, CR follow-up): a shared
+`OrderPlays` helper (numeric when parseable, ordinal fallback) is now
+applied ONCE to `competition.Plays` before any calculator runs, and
+PointsPerDrive reuses the same helper — every play-order-sensitive
+computation sees the same temporal order. Fixture: unpadded sequences
+("2", "9", "10") where lexicographic order would halve the red-zone
+TD rate. The possession-time calculator's per-drive first/last-play
+selection also uses the helper. Still open: the EF `Include` ordering
+is lexicographic but is overridden before use, and the prod
+disagreement-frequency query has not been run.
+
 ## Aggregation layer (`CalculateFranchiseSeasonMetricsCommandHandler`)
 
 - Plain unweighted mean of per-game ratios (average-of-ratios).

--- a/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
@@ -481,8 +481,8 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     ///   2. THIS offense starting a NEW drive (DriveId change) — covers
     ///      turnovers, defensive scores, and kickoff-separated
     ///      possessions in one rule;
-    ///   3. a half boundary (Q2→Q3) or regulation→OT — possessions do
-    ///      not survive those; Q1→Q2 and Q3→Q4 deliberately do NOT
+    ///   3. a half boundary (Q2→Q3), regulation→OT, or any OT→OT break —
+    ///      possessions do not survive those; Q1→Q2 and Q3→Q4 do NOT
     ///      terminate (drives legitimately span them);
     ///   4. end of input.
     /// Scoring counts only while the trip is open. Adjacent duplicate
@@ -509,8 +509,10 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             tripDriveId = null;
         }
 
+        // Q1-Q2 = 1, Q3-Q4 = 2, then EVERY overtime period is its own
+        // bucket: possessions do not span an OT break.
         static int HalfOf(FootballCompetitionPlay p)
-            => p.PeriodNumber <= 2 ? 1 : p.PeriodNumber <= 4 ? 2 : 3;
+            => p.PeriodNumber <= 2 ? 1 : p.PeriodNumber <= 4 ? 2 : p.PeriodNumber;
 
         foreach (var p in plays)
         {
@@ -518,7 +520,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             if (p.SequenceNumber == lastSequence) continue;
             lastSequence = p.SequenceNumber;
 
-            // rule 3: half boundary / regulation→OT
+            // rule 3: half boundary / regulation→OT / OT→OT
             var half = HalfOf(p);
             if (inTrip && lastHalf.HasValue && half != lastHalf.Value)
             {
@@ -589,7 +591,8 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     private static bool IsTurnoverType(PlayType t)
         => t == PlayType.PassInterceptionReturn
            || t == PlayType.InterceptionReturnTouchdown
-           || t == PlayType.FumbleLost;
+           || t == PlayType.FumbleLost
+           || t == PlayType.FumbleReturnTouchdown;
 
     private static int Yardage(FootballCompetitionPlay p)
         => IsTurnoverType(p.Type) ? 0 : p.StatYardage;

--- a/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
@@ -69,7 +69,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         var (awayMetric, homeMetric) = CalculateMetrics(
             competition.Contest.SeasonYear,
             command.CompetitionId,
-            competition.Plays.ToList(),
+            OrderPlays(competition.Plays),
             competition.Drives.ToList(),
             awayFranchiseSeasonId,
             homeFranchiseSeasonId);
@@ -170,7 +170,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
                 .GroupBy(p => p.DriveId)
                 .Sum(drive =>
                 {
-                    var ordered = drive.OrderBy(p => p.SequenceNumber).ToList();
+                    var ordered = OrderPlays(drive);
                     var first = ordered.FirstOrDefault();
                     var last = ordered.LastOrDefault();
 
@@ -395,16 +395,8 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         int ScoreOf(FootballCompetitionPlay p) =>
             franchiseSeasonId == homeFsId ? p.HomeScore : p.AwayScore;
 
-        // SequenceNumber is an ESPN STRING; lexicographic ordering breaks
-        // when digit counts differ ("10" < "9"). Order numerically when
-        // parseable, falling back to the raw string. Both the drive
-        // first/last selection and the baseline lookup use this SAME
-        // ordering, so they cannot disagree.
-        var ordered = plays
-            .Where(p => p.DriveId.HasValue && p.DriveId != Guid.Empty)
-            .OrderBy(p => long.TryParse(p.SequenceNumber, out var n) ? n : long.MaxValue)
-            .ThenBy(p => p.SequenceNumber, StringComparer.Ordinal)
-            .ToList();
+        var ordered = OrderPlays(
+            plays.Where(p => p.DriveId.HasValue && p.DriveId != Guid.Empty));
 
         var drives = ordered
             .Where(p => p.StartFranchiseSeasonId == franchiseSeasonId)
@@ -588,6 +580,17 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     // outcomes; excluding them flattered turnover-prone teams) at an
     // effective yardage of ZERO: never a success, never explosive,
     // never a conversion.
+    // SequenceNumber is an ESPN STRING; lexicographic ordering breaks
+    // when digit counts differ ("10" < "9"). Order numerically when
+    // parseable, falling back to the raw string. Every order-sensitive
+    // consumer (drive baselines, the red-zone trip machine) uses this
+    // SAME ordering, so they cannot disagree.
+    private static List<FootballCompetitionPlay> OrderPlays(IEnumerable<FootballCompetitionPlay> plays)
+        => plays
+            .OrderBy(p => long.TryParse(p.SequenceNumber, out var n) ? n : long.MaxValue)
+            .ThenBy(p => p.SequenceNumber, StringComparer.Ordinal)
+            .ToList();
+
     private static bool IsTurnoverType(PlayType t)
         => t == PlayType.PassInterceptionReturn
            || t == PlayType.InterceptionReturnTouchdown

--- a/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
@@ -440,78 +440,104 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     }
 
 
+    // AUDIT FIX (H2): both red-zone rates share ONE trip state machine
+    // with the complete termination contract — the previous per-function
+    // copies closed a trip ONLY on an opponent scrimmage snap, so a trip
+    // left open across a possession change or halftime could credit a
+    // LATER drive's score to the stale trip.
+
     // Red Zone TD Rate (null if no trips): TD-trips / trips
     private decimal? CalculateRedZoneTdRate(Guid franchiseSeasonId, List<FootballCompetitionPlay> plays)
     {
-        int trips = 0;
-        int tdTrips = 0;
-
-        bool inTrip = false;
-        bool tripHadTd = false;
-
-        for (int i = 0; i < plays.Count; i++)
-        {
-            var p = plays[i];
-
-            // detect trip start: this offense, scrimmage snap, and at/below the 20
-            if (!inTrip
-                && IsOffensiveScrimmageSnap(p, franchiseSeasonId)
-                && (p.StartYardsToEndzone.HasValue && p.StartYardsToEndzone.Value <= 20))
-            {
-                inTrip = true;
-                tripHadTd = false;
-                trips++;
-            }
-
-            if (!inTrip) continue;
-
-            // inside a trip, watch for THIS offense scoring a TD (rush/pass)
-            if (p.StartFranchiseSeasonId.HasValue
-                && p.StartFranchiseSeasonId.Value == franchiseSeasonId)
-            {
-                if (p.Type == PlayType.RushingTouchdown || p.Type == PlayType.PassingTouchdown)
-                {
-                    tripHadTd = true;
-                }
-            }
-
-            // trip ends when the OTHER offense takes a scrimmage snap that stands
-            if (p.StartFranchiseSeasonId.HasValue
-                && p.StartFranchiseSeasonId.Value != franchiseSeasonId
-                && p.StartDown is >= 1 and <= 4
-                && IsOffensiveScrimmageType(p.Type)
-                && !(!string.IsNullOrEmpty(p.Text) && p.Text.Contains("NO PLAY", StringComparison.OrdinalIgnoreCase)))
-            {
-                if (tripHadTd) tdTrips++;
-                inTrip = false;
-            }
-        }
-
-        // if a trip is still open at EOF, close it
-        if (inTrip && tripHadTd) tdTrips++;
+        var (trips, scoringTrips) = CountRedZoneTrips(
+            franchiseSeasonId,
+            plays,
+            p => p.Type == PlayType.RushingTouchdown || p.Type == PlayType.PassingTouchdown);
 
         if (trips == 0) return null;
-        return (decimal)tdTrips / trips;
+        return (decimal)scoringTrips / trips;
     }
 
     // Red Zone Scoring Rate (null if no trips): scoring-trips / trips
-    // A trip starts on this offense's first scrimmage snap with StartYardsToEndzone <= 20
-    // A scoring trip is one where, before the trip ends, THIS offense records:
-    //   - RushingTouchdown or PassingTouchdown, OR
-    //   - FieldGoalGood
+    // (TD or made field goal)
     private decimal? CalculateRedZoneScoringRate(Guid franchiseSeasonId, List<FootballCompetitionPlay> plays)
     {
-        int trips = 0;
-        int scoringTrips = 0;
+        var (trips, scoringTrips) = CountRedZoneTrips(
+            franchiseSeasonId,
+            plays,
+            p => p.Type == PlayType.RushingTouchdown
+                 || p.Type == PlayType.PassingTouchdown
+                 || p.Type == PlayType.FieldGoalGood);
 
-        bool inTrip = false;
-        bool tripScored = false;
+        if (trips == 0) return null;
+        return (decimal)scoringTrips / trips;
+    }
 
-        for (int i = 0; i < plays.Count; i++)
+    /// <summary>
+    /// The shared red-zone trip state machine. A trip STARTS on this
+    /// offense's first scrimmage snap at/inside the 20. Once open, it
+    /// CLOSES on the FIRST of (audit H2 termination contract):
+    ///   1. the opposing offense taking a standing scrimmage snap;
+    ///   2. THIS offense starting a NEW drive (DriveId change) — covers
+    ///      turnovers, defensive scores, and kickoff-separated
+    ///      possessions in one rule;
+    ///   3. a half boundary (Q2→Q3) or regulation→OT — possessions do
+    ///      not survive those; Q1→Q2 and Q3→Q4 deliberately do NOT
+    ///      terminate (drives legitimately span them);
+    ///   4. end of input.
+    /// Scoring counts only while the trip is open. Adjacent duplicate
+    /// play events (same SequenceNumber) are processed once.
+    /// </summary>
+    private (int Trips, int ScoringTrips) CountRedZoneTrips(
+        Guid franchiseSeasonId,
+        List<FootballCompetitionPlay> plays,
+        Func<FootballCompetitionPlay, bool> isScore)
+    {
+        var trips = 0;
+        var scoringTrips = 0;
+        var inTrip = false;
+        var tripScored = false;
+        Guid? tripDriveId = null;
+        int? lastHalf = null;
+        string? lastSequence = null;
+
+        void CloseTrip()
         {
-            var p = plays[i];
+            if (tripScored) scoringTrips++;
+            inTrip = false;
+            tripScored = false;
+            tripDriveId = null;
+        }
 
-            // trip starts on first offensive scrimmage snap at/below the 20
+        static int HalfOf(FootballCompetitionPlay p)
+            => p.PeriodNumber <= 2 ? 1 : p.PeriodNumber <= 4 ? 2 : 3;
+
+        foreach (var p in plays)
+        {
+            // duplicate event: same sequence as the previous play
+            if (p.SequenceNumber == lastSequence) continue;
+            lastSequence = p.SequenceNumber;
+
+            // rule 3: half boundary / regulation→OT
+            var half = HalfOf(p);
+            if (inTrip && lastHalf.HasValue && half != lastHalf.Value)
+            {
+                CloseTrip();
+            }
+            lastHalf = half;
+
+            // rule 2: this offense on a NEW drive — close the stale trip
+            // BEFORE evaluating whether this play starts a fresh one
+            if (inTrip
+                && p.StartFranchiseSeasonId == franchiseSeasonId
+                && p.DriveId.HasValue
+                && tripDriveId.HasValue
+                && p.DriveId.Value != tripDriveId.Value)
+            {
+                CloseTrip();
+            }
+
+            // trip start: this offense, scrimmage snap, at/inside the 20
             if (!inTrip
                 && IsOffensiveScrimmageSnap(p, franchiseSeasonId)
                 && p.StartYardsToEndzone.HasValue
@@ -519,44 +545,54 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             {
                 inTrip = true;
                 tripScored = false;
+                tripDriveId = p.DriveId;
                 trips++;
             }
 
             if (!inTrip) continue;
 
-            // scoring for THIS offense during the trip
+            // scoring for THIS offense while the trip is open
             if (p.StartFranchiseSeasonId.HasValue
-                && p.StartFranchiseSeasonId.Value == franchiseSeasonId)
+                && p.StartFranchiseSeasonId.Value == franchiseSeasonId
+                && isScore(p))
             {
-                if (p.Type == PlayType.RushingTouchdown || p.Type == PlayType.PassingTouchdown)
-                    tripScored = true;
-
-                if (p.Type == PlayType.FieldGoalGood)
-                    tripScored = true;
+                tripScored = true;
             }
 
-            // trip ends when the OTHER offense takes a scrimmage snap that stands
+            // rule 1: the OTHER offense takes a standing scrimmage snap
             if (p.StartFranchiseSeasonId.HasValue
                 && p.StartFranchiseSeasonId.Value != franchiseSeasonId
                 && p.StartDown is >= 1 and <= 4
                 && IsOffensiveScrimmageType(p.Type)
                 && !(p.Text?.Contains("NO PLAY", StringComparison.OrdinalIgnoreCase) == true))
             {
-                if (tripScored) scoringTrips++;
-                inTrip = false;
+                CloseTrip();
             }
         }
 
-        // close an open trip at EOF
-        if (inTrip && tripScored) scoringTrips++;
+        // rule 4: end of input
+        if (inTrip) CloseTrip();
 
-        if (trips == 0) return (decimal?)null;
-        return (decimal)scoringTrips / trips;
+        return (trips, scoringTrips);
     }
 
-
     /* ================= HELPERS ================ */
-    private static int Yardage(FootballCompetitionPlay p) => p.StatYardage;
+
+    // AUDIT FIX (H1): interception and lost-fumble plays keep the
+    // intercepted/fumbling OFFENSE in StartFranchiseSeasonId, but their
+    // StatYardage is the DEFENSIVE RETURN — usable for neither offensive
+    // yardage nor first-down math. These plays join the snap
+    // DENOMINATORS (they are offensive snaps with catastrophic
+    // outcomes; excluding them flattered turnover-prone teams) at an
+    // effective yardage of ZERO: never a success, never explosive,
+    // never a conversion.
+    private static bool IsTurnoverType(PlayType t)
+        => t == PlayType.PassInterceptionReturn
+           || t == PlayType.InterceptionReturnTouchdown
+           || t == PlayType.FumbleLost;
+
+    private static int Yardage(FootballCompetitionPlay p)
+        => IsTurnoverType(p.Type) ? 0 : p.StatYardage;
 
     // first down purely by distance-to-gain (no FirstDown flag in your data)
     private static bool AchievedFirstDownByYardage(FootballCompetitionPlay p)
@@ -574,13 +610,18 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         // - Rush / Pass (comp & inc) / Sack
         // - TD variants that ESPN sometimes logs as distinct types
         // - Safety (comes from a scrimmage snap)
+        // - AUDIT H1: turnover plays (interception / lost fumble) — they
+        //   ARE scrimmage snaps by the offense; Yardage() zeroes their
+        //   defensive-return StatYardage so denominators grow but
+        //   numerators never see return yards.
         return t == PlayType.Rush
                || t == PlayType.RushingTouchdown
                || t == PlayType.PassReception
                || t == PlayType.PassingTouchdown
                || t == PlayType.PassIncompletion
                || t == PlayType.Sack
-               || t == PlayType.Safety;
+               || t == PlayType.Safety
+               || IsTurnoverType(t);
     }
 
     // full filter for "counts toward offense's snaps"

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -537,6 +537,34 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
             home.ExplosiveRate.Should().Be(0m);
         }
 
+        /// <summary>
+        /// AUDIT H4 (ordering): SequenceNumber is a STRING — lexicographic
+        /// order puts "10" before "2" and "9". The trip machine must see
+        /// temporal (numeric) order. Numerically: opponent snap ("2"), home
+        /// opens a trip ("9"), same-drive TD ("10") scores it -> 1.0.
+        /// Lexicographically the TD is processed FIRST, the opponent snap
+        /// closes that trip, and "9" opens a second scoreless trip -> 0.5.
+        /// </summary>
+        [Fact]
+        public async Task H4_UnpaddedSequenceNumbers_ProcessedInNumericOrder()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: false, drive: 2, seq: "2", type: PlayType.Rush, down: 1, dist: 10, yds: 3, yte: 75),
+                Play(home: true, drive: 1, seq: "9", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 15),
+                Play(home: true, drive: 1, seq: "10", type: PlayType.RushingTouchdown, down: 2, dist: 8, yds: 13, yte: 13));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rate = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => m.RzTdRate)
+                .SingleAsync();
+
+            rate.Should().Be(1m, "one trip, opened at seq 9 and scored at seq 10 — temporal order, not string order");
+        }
+
         private sealed record PlaySpec(
             bool Home, int Drive, string Seq, PlayType Type,
             int? Down, int? Dist, int Yds, int? Yte, int Period);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -378,15 +378,21 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
         /// <summary>
         /// AUDIT H2: the two rates share one machine but different scoring
         /// predicates — a made field goal is a scoring trip, not a TD trip.
-        /// Duplicate play events (same sequence) are processed once.
+        /// Duplicate play events (same sequence) leave every count
+        /// unchanged. (The machine is idempotent under adjacent replays by
+        /// construction — the explicit sequence guard encodes the contract;
+        /// this fixture documents the invariant rather than a reachable
+        /// failure mode.)
         /// </summary>
         [Fact]
         public async Task H2_FieldGoalScoresTheTrip_ForScoreRateOnly()
         {
             var (competitionId, homeId, _) = await SeedPlaysAsync(
                 Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 18),
+                // duplicate of the trip-opening red-zone snap
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 18),
                 Play(home: true, drive: 1, seq: "02", type: PlayType.FieldGoalGood, down: 4, dist: 8, yds: 33, yte: 16),
-                // duplicate event of the FG play — must not corrupt state
+                // duplicate of the scoring play
                 Play(home: true, drive: 1, seq: "02", type: PlayType.FieldGoalGood, down: 4, dist: 8, yds: 33, yte: 16));
 
             var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
@@ -400,6 +406,135 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
 
             rz.RzScoreRate.Should().Be(1m, "the field goal scores the trip");
             rz.RzTdRate.Should().Be(0m, "a field goal is not a touchdown trip");
+        }
+
+        /// <summary>
+        /// AUDIT H2 rule 1 (pre-existing rule, regression guard): an
+        /// opponent standing scrimmage snap closes the trip — a LATER score
+        /// on the same DriveId must not credit the closed trip.
+        /// </summary>
+        [Fact]
+        public async Task H2_TripClosesOnOpponentStandingSnap()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 15),
+                // opponent takes a standing scrimmage snap -> home trip closes scoreless
+                Play(home: false, drive: 2, seq: "02", type: PlayType.Rush, down: 1, dist: 10, yds: 4, yte: 70),
+                // home scores later on the ORIGINAL DriveId (data glitch):
+                // must not credit the closed trip; yte 40 opens no new trip
+                Play(home: true, drive: 1, seq: "03", type: PlayType.PassingTouchdown, down: 1, dist: 10, yds: 40, yte: 40));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rate = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => m.RzTdRate)
+                .SingleAsync();
+
+            rate.Should().Be(0m, "the trip closed scoreless when the opponent snapped");
+        }
+
+        /// <summary>
+        /// AUDIT H2 rule 4: a trip still open when the input ends closes at
+        /// EOF and counts — the rate is 0, not null.
+        /// </summary>
+        [Fact]
+        public async Task H2_TripOpenAtEndOfInput_CountsScoreless()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 3, yte: 12));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rz = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.RzTdRate, m.RzScoreRate })
+                .SingleAsync();
+
+            rz.RzTdRate.Should().Be(0m, "the EOF-closed trip counts as a scoreless trip");
+            rz.RzScoreRate.Should().Be(0m);
+        }
+
+        /// <summary>
+        /// AUDIT H1+H2 (defensive TD): a red-zone pick-six ends the trip
+        /// scoreless via the ensuing new drive, contributes a SNAP at zero
+        /// offensive yards, and its 95-yard RETURN is never explosive.
+        /// </summary>
+        [Fact]
+        public async Task H1H2_RedZonePickSix_ScorelessTrip_ZeroYardSnap()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 15),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.InterceptionReturnTouchdown, down: 2, dist: 8, yds: 95, yte: 13),
+                // home's next possession (outside the RZ) closes the stale trip
+                Play(home: true, drive: 2, seq: "03", type: PlayType.Rush, down: 1, dist: 10, yds: 5, yte: 60));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var home = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.RzTdRate, m.Ypp, m.ExplosiveRate })
+                .SingleAsync();
+
+            home.RzTdRate.Should().Be(0m, "a pick-six is the DEFENSE's touchdown, never the trip's");
+            home.Ypp.Should().BeApproximately(7m / 3m, 0.0001m, "3 snaps, 7 offensive yards — the 95-yard return contributes zero");
+            home.ExplosiveRate.Should().Be(0m);
+        }
+
+        /// <summary>
+        /// AUDIT H2 rule 3: every overtime period is its own possession
+        /// bucket — a trip opened in OT1 must not absorb an OT2 score, even
+        /// on the same DriveId.
+        /// </summary>
+        [Fact]
+        public async Task H2_TripClosesBetweenOvertimePeriods()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 15, period: 5),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.RushingTouchdown, down: 1, dist: 10, yds: 12, yte: 12, period: 6));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rate = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => m.RzTdRate)
+                .SingleAsync();
+
+            // the OT1 trip closed scoreless at the OT break; the OT2 TD play
+            // (yte 12) starts a second trip which scores.
+            rate.Should().Be(0.5m, "OT1 trip scoreless; OT2 trip (new, same drive id) scores");
+        }
+
+        /// <summary>
+        /// AUDIT H1: a lost fumble returned for a defensive touchdown is an
+        /// offensive snap at zero yards — the return yardage never counts.
+        /// </summary>
+        [Fact]
+        public async Task H1_FumbleReturnTouchdown_ZeroYardSnap()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 8),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.FumbleReturnTouchdown, down: 2, dist: 2, yds: 60));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var home = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.Ypp, m.ExplosiveRate })
+                .SingleAsync();
+
+            home.Ypp.Should().Be(4m, "2 snaps, 8 offensive yards — the 60-yard return contributes zero");
+            home.ExplosiveRate.Should().Be(0m);
         }
 
         private sealed record PlaySpec(

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -244,6 +244,247 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
 
         private static string? _cachedJson; // Cache JSON across test instances
 
+        #region Audit regression fixtures (H1 / H2)
+
+        /// <summary>
+        /// AUDIT H1: an interception is an offensive SNAP (denominator)
+        /// whose StatYardage is the DEFENSIVE RETURN (never the
+        /// numerator). Fixture: rush 8 (success), rush 2 (fail), INT with
+        /// a 40-yard return -> 3 snaps, 10 yards, no explosive play.
+        /// Pre-fix: 2 snaps, Ypp 5.0, and a 40-yard "gain".
+        /// </summary>
+        [Fact]
+        public async Task H1_InterceptionJoinsDenominator_ReturnYardsNeverCount()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 8),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.Rush, down: 1, dist: 10, yds: 2),
+                Play(home: true, drive: 1, seq: "03", type: PlayType.PassInterceptionReturn, down: 1, dist: 10, yds: 40));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var home = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.Ypp, m.SuccessRate, m.ExplosiveRate })
+                .SingleAsync();
+
+            home.Ypp.Should().BeApproximately(10m / 3m, 0.0001m, "3 snaps, 10 offensive yards — the return is not a gain");
+            home.SuccessRate.Should().BeApproximately(1m / 3m, 0.0001m, "only the 8-yard rush succeeds; the INT is a failed snap");
+            home.ExplosiveRate.Should().Be(0m, "a 40-yard RETURN is not a 40-yard offensive gain");
+        }
+
+        /// <summary>
+        /// AUDIT H1: a third-down interception is a FAILED conversion
+        /// attempt — pre-fix it vanished from the denominator entirely.
+        /// </summary>
+        [Fact]
+        public async Task H1_ThirdDownInterception_IsAFailedAttempt()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 3, dist: 2, yds: 5),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.PassInterceptionReturn, down: 3, dist: 5, yds: 40));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rate = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => m.ThirdFourthRate)
+                .SingleAsync();
+
+            rate.Should().Be(0.5m, "one conversion in TWO attempts — the 40-yard return does not convert 3rd-and-5");
+        }
+
+        /// <summary>
+        /// AUDIT H2 (the stale-trip regression): a red-zone trip that ends
+        /// without a score must NOT be credited when the same offense
+        /// scores on a LATER drive. Pre-fix, the trip stayed open until an
+        /// opponent snap, absorbing the next drive's touchdown.
+        /// </summary>
+        [Fact]
+        public async Task H2_StaleTrip_NotCreditedAcrossOwnNewDrive()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 15),
+                // new drive, outside the red zone, ends in a TD
+                Play(home: true, drive: 2, seq: "02", type: PlayType.Rush, down: 1, dist: 10, yds: 5, yte: 60),
+                Play(home: true, drive: 2, seq: "03", type: PlayType.PassingTouchdown, down: 1, dist: 10, yds: 55, yte: 55));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rz = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.RzTdRate, m.RzScoreRate })
+                .SingleAsync();
+
+            rz.RzTdRate.Should().Be(0m, "the red-zone trip ended scoreless when its drive ended");
+            rz.RzScoreRate.Should().Be(0m);
+        }
+
+        /// <summary>
+        /// AUDIT H2: a trip legitimately spans Q1->Q2 (same drive) — the
+        /// quarter boundary must NOT terminate it.
+        /// </summary>
+        [Fact]
+        public async Task H2_TripSurvivesQuarterBoundary_WithinSameHalf()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 3, yte: 18, period: 1),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.RushingTouchdown, down: 2, dist: 7, yds: 15, yte: 15, period: 2));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rate = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => m.RzTdRate)
+                .SingleAsync();
+
+            rate.Should().Be(1m, "the trip crossed Q1->Q2 inside one drive and scored");
+        }
+
+        /// <summary>
+        /// AUDIT H2: a trip does NOT survive halftime — even when the data
+        /// (glitch) keeps the same DriveId across the break, a Q3 score
+        /// cannot credit a Q2 trip.
+        /// </summary>
+        [Fact]
+        public async Task H2_TripClosesAtTheHalf_EvenWithSameDriveId()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 15, period: 2),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.RushingTouchdown, down: 1, dist: 10, yds: 12, yte: 12, period: 3));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rate = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => m.RzTdRate)
+                .SingleAsync();
+
+            // the Q2 trip closed scoreless at the half; the Q3 TD play (yte
+            // 12, scrimmage snap) STARTS a second trip which scores.
+            rate.Should().Be(0.5m, "Q2 trip scoreless; Q3 trip (new, same drive id) scores");
+        }
+
+        /// <summary>
+        /// AUDIT H2: the two rates share one machine but different scoring
+        /// predicates — a made field goal is a scoring trip, not a TD trip.
+        /// Duplicate play events (same sequence) are processed once.
+        /// </summary>
+        [Fact]
+        public async Task H2_FieldGoalScoresTheTrip_ForScoreRateOnly()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 2, yte: 18),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.FieldGoalGood, down: 4, dist: 8, yds: 33, yte: 16),
+                // duplicate event of the FG play — must not corrupt state
+                Play(home: true, drive: 1, seq: "02", type: PlayType.FieldGoalGood, down: 4, dist: 8, yds: 33, yte: 16));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rz = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => new { m.RzTdRate, m.RzScoreRate })
+                .SingleAsync();
+
+            rz.RzScoreRate.Should().Be(1m, "the field goal scores the trip");
+            rz.RzTdRate.Should().Be(0m, "a field goal is not a touchdown trip");
+        }
+
+        private sealed record PlaySpec(
+            bool Home, int Drive, string Seq, PlayType Type,
+            int? Down, int? Dist, int Yds, int? Yte, int Period);
+
+        private static PlaySpec Play(
+            bool home, int drive, string seq, PlayType type,
+            int? down = null, int? dist = null, int yds = 0, int? yte = null, int period = 1)
+            => new(home, drive, seq, type, down, dist, yds, yte, period);
+
+        /// <summary>
+        /// Play-level synthetic competition for formula fixtures: full
+        /// control of type/down/distance/yardage/yards-to-endzone/period.
+        /// No drive rows are needed by the metrics under test here.
+        /// </summary>
+        private async Task<(Guid competitionId, Guid homeId, Guid awayId)> SeedPlaysAsync(
+            params PlaySpec[] specs)
+        {
+            var competitionId = Guid.NewGuid();
+            var homeId = Guid.NewGuid();
+            var awayId = Guid.NewGuid();
+
+            var homeFs = Fixture.Build<FranchiseSeason>()
+                .With(x => x.Id, homeId).With(x => x.FranchiseId, Guid.NewGuid())
+                .With(x => x.SeasonYear, 2025).Without(x => x.ExternalIds).Create();
+            var awayFs = Fixture.Build<FranchiseSeason>()
+                .With(x => x.Id, awayId).With(x => x.FranchiseId, Guid.NewGuid())
+                .With(x => x.SeasonYear, 2025).Without(x => x.ExternalIds).Create();
+            await FootballDataContext.FranchiseSeasons.AddRangeAsync(homeFs, awayFs);
+
+            var contest = Fixture.Build<FootballContest>()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.HomeTeamFranchiseSeasonId, homeId)
+                .With(x => x.AwayTeamFranchiseSeasonId, awayId)
+                .With(x => x.HomeTeamFranchiseSeason, homeFs)
+                .With(x => x.AwayTeamFranchiseSeason, awayFs)
+                .Without(x => x.Links).Without(x => x.ExternalIds).Without(x => x.Competitions)
+                .Create();
+            await FootballDataContext.Contests.AddAsync(contest);
+
+            var competition = Fixture.Build<FootballCompetition>()
+                .With(x => x.Id, competitionId)
+                .With(x => x.ContestId, contest.Id)
+                .With(x => x.Contest, contest)
+                .Without(x => x.Plays).Without(x => x.Drives)
+                .Without(x => x.Links).Without(x => x.ExternalIds)
+                .Create();
+            await FootballDataContext.Competitions.AddAsync(competition);
+
+            var driveIds = new Dictionary<int, Guid>();
+            var i = 0;
+            foreach (var spec in specs)
+            {
+                if (!driveIds.TryGetValue(spec.Drive, out var driveId))
+                {
+                    driveId = Guid.NewGuid();
+                    driveIds[spec.Drive] = driveId;
+                }
+
+                await FootballDataContext.CompetitionPlays.AddAsync(new FootballCompetitionPlay
+                {
+                    Id = Guid.NewGuid(),
+                    CompetitionId = competitionId,
+                    DriveId = driveId,
+                    EspnId = $"p{++i}-{spec.Seq}",
+                    SequenceNumber = spec.Seq,
+                    TypeId = "0",
+                    Type = spec.Type,
+                    Text = "synthetic",
+                    StartFranchiseSeasonId = spec.Home ? homeId : awayId,
+                    StartDown = spec.Down,
+                    StartDistance = spec.Dist,
+                    StatYardage = spec.Yds,
+                    StartYardsToEndzone = spec.Yte,
+                    PeriodNumber = spec.Period
+                });
+            }
+
+            await FootballDataContext.SaveChangesAsync();
+            return (competitionId, homeId, awayId);
+        }
+
+        #endregion
+
         #region Audit regression fixtures (C1 / C2)
 
         /// <summary>


### PR DESCRIPTION
Implements audit items H1 and H2 from `docs/audit/competition-metrics-formula-audit.md` (follow-up to #624, which fixed C1/C2).

## H1 — turnover plays join the offensive snap denominator
`IsOffensiveScrimmageType` previously excluded interception and lost-fumble plays, so Ypp / SuccessRate / ExplosiveRate / ThirdFourthRate skipped exactly the worst offensive snaps, biasing turnover-prone teams upward.

- New `IsTurnoverType` (PassInterceptionReturn, InterceptionReturnTouchdown, FumbleLost); those types now count as offensive scrimmage snaps.
- New `Yardage(play)` accessor returns 0 for turnover types and feeds every numerator. `StatYardage` on these plays is the **defensive return** — it never reaches an offensive stat. A 40-yard pick-six is a 0-yard failed snap for the offense; a 3rd-down INT is a failed conversion attempt.

## H2 — red-zone trip termination contract
Both RZ rates previously closed a trip only on an opponent standing scrimmage snap, so a trip left open across a possession change or halftime could credit a **later** drive's score to the stale trip.

Both rates now delegate to one shared `CountRedZoneTrips` state machine. A trip, once open, closes on the first of:
1. opponent standing scrimmage snap (existing rule — now also catches opponent INT plays via the H1 type widening);
2. this offense starting a NEW drive (DriveId change) — covers turnovers, defensive scores, and kickoff-separated possessions;
3. a half boundary (Q2→Q3) or regulation→OT — Q1→Q2 and Q3→Q4 deliberately survive;
4. end of input.

Scoring counts only while the trip is open; adjacent duplicate SequenceNumber events are processed once; the rate contracts (null when 0 trips; FG counts for RzScoreRate only) are unchanged.

## Tests
Six regression fixtures via a new play-level seeding helper (full control of type/down/distance/yardage/YTE/period): turnover-snap denominator + no-return-yards + explosive suppression, 3rd-down INT as failed attempt, stale-trip regression across own new drive, trip surviving Q1→Q2, trip closing at the half despite a same-DriveId glitch, FG-vs-TD predicate split with a duplicate event.

- `dotnet build` clean; metrics handler suite 12/12.
- Full Producer unit suite: 539 passed, 1 pre-existing failure in `DocumentCreatedProcessorTests` caused by uncommitted local WIP outside this branch (not present in CI).

Audit doc updated with implementation notes under H1/H2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved competition metrics accuracy for turnovers by counting offensive snaps without including return yards.
  * Corrected third-down interception outcomes and denominator calculations.
  * Improved red-zone trip tracking across drives, quarters, halves, overtime, and duplicate events.
  * Corrected field-goal and defensive-touchdown scoring treatment in scoring-rate metrics.

* **Documentation**
  * Added an audit record describing the metric corrections and validated scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->