### PR TITLE
feat(notification): name the game in line-move pushes and carry a deep link

### DIFF
--- a/docs/features/line-move-notification-deep-link.md
+++ b/docs/features/line-move-notification-deep-link.md
@@ -1,0 +1,119 @@
+# Line-move notifications: name the game, link to it
+
+**Status**: backend shipped; mobile pending device validation ·
+**Origin**: tester feedback, 2026-08-16
+
+## Problem
+
+The line-move push read:
+
+> **Line moved**
+> The line moved on a game you picked: spread -3 → -1.5, total 36.5 → 37.5 (DraftKings).
+
+Two defects, both visible in a single screenshot of a stacked tray:
+
+1. **No game identity.** Nothing in the copy said *which* matchup moved, so
+   two alerts an hour apart were indistinguishable.
+2. **No destination.** Tapping opened the app's last screen; the user had to
+   navigate to the game manually.
+
+Root cause of (1) is structural, not editorial: `ContestOddsUpdated` carries
+numbers and no team names, so no rewording could fix it.
+
+## Decisions
+
+**Enrich from Producer, don't widen the event.** `ContestOddsUpdated` stays a
+thin fact ("odds moved, here are the numbers"). Notification fetches the
+contest from Producer via `IContestClientFactory` → `GetContestById`. The
+alternative — adding a name to the event — was cheaper in the moment (Producer
+already has `Contest` loaded, so it was a free field) but worse in shape: it
+bloats a contract three consumers compile against, forces a nullable-field
+dance on every rolling deploy, and buys exactly one field. `SeasonContestDto`
+already carries `ShortName`, `Name`, and `Week` — everything the copy and the
+deep link need, with no contract change at all.
+
+**`ShortName` needs no new abbreviation fields.** Producer already stores the
+abbreviated form (`KC @ LV`, `IND @ NE`), which is what fits a notification
+title.
+
+**Enrich after the picker gate.** The consumer already returns early when
+nobody picked the contest in an odds-sensitive league. The client call sits
+after that, so only line moves that actually notify someone cost a request —
+not every provider tick on every game.
+
+**Degrade, never drop.** Any failure — unconfigured client slot, transport
+error, non-success result — falls back to the original number-only copy and
+still sends. Current behavior is the floor, so the worst case of adding this
+dependency is what users already got.
+
+## Copy
+
+| | Before | After |
+|---|---|---|
+| Title | `Line moved` | `Line moved: KC @ LV` |
+| Body | `The line moved on a game you picked: spread -3 → -1.5 …` | `Kansas City Chiefs at Las Vegas Raiders: spread -3 → -1.5 …` |
+
+The matchup goes in the **title** because that is the boldest line in the tray
+and the one that disambiguates stacked alerts; the full name in the body
+disambiguates the abbreviation.
+
+## Deep link
+
+Payload follows the `kind`/id contract established by
+`UserInvitedToPickemGroupConsumer`:
+
+| key | value |
+|---|---|
+| `kind` | `OddsChanged` |
+| `target` | `matchup` |
+| `contestId` | contest guid |
+| `sport` | backend Sport enum name (`FootballNcaa`) |
+| `leagueId` | the picked league (see below) |
+| `week` | from `SeasonContestDto.Week`, when present |
+
+Sport travels as the **enum name**, not route segments: the client maps it via
+its own `resolveSportLeague`, keeping URL conventions client-owned. Mobile
+routes through the existing `gameRoute()` helper, which already accepts
+exactly `{sport, league, contestId, leagueId?, week?}`.
+
+### Which league, when the user has several
+
+A user routinely picks the same contest in more than one league. The target is
+taken **from the already-filtered qualifying set** — the join that applies the
+`PickType` filter — never from a separate "user's picks on this contest"
+lookup. This matters: on 2026-08-16 production had 95 (user, contest) pairs
+spanning multiple leagues, **57 of them spanning mixed pick types**. A naive
+"oldest pick" lookup would have deep-linked into a StraightUp league — where a
+line move is irrelevant — roughly 60% of the time. Within the qualifying set,
+ordering is by the league's `CreatedUtc` (then id) so the choice is
+deterministic across redelivery.
+
+## Configuration (required)
+
+Notification now calls `services.AddClients(config, mode)`. The contest client
+resolves per sport, falling back to a mode-agnostic slot:
+
+```
+CommonConfig:ContestClientConfig:FootballNcaa:ApiUrl → http://producer-svc-football-ncaa
+CommonConfig:ContestClientConfig:FootballNfl:ApiUrl  → http://producer-svc-football-nfl
+CommonConfig:ContestClientConfig:ApiUrl              (fallback)
+```
+
+Add these under the Notification label in Azure AppConfig. **If they are
+absent the feature degrades silently to the old copy** — the notification
+still sends, so a missed config slot is a quality regression, not an outage.
+
+## Silent-gap diagnostic
+
+When a contest has picks but no qualifying targets, the consumer now counts
+picks whose `PickemGroup` projection is missing and logs a warning naming
+`admin/backfill/pickemgroups`. This class of gap was real and invisible: on
+2026-08-16, **13 of 16 AgainstTheSpread leagues had no local projection**, so
+their members had never received a line-move notification and nothing was
+logged. The inner join fails closed, which is right — but it should say so.
+
+## Not in scope
+
+`UserPickScoredConsumer` and the contest-start reminders have the same
+"nowhere to tap" gap and could reuse this payload shape. Deliberately deferred
+to keep this change reviewable.

--- a/docs/features/line-move-notification-deep-link.md
+++ b/docs/features/line-move-notification-deep-link.md
@@ -93,7 +93,7 @@ deterministic across redelivery.
 Notification now calls `services.AddClients(config, mode)`. The contest client
 resolves per sport, falling back to a mode-agnostic slot:
 
-```
+```text
 CommonConfig:ContestClientConfig:FootballNcaa:ApiUrl → http://producer-svc-football-ncaa
 CommonConfig:ContestClientConfig:FootballNfl:ApiUrl  → http://producer-svc-football-nfl
 CommonConfig:ContestClientConfig:ApiUrl              (fallback)

--- a/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
@@ -186,6 +186,16 @@ namespace SportsData.Notification.Application.Consumers
                     "Contest lookup returned no contest for {ContestId}; sending un-enriched line-move copy.",
                     msg.ContestId);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // The consumer itself is being cancelled — stop now rather than
+                // logging a "lookup failure" and walking into the dispatch loop
+                // with a dead token. The `when` guard is load-bearing: an
+                // HttpClient TIMEOUT also surfaces as TaskCanceledException but
+                // on a different token, and that case must still degrade to the
+                // un-enriched copy rather than abandoning the notification.
+                throw;
+            }
             catch (Exception ex)
             {
                 // Includes the unconfigured-client case: the factory always
@@ -213,7 +223,7 @@ namespace SportsData.Notification.Application.Consumers
             var unprojected = await (
                 from p in _dataContext.UserPicks.AsNoTracking()
                 where p.ContestId == contestId
-                    && !_dataContext.PickemGroups.Any(g => g.Id == p.PickemGroupId)
+                    && !_dataContext.PickemGroups.AsNoTracking().Any(g => g.Id == p.PickemGroupId)
                 select p.PickemGroupId)
                 .Distinct()
                 .CountAsync(cancellationToken);

--- a/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Infrastructure.Clients.Contest.Queries;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Data.Entities;
 using SportsData.Notification.Infrastructure.Notifications;
@@ -39,6 +41,16 @@ namespace SportsData.Notification.Application.Consumers
     /// </para>
     ///
     /// <para>
+    /// Enrichment: after the picker gate (so only line moves that actually
+    /// notify someone cost a call), the contest is fetched from Producer via
+    /// <c>IContestClientFactory</c> to put the matchup in the title
+    /// ("Line moved: KC @ LV") and to carry deep-link context. Stacked
+    /// number-only alerts were indistinguishable from one another. Enrichment
+    /// is strictly additive — any failure, including an unconfigured client
+    /// slot, falls back to the original number-only copy and still sends.
+    /// </para>
+    ///
+    /// <para>
     /// Per-user dispatch mirrors <see cref="UserPickScoredConsumer"/>: atomic
     /// NotificationLog claim on the unique <c>(CorrelationId, UserId, Channel)</c>
     /// index (idempotent across redelivery and across pickers of the same
@@ -53,17 +65,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPushNotificationSender _pushSender;
+        private readonly IContestClientFactory _contestClientFactory;
 
         public ContestOddsUpdatedConsumer(
             ILogger<ContestOddsUpdatedConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
-            IPushNotificationSender pushSender)
+            IPushNotificationSender pushSender,
+            IContestClientFactory contestClientFactory)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _pushSender = pushSender;
+            _contestClientFactory = contestClientFactory;
         }
 
         public async Task Consume(ConsumeContext<ContestOddsUpdated> context)
@@ -87,41 +102,156 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // Pickers in leagues whose scoring depends on the moved dimension,
-            // deduped across leagues. The join to PickemGroups applies the
-            // PickType filter (ATS↔spread, OverUnder↔total, StraightUp never)
-            // and drops picks whose league projection hasn't landed yet. One
-            // physical line move → one push per user regardless of how many
-            // qualifying leagues they picked it in.
-            var userIds = await (
+            // Pickers in leagues whose scoring depends on the moved dimension.
+            // The join to PickemGroups applies the PickType filter (ATS↔spread,
+            // OverUnder↔total, StraightUp never) and drops picks whose league
+            // projection hasn't landed yet. One physical line move → one push
+            // per user regardless of how many qualifying leagues they picked
+            // it in.
+            //
+            // The deep-link target league is taken from THIS filtered set, so
+            // it is guaranteed to be a league where the line actually matters.
+            // Resolving it from a separate "user's picks on this contest" query
+            // would be wrong: users routinely pick the same contest in leagues
+            // of mixed types, and the earliest of those is often StraightUp —
+            // a league where the move is irrelevant. Ordered by the league's
+            // CreatedUtc so the choice is deterministic across redelivery.
+            var qualifyingPicks = await (
                 from p in _dataContext.UserPicks.AsNoTracking()
                 join g in _dataContext.PickemGroups.AsNoTracking() on p.PickemGroupId equals g.Id
                 where p.ContestId == msg.ContestId
                     && ((spreadMoved && g.PickType == LeaguePickType.AgainstTheSpread)
                         || (totalMoved && g.PickType == LeaguePickType.OverUnder))
-                select p.UserId)
-                .Distinct()
+                select new { p.UserId, LeagueId = g.Id, g.CreatedUtc })
                 .ToListAsync(context.CancellationToken);
 
-            if (userIds.Count == 0)
+            var targets = qualifyingPicks
+                .GroupBy(x => x.UserId)
+                .Select(grp => new
+                {
+                    UserId = grp.Key,
+                    LeagueId = grp.OrderBy(x => x.CreatedUtc).ThenBy(x => x.LeagueId).First().LeagueId
+                })
+                .ToList();
+
+            if (targets.Count == 0)
             {
                 _logger.LogInformation(
                     "No pickers in odds-sensitive leagues for ContestId {ContestId}; nothing to notify.",
                     msg.ContestId);
+
+                await WarnOnUnprojectedLeaguesAsync(msg.ContestId, context.CancellationToken);
                 return;
             }
 
-            var title = "Line moved";
-            var body = ComposeBody(msg, spreadMoved, totalMoved);
+            // Enrich AFTER the picker gate: only line moves that actually
+            // notify someone are worth a call to Producer. A failure here
+            // costs the matchup name and the deep link, never the push.
+            var contest = await TryGetContestAsync(msg, context.CancellationToken);
+
+            var title = ComposeTitle(contest);
+            var body = ComposeBody(msg, contest, spreadMoved, totalMoved);
 
             _logger.LogInformation(
-                "Dispatching line-move notification to {PickerCount} picker(s). SpreadMoved={SpreadMoved}, TotalMoved={TotalMoved}",
-                userIds.Count, spreadMoved, totalMoved);
+                "Dispatching line-move notification to {PickerCount} picker(s). SpreadMoved={SpreadMoved}, TotalMoved={TotalMoved}, Enriched={Enriched}",
+                targets.Count, spreadMoved, totalMoved, contest is not null);
 
-            foreach (var userId in userIds)
+            foreach (var target in targets)
             {
-                await DispatchToUserAsync(userId, msg, title, body, context.CancellationToken);
+                var data = BuildDeepLinkData(msg, contest, target.LeagueId);
+                await DispatchToUserAsync(target.UserId, msg, title, body, data, context.CancellationToken);
             }
+        }
+
+        /// <summary>
+        /// Fetches the contest from Producer for notification copy + deep-link
+        /// context. Returns null on ANY failure — an unconfigured client slot,
+        /// a transport error, or a non-success result — so the caller falls back
+        /// to the number-only copy this consumer shipped originally. Enrichment
+        /// is strictly additive; it must never cost a notification.
+        /// </summary>
+        private async Task<SeasonContestDto> TryGetContestAsync(
+            ContestOddsUpdated msg,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var client = _contestClientFactory.Resolve(msg.Sport);
+                var result = await client.GetContestById(msg.ContestId, cancellationToken);
+
+                if (result is Success<GetContestByIdResponse> { Value.Contest: not null } success)
+                    return success.Value.Contest;
+
+                _logger.LogWarning(
+                    "Contest lookup returned no contest for {ContestId}; sending un-enriched line-move copy.",
+                    msg.ContestId);
+            }
+            catch (Exception ex)
+            {
+                // Includes the unconfigured-client case: the factory always
+                // returns a client, so a missing base address surfaces here as
+                // an invalid-request-URI exception rather than a null.
+                _logger.LogWarning(ex,
+                    "Contest lookup failed for {ContestId}; sending un-enriched line-move copy.",
+                    msg.ContestId);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Diagnostic for the silent-gap class of bug: picks exist on this
+        /// contest but no league projection backs them, so the inner join above
+        /// drops them and nobody is notified. Fails closed by design, but it
+        /// used to fail closed INVISIBLY — on 2026-08-16 thirteen of sixteen
+        /// AgainstTheSpread leagues were missing from the projection and no
+        /// line-move notification had ever reached them. Remedy is
+        /// <c>POST admin/backfill/pickemgroups</c>.
+        /// </summary>
+        private async Task WarnOnUnprojectedLeaguesAsync(Guid contestId, CancellationToken cancellationToken)
+        {
+            var unprojected = await (
+                from p in _dataContext.UserPicks.AsNoTracking()
+                where p.ContestId == contestId
+                    && !_dataContext.PickemGroups.Any(g => g.Id == p.PickemGroupId)
+                select p.PickemGroupId)
+                .Distinct()
+                .CountAsync(cancellationToken);
+
+            if (unprojected > 0)
+            {
+                _logger.LogWarning(
+                    "Picks exist on ContestId {ContestId} for {UnprojectedLeagueCount} league(s) with no local " +
+                    "PickemGroup projection; those pickers cannot be targeted. Run admin/backfill/pickemgroups.",
+                    contestId, unprojected);
+            }
+        }
+
+        /// <summary>
+        /// Deep-link payload consumed by the mobile tap handlers. Mirrors the
+        /// kind/id contract established by UserInvitedToPickemGroupConsumer.
+        /// Sport travels as the backend enum name; the client maps it to route
+        /// segments via its own resolveSportLeague, so URL conventions stay
+        /// owned by the client.
+        /// </summary>
+        private static Dictionary<string, string> BuildDeepLinkData(
+            ContestOddsUpdated msg,
+            SeasonContestDto contest,
+            Guid leagueId)
+        {
+            var data = new Dictionary<string, string>
+            {
+                ["kind"] = "OddsChanged",
+                ["target"] = "matchup",
+                ["contestId"] = msg.ContestId.ToString(),
+                ["sport"] = msg.Sport.ToString(),
+                ["leagueId"] = leagueId.ToString()
+            };
+
+            if (contest?.Week is { } week)
+                data["week"] = week.ToString();
+
+            return data;
         }
 
         private async Task DispatchToUserAsync(
@@ -129,6 +259,7 @@ namespace SportsData.Notification.Application.Consumers
             ContestOddsUpdated msg,
             string title,
             string body,
+            IReadOnlyDictionary<string, string> data,
             CancellationToken cancellationToken)
         {
             using var _ = _logger.BeginScope(new Dictionary<string, object> { ["UserId"] = userId });
@@ -193,7 +324,7 @@ namespace SportsData.Notification.Application.Consumers
             var successCount = 0;
             foreach (var device in devices)
             {
-                var result = await _pushSender.SendAsync(device.FcmToken, title, body);
+                var result = await _pushSender.SendAsync(device.FcmToken, title, body, data, cancellationToken);
                 if (result is Success<string>)
                     successCount++;
                 else
@@ -216,21 +347,45 @@ namespace SportsData.Notification.Application.Consumers
             await _dataContext.SaveChangesAsync(cancellationToken);
         }
 
-        private static string ComposeBody(ContestOddsUpdated msg, bool spreadMoved, bool totalMoved)
+        /// <summary>
+        /// Title carries the matchup because that's the boldest line in the
+        /// tray — stacked "Line moved" alerts were indistinguishable without
+        /// it. ShortName is already the abbreviated form Producer stores
+        /// ("KC @ LV"), which is what keeps the title inside the notification
+        /// width. Falls back to the original bare title when un-enriched.
+        /// </summary>
+        private static string ComposeTitle(SeasonContestDto contest)
         {
-            // The event carries numbers but no team names, so the copy is
-            // number-only. Provider name is included when present to anchor the
-            // move ("per DraftKings"). MLB never reaches here (all-null deltas
-            // are gated out upstream), so this only formats football lines.
+            return string.IsNullOrWhiteSpace(contest?.ShortName)
+                ? "Line moved"
+                : $"Line moved: {contest.ShortName}";
+        }
+
+        private static string ComposeBody(
+            ContestOddsUpdated msg,
+            SeasonContestDto contest,
+            bool spreadMoved,
+            bool totalMoved)
+        {
+            // Provider name is included when present to anchor the move ("per
+            // DraftKings"). MLB never reaches here (all-null deltas are gated
+            // out upstream), so this only formats football lines.
             var via = string.IsNullOrWhiteSpace(msg.ProviderName) ? "" : $" ({msg.ProviderName})";
 
+            // The full name disambiguates the abbreviation in the title. When
+            // un-enriched we keep the original "a game you picked" phrasing so
+            // the copy still reads as a sentence.
+            var subject = string.IsNullOrWhiteSpace(contest?.Name)
+                ? "a game you picked"
+                : contest.Name;
+
             if (spreadMoved && totalMoved)
-                return $"The line moved on a game you picked: spread {FormatLine(msg.OldSpread)} → {FormatLine(msg.NewSpread)}, total {FormatLine(msg.OldOverUnder)} → {FormatLine(msg.NewOverUnder)}{via}.";
+                return $"{subject}: spread {FormatLine(msg.OldSpread)} → {FormatLine(msg.NewSpread)}, total {FormatLine(msg.OldOverUnder)} → {FormatLine(msg.NewOverUnder)}{via}.";
 
             if (spreadMoved)
-                return $"The spread moved on a game you picked: {FormatLine(msg.OldSpread)} → {FormatLine(msg.NewSpread)}{via}.";
+                return $"{subject}: spread {FormatLine(msg.OldSpread)} → {FormatLine(msg.NewSpread)}{via}.";
 
-            return $"The total moved on a game you picked: {FormatLine(msg.OldOverUnder)} → {FormatLine(msg.NewOverUnder)}{via}.";
+            return $"{subject}: total {FormatLine(msg.OldOverUnder)} → {FormatLine(msg.NewOverUnder)}{via}.";
         }
 
         private static string FormatLine(decimal? value)

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -31,6 +31,13 @@ namespace SportsData.Notification
 
             var services = builder.Services;
             services.AddCoreServices(config, mode);
+            // Typed service clients. ContestOddsUpdatedConsumer resolves
+            // IContestClientFactory to enrich line-move pushes with the
+            // matchup (Producer owns canonical contest data). Every client
+            // call there degrades gracefully, so a missing
+            // CommonConfig:ContestClientConfig:* slot costs the enrichment,
+            // not the notification.
+            services.AddClients(config, mode);
             services.AddControllers();
             services.AddEndpointsApiExplorer();
             services.AddSwaggerGen();

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
@@ -8,6 +8,8 @@ using Moq;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Contests;
+using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Infrastructure.Clients.Contest.Queries;
 using SportsData.Notification.Application.Consumers;
 using SportsData.Notification.Infrastructure.Data.Entities;
 using SportsData.Notification.Infrastructure.Notifications;
@@ -242,5 +244,172 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
 
         VerifySendCount(Times.Never());
+    }
+
+    // ─── Enrichment + deep link ───────────────────────────────────────────
+
+    private const string ShortName = "LSU @ BAMA";
+    private const string FullName = "LSU Tigers at Alabama Crimson Tide";
+
+    /// <summary>
+    /// Stubs Producer's contest lookup. The consumer resolves the client per
+    /// sport off IContestClientFactory.
+    /// </summary>
+    private void StubContest(SeasonContestDto contest)
+    {
+        var client = new Mock<IProvideContests>();
+        client
+            .Setup(x => x.GetContestById(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<GetContestByIdResponse>(new GetContestByIdResponse(contest)));
+
+        Mocker.GetMock<IContestClientFactory>()
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(client.Object);
+    }
+
+    private void StubContestThrows()
+    {
+        var client = new Mock<IProvideContests>();
+        client
+            .Setup(x => x.GetContestById(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("producer unreachable"));
+
+        Mocker.GetMock<IContestClientFactory>()
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(client.Object);
+    }
+
+    private (string Title, string Body, IReadOnlyDictionary<string, string> Data) CapturedSend()
+    {
+        string title = null, body = null;
+        IReadOnlyDictionary<string, string> data = null;
+        _pushSender.Verify(x => x.SendAsync(
+            It.IsAny<string>(),
+            It.Is<string>(t => Capture(t, ref title)),
+            It.Is<string>(b => Capture(b, ref body)),
+            It.Is<IReadOnlyDictionary<string, string>>(d => CaptureData(d, ref data)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        return (title, body, data);
+    }
+
+    private static bool Capture(string value, ref string slot) { slot = value; return true; }
+    private static bool CaptureData(IReadOnlyDictionary<string, string> value, ref IReadOnlyDictionary<string, string> slot)
+    { slot = value; return true; }
+
+    [Fact]
+    public async Task Consume_EnrichedContest_PutsMatchupInTitleAndDeepLinkInData()
+    {
+        // The reported defect: stacked "Line moved" alerts were
+        // indistinguishable because no copy named the game.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, groupId, LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+
+        StubContest(new SeasonContestDto
+        {
+            Id = contestId,
+            Name = FullName,
+            ShortName = ShortName,
+            Week = 3
+        });
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -1.5m)));
+
+        var (title, body, data) = CapturedSend();
+
+        title.Should().Be($"Line moved: {ShortName}");
+        body.Should().StartWith(FullName, "the full name disambiguates the abbreviated title");
+        body.Should().Contain("-3").And.Contain("-1.5");
+
+        data["kind"].Should().Be("OddsChanged");
+        data["contestId"].Should().Be(contestId.ToString());
+        data["leagueId"].Should().Be(groupId.ToString());
+        data["sport"].Should().Be(nameof(Sport.FootballNcaa));
+        data["week"].Should().Be("3");
+    }
+
+    [Fact]
+    public async Task Consume_ContestLookupFails_StillSendsUnEnriched()
+    {
+        // Enrichment is additive: losing Producer costs the matchup name and
+        // the deep link, never the notification.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+
+        StubContestThrows();
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -1.5m)));
+
+        var (title, body, data) = CapturedSend();
+
+        title.Should().Be("Line moved");
+        body.Should().Contain("a game you picked");
+        data["kind"].Should().Be("OddsChanged");
+        data.ContainsKey("week").Should().BeFalse("no contest means no week");
+    }
+
+    [Fact]
+    public async Task Consume_UserInMixedPickTypeLeagues_DeepLinksToTheQualifyingLeague()
+    {
+        // The trap: users pick the same contest in leagues of different types,
+        // and the OLDEST is frequently StraightUp — where a line move is
+        // irrelevant. The target must come from the odds-sensitive set, not
+        // from "earliest pick" overall.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var straightUpId = Guid.NewGuid();
+        var atsId = Guid.NewGuid();
+
+        // StraightUp league created FIRST, so any naive ordering picks it.
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = straightUpId,
+            Name = "SU league",
+            Sport = Sport.FootballNcaa,
+            CommissionerUserId = Guid.NewGuid(),
+            PickType = LeaguePickType.StraightUp,
+            CreatedUtc = FixedNow.AddDays(-30),
+            CreatedBy = Guid.NewGuid()
+        });
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = atsId,
+            Name = "ATS league",
+            Sport = Sport.FootballNcaa,
+            CommissionerUserId = Guid.NewGuid(),
+            PickType = LeaguePickType.AgainstTheSpread,
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        foreach (var gid in new[] { straightUpId, atsId })
+        {
+            DataContext.UserPicks.Add(new UserPick
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ContestId = contestId,
+                PickemGroupId = gid,
+                CreatedUtc = FixedNow.AddDays(-1),
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+        await DataContext.SaveChangesAsync();
+        await SeedDeviceAsync(userId);
+
+        StubContest(new SeasonContestDto { Id = contestId, Name = FullName, ShortName = ShortName });
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -1.5m)));
+
+        // Notified once (deduped across leagues), targeting the ATS league.
+        var (_, _, data) = CapturedSend();
+        data["leagueId"].Should().Be(atsId.ToString(),
+            "the deep link must land on a league where the line actually matters");
     }
 }


### PR DESCRIPTION
Backend half of the tester-reported line-move feedback. Mobile deep-link handling is deliberately **not** in this PR — it's in my working tree awaiting your device test, and the payload is inert until a client reads it, so this ships safely on its own.

## Problem

From the tester screenshot — two stacked alerts, neither identifying its game:

> **Line moved**
> The line moved on a game you picked: spread -3 → -1.5, total 36.5 → 37.5 (DraftKings).

The missing game name is structural, not editorial: `ContestOddsUpdated` carries numbers and no team names, so no rewording fixes it.

## Approach

**Enrich from Producer instead of widening the event.** `ContestOddsUpdated` stays a thin fact; Notification fetches the contest via `IContestClientFactory` → `GetContestById`. Adding a name to the event was cheaper in the moment (Producer already has `Contest` loaded) but worse in shape — it bloats a contract three consumers compile against, forces a nullable-field dance on rolling deploys, and buys one field. `SeasonContestDto` already has `ShortName`, `Name`, **and `Week`**, so there's no contract change at all.

| | Before | After |
|---|---|---|
| Title | `Line moved` | `Line moved: KC @ LV` |
| Body | `The line moved on a game you picked: spread…` | `Kansas City Chiefs at Las Vegas Raiders: spread…` |

**Enriched after the picker gate**, so only line moves that actually notify someone cost a request. **Degrades, never drops** — unconfigured client slot, transport error, or non-success result all fall back to the original copy and still send.

## The multi-league trap

The deep-link target league comes from the **already-`PickType`-filtered** set, never a separate "oldest pick on this contest" lookup. Production data on why that matters: **95** (user, contest) pairs span multiple leagues, **57 of them spanning mixed pick types** — so a naive lookup would have deep-linked into a StraightUp league, where a line move is meaningless, roughly 60% of the time. Within the qualifying set, ordering is by league `CreatedUtc` then id, so it's deterministic across redelivery.

## Silent-gap diagnostic

Added a warning when picks exist for leagues with no local `PickemGroup` projection. This was real and invisible: on 2026-08-16, **13 of 16 AgainstTheSpread leagues had no projection**, so their members had never received a line-move notification — and nothing was logged. (Backfill has since been run; all 16 now project.)

## ⚠️ Config required before this does anything

```
CommonConfig:ContestClientConfig:FootballNcaa:ApiUrl → http://producer-svc-football-ncaa
CommonConfig:ContestClientConfig:FootballNfl:ApiUrl  → http://producer-svc-football-nfl
```

Under the **Notification** label in Azure AppConfig. Absent these, the feature degrades silently to the old copy — a quality regression, not an outage.

## Tests

Notification consumer suite **12/12**, including three new cases: enriched title/body + full deep-link payload, graceful degrade when Producer throws, and the mixed-pick-type league selection. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Line-movement notifications now include contest names and matchup details when available.
  * Notifications can link directly to the relevant contest.
  * Titles use abbreviated matchups, while notification bodies provide full matchup names.

* **Bug Fixes**
  * Notifications continue to send in their original format when contest details or configuration are unavailable.
  * Improved league selection for users with mixed pick types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->