### PR TITLE
feat(mobile): route notification taps to the matchup (client half of #640/#641)

### DIFF
--- a/src/UI/sd-mobile/__tests__/utils/deepLinks.test.ts
+++ b/src/UI/sd-mobile/__tests__/utils/deepLinks.test.ts
@@ -1,0 +1,109 @@
+import {
+  getLeagueInviteId,
+  getMatchupTarget,
+  toPendingDeepLink,
+} from '@/src/utils/deepLinks';
+
+// FCM data payloads are string maps on the wire — every fixture below uses
+// strings, including week, so the parsing under test is the real thing.
+
+describe('getLeagueInviteId', () => {
+  it('returns the leagueId for a LeagueInvite payload', () => {
+    expect(
+      getLeagueInviteId({ kind: 'LeagueInvite', leagueId: 'abc' }),
+    ).toBe('abc');
+  });
+
+  it('returns null for other kinds and for missing data', () => {
+    expect(getLeagueInviteId({ kind: 'OddsChanged', leagueId: 'abc' })).toBeNull();
+    expect(getLeagueInviteId(null)).toBeNull();
+    expect(getLeagueInviteId({ kind: 'LeagueInvite' })).toBeNull();
+  });
+});
+
+describe('getMatchupTarget', () => {
+  const base = {
+    kind: 'OddsChanged',
+    target: 'matchup',
+    contestId: 'contest-1',
+    sport: 'FootballNcaa',
+  };
+
+  it('maps the Sport enum to route segments', () => {
+    expect(getMatchupTarget(base)).toEqual({
+      sport: 'football',
+      league: 'ncaa',
+      contestId: 'contest-1',
+      leagueId: undefined,
+      week: undefined,
+    });
+  });
+
+  it('carries leagueId and parses week from its wire string', () => {
+    const result = getMatchupTarget({ ...base, leagueId: 'lg-1', week: '3' });
+    expect(result?.leagueId).toBe('lg-1');
+    expect(result?.week).toBe(3);
+  });
+
+  it('drops an unparseable week rather than passing NaN downstream', () => {
+    expect(getMatchupTarget({ ...base, week: 'soon' })?.week).toBeUndefined();
+  });
+
+  it('accepts PickScored, the other matchup-bound kind', () => {
+    // Both line-move and pick-scored pushes land on the game page; the
+    // server-side twin is MatchupDeepLink's *Kind constants.
+    const result = getMatchupTarget({ ...base, kind: 'PickScored', leagueId: 'lg-9', week: '5' });
+    expect(result).toEqual({
+      sport: 'football',
+      league: 'ncaa',
+      contestId: 'contest-1',
+      leagueId: 'lg-9',
+      week: 5,
+    });
+  });
+
+  it('returns null for an unknown sport enum', () => {
+    // resolveSportLeague is deliberately strict; an unsupported sport must
+    // not route to a wrong-sport screen.
+    expect(getMatchupTarget({ ...base, sport: 'CricketIpl' })).toBeNull();
+  });
+
+  it('returns null when required fields are missing or the kind differs', () => {
+    expect(getMatchupTarget({ ...base, contestId: undefined })).toBeNull();
+    expect(getMatchupTarget({ ...base, kind: 'LeagueInvite' })).toBeNull();
+    expect(getMatchupTarget(null)).toBeNull();
+  });
+});
+
+describe('toPendingDeepLink', () => {
+  it('discriminates invite payloads', () => {
+    expect(toPendingDeepLink({ kind: 'LeagueInvite', leagueId: 'lg' })).toEqual({
+      kind: 'invite',
+      leagueId: 'lg',
+    });
+  });
+
+  it('discriminates matchup payloads', () => {
+    expect(
+      toPendingDeepLink({
+        kind: 'OddsChanged',
+        contestId: 'c1',
+        sport: 'FootballNfl',
+        leagueId: 'lg',
+        week: '2',
+      }),
+    ).toEqual({
+      kind: 'matchup',
+      sport: 'football',
+      league: 'nfl',
+      contestId: 'c1',
+      leagueId: 'lg',
+      week: 2,
+    });
+  });
+
+  it('returns null for an unrecognized payload so the tap is a no-op', () => {
+    expect(toPendingDeepLink({ kind: 'SomethingElse' })).toBeNull();
+    expect(toPendingDeepLink(undefined)).toBeNull();
+  });
+});

--- a/src/UI/sd-mobile/__tests__/utils/deepLinks.test.ts
+++ b/src/UI/sd-mobile/__tests__/utils/deepLinks.test.ts
@@ -49,6 +49,24 @@ describe('getMatchupTarget', () => {
     expect(getMatchupTarget({ ...base, week: 'soon' })?.week).toBeUndefined();
   });
 
+  it.each([
+    ['a numeric prefix', '3invalid'],
+    ['a decimal', '3.5'],
+    ['a negative', '-3'],
+    ['whitespace only', '   '],
+    ['an empty string', ''],
+    ['a precision-losing digit string', '999999999999999999999'],
+  ])('rejects %s rather than routing to a wrong week', (_label, week) => {
+    // parseInt would take the valid PREFIX of "3invalid" and "3.5", yielding 3
+    // — a plausible-looking wrong week is worse than no week at all, since
+    // gameRoute treats week as optional and degrades cleanly without it.
+    expect(getMatchupTarget({ ...base, week })?.week).toBeUndefined();
+  });
+
+  it('still accepts a clean integer week', () => {
+    expect(getMatchupTarget({ ...base, week: '12' })?.week).toBe(12);
+  });
+
   it('accepts PickScored, the other matchup-bound kind', () => {
     // Both line-move and pick-scored pushes land on the game page; the
     // server-side twin is MatchupDeepLink's *Kind constants.

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -31,6 +31,8 @@ import { useAuthInit, useAuth } from '@/src/hooks/useAuth';
 import { useOtaUpdates } from '@/src/hooks/useOtaUpdates';
 import { useRegisterPushDevice } from '@/src/hooks/useRegisterPushDevice';
 import { ThemeProvider, useThemeMode } from '@/src/lib/theme/ThemeContext';
+import { gameRoute } from '@/src/utils/sportLinks';
+import { toPendingDeepLink, type PendingDeepLink } from '@/src/utils/deepLinks';
 import { TextSizeProvider, useTextSize } from '@/src/lib/textSize/TextSizeContext';
 import { SignalRGate } from '@/src/components/signalR/SignalRGate';
 import Toast from 'react-native-toast-message';
@@ -62,19 +64,6 @@ export const unstable_settings = {
 };
 
 SplashScreen.preventAutoHideAsync();
-
-/**
- * Wire contract for a LeagueInvite deep-link: kind === 'LeagueInvite' with a
- * string leagueId. Shared by the expo (Android content.data) and RNFirebase
- * (iOS remoteMessage.data) tap paths so the payload shape lives in one place.
- * Returns the validated leagueId, or null when it's not a LeagueInvite.
- */
-function getLeagueInviteId(data: Record<string, unknown> | null | undefined): string | null {
-  if (!data) return null;
-  return data.kind === 'LeagueInvite' && typeof data.leagueId === 'string'
-    ? data.leagueId
-    : null;
-}
 
 // Notification handler — controls what happens when a push arrives
 // while the app is in the foreground. iOS does not show foreground
@@ -248,7 +237,7 @@ function NativePushDiagnostics() {
   const router = useRouter();
   const segments = useSegments();
   const { user, isInitialized } = useAuth();
-  const [pendingLeagueId, setPendingLeagueId] = useState<string | null>(null);
+  const [pendingDeepLink, setPendingDeepLink] = useState<PendingDeepLink | null>(null);
 
   useEffect(() => {
     // Privacy: log only non-content fields. console.log feeds Sentry
@@ -272,8 +261,8 @@ function NativePushDiagnostics() {
 
       // Deep-link dispatch. Stash the target; the auth-gated effect below
       // navigates once the router/auth tree is ready.
-      const inviteLeagueId = getLeagueInviteId(data);
-      if (inviteLeagueId) setPendingLeagueId(inviteLeagueId);
+      const target = toPendingDeepLink(data);
+      if (target) setPendingDeepLink(target);
     };
 
     if (lastResponse) {
@@ -307,8 +296,8 @@ function NativePushDiagnostics() {
       remoteMessage: FirebaseMessagingTypes.RemoteMessage | null,
     ) => {
       if (!remoteMessage) return;
-      const inviteLeagueId = getLeagueInviteId(remoteMessage.data ?? {});
-      if (inviteLeagueId) setPendingLeagueId(inviteLeagueId);
+      const target = toPendingDeepLink(remoteMessage.data ?? {});
+      if (target) setPendingDeepLink(target);
     };
 
     let cancelled = false;
@@ -346,16 +335,33 @@ function NativePushDiagnostics() {
   // signal AuthGuard keys off, so once it's no longer '(auth)' the redirect
   // has settled. Keep pendingLeagueId cached until then.
   useEffect(() => {
-    if (!pendingLeagueId) return;
+    if (!pendingDeepLink) return;
     if (!isInitialized || !user) return;
     if (segments[0] === '(auth)') return;
-    const leagueId = pendingLeagueId;
-    setPendingLeagueId(null);
-    router.push({
-      pathname: '/league-invite/[leagueId]',
-      params: { leagueId },
-    } as never);
-  }, [pendingLeagueId, isInitialized, user, router, segments]);
+
+    const target = pendingDeepLink;
+    setPendingDeepLink(null);
+
+    if (target.kind === 'invite') {
+      router.push({
+        pathname: '/league-invite/[leagueId]',
+        params: { leagueId: target.leagueId },
+      } as never);
+      return;
+    }
+
+    // Line-move push → the game page, scoped to the picked league when the
+    // payload carried one. gameRoute owns the segment convention.
+    router.push(
+      gameRoute({
+        sport: target.sport,
+        league: target.league,
+        contestId: target.contestId,
+        leagueId: target.leagueId,
+        week: target.week,
+      }) as never,
+    );
+  }, [pendingDeepLink, isInitialized, user, router, segments]);
 
   return null;
 }

--- a/src/UI/sd-mobile/src/utils/deepLinks.ts
+++ b/src/UI/sd-mobile/src/utils/deepLinks.ts
@@ -71,14 +71,20 @@ export function getMatchupTarget(
   if (!resolved) return null;
 
   // week is a string on the wire; drop it rather than pass NaN downstream.
-  const parsedWeek = typeof data.week === 'string' ? parseInt(data.week, 10) : NaN;
+  // Validate the WHOLE string — parseInt takes a valid prefix, so "3invalid"
+  // and "3.5" would both yield 3 and route to a plausible-looking wrong week
+  // instead of being rejected. Season weeks are positive integers, so
+  // digits-only is the exact contract; isSafeInteger then rejects a digit
+  // string long enough to lose precision.
+  const rawWeek = typeof data.week === 'string' ? data.week.trim() : '';
+  const parsedWeek = /^\d+$/.test(rawWeek) ? Number(rawWeek) : NaN;
 
   return {
     sport: resolved.sport,
     league: resolved.league,
     contestId: data.contestId,
     leagueId: typeof data.leagueId === 'string' ? data.leagueId : undefined,
-    week: Number.isFinite(parsedWeek) ? parsedWeek : undefined,
+    week: Number.isSafeInteger(parsedWeek) ? parsedWeek : undefined,
   };
 }
 

--- a/src/UI/sd-mobile/src/utils/deepLinks.ts
+++ b/src/UI/sd-mobile/src/utils/deepLinks.ts
@@ -1,0 +1,96 @@
+import { resolveSportLeague } from './sportLinks';
+
+/**
+ * Push-notification deep-link wire contract.
+ *
+ * Payloads are produced by SportsData.Notification's consumers and arrive on
+ * two different paths depending on platform: expo-notifications delivers them
+ * as `content.data` on Android, while on iOS RNFirebase owns the FCM message
+ * and they land in `remoteMessage.data` (expo's content.data arrives EMPTY —
+ * confirmed via Sentry). Both funnel through {@link toPendingDeepLink} so the
+ * payload shape lives in exactly one place.
+ *
+ * Every value is a string on the wire — FCM data payloads are string maps —
+ * so anything numeric is parsed here rather than trusted.
+ */
+
+/**
+ * A tapped notification's navigation target. Discriminated so new push kinds
+ * slot in without a state variable per kind.
+ */
+export type PendingDeepLink =
+  | { kind: 'invite'; leagueId: string }
+  | {
+      kind: 'matchup';
+      sport: string;
+      league: string;
+      contestId: string;
+      leagueId?: string;
+      week?: number;
+    };
+
+/**
+ * LeagueInvite contract: kind === 'LeagueInvite' with a string leagueId.
+ * Returns the validated leagueId, or null when it's not a LeagueInvite.
+ */
+export function getLeagueInviteId(
+  data: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!data) return null;
+  return data.kind === 'LeagueInvite' && typeof data.leagueId === 'string'
+    ? data.leagueId
+    : null;
+}
+
+/**
+ * Notification kinds that land on a game page. Kept as a set rather than a
+ * single literal so a new matchup-bound notification only needs an entry here
+ * (server side: MatchupDeepLink's *Kind constants).
+ *
+ * - `OddsChanged` — the line moved on a contest the user picked
+ * - `PickScored`  — the user's pick was scored
+ */
+const MATCHUP_KINDS = new Set(['OddsChanged', 'PickScored']);
+
+/**
+ * Matchup deep-link contract: a kind in {@link MATCHUP_KINDS} with a string
+ * contestId and the backend Sport enum name. leagueId and week are optional
+ * enrichments — leagueId scopes the game page to the user's pick, week narrows
+ * the matchup fetch. Sport arrives as the enum ("FootballNcaa") and is mapped
+ * to route segments here, so URL conventions stay owned by the client.
+ * Returns null when the payload isn't matchup-bound or the sport is unknown.
+ */
+export function getMatchupTarget(
+  data: Record<string, unknown> | null | undefined,
+): { sport: string; league: string; contestId: string; leagueId?: string; week?: number } | null {
+  if (!data) return null;
+  if (typeof data.kind !== 'string' || !MATCHUP_KINDS.has(data.kind)) return null;
+  if (typeof data.contestId !== 'string' || typeof data.sport !== 'string') return null;
+
+  const resolved = resolveSportLeague(data.sport);
+  if (!resolved) return null;
+
+  // week is a string on the wire; drop it rather than pass NaN downstream.
+  const parsedWeek = typeof data.week === 'string' ? parseInt(data.week, 10) : NaN;
+
+  return {
+    sport: resolved.sport,
+    league: resolved.league,
+    contestId: data.contestId,
+    leagueId: typeof data.leagueId === 'string' ? data.leagueId : undefined,
+    week: Number.isFinite(parsedWeek) ? parsedWeek : undefined,
+  };
+}
+
+/** Maps a raw FCM data payload to a pending target, or null if unrecognized. */
+export function toPendingDeepLink(
+  data: Record<string, unknown> | null | undefined,
+): PendingDeepLink | null {
+  const inviteLeagueId = getLeagueInviteId(data);
+  if (inviteLeagueId) return { kind: 'invite', leagueId: inviteLeagueId };
+
+  const matchup = getMatchupTarget(data);
+  if (matchup) return { kind: 'matchup', ...matchup };
+
+  return null;
+}


### PR DESCRIPTION
Client half of the deep-link work. Consumes the payloads already shipping from `ContestOddsUpdatedConsumer` (#640) and `UserPickScoredConsumer` (#641) — both land on the game page, league-scoped when the payload carries a `leagueId` so the user's pick renders alongside the contest.

## ⚠️ Not device-validated

The payloads only exist in production as of the #640/#641 deploys, and tapping a real push requires an EAS build. The **parser is unit-tested**; the **navigation wiring is the untested part**. Merging is safe (an unrecognized payload is a no-op — taps behave exactly as they do today), but the tap-through should happen on the next EAS build before we consider it done.

## What changed

**`src/utils/deepLinks.ts`** (new) — the wire contract in one testable place, mirroring Notification's `Application/Dispatching/MatchupDeepLink`. Design notes:

- `MATCHUP_KINDS` is a set, so a third matchup-bound kind is a one-line addition on each side.
- Sport arrives as the backend enum name (`FootballNcaa`) and is mapped to route segments here via `resolveSportLeague`, keeping URL conventions client-owned. An unknown sport returns **null** rather than routing to a wrong-sport screen.
- `week` is parsed from its wire string (FCM data payloads are string maps) and **dropped when unparseable**, so `NaN` never reaches the route.

**`app/_layout.tsx`** — `pendingLeagueId` (invite-only) generalized to a discriminated `PendingDeepLink`. Both tap paths already funnelled through a single handler — expo's `content.data` on Android, RNFirebase's `remoteMessage.data` on iOS, since expo's arrives empty there — so both new kinds ride the existing cold-start and auth-gated flush logic without touching it. Navigation goes through the existing `gameRoute()` helper.

## Tests

Full mobile suite **123/123**, `tsc --noEmit` clean. 11 parser cases cover both kinds, the optional `leagueId`/`week`, unparseable week, unknown sport, missing fields, and unrecognized payloads.

## Device test plan (post-EAS)

Both platforms, and for each: tap from **backgrounded** and from **fully quit** (cold start exercises a different code path — `getInitialNotification` / `useLastNotificationResponse` — than the foreground listener).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deep-link navigation from notification taps for league invitations and matchup alerts.
  * Routes users to the appropriate sport, league, contest, optional league, and week.
  * Supports notifications received before sign-in and navigates after authentication.

* **Bug Fixes**
  * Improved handling of incomplete, unsupported, malformed, or null notification data.
  * Added support for string-valued notification fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->