### PR TITLE
fix(mobile): page-sheet modals clear the Android status bar

### DIFF
--- a/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
@@ -52,6 +52,11 @@ export function InsightModal({ visible, onClose, matchup, preview, isLoading }: 
       visible={visible}
       animationType="slide"
       presentationStyle="pageSheet"
+      // Android: force the modal window edge-to-edge on EVERY API level so
+      // the usePageSheetTopInset padding is always the right amount — without
+      // this, hosts that place the modal below the status bar would get the
+      // status-bar offset AND the padding (double spacing). iOS ignores it.
+      statusBarTranslucent
       onRequestClose={onClose}
     >
       <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>

--- a/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/InsightModal.tsx
@@ -14,6 +14,7 @@ import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, PreviewResponse } from '@/src/types/models';
 import { formatToUserTime } from '@/src/utils/timeUtils';
 import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
+import { usePageSheetTopInset } from '@/src/hooks/usePageSheetTopInset';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -43,6 +44,7 @@ function Section({ label, children }: { label: string; children: React.ReactNode
 export function InsightModal({ visible, onClose, matchup, preview, isLoading }: InsightModalProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const topInset = usePageSheetTopInset();
   const userTz = useUserTimeZone();
 
   return (
@@ -52,7 +54,7 @@ export function InsightModal({ visible, onClose, matchup, preview, isLoading }: 
       presentationStyle="pageSheet"
       onRequestClose={onClose}
     >
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>
         {/* Header */}
         <View style={[styles.header, { borderBottomColor: theme.border }]}>
           <View style={styles.headerLeft} />

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -12,6 +12,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, TeamComparisonData, TeamStatEntry } from '@/src/types/models';
+import { usePageSheetTopInset } from '@/src/hooks/usePageSheetTopInset';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -175,6 +176,7 @@ export function StatsComparisonModal({
 }: StatsComparisonModalProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const topInset = usePageSheetTopInset();
 
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
 
@@ -198,7 +200,7 @@ export function StatsComparisonModal({
       presentationStyle="pageSheet"
       onRequestClose={onClose}
     >
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>
         {/* Header */}
         <View style={[styles.header, { borderBottomColor: theme.border }]}>
           <View style={styles.headerLeft} />

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -198,6 +198,11 @@ export function StatsComparisonModal({
       visible={visible}
       animationType="slide"
       presentationStyle="pageSheet"
+      // Android: force the modal window edge-to-edge on EVERY API level so
+      // the usePageSheetTopInset padding is always the right amount — without
+      // this, hosts that place the modal below the status bar would get the
+      // status-bar offset AND the padding (double spacing). iOS ignores it.
+      statusBarTranslucent
       onRequestClose={onClose}
     >
       <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>

--- a/src/UI/sd-mobile/src/components/features/leagues/CloneLeagueModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/CloneLeagueModal.tsx
@@ -53,6 +53,11 @@ export function CloneLeagueModal({ visible, league, submitting, onClose, onConfi
       visible={visible && !!league}
       animationType="slide"
       presentationStyle="pageSheet"
+      // Android: force the modal window edge-to-edge on EVERY API level so
+      // the usePageSheetTopInset padding is always the right amount — without
+      // this, hosts that place the modal below the status bar would get the
+      // status-bar offset AND the padding (double spacing). iOS ignores it.
+      statusBarTranslucent
       onRequestClose={submitting ? undefined : onClose}
     >
       <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>

--- a/src/UI/sd-mobile/src/components/features/leagues/CloneLeagueModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/leagues/CloneLeagueModal.tsx
@@ -12,6 +12,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { LeagueSummary } from '@/src/services/api/leaguesApi';
+import { usePageSheetTopInset } from '@/src/hooks/usePageSheetTopInset';
 
 interface Props {
   visible: boolean;
@@ -29,6 +30,7 @@ interface Props {
 export function CloneLeagueModal({ visible, league, submitting, onClose, onConfirm }: Props) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const topInset = usePageSheetTopInset();
 
   const [name, setName] = useState('');
   const [inviteMembers, setInviteMembers] = useState(false);
@@ -53,7 +55,7 @@ export function CloneLeagueModal({ visible, league, submitting, onClose, onConfi
       presentationStyle="pageSheet"
       onRequestClose={submitting ? undefined : onClose}
     >
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>
         <View style={[styles.header, { borderBottomColor: theme.border }]}>
           <Text style={[styles.headerTitle, { color: theme.text }]}>Duplicate league</Text>
           <TouchableOpacity onPress={onClose} disabled={submitting} hitSlop={12}>

--- a/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
@@ -12,6 +12,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
+import { usePageSheetTopInset } from '@/src/hooks/usePageSheetTopInset';
 
 export interface ImportItemRow {
   contestId: string;
@@ -42,6 +43,7 @@ interface Props {
 export function ImportPicksModal({ visible, sources, importing, onClose, onImport }: Props) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const topInset = usePageSheetTopInset();
 
   const [selectedSourceId, setSelectedSourceId] = useState<string | null>(
     sources[0]?.leagueId ?? null,
@@ -105,7 +107,7 @@ export function ImportPicksModal({ visible, sources, importing, onClose, onImpor
       presentationStyle="pageSheet"
       onRequestClose={importing ? undefined : onClose}
     >
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>
         <View style={[styles.header, { borderBottomColor: theme.border }]}>
           <Text style={[styles.headerTitle, { color: theme.text }]}>Import picks</Text>
           <TouchableOpacity onPress={onClose} disabled={importing} hitSlop={12}>

--- a/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/picks/ImportPicksModal.tsx
@@ -105,6 +105,11 @@ export function ImportPicksModal({ visible, sources, importing, onClose, onImpor
       visible={visible}
       animationType="slide"
       presentationStyle="pageSheet"
+      // Android: force the modal window edge-to-edge on EVERY API level so
+      // the usePageSheetTopInset padding is always the right amount — without
+      // this, hosts that place the modal below the status bar would get the
+      // status-bar offset AND the padding (double spacing). iOS ignores it.
+      statusBarTranslucent
       onRequestClose={importing ? undefined : onClose}
     >
       <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>

--- a/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
@@ -119,6 +119,11 @@ export function TimezonePickerModal({
       visible={visible}
       animationType="slide"
       presentationStyle="pageSheet"
+      // Android: force the modal window edge-to-edge on EVERY API level so
+      // the usePageSheetTopInset padding is always the right amount — without
+      // this, hosts that place the modal below the status bar would get the
+      // status-bar offset AND the padding (double spacing). iOS ignores it.
+      statusBarTranslucent
       onRequestClose={handleClose}
     >
       <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>

--- a/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/settings/TimezonePickerModal.tsx
@@ -12,6 +12,7 @@ import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import { DEFAULT_TIMEZONE } from '@/src/utils/timeUtils';
+import { usePageSheetTopInset } from '@/src/hooks/usePageSheetTopInset';
 
 /**
  * Curated short-list mirrors the web SettingsPage. Order matters: Eastern,
@@ -66,6 +67,7 @@ export function TimezonePickerModal({
 }: TimezonePickerModalProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
+  const topInset = usePageSheetTopInset();
 
   const allZones = useMemo(() => getAllIanaZones(), []);
   const isCurated = CURATED_TIMEZONES.some((z) => z.value === currentTimezone);
@@ -119,7 +121,7 @@ export function TimezonePickerModal({
       presentationStyle="pageSheet"
       onRequestClose={handleClose}
     >
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, { backgroundColor: theme.background, paddingTop: topInset }]}>
         <View style={[styles.header, { borderBottomColor: theme.border }]}>
           <View style={styles.headerLeft} />
           <Text style={[styles.headerTitle, { color: theme.text }]}>Timezone</Text>

--- a/src/UI/sd-mobile/src/hooks/usePageSheetTopInset.ts
+++ b/src/UI/sd-mobile/src/hooks/usePageSheetTopInset.ts
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import { Platform, StatusBar } from 'react-native';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+
+/**
+ * Top padding for full-screen Modal content on Android.
+ *
+ * `presentationStyle="pageSheet"` is an iOS-only prop: iOS presents the
+ * sheet below the status bar, but Android ignores it and renders the
+ * Modal edge-to-edge, so a modal's header row (title + close button)
+ * lands underneath the system status bar icons. Every page-sheet modal
+ * applies this inset as `paddingTop` on its root container.
+ *
+ * Returns 0 on iOS (the native sheet already clears the status bar).
+ * On Android, prefers the safe-area inset and falls back to
+ * `StatusBar.currentHeight` for the rare host where the modal window
+ * reports a zero inset. Reads the insets context directly (not
+ * useSafeAreaInsets, which THROWS with no provider) so component tests
+ * can render modal-bearing trees without a SafeAreaProvider — the
+ * StatusBar fallback covers that path.
+ */
+export function usePageSheetTopInset(): number {
+  const insets = useContext(SafeAreaInsetsContext);
+  if (Platform.OS !== 'android') return 0;
+  return Math.max(insets?.top ?? 0, StatusBar.currentHeight ?? 0);
+}


### PR DESCRIPTION
`presentationStyle="pageSheet"` is iOS-only: iOS presents the sheet below the status bar; Android ignores the prop and renders the Modal edge-to-edge, putting the modal header (title + ✕) under the system status-bar icons. Reported on the AI Preview dialog — an audit found the same defect in all five page-sheet modals.

- New `usePageSheetTopInset`: 0 on iOS; Android = max(safe-area top inset, `StatusBar.currentHeight`). Reads `SafeAreaInsetsContext` directly (non-throwing) so component tests don't need `SafeAreaProvider` scaffolding — the StatusBar fallback covers provider-less renders.
- Applied as root-container `paddingTop` in InsightModal, StatsComparisonModal, CloneLeagueModal, ImportPicksModal, TimezonePickerModal.
- Transparent bottom-sheets (ConfidencePicker, JoinLeagueConfirmSheet) are unaffected by design.

tsc clean; jest 107/107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved page-sheet modal layouts across games, leagues, picks, and settings.
  - Added appropriate top spacing on Android to account for the status bar and safe-area insets.
  - Prevented modal content from appearing beneath system UI elements.
  - Improved edge-to-edge modal behavior for more consistent positioning across supported devices.
  - Applied safer inset handling in environments where safe-area information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->