### PR TITLE
fix(mobile,web): hide league Create until a sport's creation gate opens (or admin)

### DIFF
--- a/src/UI/sd-mobile/__tests__/hooks/useLeagueCreationGates.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useLeagueCreationGates.test.ts
@@ -9,6 +9,7 @@ jest.mock('@/src/services/api/client', () => ({
 }));
 
 import {
+  anySportOpenForCreation,
   formatGateDate,
   formatGateDateOrSoon,
 } from '@/src/hooks/useLeagueCreationGates';
@@ -22,6 +23,42 @@ describe('formatGateDate', () => {
 
   it('returns null for an unparseable value', () => {
     expect(formatGateDate('not-a-date')).toBeNull();
+  });
+});
+
+describe('anySportOpenForCreation', () => {
+  const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  const PAST = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  it('is closed when every non-admin sport has a future gate', () => {
+    expect(
+      anySportOpenForCreation({ FootballNcaa: FUTURE, FootballNfl: FUTURE }),
+    ).toBe(false);
+  });
+
+  it('is open when a sport is absent from the gates (API omits elapsed gates)', () => {
+    expect(anySportOpenForCreation({ FootballNfl: FUTURE })).toBe(true);
+  });
+
+  it('is open when a gate instant has elapsed (defensive against contract drift)', () => {
+    expect(
+      anySportOpenForCreation({ FootballNcaa: PAST, FootballNfl: FUTURE }),
+    ).toBe(true);
+  });
+
+  it('is open on an empty map (no gates configured / resolved fetch failure)', () => {
+    expect(anySportOpenForCreation({})).toBe(true);
+  });
+
+  it('ignores gates for sports non-admins cannot create (MLB)', () => {
+    // MLB gated or not is irrelevant — NCAA/NFL both closed means closed.
+    expect(
+      anySportOpenForCreation({
+        FootballNcaa: FUTURE,
+        FootballNfl: FUTURE,
+        BaseballMlb: PAST,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/UI/sd-mobile/app/leagues.tsx
+++ b/src/UI/sd-mobile/app/leagues.tsx
@@ -19,7 +19,11 @@ import { getTheme } from '@/constants/Colors';
 import { CloneLeagueModal } from '@/src/components/features/leagues/CloneLeagueModal';
 import { LeagueCard } from '@/src/components/features/leagues/LeagueCard';
 import { leaguesApi, leaguesKeys, type LeagueSummary } from '@/src/services/api/leaguesApi';
-import { standingsKeys } from '@/src/hooks/useStandings';
+import { standingsKeys, useCurrentUser } from '@/src/hooks/useStandings';
+import {
+  anySportOpenForCreation,
+  useLeagueCreationGatesState,
+} from '@/src/hooks/useLeagueCreationGates';
 
 // leaguesKeys moved to services/api/leaguesApi.ts — shared cache keys must
 // not live in a route module (see PR #570 review).
@@ -46,6 +50,16 @@ export default function LeaguesScreen() {
   const theme = getTheme(scheme);
   const router = useRouter();
   const queryClient = useQueryClient();
+
+  // League creation is visible only to admins until at least one sport's
+  // creation gate opens (pre-season lockout). The server enforces the gate on
+  // create; this only hides the affordance. While the gates query is pending,
+  // non-admins see no button (fail closed visually) instead of a flash; a
+  // RESOLVED failure fails open per the gates hook's contract.
+  const { data: me } = useCurrentUser();
+  const isAdmin = me?.isAdmin === true;
+  const { gates, isPending: gatesPending } = useLeagueCreationGatesState();
+  const canCreate = isAdmin || (!gatesPending && anySportOpenForCreation(gates));
 
   const [cloneTarget, setCloneTarget] = useState<LeagueSummary | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -153,20 +167,21 @@ export default function LeaguesScreen() {
           // Mirrors sd-ui's Leagues.jsx header (title left, "+ Create League"
           // right). The in-content button below only renders on the empty state,
           // so without this there's no way to create a second league from here.
-          // Left unconditional to match web: the create screen surfaces the
-          // per-sport availability gate, and the API enforces it server-side.
-          headerRight: () => (
-            <TouchableOpacity
-              style={styles.headerCreate}
-              onPress={() => router.push('/create-league' as never)}
-              hitSlop={8}
-              accessibilityRole="button"
-              accessibilityLabel="Create league"
-            >
-              <Ionicons name="add" size={18} color={theme.tint} />
-              <Text style={[styles.headerCreateText, { color: theme.tint }]}>Create</Text>
-            </TouchableOpacity>
-          ),
+          // Hidden while every sport's creation gate is closed unless the user
+          // is an admin; the API enforces the same gate server-side.
+          headerRight: () =>
+            canCreate ? (
+              <TouchableOpacity
+                style={styles.headerCreate}
+                onPress={() => router.push('/create-league' as never)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Create league"
+              >
+                <Ionicons name="add" size={18} color={theme.tint} />
+                <Text style={[styles.headerCreateText, { color: theme.tint }]}>Create</Text>
+              </TouchableOpacity>
+            ) : null,
         }}
       />
 
@@ -251,14 +266,16 @@ export default function LeaguesScreen() {
             <Text style={[styles.emptyText, { color: theme.textMuted }]}>
               You&rsquo;re not part of any leagues yet.
             </Text>
-            <TouchableOpacity
-              style={[styles.createButton, { backgroundColor: theme.tint }]}
-              onPress={() => router.push('/create-league' as never)}
-            >
-              <Text style={[styles.createButtonText, { color: theme.textOnAccent }]}>
-                Create League
-              </Text>
-            </TouchableOpacity>
+            {canCreate && (
+              <TouchableOpacity
+                style={[styles.createButton, { backgroundColor: theme.tint }]}
+                onPress={() => router.push('/create-league' as never)}
+              >
+                <Text style={[styles.createButtonText, { color: theme.textOnAccent }]}>
+                  Create League
+                </Text>
+              </TouchableOpacity>
+            )}
           </View>
         ) : visibleLeagues.length === 0 ? (
           <Text style={[styles.emptyText, { color: theme.textMuted }]}>

--- a/src/UI/sd-mobile/src/hooks/useLeagueCreationGates.ts
+++ b/src/UI/sd-mobile/src/hooks/useLeagueCreationGates.ts
@@ -17,26 +17,61 @@ const MONTHS_SHORT = [
 ];
 
 /**
- * The active creation gates as a lookup of backend Sport enum ("FootballNcaa")
- * → the UTC ISO instant it opens. A sport absent is open. Fails open (empty map)
- * on error — the server still enforces the gate, so the worst case is a user
- * seeing a create option the API then rejects.
+ * Sports a non-admin can create a league for. MLB is admin-gated in the create
+ * flow, so it never factors into non-admin visibility decisions.
  */
-export function useLeagueCreationGates(): Record<string, string> {
-  const { data } = useQuery({
+export const NON_ADMIN_CREATABLE_SPORTS = ['FootballNcaa', 'FootballNfl'] as const;
+
+/**
+ * Pending-aware variant of {@link useLeagueCreationGates} for surfaces that
+ * HIDE an affordance while every sport is gated (e.g. the leagues screen's
+ * "+ Create"): without the pending flag those surfaces would flash the
+ * affordance during the initial fetch (empty map = "everything open") and then
+ * yank it. A resolved failure still fails open — the server enforces the gate.
+ */
+export function useLeagueCreationGatesState(): {
+  gates: Record<string, string>;
+  isPending: boolean;
+} {
+  const { data, isPending } = useQuery({
     queryKey: ['leagues', 'creation-availability'],
     queryFn: () => leaguesApi.getCreationAvailability().then((r) => r.data),
     staleTime: 1000 * 60 * 60, // gate dates barely move; refetch hourly at most
     retry: false, // a failed fetch fails open; don't hammer it
   });
 
-  return useMemo(() => {
-    const gates: Record<string, string> = {};
+  const gates = useMemo(() => {
+    const map: Record<string, string> = {};
     for (const g of data?.gates ?? []) {
-      if (g?.sport && g?.opensUtc) gates[g.sport] = g.opensUtc;
+      if (g?.sport && g?.opensUtc) map[g.sport] = g.opensUtc;
     }
-    return gates;
+    return map;
   }, [data]);
+
+  return { gates, isPending };
+}
+
+/**
+ * The active creation gates as a lookup of backend Sport enum ("FootballNcaa")
+ * → the UTC ISO instant it opens. A sport absent is open. Fails open (empty map)
+ * on error — the server still enforces the gate, so the worst case is a user
+ * seeing a create option the API then rejects.
+ */
+export function useLeagueCreationGates(): Record<string, string> {
+  return useLeagueCreationGatesState().gates;
+}
+
+/**
+ * Whether at least one non-admin-creatable sport is open for league creation.
+ * The API only returns FUTURE gates (an elapsed gate is omitted), so "absent"
+ * means open; the elapsed-instant check is defensive in case that contract
+ * ever loosens.
+ */
+export function anySportOpenForCreation(gates: Record<string, string>): boolean {
+  return NON_ADMIN_CREATABLE_SPORTS.some((sport) => {
+    const opensUtc = gates[sport];
+    return !opensUtc || Date.parse(opensUtc) <= Date.now();
+  });
 }
 
 /**

--- a/src/UI/sd-ui/src/components/leagues/Leagues.jsx
+++ b/src/UI/sd-ui/src/components/leagues/Leagues.jsx
@@ -6,6 +6,11 @@ import toast from "react-hot-toast";
 import LeaguesApi from "api/leagues/leaguesApi";
 import LeagueOverviewCard from "./LeagueOverviewCard";
 import CloneLeagueDialog from "./CloneLeagueDialog";
+import { useUserDto } from "../../contexts/UserContext";
+import {
+  anySportOpenForCreation,
+  getLeagueCreationGates,
+} from "../../utils/leagueCreationGates";
 import "./Leagues.css"; // for grid styling
 
 const ALL_LEAGUES = "All";
@@ -37,8 +42,30 @@ function loadPersistedFilters() {
 }
 
 const Leagues = () => {
+  const { userDto } = useUserDto();
+  const isAdmin = userDto?.isAdmin === true;
+
   const [leagues, setLeagues] = useState([]);
   const [cloneTarget, setCloneTarget] = useState(null);
+
+  // League creation is visible only to admins until at least one sport's
+  // creation gate opens (pre-season lockout). The server enforces the gate on
+  // create; this only hides the affordance. null = gates not loaded yet, so
+  // non-admins see no button during the fetch (no flash) — a RESOLVED failure
+  // fails open per getLeagueCreationGates' contract. Mirrors sd-mobile's
+  // leagues screen.
+  const [creationGates, setCreationGates] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    getLeagueCreationGates().then((gates) => {
+      if (!cancelled) setCreationGates(gates);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const canCreate =
+    isAdmin || (creationGates !== null && anySportOpenForCreation(creationGates));
   const [cloning, setCloning] = useState(false);
   const [showPast, setShowPast] = useState(() => loadPersistedFilters().showPast);
   const [leagueFilter, setLeagueFilter] = useState(() => loadPersistedFilters().leagueFilter ?? ALL_LEAGUES);
@@ -149,9 +176,11 @@ const Leagues = () => {
     <div className="page-container">
       <div className="leagues-header">
         <h1>My Leagues</h1>
-        <Link to="/app/league/create" className="create-league-button">
-          + Create League
-        </Link>
+        {canCreate && (
+          <Link to="/app/league/create" className="create-league-button">
+            + Create League
+          </Link>
+        )}
       </div>
 
       {leagues.length > 0 && showFilterBar && (
@@ -226,8 +255,13 @@ const Leagues = () => {
 
       {leagues.length === 0 ? (
         <p>
-          You’re not part of any leagues yet.{" "}
-          <Link to="/app/league/create">Create one</Link>.
+          You’re not part of any leagues yet.
+          {canCreate && (
+            <>
+              {" "}
+              <Link to="/app/league/create">Create one</Link>.
+            </>
+          )}
         </p>
       ) : visibleLeagues.length === 0 ? (
         <p>No leagues match this filter.</p>

--- a/src/UI/sd-ui/src/utils/leagueCreationGates.js
+++ b/src/UI/sd-ui/src/utils/leagueCreationGates.js
@@ -30,6 +30,27 @@ export async function getLeagueCreationGates() {
 }
 
 /**
+ * Sports a non-admin can create a league for. MLB is admin-gated in the create
+ * flow, so it never factors into non-admin visibility decisions.
+ */
+export const NON_ADMIN_CREATABLE_SPORTS = ["FootballNcaa", "FootballNfl"];
+
+/**
+ * Whether at least one non-admin-creatable sport is open for league creation.
+ * The API only returns FUTURE gates (an elapsed gate is omitted), so "absent"
+ * means open; the elapsed-instant check is defensive in case that contract
+ * ever loosens. Mirrors sd-mobile's anySportOpenForCreation.
+ * @param {Record<string, string>} gates
+ * @returns {boolean}
+ */
+export function anySportOpenForCreation(gates) {
+  return NON_ADMIN_CREATABLE_SPORTS.some((sport) => {
+    const opensUtc = gates?.[sport];
+    return !opensUtc || Date.parse(opensUtc) <= Date.now();
+  });
+}
+
+/**
  * "Aug 17" from a UTC ISO instant. Formatted in UTC so the gate's authored
  * calendar day (a UTC wall-clock) isn't shifted back a day in western
  * timezones. Returns null for an unparseable value.

--- a/src/UI/sd-ui/src/utils/leagueCreationGates.test.js
+++ b/src/UI/sd-ui/src/utils/leagueCreationGates.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { anySportOpenForCreation } from './leagueCreationGates';
+
+// Mock the API module so importing the util doesn't pull in the real axios
+// client chain — these tests only exercise the pure helper. (vi.mock is
+// hoisted above the imports at runtime, so placement here is safe.)
+vi.mock('../api/leagues/leaguesApi', () => ({
+  default: { getCreationAvailability: vi.fn() },
+}));
+
+describe('anySportOpenForCreation', () => {
+  const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  const PAST = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  it('is closed when every non-admin sport has a future gate', () => {
+    expect(
+      anySportOpenForCreation({ FootballNcaa: FUTURE, FootballNfl: FUTURE })
+    ).toBe(false);
+  });
+
+  it('is open when a sport is absent from the gates (API omits elapsed gates)', () => {
+    expect(anySportOpenForCreation({ FootballNfl: FUTURE })).toBe(true);
+  });
+
+  it('is open when a gate instant has elapsed (defensive against contract drift)', () => {
+    expect(
+      anySportOpenForCreation({ FootballNcaa: PAST, FootballNfl: FUTURE })
+    ).toBe(true);
+  });
+
+  it('is open on an empty or missing map (no gates / resolved fetch failure)', () => {
+    expect(anySportOpenForCreation({})).toBe(true);
+    expect(anySportOpenForCreation(undefined)).toBe(true);
+  });
+
+  it('ignores gates for sports non-admins cannot create (MLB)', () => {
+    expect(
+      anySportOpenForCreation({
+        FootballNcaa: FUTURE,
+        FootballNfl: FUTURE,
+        BaseballMlb: PAST,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

On the leagues surfaces (mobile /leagues, web /app/leagues), the `+ Create` affordances rendered unconditionally, so non-admin users saw a create option during the pre-season lockout (NCAAFB opens Aug 18, NFL Sep 1 per `/ui/leagues/creation-availability`).

## What

Visibility on both platforms now requires **admin OR at least one non-admin-creatable sport (NCAA/NFL) open**:

- The API returns only FUTURE gates (`LeagueCreationAvailability.GetActiveGates` filters elapsed instants), so a sport absent from the response is open; an elapsed `opensUtc` is also treated as open defensively in case that contract loosens.
- **Mobile**: new pending-aware `useLeagueCreationGatesState` exposes `isPending` so non-admins don't see a flash of the button during the initial fetch (visually fail-closed while pending). A **resolved** failure still fails open, matching the hook's existing contract — the server enforces the gate on create either way. Gates both the header `+ Create` and the empty-state `Create League` button. `anySportOpenForCreation` is a pure helper (MLB ignored — admin-gated in the create flow); existing consumers untouched.
- **Web parity**: same rule on `Leagues.jsx` — header `+ Create League` and the empty-state `Create one` link. `creationGates` state starts null for the same no-flash behavior. `anySportOpenForCreation` mirrored in `leagueCreationGates.js`. (`LeagueMembership.jsx` also links to create but is orphaned — not imported anywhere; the off-season countdown card is already gate-aware.)

## Tests

- Mobile: 5 unit cases for the helper; full suite 112/112; `tsc --noEmit` clean
- Web: 5 mirrored vitest cases; lint clean

No EAS build kicked off (batching per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - League creation controls now appear only for administrators or when at least one eligible sport is open for creation.
  - Creation options remain hidden while availability information is loading, preventing premature access.
  - Consistent visibility behavior is now available across mobile and web experiences.

- **Bug Fixes**
  - Improved handling of closed, missing, expired, and unavailable sport creation windows.
  - Added coverage for league creation visibility across supported gate states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->