### PR TITLE
fix(producer): synthesize athletes roster index ref for historical TeamSeason docs

### DIFF
--- a/docs/audit/athlete-season-fabrication-remediation.md
+++ b/docs/audit/athlete-season-fabrication-remediation.md
@@ -173,3 +173,37 @@ metrics campaign gates).
    `AthleteSeason` rows (+ their `AthleteSeasonExternalId`), then the
    roster rebuild recreates roster-era membership under the
    corroborated-binding contract.
+
+## NFL campaign run 1 (2026-08-15) — purge OK, rebuild no-op; fix shipped
+
+The first NFL execution validated the purge and exposed a gap in the
+rebuild mechanism:
+
+- **Purge**: 461,302 dependent-less rows deleted (52,224 evidence rows
+  kept). Formal gates passed (pairs-over-23-years: 0; orphaned
+  dependents: 0).
+- **Rebuild**: all 27 season POSTs accepted and fanned out (Seq:
+  `Requested=32, Skipped=0, Failed=0` per season), but **zero new bound
+  rows were created for any historical season** — only 2025 (+1,769)
+  and 2026 (+638) gained rows. Per-season `CreatedUtc` proved it: no
+  row for 2000–2024 was created during the run.
+- **Root cause**: ESPN renders the `athletes` $ref **only on the
+  current season's TeamSeason document**. Historical TeamSeason docs
+  (verified live against 2005 and 2020) omit the link entirely — even
+  though the roster index itself
+  (`/seasons/{y}/teams/{id}/athletes`) exists and serves honest data.
+  `TeamSeasonDocumentProcessor` therefore logged
+  `SKIP_CHILD_DOCUMENT: parent DTO link is null` for every historical
+  team and the cascade died at the first hop. (The historical seasons'
+  seemingly-healthy 2004–2018 roster counts in the gate table were
+  surviving evidence rows, not rebuilt rows.)
+- **Fix**: when the athletes link is absent, the processor synthesizes
+  the roster index URL from the TeamSeason document's own ref
+  (`{cleanRef}/athletes`). The synthesized URL classifies as a
+  resource index in the Provider, and the fan-out propagates the
+  franchise season's id as `ParentId` — exactly the provenance the
+  corroborated-binding guard requires. Empty pre-2004 indexes remain
+  no-harm-no-foul.
+- **Re-run**: after the fix deploys, re-POST seasons 2000–2024 (the
+  same script; purge pass is idempotent). 2025/2026 are already
+  rebuilt.

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
@@ -514,12 +514,19 @@ public static class EspnUriMapper
         var path = teamSeasonRef.GetLeftPart(UriPartial.Path);
         var parts = path.Split('/');
 
-        // Expect: ... / seasons / {year} / teams / {teamId}
+        // Expect: ... / seasons / {year} / teams / {teamId} — strictly in
+        // that order and adjacency; independently-located segments would
+        // accept reordered paths like .../teams/{id}/seasons/{year}.
         var seasonsIndex = Array.IndexOf(parts, "seasons");
         var teamsIndex = Array.IndexOf(parts, "teams");
 
-        if (seasonsIndex < 0 || teamsIndex < 0 || teamsIndex + 1 >= parts.Length)
+        if (seasonsIndex < 0 || teamsIndex != seasonsIndex + 2 || teamsIndex + 1 >= parts.Length)
             throw new InvalidOperationException($"Unexpected ESPN TeamSeason ref format: {teamSeasonRef}");
+
+        var seasonYearPart = parts[seasonsIndex + 1];
+
+        if (!int.TryParse(seasonYearPart, out _))
+            throw new InvalidOperationException($"Missing or invalid season year in ref: {teamSeasonRef}");
 
         var teamIdPart = parts[teamsIndex + 1];
 

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
@@ -496,6 +496,44 @@ public static class EspnUriMapper
     }
 
     /// <summary>
+    /// Maps a TeamSeason URI to its athletes roster index URI.
+    /// Example: .../seasons/{year}/teams/{teamId} -> .../seasons/{year}/teams/{teamId}/athletes
+    /// </summary>
+    /// <remarks>
+    /// ESPN renders the <c>athletes</c> $ref only on the CURRENT season's
+    /// TeamSeason document; historical documents omit it even though the
+    /// roster index resource exists (honest, season-scoped, empty before
+    /// ~2004). This mapping lets historical roster sourcing cascade without
+    /// depending on the link being present in the payload.
+    /// </remarks>
+    public static Uri TeamSeasonRefToAthletesIndexRef(Uri teamSeasonRef)
+    {
+        if (teamSeasonRef == null)
+            throw new ArgumentNullException(nameof(teamSeasonRef));
+
+        var path = teamSeasonRef.GetLeftPart(UriPartial.Path);
+        var parts = path.Split('/');
+
+        // Expect: ... / seasons / {year} / teams / {teamId}
+        var seasonsIndex = Array.IndexOf(parts, "seasons");
+        var teamsIndex = Array.IndexOf(parts, "teams");
+
+        if (seasonsIndex < 0 || teamsIndex < 0 || teamsIndex + 1 >= parts.Length)
+            throw new InvalidOperationException($"Unexpected ESPN TeamSeason ref format: {teamSeasonRef}");
+
+        var teamIdPart = parts[teamsIndex + 1];
+
+        if (!IsValidEspnId(teamIdPart))
+            throw new InvalidOperationException($"Missing or invalid team id in ref: {teamSeasonRef}");
+
+        // Build path up to teams/{teamId}, then append "athletes"
+        var baseParts = parts.Take(teamsIndex + 2).Append("athletes");
+        var result = string.Join('/', baseParts);
+
+        return new Uri(result, UriKind.Absolute);
+    }
+
+    /// <summary>
     /// Maps a TeamSeason child URI (e.g., statistics, leaders, record) back to the TeamSeason URI.
     /// Common helper for all TeamSeason child resources.
     /// </summary>

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessor.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events;
 using SportsData.Core.Eventing.Events.Franchise;
 using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.Refs;
@@ -215,20 +216,20 @@ public class TeamSeasonDocumentProcessor<TDataContext> : DocumentProcessorBase<T
             // TeamSeason document; historical documents omit it even though
             // the roster index itself (/seasons/{y}/teams/{id}/athletes)
             // exists and is honest back to ~2004 (empty before that).
-            // Synthesize the index URL from the document's own ref so
-            // historical roster sourcing can cascade — the Provider fan-out
-            // carries this entity's id as ParentId, which is what corroborates
-            // the FranchiseSeasonId binding in AthleteSeasonDocumentProcessor.
+            // Infer the index URL from the document's own ref so historical
+            // roster sourcing can cascade — the Provider fan-out carries
+            // this entity's id as ParentId, which is what corroborates the
+            // FranchiseSeasonId binding in AthleteSeasonDocumentProcessor.
             var athletes = dto.Athletes;
             if (athletes?.Ref is null)
             {
                 athletes = new EspnResourceIndexItem
                 {
-                    Ref = new Uri($"{dto.Ref.ToCleanUrl()}/athletes")
+                    Ref = EspnUriMapper.TeamSeasonRefToAthletesIndexRef(dto.Ref)
                 };
 
                 _logger.LogInformation(
-                    "Athletes link absent on TeamSeason document (historical shape); synthesized roster index ref. Ref={Ref}",
+                    "Athletes link absent on TeamSeason document (historical shape); inferred roster index ref. Ref={Ref}",
                     athletes.Ref);
             }
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessor.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events;
 using SportsData.Core.Eventing.Events.Franchise;
 using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.DataSources.Espn.Dtos;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
@@ -210,9 +211,30 @@ public class TeamSeasonDocumentProcessor<TDataContext> : DocumentProcessorBase<T
         // athletes
         if (isNew || ShouldSpawn(DocumentType.AthleteSeason, command))
         {
+            // ESPN renders the athletes $ref only on the CURRENT season's
+            // TeamSeason document; historical documents omit it even though
+            // the roster index itself (/seasons/{y}/teams/{id}/athletes)
+            // exists and is honest back to ~2004 (empty before that).
+            // Synthesize the index URL from the document's own ref so
+            // historical roster sourcing can cascade — the Provider fan-out
+            // carries this entity's id as ParentId, which is what corroborates
+            // the FranchiseSeasonId binding in AthleteSeasonDocumentProcessor.
+            var athletes = dto.Athletes;
+            if (athletes?.Ref is null)
+            {
+                athletes = new EspnResourceIndexItem
+                {
+                    Ref = new Uri($"{dto.Ref.ToCleanUrl()}/athletes")
+                };
+
+                _logger.LogInformation(
+                    "Athletes link absent on TeamSeason document (historical shape); synthesized roster index ref. Ref={Ref}",
+                    athletes.Ref);
+            }
+
             await PublishChildDocumentRequest(
                 command,
-                dto.Athletes,
+                athletes,
                 canonicalEntity.Id,
                 DocumentType.AthleteSeason);
         }

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
@@ -384,6 +384,42 @@ namespace SportsData.Core.Tests.Unit.Infrastructure.DataSources.Espn
 
         [Theory]
         [InlineData(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/teams/99",
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/teams/99/athletes")]
+        [InlineData(
+            "https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2020/teams/15?lang=en&region=us",
+            "https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2020/teams/15/athletes")]
+        [InlineData(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2005/teams/-2",
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2005/teams/-2/athletes")] // negative team ids are valid
+        public void TeamSeasonRefToAthletesIndexRef_Should_Append_Athletes_Without_Query(
+            string teamSeasonRef,
+            string expectedAthletesIndexRef)
+        {
+            var input = new Uri(teamSeasonRef);
+            var result = EspnUriMapper.TeamSeasonRefToAthletesIndexRef(input);
+            result.Should().Be(new Uri(expectedAthletesIndexRef));
+        }
+
+        [Theory]
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/franchises/99")] // no seasons segment
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/teams/abc")] // non-numeric team id
+        public void TeamSeasonRefToAthletesIndexRef_Should_Throw_On_Unexpected_Shape(string badRef)
+        {
+            var input = new Uri(badRef);
+            Action act = () => EspnUriMapper.TeamSeasonRefToAthletesIndexRef(input);
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void TeamSeasonRefToAthletesIndexRef_Should_Throw_On_Null()
+        {
+            Action act = () => EspnUriMapper.TeamSeasonRefToAthletesIndexRef(null!);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData(
             "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/teams/395/statistics/0",
             "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/teams/395")]
         [InlineData(

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
@@ -404,6 +404,9 @@ namespace SportsData.Core.Tests.Unit.Infrastructure.DataSources.Espn
         [Theory]
         [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/franchises/99")] // no seasons segment
         [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/teams/abc")] // non-numeric team id
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/teams/99/seasons/2024")] // reordered segments
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/abc/teams/99")] // non-numeric season year
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/types/2/teams/99")] // non-adjacent seasons/teams
         public void TeamSeasonRefToAthletesIndexRef_Should_Throw_On_Unexpected_Shape(string badRef)
         {
             var input = new Uri(badRef);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessorTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Core.Eventing.Events.Franchise;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
@@ -165,5 +166,101 @@ public class TeamSeasonDocumentProcessorTests :
         count.Should().Be(1);
 
         bus.Verify(x => x.Publish(It.IsAny<FranchiseSeasonCreated>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenAthletesLinkAbsent_ShouldSynthesizeRosterIndexRequestFromDocumentRef()
+    {
+        // ESPN renders the athletes $ref only on the current season's
+        // TeamSeason document; historical documents omit it even though the
+        // roster index (/seasons/{y}/teams/{id}/athletes) exists. The
+        // processor must synthesize the index URL from the document's own
+        // ref and carry the franchise season's id as ParentId — the
+        // provenance AthleteSeasonDocumentProcessor's corroborated-binding
+        // guard requires.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var bus = Mocker.GetMock<IEventBus>();
+        var sut = Mocker.CreateInstance<TeamSeasonDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaTeamSeason.json");
+        var node = System.Text.Json.Nodes.JsonNode.Parse(json)!.AsObject();
+        node.Remove("athletes");
+        json = node.ToJsonString();
+
+        var dto = json.FromJson<EspnTeamSeasonDto>();
+
+        var groupSeasonIdentity = generator.Generate(dto.Groups.Ref);
+        var group = Fixture.Build<GroupSeason>()
+            .OmitAutoProperties()
+            .With(x => x.Id, groupSeasonIdentity.CanonicalId)
+            .With(x => x.Abbreviation, "foo")
+            .With(x => x.Name, "Name")
+            .With(x => x.ShortName, "Name")
+            .With(x => x.Slug, "Name")
+            .With(x => x.ExternalIds, new List<GroupSeasonExternalId>()
+            {
+                new GroupSeasonExternalId()
+                {
+                    Id = Guid.NewGuid(),
+                    Value = groupSeasonIdentity.CanonicalId.ToString(),
+                    SourceUrlHash = groupSeasonIdentity.UrlHash,
+                    SourceUrl = groupSeasonIdentity.CleanUrl,
+                    GroupSeasonId = groupSeasonIdentity.CanonicalId
+                }
+            })
+            .Create();
+        await FootballDataContext.GroupSeasons.AddAsync(group);
+        await FootballDataContext.SaveChangesAsync();
+
+        var franchiseIdentity = generator.Generate(SourceUrl);
+
+        var franchise = Fixture.Build<Franchise>()
+            .WithAutoProperties()
+            .With(x => x.Id, franchiseIdentity.CanonicalId)
+            .With(x => x.Name, "Test Franchise")
+            .With(x => x.ExternalIds, new List<FranchiseExternalId>
+            {
+                Fixture.Build<FranchiseExternalId>()
+                    .WithAutoProperties()
+                    .With(x => x.Provider, SourceDataProvider.Espn)
+                    .With(x => x.SourceUrl, franchiseIdentity.CleanUrl)
+                    .With(x => x.SourceUrlHash, franchiseIdentity.UrlHash)
+                    .With(x => x.Value, franchiseIdentity.UrlHash)
+                    .Create()
+            })
+            .With(x => x.Seasons, new List<FranchiseSeason>())
+            .Create();
+
+        await FootballDataContext.Franchises.AddAsync(franchise);
+        await FootballDataContext.SaveChangesAsync();
+
+        var published = new List<DocumentRequested>();
+        bus.Setup(x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()))
+            .Callback<DocumentRequested, CancellationToken>((evt, _) => published.Add(evt))
+            .Returns(Task.CompletedTask);
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.DocumentType, DocumentType.TeamSeason)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, _urlHash)
+            .OmitAutoProperties()
+            .Create();
+
+        // Act
+        await sut.ProcessAsync(command);
+
+        // Assert
+        var fs = await FootballDataContext.FranchiseSeasons.SingleAsync();
+
+        var rosterRequest = published.SingleOrDefault(e => e.DocumentType == DocumentType.AthleteSeason);
+        rosterRequest.Should().NotBeNull("the athletes index must be requested even when ESPN omits the link");
+        rosterRequest!.Uri.AbsolutePath.Should().EndWith("/athletes");
+        rosterRequest.Uri.ToCleanUrl().Should().Be($"{dto.Ref.ToCleanUrl()}/athletes");
+        rosterRequest.ParentId.Should().Be(fs.Id.ToString(),
+            "the fan-out ParentId is what corroborates the roster binding downstream");
     }
 }


### PR DESCRIPTION
## Why

NFL athlete-season rebuild campaign run 1 (docs/audit/athlete-season-fabrication-remediation.md) purged 461k fabricated rows and fanned out all 27 season re-source requests cleanly — but created **zero** historical roster rows. Per-season `CreatedUtc` proved only 2025 (+1,769) and 2026 (+638) gained rows.

Root cause (verified live against ESPN): the `athletes` $ref is rendered **only on the current season's TeamSeason document**. Historical TeamSeason docs (checked 2005 and 2020) omit the link entirely, even though the roster index itself (`/seasons/{y}/teams/{id}/athletes`) exists and serves honest per-season data (93 athletes for KC 2018–2025). `TeamSeasonDocumentProcessor` logged `SKIP_CHILD_DOCUMENT: parent DTO link is null` for every historical team, killing the cascade at the first hop.

## What

When `dto.Athletes?.Ref` is null, synthesize the roster index URL from the TeamSeason document's own ref (`{cleanRef}/athletes`) and publish the child request as usual.

Safety of the synthesized URL, verified end-to-end:
- `EspnResourceIndexClassifier`: `athletes` is not a leaf suffix → classified as a resource index
- `DocumentRequestedHandler` index fan-out propagates `ParentId` (the franchise season id) to every athlete leaf — exactly the provenance the corroborated-binding guard from #634 requires, so rebuilt rows bind correctly
- Pre-2004 seasons: empty index → `Empty ResourceIndex` → no-op (per the agreed no-harm-no-foul floor)

## Tests

New unit test strips the `athletes` link from the fixture and asserts the synthesized request's URL shape and `ParentId` provenance. Full Producer unit suite green (the single `DocumentCreatedProcessorTests.Process_LogsEntryAndCompletion` failure is from uncommitted local WIP on `DocumentCreatedProcessor`, not this branch).

Also appends the campaign run-1 postmortem to the remediation doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved historical NFL roster processing when ESPN team-season data lacks an athlete link.
  * Roster references are now derived from available team-season information, preserving season associations.
  * Enabled successful rebuilding of affected historical seasons.
  * Added validation for roster reference formats and clearer handling of invalid references.

* **Documentation**
  * Added a campaign report covering the remediation, root cause, fix, and rebuild results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->