### PR TITLE
fix(producer): gate roster-index inference to NCAAFB — ESPN NFL/MLB historical indexes are fabricated

### DIFF
--- a/docs/audit/athlete-season-fabrication-remediation.md
+++ b/docs/audit/athlete-season-fabrication-remediation.md
@@ -207,3 +207,46 @@ rebuild mechanism:
 - **Re-run**: after the fix deploys, re-POST seasons 2000–2024 (the
   same script; purge pass is idempotent). 2025/2026 are already
   rebuilt.
+
+## NFL campaign run 2 (2026-08-15) — ESPN's per-team NFL index is FABRICATED
+
+Run 2 (producer:6161, inferred roster refs) mechanically succeeded —
+all 25 season POSTs cascaded, ~70k rows created bound — but the gates
+tripped hard: **pairs-over-23-years = 2,155**, roster averages 144–157
+for 2004–2018 (sane bound: 40–95), and Joe Burrow bound to the Bengals
+for 2000–2024.
+
+**Root cause — a second fabrication layer at ESPN**: the per-team NFL
+roster index (`/seasons/{y}/teams/{id}/athletes`) renders the CURRENT
+~90-man roster under every historical season path. Verified by content:
+Bengals index = count 90 with Burrow present for 2015, 2020, and 2025
+alike. The pre-campaign validation had checked this index by COUNT
+(93 ≈ real roster, not the 104k league DB) but not by content.
+Content honesty is PER-LEAGUE:
+
+| League | Historical per-team index | Evidence |
+|---|---|---|
+| NCAAFB | **Honest** | LSU counts 55 (2005) / 137 (2015) / 160 (2025); DJ Pickett only in 2025 |
+| NFL | **Fabricated** | identical current roster every year; Burrow in 2015 |
+| MLB | **Fabricated (presumed)** | Yankees identical count 285 in 2015 and 2025 |
+
+**Verdict**: ESPN has NO honest historical NFL roster data via any
+endpoint. Historical NFL membership is therefore EVIDENCE-DERIVED ONLY
+(an athlete is on a season's roster iff play/stat evidence ties them to
+it — accepted by Randall 2026-08-15: "If an athlete is not tied to a
+play, were they really on the team?"). The 2019–2024 thinness is an
+athlete-stat sourcing gap, to be closed by the player pick'em
+athlete-stat audit — not by roster sourcing.
+
+**Remediation**:
+1. Code: roster-index inference gated to `Sport.FootballNcaa` (this
+   PR). NFL/MLB current seasons still source via the explicit link on
+   the current TeamSeason document; absent historical links stay
+   absent.
+2. Data: purge run 3 — dependent-less rows bound to seasons ≤ 2024
+   (plus dependent-less unbound rows with 2000–2024 season-scoped
+   URLs). No rebuild.
+3. NCAAFB campaign proceeds — its index is verified honest by content,
+   and every campaign gate now includes a CONTENT-based probe (known
+   current player must not appear in historical rosters), not just
+   counts.

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessor.cs
@@ -213,15 +213,24 @@ public class TeamSeasonDocumentProcessor<TDataContext> : DocumentProcessorBase<T
         if (isNew || ShouldSpawn(DocumentType.AthleteSeason, command))
         {
             // ESPN renders the athletes $ref only on the CURRENT season's
-            // TeamSeason document; historical documents omit it even though
-            // the roster index itself (/seasons/{y}/teams/{id}/athletes)
-            // exists and is honest back to ~2004 (empty before that).
-            // Infer the index URL from the document's own ref so historical
-            // roster sourcing can cascade — the Provider fan-out carries
-            // this entity's id as ParentId, which is what corroborates the
-            // FranchiseSeasonId binding in AthleteSeasonDocumentProcessor.
+            // TeamSeason document; historical documents omit it. Whether the
+            // roster index itself (/seasons/{y}/teams/{id}/athletes) is
+            // honest for historical seasons is PER-LEAGUE (verified by
+            // content 2026-08-15):
+            //   NCAAFB: honest — season-scoped rosters, counts vary by year.
+            //   NFL:    fabricated — the CURRENT roster is rendered under
+            //           every historical season path (Bengals 2015 contains
+            //           Joe Burrow).
+            //   MLB:    fabricated — identical counts across seasons.
+            // Infer the index URL from the document's own ref ONLY for
+            // leagues whose historical index is honest; for the others the
+            // absent link stays absent and historical rosters remain
+            // evidence-derived (athlete-season-fabrication-remediation.md).
+            // The Provider fan-out carries this entity's id as ParentId,
+            // which is what corroborates the FranchiseSeasonId binding in
+            // AthleteSeasonDocumentProcessor.
             var athletes = dto.Athletes;
-            if (athletes?.Ref is null)
+            if (athletes?.Ref is null && command.Sport == Sport.FootballNcaa)
             {
                 athletes = new EspnResourceIndexItem
                 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonDocumentProcessorTests.cs
@@ -263,4 +263,92 @@ public class TeamSeasonDocumentProcessorTests :
         rosterRequest.ParentId.Should().Be(fs.Id.ToString(),
             "the fan-out ParentId is what corroborates the roster binding downstream");
     }
+
+    [Fact]
+    public async Task WhenAthletesLinkAbsent_ForNfl_ShouldNotInferRosterIndexRequest()
+    {
+        // ESPN's historical NFL roster index is FABRICATED (the current
+        // roster is rendered under every season path — verified by content
+        // 2026-08-15), so the inference is gated to NCAAFB. An absent link
+        // on an NFL TeamSeason document must stay absent: historical NFL
+        // membership is evidence-derived only.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var bus = Mocker.GetMock<IEventBus>();
+        var sut = Mocker.CreateInstance<TeamSeasonDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaTeamSeason.json");
+        var node = System.Text.Json.Nodes.JsonNode.Parse(json)!.AsObject();
+        node.Remove("athletes");
+        json = node.ToJsonString();
+
+        var dto = json.FromJson<EspnTeamSeasonDto>();
+
+        var groupSeasonIdentity = generator.Generate(dto.Groups.Ref);
+        var group = Fixture.Build<GroupSeason>()
+            .OmitAutoProperties()
+            .With(x => x.Id, groupSeasonIdentity.CanonicalId)
+            .With(x => x.Abbreviation, "foo")
+            .With(x => x.Name, "Name")
+            .With(x => x.ShortName, "Name")
+            .With(x => x.Slug, "Name")
+            .With(x => x.ExternalIds, new List<GroupSeasonExternalId>()
+            {
+                new GroupSeasonExternalId()
+                {
+                    Id = Guid.NewGuid(),
+                    Value = groupSeasonIdentity.CanonicalId.ToString(),
+                    SourceUrlHash = groupSeasonIdentity.UrlHash,
+                    SourceUrl = groupSeasonIdentity.CleanUrl,
+                    GroupSeasonId = groupSeasonIdentity.CanonicalId
+                }
+            })
+            .Create();
+        await FootballDataContext.GroupSeasons.AddAsync(group);
+        await FootballDataContext.SaveChangesAsync();
+
+        var franchiseIdentity = generator.Generate(SourceUrl);
+
+        var franchise = Fixture.Build<Franchise>()
+            .WithAutoProperties()
+            .With(x => x.Id, franchiseIdentity.CanonicalId)
+            .With(x => x.Name, "Test Franchise")
+            .With(x => x.ExternalIds, new List<FranchiseExternalId>
+            {
+                Fixture.Build<FranchiseExternalId>()
+                    .WithAutoProperties()
+                    .With(x => x.Provider, SourceDataProvider.Espn)
+                    .With(x => x.SourceUrl, franchiseIdentity.CleanUrl)
+                    .With(x => x.SourceUrlHash, franchiseIdentity.UrlHash)
+                    .With(x => x.Value, franchiseIdentity.UrlHash)
+                    .Create()
+            })
+            .With(x => x.Seasons, new List<FranchiseSeason>())
+            .Create();
+
+        await FootballDataContext.Franchises.AddAsync(franchise);
+        await FootballDataContext.SaveChangesAsync();
+
+        var published = new List<DocumentRequested>();
+        bus.Setup(x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()))
+            .Callback<DocumentRequested, CancellationToken>((evt, _) => published.Add(evt))
+            .Returns(Task.CompletedTask);
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNfl)
+            .With(x => x.SeasonYear, 2015)
+            .With(x => x.DocumentType, DocumentType.TeamSeason)
+            .With(x => x.Document, json)
+            .With(x => x.UrlHash, _urlHash)
+            .OmitAutoProperties()
+            .Create();
+
+        // Act
+        await sut.ProcessAsync(command);
+
+        // Assert
+        published.Should().NotContain(e => e.DocumentType == DocumentType.AthleteSeason,
+            "an absent athletes link on a non-NCAAFB TeamSeason must not be inferred");
+    }
 }


### PR DESCRIPTION
## Why

Rebuild run 2 (post-#635) exposed a second fabrication layer at ESPN: the **per-team** NFL roster index (`/seasons/{y}/teams/{id}/athletes`) renders the CURRENT ~90-man roster under every historical season path. Verified by content: the Bengals index returns count 90 **with Joe Burrow present for 2015, 2020, and 2025 alike**. The campaign gates caught it (pairs-over-23-years = 2,155; roster averages 144–157 vs sane 40–95).

Per-league honesty (verified by content 2026-08-15):

| League | Historical per-team index |
|---|---|
| NCAAFB | Honest — LSU 55 (2005) / 137 (2015) / 160 (2025); DJ Pickett only in 2025 |
| NFL | Fabricated — identical current roster every year |
| MLB | Fabricated (presumed) — Yankees identical count 285 in 2015 and 2025 |

## What

Gate the #635 athletes-link inference to `Sport.FootballNcaa`. NFL/MLB current seasons still source rosters via the explicit `athletes` link ESPN renders on the current TeamSeason document; absent historical links now stay absent, so historical NFL/MLB membership remains evidence-derived only (play/stat evidence — the accepted standard).

- NFL negative test: absent link with `Sport.FootballNfl` must publish no AthleteSeason request
- Remediation doc: run-2 postmortem, per-league honesty matrix, revised remediation (scoped purge run 3, no NFL rebuild, NCAAFB campaign proceeds with content-based probes)

## Tests

Producer TeamSeason processor suite 4/4 (NCAAFB inference positive + NFL negative + the two originals). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented historical NFL and MLB athlete roster links from being inferred when ESPN does not provide them.
  * Continued supporting roster link inference for NCAA football.
  * Added validation to ensure historical NFL athlete-season requests are not incorrectly published.

* **Documentation**
  * Documented findings and remediation decisions for inaccurate historical NFL roster data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->