### PR TITLE
fix: stop AthleteSeason fabrication — saga tier removal + corroborated binding

### DIFF
--- a/docs/audit/athlete-season-fabrication-remediation.md
+++ b/docs/audit/athlete-season-fabrication-remediation.md
@@ -1,0 +1,175 @@
+# AthleteSeason fabrication — findings and remediation design
+
+**Status**: findings verified in prod 2026-08-15; remediation NOT yet
+executed. This document is the authorization gate for the campaign.
+**Blocks**: player pick'em go-live (data-correctness gate, per the
+feature's athlete-stat audit prerequisite). Does NOT block current-season
+surfaces — see impact triage.
+
+## Finding
+
+`AthleteSeason` is dominated by fabricated rows binding modern athletes
+to historical franchise-seasons they never played in.
+
+Exhibit: DJ Pickett (LSU CB, true freshman class of 2025) carries an
+LSU `AthleteSeason` row for **every season 1990–2026** — 35 rows, one
+per historical LSU `FranchiseSeason`, created near-daily through the
+March 2026 historical backfill (`sql/pgsql/_debug_athleteSeasons.sql`
+preserves the discovery trail).
+
+Scale (distinct season-years per athlete-franchise pair):
+
+| DB | 1–6 seasons (plausible) | 7–19 | 20+ (fabricated class) |
+|---|---|---|---|
+| FootballNcaa | 73,037 | 265* | 99,572 |
+| FootballNfl | 11,714 | 3,081 | 16,930 |
+
+\* NCAA 7–19 partially legitimate (long careers are not); NFL 7–19
+contains real long careers AND fabrication tails — classification is
+per-row (below), not per-bucket.
+
+NCAAFB row count: **3,617,609** `AthleteSeason` rows for 153,005
+athletes; the fabricated class accounts for roughly 3.4M.
+
+## Root cause
+
+An ESPN API quirk multiplied by our historical backfill:
+
+1. **ESPN's league-level season athletes index is not season-scoped.**
+   `GET /v2/.../seasons/1994/athletes` returns count=104,244 — the
+   entire athlete database re-rendered under every season path. The
+   per-athlete docs under those paths (`/seasons/1994/athletes/5141632`)
+   resolve and render the athlete's **current** team as `Team.$ref`
+   under the requested season (`/seasons/1994/teams/99`).
+2. **The per-team roster index IS season-scoped and honest.**
+   `/seasons/{year}/teams/{id}/athletes` returns real rosters from
+   roughly 2004 onward (LSU probe: 2000=0, 2002=0, 2004=62, 2006=58,
+   2010=58, 2014+=137–170) and empty before.
+3. **The March 2026 historical backfill sourced the league-level index
+   per season.** `AthleteSeasonDocumentProcessor.TryResolveFranchiseSeasonIdAsync`
+   trusts the doc's `Team.$ref` at face value, minting an
+   `AthleteSeason` that binds the modern athlete to the historical
+   franchise-season.
+
+**Why the purge predicate cannot be "created by that campaign"**: for an
+athlete who genuinely played in season X, the same flow produced a
+CORRECT row (ESPN renders their real season-X team under the season-X
+path). Correct and fabricated rows are interleaved within the same
+sourcing campaign, same timestamps, same creator identity.
+
+## Design principle (mirrors ESPN's own product)
+
+ESPN's site never shows historical rosters. A team page has a roster
+for the CURRENT season only; a former player's page shows
+season-by-season STATS — participation evidence, not roster claims.
+
+Adopt the same contract:
+
+- **`AthleteSeason` = roster membership**, trustworthy only where a
+  roster document exists (roster era, ~2004+) or where game
+  participation proves it.
+- **Historical career views derive from participation** (statistics,
+  competitions, leader rows), not from `AthleteSeason` coverage.
+- Pre-roster-era seasons get NO dependent-less `AthleteSeason` rows.
+  An athlete with 2001 game stats keeps their row via evidence; a
+  roster claim with no evidence does not exist.
+
+## Remediation phases
+
+### Phase 0 — stop the bleeding (code, PR) — IMPLEMENTED
+
+- **Provider**: the historical sourcing saga's AthleteSeason tier
+  (Tier 4) is removed — saga finalizes after TeamSeason; the
+  `HistoricalSourcingUriBuilder` mapping for the league-level index is
+  gone (any legacy tier-4 job that slips through now throws instead of
+  building the poisoned URL); legacy tier-4 `ResourceIndexJobs` rows
+  are excluded from force-reschedule.
+- **Producer guard — corroborated binding** (required, not belt: ~3.4M
+  poisoned docs remain CACHED IN MONGO, and any replay would otherwise
+  recreate rows post-purge): `AthleteSeasonDocumentProcessor` binds
+  `FranchiseSeasonId` ONLY when the command's `ParentId` equals the
+  resolved franchise-season's canonical id — the provenance only the
+  TeamSeason roster cascade provides (Provider propagates ParentId
+  through index fan-out). Uncorroborated docs still create/update the
+  row **unbound** (dependency consumers — injuries, leaders, play
+  participants — FK to the row and retry until it exists, so skipping
+  creation would loop them; the binding is the poison, not the row),
+  and an uncorroborated update never strips a roster-established
+  binding. The roster cascade binds on its next pass.
+
+### Phase 1 — evidence inventory (read-only SQL, both DBs)
+
+Classify every `AthleteSeason` row:
+
+- **KEEP-dependent**: referenced by any of `AthleteCompetition`,
+  `AthleteCompetitionStatistic`, `AthleteSeasonStatistic`,
+  `AthleteSeasonInjury`, `AthleteSeasonNotes`, `CompetitionLeaderStat`,
+  `FranchiseSeasonLeaderStat`, `SeasonFutureBook` — participation or
+  business evidence.
+- **KEEP-roster**: (athlete, franchise-season) appears in that
+  season's re-sourced ESPN team roster (roster era only).
+- **PURGE**: everything else — which includes ALL dependent-less
+  pre-roster-era rows (unverifiable by design) and roster-era rows
+  ESPN's roster disowns.
+
+Inventory queries emit counts per class per season-year; the report is
+reviewed BEFORE phase 2 runs (halt-on-surprise, same discipline as the
+metrics campaign gates).
+
+### Phase 2 — purge (batched deletes, both DBs)
+
+- Delete PURGE rows + their `AthleteSeasonExternalId` children (the
+  only dependent they can have, by classification).
+- Batched (e.g., 50k/transaction), logged counts per batch,
+  resumable; the metricbot-pod orchestrator idiom from the metrics
+  recompute campaign applies directly.
+
+### Phase 3 — roster-era rebuild + gates
+
+- Re-source team rosters for every franchise-season in the roster era
+  (existing `TeamSeason` linked-document flow — the same filtered
+  re-sourcing machinery as #618/#619).
+- Gates, per franchise-season: roster count within sanity bounds
+  (NCAA 40–150; NFL 40–95); zero athletes with >6 distinct season-years
+  per franchise (NCAA) / >23 (NFL, career-length bound); the DJ Pickett
+  probe returns exactly his real rows.
+- Spot parity: N sampled rosters diffed against ESPN's live roster
+  index.
+
+## Impact triage
+
+- **NOT blocked**: current-season (2025/2026) rosters — sourced via the
+  legitimate roster flow; the LSU 2026 roster in the discovery file is
+  correct. Player pick'em's carry-over-lineup core reads current
+  rosters.
+- **Poisoned until remediation**: any historical roster view, athlete
+  career timelines derived from AthleteSeason, per-season athlete
+  counts, and any consumer that trusts (athlete, franchise-season)
+  affiliation historically.
+- **Avatar batch (marks pipeline)**: unaffected — the athletes dump
+  picks each athlete's MOST RECENT affiliation, which is the real one
+  for modern athletes (fabrication attaches modern athletes backward,
+  never old athletes forward). Optional post-purge regen tightens the
+  dump's athlete set.
+- **Metrics/MetricBot**: unaffected — competition metrics never read
+  AthleteSeason.
+
+## Decisions (Randall, 2026-08-15)
+
+1. **NFL first** — dress rehearsal for the runbook; a mistake on
+   NCAAFB would delay player pick'em. NCAAFB runs after NFL review.
+2. **Rebuild floor: 2000** — ESPN rosters materialize ~2004; running
+   the rebuild back to 2000 is no-harm-no-foul (empty roster index =
+   no documents = no rows).
+3. **Timing: now** — this is the current focus.
+4. **Rebuild mechanism** (verified end-to-end): per seasonYear, POST
+   the existing `RequestFranchiseSeasonSourcing` endpoint (#618) —
+   **current season (2026) with NO filter** (full cascade: odds, records,
+   everything fresh), **historical seasons (2000–2025) with
+   `IncludeLinkedDocumentTypes: ["AthleteSeason"]`** — caught by
+   `TeamSeasonDocumentProcessor`'s athletes spawn filter, which follows
+   the doc's own season-scoped per-team roster ref.
+5. **Purge before rebuild**: batched delete of dependent-less
+   `AthleteSeason` rows (+ their `AthleteSeasonExternalId`), then the
+   roster rebuild recreates roster-era membership under the
+   corroborated-binding contract.

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessor.cs
@@ -84,6 +84,31 @@ public class AthleteSeasonDocumentProcessor<TDataContext> : DocumentProcessorBas
             _logger.LogDebug("No Team.Ref on AthleteSeason {Ref} — placeholder athlete, proceeding without FranchiseSeasonId", dto.Ref);
         }
 
+        // FABRICATION GUARD: ESPN renders an athlete-season doc under ANY
+        // season path, with Team.$ref pointing at the athlete's CURRENT team
+        // re-rendered under that season — so the doc's own Team.Ref is NOT
+        // evidence the athlete belonged to that franchise-season (this
+        // fabricated millions of rows via the league-level athletes index;
+        // see docs/audit/athlete-season-fabrication-remediation.md).
+        // The binding is trusted only when the command DESCENDS from that
+        // franchise-season's own TeamSeason cascade: the roster child request
+        // carries the FranchiseSeason canonical id as ParentId, and Provider
+        // propagates ParentId through index fan-out. Uncorroborated docs
+        // still create/update the row (dependency consumers FK to the row,
+        // not the binding) but never bind — the roster cascade binds later.
+        var bindingCorroborated =
+            franchiseSeasonId is not null &&
+            Guid.TryParse(command.ParentId, out var parentGuid) &&
+            parentGuid == franchiseSeasonId.Value;
+
+        if (franchiseSeasonId is not null && !bindingCorroborated)
+        {
+            _logger.LogInformation(
+                "Uncorroborated Team.Ref on AthleteSeason {Ref} (ParentId={ParentId}) — proceeding UNBOUND; the TeamSeason roster cascade owns the binding",
+                dto.Ref, command.ParentId);
+            franchiseSeasonId = null;
+        }
+
         var positionId = await TryResolvePositionIdAsync(dto, command);
         if (positionId == Guid.Empty)
         {
@@ -162,7 +187,10 @@ public class AthleteSeasonDocumentProcessor<TDataContext> : DocumentProcessorBas
         entity.ExperienceDisplayValue = newEntity.ExperienceDisplayValue;
         entity.ExperienceYears = newEntity.ExperienceYears;
         entity.FirstName = newEntity.FirstName;
-        entity.FranchiseSeasonId = franchiseSeasonId;
+        // Corroborated bindings overwrite (transfers rebind to the new
+        // franchise-season); uncorroborated/placeholder updates arrive with
+        // a null binding and must NOT strip one the roster cascade set.
+        entity.FranchiseSeasonId = franchiseSeasonId ?? entity.FranchiseSeasonId;
         entity.HeightDisplay = newEntity.HeightDisplay;
         entity.HeightDisplay = newEntity.HeightDisplay;
         entity.HeightIn = newEntity.HeightIn;

--- a/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSeasonSourcingService.cs
+++ b/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSeasonSourcingService.cs
@@ -241,10 +241,12 @@ public class HistoricalSeasonSourcingService : IHistoricalSeasonSourcingService
                 x.Provider == request.SourceDataProvider &&
                 x.SportId == _sport &&
                 x.SeasonYear == request.SeasonYear &&
+                // AthleteSeason intentionally excluded: legacy tier-4 job
+                // rows from pre-remediation campaigns must never be
+                // rescheduled (they source the poisoned league-level index).
                 (x.DocumentType == DocumentType.Season ||
                  x.DocumentType == DocumentType.Venue ||
-                 x.DocumentType == DocumentType.TeamSeason ||
-                 x.DocumentType == DocumentType.AthleteSeason))
+                 x.DocumentType == DocumentType.TeamSeason))
             .ToListAsync(cancellationToken);
     }
 
@@ -268,7 +270,6 @@ public class HistoricalSeasonSourcingService : IHistoricalSeasonSourcingService
                     DocumentType.Season => tierDelays.Season,
                     DocumentType.Venue => tierDelays.Venue,
                     DocumentType.TeamSeason => tierDelays.TeamSeason,
-                    DocumentType.AthleteSeason => tierDelays.AthleteSeason,
                     _ => LogUnexpectedDocumentType(job.DocumentType)
                 };
 
@@ -379,12 +380,14 @@ public class HistoricalSeasonSourcingService : IHistoricalSeasonSourcingService
     /// </summary>
     private static TierDefinition[] DefineTiers(TierDelays tierDelays)
     {
+        // No AthleteSeason tier: the league-level athletes index is not
+        // season-scoped (see HistoricalSourcingUriBuilder) — athlete-seasons
+        // flow from the TeamSeason cascade's per-team roster ref.
         return
         [
             new TierDefinition(DocumentType.Season, ResourceShape.Leaf, tierDelays.Season),
             new TierDefinition(DocumentType.Venue, ResourceShape.Index, tierDelays.Venue),
-            new TierDefinition(DocumentType.TeamSeason, ResourceShape.Index, tierDelays.TeamSeason),
-            new TierDefinition(DocumentType.AthleteSeason, ResourceShape.Index, tierDelays.AthleteSeason)
+            new TierDefinition(DocumentType.TeamSeason, ResourceShape.Index, tierDelays.TeamSeason)
         ];
     }
 

--- a/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSeasonSourcingService.cs
+++ b/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSeasonSourcingService.cs
@@ -601,7 +601,7 @@ public class HistoricalSeasonSourcingService : IHistoricalSeasonSourcingService
     }
 
     /// <summary>
-    /// Creates ResourceIndex entities for all 4 tiers WITHOUT scheduling them in Hangfire.
+    /// Creates ResourceIndex entities for all tiers WITHOUT scheduling them in Hangfire.
     /// Used by saga-based orchestration where the saga triggers each tier via events.
     /// Idempotent: Returns existing correlationId if ResourceIndex entities already exist for this Sport/Season/Provider.
     /// </summary>
@@ -687,7 +687,8 @@ public class HistoricalSeasonSourcingService : IHistoricalSeasonSourcingService
             await _dataContext.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation(
-                "✅ All 4 ResourceIndex entities created for saga. CorrelationId={CorrelationId}",
+                "✅ All {TierCount} ResourceIndex entities created for saga. CorrelationId={CorrelationId}",
+                tiers.Length,
                 correlationId);
 
             return correlationId;

--- a/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSeasonSourcingService.cs
+++ b/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSeasonSourcingService.cs
@@ -648,14 +648,16 @@ public class HistoricalSeasonSourcingService : IHistoricalSeasonSourcingService
                 "Creating NEW ResourceIndex entities for saga orchestration. Year={Year}",
                 request.SeasonYear);
 
-            // Define all 4 tiers (delays don't matter for saga - saga controls timing)
-            // ResourceShape must match DefineTiers to ensure consistent execution paths
+            // Define the 3 tiers (delays don't matter for saga - saga controls timing)
+            // ResourceShape must match DefineTiers to ensure consistent execution paths.
+            // No AthleteSeason tier — the league-level athletes index is not
+            // season-scoped (see HistoricalSourcingUriBuilder, which now throws
+            // for that type).
             var tiers = new[]
             {
                 (DocumentType.Season, ResourceShape.Leaf),  // Single document, no pagination
                 (DocumentType.Venue, ResourceShape.Index),
-                (DocumentType.TeamSeason, ResourceShape.Index),
-                (DocumentType.AthleteSeason, ResourceShape.Index)
+                (DocumentType.TeamSeason, ResourceShape.Index)
             };
 
             var baseOrdinal = GenerateBaseOrdinal();

--- a/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSourcingUriBuilder.cs
+++ b/src/SportsData.Provider/Application/Sourcing/Historical/HistoricalSourcingUriBuilder.cs
@@ -44,7 +44,14 @@ public class HistoricalSourcingUriBuilder : IHistoricalSourcingUriBuilder
             DocumentType.Venue => $"{baseUrl}/venues",
 
             DocumentType.TeamSeason => $"{baseUrl}/seasons/{seasonYear}/teams",
-            DocumentType.AthleteSeason => $"{baseUrl}/seasons/{seasonYear}/athletes",
+
+            // DocumentType.AthleteSeason is deliberately ABSENT. ESPN's
+            // league-level /seasons/{year}/athletes index is NOT
+            // season-scoped: it returns the full athlete database under
+            // every season path with each athlete's CURRENT team as
+            // Team.$ref, which fabricated millions of AthleteSeason rows
+            // (docs/audit/athlete-season-fabrication-remediation.md).
+            // Athlete-seasons come from the TeamSeason roster cascade only.
             _ => throw new ArgumentException(
                 $"Document type {documentType} is not supported for historical sourcing")
         };

--- a/src/SportsData.Provider/Application/Sourcing/Historical/Saga/HistoricalSeasonSourcingSaga.cs
+++ b/src/SportsData.Provider/Application/Sourcing/Historical/Saga/HistoricalSeasonSourcingSaga.cs
@@ -7,8 +7,18 @@ using SportsData.Core.Eventing.Events.Documents;
 namespace SportsData.Provider.Application.Sourcing.Historical.Saga;
 
 /// <summary>
-/// Orchestrates historical season sourcing across four tiers: Season → Venue → TeamSeason → AthleteSeason.
+/// Orchestrates historical season sourcing across three tiers:
+/// Season → Venue → TeamSeason.
 /// Uses completion events from Producer to trigger each subsequent tier progressively.
+///
+/// There is deliberately NO AthleteSeason tier. ESPN's league-level
+/// /seasons/{year}/athletes index is NOT season-scoped — it returns the
+/// entire athlete database under every season path, with each athlete's
+/// CURRENT team rendered as Team.$ref. Sourcing it fabricated millions of
+/// AthleteSeason rows binding modern athletes to historical seasons (see
+/// docs/audit/athlete-season-fabrication-remediation.md). Athlete-seasons
+/// are born exclusively from the TeamSeason cascade's per-team roster ref,
+/// which IS season-scoped (and empty for pre-roster-era seasons).
 /// </summary>
 public class HistoricalSeasonSourcingSaga : MassTransitStateMachine<HistoricalSeasonSourcingState>
 {
@@ -23,6 +33,9 @@ public class HistoricalSeasonSourcingSaga : MassTransitStateMachine<HistoricalSe
     public State WaitingForSeasonCompletion { get; private set; } = null!;
     public State WaitingForVenueCompletion { get; private set; } = null!;
     public State WaitingForTeamSeasonCompletion { get; private set; } = null!;
+    // Legacy state: the AthleteSeason tier was removed (see class doc). The
+    // state stays DECLARED so persisted saga instances parked in it still
+    // resolve by name; nothing transitions into it anymore.
     public State WaitingForAthleteSeasonCompletion { get; private set; } = null!;
 
     public Event<SeasonSourcingStarted> SourcingStarted { get; private set; } = null!;
@@ -208,53 +221,8 @@ public class HistoricalSeasonSourcingSaga : MassTransitStateMachine<HistoricalSe
                                 new KeyValuePair<string, object?>("provider", context.Saga.Provider.ToString()),
                                 new KeyValuePair<string, object?>("tier", "TeamSeason"));
 
-                            _logger.LogInformation(
-                                "🎯 TIER3_COMPLETE: TeamSeason tier completed, triggering AthleteSeason tier. " +
-                                "CorrelationId={CorrelationId}, EventsReceived={EventsReceived}, Duration={Duration}s",
-                                context.Saga.CorrelationId,
-                                context.Saga.TeamSeasonCompletionEventsReceived,
-                                (context.Saga.TeamSeasonCompletedUtc.Value - context.Saga.VenueCompletedUtc!.Value).TotalSeconds);
-                        })
-                        .PublishAsync(context => context.Init<TriggerTierSourcing>(new
-                        {
-                            context.Saga.CorrelationId,
-                            context.Saga.Sport,
-                            context.Saga.SeasonYear,
-                            context.Saga.Provider,
-                            Tier = 4,
-                            TierName = "AthleteSeason"
-                        }))
-                        .TransitionTo(WaitingForAthleteSeasonCompletion))
-        );
-
-        // Tier 4: AthleteSeason → Completed
-        During(WaitingForAthleteSeasonCompletion,
-            When(DocumentCompleted, context => context.Message.DocumentType == DocumentType.AthleteSeason)
-                .Then(context =>
-                {
-                    context.Saga.AthleteSeasonCompletionEventsReceived++;
-                    
-                    _logger.LogInformation(
-                        "✅ TIER4_PROGRESS: AthleteSeason completion event received ({Count}/{Threshold}). " +
-                        "CorrelationId={CorrelationId}, DocumentType={DocumentType}",
-                        context.Saga.AthleteSeasonCompletionEventsReceived,
-                        _config.SagaConfig.CompletionThreshold,
-                        context.Saga.CorrelationId,
-                        context.Message.DocumentType);
-                })
-                .If(context => context.Saga.AthleteSeasonCompletionEventsReceived >= _config.SagaConfig.CompletionThreshold,
-                    binder => binder
-                        .Then(context =>
-                        {
                             context.Saga.CompletedUtc = DateTime.UtcNow;
-                            
                             var totalDuration = (context.Saga.CompletedUtc.Value - context.Saga.StartedUtc).TotalSeconds;
-                            
-                            _tierCompletedCounter.Add(1,
-                                new KeyValuePair<string, object?>("sport", context.Saga.Sport.ToString()),
-                                new KeyValuePair<string, object?>("season", context.Saga.SeasonYear),
-                                new KeyValuePair<string, object?>("provider", context.Saga.Provider.ToString()),
-                                new KeyValuePair<string, object?>("tier", "AthleteSeason"));
 
                             _sagaCompletedCounter.Add(1,
                                 new KeyValuePair<string, object?>("sport", context.Saga.Sport.ToString()),
@@ -267,22 +235,22 @@ public class HistoricalSeasonSourcingSaga : MassTransitStateMachine<HistoricalSe
                                 new KeyValuePair<string, object?>("provider", context.Saga.Provider.ToString()));
 
                             _logger.LogInformation(
-                                "🏁 SAGA_COMPLETE: All tiers completed successfully! " +
+                                "🏁 SAGA_COMPLETE: TeamSeason tier completed — final tier (AthleteSeason " +
+                                "tier removed; athlete-seasons flow from the TeamSeason roster cascade). " +
                                 "CorrelationId={CorrelationId}, Sport={Sport}, Season={Season}, " +
                                 "TotalDuration={TotalDuration}s, " +
-                                "Tier1Events={Tier1Events}, Tier2Events={Tier2Events}, " +
-                                "Tier3Events={Tier3Events}, Tier4Events={Tier4Events}",
+                                "Tier1Events={Tier1Events}, Tier2Events={Tier2Events}, Tier3Events={Tier3Events}",
                                 context.Saga.CorrelationId,
                                 context.Saga.Sport,
                                 context.Saga.SeasonYear,
                                 totalDuration,
                                 context.Saga.SeasonCompletionEventsReceived,
                                 context.Saga.VenueCompletionEventsReceived,
-                                context.Saga.TeamSeasonCompletionEventsReceived,
-                                context.Saga.AthleteSeasonCompletionEventsReceived);
+                                context.Saga.TeamSeasonCompletionEventsReceived);
                         })
                         .Finalize())
         );
+
     }
 }
 

--- a/src/SportsData.Provider/Application/Sourcing/Historical/Saga/HistoricalSeasonSourcingSaga.cs
+++ b/src/SportsData.Provider/Application/Sourcing/Historical/Saga/HistoricalSeasonSourcingSaga.cs
@@ -251,6 +251,36 @@ public class HistoricalSeasonSourcingSaga : MassTransitStateMachine<HistoricalSe
                         .Finalize())
         );
 
+        // LEGACY DRAIN: instances persisted in the removed Tier 4 state.
+        // Nothing schedules AthleteSeason work anymore, but a saga that had
+        // already triggered Tier 4 before this deploy still receives
+        // completion events for the in-flight documents — count them and
+        // finalize at threshold exactly as the old tier did, so those
+        // instances terminate instead of parking forever.
+        During(WaitingForAthleteSeasonCompletion,
+            When(DocumentCompleted, context => context.Message.DocumentType == DocumentType.AthleteSeason)
+                .Then(context =>
+                {
+                    context.Saga.AthleteSeasonCompletionEventsReceived++;
+
+                    _logger.LogInformation(
+                        "LEGACY_TIER4_DRAIN: AthleteSeason completion received ({Count}/{Threshold}) for a pre-remediation saga instance. " +
+                        "CorrelationId={CorrelationId}",
+                        context.Saga.AthleteSeasonCompletionEventsReceived,
+                        _config.SagaConfig.CompletionThreshold,
+                        context.Saga.CorrelationId);
+                })
+                .If(context => context.Saga.AthleteSeasonCompletionEventsReceived >= _config.SagaConfig.CompletionThreshold,
+                    binder => binder
+                        .Then(context =>
+                        {
+                            context.Saga.CompletedUtc = DateTime.UtcNow;
+                            _logger.LogInformation(
+                                "LEGACY_TIER4_DRAIN: pre-remediation saga instance finalized. CorrelationId={CorrelationId}",
+                                context.Saga.CorrelationId);
+                        })
+                        .Finalize())
+        );
     }
 }
 

--- a/src/SportsData.Provider/Application/Sourcing/Historical/Saga/HistoricalSeasonSourcingSaga.cs
+++ b/src/SportsData.Provider/Application/Sourcing/Historical/Saga/HistoricalSeasonSourcingSaga.cs
@@ -275,9 +275,31 @@ public class HistoricalSeasonSourcingSaga : MassTransitStateMachine<HistoricalSe
                         .Then(context =>
                         {
                             context.Saga.CompletedUtc = DateTime.UtcNow;
+                            var totalDuration = (context.Saga.CompletedUtc.Value - context.Saga.StartedUtc).TotalSeconds;
+
+                            // Same terminal telemetry as the active completion
+                            // path — a drained legacy instance is still a
+                            // completed saga on the dashboards.
+                            _tierCompletedCounter.Add(1,
+                                new KeyValuePair<string, object?>("sport", context.Saga.Sport.ToString()),
+                                new KeyValuePair<string, object?>("season", context.Saga.SeasonYear),
+                                new KeyValuePair<string, object?>("provider", context.Saga.Provider.ToString()),
+                                new KeyValuePair<string, object?>("tier", "AthleteSeason"));
+
+                            _sagaCompletedCounter.Add(1,
+                                new KeyValuePair<string, object?>("sport", context.Saga.Sport.ToString()),
+                                new KeyValuePair<string, object?>("season", context.Saga.SeasonYear),
+                                new KeyValuePair<string, object?>("provider", context.Saga.Provider.ToString()));
+
+                            _sagaDurationHistogram.Record(totalDuration,
+                                new KeyValuePair<string, object?>("sport", context.Saga.Sport.ToString()),
+                                new KeyValuePair<string, object?>("season", context.Saga.SeasonYear),
+                                new KeyValuePair<string, object?>("provider", context.Saga.Provider.ToString()));
+
                             _logger.LogInformation(
-                                "LEGACY_TIER4_DRAIN: pre-remediation saga instance finalized. CorrelationId={CorrelationId}",
-                                context.Saga.CorrelationId);
+                                "LEGACY_TIER4_DRAIN: pre-remediation saga instance finalized. CorrelationId={CorrelationId}, TotalDuration={TotalDuration}s",
+                                context.Saga.CorrelationId,
+                                totalDuration);
                         })
                         .Finalize())
         );

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessorTests.cs
@@ -144,7 +144,10 @@ public class AthleteSeasonDocumentProcessorTests :
             .With(x => x.DocumentType, DocumentType.AthleteSeason)
             .With(x => x.Document, json)
             .With(x => x.UrlHash, dtoIdentity.UrlHash)
-            .Without(x => x.ParentId)
+            // The TeamSeason roster cascade passes the FranchiseSeason
+            // canonical id as ParentId — that provenance is what authorizes
+            // the FranchiseSeasonId binding (fabrication guard).
+            .With(x => x.ParentId, franchiseSeasonId.ToString())
             .Create();
 
         // Act
@@ -909,6 +912,177 @@ public class AthleteSeasonDocumentProcessorTests :
 
         (await FootballDataContext.AthleteSeasons.CountAsync()).Should().Be(1);
     }
+
+    /// <summary>
+    /// FABRICATION GUARD: ESPN renders an athlete-season doc under ANY
+    /// season path with Team.$ref = the athlete's CURRENT team, so a doc
+    /// arriving WITHOUT roster-cascade provenance (ParentId != the resolved
+    /// FranchiseSeason id) must create the row UNBOUND. This is the exact
+    /// vector that fabricated millions of historical roster rows.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_UncorroboratedTeamRef_CreatesUnbound()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<AthleteSeasonDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaAthleteSeason.json");
+        var dto = json.FromJson<EspnAthleteSeasonDto>();
+        var dtoIdentity = generator.Generate(dto!.Ref);
+
+        await SeedGuardDependenciesAsync(generator, dto);
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.DocumentType, DocumentType.AthleteSeason)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, dtoIdentity.UrlHash)
+            .Without(x => x.ParentId)
+            .Create();
+
+        await sut.ProcessAsync(command);
+
+        var entity = await FootballDataContext.AthleteSeasons.FirstOrDefaultAsync();
+        entity.Should().NotBeNull("dependency consumers FK to the row and must not retry-loop");
+        entity!.FranchiseSeasonId.Should().BeNull(
+            "the doc's own Team.Ref is not evidence of season membership — only the roster cascade binds");
+    }
+
+    /// <summary>
+    /// FABRICATION GUARD: an uncorroborated UPDATE (stats cascade, replayed
+    /// doc) must not strip a binding the roster cascade established.
+    /// </summary>
+    [Fact]
+    public async Task ProcessAsync_UncorroboratedUpdate_PreservesExistingBinding()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<AthleteSeasonDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaAthleteSeason.json");
+        var dto = json.FromJson<EspnAthleteSeasonDto>();
+        var dtoIdentity = generator.Generate(dto!.Ref);
+        var franchiseSeasonId = generator.Generate(dto.Team!.Ref!).CanonicalId;
+
+        await SeedGuardDependenciesAsync(generator, dto);
+
+        // Roster cascade creates and binds first
+        var rosterCommand = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.DocumentType, DocumentType.AthleteSeason)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, dtoIdentity.UrlHash)
+            .With(x => x.ParentId, franchiseSeasonId.ToString())
+            .Create();
+        await sut.ProcessAsync(rosterCommand);
+
+        // An uncorroborated replay of the same doc updates the row
+        var replayCommand = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.DocumentType, DocumentType.AthleteSeason)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, dtoIdentity.UrlHash)
+            .Without(x => x.ParentId)
+            .Create();
+        await sut.ProcessAsync(replayCommand);
+
+        var entity = await FootballDataContext.AthleteSeasons.SingleAsync();
+        entity.FranchiseSeasonId.Should().Be(franchiseSeasonId,
+            "an uncorroborated update must preserve the roster-established binding");
+    }
+
+    /// <summary>
+    /// Shared dependency seeding for the guard tests: franchise season (with
+    /// external id matching the dto's Team.Ref), position, athlete.
+    /// </summary>
+    private async Task SeedGuardDependenciesAsync(
+        ExternalRefIdentityGenerator generator, EspnAthleteSeasonDto dto)
+    {
+        var franchiseSeasonIdentity = generator.Generate(dto.Team!.Ref!);
+        var positionIdentity = generator.Generate(dto.Position!.Ref!);
+        var athleteRef = $"http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/athletes/{dto.Id}";
+        var athleteIdentity = generator.Generate(athleteRef);
+
+        var franchiseSeasonId = franchiseSeasonIdentity.CanonicalId;
+        await FootballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+        {
+            Id = franchiseSeasonId,
+            FranchiseId = Guid.NewGuid(),
+            SeasonYear = 2024,
+            Abbreviation = "TEAM",
+            DisplayName = "Team",
+            DisplayNameShort = "T",
+            Location = "Location",
+            Name = "Team",
+            Slug = "team",
+            ColorCodeHex = "#FFFFFF",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds =
+            [
+                new FranchiseSeasonExternalId
+                {
+                    Id = Guid.NewGuid(),
+                    FranchiseSeasonId = franchiseSeasonId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = franchiseSeasonIdentity.CleanUrl,
+                    SourceUrlHash = franchiseSeasonIdentity.UrlHash,
+                    Value = franchiseSeasonIdentity.UrlHash
+                }
+            ]
+        });
+
+        var positionId = Guid.NewGuid();
+        await FootballDataContext.AthletePositions.AddAsync(new AthletePosition
+        {
+            Id = positionId,
+            Abbreviation = "QB",
+            Name = "Quarterback",
+            DisplayName = "Quarterback",
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            ExternalIds =
+            [
+                new AthletePositionExternalId
+                {
+                    Id = Guid.NewGuid(),
+                    AthletePositionId = positionId,
+                    Provider = SourceDataProvider.Espn,
+                    SourceUrl = positionIdentity.CleanUrl,
+                    SourceUrlHash = positionIdentity.UrlHash,
+                    Value = positionIdentity.UrlHash
+                }
+            ]
+        });
+
+        var athleteId = athleteIdentity.CanonicalId;
+        await FootballDataContext.Athletes.AddAsync(new FootballAthlete
+        {
+            Id = athleteId,
+            LastName = dto.LastName,
+            FirstName = dto.FirstName,
+            DisplayName = $"{dto.FirstName} {dto.LastName}",
+            ShortName = dto.LastName,
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.AthleteExternalIds.AddAsync(new AthleteExternalId
+        {
+            Id = Guid.NewGuid(),
+            AthleteId = athleteId,
+            Provider = SourceDataProvider.Espn,
+            SourceUrl = athleteRef,
+            SourceUrlHash = athleteIdentity.UrlHash,
+            Value = dto.Id
+        });
+        await FootballDataContext.SaveChangesAsync();
+    }
+
 }
-
-

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessorTests.cs
@@ -949,6 +949,24 @@ public class AthleteSeasonDocumentProcessorTests :
         entity.Should().NotBeNull("dependency consumers FK to the row and must not retry-loop");
         entity!.FranchiseSeasonId.Should().BeNull(
             "the doc's own Team.Ref is not evidence of season membership — only the roster cascade binds");
+
+        // A parseable-but-WRONG ParentId (e.g. a competition id from a play
+        // cascade) is equally uncorroborated: only the resolved
+        // franchise-season's own id authorizes the binding.
+        var wrongParentCommand = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.DocumentType, DocumentType.AthleteSeason)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, dtoIdentity.UrlHash)
+            .With(x => x.ParentId, Guid.NewGuid().ToString())
+            .Create();
+        await sut.ProcessAsync(wrongParentCommand);
+
+        var updated = await FootballDataContext.AthleteSeasons.SingleAsync();
+        updated.FranchiseSeasonId.Should().BeNull(
+            "any ParentId other than the resolved franchise-season id must not bind");
     }
 
     /// <summary>
@@ -998,6 +1016,9 @@ public class AthleteSeasonDocumentProcessorTests :
             "an uncorroborated update must preserve the roster-established binding");
     }
 
+    // Deterministic seed timestamp (house rule: no DateTime.UtcNow in tests).
+    private static readonly DateTime SeedStamp = new(2024, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+
     /// <summary>
     /// Shared dependency seeding for the guard tests: franchise season (with
     /// external id matching the dto's Team.Ref), position, athlete.
@@ -1023,7 +1044,7 @@ public class AthleteSeasonDocumentProcessorTests :
             Name = "Team",
             Slug = "team",
             ColorCodeHex = "#FFFFFF",
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = SeedStamp,
             CreatedBy = Guid.NewGuid(),
             ExternalIds =
             [
@@ -1046,7 +1067,7 @@ public class AthleteSeasonDocumentProcessorTests :
             Abbreviation = "QB",
             Name = "Quarterback",
             DisplayName = "Quarterback",
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = SeedStamp,
             CreatedBy = Guid.NewGuid(),
             ExternalIds =
             [
@@ -1070,7 +1091,7 @@ public class AthleteSeasonDocumentProcessorTests :
             FirstName = dto.FirstName,
             DisplayName = $"{dto.FirstName} {dto.LastName}",
             ShortName = dto.LastName,
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = SeedStamp,
             CreatedBy = Guid.NewGuid()
         });
         await FootballDataContext.AthleteExternalIds.AddAsync(new AthleteExternalId

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Sourcing/Historical/HistoricalSeasonSourcingServiceTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Sourcing/Historical/HistoricalSeasonSourcingServiceTests.cs
@@ -87,7 +87,7 @@ public class HistoricalSeasonSourcingServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SourceSeason_NewSeason_Creates4ResourceIndexRecords()
+    public async Task SourceSeason_NewSeason_Creates3ResourceIndexRecords()
     {
         // Arrange
         var request = new HistoricalSeasonSourcingRequest
@@ -103,11 +103,13 @@ public class HistoricalSeasonSourcingServiceTests : IDisposable
         response.CorrelationId.Should().NotBeEmpty();
 
         var resourceIndexes = await _context.ResourceIndexJobs.ToListAsync();
-        resourceIndexes.Should().HaveCount(4);
+        resourceIndexes.Should().HaveCount(3);
         resourceIndexes.Should().Contain(x => x.DocumentType == DocumentType.Season);
         resourceIndexes.Should().Contain(x => x.DocumentType == DocumentType.Venue);
         resourceIndexes.Should().Contain(x => x.DocumentType == DocumentType.TeamSeason);
-        resourceIndexes.Should().Contain(x => x.DocumentType == DocumentType.AthleteSeason);
+        // No AthleteSeason tier: the league-level athletes index is not
+        // season-scoped and fabricated rows (athlete-season remediation).
+        resourceIndexes.Should().NotContain(x => x.DocumentType == DocumentType.AthleteSeason);
 
         // All should be non-recurring, enabled, season-specific
         resourceIndexes.Should().AllSatisfy(x =>
@@ -122,7 +124,7 @@ public class HistoricalSeasonSourcingServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SourceSeason_NewSeason_Schedules4HangfireJobs()
+    public async Task SourceSeason_NewSeason_Schedules3HangfireJobs()
     {
         // Arrange
         var request = new HistoricalSeasonSourcingRequest
@@ -137,7 +139,7 @@ public class HistoricalSeasonSourcingServiceTests : IDisposable
         // Assert - Verify 4 jobs scheduled with correct delays
         _backgroundJobProviderMock.Verify(
             x => x.Schedule<ResourceIndexJob>(It.IsAny<Expression<Func<ResourceIndexJob, Task>>>(), It.IsAny<TimeSpan>()),
-            Times.Exactly(4));
+            Times.Exactly(3));
     }
 
     [Fact]
@@ -218,10 +220,10 @@ public class HistoricalSeasonSourcingServiceTests : IDisposable
         await _service.SourceSeasonAsync(request);
 
         // Assert - Can't easily verify exact delay times without exposing internals,
-        // but we can verify all 4 jobs were scheduled
+        // but we can verify all 3 jobs were scheduled
         _backgroundJobProviderMock.Verify(
             x => x.Schedule<ResourceIndexJob>(It.IsAny<Expression<Func<ResourceIndexJob, Task>>>(), It.IsAny<TimeSpan>()),
-            Times.Exactly(4));
+            Times.Exactly(3));
     }
 
     [Fact]
@@ -264,7 +266,7 @@ public class HistoricalSeasonSourcingServiceTests : IDisposable
         // Assert
         response.CorrelationId.Should().NotBeEmpty();
         var resourceIndexes = await _context.ResourceIndexJobs.ToListAsync();
-        resourceIndexes.Should().HaveCount(4);
+        resourceIndexes.Should().HaveCount(3);
     }
 
     public void Dispose()

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Sourcing/Historical/HistoricalSeasonSourcingServiceTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Sourcing/Historical/HistoricalSeasonSourcingServiceTests.cs
@@ -274,4 +274,27 @@ public class HistoricalSeasonSourcingServiceTests : IDisposable
         _context.Database.EnsureDeleted();
         _context.Dispose();
     }
+
+    [Fact]
+    public async Task CreateSagaResourceIndexes_CreatesOnlyThreeTiers_NoAthleteSeason()
+    {
+        // The saga-orchestrated path must define the same three tiers as
+        // SourceSeason — an AthleteSeason tuple here would call BuildUri,
+        // which now throws for that type (league-level athletes index is
+        // not season-scoped; athlete-season remediation).
+        var request = new HistoricalSeasonSourcingRequest
+        {
+            SourceDataProvider = SourceDataProvider.Espn,
+            SeasonYear = 2024
+        };
+
+        await _service.CreateSagaResourceIndexesAsync(request);
+
+        var resourceIndexes = await _context.ResourceIndexJobs.ToListAsync();
+        resourceIndexes.Should().HaveCount(3);
+        resourceIndexes.Should().Contain(x => x.DocumentType == DocumentType.Season);
+        resourceIndexes.Should().Contain(x => x.DocumentType == DocumentType.Venue);
+        resourceIndexes.Should().Contain(x => x.DocumentType == DocumentType.TeamSeason);
+        resourceIndexes.Should().NotContain(x => x.DocumentType == DocumentType.AthleteSeason);
+    }
 }


### PR DESCRIPTION
Phase 0 of the [AthleteSeason fabrication remediation](docs/audit/athlete-season-fabrication-remediation.md) (design doc included in this PR).

**The finding**: ~3.4M of 3.6M NCAAFB `AthleteSeason` rows bind modern athletes to historical seasons they never played in (a 2025 freshman on every LSU roster 1990–2026). NFL has the same class.

**Root cause**: ESPN's league-level `seasons/{year}/athletes` index is season-invariant (full athlete DB under every season path, `Team.$ref` = current team) × the historical saga's Tier 4 × a processor that trusts `Team.$ref`.

**Provider**: historical saga drops to three tiers (Tier 3 finalizes); the URI builder no longer maps AthleteSeason; legacy tier-4 jobs excluded from reschedule. Legacy saga state stays declared for persisted-instance name resolution.

**Producer — corroborated binding**: `FranchiseSeasonId` binds only when `ParentId` == the resolved franchise-season id (roster-cascade provenance, propagated through Provider's index fan-out). Uncorroborated docs create/update **unbound** — dependency consumers FK to the row and retry until it exists, so refusing creation would loop them; the binding is the poison, not the row. Required (not belt): ~3.4M poisoned docs remain Mongo-cached and replays would recreate rows post-purge.

**Next (after merge+deploy, per the doc)**: NFL purge → roster rebuild 2000–2026 (2026 full-cascade, historical `["AthleteSeason"]`-filtered via the #618 endpoint) → gates → NCAAFB with the proven runbook.

Tests: Provider 78/78; Producer suites green (one pre-existing local-WIP failure unrelated); new guard fixtures cover unbound-create and binding-preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved historical athlete-season data integrity by accepting roster associations only when supported by verified season context.
  * Preserved valid existing associations when newer information cannot be corroborated.

* **Improvements**
  * Historical athlete information is now sourced through verified team-roster records.
  * Streamlined historical season processing now covers season, venue, and team-roster data.

* **Documentation**
  * Added guidance for identifying, reviewing, and remediating affected historical records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->