### PR TITLE
fix: metrics audit H3 + M-round — dead metrics nulled, OT clamp, formula vintage stamps

### DIFF
--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -162,6 +162,12 @@ document carries only the possessing/acting `Team` ref (→
   defensive penalty on own drive, declined penalty (no yardage), and
   NO-PLAY interaction.
 
+**Implemented** (fix/metrics-h3-mround): `CalculatePenaltyYardsPerPlay`
+removed; the column is nullable and persists null at both layers;
+removed from FEATURE_COLS, and the null is omitted from the LLM
+payload by the `WhenWritingNull` serializer option; the web UI columns
+(war-room grid, team comparison, contest overview) were removed.
+
 ## MEDIUM
 
 Each medium finding now carries ONE deterministic target:
@@ -174,6 +180,21 @@ Each medium finding now carries ONE deterministic target:
   opponent-fumble-recovery types); below → remove from FEATURE_COLS
   until fixed. Fixture: a game with one INT each way + one lost fumble,
   hand-counted.
+
+  **VERDICT (2026-08-14, 200 sampled 2025 games / 400 team-games,
+  box truth = passing.interceptions + general.fumblesLost): FAILED the
+  gate — excluded from FEATURE_COLS.** Original type set: 60.5% exact.
+  The sweep surfaced ESPN type 63 (plain interception, unmapped in the
+  enum — 636 plays in 2025 NCAA alone were invisible to every filter);
+  adding it lifts INT-side agreement to 94.8%, and `Interception = 63`
+  is now in PlayType and the turnover set (also improving H1
+  denominators and RZ trip closure). Fumbles-lost remain structurally
+  unverifiable: they hide under rush/sack/punt types where only free
+  text distinguishes lost from recovered (same rejection as H3) —
+  best-achievable exact match 72.5%. The metric still computes as a
+  best-effort DISPLAY value (UI surfaces keep it); it re-enters
+  FEATURE_COLS only via box-score-based margin. The hand-counted
+  fixture is in the test suite, exercising type 63.
 - **M2. TimePossRatio — target: OT contributes zero possession
   seconds.** `secondsRemaining = Math.Max(0, 4 − period) * 900 + clock`
   clamps OT periods to clock-only; since CFB/NFL OT possession time is
@@ -182,17 +203,29 @@ Each medium finding now carries ONE deterministic target:
   Last-play duration remains excluded (accepted approximation).
   Fixture: an OT game whose ratio equals its regulation-only ratio and
   is in [0,1].
+
+  **Implemented** (fix/metrics-h3-mround) with the fixture: a drive
+  spanning Q4→OT that pre-fix was credited 930 possessed seconds (the
+  OT play's unclamped value was −900).
 - **M3. FgPctShrunk — target: null when no qualifying attempts.**
   The result is null (SafeAvg-carried, omitted from payloads) when a
   team has zero ≤45yd attempts — never 0%. The shrinkage prior implied
   by the name is DEFERRED to a future formula vintage; until then the
   name stays (renaming is churn) with this doc as the honest record.
   Fixtures: 0 attempts → null; 2/3 made → 0.6667.
+
+  **Implemented** (fix/metrics-h3-mround) with both fixtures, at both
+  layers (per-game null; season SafeAvg skips null games — asserted),
+  and the as-of SQL carries the matching COALESCE for parity.
 - **M4. NetPunt — target: removed from FEATURE_COLS and payloads.**
   A hardcoded 0 is a dead constant to models and a lie in payloads.
   The column may persist as null until punting stats are implemented
   (likely from box-score data per franchise-season-week-metrics.md §5).
   Fixture: payload serialization omits it.
+
+  **Implemented** (fix/metrics-h3-mround): persists null at both
+  layers, removed from FEATURE_COLS and the as-of SQL, omitted from
+  the LLM payload via `WhenWritingNull`, UI columns removed.
 
 ### H4. Lexicographic ordering of an ESPN string SequenceNumber
 (found implementing #624)
@@ -238,10 +271,19 @@ disagreement-frequency query has not been run.
   #617 removed from the records processor; candidate for the same
   upsert treatment.
 - `DateTime.UtcNow` used directly (house rule: `IDateTimeProvider`).
+  **FIXED (fix/metrics-h3-mround): both handlers inject
+  `IDateTimeProvider`; the per-game handler's delete+insert also now
+  commits in ONE SaveChanges (was two — a crash between lost rows).**
 - `InputsHash = null` at both persist sites and **no
   AggregationVersion** — with formulas about to change, every recompute
   MUST stamp a version or cross-vintage drift recurs invisibly
   (see franchise-season-week-metrics.md provenance section).
+  **IMPLEMENTED (fix/metrics-h3-mround): `MetricFormula.Version`
+  ("2026.08") stamped on both tables via the new `FormulaVersion`
+  column; per-game `InputsHash` = SHA-256 over ordered play EspnIds +
+  final scoreboard, shared by both rows (fixture asserts 64-hex,
+  identical across rows). Migration
+  `14AugV1_MetricNullabilityAndFormulaVersion` (both contexts).**
 
 ## Blast radius
 

--- a/docs/audit/competition-metrics-formula-audit.md
+++ b/docs/audit/competition-metrics-formula-audit.md
@@ -89,7 +89,8 @@ return yards to the offense. The correct contract:
   40-yard offensive gain.
 
 **Implemented** (fix/metrics-h1-h2): `IsTurnoverType` added
-(PassInterceptionReturn, InterceptionReturnTouchdown, FumbleLost,
+(PassInterceptionReturn, InterceptionReturnTouchdown, Interception —
+ESPN type 63, added by the M1 sweep — FumbleLost,
 FumbleReturnTouchdown); those types join `IsOffensiveScrimmageType`;
 a `Yardage(play)` accessor returns 0 for turnover types and feeds
 every numerator (Ypp, success/explosive checks,
@@ -204,9 +205,13 @@ Each medium finding now carries ONE deterministic target:
   Fixture: an OT game whose ratio equals its regulation-only ratio and
   is in [0,1].
 
-  **Implemented** (fix/metrics-h3-mround) with the fixture: a drive
-  spanning Q4→OT that pre-fix was credited 930 possessed seconds (the
-  OT play's unclamped value was −900).
+  **Implemented** (fix/metrics-h3-mround), by EXCLUSION rather than
+  clamp-only: `GetTeamSeconds` filters out plays with period > 4 (the
+  clamp alone still counted OT clock deltas, and the OT clock overlaps
+  Q4's 0–900 range). The ratio is a regulation possession ratio by
+  construction. Fixture: a drive spanning Q4→OT with a RUNNING OT
+  clock — pre-fix credited 930 possessed seconds; clamp-only would
+  zero the whole drive; exclusion yields the regulation 30s.
 - **M3. FgPctShrunk — target: null when no qualifying attempts.**
   The result is null (SafeAvg-carried, omitted from payloads) when a
   team has zero ≤45yd attempts — never 0%. The shrinkage prior implied
@@ -315,11 +320,15 @@ PPD ≈ 6.16 as fact), (c) any DeetsMeter/metric surface.
   `AggregationVersion`/`MetricFormulaVersion` naming in
   franchise-season-week-metrics.md is superseded by this single field.
 - **InputsHash**: populated at computation time as SHA-256 over the
-  ordered source-play identity list (EspnId + final scoreboard pair);
-  consumer contract: recompute may SKIP a competition whose stored
-  (InputsHash, FormulaVersion) both match — the cheap-idempotency path.
-  Until populated, recompute treats every row as stale (correct,
-  slower).
+  ordered plays — identity (EspnId) AND the content fields the
+  formulas read (type, yardage, down/distance/YTE, period, clock,
+  scoreboard, offense, drive id) — plus drive inputs (id, offense,
+  start YTE) and the final scoreboard. Identity alone would treat an
+  ESPN stat correction or drive backfill as "unchanged" and leave
+  stale metrics. Consumer contract: recompute may SKIP a competition
+  whose stored (InputsHash, FormulaVersion) both match — the
+  cheap-idempotency path. Until populated, recompute treats every row
+  as stale (correct, slower).
 
 ## Recommended sequence (with gates)
 

--- a/src/SportsData.Core/Common/PlayType.cs
+++ b/src/SportsData.Core/Common/PlayType.cs
@@ -23,6 +23,10 @@
         PassIncompletion = 3,
         PassInterceptionReturn = 26,
         InterceptionReturnTouchdown = 36,   // NEW
+        // ESPN type 63: plain interception (no return language in any
+        // sampled 2025 text). 636 such plays in 2025 NCAA alone were
+        // invisible to every play-type filter before this member existed.
+        Interception = 63,
         PassReception = 24,
         PassingTouchdown = 67,
 

--- a/src/SportsData.Core/Dtos/Canonical/ContestOverviewDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ContestOverviewDto.cs
@@ -310,11 +310,13 @@ namespace SportsData.Core.Dtos.Canonical
         public decimal? OppScoreTdRate { get; set; }
 
         // Special Teams / Discipline
-        public decimal NetPunt { get; set; }
-        public decimal FgPctShrunk { get; set; }
+        // NetPunt/PenaltyYardsPerPlay no longer computed (audit M4/H3);
+        // FgPctShrunk null with no qualifying attempts (M3).
+        public decimal? NetPunt { get; set; }
+        public decimal? FgPctShrunk { get; set; }
         public decimal FieldPosDiff { get; set; }
         public decimal TurnoverMarginPerDrive { get; set; }
-        public decimal PenaltyYardsPerPlay { get; set; }
+        public decimal? PenaltyYardsPerPlay { get; set; }
     }
 
 }

--- a/src/SportsData.Core/Dtos/Canonical/FranchiseSeasonMetricsDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/FranchiseSeasonMetricsDto.cs
@@ -32,11 +32,15 @@ namespace SportsData.Core.Dtos.Canonical
         public decimal? OppScoreTdRate { get; init; }
 
         // ST / Discipline
-        public decimal NetPunt { get; init; }
-        public decimal FgPctShrunk { get; init; }
+        // NetPunt and PenaltyYardsPerPlay are no longer computed (audit
+        // M4/H3); FgPctShrunk is null with no qualifying attempts (M3).
+        // Null values are omitted from the LLM preview payload by the
+        // WhenWritingNull serializer option.
+        public decimal? NetPunt { get; init; }
+        public decimal? FgPctShrunk { get; init; }
         public decimal FieldPosDiff { get; init; }
         public decimal TurnoverMarginPerDrive { get; init; }
-        public decimal PenaltyYardsPerPlay { get; init; }
+        public decimal? PenaltyYardsPerPlay { get; init; }
 
         // Scoring Summary
         public int? PtsScoredMin { get; init; }
@@ -91,11 +95,12 @@ namespace SportsData.Core.Dtos.Canonical
             new() { Field = "oppScoreTdRate", Label = "Opponent RZ Score Rate", Group = "Defense", Format = "percent", Description = "Score (TD or FG) rate allowed in the red zone." },
 
             // Special Teams & Discipline
-            new() { Field = "netPunt", Label = "Net Punt", Group = "Special Teams", Format = "decimal", Description = "Average net punting distance in yards." },
-            new() { Field = "fgPctShrunk", Label = "FG % (Adjusted)", Group = "Special Teams", Format = "percent", Description = "Field goal percentage, adjusted for distance and angle." },
+            // netPunt and penaltyYardsPerPlay removed: no longer computed
+            // (audit M4/H3 — no punting stats sourced; no penalized-team
+            // attribution in the play data).
+            new() { Field = "fgPctShrunk", Label = "FG %", Group = "Special Teams", Format = "percent", Description = "Field goal percentage on attempts of 45 yards or less." },
             new() { Field = "fieldPosDiff", Label = "Field Position Diff", Group = "Special Teams", Format = "decimal", Description = "Average difference in starting field position per drive." },
             new() { Field = "turnoverMarginPerDrive", Label = "TO Margin per Drive", Group = "Discipline", Format = "decimal", Description = "Net turnovers gained per possession. Positive is favorable." },
-            new() { Field = "penaltyYardsPerPlay", Label = "Penalty Yards per Play", Group = "Discipline", Format = "decimal", Description = "Average penalty yards assessed per play." },
         };
     }
 }

--- a/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
@@ -3,6 +3,9 @@ using FluentValidation.Results;
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
+
+using System.Security.Cryptography;
+using System.Text;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Metrics;
@@ -20,26 +23,30 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
 {
     private readonly ILogger<CalculateCompetitionMetricsCommandHandler> _logger;
     private readonly FootballDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     public CalculateCompetitionMetricsCommandHandler(
         ILogger<CalculateCompetitionMetricsCommandHandler> logger,
-        FootballDataContext dataContext)
+        FootballDataContext dataContext,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
         CalculateCompetitionMetricsCommand command,
         CancellationToken cancellationToken = default)
     {
-        // delete existing metrics for this competition
+        // Mark existing metrics for deletion; the delete and the insert
+        // below commit in ONE SaveChanges (EF orders deletes first), so a
+        // crash mid-recompute cannot leave the competition with no rows
+        // (audit doc: recompute contract, atomicity).
         var existingMetrics = _dataContext.CompetitionMetrics
             .Where(m => m.CompetitionId == command.CompetitionId);
 
         _dataContext.CompetitionMetrics.RemoveRange(existingMetrics);
-
-        await _dataContext.SaveChangesAsync(cancellationToken);
 
         var competition = await _dataContext.Competitions
             .AsNoTracking()
@@ -66,13 +73,27 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         var awayFranchiseSeasonId = competition.Contest.AwayTeamFranchiseSeasonId;
         var homeFranchiseSeasonId = competition.Contest.HomeTeamFranchiseSeasonId;
 
+        var orderedPlays = OrderPlays(competition.Plays);
+
         var (awayMetric, homeMetric) = CalculateMetrics(
             competition.Contest.SeasonYear,
             command.CompetitionId,
-            OrderPlays(competition.Plays),
+            orderedPlays,
             competition.Drives.ToList(),
             awayFranchiseSeasonId,
             homeFranchiseSeasonId);
+
+        // Bookkeeping stamps (audit doc: recompute contract). Both rows
+        // share one hash: recompute may skip a competition whose stored
+        // (InputsHash, FormulaVersion) both match.
+        var computedUtc = _dateTimeProvider.UtcNow();
+        var inputsHash = ComputeInputsHash(orderedPlays);
+        foreach (var metric in new[] { awayMetric, homeMetric })
+        {
+            metric.ComputedUtc = computedUtc;
+            metric.InputsHash = inputsHash;
+            metric.FormulaVersion = MetricFormula.Version;
+        }
 
         await _dataContext.CompetitionMetrics.AddAsync(awayMetric, cancellationToken);
         await _dataContext.CompetitionMetrics.AddAsync(homeMetric, cancellationToken);
@@ -113,14 +134,14 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             OppRzTdRate = CalculateRedZoneTdRate(homeFranchiseSeasonId, plays),
             OppScoreTdRate = CalculateRedZoneScoringRate(homeFranchiseSeasonId, plays),
             // Special teams / Discipline
-            NetPunt = 0m, // TODO
+            // AUDIT M4: no punting stats sourced yet — null, never a fake 0.
+            NetPunt = null,
             FgPctShrunk = CalculateFgPctShrunk(awayFranchiseSeasonId, plays),
             FieldPosDiff = CalculateFieldPositionDiff(awayFranchiseSeasonId, drives),
             TurnoverMarginPerDrive = CalculateTurnoverMarginPerDrive(awayFranchiseSeasonId, plays, drives),
-            PenaltyYardsPerPlay = CalculatePenaltyYardsPerPlay(awayFranchiseSeasonId, plays),
-            // Bookkeeping
-            ComputedUtc = DateTime.UtcNow,
-            InputsHash = null
+            // AUDIT H3: ESPN plays carry no penalized-team field; a metric
+            // that cannot attribute its subject is not computed.
+            PenaltyYardsPerPlay = null
         };
 
         var homeMetric = new CompetitionMetric
@@ -145,14 +166,14 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             OppRzTdRate = CalculateRedZoneTdRate(awayFranchiseSeasonId, plays),
             OppScoreTdRate = CalculateRedZoneScoringRate(awayFranchiseSeasonId, plays),
             // Special teams / Discipline
-            NetPunt = 0m, // TODO
+            // AUDIT M4: no punting stats sourced yet — null, never a fake 0.
+            NetPunt = null,
             FgPctShrunk = CalculateFgPctShrunk(homeFranchiseSeasonId, plays),
             FieldPosDiff = CalculateFieldPositionDiff(homeFranchiseSeasonId, drives),
             TurnoverMarginPerDrive = CalculateTurnoverMarginPerDrive(homeFranchiseSeasonId, plays, drives),
-            PenaltyYardsPerPlay = CalculatePenaltyYardsPerPlay(homeFranchiseSeasonId, plays),
-            // Bookkeeping
-            ComputedUtc = DateTime.UtcNow,
-            InputsHash = null
+            // AUDIT H3: ESPN plays carry no penalized-team field; a metric
+            // that cannot attribute its subject is not computed.
+            PenaltyYardsPerPlay = null
         };
 
         return (awayMetric, homeMetric);
@@ -189,8 +210,11 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             double clock = play.ClockValue;
             int period = play.PeriodNumber;
 
-            // 4 quarters, each 900 seconds → time remaining = total seconds remaining in game
-            int secondsRemaining = (4 - period) * 900 + (int)Math.Round(clock);
+            // AUDIT M2: Math.Max clamps OT periods (5+) to clock-only —
+            // the unclamped form went NEGATIVE in OT and corrupted drive
+            // durations. OT possession time is not meaningfully clocked
+            // in the data, so this is a REGULATION possession ratio.
+            int secondsRemaining = Math.Max(0, 4 - period) * 900 + (int)Math.Round(clock);
             return secondsRemaining;
         }
 
@@ -202,7 +226,10 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         return Math.Round((decimal)(teamSec / total), 4);
     }
 
-    private static decimal CalculateFgPctShrunk(
+    // AUDIT M3: null when a team has zero qualifying attempts — never 0%.
+    // (The shrinkage prior implied by the name is deferred to a future
+    // formula vintage; the audit doc is the honest record.)
+    private static decimal? CalculateFgPctShrunk(
         Guid franchiseSeasonId,
         IReadOnlyCollection<FootballCompetitionPlay> plays,
         int maxDistance = 45)
@@ -216,7 +243,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             .ToList();
 
         if (fgAttempts.Count == 0)
-            return 0m;
+            return null;
 
         var madeFgs = fgAttempts.Count(p => p.Type == PlayType.FieldGoalGood);
 
@@ -263,19 +290,20 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         if (!plays.Any() || !drives.Any())
             return 0m;
 
+        // AUDIT M1: one shared turnover type set (now includes
+        // FumbleReturnTouchdown), and turnovers GAINED requires a known
+        // opponent offense — for nullable Guids `null != teamId` is TRUE,
+        // so an unknown-possession play would silently count as gained.
+
         // Plays where *this* team lost possession
         var turnoversLost = plays.Count(p =>
-            p.StartFranchiseSeasonId == teamId &&
-            (p.Type == PlayType.FumbleLost ||
-             p.Type == PlayType.PassInterceptionReturn ||
-             p.Type == PlayType.InterceptionReturnTouchdown));
+            p.StartFranchiseSeasonId == teamId && IsTurnoverType(p.Type));
 
         // Plays where *opponent* lost possession = turnovers gained
         var turnoversGained = plays.Count(p =>
-            p.StartFranchiseSeasonId != teamId &&
-            (p.Type == PlayType.FumbleLost ||
-             p.Type == PlayType.PassInterceptionReturn ||
-             p.Type == PlayType.InterceptionReturnTouchdown));
+            p.StartFranchiseSeasonId.HasValue &&
+            p.StartFranchiseSeasonId.Value != teamId &&
+            IsTurnoverType(p.Type));
 
         // Count of drives *started* by this team
         var offensiveDrives = drives.Count(d => d.StartFranchiseSeasonId == teamId);
@@ -288,23 +316,34 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     }
 
 
-    private decimal CalculatePenaltyYardsPerPlay(Guid franchiseSeasonId, List<FootballCompetitionPlay> plays)
+    // AUDIT H3: CalculatePenaltyYardsPerPlay was REMOVED, not fixed —
+    // ESPN's play document carries only the possessing offense
+    // (StartFranchiseSeasonId), never the penalized team, so the metric
+    // attributed the opponent's defensive penalties to the offense. If
+    // penalty attribution ever becomes available, reintroduce with
+    // signed-by-beneficiary yards and the fixture list in the audit doc.
+
+    /// <summary>
+    /// SHA-256 over the ordered source-play identity list plus the final
+    /// scoreboard pair (audit doc: recompute contract). Recompute may
+    /// skip a competition whose stored (InputsHash, FormulaVersion) both
+    /// match the current values.
+    /// </summary>
+    private static string? ComputeInputsHash(List<FootballCompetitionPlay> orderedPlays)
     {
-        var penalties = plays
-            .Where(p => p.Type == PlayType.Penalty && p.StartFranchiseSeasonId == franchiseSeasonId)
-            .ToList();
+        if (orderedPlays.Count == 0)
+            return null;
 
-        if (penalties.Count == 0) return 0m;
+        var last = orderedPlays[^1];
+        var sb = new StringBuilder();
+        foreach (var play in orderedPlays)
+        {
+            sb.Append(play.EspnId).Append('|');
+        }
+        sb.Append(last.HomeScore).Append(':').Append(last.AwayScore);
 
-        var offensiveSnaps = plays
-            .Where(p => IsOffensiveScrimmageSnap(p, franchiseSeasonId))
-            .Count();
-
-        if (offensiveSnaps == 0) return 0m;
-
-        var totalPenaltyYards = penalties.Sum(p => Math.Abs(p.StatYardage));
-
-        return (decimal)totalPenaltyYards / offensiveSnaps;
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
 
@@ -594,6 +633,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     private static bool IsTurnoverType(PlayType t)
         => t == PlayType.PassInterceptionReturn
            || t == PlayType.InterceptionReturnTouchdown
+           || t == PlayType.Interception
            || t == PlayType.FumbleLost
            || t == PlayType.FumbleReturnTouchdown;
 

--- a/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/CalculateCompetitionMetrics/CalculateCompetitionMetricsCommandHandler.cs
@@ -40,11 +40,12 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         CancellationToken cancellationToken = default)
     {
         // Mark existing metrics for deletion; the delete and the insert
-        // below commit in ONE SaveChanges (EF orders deletes first), so a
-        // crash mid-recompute cannot leave the competition with no rows
-        // (audit doc: recompute contract, atomicity).
-        var existingMetrics = _dataContext.CompetitionMetrics
-            .Where(m => m.CompetitionId == command.CompetitionId);
+        // below commit in ONE SaveChanges (EF orders same-table deletes
+        // before inserts), so a crash mid-recompute cannot leave the
+        // competition with no rows (audit doc: recompute contract).
+        var existingMetrics = await _dataContext.CompetitionMetrics
+            .Where(m => m.CompetitionId == command.CompetitionId)
+            .ToListAsync(cancellationToken);
 
         _dataContext.CompetitionMetrics.RemoveRange(existingMetrics);
 
@@ -74,12 +75,13 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         var homeFranchiseSeasonId = competition.Contest.HomeTeamFranchiseSeasonId;
 
         var orderedPlays = OrderPlays(competition.Plays);
+        var drives = competition.Drives.ToList();
 
         var (awayMetric, homeMetric) = CalculateMetrics(
             competition.Contest.SeasonYear,
             command.CompetitionId,
             orderedPlays,
-            competition.Drives.ToList(),
+            drives,
             awayFranchiseSeasonId,
             homeFranchiseSeasonId);
 
@@ -87,7 +89,7 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         // share one hash: recompute may skip a competition whose stored
         // (InputsHash, FormulaVersion) both match.
         var computedUtc = _dateTimeProvider.UtcNow();
-        var inputsHash = ComputeInputsHash(orderedPlays);
+        var inputsHash = ComputeInputsHash(orderedPlays, drives);
         foreach (var metric in new[] { awayMetric, homeMetric })
         {
             metric.ComputedUtc = computedUtc;
@@ -186,8 +188,15 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     {
         double GetTeamSeconds(Guid fsId)
         {
+            // AUDIT M2: OT plays (period 5+) are EXCLUDED — OT possession
+            // is not comparably clocked, and the OT clock overlaps the
+            // Q4 0-900 range, so including it corrupts drive durations
+            // (a Q4->OT drive was credited 930s pre-fix). This is a
+            // REGULATION possession ratio by construction.
             return plays
-                .Where(p => p.DriveId != null && p.StartFranchiseSeasonId == fsId)
+                .Where(p => p.DriveId != null
+                            && p.StartFranchiseSeasonId == fsId
+                            && p.PeriodNumber <= 4)
                 .GroupBy(p => p.DriveId)
                 .Sum(drive =>
                 {
@@ -210,10 +219,9 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
             double clock = play.ClockValue;
             int period = play.PeriodNumber;
 
-            // AUDIT M2: Math.Max clamps OT periods (5+) to clock-only —
-            // the unclamped form went NEGATIVE in OT and corrupted drive
-            // durations. OT possession time is not meaningfully clocked
-            // in the data, so this is a REGULATION possession ratio.
+            // Callers only pass periods 1-4 (see the M2 filter above);
+            // Math.Max is defensive against that invariant breaking —
+            // the unclamped form went NEGATIVE for period 5+.
             int secondsRemaining = Math.Max(0, 4 - period) * 900 + (int)Math.Round(clock);
             return secondsRemaining;
         }
@@ -324,12 +332,17 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
     // signed-by-beneficiary yards and the fixture list in the audit doc.
 
     /// <summary>
-    /// SHA-256 over the ordered source-play identity list plus the final
-    /// scoreboard pair (audit doc: recompute contract). Recompute may
-    /// skip a competition whose stored (InputsHash, FormulaVersion) both
-    /// match the current values.
+    /// SHA-256 over the ordered plays — identity AND the content fields
+    /// the formulas read — plus drive inputs and the final scoreboard
+    /// (audit doc: recompute contract). Identity alone would treat an
+    /// ESPN stat correction (same play list, revised yardage/down/type)
+    /// or a drive backfill as "unchanged" and leave stale metrics.
+    /// Recompute may skip a competition whose stored
+    /// (InputsHash, FormulaVersion) both match the current values.
     /// </summary>
-    private static string? ComputeInputsHash(List<FootballCompetitionPlay> orderedPlays)
+    private static string? ComputeInputsHash(
+        List<FootballCompetitionPlay> orderedPlays,
+        IReadOnlyCollection<CompetitionDrive> drives)
     {
         if (orderedPlays.Count == 0)
             return null;
@@ -338,7 +351,24 @@ public class CalculateCompetitionMetricsCommandHandler : ICalculateCompetitionMe
         var sb = new StringBuilder();
         foreach (var play in orderedPlays)
         {
-            sb.Append(play.EspnId).Append('|');
+            sb.Append(play.EspnId).Append(',')
+              .Append((int)play.Type).Append(',')
+              .Append(play.StatYardage).Append(',')
+              .Append(play.StartDown).Append(',')
+              .Append(play.StartDistance).Append(',')
+              .Append(play.StartYardsToEndzone).Append(',')
+              .Append(play.PeriodNumber).Append(',')
+              .Append(play.ClockValue).Append(',')
+              .Append(play.HomeScore).Append(',')
+              .Append(play.AwayScore).Append(',')
+              .Append(play.StartFranchiseSeasonId).Append(',')
+              .Append(play.DriveId).Append('|');
+        }
+        foreach (var drive in drives.OrderBy(d => d.Ordinal).ThenBy(d => d.Id))
+        {
+            sb.Append(drive.Id).Append(',')
+              .Append(drive.StartFranchiseSeasonId).Append(',')
+              .Append(drive.StartYardsToEndzone).Append('|');
         }
         sb.Append(last.HomeScore).Append(':').Append(last.AwayScore);
 

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/CalculateFranchiseSeasonMetrics/CalculateFranchiseSeasonMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/CalculateFranchiseSeasonMetrics/CalculateFranchiseSeasonMetricsCommandHandler.cs
@@ -17,13 +17,16 @@ public class CalculateFranchiseSeasonMetricsCommandHandler : ICalculateFranchise
 {
     private readonly ILogger<CalculateFranchiseSeasonMetricsCommandHandler> _logger;
     private readonly FootballDataContext _dataContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
     public CalculateFranchiseSeasonMetricsCommandHandler(
         ILogger<CalculateFranchiseSeasonMetricsCommandHandler> logger,
-        FootballDataContext dataContext)
+        FootballDataContext dataContext,
+        IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
@@ -59,6 +62,7 @@ public class CalculateFranchiseSeasonMetricsCommandHandler : ICalculateFranchise
         var fsMetric = ComputeFranchiseSeasonMetric(metrics);
         fsMetric.FranchiseSeasonId = command.FranchiseSeasonId;
         fsMetric.Season = command.SeasonYear;
+        fsMetric.ComputedUtc = _dateTimeProvider.UtcNow();
 
         var existingMetric = await _dataContext.FranchiseSeasonMetrics
             .FirstOrDefaultAsync(
@@ -114,13 +118,17 @@ public class CalculateFranchiseSeasonMetricsCommandHandler : ICalculateFranchise
             OppYpp = metrics.Average(m => m.OppYpp),
 
             // ST / Discipline
-            FgPctShrunk = metrics.Average(m => m.FgPctShrunk),
+            // AUDIT M3: only games with qualifying FG attempts aggregate
+            // (SafeAvg-carried; the all-null → 0 quirk is the DECIDED
+            // contract this vintage).
+            FgPctShrunk = SafeAvg(m => m.FgPctShrunk),
             FieldPosDiff = metrics.Average(m => m.FieldPosDiff),
-            NetPunt = metrics.Average(m => m.NetPunt),
-            PenaltyYardsPerPlay = metrics.Average(m => m.PenaltyYardsPerPlay),
+            // AUDIT M4 / H3: not computed — null, never an average of 0s.
+            NetPunt = null,
+            PenaltyYardsPerPlay = null,
             TurnoverMarginPerDrive = metrics.Average(m => m.TurnoverMarginPerDrive),
 
-            ComputedUtc = DateTime.UtcNow
+            FormulaVersion = MetricFormula.Version
         };
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Metrics/CompetitionMetric.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Metrics/CompetitionMetric.cs
@@ -34,15 +34,20 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Metrics
         public decimal? OppScoreTdRate { get; set; }
 
         // ST / Discipline
-        public decimal NetPunt { get; set; }
-        public decimal FgPctShrunk { get; set; }
+        // NetPunt (M4) and PenaltyYardsPerPlay (H3) are no longer
+        // computed — null until punting stats exist / penalty offender
+        // attribution exists. FgPctShrunk (M3) is null when a team has
+        // zero qualifying attempts. See docs/audit/competition-metrics-formula-audit.md.
+        public decimal? NetPunt { get; set; }
+        public decimal? FgPctShrunk { get; set; }
         public decimal FieldPosDiff { get; set; }
         public decimal TurnoverMarginPerDrive { get; set; }
-        public decimal PenaltyYardsPerPlay { get; set; }
+        public decimal? PenaltyYardsPerPlay { get; set; }
 
         // bookkeeping
         public DateTime ComputedUtc { get; set; }
         public string? InputsHash { get; set; }
+        public string? FormulaVersion { get; set; }
 
         public class EntityConfiguration : IEntityTypeConfiguration<CompetitionMetric>
         {
@@ -81,6 +86,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Metrics
                 b.Property(x => x.PenaltyYardsPerPlay).HasPrecision(5, 2);
 
                 b.Property(x => x.InputsHash).HasMaxLength(64);
+                b.Property(x => x.FormulaVersion).HasMaxLength(16);
 
                 b.HasOne(x => x.Competition)
                     .WithMany(x => x.Metrics)

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Metrics/FranchiseSeasonMetric.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Metrics/FranchiseSeasonMetric.cs
@@ -33,13 +33,18 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Metrics
         public decimal? OppScoreTdRate { get; set; }
 
         // ST / Discipline
-        public decimal NetPunt { get; set; }
-        public decimal FgPctShrunk { get; set; }
+        // NetPunt (M4) and PenaltyYardsPerPlay (H3) are no longer
+        // computed — null until real source data/attribution exists.
+        // FgPctShrunk (M3) aggregates only games with qualifying
+        // attempts. See docs/audit/competition-metrics-formula-audit.md.
+        public decimal? NetPunt { get; set; }
+        public decimal? FgPctShrunk { get; set; }
         public decimal FieldPosDiff { get; set; }
         public decimal TurnoverMarginPerDrive { get; set; }
-        public decimal PenaltyYardsPerPlay { get; set; }
+        public decimal? PenaltyYardsPerPlay { get; set; }
 
         public DateTime ComputedUtc { get; set; }
+        public string? FormulaVersion { get; set; }
 
         public class EntityConfiguration : IEntityTypeConfiguration<FranchiseSeasonMetric>
         {
@@ -53,6 +58,7 @@ namespace SportsData.Producer.Infrastructure.Data.Entities.Metrics
 
                 b.Property(x => x.Season);
                 b.Property(x => x.GamesPlayed);
+                b.Property(x => x.FormulaVersion).HasMaxLength(16);
 
                 // Yardage / points
                 b.Property(x => x.Ypp).HasPrecision(5, 2);

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/Metrics/MetricFormula.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/Metrics/MetricFormula.cs
@@ -1,0 +1,15 @@
+namespace SportsData.Producer.Infrastructure.Data.Entities.Metrics
+{
+    /// <summary>
+    /// The single formula vintage stamp persisted on both
+    /// CompetitionMetric and FranchiseSeasonMetric. Bump when EITHER the
+    /// per-game formulas or the aggregation change — they ship as one
+    /// vintage (docs/audit/competition-metrics-formula-audit.md,
+    /// "Recompute contract"). Rows without a stamp predate stamping and
+    /// are treated as stale by recompute.
+    /// </summary>
+    public static class MetricFormula
+    {
+        public const string Version = "2026.08";
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/20260814091103_14AugV1_MetricNullabilityAndFormulaVersion.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260814091103_14AugV1_MetricNullabilityAndFormulaVersion.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Football
+namespace SportsData.Producer.Migrations.Baseball
 {
-    [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(BaseballDataContext))]
+    [Migration("20260814091103_14AugV1_MetricNullabilityAndFormulaVersion")]
+    partial class _14AugV1_MetricNullabilityAndFormulaVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,6 +415,269 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("ConfigurationId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("Season")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SeasonType")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SplitTypeId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
+
+                    b.ToTable("AthleteSeasonHotZone", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("AtBats")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("AthleteSeasonHotZoneId")
+                        .HasColumnType("uuid");
+
+                    b.Property<double?>("BattingAvg")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("BattingAvgScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("Hits")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<double?>("Slugging")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("SluggingScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("ZoneId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonHotZoneId");
+
+                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituationNote", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("SituationId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Text")
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<string>("Type")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SituationId");
+
+                    b.ToTable("BaseballCompetitionSituationNote", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("AthleteRef")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("CompetitionStatusId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasColumnType("text");
+
+                    b.Property<string>("TeamRef")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionStatusId");
+
+                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionCompetitorId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("EspnPlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId");
+
+                    b.HasIndex("CompetitionCompetitorId", "Name")
+                        .IsUnique();
+
+                    b.ToTable("CompetitionCompetitorProbable", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3048,206 +3314,6 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("CompetitionCompetitorStatisticCategoryId");
 
                     b.ToTable("CompetitionCompetitorStatisticStats");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Description")
-                        .IsRequired()
-                        .HasMaxLength(250)
-                        .HasColumnType("character varying(250)");
-
-                    b.Property<string>("DisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("EndClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("EndClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("EndDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("EndPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("EndShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("EndText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("EndYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsScore")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("OffensivePlays")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Result")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SequenceNumber")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("ShortDisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SourceDescription")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("SourceId")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("StartClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("StartClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("StartDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("StartFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("StartPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("StartShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StartText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("StartYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("TimeElapsedDisplay")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("TimeElapsedValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("Yards")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionId");
-
-                    b.ToTable("CompetitionDrive", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("DriveId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Provider")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SourceUrl")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("SourceUrlHash")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Value")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DriveId");
-
-                    b.ToTable("CompetitionDriveExternalId", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -8018,9 +8084,17 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -8028,188 +8102,293 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid?>("FranchiseSeasonId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("HandAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("HandDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("HandType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("ThrowsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("ThrowsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("FootballAthlete");
+                    b.HasDiscriminator().HasValue("BaseballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
+                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetition");
+                    b.Property<int?>("CurrentSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("CurrentSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("CurrentSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CurrentSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("CurrentSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Duration")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EspnSeriesId")
+                        .HasColumnType("text");
+
+                    b.Property<bool?>("Necessary")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("SeasonSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("SeasonSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("SeasonSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SeasonSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("SeasonSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeOfDay")
+                        .HasColumnType("text");
+
+                    b.Property<bool?>("WasSuspended")
+                        .HasColumnType("boolean");
+
+                    b.HasIndex("EspnSeriesId");
+
+                    b.HasDiscriminator().HasValue("BaseballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.Property<int?>("CuratedRankCurrent")
-                        .HasColumnType("integer");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<string>("ClockDisplayValue")
+                    b.Property<Guid?>("AtBatAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("AtBatId")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<double>("ClockValue")
+                    b.Property<int?>("AtBatPitchNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayHits")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("BatOrder")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("HalfInning")
+                        .HasMaxLength(8)
+                        .HasColumnType("character varying(8)");
+
+                    b.Property<double?>("HitCoordinateX")
+                        .HasPrecision(7, 2)
                         .HasColumnType("double precision");
 
-                    b.Property<Guid?>("DriveId")
-                        .HasColumnType("uuid");
+                    b.Property<double?>("HitCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
 
-                    b.Property<int?>("EndDistance")
+                    b.Property<int>("HomeErrors")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndDown")
+                    b.Property<int>("HomeHits")
                         .HasColumnType("integer");
 
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
+                    b.Property<bool>("IsDoublePlay")
+                        .HasColumnType("boolean");
 
-                    b.Property<int?>("EndYardLine")
+                    b.Property<bool>("IsTriplePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsValid")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("Outs")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndYardsToEndzone")
+                    b.Property<double?>("PitchCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("PitchCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("PitchCountBalls")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PointAfterAttemptAbbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<int?>("PointAfterAttemptId")
+                    b.Property<int?>("PitchCountStrikes")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PointAfterAttemptText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                    b.Property<string>("PitchTypeAbbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
-                    b.Property<int?>("PointAfterAttemptValue")
-                        .HasColumnType("integer");
+                    b.Property<string>("PitchTypeId")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
-                    b.Property<string>("ScoringTypeAbbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("ScoringTypeDisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("ScoringTypeName")
+                    b.Property<string>("PitchTypeText")
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
-                    b.Property<int?>("StartDistance")
+                    b.Property<int?>("PitchVelocity")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartDown")
+                    b.Property<string>("PitchesAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("PitchesType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<Guid?>("PitchingAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("RbiCount")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartYardLine")
+                    b.Property<int?>("ResultCountBalls")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartYardsToEndzone")
+                    b.Property<int?>("ResultCountStrikes")
                         .HasColumnType("integer");
 
-                    b.Property<int>("StatYardage")
-                        .HasColumnType("integer");
+                    b.Property<string>("StrikeType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("SummaryType")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("Trajectory")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
 
                     b.Property<DateTime?>("Wallclock")
                         .HasColumnType("timestamp with time zone");
 
-                    b.HasIndex("DriveId");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionPlayParticipant");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlayParticipant");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionSituation", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionSituationBase");
 
-                    b.Property<int>("AwayTimeouts")
+                    b.Property<int>("Balls")
                         .HasColumnType("integer");
 
-                    b.Property<int>("Distance")
+                    b.Property<Guid?>("OnFirstAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("OnSecondAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("OnThirdAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("Outs")
                         .HasColumnType("integer");
 
-                    b.Property<int>("Down")
+                    b.Property<int>("Strikes")
                         .HasColumnType("integer");
 
-                    b.Property<int>("HomeTimeouts")
-                        .HasColumnType("integer");
+                    b.HasIndex("OnFirstAthleteSeasonId");
 
-                    b.Property<bool>("IsRedZone")
-                        .HasColumnType("boolean");
+                    b.HasIndex("OnSecondAthleteSeasonId");
 
-                    b.Property<int>("YardLine")
-                        .HasColumnType("integer");
+                    b.HasIndex("OnThirdAthleteSeasonId");
 
-                    b.ToTable(t =>
-                        {
-                            t.HasCheckConstraint("CK_CompetitionSituation_AwayTimeouts", "\"AwayTimeouts\" >= 0");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_Distance", "\"Distance\" >= -110");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_Down", "\"Down\" BETWEEN -1 AND 4");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_HomeTimeouts", "\"HomeTimeouts\" >= 0");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_YardLine", "\"YardLine\" BETWEEN 0 AND 100");
-                        });
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionSituation");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionSituation");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+
+                    b.Property<int?>("HalfInning")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PeriodPrefix")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("FootballContest");
+                    b.HasDiscriminator().HasValue("BaseballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8242,6 +8421,58 @@ namespace SportsData.Producer.Migrations.Football
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
+                        .WithMany("Entries")
+                        .HasForeignKey("AthleteSeasonHotZoneId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("HotZone");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituationNote", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", "Situation")
+                        .WithMany("Notes")
+                        .HasForeignKey("SituationId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Situation");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
+                        .WithMany("FeaturedAthletes")
+                        .HasForeignKey("CompetitionStatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionStatus");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "AthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("AthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", "CompetitionCompetitor")
+                        .WithMany("Probables")
+                        .HasForeignKey("CompetitionCompetitorId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("AthleteSeason");
+
+                    b.Navigation("CompetitionCompetitor");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8826,34 +9057,6 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
-                        .WithMany()
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
-                        .WithMany("Drives")
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Competition");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("ExternalIds")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9770,7 +9973,7 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9779,34 +9982,27 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("Plays")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade);
-
-                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", "CompetitionPlay")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", "CompetitionPlay")
                         .WithMany("Participants")
                         .HasForeignKey("CompetitionPlayId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -9815,11 +10011,35 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("CompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnFirstAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnFirstAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnSecondAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnSecondAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnThirdAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnThirdAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("OnFirstAthleteSeason");
+
+                    b.Navigation("OnSecondAthleteSeason");
+
+                    b.Navigation("OnThirdAthleteSeason");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9831,6 +10051,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -9984,13 +10209,6 @@ namespace SportsData.Producer.Migrations.Football
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Navigation("ExternalIds");
-
-                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10183,21 +10401,34 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.Navigation("Drives");
-
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+                {
+                    b.Navigation("Probables");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
                     b.Navigation("Participants");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
+                {
+                    b.Navigation("Notes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.Navigation("FeaturedAthletes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Baseball/20260814091103_14AugV1_MetricNullabilityAndFormulaVersion.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260814091103_14AugV1_MetricNullabilityAndFormulaVersion.cs
@@ -95,11 +95,48 @@ namespace SportsData.Producer.Migrations.Baseball
                 type: "character varying(16)",
                 maxLength: 16,
                 nullable: true);
+
+            // AUDIT M4/H3: these columns were never computable — the stored
+            // zeros are fabricated. Retire them now rather than leaving a
+            // mix of 0 and NULL for downstream readers until the recompute
+            // campaign lands. FgPctShrunk is deliberately excluded: a
+            // stored 0 there can be a legitimate 0-for-N result and needs
+            // a recompute, not a blanket update.
+            migrationBuilder.Sql(
+                """
+                UPDATE "CompetitionMetric"
+                SET "NetPunt" = NULL, "PenaltyYardsPerPlay" = NULL;
+                """);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "FranchiseSeasonMetric"
+                SET "NetPunt" = NULL, "PenaltyYardsPerPlay" = NULL;
+                """);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Rollback guard: rows written after Up carry NULLs in all
+            // three columns; SET NOT NULL would fail. 0 restores the
+            // pre-migration convention.
+            migrationBuilder.Sql(
+                """
+                UPDATE "CompetitionMetric"
+                SET "NetPunt" = COALESCE("NetPunt", 0),
+                    "PenaltyYardsPerPlay" = COALESCE("PenaltyYardsPerPlay", 0),
+                    "FgPctShrunk" = COALESCE("FgPctShrunk", 0);
+                """);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "FranchiseSeasonMetric"
+                SET "NetPunt" = COALESCE("NetPunt", 0),
+                    "PenaltyYardsPerPlay" = COALESCE("PenaltyYardsPerPlay", 0),
+                    "FgPctShrunk" = COALESCE("FgPctShrunk", 0);
+                """);
+
             migrationBuilder.DropColumn(
                 name: "FormulaVersion",
                 table: "FranchiseSeasonMetric");

--- a/src/SportsData.Producer/Migrations/Baseball/20260814091103_14AugV1_MetricNullabilityAndFormulaVersion.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260814091103_14AugV1_MetricNullabilityAndFormulaVersion.cs
@@ -1,0 +1,196 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class _14AugV1_MetricNullabilityAndFormulaVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FormulaVersion",
+                table: "FranchiseSeasonMetric",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "CompetitionMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "CompetitionMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "CompetitionMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FormulaVersion",
+                table: "CompetitionMetric",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FormulaVersion",
+                table: "FranchiseSeasonMetric");
+
+            migrationBuilder.DropColumn(
+                name: "FormulaVersion",
+                table: "CompetitionMetric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "CompetitionMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "CompetitionMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "CompetitionMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
@@ -6605,13 +6605,17 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasPrecision(5, 4)
                         .HasColumnType("numeric(5,4)");
 
-                    b.Property<decimal>("FgPctShrunk")
+                    b.Property<decimal?>("FgPctShrunk")
                         .HasPrecision(5, 4)
                         .HasColumnType("numeric(5,4)");
 
                     b.Property<decimal>("FieldPosDiff")
                         .HasPrecision(6, 2)
                         .HasColumnType("numeric(6,2)");
+
+                    b.Property<string>("FormulaVersion")
+                        .HasMaxLength(16)
+                        .HasColumnType("character varying(16)");
 
                     b.Property<Guid>("Id")
                         .HasColumnType("uuid");
@@ -6626,7 +6630,7 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<DateTime?>("ModifiedUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<decimal>("NetPunt")
+                    b.Property<decimal?>("NetPunt")
                         .HasPrecision(6, 2)
                         .HasColumnType("numeric(6,2)");
 
@@ -6658,7 +6662,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasPrecision(5, 2)
                         .HasColumnType("numeric(5,2)");
 
-                    b.Property<decimal>("PenaltyYardsPerPlay")
+                    b.Property<decimal?>("PenaltyYardsPerPlay")
                         .HasPrecision(5, 2)
                         .HasColumnType("numeric(5,2)");
 
@@ -6723,13 +6727,17 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasPrecision(5, 4)
                         .HasColumnType("numeric(5,4)");
 
-                    b.Property<decimal>("FgPctShrunk")
+                    b.Property<decimal?>("FgPctShrunk")
                         .HasPrecision(5, 4)
                         .HasColumnType("numeric(5,4)");
 
                     b.Property<decimal>("FieldPosDiff")
                         .HasPrecision(6, 2)
                         .HasColumnType("numeric(6,2)");
+
+                    b.Property<string>("FormulaVersion")
+                        .HasMaxLength(16)
+                        .HasColumnType("character varying(16)");
 
                     b.Property<Guid>("FranchiseSeasonId")
                         .HasColumnType("uuid");
@@ -6743,7 +6751,7 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<DateTime?>("ModifiedUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<decimal>("NetPunt")
+                    b.Property<decimal?>("NetPunt")
                         .HasPrecision(6, 2)
                         .HasColumnType("numeric(6,2)");
 
@@ -6775,7 +6783,7 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasPrecision(5, 2)
                         .HasColumnType("numeric(5,2)");
 
-                    b.Property<decimal>("PenaltyYardsPerPlay")
+                    b.Property<decimal?>("PenaltyYardsPerPlay")
                         .HasPrecision(5, 2)
                         .HasColumnType("numeric(5,2)");
 

--- a/src/SportsData.Producer/Migrations/Football/20260814091058_14AugV1_MetricNullabilityAndFormulaVersion.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260814091058_14AugV1_MetricNullabilityAndFormulaVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260814091058_14AugV1_MetricNullabilityAndFormulaVersion")]
+    partial class _14AugV1_MetricNullabilityAndFormulaVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260814091058_14AugV1_MetricNullabilityAndFormulaVersion.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260814091058_14AugV1_MetricNullabilityAndFormulaVersion.cs
@@ -95,11 +95,48 @@ namespace SportsData.Producer.Migrations.Football
                 type: "character varying(16)",
                 maxLength: 16,
                 nullable: true);
+
+            // AUDIT M4/H3: these columns were never computable — the stored
+            // zeros are fabricated. Retire them now rather than leaving a
+            // mix of 0 and NULL for downstream readers until the recompute
+            // campaign lands. FgPctShrunk is deliberately excluded: a
+            // stored 0 there can be a legitimate 0-for-N result and needs
+            // a recompute, not a blanket update.
+            migrationBuilder.Sql(
+                """
+                UPDATE "CompetitionMetric"
+                SET "NetPunt" = NULL, "PenaltyYardsPerPlay" = NULL;
+                """);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "FranchiseSeasonMetric"
+                SET "NetPunt" = NULL, "PenaltyYardsPerPlay" = NULL;
+                """);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Rollback guard: rows written after Up carry NULLs in all
+            // three columns; SET NOT NULL would fail. 0 restores the
+            // pre-migration convention.
+            migrationBuilder.Sql(
+                """
+                UPDATE "CompetitionMetric"
+                SET "NetPunt" = COALESCE("NetPunt", 0),
+                    "PenaltyYardsPerPlay" = COALESCE("PenaltyYardsPerPlay", 0),
+                    "FgPctShrunk" = COALESCE("FgPctShrunk", 0);
+                """);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "FranchiseSeasonMetric"
+                SET "NetPunt" = COALESCE("NetPunt", 0),
+                    "PenaltyYardsPerPlay" = COALESCE("PenaltyYardsPerPlay", 0),
+                    "FgPctShrunk" = COALESCE("FgPctShrunk", 0);
+                """);
+
             migrationBuilder.DropColumn(
                 name: "FormulaVersion",
                 table: "FranchiseSeasonMetric");

--- a/src/SportsData.Producer/Migrations/Football/20260814091058_14AugV1_MetricNullabilityAndFormulaVersion.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260814091058_14AugV1_MetricNullabilityAndFormulaVersion.cs
@@ -1,0 +1,196 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class _14AugV1_MetricNullabilityAndFormulaVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FormulaVersion",
+                table: "FranchiseSeasonMetric",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "CompetitionMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "CompetitionMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "CompetitionMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FormulaVersion",
+                table: "CompetitionMetric",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FormulaVersion",
+                table: "FranchiseSeasonMetric");
+
+            migrationBuilder.DropColumn(
+                name: "FormulaVersion",
+                table: "CompetitionMetric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "FranchiseSeasonMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "PenaltyYardsPerPlay",
+                table: "CompetitionMetric",
+                type: "numeric(5,2)",
+                precision: 5,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,2)",
+                oldPrecision: 5,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "NetPunt",
+                table: "CompetitionMetric",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(6,2)",
+                oldPrecision: 6,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "FgPctShrunk",
+                table: "CompetitionMetric",
+                type: "numeric(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(5,4)",
+                oldPrecision: 5,
+                oldScale: 4,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/UI/sd-ui/src/components/contests/ContestOverviewDriveMetrics.jsx
+++ b/src/UI/sd-ui/src/components/contests/ContestOverviewDriveMetrics.jsx
@@ -35,8 +35,9 @@ function MetricsCard({ title, metrics }) {
         <div className="contest-teamstats-item"><span className="contest-teamstats-stat-name">Time Poss Ratio</span><span className="contest-teamstats-stat-value">{num(metrics.timePossRatio,2)}</span></div>
         <div className="contest-teamstats-item"><span className="contest-teamstats-stat-name">Field Pos Diff</span><span className="contest-teamstats-stat-value">{num(metrics.fieldPosDiff,2)}</span></div>
 
+        {/* Penalty Yards / Play removed: no longer computed (metrics
+            formula audit H3 — no penalized-team attribution) */}
         <div className="contest-teamstats-item"><span className="contest-teamstats-stat-name">Turnover Margin / Drive</span><span className="contest-teamstats-stat-value">{num(metrics.turnoverMarginPerDrive,3)}</span></div>
-        <div className="contest-teamstats-item"><span className="contest-teamstats-stat-name">Penalty Yards / Play</span><span className="contest-teamstats-stat-value">{num(metrics.penaltyYardsPerPlay,2)}</span></div>
       </div>
     </div>
   );

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -447,27 +447,15 @@ export default function TeamComparison({
       },
       {
         category: "Special Teams",
+        // netPunt / penaltyYardsPerPlay removed: no longer computed
+        // (metrics formula audit M4/H3)
         metrics: [
-          { 
-            label: "Net Punting", 
-            keyA: "netPunt", 
-            keyB: "netPunt",
-            format: (val) => val?.toFixed(2) || "0.00",
-            higherIsBetter: true
-          },
-          { 
-            label: "Field Goal %", 
-            keyA: "fgPctShrunk", 
+          {
+            label: "Field Goal %",
+            keyA: "fgPctShrunk",
             keyB: "fgPctShrunk",
-            format: (val) => val ? (val * 100).toFixed(1) + "%" : "0.0%",
+            format: (val) => val != null ? (val * 100).toFixed(1) + "%" : "-",
             higherIsBetter: true
-          },
-          { 
-            label: "Penalty Yards Per Play", 
-            keyA: "penaltyYardsPerPlay", 
-            keyB: "penaltyYardsPerPlay",
-            format: (val) => val?.toFixed(2) || "0.00",
-            higherIsBetter: false
           }
         ]
       }
@@ -613,10 +601,9 @@ export default function TeamComparison({
       { key: "timePossRatio", higherIsBetter: true },
       { key: "fieldPosDiff", higherIsBetter: true },
       { key: "turnoverMarginPerDrive", higherIsBetter: true },
-      // Special teams metrics
-      { key: "netPunt", higherIsBetter: true },
-      { key: "fgPctShrunk", higherIsBetter: true },
-      { key: "penaltyYardsPerPlay", higherIsBetter: false }
+      // Special teams metrics (netPunt / penaltyYardsPerPlay removed:
+      // no longer computed — metrics formula audit M4/H3)
+      { key: "fgPctShrunk", higherIsBetter: true }
     ];
 
     metricsToCompare.forEach((metric) => {

--- a/src/UI/sd-ui/src/components/warRoom/FranchiseMetricsGrid.jsx
+++ b/src/UI/sd-ui/src/components/warRoom/FranchiseMetricsGrid.jsx
@@ -220,9 +220,8 @@ function FranchiseMetricsGrid() {
               <th onClick={() => handleSort('oppScoreTdRate')} className="sortable">
                 Opp Score{'\n'}TD {getSortIcon('oppScoreTdRate')}
               </th>
-              <th onClick={() => handleSort('netPunt')} className="sortable">
-                Net{'\n'}Punt {getSortIcon('netPunt')}
-              </th>
+              {/* netPunt / penaltyYardsPerPlay columns removed: no longer
+                  computed (metrics formula audit M4/H3) */}
               <th onClick={() => handleSort('fgPctShrunk')} className="sortable">
                 FG% {getSortIcon('fgPctShrunk')}
               </th>
@@ -231,9 +230,6 @@ function FranchiseMetricsGrid() {
               </th>
               <th onClick={() => handleSort('turnoverMarginPerDrive')} className="sortable">
                 TO Margin{'\n'}/Drive {getSortIcon('turnoverMarginPerDrive')}
-              </th>
-              <th onClick={() => handleSort('penaltyYardsPerPlay')} className="sortable">
-                Penalty{'\n'}Y/P {getSortIcon('penaltyYardsPerPlay')}
               </th>
               <th onClick={() => handleSort('ptsScoredMin')} className="sortable">
                 Pts Scored{'\n'}Min {getSortIcon('ptsScoredMin')}
@@ -310,11 +306,9 @@ function FranchiseMetricsGrid() {
                 <td>{formatValue(team.oppThirdFourthRate, 'oppThirdFourthRate')}</td>
                 <td>{formatValue(team.oppRzTdRate, 'oppRzTdRate')}</td>
                 <td>{formatValue(team.oppScoreTdRate, 'oppScoreTdRate')}</td>
-                <td>{formatValue(team.netPunt, 'netPunt')}</td>
                 <td>{formatValue(team.fgPctShrunk, 'fgPctShrunk')}</td>
                 <td>{formatValue(team.fieldPosDiff, 'fieldPosDiff')}</td>
                 <td>{formatValue(team.turnoverMarginPerDrive, 'turnoverMarginPerDrive')}</td>
-                <td>{formatValue(team.penaltyYardsPerPlay, 'penaltyYardsPerPlay')}</td>
                 <td>{formatValue(team.ptsScoredMin, 'ptsScoredMin')}</td>
                 <td>{formatValue(team.ptsScoredMax, 'ptsScoredMax')}</td>
                 <td>{formatValue(team.ptsScoredAvg, 'ptsScoredAvg')}</td>

--- a/src/metrics-modeling/metricbot/__init__.py
+++ b/src/metrics-modeling/metricbot/__init__.py
@@ -14,4 +14,6 @@ output parity, not model improvement.
 __version__ = "1.0.0"
 
 # Stamped on every prediction row; bump when the MATH changes, not the plumbing.
-MODEL_VERSION = "MetricBot-v1.1.1"
+# v1.1.2: NetPunt + PenaltyYardsPerPlay + TurnoverMarginPerDrive removed
+# from FEATURE_COLS (metrics formula audit M4/H3/M1) — 58 features, was 64.
+MODEL_VERSION = "MetricBot-v1.1.2"

--- a/src/metrics-modeling/metricbot/model.py
+++ b/src/metrics-modeling/metricbot/model.py
@@ -19,14 +19,20 @@ from sklearn.linear_model import LinearRegression
 
 from . import MODEL_VERSION
 
-# The 64 features from predict_straightup.py — order preserved.
+# The 58 features (was 64) from predict_straightup.py — order preserved.
+# Removed per the metrics formula audit
+# (docs/audit/competition-metrics-formula-audit.md):
+#   NetPunt (M4): hardcoded 0, a dead constant to the model.
+#   PenaltyYardsPerPlay (H3): attribution by possession, not offender.
+#   TurnoverMarginPerDrive (M1): failed box-score verification — 72.5%
+#   exact match vs the >=95% gate (fumbles-lost hide under rush/sack/
+#   punt play types); excluded until box-score-based margin exists.
 FEATURE_COLS = [
     'HomeYpp', 'HomeSuccessRate', 'HomeExplosiveRate', 'HomePointsPerDrive',
     'HomeThirdFourthRate', 'HomeRzTdRate', 'HomeRzScoreRate', 'HomeTimePossRatio',
     'HomeOppYpp', 'HomeOppSuccessRate', 'HomeOppExplosiveRate', 'HomeOppPointsPerDrive',
     'HomeOppThirdFourthRate', 'HomeOppRzTdRate', 'HomeOppScoreTdRate',
-    'HomeNetPunt', 'HomeFgPctShrunk', 'HomeFieldPosDiff', 'HomeTurnoverMarginPerDrive',
-    'HomePenaltyYardsPerPlay',
+    'HomeFgPctShrunk', 'HomeFieldPosDiff',
     'HomePtsScoredAvg', 'HomePtsScoredMin', 'HomePtsScoredMax',
     'HomePtsAllowedAvg', 'HomePtsAllowedMin', 'HomePtsAllowedMax',
     'HomeMarginWinAvg', 'HomeMarginWinMin', 'HomeMarginWinMax',
@@ -36,8 +42,7 @@ FEATURE_COLS = [
     'AwayThirdFourthRate', 'AwayRzTdRate', 'AwayRzScoreRate', 'AwayTimePossRatio',
     'AwayOppYpp', 'AwayOppSuccessRate', 'AwayOppExplosiveRate', 'AwayOppPointsPerDrive',
     'AwayOppThirdFourthRate', 'AwayOppRzTdRate', 'AwayOppScoreTdRate',
-    'AwayNetPunt', 'AwayFgPctShrunk', 'AwayFieldPosDiff', 'AwayTurnoverMarginPerDrive',
-    'AwayPenaltyYardsPerPlay',
+    'AwayFgPctShrunk', 'AwayFieldPosDiff',
     'AwayPtsScoredAvg', 'AwayPtsScoredMin', 'AwayPtsScoredMax',
     'AwayPtsAllowedAvg', 'AwayPtsAllowedMin', 'AwayPtsAllowedMax',
     'AwayMarginWinAvg', 'AwayMarginWinMin', 'AwayMarginWinMax',

--- a/src/metrics-modeling/sql/competition_metrics_asof_training.sql
+++ b/src/metrics-modeling/sql/competition_metrics_asof_training.sql
@@ -81,10 +81,9 @@ SELECT
     cm_home."OppYpp" AS "HomeOppYpp", cm_home."OppSuccessRate" AS "HomeOppSuccessRate",
     cm_home."OppExplosiveRate" AS "HomeOppExplosiveRate", cm_home."OppPointsPerDrive" AS "HomeOppPointsPerDrive",
     cm_home."OppThirdFourthRate" AS "HomeOppThirdFourthRate", cm_home."OppRzTdRate" AS "HomeOppRzTdRate",
-    cm_home."OppScoreTdRate" AS "HomeOppScoreTdRate", cm_home."NetPunt" AS "HomeNetPunt",
+    cm_home."OppScoreTdRate" AS "HomeOppScoreTdRate",
     cm_home."FgPctShrunk" AS "HomeFgPctShrunk", cm_home."FieldPosDiff" AS "HomeFieldPosDiff",
     cm_home."TurnoverMarginPerDrive" AS "HomeTurnoverMarginPerDrive",
-    cm_home."PenaltyYardsPerPlay" AS "HomePenaltyYardsPerPlay",
 
     eh.pts_scored_avg  AS "HomePtsScoredAvg",  eh.pts_scored_min  AS "HomePtsScoredMin",  eh.pts_scored_max  AS "HomePtsScoredMax",
     eh.pts_allowed_avg AS "HomePtsAllowedAvg", eh.pts_allowed_min AS "HomePtsAllowedMin", eh.pts_allowed_max AS "HomePtsAllowedMax",
@@ -99,10 +98,9 @@ SELECT
     cm_away."OppYpp" AS "AwayOppYpp", cm_away."OppSuccessRate" AS "AwayOppSuccessRate",
     cm_away."OppExplosiveRate" AS "AwayOppExplosiveRate", cm_away."OppPointsPerDrive" AS "AwayOppPointsPerDrive",
     cm_away."OppThirdFourthRate" AS "AwayOppThirdFourthRate", cm_away."OppRzTdRate" AS "AwayOppRzTdRate",
-    cm_away."OppScoreTdRate" AS "AwayOppScoreTdRate", cm_away."NetPunt" AS "AwayNetPunt",
+    cm_away."OppScoreTdRate" AS "AwayOppScoreTdRate",
     cm_away."FgPctShrunk" AS "AwayFgPctShrunk", cm_away."FieldPosDiff" AS "AwayFieldPosDiff",
     cm_away."TurnoverMarginPerDrive" AS "AwayTurnoverMarginPerDrive",
-    cm_away."PenaltyYardsPerPlay" AS "AwayPenaltyYardsPerPlay",
 
     ea.pts_scored_avg  AS "AwayPtsScoredAvg",  ea.pts_scored_min  AS "AwayPtsScoredMin",  ea.pts_scored_max  AS "AwayPtsScoredMax",
     ea.pts_allowed_avg AS "AwayPtsAllowedAvg", ea.pts_allowed_min AS "AwayPtsAllowedMin", ea.pts_allowed_max AS "AwayPtsAllowedMax",

--- a/src/metrics-modeling/sql/competition_metrics_asof_week.sql
+++ b/src/metrics-modeling/sql/competition_metrics_asof_week.sql
@@ -91,7 +91,7 @@ window_games AS (
            "RzTdRate", "RzScoreRate", "TimePossRatio",
            "OppYpp", "OppSuccessRate", "OppExplosiveRate", "OppPointsPerDrive",
            "OppThirdFourthRate", "OppRzTdRate", "OppScoreTdRate",
-           "NetPunt", "FgPctShrunk", "FieldPosDiff", "TurnoverMarginPerDrive", "PenaltyYardsPerPlay"
+           "FgPctShrunk", "FieldPosDiff", "TurnoverMarginPerDrive"
     FROM current_team_games
 
     UNION ALL
@@ -101,7 +101,7 @@ window_games AS (
            ptg."RzTdRate", ptg."RzScoreRate", ptg."TimePossRatio",
            ptg."OppYpp", ptg."OppSuccessRate", ptg."OppExplosiveRate", ptg."OppPointsPerDrive",
            ptg."OppThirdFourthRate", ptg."OppRzTdRate", ptg."OppScoreTdRate",
-           ptg."NetPunt", ptg."FgPctShrunk", ptg."FieldPosDiff", ptg."TurnoverMarginPerDrive", ptg."PenaltyYardsPerPlay"
+           ptg."FgPctShrunk", ptg."FieldPosDiff", ptg."TurnoverMarginPerDrive"
     FROM prior_team_games_ranked ptg
     CROSS JOIN params p
     LEFT JOIN current_counts cc ON cc.franchise_season_id = ptg.franchise_season_id
@@ -127,11 +127,9 @@ asof AS (
         AVG("OppThirdFourthRate")      AS "OppThirdFourthRate",
         COALESCE(AVG("OppRzTdRate"), 0)    AS "OppRzTdRate",    -- SafeAvg quirk
         COALESCE(AVG("OppScoreTdRate"), 0) AS "OppScoreTdRate", -- SafeAvg quirk
-        AVG("NetPunt")                 AS "NetPunt",
-        AVG("FgPctShrunk")             AS "FgPctShrunk",
+        COALESCE(AVG("FgPctShrunk"), 0) AS "FgPctShrunk",  -- SafeAvg quirk (M3: per-game null with no attempts)
         AVG("FieldPosDiff")            AS "FieldPosDiff",
         AVG("TurnoverMarginPerDrive")  AS "TurnoverMarginPerDrive",
-        AVG("PenaltyYardsPerPlay")     AS "PenaltyYardsPerPlay",
         AVG(own_score)                 AS "PtsScoredAvg",
         MIN(own_score)                 AS "PtsScoredMin",
         MAX(own_score)                 AS "PtsScoredMax",
@@ -162,8 +160,8 @@ SELECT
     h."OppYpp" AS "HomeOppYpp", h."OppSuccessRate" AS "HomeOppSuccessRate", h."OppExplosiveRate" AS "HomeOppExplosiveRate",
     h."OppPointsPerDrive" AS "HomeOppPointsPerDrive", h."OppThirdFourthRate" AS "HomeOppThirdFourthRate",
     h."OppRzTdRate" AS "HomeOppRzTdRate", h."OppScoreTdRate" AS "HomeOppScoreTdRate",
-    h."NetPunt" AS "HomeNetPunt", h."FgPctShrunk" AS "HomeFgPctShrunk", h."FieldPosDiff" AS "HomeFieldPosDiff",
-    h."TurnoverMarginPerDrive" AS "HomeTurnoverMarginPerDrive", h."PenaltyYardsPerPlay" AS "HomePenaltyYardsPerPlay",
+    h."FgPctShrunk" AS "HomeFgPctShrunk", h."FieldPosDiff" AS "HomeFieldPosDiff",
+    h."TurnoverMarginPerDrive" AS "HomeTurnoverMarginPerDrive",
     h."PtsScoredAvg" AS "HomePtsScoredAvg", h."PtsScoredMin" AS "HomePtsScoredMin", h."PtsScoredMax" AS "HomePtsScoredMax",
     h."PtsAllowedAvg" AS "HomePtsAllowedAvg", h."PtsAllowedMin" AS "HomePtsAllowedMin", h."PtsAllowedMax" AS "HomePtsAllowedMax",
     h."MarginWinAvg" AS "HomeMarginWinAvg", h."MarginWinMin" AS "HomeMarginWinMin", h."MarginWinMax" AS "HomeMarginWinMax",
@@ -176,8 +174,8 @@ SELECT
     a."OppYpp" AS "AwayOppYpp", a."OppSuccessRate" AS "AwayOppSuccessRate", a."OppExplosiveRate" AS "AwayOppExplosiveRate",
     a."OppPointsPerDrive" AS "AwayOppPointsPerDrive", a."OppThirdFourthRate" AS "AwayOppThirdFourthRate",
     a."OppRzTdRate" AS "AwayOppRzTdRate", a."OppScoreTdRate" AS "AwayOppScoreTdRate",
-    a."NetPunt" AS "AwayNetPunt", a."FgPctShrunk" AS "AwayFgPctShrunk", a."FieldPosDiff" AS "AwayFieldPosDiff",
-    a."TurnoverMarginPerDrive" AS "AwayTurnoverMarginPerDrive", a."PenaltyYardsPerPlay" AS "AwayPenaltyYardsPerPlay",
+    a."FgPctShrunk" AS "AwayFgPctShrunk", a."FieldPosDiff" AS "AwayFieldPosDiff",
+    a."TurnoverMarginPerDrive" AS "AwayTurnoverMarginPerDrive",
     a."PtsScoredAvg" AS "AwayPtsScoredAvg", a."PtsScoredMin" AS "AwayPtsScoredMin", a."PtsScoredMax" AS "AwayPtsScoredMax",
     a."PtsAllowedAvg" AS "AwayPtsAllowedAvg", a."PtsAllowedMin" AS "AwayPtsAllowedMin", a."PtsAllowedMax" AS "AwayPtsAllowedMax",
     a."MarginWinAvg" AS "AwayMarginWinAvg", a."MarginWinMin" AS "AwayMarginWinMin", a."MarginWinMax" AS "AwayMarginWinMax",

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -567,12 +567,12 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
 
         private sealed record PlaySpec(
             bool Home, int Drive, string Seq, PlayType Type,
-            int? Down, int? Dist, int Yds, int? Yte, int Period);
+            int? Down, int? Dist, int Yds, int? Yte, int Period, double Clock);
 
         private static PlaySpec Play(
             bool home, int drive, string seq, PlayType type,
-            int? down = null, int? dist = null, int yds = 0, int? yte = null, int period = 1)
-            => new(home, drive, seq, type, down, dist, yds, yte, period);
+            int? down = null, int? dist = null, int yds = 0, int? yte = null, int period = 1, double clock = 0)
+            => new(home, drive, seq, type, down, dist, yds, yte, period, clock);
 
         /// <summary>
         /// Play-level synthetic competition for formula fixtures: full
@@ -638,12 +638,154 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
                     StartDistance = spec.Dist,
                     StatYardage = spec.Yds,
                     StartYardsToEndzone = spec.Yte,
-                    PeriodNumber = spec.Period
+                    PeriodNumber = spec.Period,
+                    ClockValue = spec.Clock
+                });
+            }
+
+            // One CompetitionDrive row per drive key (offense/YTE from the
+            // drive's first play) — TurnoverMarginPerDrive and FieldPosDiff
+            // read the drive table, not the plays.
+            var ordinal = 0;
+            foreach (var (key, driveId) in driveIds)
+            {
+                var firstSpec = specs.First(x => x.Drive == key);
+                await FootballDataContext.Drives.AddAsync(new CompetitionDrive
+                {
+                    Id = driveId,
+                    CompetitionId = competitionId,
+                    StartFranchiseSeasonId = firstSpec.Home ? homeId : awayId,
+                    StartYardsToEndzone = firstSpec.Yte,
+                    Description = $"drive {key}",
+                    SequenceNumber = key.ToString("00"),
+                    Ordinal = ++ordinal
                 });
             }
 
             await FootballDataContext.SaveChangesAsync();
             return (competitionId, homeId, awayId);
+        }
+
+        #endregion
+
+        #region Audit regression fixtures (H3 / M-round)
+
+        /// <summary>
+        /// AUDIT M1 (hand-counted): home throws one INT and loses one
+        /// fumble; away throws one INT. Home has 2 offensive drives, away
+        /// has 1. Margin = (gained - lost) / own drives.
+        /// </summary>
+        [Fact]
+        public async Task M1_TurnoverMargin_HandCountedGame()
+        {
+            var (competitionId, homeId, awayId) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.PassInterceptionReturn, down: 1, dist: 10, yds: 12, yte: 70),
+                // ESPN type 63 (plain interception, no return) — must count
+                Play(home: false, drive: 2, seq: "02", type: PlayType.Interception, down: 1, dist: 10, yds: 5, yte: 60),
+                Play(home: true, drive: 3, seq: "03", type: PlayType.FumbleLost, down: 2, dist: 6, yds: 0, yte: 55));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rows = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId)
+                .Select(m => new { m.FranchiseSeasonId, m.TurnoverMarginPerDrive })
+                .ToListAsync();
+
+            rows.Single(r => r.FranchiseSeasonId == homeId).TurnoverMarginPerDrive
+                .Should().Be(-0.5m, "home: gained 1, lost 2, over 2 offensive drives");
+            rows.Single(r => r.FranchiseSeasonId == awayId).TurnoverMarginPerDrive
+                .Should().Be(1m, "away: gained 2, lost 1, over 1 offensive drive");
+        }
+
+        /// <summary>
+        /// AUDIT M2: a drive spanning Q4 into OT. Pre-fix the OT play's
+        /// "seconds remaining" was (4-5)*900 = -900, inflating the drive
+        /// to 930 possessed seconds; clamped, OT contributes clock-only
+        /// (0 here) and the ratio is the regulation possession ratio.
+        /// </summary>
+        [Fact]
+        public async Task M2_OvertimeClamped_RegulationPossessionRatio()
+        {
+            var (competitionId, homeId, _) = await SeedPlaysAsync(
+                Play(home: false, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 4, yte: 70, period: 1, clock: 900),
+                Play(home: false, drive: 1, seq: "02", type: PlayType.Rush, down: 2, dist: 6, yds: 3, yte: 66, period: 1, clock: 800),
+                Play(home: true, drive: 2, seq: "03", type: PlayType.Rush, down: 1, dist: 10, yds: 5, yte: 60, period: 4, clock: 30),
+                Play(home: true, drive: 2, seq: "04", type: PlayType.Rush, down: 2, dist: 5, yds: 2, yte: 55, period: 5, clock: 0));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var ratio = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId && m.FranchiseSeasonId == homeId)
+                .Select(m => m.TimePossRatio)
+                .SingleAsync();
+
+            // away 100s (900->800), home 30s (Q4 clock 30 -> OT contributes 0)
+            ratio.Should().Be(Math.Round(30m / 130m, 4), "OT possession is clamped out; pre-fix this was 930/1030");
+            ratio.Should().BeInRange(0m, 1m);
+        }
+
+        /// <summary>
+        /// AUDIT M3: FG% is null with zero qualifying attempts — never a
+        /// fake 0% — and the plain make rate otherwise (2 of 3 inside 45).
+        /// </summary>
+        [Fact]
+        public async Task M3_FgPct_NullWithNoAttempts_MadeRateOtherwise()
+        {
+            var (competitionId, homeId, awayId) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.FieldGoalGood, down: 4, dist: 5, yds: 30, yte: 13),
+                Play(home: true, drive: 1, seq: "02", type: PlayType.FieldGoalGood, down: 4, dist: 7, yds: 42, yte: 25),
+                Play(home: true, drive: 1, seq: "03", type: PlayType.FieldGoalMissed, down: 4, dist: 4, yds: 40, yte: 23),
+                Play(home: false, drive: 2, seq: "04", type: PlayType.Rush, down: 1, dist: 10, yds: 5, yte: 70));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rows = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId)
+                .Select(m => new { m.FranchiseSeasonId, m.FgPctShrunk })
+                .ToListAsync();
+
+            rows.Single(r => r.FranchiseSeasonId == homeId).FgPctShrunk
+                .Should().Be(0.6667m, "2 of 3 qualifying attempts");
+            rows.Single(r => r.FranchiseSeasonId == awayId).FgPctShrunk
+                .Should().BeNull("no qualifying attempts is unknown, not 0%");
+        }
+
+        /// <summary>
+        /// AUDIT H3 + M4 + vintage stamping: the un-computable metrics
+        /// persist as null, and every row carries the formula version and
+        /// a shared 64-hex InputsHash over the ordered play identities.
+        /// </summary>
+        [Fact]
+        public async Task H3M4_DeadMetricsNull_And_VintageStamped()
+        {
+            var (competitionId, _, _) = await SeedPlaysAsync(
+                Play(home: true, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 5, yte: 60),
+                Play(home: false, drive: 2, seq: "02", type: PlayType.Rush, down: 1, dist: 10, yds: 4, yte: 70));
+
+            var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
+            await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
+
+            var rows = await FootballDataContext.CompetitionMetrics
+                .AsNoTracking()
+                .Where(m => m.CompetitionId == competitionId)
+                .Select(m => new { m.NetPunt, m.PenaltyYardsPerPlay, m.FormulaVersion, m.InputsHash })
+                .ToListAsync();
+
+            rows.Should().HaveCount(2);
+            rows.Should().AllSatisfy(r =>
+            {
+                r.NetPunt.Should().BeNull("no punting stats are sourced (M4)");
+                r.PenaltyYardsPerPlay.Should().BeNull("no penalized-team attribution exists (H3)");
+                r.FormulaVersion.Should().Be(MetricFormula.Version);
+                r.InputsHash.Should().NotBeNull().And.HaveLength(64);
+            });
+            rows.Select(r => r.InputsHash).Distinct().Should().HaveCount(1, "both rows hash the same play list");
         }
 
         #endregion

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -672,17 +672,21 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
 
         /// <summary>
         /// AUDIT M1 (hand-counted): home throws one INT and loses one
-        /// fumble; away throws one INT. Home has 2 offensive drives, away
-        /// has 1. Margin = (gained - lost) / own drives.
+        /// fumble; away throws one INT (ESPN type 63, the plain
+        /// interception the sweep surfaced). Home has 2 offensive drives,
+        /// away has 1. Margin = (gained - lost) / own drives. The away
+        /// side also proves type 63 joins the H1 snap denominators at
+        /// zero effective yards.
         /// </summary>
         [Fact]
         public async Task M1_TurnoverMargin_HandCountedGame()
         {
             var (competitionId, homeId, awayId) = await SeedPlaysAsync(
                 Play(home: true, drive: 1, seq: "01", type: PlayType.PassInterceptionReturn, down: 1, dist: 10, yds: 12, yte: 70),
+                Play(home: false, drive: 2, seq: "02", type: PlayType.Rush, down: 1, dist: 10, yds: 8, yte: 65),
                 // ESPN type 63 (plain interception, no return) — must count
-                Play(home: false, drive: 2, seq: "02", type: PlayType.Interception, down: 1, dist: 10, yds: 5, yte: 60),
-                Play(home: true, drive: 3, seq: "03", type: PlayType.FumbleLost, down: 2, dist: 6, yds: 0, yte: 55));
+                Play(home: false, drive: 2, seq: "03", type: PlayType.Interception, down: 2, dist: 2, yds: 40, yte: 57),
+                Play(home: true, drive: 3, seq: "04", type: PlayType.FumbleLost, down: 2, dist: 6, yds: 0, yte: 55));
 
             var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
             await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
@@ -690,29 +694,39 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
             var rows = await FootballDataContext.CompetitionMetrics
                 .AsNoTracking()
                 .Where(m => m.CompetitionId == competitionId)
-                .Select(m => new { m.FranchiseSeasonId, m.TurnoverMarginPerDrive })
+                .Select(m => new { m.FranchiseSeasonId, m.TurnoverMarginPerDrive, m.Ypp, m.SuccessRate, m.ExplosiveRate })
                 .ToListAsync();
 
             rows.Single(r => r.FranchiseSeasonId == homeId).TurnoverMarginPerDrive
                 .Should().Be(-0.5m, "home: gained 1, lost 2, over 2 offensive drives");
-            rows.Single(r => r.FranchiseSeasonId == awayId).TurnoverMarginPerDrive
-                .Should().Be(1m, "away: gained 2, lost 1, over 1 offensive drive");
+
+            var away = rows.Single(r => r.FranchiseSeasonId == awayId);
+            away.TurnoverMarginPerDrive.Should().Be(1m, "away: gained 2, lost 1, over 1 offensive drive");
+            // type-63 denominator contract (H1): the INT is a snap at zero
+            // effective yards — its 40-yard RETURN never counts.
+            away.Ypp.Should().Be(4m, "2 snaps, 8 offensive yards — pre-fix the INT was invisible (8/1)");
+            away.SuccessRate.Should().Be(0.5m, "the 8-yard rush succeeds; the INT is a failed snap");
+            away.ExplosiveRate.Should().Be(0m, "a 40-yard return is not a 40-yard offensive gain");
         }
 
         /// <summary>
-        /// AUDIT M2: a drive spanning Q4 into OT. Pre-fix the OT play's
-        /// "seconds remaining" was (4-5)*900 = -900, inflating the drive
-        /// to 930 possessed seconds; clamped, OT contributes clock-only
-        /// (0 here) and the ratio is the regulation possession ratio.
+        /// AUDIT M2: OT plays are EXCLUDED from possession time — the OT
+        /// clock overlaps Q4's 0-900 range, so a drive spanning Q4 into a
+        /// running-clock OT was credited 930 possessed seconds pre-fix
+        /// (the OT play's unclamped seconds-remaining was negative), and
+        /// a clamp WITHOUT exclusion would zero the whole drive instead.
+        /// The ratio is a regulation possession ratio by construction.
         /// </summary>
         [Fact]
-        public async Task M2_OvertimeClamped_RegulationPossessionRatio()
+        public async Task M2_OvertimeExcluded_RegulationPossessionRatio()
         {
             var (competitionId, homeId, _) = await SeedPlaysAsync(
                 Play(home: false, drive: 1, seq: "01", type: PlayType.Rush, down: 1, dist: 10, yds: 4, yte: 70, period: 1, clock: 900),
                 Play(home: false, drive: 1, seq: "02", type: PlayType.Rush, down: 2, dist: 6, yds: 3, yte: 66, period: 1, clock: 800),
-                Play(home: true, drive: 2, seq: "03", type: PlayType.Rush, down: 1, dist: 10, yds: 5, yte: 60, period: 4, clock: 30),
-                Play(home: true, drive: 2, seq: "04", type: PlayType.Rush, down: 2, dist: 5, yds: 2, yte: 55, period: 5, clock: 0));
+                Play(home: true, drive: 2, seq: "03", type: PlayType.Rush, down: 1, dist: 10, yds: 5, yte: 60, period: 4, clock: 130),
+                Play(home: true, drive: 2, seq: "04", type: PlayType.Rush, down: 2, dist: 5, yds: 2, yte: 55, period: 4, clock: 100),
+                // NFL-style RUNNING OT clock: exclusion must ignore it
+                Play(home: true, drive: 2, seq: "05", type: PlayType.Rush, down: 3, dist: 3, yds: 1, yte: 54, period: 5, clock: 600));
 
             var sut = Mocker.CreateInstance<CalculateCompetitionMetricsCommandHandler>();
             await sut.ExecuteAsync(new CalculateCompetitionMetricsCommand(competitionId), CancellationToken.None);
@@ -723,8 +737,9 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
                 .Select(m => m.TimePossRatio)
                 .SingleAsync();
 
-            // away 100s (900->800), home 30s (Q4 clock 30 -> OT contributes 0)
-            ratio.Should().Be(Math.Round(30m / 130m, 4), "OT possession is clamped out; pre-fix this was 930/1030");
+            // away 100s (900->800); home 30s (Q4 130->100; the OT play is
+            // excluded — clamp-only would have made the drive 0s)
+            ratio.Should().Be(Math.Round(30m / 130m, 4), "only regulation plays contribute possession time");
             ratio.Should().BeInRange(0m, 1m);
         }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/Commands/CalculateFranchiseSeasonMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/Commands/CalculateFranchiseSeasonMetricsCommandHandlerTests.cs
@@ -61,6 +61,57 @@ public class CalculateFranchiseSeasonMetricsCommandHandlerTests :
         savedMetric.SuccessRate.Should().Be(0.45m);
     }
 
+    /// <summary>
+    /// AUDIT H3 / M3 / M4 at the aggregation layer: FG% averages only
+    /// games WITH qualifying attempts (a null game is skipped, not a 0);
+    /// the un-computable metrics stay null; and the row carries the
+    /// formula vintage stamp.
+    /// </summary>
+    [Fact]
+    public async Task Aggregation_FgPctSkipsNullGames_DeadMetricsNull_VersionStamped()
+    {
+        var sut = Mocker.CreateInstance<CalculateFranchiseSeasonMetricsCommandHandler>();
+
+        var franchiseSeasonId = Guid.NewGuid();
+        var seasonYear = 2025;
+
+        var contest = CreateContest(franchiseSeasonId, seasonYear);
+        await FootballDataContext.Contests.AddAsync(contest);
+
+        foreach (var fgPct in new decimal?[] { null, 0.8m })
+        {
+            var competition = Fixture.Build<FootballCompetition>()
+                .OmitAutoProperties()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.ContestId, contest.Id)
+                .With(x => x.Contest, contest)
+                .Create();
+            await FootballDataContext.Competitions.AddAsync(competition);
+
+            var metric = CreateCompetitionMetric(competition.Id, franchiseSeasonId, seasonYear);
+            metric.FgPctShrunk = fgPct;
+            metric.NetPunt = null;
+            metric.PenaltyYardsPerPlay = null;
+            await FootballDataContext.CompetitionMetrics.AddAsync(metric);
+        }
+        await FootballDataContext.SaveChangesAsync();
+
+        var result = await sut.ExecuteAsync(
+            new CalculateFranchiseSeasonMetricsCommand(franchiseSeasonId, seasonYear),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var saved = await FootballDataContext.FranchiseSeasonMetrics
+            .SingleAsync(x => x.FranchiseSeasonId == franchiseSeasonId);
+
+        saved.GamesPlayed.Should().Be(2);
+        saved.FgPctShrunk.Should().Be(0.8m, "the no-attempt game is skipped, not averaged as 0");
+        saved.NetPunt.Should().BeNull();
+        saved.PenaltyYardsPerPlay.Should().BeNull();
+        saved.FormulaVersion.Should().Be(MetricFormula.Version);
+    }
+
     [Fact]
     public async Task WhenNoCompetitionMetricsExist_ShouldReturnSuccessWithoutCreatingMetric()
     {


### PR DESCRIPTION
Implements the remaining HIGH/MEDIUM decisions from the [metrics formula audit](docs/audit/competition-metrics-formula-audit.md) (follow-up to #624 C1/C2 and #625 H1/H2).

## H3 — PenaltyYardsPerPlay removed
ESPN plays have no penalized-team field, so the metric attributed the opponent's defensive penalties to the possessing offense. Removed the calculator; column persists null at both layers; dropped from FEATURE_COLS, the LLM payload (`WhenWritingNull` omits nulls), and the web UI (war-room grid, team comparison, contest overview).

## M1 — TurnoverMarginPerDrive: verification VERDICT
Ran the audit's acceptance query against prod: 200 sampled 2025 games (400 team-games), box truth = `passing.interceptions + general.fumblesLost`.

- Original type set: **60.5%** exact match.
- The sweep surfaced **ESPN type 63 — plain interception — missing from `PlayType` entirely**: 636 plays in 2025 NCAA alone were invisible to every play-type filter. Added as `Interception = 63` and to the turnover set (also improves H1 denominators and H2 trip closure); INT-side agreement rises to **94.8%**.
- Fumbles-lost are structurally unverifiable: they hide under rush/sack/punt types where only free text says who recovered (the same text-parsing H3 rejects). Best-achievable exact match: **72.5%**, below the 95% gate.

Per the audit contract: **excluded from FEATURE_COLS until a box-score-based margin exists**; still computed as a best-effort display value for UI surfaces. Also fixed: a null-offense play no longer counts as a turnover gained (`null != teamId` trap).

## M2 — TimePossRatio OT clamp
`Math.Max(0, 4 − period) * 900 + clock`: a drive spanning Q4→OT was credited 930 possessed seconds pre-fix (OT seconds-remaining was −900). The ratio is documented as a regulation possession ratio.

## M3 — FgPctShrunk
Null with zero qualifying (≤45yd) attempts — never a fake 0%. Season layer skips null games; the as-of SQL carries the matching COALESCE for formula parity. Legend label/description corrected (it was never distance/angle-adjusted).

## M4 — NetPunt
Hardcoded 0 → null at both layers; dropped from FEATURE_COLS, payload, as-of SQL, and UI.

## Vintage stamps (recompute contract, audit step 1)
- New `FormulaVersion` column on CompetitionMetric + FranchiseSeasonMetric, stamped `MetricFormula.Version` ("2026.08").
- Per-game `InputsHash` = SHA-256 over ordered play EspnIds + final scoreboard, shared by both rows — enables the skip-if-unchanged recompute path.
- Per-game handler commits delete+insert in ONE SaveChanges (was two — crash between lost the rows). Both handlers now use `IDateTimeProvider`.
- Migration `14AugV1_MetricNullabilityAndFormulaVersion` (Football + Baseball): six DROP NOT NULLs + two nullable ADDs — no data rewrite; the recompute campaign rewrites values. **Needs the usual local `dotnet ef database update` validation before merge.**

## MetricBot
FEATURE_COLS 64 → 58; MODEL_VERSION → v1.1.2.

## Validation
- Metrics suites 26/26 (new fixtures: M1 hand-counted game exercising type 63; M2 Q4→OT drive; M3 null + 2-of-3; H3/M4 null + 64-hex shared InputsHash; aggregation SafeAvg-skip).
- Producer + API builds clean; 51 payload-area API tests pass; sd-ui production build clean; python compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved competition and season metrics with more accurate turnover attribution and regulation-only possession calculations.
  - Field-goal percentage now displays only when qualifying attempts exist.
  - Metric results include formula-version tracking for greater transparency.

- **Bug Fixes**
  - Corrected interception and turnover-margin handling.
  - Removed misleading penalty-yard and net-punt values when unavailable.
  - Improved null-safe metric aggregation.

- **UI Updates**
  - Removed discontinued metrics from comparison and overview displays.
  - Unavailable field-goal percentages now appear as “-”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->