### PR TITLE
feat: vintage-aware metrics refresh — recompute-campaign trigger

### DIFF
--- a/src/SportsData.Producer/Application/Competitions/Commands/RefreshCompetitionMetrics/RefreshCompetitionMetricsCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Competitions/Commands/RefreshCompetitionMetrics/RefreshCompetitionMetricsCommandHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SportsData.Core.Common;
 using SportsData.Core.Processing;
 using SportsData.Producer.Application.Competitions.Commands.CalculateCompetitionMetrics;
+using SportsData.Producer.Infrastructure.Data.Entities.Metrics;
 using SportsData.Producer.Infrastructure.Data.Football;
 
 namespace SportsData.Producer.Application.Competitions.Commands.RefreshCompetitionMetrics;
@@ -50,7 +51,14 @@ public class RefreshCompetitionMetricsCommandHandler : IRefreshCompetitionMetric
             if (competition is null)
                 continue;
 
-            if (competition.Metrics.Count == ExpectedCompetitionMetricsCount)
+            // Skip only when the rows exist AND carry the current formula
+            // vintage — rows from an older vintage (or with no stamp at
+            // all) are stale and recompute. This makes the endpoint the
+            // recompute-campaign trigger (audit doc: recompute contract)
+            // and makes the campaign resumable: re-POSTing skips
+            // everything already restamped.
+            if (competition.Metrics.Count == ExpectedCompetitionMetricsCount &&
+                competition.Metrics.All(m => m.FormulaVersion == MetricFormula.Version))
                 continue;
 
             var calculateCommand = new CalculateCompetitionMetricsCommand(competition.Id);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/RefreshCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/RefreshCompetitionMetricsCommandHandlerTests.cs
@@ -20,6 +20,10 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions;
 
 public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<RefreshCompetitionMetricsCommandHandler>
 {
+    // The handler only checks FinalizedUtc for null — a fixed literal keeps
+    // the fixtures deterministic (house rule: no DateTime.UtcNow in tests).
+    private static readonly DateTime FinalizedStamp = new(2025, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
     [Fact]
     public async Task ExecuteAsync_WithFinalizedContests_EnqueuesMetricCalculationJobs()
     {
@@ -34,7 +38,7 @@ public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<Ref
         var contest1 = Fixture.Build<FootballContest>()
             .With(x => x.Id, contestId1)
             .With(x => x.SeasonYear, seasonYear)
-            .With(x => x.FinalizedUtc, DateTime.UtcNow)
+            .With(x => x.FinalizedUtc, FinalizedStamp)
             .Without(x => x.Links)
             .Without(x => x.ExternalIds)
             .Without(x => x.Competitions)
@@ -45,7 +49,7 @@ public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<Ref
         var contest2 = Fixture.Build<FootballContest>()
             .With(x => x.Id, contestId2)
             .With(x => x.SeasonYear, seasonYear)
-            .With(x => x.FinalizedUtc, DateTime.UtcNow)
+            .With(x => x.FinalizedUtc, FinalizedStamp)
             .Without(x => x.Links)
             .Without(x => x.ExternalIds)
             .Without(x => x.Competitions)
@@ -109,7 +113,7 @@ public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<Ref
         var contest = Fixture.Build<FootballContest>()
             .With(x => x.Id, contestId)
             .With(x => x.SeasonYear, seasonYear)
-            .With(x => x.FinalizedUtc, DateTime.UtcNow)
+            .With(x => x.FinalizedUtc, FinalizedStamp)
             .Without(x => x.Links)
             .Without(x => x.ExternalIds)
             .Without(x => x.Competitions)
@@ -178,7 +182,7 @@ public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<Ref
         var contest = Fixture.Build<FootballContest>()
             .With(x => x.Id, contestId)
             .With(x => x.SeasonYear, seasonYear)
-            .With(x => x.FinalizedUtc, DateTime.UtcNow)
+            .With(x => x.FinalizedUtc, FinalizedStamp)
             .Without(x => x.Links)
             .Without(x => x.ExternalIds)
             .Without(x => x.Competitions)
@@ -225,6 +229,69 @@ public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<Ref
 
         result.Should().BeOfType<Success<RefreshCompetitionMetricsResult>>();
         result.Value.EnqueuedJobs.Should().Be(1, "existing rows without the current vintage stamp are stale");
+    }
+
+    /// <summary>
+    /// One row current vintage, one row an OLDER non-null vintage — the
+    /// All predicate must treat the pair as stale and enqueue exactly one
+    /// job for the competition.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WithMixedVintageMetrics_EnqueuesOnce()
+    {
+        var seasonYear = 2025;
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+
+        var contest = Fixture.Build<FootballContest>()
+            .With(x => x.Id, contestId)
+            .With(x => x.SeasonYear, seasonYear)
+            .With(x => x.FinalizedUtc, FinalizedStamp)
+            .Without(x => x.Links)
+            .Without(x => x.ExternalIds)
+            .Without(x => x.Competitions)
+            .Without(x => x.HomeTeamFranchiseSeason)
+            .Without(x => x.AwayTeamFranchiseSeason)
+            .Create();
+
+        var competition = Fixture.Build<FootballCompetition>()
+            .With(x => x.Id, competitionId)
+            .With(x => x.ContestId, contestId)
+            .Without(x => x.Plays)
+            .Without(x => x.Drives)
+            .Without(x => x.ExternalIds)
+            .Without(x => x.Media)
+            .Without(x => x.Metrics)
+            .Without(x => x.Contest)
+            .Create();
+
+        var currentVintage = Fixture.Build<CompetitionMetric>()
+            .With(x => x.CompetitionId, competitionId)
+            .With(x => x.FormulaVersion, MetricFormula.Version)
+            .Without(x => x.Competition)
+            .Create();
+
+        var olderVintage = Fixture.Build<CompetitionMetric>()
+            .With(x => x.CompetitionId, competitionId)
+            .With(x => x.FormulaVersion, "2025.01")
+            .Without(x => x.Competition)
+            .Create();
+
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.Competitions.AddAsync(competition);
+        await FootballDataContext.CompetitionMetrics.AddRangeAsync(currentVintage, olderVintage);
+        await FootballDataContext.SaveChangesAsync();
+
+        var backgroundJobProvider = new Mock<IProvideBackgroundJobs>();
+        Mocker.Use(backgroundJobProvider.Object);
+
+        var command = new RefreshCompetitionMetricsCommand(seasonYear);
+        var sut = Mocker.CreateInstance<RefreshCompetitionMetricsCommandHandler>();
+
+        var result = await sut.ExecuteAsync(command, CancellationToken.None);
+
+        result.Should().BeOfType<Success<RefreshCompetitionMetricsResult>>();
+        result.Value.EnqueuedJobs.Should().Be(1, "a competition with ANY non-current row recomputes, once");
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/RefreshCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/RefreshCompetitionMetricsCommandHandlerTests.cs
@@ -128,14 +128,17 @@ public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<Ref
             .Without(x => x.Contest)
             .Create();
 
-        // Add 2 metrics (expected count)
+        // Add 2 metrics (expected count) stamped with the CURRENT formula
+        // vintage — only current-vintage rows are skippable
         var metric1 = Fixture.Build<CompetitionMetric>()
             .With(x => x.CompetitionId, competitionId)
+            .With(x => x.FormulaVersion, MetricFormula.Version)
             .Without(x => x.Competition)
             .Create();
 
         var metric2 = Fixture.Build<CompetitionMetric>()
             .With(x => x.CompetitionId, competitionId)
+            .With(x => x.FormulaVersion, MetricFormula.Version)
             .Without(x => x.Competition)
             .Create();
 
@@ -158,6 +161,70 @@ public class RefreshCompetitionMetricsCommandHandlerTests : ProducerTestBase<Ref
         result.Value.EnqueuedJobs.Should().Be(0);
 
         // Verify no enqueueing by checking result shows 0 jobs
+    }
+
+    /// <summary>
+    /// Recompute-campaign semantics: rows that EXIST but carry a stale
+    /// (or absent) FormulaVersion are re-enqueued — this is how the
+    /// vintage recompute is triggered and how a re-POST resumes it.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WithStaleVintageMetrics_Enqueues()
+    {
+        var seasonYear = 2025;
+        var contestId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+
+        var contest = Fixture.Build<FootballContest>()
+            .With(x => x.Id, contestId)
+            .With(x => x.SeasonYear, seasonYear)
+            .With(x => x.FinalizedUtc, DateTime.UtcNow)
+            .Without(x => x.Links)
+            .Without(x => x.ExternalIds)
+            .Without(x => x.Competitions)
+            .Without(x => x.HomeTeamFranchiseSeason)
+            .Without(x => x.AwayTeamFranchiseSeason)
+            .Create();
+
+        var competition = Fixture.Build<FootballCompetition>()
+            .With(x => x.Id, competitionId)
+            .With(x => x.ContestId, contestId)
+            .Without(x => x.Plays)
+            .Without(x => x.Drives)
+            .Without(x => x.ExternalIds)
+            .Without(x => x.Media)
+            .Without(x => x.Metrics)
+            .Without(x => x.Contest)
+            .Create();
+
+        // Both rows exist but predate stamping (FormulaVersion null)
+        var metric1 = Fixture.Build<CompetitionMetric>()
+            .With(x => x.CompetitionId, competitionId)
+            .Without(x => x.FormulaVersion)
+            .Without(x => x.Competition)
+            .Create();
+
+        var metric2 = Fixture.Build<CompetitionMetric>()
+            .With(x => x.CompetitionId, competitionId)
+            .Without(x => x.FormulaVersion)
+            .Without(x => x.Competition)
+            .Create();
+
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.Competitions.AddAsync(competition);
+        await FootballDataContext.CompetitionMetrics.AddRangeAsync(metric1, metric2);
+        await FootballDataContext.SaveChangesAsync();
+
+        var backgroundJobProvider = new Mock<IProvideBackgroundJobs>();
+        Mocker.Use(backgroundJobProvider.Object);
+
+        var command = new RefreshCompetitionMetricsCommand(seasonYear);
+        var sut = Mocker.CreateInstance<RefreshCompetitionMetricsCommandHandler>();
+
+        var result = await sut.ExecuteAsync(command, CancellationToken.None);
+
+        result.Should().BeOfType<Success<RefreshCompetitionMetricsResult>>();
+        result.Value.EnqueuedJobs.Should().Be(1, "existing rows without the current vintage stamp are stale");
     }
 
     [Fact]


### PR DESCRIPTION
Small enabler for the metrics recompute campaign ([audit doc](docs/audit/competition-metrics-formula-audit.md), recommended sequence step 2).

`POST competitions/metrics/generate/{seasonYear}` previously skipped any competition that already had its 2 metric rows — a gap-filler, useless for recomputing the stale vintage. The skip is now vintage-aware: only competitions whose both rows carry the current `MetricFormula.Version` stamp are skipped.

- Rows written before stamping existed (`FormulaVersion` null) → stale → recompute.
- Restamped competitions → skip, so re-POSTing resumes a partially completed campaign after any interruption.

Tests 4/4 (existing skip test now stamps the current vintage; new stale-vintage fixture asserts re-enqueue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Competition metrics are now recalculated when their formula version is missing, outdated, or inconsistent.
  * Existing metrics are skipped only when all expected records match the current formula version.
  * Prevents stale competition metrics from remaining unchanged.
  * Ensures only one recalculation is queued for competitions with mixed metric versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->