### PR TITLE
chore(bruno): metrics recompute campaign requests

### DIFF
--- a/bruno/producer/competition-metrics-recompute-seasonYear.yml
+++ b/bruno/producer/competition-metrics-recompute-seasonYear.yml
@@ -1,0 +1,23 @@
+info:
+  name: competition-metrics-recompute-seasonYear
+  type: http
+  seq: 20
+
+# PHASE 1 of the metrics recompute campaign
+# (docs/audit/competition-metrics-formula-audit.md, recommended sequence).
+# Enqueues CalculateCompetitionMetrics for every finalized competition in
+# the season whose metric rows are missing OR carry a stale FormulaVersion.
+# Re-POSTing resumes a partially completed campaign (restamped rows skip).
+# Returns counts synchronously; Hangfire drains the queue.
+http:
+  method: POST
+  url: "{{baseUrlProducer}}/api/competitions/metrics/generate/2025"
+  headers:
+    - name: X-Admin-Token
+      value: "{{X-Admin-Token}}"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/bruno/producer/franchise-season-metrics-recompute-seasonYear.yml
+++ b/bruno/producer/franchise-season-metrics-recompute-seasonYear.yml
@@ -1,0 +1,22 @@
+info:
+  name: franchise-season-metrics-recompute-seasonYear
+  type: http
+  seq: 21
+
+# PHASE 2 of the metrics recompute campaign — run ONLY after phase 1's
+# gates pass (docs/audit/competition-metrics-formula-audit.md): the
+# season aggregation reads persisted CompetitionMetric rows, so ordering
+# is load-bearing. Sport comes from the target Producer's app mode.
+# NOTE: aggregates FBS franchise seasons only (handler filter).
+http:
+  method: POST
+  url: "{{baseUrlProducer}}/api/franchise-seasons/seasonYear/2025/metrics/generate"
+  headers:
+    - name: X-Admin-Token
+      value: "{{X-Admin-Token}}"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5


### PR DESCRIPTION
Two Bruno requests for the metrics recompute campaign ([audit doc](docs/audit/competition-metrics-formula-audit.md)):

- `competition-metrics-recompute-seasonYear` — phase 1, vintage-aware per-competition recompute (#627), resumable by re-POST.
- `franchise-season-metrics-recompute-seasonYear` — phase 2, run only after phase 1's gates pass; FBS-only per the existing handler filter.

Docs-only/tooling change, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ready-to-use API requests for recomputing 2025 competition metrics.
  * Added an authenticated request for generating 2025 franchise-season metrics.
  * Included campaign guidance and resumability notes for the recompute operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->