### PR TITLE
feat(notification): deep-link scored-pick pushes to the game

### DIFF
--- a/docs/features/line-move-notification-deep-link.md
+++ b/docs/features/line-move-notification-deep-link.md
@@ -97,9 +97,13 @@ and `AppConfiguration` selects `CommonConfig:*` at `{label}.{mode}`) — no
 provisioning was needed:
 
 ```text
-CommonConfig:ContestClientConfig:FootballNcaa:ApiUrl → http://producer-svc-football-ncaa
-CommonConfig:ContestClientConfig:FootballNfl:ApiUrl  → http://producer-svc-football-nfl
-CommonConfig:ContestClientConfig:ApiUrl              (fallback)
+# label Prod.All (per-sport, what the factory resolves first)
+CommonConfig:ContestClientConfig:FootballNcaa:ApiUrl → http://producer-svc-football-ncaa/api/
+CommonConfig:ContestClientConfig:FootballNfl:ApiUrl  → http://producer-svc-football-nfl/api/
+CommonConfig:ContestClientConfig:BaseballMlb:ApiUrl  → http://producer-svc-baseball-mlb/api/
+
+# label Prod (mode-agnostic fallback)
+CommonConfig:ContestClientConfig:ApiUrl              → http://producer-svc-football-ncaa/api/
 ```
 
 Note the trailing `/api/` **with** the trailing slash: `HttpClient` relative

--- a/docs/features/line-move-notification-deep-link.md
+++ b/docs/features/line-move-notification-deep-link.md
@@ -64,7 +64,7 @@ Payload follows the `kind`/id contract established by
 
 | key | value |
 |---|---|
-| `kind` | `OddsChanged` |
+| `kind` | `OddsChanged` or `PickScored` |
 | `target` | `matchup` |
 | `contestId` | contest guid |
 | `sport` | backend Sport enum name (`FootballNcaa`) |
@@ -88,10 +88,13 @@ line move is irrelevant — roughly 60% of the time. Within the qualifying set,
 ordering is by the league's `CreatedUtc` (then id) so the choice is
 deterministic across redelivery.
 
-## Configuration (required)
+## Configuration (already provisioned)
 
 Notification now calls `services.AddClients(config, mode)`. The contest client
-resolves per sport, falling back to a mode-agnostic slot:
+resolves per sport, falling back to a mode-agnostic slot. **These keys already
+existed** in Azure AppConfig under `Prod.All` (Notification runs `mode=All`,
+and `AppConfiguration` selects `CommonConfig:*` at `{label}.{mode}`) — no
+provisioning was needed:
 
 ```text
 CommonConfig:ContestClientConfig:FootballNcaa:ApiUrl → http://producer-svc-football-ncaa
@@ -99,9 +102,15 @@ CommonConfig:ContestClientConfig:FootballNfl:ApiUrl  → http://producer-svc-foo
 CommonConfig:ContestClientConfig:ApiUrl              (fallback)
 ```
 
-Add these under the Notification label in Azure AppConfig. **If they are
-absent the feature degrades silently to the old copy** — the notification
-still sends, so a missed config slot is a quality regression, not an outage.
+Note the trailing `/api/` **with** the trailing slash: `HttpClient` relative
+resolution only appends when the base ends in `/`, otherwise `contests/{id}`
+would replace the last segment and drop the `/api` prefix. Producer's
+`ContestController` has no auth filter, so the per-sport `SecretKey` entries
+alongside these are unused on this path.
+
+If a slot were ever absent the feature degrades silently to the old copy — the
+notification still sends, so a missing key is a quality regression, not an
+outage.
 
 ## Silent-gap diagnostic
 
@@ -112,8 +121,21 @@ picks whose `PickemGroup` projection is missing and logs a warning naming
 their members had never received a line-move notification and nothing was
 logged. The inner join fails closed, which is right — but it should say so.
 
+## Reuse: one contract, many kinds
+
+The payload is built by `Application/Dispatching/MatchupDeepLink`, the
+server-side twin of the client's `src/utils/deepLinks.ts`. Each side names the
+contract once, so a new matchup-bound notification adds a kind constant on the
+server and an entry in the client's `MATCHUP_KINDS` set — nothing else.
+
+Kinds landing on the game page:
+
+| Kind | Source | Notes |
+|---|---|---|
+| `OddsChanged` | `ContestOddsUpdatedConsumer` | week from `SeasonContestDto` (service call) |
+| `PickScored` | `UserPickScoredConsumer` | week from the local `PickemGroupMatchup` projection — **no service call**; ids all ride on the event |
+
 ## Not in scope
 
-`UserPickScoredConsumer` and the contest-start reminders have the same
-"nowhere to tap" gap and could reuse this payload shape. Deliberately deferred
-to keep this change reviewable.
+Contest-start reminders have the same "nowhere to tap" gap and could reuse this
+payload shape. Deferred to keep each change reviewable.

--- a/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Infrastructure.Clients.Contest.Queries;
+using SportsData.Notification.Application.Dispatching;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Data.Entities;
 using SportsData.Notification.Infrastructure.Notifications;
@@ -237,32 +238,16 @@ namespace SportsData.Notification.Application.Consumers
             }
         }
 
-        /// <summary>
-        /// Deep-link payload consumed by the mobile tap handlers. Mirrors the
-        /// kind/id contract established by UserInvitedToPickemGroupConsumer.
-        /// Sport travels as the backend enum name; the client maps it to route
-        /// segments via its own resolveSportLeague, so URL conventions stay
-        /// owned by the client.
-        /// </summary>
         private static Dictionary<string, string> BuildDeepLinkData(
             ContestOddsUpdated msg,
             SeasonContestDto contest,
             Guid leagueId)
-        {
-            var data = new Dictionary<string, string>
-            {
-                ["kind"] = "OddsChanged",
-                ["target"] = "matchup",
-                ["contestId"] = msg.ContestId.ToString(),
-                ["sport"] = msg.Sport.ToString(),
-                ["leagueId"] = leagueId.ToString()
-            };
-
-            if (contest?.Week is { } week)
-                data["week"] = week.ToString();
-
-            return data;
-        }
+            => MatchupDeepLink.Build(
+                MatchupDeepLink.OddsChangedKind,
+                msg.ContestId,
+                msg.Sport,
+                leagueId,
+                contest?.Week);
 
         private async Task DispatchToUserAsync(
             Guid userId,

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Notification.Application.Dispatching;
 using SportsData.Notification.Infrastructure.Data;
 using SportsData.Notification.Infrastructure.Data.Entities;
 using SportsData.Notification.Infrastructure.Notifications;
@@ -151,6 +152,23 @@ namespace SportsData.Notification.Application.Consumers
             var title = msg.IsCorrect == true ? "Nice pick!" : "Tough loss";
             var body = ComposeBody(msg, leagueName);
 
+            // Deep link to the scored game. Everything needed rides on the
+            // event except the week, which comes from the local matchup
+            // projection — no service call on this path. A missing projection
+            // just omits the week; gameRoute treats it as optional.
+            var week = await _dataContext.PickemGroupMatchups
+                .AsNoTracking()
+                .Where(m => m.ContestId == msg.ContestId && m.PickemGroupId == msg.LeagueId)
+                .Select(m => (int?)m.SeasonWeek)
+                .FirstOrDefaultAsync();
+
+            var data = MatchupDeepLink.Build(
+                MatchupDeepLink.PickScoredKind,
+                msg.ContestId,
+                msg.Sport,
+                msg.LeagueId,
+                week);
+
             // Per-device dispatch. Single-token send rather than multicast
             // because v1's IPushNotificationSender surface is one-at-a-time;
             // multicast batching can come later if device counts per user
@@ -163,7 +181,8 @@ namespace SportsData.Notification.Application.Consumers
             var failureReasons = new List<string>();
             foreach (var device in devices)
             {
-                var result = await _pushSender.SendAsync(device.FcmToken, title, body);
+                var result = await _pushSender.SendAsync(
+                    device.FcmToken, title, body, data, context.CancellationToken);
                 if (result is Success<string>)
                 {
                     successCount++;

--- a/src/SportsData.Notification/Application/Dispatching/MatchupDeepLink.cs
+++ b/src/SportsData.Notification/Application/Dispatching/MatchupDeepLink.cs
@@ -1,0 +1,59 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Notification.Application.Dispatching;
+
+/// <summary>
+/// Builds the FCM data payload that sends a notification tap to a specific
+/// matchup. Server-side twin of the mobile client's
+/// <c>src/utils/deepLinks.ts</c> — the wire contract lives in exactly one
+/// place per side, so adding a notification kind that lands on a game page
+/// doesn't re-derive the key names.
+///
+/// <para>
+/// Shape follows the kind/id convention established by
+/// <c>UserInvitedToPickemGroupConsumer</c>. Sport travels as the backend enum
+/// NAME ("FootballNcaa"), not route segments: the client maps it through its
+/// own resolveSportLeague, keeping URL conventions client-owned.
+/// </para>
+///
+/// <para>
+/// Every value is a string because FCM data payloads are string maps; the
+/// client parses <c>week</c> back to a number and drops it when unparseable.
+/// Optional values are OMITTED rather than sent empty, so the client's
+/// "is this key present" checks stay meaningful.
+/// </para>
+/// </summary>
+public static class MatchupDeepLink
+{
+    /// <summary>Line moved on a contest the user picked.</summary>
+    public const string OddsChangedKind = "OddsChanged";
+
+    /// <summary>The user's pick was scored.</summary>
+    public const string PickScoredKind = "PickScored";
+
+    public static Dictionary<string, string> Build(
+        string kind,
+        Guid contestId,
+        Sport sport,
+        Guid? leagueId = null,
+        int? week = null)
+    {
+        var data = new Dictionary<string, string>
+        {
+            ["kind"] = kind,
+            ["target"] = "matchup",
+            ["contestId"] = contestId.ToString(),
+            ["sport"] = sport.ToString()
+        };
+
+        // Scopes the game page to the user's league so their pick renders
+        // alongside the contest.
+        if (leagueId is { } league && league != Guid.Empty)
+            data["leagueId"] = league.ToString();
+
+        if (week is { } w)
+            data["week"] = w.ToString();
+
+        return data;
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
@@ -237,4 +237,80 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
 
         (await DataContext.UserDevices.CountAsync(d => d.UserId == userId)).Should().Be(0);
     }
+
+    [Fact]
+    public async Task Consume_SendsMatchupDeepLinkPayload()
+    {
+        // Tapping a result push must land on the scored game, not the app's
+        // last screen. Week comes from the local matchup projection so this
+        // path makes no service call.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var leagueId = Guid.NewGuid();
+
+        DataContext.PickemGroupMatchups.Add(new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            ContestId = contestId,
+            StartDateUtc = FixedNow,
+            SeasonYear = 2026,
+            SeasonWeek = 7,
+            StatusTypeName = "STATUS_FINAL",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+        await SeedDeviceAsync(userId);
+
+        IReadOnlyDictionary<string, string> captured = null;
+        _pushSender
+            .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, IReadOnlyDictionary<string, string>, CancellationToken>(
+                (_, _, _, data, _) => captured = data)
+            .ReturnsAsync(new Success<string>("msg-id"));
+
+        var sut = Mocker.CreateInstance<UserPickScoredConsumer>();
+        await sut.Consume(ContextFor(Msg(
+            userId, "BOS", "NYY", awayScore: 3, homeScore: 2,
+            isCorrect: true, pickedIsHome: false, pickedSpread: null,
+            contestId: contestId, leagueId: leagueId)));
+
+        captured.Should().NotBeNull();
+        captured["kind"].Should().Be("PickScored");
+        captured["target"].Should().Be("matchup");
+        captured["contestId"].Should().Be(contestId.ToString());
+        captured["leagueId"].Should().Be(leagueId.ToString());
+        captured["sport"].Should().Be(nameof(Sport.BaseballMlb));
+        captured["week"].Should().Be("7");
+    }
+
+    [Fact]
+    public async Task Consume_NoMatchupProjection_OmitsWeekButStillDeepLinks()
+    {
+        // A missing projection must not cost the deep link — week is optional
+        // on the route.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedDeviceAsync(userId);
+
+        IReadOnlyDictionary<string, string> captured = null;
+        _pushSender
+            .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, IReadOnlyDictionary<string, string>, CancellationToken>(
+                (_, _, _, data, _) => captured = data)
+            .ReturnsAsync(new Success<string>("msg-id"));
+
+        var sut = Mocker.CreateInstance<UserPickScoredConsumer>();
+        await sut.Consume(ContextFor(Msg(
+            userId, "BOS", "NYY", awayScore: 3, homeScore: 2,
+            isCorrect: true, pickedIsHome: false, pickedSpread: null,
+            contestId: contestId)));
+
+        captured.Should().NotBeNull();
+        captured["contestId"].Should().Be(contestId.ToString());
+        captured.ContainsKey("week").Should().BeFalse();
+    }
 }


### PR DESCRIPTION
Second matchup-bound notification kind, following #640. Tapping a "Nice pick! / Tough loss" push landed on the app's last screen; it now opens the scored game, league-scoped so the user's pick renders alongside it.

## Cheaper than the line-move path

No service call here. `UserPickScored` is a fat event that already carries `ContestId`, `LeagueId` and `Sport`; the only missing piece is the week, which comes from the local `PickemGroupMatchup` projection. A missing projection simply omits the week — `gameRoute` treats it as optional.

Copy is untouched: it already names both teams (`Sluggers: BOS 3, NYY 2 — you picked BOS ✓`), so unlike the line-move push there was nothing to enrich.

## One contract, two kinds

Extracted `Application/Dispatching/MatchupDeepLink` as the server-side twin of the client's `src/utils/deepLinks.ts`. Each side names the wire contract once, so adding a matchup-bound kind means a constant here plus an entry in the client's `MATCHUP_KINDS` set — nothing else. `ContestOddsUpdatedConsumer` now builds through it too.

| Kind | Source | Week from |
|---|---|---|
| `OddsChanged` | `ContestOddsUpdatedConsumer` | `SeasonContestDto` (service call) |
| `PickScored` | `UserPickScoredConsumer` | local projection (no call) |

## Doc correction

The feature doc told you to add `CommonConfig:ContestClientConfig:*` to AppConfig. **That was wrong** — the keys already existed under `Prod.All`, which is exactly the label Notification loads (`mode=All`, and `AppConfiguration` selects `CommonConfig:*` at `{label}.{mode}`). Corrected, and I recorded why the trailing `/api/` **slash** matters: `HttpClient` only appends a relative path when the base ends in `/`, otherwise `contests/{id}` would replace the last segment and drop the `/api` prefix.

## Tests

Full Notification suite **60/60**, including two new cases: the complete payload with week resolved from the projection, and the missing-projection case that must still deep-link without a week.

Mobile side (accepting the new kind) is in my working tree with the rest of the deep-link handling, pending your EAS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deep links for matchup-related push notifications when odds change or a user’s pick is scored.
  - Notifications now include relevant contest, sport, league, and matchup week details when available.
  - Deep links remain available even when week information cannot be determined.

- **Documentation**
  - Updated configuration and reuse guidance for matchup deep links, including URL behavior and supported notification types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->