### PR TITLE
fix(mobile): team roundels, not athlete headshots, on game-page leaders

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -29,6 +29,20 @@ import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 
 // ─── BoxScore ─────────────────────────────────────────────────────────────────
 
+
+// Prefer the explicit per-scheme variant; fall back to the default
+// `logoUrl` when the backend hasn't supplied one (legacy data or teams
+// without a curated light/dark asset). Shared by TeamScoreRow and
+// LeadersCard so the two cards can't drift onto different variants.
+function selectTeamLogo(
+  team: ContestOverviewDto['header']['homeTeam'],
+  scheme: ReturnType<typeof useColorScheme>,
+): string | null | undefined {
+  return scheme === 'dark'
+    ? team.logoUrlDark ?? team.logoUrl
+    : team.logoUrlLight ?? team.logoUrl;
+}
+
 function TeamScoreRow({
   team,
   total,
@@ -48,13 +62,7 @@ function TeamScoreRow({
 }) {
   const router = useRouter();
   const scheme = useColorScheme();
-  // Prefer the explicit per-scheme variant; fall back to the default
-  // `logoUrl` when the backend hasn't supplied one (legacy data or
-  // teams without a curated light/dark asset).
-  const logoUrl =
-    scheme === 'dark'
-      ? team.logoUrlDark ?? team.logoUrl
-      : team.logoUrlLight ?? team.logoUrl;
+  const logoUrl = selectTeamLogo(team, scheme);
   return (
     <View style={styles.teamScoreRow}>
       {logoUrl ? (
@@ -188,13 +196,8 @@ function LeadersCard({
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
 
-  // Same per-scheme roundel selection as TeamScoreRow above.
-  const teamLogo = (team: ContestOverviewDto['header']['homeTeam']) =>
-    scheme === 'dark'
-      ? team.logoUrlDark ?? team.logoUrl
-      : team.logoUrlLight ?? team.logoUrl;
-  const awayLogo = teamLogo(awayTeam);
-  const homeLogo = teamLogo(homeTeam);
+  const awayLogo = selectTeamLogo(awayTeam, scheme);
+  const homeLogo = selectTeamLogo(homeTeam, scheme);
 
   if (!categories.length) return null;
 
@@ -215,7 +218,9 @@ function LeadersCard({
                       ContestOverviewLeaders. */}
                   {awayLogo ? (
                     <Image source={{ uri: awayLogo }} style={styles.leaderTeamLogo} resizeMode="contain" />
-                  ) : null}
+                  ) : (
+                    <View style={[styles.leaderTeamLogo, { backgroundColor: theme.separator, borderRadius: 13 }]} />
+                  )}
                   <View style={{ flex: 1 }}>
                     <Text style={[styles.leaderName, { color: theme.text }]} numberOfLines={1}>
                       {l.playerName}
@@ -243,7 +248,9 @@ function LeadersCard({
                 <View key={i} style={[styles.leaderPlayer, { flexDirection: 'row-reverse' }]}>
                   {homeLogo ? (
                     <Image source={{ uri: homeLogo }} style={styles.leaderTeamLogo} resizeMode="contain" />
-                  ) : null}
+                  ) : (
+                    <View style={[styles.leaderTeamLogo, { backgroundColor: theme.separator, borderRadius: 13 }]} />
+                  )}
                   <View style={{ flex: 1, alignItems: 'flex-end' }}>
                     <Text style={[styles.leaderName, { color: theme.text }]} numberOfLines={1}>
                       {l.playerName}

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/game/[id].tsx
@@ -178,15 +178,23 @@ function BoxScoreCard({
 
 function LeadersCard({
   categories,
-  awayName,
-  homeName,
+  awayTeam,
+  homeTeam,
 }: {
   categories: ContestOverviewLeaderCategory[];
-  awayName: string;
-  homeName: string;
+  awayTeam: ContestOverviewDto['header']['awayTeam'];
+  homeTeam: ContestOverviewDto['header']['homeTeam'];
 }) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+
+  // Same per-scheme roundel selection as TeamScoreRow above.
+  const teamLogo = (team: ContestOverviewDto['header']['homeTeam']) =>
+    scheme === 'dark'
+      ? team.logoUrlDark ?? team.logoUrl
+      : team.logoUrlLight ?? team.logoUrl;
+  const awayLogo = teamLogo(awayTeam);
+  const homeLogo = teamLogo(homeTeam);
 
   if (!categories.length) return null;
 
@@ -201,8 +209,12 @@ function LeadersCard({
             <View style={styles.leaderSide}>
               {cat.away.leaders.map((l, i) => (
                 <View key={i} style={styles.leaderPlayer}>
-                  {l.playerHeadshotUrl ? (
-                    <Image source={{ uri: l.playerHeadshotUrl }} style={styles.headshot} resizeMode="cover" />
+                  {/* Team roundel, NOT the player headshot: ESPN-sourced
+                      athlete images are licensed and can't ship — the same
+                      permanent constraint as real team marks. Mirrors web's
+                      ContestOverviewLeaders. */}
+                  {awayLogo ? (
+                    <Image source={{ uri: awayLogo }} style={styles.leaderTeamLogo} resizeMode="contain" />
                   ) : null}
                   <View style={{ flex: 1 }}>
                     <Text style={[styles.leaderName, { color: theme.text }]} numberOfLines={1}>
@@ -229,8 +241,8 @@ function LeadersCard({
             <View style={[styles.leaderSide, { alignItems: 'flex-end' }]}>
               {cat.home.leaders.map((l, i) => (
                 <View key={i} style={[styles.leaderPlayer, { flexDirection: 'row-reverse' }]}>
-                  {l.playerHeadshotUrl ? (
-                    <Image source={{ uri: l.playerHeadshotUrl }} style={styles.headshot} resizeMode="cover" />
+                  {homeLogo ? (
+                    <Image source={{ uri: homeLogo }} style={styles.leaderTeamLogo} resizeMode="contain" />
                   ) : null}
                   <View style={{ flex: 1, alignItems: 'flex-end' }}>
                     <Text style={[styles.leaderName, { color: theme.text }]} numberOfLines={1}>
@@ -247,8 +259,8 @@ function LeadersCard({
             </View>
           </View>
           <View style={styles.leaderTeamLabels}>
-            <Text style={[styles.leaderTeamLabel, { color: theme.textMuted }]}>{awayName}</Text>
-            <Text style={[styles.leaderTeamLabel, { color: theme.textMuted }]}>{homeName}</Text>
+            <Text style={[styles.leaderTeamLabel, { color: theme.textMuted }]}>{awayTeam.displayName}</Text>
+            <Text style={[styles.leaderTeamLabel, { color: theme.textMuted }]}>{homeTeam.displayName}</Text>
           </View>
         </View>
       ))}
@@ -514,8 +526,8 @@ export default function GameDetailScreen() {
             {overview.leaders?.categories?.length ? (
               <LeadersCard
                 categories={overview.leaders.categories}
-                awayName={overview.header.awayTeam.displayName}
-                homeName={overview.header.homeTeam.displayName}
+                awayTeam={overview.header.awayTeam}
+                homeTeam={overview.header.homeTeam}
               />
             ) : null}
             <GameInfoCard info={overview.info} sport={sport} />
@@ -615,7 +627,7 @@ const styles = StyleSheet.create({
     letterSpacing: 0.3,
   },
   leaderPlayer: { flexDirection: 'row', alignItems: 'center', gap: 6 },
-  headshot: { width: 30, height: 30, borderRadius: 15 },
+  leaderTeamLogo: { width: 26, height: 26 },
   leaderName: { fontSize: 12, fontWeight: '600' },
   leaderStat: { fontSize: 11 },
   leaderTeamLabels: {


### PR DESCRIPTION
The mobile game page's Leaders card showed real ESPN athlete headshots. Licensed athlete imagery can't ship — the same permanent constraint as real team marks — and web's `ContestOverviewLeaders` already made this exact correction (headshot removed, team roundel + name/stat line).

Mobile now mirrors web: `LeadersCard` receives the team objects and renders the scheme-aware generated roundel (`logoUrlDark`/`logoUrlLight` → `logoUrl` fallback, same selection as `TeamScoreRow`) beside each leader. tsc clean; jest 107/107.

Known related issue, deliberately out of scope pending a decision: the live BASEBALL cards render at-bat/pitcher headshots on BOTH platforms (web `BaseballGameStatusInProgress`, mobile `GameStatus`) — same constraint, larger design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated game leader displays to show the relevant team logos instead of player headshots.
  * Improved away and home team labeling for greater consistency.
  * Added theme-specific team logo support with a fallback when a themed logo is unavailable.
  * Applied consistent logo styling across team score and leader displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->