### PR TITLE
fix: resolve FBS group root across hierarchy slug vintages

### DIFF
--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/EnqueueFranchiseSeasonMetricsGeneration/EnqueueFranchiseSeasonMetricsGenerationCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/EnqueueFranchiseSeasonMetricsGeneration/EnqueueFranchiseSeasonMetricsGenerationCommandHandler.cs
@@ -52,27 +52,28 @@ public class EnqueueFranchiseSeasonMetricsGenerationCommandHandler : IEnqueueFra
             ? await _groupSeasonsService.GetFbsGroupSeasonIds(command.SeasonYear)
             : null;
 
-        var franchiseSeasons = await _dataContext.FranchiseSeasons
-            .Include(fs => fs.Franchise)
+        // Only the ids are needed; the Sport predicate translates through
+        // the Franchise navigation without an Include.
+        var franchiseSeasonIds = await _dataContext.FranchiseSeasons
             .Where(fs =>
                 fs.SeasonYear == command.SeasonYear &&
                 fs.Franchise.Sport == command.Sport &&
                 (fbsGroupIds == null ||
                  (fs.GroupSeasonId != null && fbsGroupIds.Contains(fs.GroupSeasonId!.Value))))
-            .AsNoTracking()
+            .Select(fs => fs.Id)
             .ToListAsync(cancellationToken);
 
         _logger.LogInformation(
             "Found {Count} franchise seasons to process. SeasonYear={SeasonYear}, Sport={Sport}",
-            franchiseSeasons.Count,
+            franchiseSeasonIds.Count,
             command.SeasonYear,
             command.Sport);
 
         var correlationId = Guid.NewGuid();
 
-        foreach (var fs in franchiseSeasons)
+        foreach (var franchiseSeasonId in franchiseSeasonIds)
         {
-            var calculateCommand = new CalculateFranchiseSeasonMetricsCommand(fs.Id, command.SeasonYear);
+            var calculateCommand = new CalculateFranchiseSeasonMetricsCommand(franchiseSeasonId, command.SeasonYear);
             _backgroundJobProvider.Enqueue<ICalculateFranchiseSeasonMetricsCommandHandler>(
                 x => x.ExecuteAsync(calculateCommand, CancellationToken.None));
         }
@@ -80,7 +81,7 @@ public class EnqueueFranchiseSeasonMetricsGenerationCommandHandler : IEnqueueFra
         _logger.LogInformation(
             "EnqueueFranchiseSeasonMetricsGeneration completed. SeasonYear={SeasonYear}, EnqueuedCount={Count}, CorrelationId={CorrelationId}",
             command.SeasonYear,
-            franchiseSeasons.Count,
+            franchiseSeasonIds.Count,
             correlationId);
 
         return new Success<Guid>(correlationId, ResultStatus.Accepted);

--- a/src/SportsData.Producer/Application/FranchiseSeasons/Commands/EnqueueFranchiseSeasonMetricsGeneration/EnqueueFranchiseSeasonMetricsGenerationCommandHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasons/Commands/EnqueueFranchiseSeasonMetricsGeneration/EnqueueFranchiseSeasonMetricsGenerationCommandHandler.cs
@@ -44,15 +44,21 @@ public class EnqueueFranchiseSeasonMetricsGenerationCommandHandler : IEnqueueFra
             command.SeasonYear,
             command.Sport);
 
-        var fbsGroupIds = await _groupSeasonsService.GetFbsGroupSeasonIds(command.SeasonYear);
+        // FBS scoping is an NCAA concept — the NFL hierarchy has no FBS
+        // root, so asking for one 500'd and NFL season metrics never
+        // generated at all. NFL (and any future non-NCAA football) takes
+        // every franchise season for the year.
+        HashSet<Guid>? fbsGroupIds = command.Sport == Sport.FootballNcaa
+            ? await _groupSeasonsService.GetFbsGroupSeasonIds(command.SeasonYear)
+            : null;
 
         var franchiseSeasons = await _dataContext.FranchiseSeasons
             .Include(fs => fs.Franchise)
             .Where(fs =>
-                fs.GroupSeasonId != null &&
                 fs.SeasonYear == command.SeasonYear &&
                 fs.Franchise.Sport == command.Sport &&
-                fbsGroupIds.Contains(fs.GroupSeasonId!.Value))
+                (fbsGroupIds == null ||
+                 (fs.GroupSeasonId != null && fbsGroupIds.Contains(fs.GroupSeasonId!.Value))))
             .AsNoTracking()
             .ToListAsync(cancellationToken);
 

--- a/src/SportsData.Producer/Application/GroupSeasons/GroupSeasonsService.cs
+++ b/src/SportsData.Producer/Application/GroupSeasons/GroupSeasonsService.cs
@@ -25,9 +25,13 @@ namespace SportsData.Producer.Application.GroupSeasons
                 .AsNoTracking()
                 .ToListAsync();
 
-            // Get all FBS roots (may be duplicates due to ESPN data)
+            // Get all FBS roots (may be duplicates due to ESPN data).
+            // Slug conventions differ by hierarchy vintage: 2025+ uses
+            // "fbs-i-a"; the backfilled pre-2025 hierarchies use "fbs"
+            // (whose descendants include "fbs-indep", verified in prod).
+            // The multi-root descendant union below dedupes any overlap.
             var fbsRoots = groupSeasons
-                .Where(gs => gs.Slug == "fbs-i-a")
+                .Where(gs => gs.Slug is "fbs-i-a" or "fbs")
                 .ToList();
 
             if (!fbsRoots.Any())

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/Commands/EnqueueFranchiseSeasonMetricsGenerationCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/FranchiseSeasons/Commands/EnqueueFranchiseSeasonMetricsGenerationCommandHandlerTests.cs
@@ -87,6 +87,69 @@ public class EnqueueFranchiseSeasonMetricsGenerationCommandHandlerTests :
             Times.Exactly(3));
     }
 
+    /// <summary>
+    /// FBS scoping is NCAA-only: for NFL the handler must enqueue every
+    /// franchise season for the year WITHOUT consulting the FBS group
+    /// service (whose lookup throws on the NFL hierarchy — the reason NFL
+    /// season metrics never generated).
+    /// </summary>
+    [Fact]
+    public async Task WhenSportIsNfl_EnqueuesAllFranchiseSeasons_WithoutFbsScoping()
+    {
+        var backgroundJobProvider = Mocker.GetMock<IProvideBackgroundJobs>();
+        var groupSeasonsService = Mocker.GetMock<IGroupSeasonsService>();
+        groupSeasonsService
+            .Setup(x => x.GetFbsGroupSeasonIds(It.IsAny<int>()))
+            .ThrowsAsync(new InvalidOperationException("FBS group root(s) not found."));
+
+        var sut = Mocker.CreateInstance<EnqueueFranchiseSeasonMetricsGenerationCommandHandler>();
+
+        for (int i = 0; i < 2; i++)
+        {
+            var franchise = Fixture.Build<Franchise>()
+                .OmitAutoProperties()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.Sport, Sport.FootballNfl)
+                .With(x => x.Name, $"Team {i}")
+                .With(x => x.Abbreviation, $"T{i}")
+                .With(x => x.Location, $"Location {i}")
+                .With(x => x.DisplayName, $"Location {i} Team {i}")
+                .With(x => x.DisplayNameShort, $"Team {i}")
+                .With(x => x.ColorCodeHex, "#000000")
+                .With(x => x.Slug, $"nfl-team-{i}")
+                .Create();
+            await FootballDataContext.Franchises.AddAsync(franchise);
+
+            var franchiseSeason = Fixture.Build<FranchiseSeason>()
+                .OmitAutoProperties()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.FranchiseId, franchise.Id)
+                .With(x => x.Franchise, franchise)
+                .With(x => x.SeasonYear, 2024)
+                // No GroupSeasonId: NFL franchise seasons must not be
+                // dropped by the (NCAA-only) group filter
+                .With(x => x.Slug, franchise.Slug)
+                .With(x => x.Location, franchise.Location)
+                .With(x => x.Name, franchise.Name)
+                .With(x => x.Abbreviation, franchise.Abbreviation ?? "TM")
+                .With(x => x.DisplayName, franchise.DisplayName)
+                .With(x => x.DisplayNameShort, franchise.DisplayNameShort)
+                .With(x => x.ColorCodeHex, franchise.ColorCodeHex)
+                .Create();
+            await FootballDataContext.FranchiseSeasons.AddAsync(franchiseSeason);
+        }
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = new EnqueueFranchiseSeasonMetricsGenerationCommand(2024, Sport.FootballNfl);
+        var result = await sut.ExecuteAsync(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        backgroundJobProvider.Verify(
+            x => x.Enqueue(It.IsAny<Expression<Func<ICalculateFranchiseSeasonMetricsCommandHandler, Task>>>()),
+            Times.Exactly(2));
+        groupSeasonsService.Verify(x => x.GetFbsGroupSeasonIds(It.IsAny<int>()), Times.Never);
+    }
+
     [Fact]
     public async Task WhenNoFranchiseSeasonsExist_ShouldReturnSuccessWithNoEnqueues()
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/GroupSeasons/GroupSeasonsServiceTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/GroupSeasons/GroupSeasonsServiceTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+
+using SportsData.Producer.Application.GroupSeasons;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.GroupSeasons;
+
+public class GroupSeasonsServiceTests : ProducerTestBase<GroupSeasonsService>
+{
+    /// <summary>
+    /// Slug conventions differ by hierarchy vintage: 2025+ uses
+    /// "fbs-i-a"; the backfilled pre-2025 hierarchies use "fbs". The
+    /// service must resolve the FBS root (and its descendants) for both —
+    /// the 2024 recompute campaign 500'd on the older vintage.
+    /// </summary>
+    [Theory]
+    [InlineData("fbs-i-a")]
+    [InlineData("fbs")]
+    public async Task GetFbsGroupSeasonIds_ResolvesRootAcrossSlugVintages(string rootSlug)
+    {
+        var seasonYear = 2024;
+        var root = NewGroup(seasonYear, rootSlug, parentId: null);
+        var conference = NewGroup(seasonYear, "acc", root.Id);
+        var independents = NewGroup(seasonYear, "fbs-indep", root.Id);
+        var fcs = NewGroup(seasonYear, "fcs", parentId: null);
+
+        await FootballDataContext.GroupSeasons.AddRangeAsync(root, conference, independents, fcs);
+        await FootballDataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<GroupSeasonsService>();
+        var ids = await sut.GetFbsGroupSeasonIds(seasonYear);
+
+        ids.Should().BeEquivalentTo(
+            [root.Id, conference.Id, independents.Id],
+            "the FBS root and every descendant qualify; the FCS tree does not");
+    }
+
+    private static GroupSeason NewGroup(int seasonYear, string slug, Guid? parentId) => new()
+    {
+        Id = Guid.NewGuid(),
+        SeasonYear = seasonYear,
+        Slug = slug,
+        Name = slug,
+        Abbreviation = slug,
+        ParentId = parentId
+    };
+}


### PR DESCRIPTION
Unblocks phase 2 of the metrics recompute campaign for pre-2025 seasons.

`GetFbsGroupSeasonIds` matched only `fbs-i-a` — the slug the 2025+ hierarchies use. The backfilled 2022–2024 hierarchies use `fbs` (verified in prod: `fbs-indep` is a descendant of `fbs` in all three seasons, so no extra root needed). The 2024 phase-2 POST 500'd with `FBS group root(s) not found`.

One-line predicate change; the existing multi-root descendant union already dedupes overlap. Theory test covers both slug vintages. Producer build clean, 2/2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FBS group season detection to support both current and backfilled hierarchy formats.
  * Ensures FBS descendants are included while excluding FCS groups.
  * Updated franchise season processing so non-NCAA sports, including NFL, are not incorrectly restricted to FBS group seasons.

* **Tests**
  * Added coverage for both supported FBS hierarchy formats.
  * Added coverage confirming NFL franchise seasons are processed without FBS filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->