### PR TITLE
fix(web): sport-aware default game day for the (Day) parenthetical

### DIFF
--- a/src/UI/sd-mobile/__tests__/utils/timeUtils.test.ts
+++ b/src/UI/sd-mobile/__tests__/utils/timeUtils.test.ts
@@ -1,0 +1,48 @@
+import {
+  formatToUserTime,
+  getDefaultGameWeekday,
+} from '../../src/utils/timeUtils';
+
+// 2026-08-15 is a Saturday; 2026-08-16 a Sunday; 2026-08-13 a Thursday.
+// 17:00Z renders 1:00 PM in the default Eastern zone (EDT) — safely away
+// from the midnight-means-TBD sentinel. Mirrors the web vitest suite.
+const SAT = '2026-08-15T17:00:00Z';
+const SUN = '2026-08-16T17:00:00Z';
+const THU = '2026-08-13T17:00:00Z';
+
+describe('getDefaultGameWeekday', () => {
+  it('maps NCAAFB to Saturday and NFL to Sunday, from enum names or slugs', () => {
+    expect(getDefaultGameWeekday('FootballNcaa')).toBe(6);
+    expect(getDefaultGameWeekday('football-ncaa')).toBe(6);
+    expect(getDefaultGameWeekday('FootballNfl')).toBe(7);
+    expect(getDefaultGameWeekday('football-nfl')).toBe(7);
+  });
+
+  it('is null (always show the day) for sports without a dominant day', () => {
+    expect(getDefaultGameWeekday('BaseballMlb')).toBeNull();
+    expect(getDefaultGameWeekday(undefined)).toBeNull();
+    expect(getDefaultGameWeekday(null)).toBeNull();
+  });
+});
+
+describe('formatToUserTime day parenthetical', () => {
+  it('suppresses the day only on the sport default day', () => {
+    // NCAAFB (Sat default): Saturday bare, Thursday annotated
+    expect(formatToUserTime(SAT, undefined, 6)).toBe('Aug 15 @ 1:00 PM');
+    expect(formatToUserTime(THU, undefined, 6)).toBe('Aug 13 (Thu) @ 1:00 PM');
+
+    // NFL (Sun default): Sunday bare, SATURDAY ANNOTATED — the preseason
+    // regression this exists for
+    expect(formatToUserTime(SUN, undefined, 7)).toBe('Aug 16 @ 1:00 PM');
+    expect(formatToUserTime(SAT, undefined, 7)).toBe('Aug 15 (Sat) @ 1:00 PM');
+  });
+
+  it('always shows the day when the default is null', () => {
+    expect(formatToUserTime(SAT, undefined, null)).toBe('Aug 15 (Sat) @ 1:00 PM');
+  });
+
+  it('keeps the legacy Saturday default when the parameter is omitted', () => {
+    expect(formatToUserTime(SAT)).toBe('Aug 15 @ 1:00 PM');
+    expect(formatToUserTime(THU)).toBe('Aug 13 (Thu) @ 1:00 PM');
+  });
+});

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -4,7 +4,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { Matchup, PickType } from '@/src/types/models';
-import { formatToUserTime } from '@/src/utils/timeUtils';
+import { formatToUserTime, getDefaultGameWeekday } from '@/src/utils/timeUtils';
 import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 import { FinalScoreResult } from './FinalScoreResult';
 
@@ -96,7 +96,7 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail, pickType }
     return (
       <View style={styles.statusSection}>
         <Text style={[styles.statusTime, { color: theme.text }]}>
-          {formatToUserTime(matchup.startDateUtc, userTz)}
+          {formatToUserTime(matchup.startDateUtc, userTz, getDefaultGameWeekday(leagueSport))}
         </Text>
         {matchup.broadcasts ? (
           <Text style={[styles.statusMeta, { color: theme.textMuted }]}>
@@ -212,7 +212,7 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail, pickType }
           {(matchup.statusDescription ?? matchup.status).toUpperCase()}
         </Text>
         <Text style={[styles.statusTime, styles.struckThrough, { color: theme.textMuted }]}>
-          {formatToUserTime(matchup.startDateUtc, userTz)}
+          {formatToUserTime(matchup.startDateUtc, userTz, getDefaultGameWeekday(leagueSport))}
         </Text>
         {matchup.venue ? (
           <Text style={[styles.statusMeta, { color: theme.textMuted }]} numberOfLines={1}>

--- a/src/UI/sd-mobile/src/utils/timeUtils.ts
+++ b/src/UI/sd-mobile/src/utils/timeUtils.ts
@@ -6,9 +6,10 @@
  * we don't need Luxon or date-fns-tz.
  *
  * Backend convention: midnight (00:00) in the rendered zone means "time not
- * yet known," and we surface that to the user as "TBD". Saturday formatting
- * deliberately omits the day-of-week pip — Saturday is the default game day
- * for college football and the bare date reads cleaner.
+ * yet known," and we surface that to the user as "TBD". The day-of-week pip
+ * is deliberately omitted when a game falls on its sport's default game day
+ * (NCAAFB: Saturday, NFL: Sunday) — the bare date reads cleaner, and the
+ * pip works as an exception marker. See getDefaultGameWeekday.
  */
 
 export const DEFAULT_TIMEZONE = 'America/New_York';
@@ -88,18 +89,55 @@ function zonedParts(date: Date, timeZone: string): ZonedParts | null {
   }
 }
 
+// Intl short-weekday string -> ISO weekday number (Mon=1 ... Sun=7), the
+// same contract the web util uses (Luxon weekday numbers).
+const WEEKDAY_NUMBERS: Record<string, number> = {
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+  Sun: 7,
+};
+
+/**
+ * The "expected" game day for a sport/league, as an ISO weekday number
+ * (Mon=1 ... Sun=7), or null when the sport has no dominant day. Nullable by
+ * design: null means "always show the day". Mirrors the web util.
+ *
+ * Accepts either the backend Sport enum name ("FootballNcaa",
+ * "FootballNfl") or slug fragments — case-insensitive substring match,
+ * same convention as getStartLabel.
+ */
+export function getDefaultGameWeekday(
+  sportOrLeague: string | null | undefined,
+): number | null {
+  const s = (sportOrLeague ?? '').toLowerCase();
+  if (!s.includes('football')) return null;
+  if (s.includes('ncaa')) return 6; // NCAAFB: Saturday
+  if (s.includes('nfl')) return 7; // NFL: Sunday
+  return null;
+}
+
 /**
  * Format a UTC ISO datetime string as a calendar+time label in the given
  * IANA zone. Returns "MMM d (Day) @ h:mm a" (e.g. "Sep 27 (Thu) @ 1:30 PM");
- * the (Day) is omitted on Saturdays. Midnight in the target zone renders as
- * "TBD" because the backend uses 00:00 to mean "time not yet known."
+ * the (Day) is omitted when the game falls on `defaultWeekday` — the sport's
+ * expected game day (see getDefaultGameWeekday). The parameter defaults to
+ * Saturday (the app's original NCAAFB-only behavior) so legacy callers are
+ * unchanged; pass null to always show the day. Midnight in the target zone
+ * renders as "TBD" because the backend uses 00:00 to mean "time not yet
+ * known."
  *
- * @param dateStr  ISO 8601 datetime string (assumed UTC)
- * @param timezone IANA zone (e.g. "America/Chicago"); defaults to ET
+ * @param dateStr        ISO 8601 datetime string (assumed UTC)
+ * @param timezone       IANA zone (e.g. "America/Chicago"); defaults to ET
+ * @param defaultWeekday ISO weekday (Mon=1...Sun=7) to omit, or null
  */
 export function formatToUserTime(
   dateStr: string | null | undefined,
   timezone: string | null | undefined = DEFAULT_TIMEZONE,
+  defaultWeekday: number | null = 6,
 ): string {
   if (!dateStr) return 'TBD';
   const d = new Date(dateStr);
@@ -113,9 +151,10 @@ export function formatToUserTime(
   if (!parts) return 'TBD';
 
   const monthLabel = MONTHS_SHORT[parts.month - 1] ?? String(parts.month);
-  const isSaturday = parts.weekday === 'Sat';
+  const isDefaultDay =
+    defaultWeekday != null && WEEKDAY_NUMBERS[parts.weekday] === defaultWeekday;
   const dateLabel =
-    `${monthLabel} ${parts.day}` + (isSaturday ? '' : ` (${parts.weekday})`);
+    `${monthLabel} ${parts.day}` + (isDefaultDay ? '' : ` (${parts.weekday})`);
 
   if (parts.hour === 0 && parts.minute === 0) {
     return `${dateLabel} @ TBD`;

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -1,6 +1,6 @@
 import "./MatchupCard.css";
 import { FaChartLine, FaLock, FaClipboardList } from "react-icons/fa";
-import { formatToUserTime } from "../../utils/timeUtils";
+import { formatToUserTime, getDefaultGameWeekday } from "../../utils/timeUtils";
 import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import { useState, useEffect } from "react";
 import TeamComparison from "../teams/TeamComparison";
@@ -111,8 +111,11 @@ function MatchupCard({
   const awayIsWinner = isFinalStatus && bothScored && matchup.awayScore > matchup.homeScore;
   const homeIsWinner = isFinalStatus && bothScored && matchup.homeScore > matchup.awayScore;
 
-  // Game details
-  const gameTime = formatToUserTime(matchup.startDateUtc, userTz);
+  // Game details. The (Day) parenthetical shows only when the game falls
+  // off the sport's expected day (NCAAFB: Sat, NFL: Sun, others: always
+  // shown) — a Saturday NFL preseason game reads "Aug 15 (Sat) @ ...".
+  const gameTime = formatToUserTime(
+    matchup.startDateUtc, userTz, getDefaultGameWeekday(leagueSport));
   const venue = matchup.venue ?? "TBD";
   const location = `${matchup.venueCity ?? ""}, ${matchup.venueState ?? ""}`;
 

--- a/src/UI/sd-ui/src/components/teams/TeamSchedule.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamSchedule.jsx
@@ -1,7 +1,7 @@
 // src/components/teams/TeamSchedule.jsx
 import { Fragment } from "react";
 import { Link } from "react-router-dom";
-import { formatToUserTime, getZoneAbbreviation, getStartLabel } from "../../utils/timeUtils";
+import { formatToUserTime, getZoneAbbreviation, getStartLabel, getDefaultGameWeekday } from "../../utils/timeUtils";
 import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import { teamLink, contestLink } from '../../utils/sportLinks';
 import "./TeamSchedule.css";
@@ -16,7 +16,7 @@ function TeamSchedule({ schedule, seasonYear, sport = 'football', league = 'ncaa
   // Midnight ("TBD") carries no meaningful clock zone, so the abbrev is
   // suppressed there.
   const kickoffLabel = (game) => {
-    const time = formatToUserTime(game.date, userTz);
+    const time = formatToUserTime(game.date, userTz, getDefaultGameWeekday(`${sport}-${league}`));
     if (time.endsWith("TBD")) return time;
     return `${time} ${getZoneAbbreviation(userTz, game.date)}`;
   };

--- a/src/UI/sd-ui/src/components/teams/TeamScheduleMUI.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamScheduleMUI.jsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import { teamLink } from '../../utils/sportLinks';
-import { formatToUserTime, getZoneAbbreviation, getStartLabel } from "../../utils/timeUtils";
+import { formatToUserTime, getZoneAbbreviation, getStartLabel, getDefaultGameWeekday } from "../../utils/timeUtils";
 import { useUserTimeZone } from "../../hooks/useUserTimeZone";
 import {
   Paper,
@@ -68,7 +68,7 @@ export default function TeamScheduleMUI({ schedule = [], seasonYear, sport = 'fo
                   }}
                 >
                   <TableCell sx={{ whiteSpace: "nowrap" }}>
-                    {formatToUserTime(game.date, userTz)}
+                    {formatToUserTime(game.date, userTz, getDefaultGameWeekday(`${sport}-${league}`))}
                   </TableCell>
 
                   <TableCell>

--- a/src/UI/sd-ui/src/utils/timeUtils.js
+++ b/src/UI/sd-ui/src/utils/timeUtils.js
@@ -4,28 +4,50 @@ import { DateTime } from "luxon";
 export const DEFAULT_TIMEZONE = "America/New_York";
 
 /**
+ * The "expected" game day for a sport/league, as a Luxon weekday number
+ * (Mon=1 … Sun=7), or null when the sport has no dominant day. Nullable by
+ * design: null means "always show the day".
+ *
+ * Accepts either the backend Sport enum name ("FootballNcaa",
+ * "FootballNfl") or slug fragments (e.g. "football-ncaa" built from route
+ * params) — match is case-insensitive substring, same convention as
+ * getStartLabel.
+ */
+export function getDefaultGameWeekday(sportOrLeague) {
+  const s = (sportOrLeague ?? "").toLowerCase();
+  if (!s.includes("football")) return null;
+  if (s.includes("ncaa")) return 6; // NCAAFB: Saturday
+  if (s.includes("nfl")) return 7;  // NFL: Sunday
+  return null;
+}
+
+/**
  * Format a UTC ISO datetime string as a calendar+time label in the given IANA zone.
  * Returns "MMM d (Day) @ h:mm a" (e.g. "Sep 27 (Thu) @ 1:30 PM"); the (Day) is
- * omitted on Saturdays. Midnight in the target zone renders as "TBD" because the
- * backend uses 00:00 to mean "time not yet known."
+ * omitted when the game falls on `defaultWeekday` — the sport's expected game
+ * day (see getDefaultGameWeekday). The parameter defaults to Saturday, the
+ * app's original NCAAFB-only behavior, so legacy callers are unchanged; pass
+ * null to always show the day. Midnight in the target zone renders as "TBD"
+ * because the backend uses 00:00 to mean "time not yet known."
  *
  * @param {string} dateStr - ISO 8601 date string in UTC
  * @param {string} [timezone] - IANA zone (e.g. "America/Chicago"); defaults to ET
+ * @param {number|null} [defaultWeekday] - Luxon weekday (Mon=1…Sun=7) to omit, or null
  * @returns {string}
  */
-export function formatToUserTime(dateStr, timezone = DEFAULT_TIMEZONE) {
+export function formatToUserTime(dateStr, timezone = DEFAULT_TIMEZONE, defaultWeekday = 6) {
   const dtUtc = DateTime.fromISO(dateStr, { zone: "utc" });
   if (!dtUtc.isValid) return "TBD";
 
   const zone = timezone || DEFAULT_TIMEZONE;
   const dtLocal = dtUtc.setZone(zone);
   if (!dtLocal.isValid) {
-    return formatToUserTime(dateStr, DEFAULT_TIMEZONE);
+    return formatToUserTime(dateStr, DEFAULT_TIMEZONE, defaultWeekday);
   }
 
   const dayAbbrev = dtLocal.toFormat("ccc");
-  const isSaturday = dtLocal.weekday === 6;
-  const dateLabel = dtLocal.toFormat("MMM d") + (isSaturday ? "" : ` (${dayAbbrev})`);
+  const isDefaultDay = defaultWeekday != null && dtLocal.weekday === defaultWeekday;
+  const dateLabel = dtLocal.toFormat("MMM d") + (isDefaultDay ? "" : ` (${dayAbbrev})`);
 
   if (dtLocal.hour === 0 && dtLocal.minute === 0) {
     return `${dateLabel} @ TBD`;

--- a/src/UI/sd-ui/src/utils/timeUtils.test.js
+++ b/src/UI/sd-ui/src/utils/timeUtils.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { formatToUserTime, getDefaultGameWeekday } from './timeUtils';
+
+// 2026-08-15 is a Saturday; 2026-08-16 a Sunday; 2026-08-13 a Thursday.
+// 17:00Z renders 1:00 PM in the default Eastern zone (EDT) — safely away
+// from the midnight-means-TBD sentinel.
+const SAT = '2026-08-15T17:00:00Z';
+const SUN = '2026-08-16T17:00:00Z';
+const THU = '2026-08-13T17:00:00Z';
+
+describe('getDefaultGameWeekday', () => {
+  it('maps NCAAFB to Saturday and NFL to Sunday, from enum names or slugs', () => {
+    expect(getDefaultGameWeekday('FootballNcaa')).toBe(6);
+    expect(getDefaultGameWeekday('football-ncaa')).toBe(6);
+    expect(getDefaultGameWeekday('FootballNfl')).toBe(7);
+    expect(getDefaultGameWeekday('football-nfl')).toBe(7);
+  });
+
+  it('is null (always show the day) for sports without a dominant day', () => {
+    expect(getDefaultGameWeekday('BaseballMlb')).toBeNull();
+    expect(getDefaultGameWeekday('baseball-mlb')).toBeNull();
+    expect(getDefaultGameWeekday(undefined)).toBeNull();
+  });
+});
+
+describe('formatToUserTime day parenthetical', () => {
+  it('suppresses the day only on the sport default day', () => {
+    // NCAAFB (Sat default): Saturday bare, Thursday annotated
+    expect(formatToUserTime(SAT, undefined, 6)).toBe('Aug 15 @ 1:00 PM');
+    expect(formatToUserTime(THU, undefined, 6)).toBe('Aug 13 (Thu) @ 1:00 PM');
+
+    // NFL (Sun default): Sunday bare, SATURDAY ANNOTATED — the preseason
+    // regression this exists for
+    expect(formatToUserTime(SUN, undefined, 7)).toBe('Aug 16 @ 1:00 PM');
+    expect(formatToUserTime(SAT, undefined, 7)).toBe('Aug 15 (Sat) @ 1:00 PM');
+  });
+
+  it('always shows the day when the default is null', () => {
+    expect(formatToUserTime(SAT, undefined, null)).toBe('Aug 15 (Sat) @ 1:00 PM');
+  });
+
+  it('keeps the legacy Saturday default when the parameter is omitted', () => {
+    expect(formatToUserTime(SAT)).toBe('Aug 15 @ 1:00 PM');
+    expect(formatToUserTime(THU)).toBe('Aug 13 (Thu) @ 1:00 PM');
+  });
+});


### PR DESCRIPTION
The matchup card's `(Day)` annotation was hardcoded to suppress Saturdays — correct for the app's NCAAFB-only origins, backwards for NFL: a Saturday preseason game showed no day while every ordinary Sunday game showed `(Sun)`.

- `formatToUserTime` gains a nullable `defaultWeekday` param (defaults to Saturday, so untouched callers keep exact legacy behavior).
- New `getDefaultGameWeekday(sportOrLeague)`: NCAAFB → Saturday, NFL → Sunday, no dominant day (MLB etc.) → null = always show. Accepts backend enum names or route slugs (same convention as `getStartLabel`).
- Wired through `MatchupCard` and both team-schedule components.
- Vitest coverage incl. the NFL-Saturday regression case.

Design intent preserved: the parenthetical is an exception marker — absent on the sport's normal game day, present exactly when a game falls somewhere unusual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Game times now display sport-specific weekday information.
  - NCAA football times omit Saturday when appropriate, while NFL times omit Sunday.
  - Other sports continue showing the weekday for clearer scheduling context.
  - Existing time formatting behavior remains compatible when no sport-specific setting is available.

- **Tests**
  - Added coverage for sport-specific weekday formatting, unsupported sports, missing values, and legacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->