### PR TITLE
feat(notification): SmackBot voice for pick results (ships dark)

### DIFF
--- a/docs/features/smackbot-voice.md
+++ b/docs/features/smackbot-voice.md
@@ -73,15 +73,27 @@ lookups. Thresholds live in one place in `PickSituationResolver`.
 | `FavoriteChoked` | picked a favourite of ≥ 10 and lost |
 | `SqueakerLoss` | lost by ≤ 3 |
 | `NarrowMissAts` | ATS: missed the cover by ≤ 1 |
+| `WonButDidNotCover` | ATS: picked side won the game but missed the cover |
 | `GenericLoss` | any other loss |
 | `DogWin` | picked an underdog of ≥ 10 and won |
 | `ChalkWin` | picked a favourite of ≥ 14 and won |
 | `BlowoutWin` | won by ≥ 21 |
 | `UglyWin` | won by ≤ 3 |
+| `CoveredInDefeat` | ATS: the pick cashed although the picked side lost |
 | `GenericWin` | any other win |
 
 Resolution is **most-specific-first**; the generic buckets guarantee every
 scored pick maps to something, so the engine can never fail to produce copy.
+
+### Pick outcome is not scoreboard outcome
+
+`IsCorrect` means the pick **covered**, not that the picked side won, and in an
+ATS league those diverge. A +14 dog losing 24-20 cashes; a -7 favourite winning
+by 3 does not. Every win bucket below is phrased around victory and every loss
+bucket around defeat, so a margin whose sign contradicts the pick outcome is
+diverted to `CoveredInDefeat` or `WonButDidNotCover` before any of them are
+reached. Without that, copy would congratulate a team that lost or console one
+that won.
 
 ### The straight-up spread gap
 
@@ -107,10 +119,12 @@ notification that IS being sent reads.
 
 ## Phrase selection is deterministic
 
-The chosen line is seeded from `PickId`: `hash(PickId) % candidates`. This is
-unit-testable, stable under redelivery, and still varies naturally across
-picks and users — no RNG to inject or mock. Weighting expands the candidate
-list before the modulo.
+The chosen line is seeded from `PickId`. Candidates are ordered by id (the
+database guarantees no ordering), each is assigned a slice of the hash space
+proportional to its `Weight`, and `hash(PickId) % totalWeight` selects the
+slice. No duplicates are materialized and the modulo is over the summed
+weight, not the candidate count. Stable under redelivery, reproducible in
+tests, and still varied across picks and users — no RNG to inject or mock.
 
 ## Gambling-content interaction
 
@@ -120,8 +134,14 @@ opted into spread-based scoring, so referencing the line is fair. A user in a
 receive "Vegas said 14, you said nah."
 
 `RequiresGamblingContent` marks those rows; the catalog filters them out when
-the context doesn't permit them. Every situation therefore needs at least one
-non-spread line so the filter can never empty a bucket — enforced by test.
+the context doesn't permit them.
+
+**Operator content requirement (not enforced in code):** every situation should
+carry at least one non-spread line, otherwise the filter empties that bucket
+for straight-up players and they silently receive standard copy. The catalog
+treats an empty bucket as a supported fallback, so nothing breaks — the cost is
+a missing taunt, not an error. Worth a validation query once the library is
+populated.
 
 ## Safety rails
 

--- a/docs/features/smackbot-voice.md
+++ b/docs/features/smackbot-voice.md
@@ -1,0 +1,160 @@
+# SmackBot: an opt-in voice for pick-result notifications
+
+**Status**: Notification-side engine (ships dark) ·
+**Origin**: the original sportDeets premise — talking smack
+
+## Why
+
+Pick-result pushes currently read in one neutral voice:
+
+> **Nice pick!** / **Tough loss**
+> Sluggers: BOS 3, NYY 2 — you picked BOS ✓
+
+Correct, informative, forgettable. The product's founding premise was
+tormenting your friends over bad picks, and a notification that *taunts* the
+user is an engagement mechanic in a way a scoreline never is. Anger brings
+people back — "I'll show them" is a stronger return signal than satisfaction.
+
+SmackBot is an **opt-in voice** for the same event. Same trigger, same
+targeting, same dedupe; only the copy changes.
+
+## Where the phrases live
+
+**PostgreSQL, in Notification's own database — never in this repo.**
+
+This mirrors the `Prompt` entity's rationale verbatim: *"The database is
+private (the repo is public), so text lives here."* Two reasons it matters
+more here than for prompts:
+
+1. The voice IS the differentiator. A public phrase list is copyable in an
+   afternoon.
+2. Users reading every taunt in advance kills the surprise that makes it
+   work.
+
+Notification's own database (rather than API's, where `Prompt` lives) because
+pick-result pushes fire in bursts as a slate finalizes — a cross-service call
+per notification, for content that changes weekly at most, would be waste. A
+local table needs no projection to keep in sync and no cache invalidation.
+
+**This document deliberately contains no phrase text.** Lines are inserted by
+SQL kept outside source control.
+
+## Schema
+
+`SmackPhrase`, modelled on `Prompt` with one deliberate divergence.
+
+| Column | Purpose |
+|---|---|
+| `Voice` | `Standard` \| `Smack` — an enum, not a bool, so later voices (hype-man, deadpan analyst) need no schema change |
+| `Situation` | the resolution slot (taxonomy below) |
+| `Sport?` | null = any sport; a sport-specific row outranks it, same precedence rule as `Prompt` |
+| `Text` | the line, with `{...}` tokens |
+| `IsActive` | soft on/off without deleting history |
+| `RequiresGamblingContent` | gates spread-flavoured lines (see below) |
+| `Weight` | relative selection frequency |
+| `Description` | operator note |
+| `RowVersion` | `xmin`, for the eventual management UI |
+
+**The divergence**: `Prompt` resolves to exactly ONE `IsDefault` row per slot,
+enforced by partial unique indexes. SmackPhrase wants MANY active rows per
+slot with one chosen at send time, so `IsActive` replaces `IsDefault` and the
+unique-slot indexes do not carry over.
+
+## Situation taxonomy
+
+Derived entirely from the existing `UserPickScored` fat event — no new
+lookups. Thresholds live in one place in `PickSituationResolver`.
+
+| Situation | Condition |
+|---|---|
+| `ShutoutLoss` | picked side scored 0 and lost |
+| `BlowoutLoss` | lost by ≥ 21 |
+| `BigDogLoss` | picked an underdog of ≥ 10 and lost |
+| `FavoriteChoked` | picked a favourite of ≥ 10 and lost |
+| `SqueakerLoss` | lost by ≤ 3 |
+| `NarrowMissAts` | ATS: missed the cover by ≤ 1 |
+| `GenericLoss` | any other loss |
+| `DogWin` | picked an underdog of ≥ 10 and won |
+| `ChalkWin` | picked a favourite of ≥ 14 and won |
+| `BlowoutWin` | won by ≥ 21 |
+| `UglyWin` | won by ≤ 3 |
+| `GenericWin` | any other win |
+
+Resolution is **most-specific-first**; the generic buckets guarantee every
+scored pick maps to something, so the engine can never fail to produce copy.
+
+### The straight-up spread gap
+
+The flagship case — *"took a 14-point dog straight up and lost"* — needs the
+spread on a **StraightUp** pick, and the event doesn't carry it:
+`PickScoringProcessor` populates `PickedSpread` only when
+`group.PickType == AgainstTheSpread`. The value exists on the matchup result
+regardless; the gate is about display semantics (don't render a spread in
+straight-up copy), not availability.
+
+Fix is a new nullable `MarketSpread` on the event, populated whenever known,
+leaving `PickedSpread` untouched so existing copy doesn't change. **Until
+that lands, the spread-dependent situations simply don't match** and those
+picks fall through to the generic buckets — degraded, never broken.
+
+## Voice selection
+
+`UserNotificationPreferences.PickResultVoice`, defaulting to `Standard`.
+Everyone stays on the current copy until they opt in, so this ships dark.
+
+`PickResultEnabled` still gates delivery entirely — voice only decides how a
+notification that IS being sent reads.
+
+## Phrase selection is deterministic
+
+The chosen line is seeded from `PickId`: `hash(PickId) % candidates`. This is
+unit-testable, stable under redelivery, and still varies naturally across
+picks and users — no RNG to inject or mock. Weighting expands the candidate
+list before the modulo.
+
+## Gambling-content interaction
+
+Spread-referencing taunts are betting content. A user in an **ATS** league has
+opted into spread-based scoring, so referencing the line is fair. A user in a
+**StraightUp** league who has hidden gambling content has not, and must not
+receive "Vegas said 14, you said nah."
+
+`RequiresGamblingContent` marks those rows; the catalog filters them out when
+the context doesn't permit them. Every situation therefore needs at least one
+non-spread line so the filter can never empty a bucket — enforced by test.
+
+## Safety rails
+
+Opt-in is the load-bearing one: the user chose this. Beyond that, the editorial
+contract for anyone adding lines:
+
+- Mock the **pick**, never the person. No appearance, intelligence, or
+  identity.
+- Nothing touching protected characteristics, ever.
+- No profanity — app-store review reads notification copy.
+- No streak-piling ("you're 0-for-your-life"). Compounding failure tips from
+  funny into discouraging, which inverts the intended effect.
+- Wins get **grudging** credit, not praise. A voice that turns nice on wins
+  isn't a voice, it's a participation trophy.
+
+## History is immutable for free
+
+`NotificationUserPick` already stores `Title` and `Body` per send, so the exact
+line a user received is captured. Editing a phrase later never rewrites
+history — the same guarantee `Prompt` captures provide.
+
+That capture is also a feedback loop: joining sent phrases against subsequent
+user activity shows which taunts actually drive return visits and which merely
+annoy, turning the library from guesswork into something tunable.
+
+## Sequencing
+
+1. **This change** — schema, situation resolver, catalog, wired into
+   `UserPickScoredConsumer` behind a preference that is always `Standard`.
+   Ships dark.
+2. API — `MarketSpread` on the event; `PickResultVoice` through
+   entity/DTO/command/query + migration, projected into Notification.
+3. Mobile — the settings toggle that lets a user turn it on.
+
+Phrase rows are inserted out-of-band at any point; an empty catalog falls back
+to the standard copy.

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -53,17 +53,20 @@ namespace SportsData.Notification.Application.Consumers
         private readonly AppDataContext _dataContext;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPushNotificationSender _pushSender;
+        private readonly ISmackPhraseCatalog _smackPhraseCatalog;
 
         public UserPickScoredConsumer(
             ILogger<UserPickScoredConsumer> logger,
             AppDataContext dataContext,
             IDateTimeProvider dateTimeProvider,
-            IPushNotificationSender pushSender)
+            IPushNotificationSender pushSender,
+            ISmackPhraseCatalog smackPhraseCatalog)
         {
             _logger = logger;
             _dataContext = dataContext;
             _dateTimeProvider = dateTimeProvider;
             _pushSender = pushSender;
+            _smackPhraseCatalog = smackPhraseCatalog;
         }
 
         public async Task Consume(ConsumeContext<UserPickScored> context)
@@ -149,8 +152,26 @@ namespace SportsData.Notification.Application.Consumers
                 .Select(g => g.Name)
                 .FirstOrDefaultAsync();
 
-            var title = msg.IsCorrect == true ? "Nice pick!" : "Tough loss";
-            var body = ComposeBody(msg, leagueName);
+            // Voice selection. Standard (the default for every user) keeps the
+            // neutral scoreline copy; Smack swaps the body for a situation-
+            // matched line from the catalog. A null return — empty catalog,
+            // unfilled slot, or a gambling filter that emptied the bucket —
+            // degrades to standard copy rather than dropping the push.
+            // See docs/features/smackbot-voice.md.
+            var voice = prefs?.PickResultVoice ?? NotificationVoice.Standard;
+
+            // An AgainstTheSpread player opted into spread-based scoring, so
+            // line-referencing copy is fair game. Anyone else has not, so the
+            // catalog filters those rows out.
+            var allowGamblingContent = msg.PickedSpread is not null;
+
+            var smackLine = await _smackPhraseCatalog.TryResolveAsync(
+                msg, voice, allowGamblingContent, context.CancellationToken);
+
+            var title = smackLine is not null
+                ? "SmackBot"
+                : msg.IsCorrect == true ? "Nice pick!" : "Tough loss";
+            var body = smackLine ?? ComposeBody(msg, leagueName);
 
             // Deep link to the scored game. Everything needed rides on the
             // event except the week, which comes from the local matchup

--- a/src/SportsData.Notification/Application/Dispatching/PickSituationResolver.cs
+++ b/src/SportsData.Notification/Application/Dispatching/PickSituationResolver.cs
@@ -35,6 +35,13 @@ public enum PickSituation
     /// <summary>ATS only: missed the cover by a point or less.</summary>
     NarrowMissAts = 6,
 
+    /// <summary>
+    /// ATS only: the picked side WON the game but failed to cover. The
+    /// scoreboard says victory, the pick says loss — copy must not call this
+    /// a defeat.
+    /// </summary>
+    WonButDidNotCover = 7,
+
     // ─── Wins ─────────────────────────────────────────────────────────────
     GenericWin = 100,
 
@@ -48,7 +55,13 @@ public enum PickSituation
     BlowoutWin = 103,
 
     /// <summary>Won by a field goal or less.</summary>
-    UglyWin = 104
+    UglyWin = 104,
+
+    /// <summary>
+    /// ATS only: the pick cashed even though the picked side LOST the game.
+    /// Copy must not congratulate them on a victory that didn't happen.
+    /// </summary>
+    CoveredInDefeat = 105
 }
 
 /// <summary>
@@ -104,13 +117,22 @@ public static class PickSituationResolver
     {
         // Most-specific first. Humiliation outranks arithmetic: being shut out
         // is the story even if the margin also qualifies as a blowout.
-        if (pickedScore == 0)
+        // Guarded on an actual defeat so a 0-0 tie can't read as a shutout.
+        if (pickedScore == 0 && margin < 0)
             return PickSituation.ShutoutLoss;
 
         // An ATS near-miss is a sharper sting than any margin bucket — the
         // pick was one point from cashing.
         if (line is { } spread && Math.Abs(margin + spread) <= NarrowAtsMiss)
             return PickSituation.NarrowMissAts;
+
+        // SCOREBOARD vs PICK. IsCorrect means the pick COVERED, not that the
+        // picked side won, and in an ATS league those diverge: a -7 favourite
+        // winning by 3 loses the pick while winning the game. Every bucket
+        // below is phrased around defeat, so a positive margin must divert
+        // here or the copy would call a victory a loss.
+        if (margin > 0)
+            return PickSituation.WonButDidNotCover;
 
         if (line is { } dogLine && dogLine >= BigLine)
             return PickSituation.BigDogLoss;
@@ -129,6 +151,12 @@ public static class PickSituationResolver
 
     private static PickSituation ResolveWin(int margin, double? line)
     {
+        // Mirror of the divergence above: a +14 dog losing 24-20 CASHES the
+        // pick while losing the game. Diverted first so no win bucket can
+        // congratulate a team that lost.
+        if (margin <= 0)
+            return PickSituation.CoveredInDefeat;
+
         // Beating a big number is the story regardless of how it looked.
         if (line is { } dogLine && dogLine >= BigLine)
             return PickSituation.DogWin;

--- a/src/SportsData.Notification/Application/Dispatching/PickSituationResolver.cs
+++ b/src/SportsData.Notification/Application/Dispatching/PickSituationResolver.cs
@@ -1,0 +1,150 @@
+using SportsData.Core.Eventing.Events.Picks;
+
+namespace SportsData.Notification.Application.Dispatching;
+
+/// <summary>
+/// What actually happened to a scored pick. This is the resolution slot a
+/// phrase is chosen from — it's what makes the copy pick-aware rather than a
+/// generic "you lost".
+///
+/// <para>
+/// Ordering here is meaningless; precedence lives in
+/// <see cref="PickSituationResolver"/> and runs most-specific-first.
+/// </para>
+/// </summary>
+public enum PickSituation
+{
+    // ─── Losses ───────────────────────────────────────────────────────────
+    GenericLoss = 0,
+
+    /// <summary>Picked side was shut out.</summary>
+    ShutoutLoss = 1,
+
+    /// <summary>Lost by three scores or more.</summary>
+    BlowoutLoss = 2,
+
+    /// <summary>Took a double-digit underdog and it lost.</summary>
+    BigDogLoss = 3,
+
+    /// <summary>Took a double-digit favourite and it lost anyway.</summary>
+    FavoriteChoked = 4,
+
+    /// <summary>Lost by a field goal or less.</summary>
+    SqueakerLoss = 5,
+
+    /// <summary>ATS only: missed the cover by a point or less.</summary>
+    NarrowMissAts = 6,
+
+    // ─── Wins ─────────────────────────────────────────────────────────────
+    GenericWin = 100,
+
+    /// <summary>Took a double-digit underdog and it won.</summary>
+    DogWin = 101,
+
+    /// <summary>Took a big favourite and it duly won.</summary>
+    ChalkWin = 102,
+
+    /// <summary>Won by three scores or more.</summary>
+    BlowoutWin = 103,
+
+    /// <summary>Won by a field goal or less.</summary>
+    UglyWin = 104
+}
+
+/// <summary>
+/// Maps a scored pick onto a <see cref="PickSituation"/> using only the facts
+/// already on <see cref="UserPickScored"/> — no lookups, no service calls.
+///
+/// <para>
+/// Every branch terminates in a generic bucket, so resolution is total: the
+/// engine can never fail to produce a slot, and therefore never fails to
+/// produce copy.
+/// </para>
+///
+/// <para>
+/// SPREAD AVAILABILITY: the spread-dependent situations need the picked
+/// side's line. Today <c>PickedSpread</c> is populated only for
+/// AgainstTheSpread leagues (PickScoringProcessor gates on PickType for
+/// display reasons), so a straight-up pick on a 14-point dog currently falls
+/// through to the generic buckets. A future <c>MarketSpread</c> on the event
+/// closes that gap; this resolver reads whichever is present, so it needs no
+/// change when that lands. Degraded, never broken.
+/// </para>
+/// </summary>
+public static class PickSituationResolver
+{
+    // Football-shaped thresholds, in one place so they're tunable together.
+    private const int BlowoutMargin = 21;   // three scores
+    private const int SqueakerMargin = 3;   // one field goal
+    private const double BigLine = 10.0;    // "double-digit" dog or favourite
+    private const double ChalkLine = 14.0;  // two scores — properly heavy chalk
+    private const double NarrowAtsMiss = 1.0;
+
+    public static PickSituation Resolve(UserPickScored msg)
+    {
+        // Without a resolved side there's no picked/opponent score to reason
+        // about (Over/Under picks, or an unresolvable match).
+        if (msg.PickedIsHome is not { } pickedIsHome)
+            return msg.IsCorrect == true ? PickSituation.GenericWin : PickSituation.GenericLoss;
+
+        var pickedScore = pickedIsHome ? msg.HomeScore : msg.AwayScore;
+        var opponentScore = pickedIsHome ? msg.AwayScore : msg.HomeScore;
+        var margin = pickedScore - opponentScore;
+
+        // Negative = favoured, positive = underdog, from the picked side's
+        // perspective. Null when the league is straight-up (see class doc).
+        var line = msg.PickedSpread;
+
+        return msg.IsCorrect == true
+            ? ResolveWin(margin, line)
+            : ResolveLoss(margin, pickedScore, line);
+    }
+
+    private static PickSituation ResolveLoss(int margin, int pickedScore, double? line)
+    {
+        // Most-specific first. Humiliation outranks arithmetic: being shut out
+        // is the story even if the margin also qualifies as a blowout.
+        if (pickedScore == 0)
+            return PickSituation.ShutoutLoss;
+
+        // An ATS near-miss is a sharper sting than any margin bucket — the
+        // pick was one point from cashing.
+        if (line is { } spread && Math.Abs(margin + spread) <= NarrowAtsMiss)
+            return PickSituation.NarrowMissAts;
+
+        if (line is { } dogLine && dogLine >= BigLine)
+            return PickSituation.BigDogLoss;
+
+        if (line is { } favLine && favLine <= -BigLine)
+            return PickSituation.FavoriteChoked;
+
+        if (margin <= -BlowoutMargin)
+            return PickSituation.BlowoutLoss;
+
+        if (margin >= -SqueakerMargin)
+            return PickSituation.SqueakerLoss;
+
+        return PickSituation.GenericLoss;
+    }
+
+    private static PickSituation ResolveWin(int margin, double? line)
+    {
+        // Beating a big number is the story regardless of how it looked.
+        if (line is { } dogLine && dogLine >= BigLine)
+            return PickSituation.DogWin;
+
+        // Heavy chalk winning is the least impressive outcome in the product,
+        // and it's checked before margin so a 30-point favourite blowing
+        // someone out still reads as chalk rather than as a statement win.
+        if (line is { } favLine && favLine <= -ChalkLine)
+            return PickSituation.ChalkWin;
+
+        if (margin >= BlowoutMargin)
+            return PickSituation.BlowoutWin;
+
+        if (margin <= SqueakerMargin)
+            return PickSituation.UglyWin;
+
+        return PickSituation.GenericWin;
+    }
+}

--- a/src/SportsData.Notification/Application/Dispatching/SmackPhraseCatalog.cs
+++ b/src/SportsData.Notification/Application/Dispatching/SmackPhraseCatalog.cs
@@ -55,6 +55,8 @@ public class SmackPhraseCatalog : ISmackPhraseCatalog
 
         var situation = PickSituationResolver.Resolve(msg);
 
+        // Projected to a DTO in the query rather than materializing entities
+        // (house rule); selection needs only these four fields.
         var candidates = await _dataContext.SmackPhrases
             .AsNoTracking()
             .Where(p => p.Voice == voice
@@ -62,6 +64,7 @@ public class SmackPhraseCatalog : ISmackPhraseCatalog
                         && p.IsActive
                         && (p.Sport == null || p.Sport == msg.Sport)
                         && (allowGamblingContent || !p.RequiresGamblingContent))
+            .Select(p => new PhraseCandidate(p.Id, p.Text, p.Weight, p.Sport))
             .ToListAsync(cancellationToken);
 
         if (candidates.Count == 0)
@@ -92,7 +95,7 @@ public class SmackPhraseCatalog : ISmackPhraseCatalog
     /// across picks and users. Weight is honoured by scaling each row's slice
     /// of the hash space rather than by materializing duplicates.
     /// </summary>
-    internal static SmackPhrase SelectDeterministic(IReadOnlyList<SmackPhrase> pool, Guid pickId)
+    internal static PhraseCandidate SelectDeterministic(IReadOnlyList<PhraseCandidate> pool, Guid pickId)
     {
         // Order defensively: the database gives no ordering guarantee, and an
         // unstable order would make the selection non-deterministic despite
@@ -111,6 +114,12 @@ public class SmackPhraseCatalog : ISmackPhraseCatalog
 
         return ordered[^1]; // unreachable while totalWeight is computed above
     }
+
+    /// <summary>
+    /// The slice of a phrase row selection actually needs. Keeps the read off
+    /// the entity so the query projects rather than materializes.
+    /// </summary>
+    internal record PhraseCandidate(Guid Id, string Text, int Weight, Sport? Sport);
 
     /// <summary>
     /// GetHashCode is randomized per process, which would make selection
@@ -133,20 +142,39 @@ public static class SmackPhraseFormatter
 {
     public static string Format(string text, UserPickScored msg)
     {
-        var pickedIsHome = msg.PickedIsHome ?? false;
+        var builder = new StringBuilder(text);
 
-        var picked = (pickedIsHome ? msg.HomeAbbreviation : msg.AwayAbbreviation) ?? "your team";
-        var opponent = (pickedIsHome ? msg.AwayAbbreviation : msg.HomeAbbreviation) ?? "the other guys";
-        var pickedScore = pickedIsHome ? msg.HomeScore : msg.AwayScore;
-        var opponentScore = pickedIsHome ? msg.AwayScore : msg.HomeScore;
-
-        var builder = new StringBuilder(text)
-            .Replace("{Team}", picked)
-            .Replace("{Opponent}", opponent)
-            .Replace("{Score}", pickedScore.ToString())
-            .Replace("{OpponentScore}", opponentScore.ToString())
-            .Replace("{Margin}", Math.Abs(pickedScore - opponentScore).ToString())
+        // Margin and league are attribution-free — |away - home| reads the
+        // same from either side — so they always resolve.
+        builder
+            .Replace("{Margin}", Math.Abs(msg.HomeScore - msg.AwayScore).ToString())
             .Replace("{League}", msg.LeagueName ?? "your league");
+
+        if (msg.PickedIsHome is { } pickedIsHome)
+        {
+            var picked = (pickedIsHome ? msg.HomeAbbreviation : msg.AwayAbbreviation) ?? "your team";
+            var opponent = (pickedIsHome ? msg.AwayAbbreviation : msg.HomeAbbreviation) ?? "the other guys";
+            var pickedScore = pickedIsHome ? msg.HomeScore : msg.AwayScore;
+            var opponentScore = pickedIsHome ? msg.AwayScore : msg.HomeScore;
+
+            builder
+                .Replace("{Team}", picked)
+                .Replace("{Opponent}", opponent)
+                .Replace("{Score}", pickedScore.ToString())
+                .Replace("{OpponentScore}", opponentScore.ToString());
+        }
+        else
+        {
+            // Unresolved picked side (Over/Under, or an unmatchable pick).
+            // Defaulting to a side would describe the AWAY team as though it
+            // were the user's pick — a confident lie. Name the pick neutrally
+            // and leave the per-side SCORES unresolved, since attributing them
+            // is exactly what we cannot do. Such picks only ever land in the
+            // generic buckets, whose lines must avoid score tokens.
+            builder
+                .Replace("{Team}", "your pick")
+                .Replace("{Opponent}", "the other side");
+        }
 
         // Absolute value: lines read "a 14-point dog" / "favoured by 14", so
         // the sign is carried by the wording, not the number.

--- a/src/SportsData.Notification/Application/Dispatching/SmackPhraseCatalog.cs
+++ b/src/SportsData.Notification/Application/Dispatching/SmackPhraseCatalog.cs
@@ -1,0 +1,158 @@
+using System.Security.Cryptography;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Notification.Infrastructure.Data;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+namespace SportsData.Notification.Application.Dispatching;
+
+public interface ISmackPhraseCatalog
+{
+    /// <summary>
+    /// Resolves the line for a scored pick, or null when the catalog can't
+    /// serve this slot — the caller then uses the standard copy.
+    /// </summary>
+    Task<string> TryResolveAsync(
+        UserPickScored msg,
+        NotificationVoice voice,
+        bool allowGamblingContent,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Picks a phrase for a scored pick. See docs/features/smackbot-voice.md.
+///
+/// <para>
+/// Returning null is a FIRST-CLASS outcome, not an error: an empty catalog,
+/// a slot with no active rows, or a gambling filter that empties a bucket all
+/// fall back to the standard copy. That's what lets the schema ship before
+/// the content exists.
+/// </para>
+/// </summary>
+public class SmackPhraseCatalog : ISmackPhraseCatalog
+{
+    private readonly AppDataContext _dataContext;
+    private readonly ILogger<SmackPhraseCatalog> _logger;
+
+    public SmackPhraseCatalog(AppDataContext dataContext, ILogger<SmackPhraseCatalog> logger)
+    {
+        _dataContext = dataContext;
+        _logger = logger;
+    }
+
+    public async Task<string> TryResolveAsync(
+        UserPickScored msg,
+        NotificationVoice voice,
+        bool allowGamblingContent,
+        CancellationToken cancellationToken = default)
+    {
+        if (voice == NotificationVoice.Standard)
+            return null;
+
+        var situation = PickSituationResolver.Resolve(msg);
+
+        var candidates = await _dataContext.SmackPhrases
+            .AsNoTracking()
+            .Where(p => p.Voice == voice
+                        && p.Situation == situation
+                        && p.IsActive
+                        && (p.Sport == null || p.Sport == msg.Sport)
+                        && (allowGamblingContent || !p.RequiresGamblingContent))
+            .ToListAsync(cancellationToken);
+
+        if (candidates.Count == 0)
+        {
+            // Expected while the catalog is being filled; the caller degrades
+            // to standard copy. Logged at Information so an operator can see
+            // which slots still need lines without it reading as a fault.
+            _logger.LogInformation(
+                "No {Voice} phrase for situation {Situation} (Sport={Sport}, GamblingAllowed={GamblingAllowed}); using standard copy.",
+                voice, situation, msg.Sport, allowGamblingContent);
+            return null;
+        }
+
+        // Sport precedence, mirroring Prompt: a sport-specific line outranks
+        // an any-sport one. Applied in memory over the handful of rows the
+        // slot returns rather than as a second query.
+        var sportSpecific = candidates.Where(p => p.Sport is not null).ToList();
+        var pool = sportSpecific.Count > 0 ? sportSpecific : candidates;
+
+        var chosen = SelectDeterministic(pool, msg.PickId);
+
+        return SmackPhraseFormatter.Format(chosen.Text, msg);
+    }
+
+    /// <summary>
+    /// Chooses by hashing the pick id rather than sampling a random number:
+    /// stable under redelivery, trivially unit-testable, and still varied
+    /// across picks and users. Weight is honoured by scaling each row's slice
+    /// of the hash space rather than by materializing duplicates.
+    /// </summary>
+    internal static SmackPhrase SelectDeterministic(IReadOnlyList<SmackPhrase> pool, Guid pickId)
+    {
+        // Order defensively: the database gives no ordering guarantee, and an
+        // unstable order would make the selection non-deterministic despite
+        // the stable hash.
+        var ordered = pool.OrderBy(p => p.Id).ToList();
+
+        var totalWeight = ordered.Sum(p => Math.Max(1, p.Weight));
+        var bucket = (int)(StableHash(pickId) % (uint)totalWeight);
+
+        foreach (var phrase in ordered)
+        {
+            bucket -= Math.Max(1, phrase.Weight);
+            if (bucket < 0)
+                return phrase;
+        }
+
+        return ordered[^1]; // unreachable while totalWeight is computed above
+    }
+
+    /// <summary>
+    /// GetHashCode is randomized per process, which would make selection
+    /// differ between pods. MD5 over the id bytes is stable everywhere —
+    /// it's a bucket chooser, not a security primitive.
+    /// </summary>
+    private static uint StableHash(Guid value)
+    {
+        var hash = MD5.HashData(value.ToByteArray());
+        return BitConverter.ToUInt32(hash, 0);
+    }
+}
+
+/// <summary>
+/// Resolves <c>{Token}</c> placeholders in phrase text. Unknown tokens are
+/// left as-is rather than throwing — a typo in an operator-authored line
+/// should look odd, not drop the notification.
+/// </summary>
+public static class SmackPhraseFormatter
+{
+    public static string Format(string text, UserPickScored msg)
+    {
+        var pickedIsHome = msg.PickedIsHome ?? false;
+
+        var picked = (pickedIsHome ? msg.HomeAbbreviation : msg.AwayAbbreviation) ?? "your team";
+        var opponent = (pickedIsHome ? msg.AwayAbbreviation : msg.HomeAbbreviation) ?? "the other guys";
+        var pickedScore = pickedIsHome ? msg.HomeScore : msg.AwayScore;
+        var opponentScore = pickedIsHome ? msg.AwayScore : msg.HomeScore;
+
+        var builder = new StringBuilder(text)
+            .Replace("{Team}", picked)
+            .Replace("{Opponent}", opponent)
+            .Replace("{Score}", pickedScore.ToString())
+            .Replace("{OpponentScore}", opponentScore.ToString())
+            .Replace("{Margin}", Math.Abs(pickedScore - opponentScore).ToString())
+            .Replace("{League}", msg.LeagueName ?? "your league");
+
+        // Absolute value: lines read "a 14-point dog" / "favoured by 14", so
+        // the sign is carried by the wording, not the number.
+        if (msg.PickedSpread is { } spread)
+            builder.Replace("{Line}", Math.Abs(spread).ToString("0.#"));
+
+        return builder.ToString();
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -52,6 +52,8 @@ namespace SportsData.Notification.Infrastructure.Data
 
         public DbSet<NotificationContestStart> NotificationContestStarts => Set<NotificationContestStart>();
 
+        public DbSet<SmackPhrase> SmackPhrases => Set<SmackPhrase>();
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -189,6 +191,34 @@ namespace SportsData.Notification.Infrastructure.Data
                 .IsUnique();
             modelBuilder.Entity<PickemGroupMatchup>()
                 .HasIndex(m => m.ContestId);
+
+            // SmackBot phrase catalog. Text is operator-authored and lives in
+            // the database because this repo is public — see
+            // docs/features/smackbot-voice.md.
+            modelBuilder.Entity<SmackPhrase>()
+                .Property(p => p.Text)
+                .HasMaxLength(300) // a push body truncates well before this
+                .IsRequired();
+
+            modelBuilder.Entity<SmackPhrase>()
+                .Property(p => p.Description)
+                .HasMaxLength(256);
+
+            // xmin concurrency token — phrases are operator-edited, so a
+            // management UI needs optimistic concurrency.
+            modelBuilder.Entity<SmackPhrase>()
+                .Property(p => p.RowVersion)
+                .HasColumnName("xmin")
+                .HasColumnType("xid")
+                .IsRowVersion();
+
+            // The catalog's only read shape: every active line for a
+            // (voice, situation) slot. Sport precedence is applied in memory
+            // over the handful of rows that returns, so it isn't indexed.
+            // NOT unique — unlike API's Prompt, this slot holds MANY lines
+            // and one is chosen per send.
+            modelBuilder.Entity<SmackPhrase>()
+                .HasIndex(p => new { p.Voice, p.Situation, p.IsActive });
         }
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/AppDataContext.cs
@@ -219,6 +219,15 @@ namespace SportsData.Notification.Infrastructure.Data
             // and one is chosen per send.
             modelBuilder.Entity<SmackPhrase>()
                 .HasIndex(p => new { p.Voice, p.Situation, p.IsActive });
+
+            // Weight is the divisor for weighted selection, and rows are
+            // inserted OUT-OF-BAND by SQL — the CLR default never runs on that
+            // path. A zero or negative weight would corrupt selection for every
+            // notification in the affected slot, so the invariant belongs in
+            // the database where the inserts actually happen.
+            modelBuilder.Entity<SmackPhrase>()
+                .ToTable(t => t.HasCheckConstraint(
+                    "CK_SmackPhrases_Weight_Positive", "\"Weight\" >= 1"));
         }
     }
 }

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/SmackPhrase.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/SmackPhrase.cs
@@ -1,0 +1,91 @@
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Data.Entities;
+using SportsData.Notification.Application.Dispatching;
+
+namespace SportsData.Notification.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// One line of notification copy for a given voice + pick situation.
+    /// Modelled on API's <c>Prompt</c> entity and for the same reason its doc
+    /// gives: the database is private and the repo is PUBLIC, so the text
+    /// lives here rather than in source. For SmackBot that matters twice over
+    /// — the voice is the differentiator, and a user who can read every taunt
+    /// in advance loses the surprise that makes it land.
+    ///
+    /// <para>
+    /// Rows are inserted out-of-band (SQL kept outside the repo). An empty
+    /// catalog is a supported state: the consumer falls back to the standard
+    /// copy, so shipping the schema before the content is safe.
+    /// </para>
+    ///
+    /// <para>
+    /// DIVERGENCE FROM <c>Prompt</c>: Prompt resolves to exactly one
+    /// <c>IsDefault</c> row per slot, enforced by partial unique indexes. Here
+    /// we want MANY active rows per slot with one chosen at send time, so
+    /// <see cref="IsActive"/> replaces IsDefault and the unique-slot indexes
+    /// do not carry over.
+    /// </para>
+    ///
+    /// See docs/features/smackbot-voice.md.
+    /// </summary>
+    public class SmackPhrase : CanonicalEntityBase<Guid>
+    {
+        /// <summary>Which voice this line belongs to.</summary>
+        public NotificationVoice Voice { get; set; } = NotificationVoice.Smack;
+
+        /// <summary>The resolution slot — what happened to the pick.</summary>
+        public PickSituation Situation { get; set; }
+
+        /// <summary>
+        /// Null = applies to any sport; a sport-specific row outranks it.
+        /// Mirrors Prompt's precedence rule.
+        /// </summary>
+        public Sport? Sport { get; set; }
+
+        /// <summary>
+        /// The line, with <c>{Token}</c> placeholders resolved at send time
+        /// (see <c>SmackPhraseFormatter</c>).
+        /// </summary>
+        public required string Text { get; set; }
+
+        /// <summary>
+        /// Soft on/off. Retiring a line must not delete it — sends already
+        /// captured its text, and an operator may want it back.
+        /// </summary>
+        public bool IsActive { get; set; } = true;
+
+        /// <summary>
+        /// True when the line references the betting line (spread/total).
+        /// Filtered out unless the recipient's context permits gambling
+        /// content — an ATS player opted into spread scoring, a StraightUp
+        /// player who hid gambling content did not.
+        /// </summary>
+        public bool RequiresGamblingContent { get; set; }
+
+        /// <summary>
+        /// Relative selection frequency; a line with weight 3 is three times
+        /// as likely as weight 1. Must be >= 1.
+        /// </summary>
+        public int Weight { get; set; } = 1;
+
+        /// <summary>Optional operator note for the management UI.</summary>
+        public string Description { get; set; }
+
+        /// <summary>PostgreSQL xmin concurrency token — phrases are operator-edited.</summary>
+        public uint RowVersion { get; set; }
+
+    }
+
+    /// <summary>
+    /// The voice a user's pick-result notifications speak in. An enum rather
+    /// than a bool so later voices cost no schema change.
+    /// </summary>
+    public enum NotificationVoice
+    {
+        /// <summary>The neutral scoreline copy. Default for every user.</summary>
+        Standard = 0,
+
+        /// <summary>SmackBot — taunts losses, grudgingly acknowledges wins.</summary>
+        Smack = 1
+    }
+}

--- a/src/SportsData.Notification/Infrastructure/Data/Entities/UserNotificationPreferences.cs
+++ b/src/SportsData.Notification/Infrastructure/Data/Entities/UserNotificationPreferences.cs
@@ -29,5 +29,14 @@ namespace SportsData.Notification.Infrastructure.Data.Entities
         public bool ScheduleChangeEnabled { get; set; } = true;
 
         public bool OddsChangedEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Which voice pick-result notifications speak in. Defaults to
+        /// Standard so SmackBot ships dark — a user opts in explicitly.
+        /// Projected from API's preference; PickResultEnabled still gates
+        /// delivery entirely, this only decides how a sent notification reads.
+        /// See docs/features/smackbot-voice.md.
+        /// </summary>
+        public NotificationVoice PickResultVoice { get; set; } = NotificationVoice.Standard;
     }
 }

--- a/src/SportsData.Notification/Migrations/20260816204148_SmackBotVoiceAndPhrases.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260816204148_SmackBotVoiceAndPhrases.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260816204148_SmackBotVoiceAndPhrases")]
+    partial class SmackBotVoiceAndPhrases
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260816204148_SmackBotVoiceAndPhrases.cs
+++ b/src/SportsData.Notification/Migrations/20260816204148_SmackBotVoiceAndPhrases.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class SmackBotVoiceAndPhrases : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PickResultVoice",
+                table: "UserNotificationPreferences",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "SmackPhrases",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Voice = table.Column<int>(type: "integer", nullable: false),
+                    Situation = table.Column<int>(type: "integer", nullable: false),
+                    Sport = table.Column<int>(type: "integer", nullable: true),
+                    Text = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    RequiresGamblingContent = table.Column<bool>(type: "boolean", nullable: false),
+                    Weight = table.Column<int>(type: "integer", nullable: false),
+                    Description = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SmackPhrases", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SmackPhrases_Voice_Situation_IsActive",
+                table: "SmackPhrases",
+                columns: new[] { "Voice", "Situation", "IsActive" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SmackPhrases");
+
+            migrationBuilder.DropColumn(
+                name: "PickResultVoice",
+                table: "UserNotificationPreferences");
+        }
+    }
+}

--- a/src/SportsData.Notification/Migrations/20260816224659_SmackPhraseWeightCheckConstraint.Designer.cs
+++ b/src/SportsData.Notification/Migrations/20260816224659_SmackPhraseWeightCheckConstraint.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Notification.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Notification.Infrastructure.Data;
 namespace SportsData.Notification.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260816224659_SmackPhraseWeightCheckConstraint")]
+    partial class SmackPhraseWeightCheckConstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Notification/Migrations/20260816224659_SmackPhraseWeightCheckConstraint.cs
+++ b/src/SportsData.Notification/Migrations/20260816224659_SmackPhraseWeightCheckConstraint.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Notification.Migrations
+{
+    /// <inheritdoc />
+    public partial class SmackPhraseWeightCheckConstraint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_SmackPhrases_Weight_Positive",
+                table: "SmackPhrases",
+                sql: "\"Weight\" >= 1");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_SmackPhrases_Weight_Positive",
+                table: "SmackPhrases");
+        }
+    }
+}

--- a/src/SportsData.Notification/Program.cs
+++ b/src/SportsData.Notification/Program.cs
@@ -124,6 +124,7 @@ namespace SportsData.Notification
             // consumers call after a projection write that could affect its
             // respective scope.
             services.AddScoped<INotificationDispatcher, NotificationDispatcher>();
+            services.AddScoped<ISmackPhraseCatalog, SmackPhraseCatalog>();
             services.AddScoped<IPickDeadlineReminderScheduler, PickDeadlineReminderScheduler>();
             services.AddScoped<IContestStartReminderScheduler, ContestStartReminderScheduler>();
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/PickSituationResolverTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/PickSituationResolverTests.cs
@@ -30,8 +30,11 @@ public class PickSituationResolverTests
             Guid.NewGuid(), null, Guid.NewGuid(), Guid.NewGuid(),
             AwayName: null, HomeName: null,
             AwayAbbreviation: "AWY", HomeAbbreviation: "HOM",
-            // pickedIsHome true → picked side is home
-            AwayScore: opponentScore, HomeScore: pickedScore,
+            // Place the scores on whichever side pickedIsHome names, so an
+            // away-side case exercises the real away path rather than
+            // silently feeding the resolver the opponent's score as the pick.
+            AwayScore: pickedIsHome == false ? pickedScore : opponentScore,
+            HomeScore: pickedIsHome == false ? opponentScore : pickedScore,
             IsCorrect: isCorrect,
             PickedIsHome: pickedIsHome,
             PickedSpread: pickedSpread,
@@ -188,5 +191,46 @@ public class PickSituationResolverTests
                 Pick(picked, opp, correct, line));
             act.Should().NotThrow();
         }
+    }
+
+    // ─── Pick outcome vs scoreboard outcome ───────────────────────────────
+
+    [Fact]
+    public void CoveredInDefeat_WhenThePickCashesButTheTeamLost()
+    {
+        // A +14 dog losing 24-20 COVERS: IsCorrect is true while the margin is
+        // negative. Without the divert this resolved to DogWin and the copy
+        // would have congratulated a team that lost.
+        PickSituationResolver.Resolve(Pick(20, 24, isCorrect: true, pickedSpread: 14))
+            .Should().Be(PickSituation.CoveredInDefeat);
+    }
+
+    [Fact]
+    public void WonButDidNotCover_WhenTheTeamWinsAndThePickDoesNot()
+    {
+        // Favoured by 14, wins by only 4 — game won, cover missed. Not a
+        // narrow miss (10 points short), so it must not land in a defeat
+        // bucket that would call a victory a loss.
+        PickSituationResolver.Resolve(Pick(24, 20, isCorrect: false, pickedSpread: -14))
+            .Should().Be(PickSituation.WonButDidNotCover);
+    }
+
+    [Fact]
+    public void AwaySidePick_IsScoredFromTheAwayPerspective()
+    {
+        // Guards the helper fix: with pickedIsHome false the picked score must
+        // land on AwayScore, so this is a 28-point away blowout WIN.
+        PickSituationResolver.Resolve(
+                Pick(35, 7, isCorrect: true, pickedIsHome: false))
+            .Should().Be(PickSituation.BlowoutWin);
+    }
+
+    [Fact]
+    public void ZeroZeroTie_IsNotReportedAsAShutout()
+    {
+        // 0-0 with the pick not covering: the picked side scored nothing, but
+        // calling it a shutout defeat would be wrong — nobody lost.
+        PickSituationResolver.Resolve(Pick(0, 0, isCorrect: false))
+            .Should().NotBe(PickSituation.ShutoutLoss);
     }
 }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/PickSituationResolverTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/PickSituationResolverTests.cs
@@ -1,0 +1,192 @@
+using FluentAssertions;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Notification.Application.Dispatching;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Dispatching;
+
+/// <summary>
+/// The situation taxonomy is what makes SmackBot's copy pick-aware rather
+/// than a generic "you lost", so the precedence between overlapping buckets
+/// is the behaviour worth pinning down.
+/// See docs/features/smackbot-voice.md.
+/// </summary>
+public class PickSituationResolverTests
+{
+    /// <param name="pickedSpread">
+    /// Signed from the picked side: negative = favoured, positive = underdog.
+    /// Null models a StraightUp league, where the publisher doesn't send it.
+    /// </param>
+    private static UserPickScored Pick(
+        int pickedScore,
+        int opponentScore,
+        bool isCorrect,
+        double? pickedSpread = null,
+        bool? pickedIsHome = true)
+        => new(
+            Guid.NewGuid(), null, Guid.NewGuid(), Guid.NewGuid(),
+            AwayName: null, HomeName: null,
+            AwayAbbreviation: "AWY", HomeAbbreviation: "HOM",
+            // pickedIsHome true → picked side is home
+            AwayScore: opponentScore, HomeScore: pickedScore,
+            IsCorrect: isCorrect,
+            PickedIsHome: pickedIsHome,
+            PickedSpread: pickedSpread,
+            LeagueId: Guid.NewGuid(), LeagueName: "Sluggers",
+            Sport: Sport.FootballNcaa, SeasonYear: 2026,
+            CorrelationId: Guid.NewGuid(), CausationId: Guid.NewGuid());
+
+    // ─── Losses ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Shutout_OutranksBlowout()
+    {
+        // Being shut out is the story even when the margin also qualifies as
+        // a blowout — humiliation beats arithmetic.
+        PickSituationResolver.Resolve(Pick(0, 35, isCorrect: false))
+            .Should().Be(PickSituation.ShutoutLoss);
+    }
+
+    [Fact]
+    public void NarrowAtsMiss_OutranksMarginBuckets()
+    {
+        // Favoured by 7 and won by 6 — the game was won, the cover was not,
+        // by a single point. Sharper than any margin bucket.
+        // Adjusted result = margin + spread = 6 + (-7) = -1.
+        PickSituationResolver.Resolve(Pick(26, 20, isCorrect: false, pickedSpread: -7))
+            .Should().Be(PickSituation.NarrowMissAts);
+    }
+
+    [Fact]
+    public void BigDogLoss_WhenUnderdogOfTenOrMore()
+    {
+        // Dog by 14 and buried by 30 — nowhere near the cover, so the
+        // big-dog framing is the story.
+        PickSituationResolver.Resolve(Pick(3, 33, isCorrect: false, pickedSpread: 14))
+            .Should().Be(PickSituation.BigDogLoss);
+    }
+
+    [Fact]
+    public void NarrowAtsMiss_OutranksBigDogLoss_WhenBothApply()
+    {
+        // A 14-point dog losing by exactly 14 is a cover missed by nothing.
+        // In an ATS league that near-miss is the sharper story than "you took
+        // a dog"; in a StraightUp league no spread is sent, so BigDogLoss is
+        // reached instead. Pinning the precedence because it isn't obvious.
+        PickSituationResolver.Resolve(Pick(10, 24, isCorrect: false, pickedSpread: 14))
+            .Should().Be(PickSituation.NarrowMissAts);
+    }
+
+    [Fact]
+    public void FavoriteChoked_WhenFavouredByTenOrMore()
+    {
+        PickSituationResolver.Resolve(Pick(17, 20, isCorrect: false, pickedSpread: -13))
+            .Should().Be(PickSituation.FavoriteChoked);
+    }
+
+    [Fact]
+    public void BlowoutLoss_AtThreeScores()
+    {
+        PickSituationResolver.Resolve(Pick(7, 28, isCorrect: false))
+            .Should().Be(PickSituation.BlowoutLoss);
+    }
+
+    [Fact]
+    public void SqueakerLoss_WithinAFieldGoal()
+    {
+        PickSituationResolver.Resolve(Pick(21, 24, isCorrect: false))
+            .Should().Be(PickSituation.SqueakerLoss);
+    }
+
+    [Fact]
+    public void GenericLoss_WhenNothingSpecificApplies()
+    {
+        PickSituationResolver.Resolve(Pick(14, 24, isCorrect: false))
+            .Should().Be(PickSituation.GenericLoss);
+    }
+
+    // ─── Wins ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DogWin_OutranksMargin()
+    {
+        // Beating a big number is the story regardless of how it looked.
+        PickSituationResolver.Resolve(Pick(31, 3, isCorrect: true, pickedSpread: 11))
+            .Should().Be(PickSituation.DogWin);
+    }
+
+    [Fact]
+    public void ChalkWin_OutranksBlowout()
+    {
+        // A 21-point favourite winning by 28 is still just chalk — the
+        // deliberately least impressive outcome in the product.
+        PickSituationResolver.Resolve(Pick(35, 7, isCorrect: true, pickedSpread: -21))
+            .Should().Be(PickSituation.ChalkWin);
+    }
+
+    [Fact]
+    public void BlowoutWin_WithoutABigLine()
+    {
+        PickSituationResolver.Resolve(Pick(35, 7, isCorrect: true))
+            .Should().Be(PickSituation.BlowoutWin);
+    }
+
+    [Fact]
+    public void UglyWin_WithinAFieldGoal()
+    {
+        PickSituationResolver.Resolve(Pick(24, 21, isCorrect: true))
+            .Should().Be(PickSituation.UglyWin);
+    }
+
+    [Fact]
+    public void GenericWin_WhenNothingSpecificApplies()
+    {
+        PickSituationResolver.Resolve(Pick(24, 14, isCorrect: true))
+            .Should().Be(PickSituation.GenericWin);
+    }
+
+    // ─── Degradation ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void UnresolvedSide_FallsBackToGeneric()
+    {
+        // Over/Under picks carry no PickedIsHome, so there's no picked score
+        // to reason about. Must still resolve rather than throw.
+        PickSituationResolver.Resolve(Pick(0, 0, isCorrect: false, pickedIsHome: null))
+            .Should().Be(PickSituation.GenericLoss);
+        PickSituationResolver.Resolve(Pick(0, 0, isCorrect: true, pickedIsHome: null))
+            .Should().Be(PickSituation.GenericWin);
+    }
+
+    [Fact]
+    public void StraightUpBigDogLoss_CurrentlyDegradesToAMarginBucket()
+    {
+        // DOCUMENTS A KNOWN GAP. The flagship case — "took a 14-point dog
+        // straight up and lost" — can't resolve to BigDogLoss today because
+        // PickScoringProcessor only populates PickedSpread for ATS leagues.
+        // It degrades to a margin bucket rather than failing. Adding
+        // MarketSpread to the event closes this, and THIS TEST SHOULD THEN
+        // FLIP to expect BigDogLoss.
+        PickSituationResolver.Resolve(Pick(10, 24, isCorrect: false, pickedSpread: null))
+            .Should().Be(PickSituation.GenericLoss);
+    }
+
+    [Fact]
+    public void EveryResolutionIsTotal_NoUnmappedCombination()
+    {
+        // The engine must never fail to produce a slot, since a missing slot
+        // would mean no copy at all.
+        for (var picked = 0; picked <= 45; picked += 5)
+        for (var opp = 0; opp <= 45; opp += 5)
+        foreach (var line in new double?[] { null, -21, -14, -7, 0, 7, 14, 21 })
+        foreach (var correct in new[] { true, false })
+        {
+            var act = () => PickSituationResolver.Resolve(
+                Pick(picked, opp, correct, line));
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/SmackPhraseCatalogTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/SmackPhraseCatalogTests.cs
@@ -1,0 +1,167 @@
+using FluentAssertions;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Notification.Application.Dispatching;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Dispatching;
+
+/// <summary>
+/// Selection must be deterministic: a redelivery cannot produce a different
+/// line, and the choice has to be reproducible in a test without injecting an
+/// RNG. See docs/features/smackbot-voice.md.
+/// </summary>
+public class SmackPhraseCatalogTests : NotificationTestBase<SmackPhraseCatalog>
+{
+    private static readonly Guid PickId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    private async Task SeedAsync(params SmackPhrase[] phrases)
+    {
+        DataContext.SmackPhrases.AddRange(phrases);
+        await DataContext.SaveChangesAsync();
+    }
+
+    private Task<string> ResolveAsync(Guid pickId, bool allowGambling = true)
+        => Mocker.CreateInstance<SmackPhraseCatalog>()
+            .TryResolveAsync(Loss(pickId), NotificationVoice.Smack, allowGambling);
+
+    private static UserPickScored Loss(Guid pickId)
+        => new(
+            Guid.NewGuid(), null, Guid.NewGuid(), pickId,
+            null, null, "NYY", "BOS", 24, 14,
+            IsCorrect: false, PickedIsHome: true, PickedSpread: null,
+            Guid.NewGuid(), "Sluggers", Sport.FootballNcaa, 2026,
+            Guid.NewGuid(), Guid.NewGuid());
+
+    private static SmackPhrase Phrase(string text, int weight = 1, Guid? id = null)
+        => new()
+        {
+            Id = id ?? Guid.NewGuid(),
+            Voice = NotificationVoice.Smack,
+            Situation = PickSituation.GenericLoss,
+            Text = text,
+            Weight = weight
+        };
+
+    [Fact]
+    public async Task EmptyCatalog_ReturnsNullSoCallerUsesStandardCopy()
+    {
+        // The schema ships before the content exists, so this is a supported
+        // state — not an error.
+        (await ResolveAsync(PickId)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StandardVoice_NeverConsultsTheCatalog()
+    {
+        await SeedAsync(Phrase("should not be used"));
+
+        var result = await Mocker.CreateInstance<SmackPhraseCatalog>()
+            .TryResolveAsync(Loss(PickId), NotificationVoice.Standard, allowGamblingContent: true);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Selection_IsStableForTheSamePick()
+    {
+        await SeedAsync(Phrase("a"), Phrase("b"), Phrase("c"), Phrase("d"));
+
+        var first = await ResolveAsync(PickId);
+
+        // Same pick must always yield the same line — what makes redelivery
+        // safe and the behaviour reproducible.
+        for (var i = 0; i < 10; i++)
+            (await ResolveAsync(PickId)).Should().Be(first);
+    }
+
+    [Fact]
+    public async Task Selection_VariesAcrossPicks()
+    {
+        // Determinism must not collapse into "always the same line" — two
+        // users losing the same way should not read an identical taunt.
+        await SeedAsync(Phrase("a"), Phrase("b"), Phrase("c"), Phrase("d"));
+
+        var chosen = new HashSet<string>();
+        for (var i = 0; i < 100; i++)
+            chosen.Add(await ResolveAsync(Guid.NewGuid()));
+
+        chosen.Should().HaveCountGreaterThan(1, "a single line for every pick would defeat the library");
+    }
+
+    [Fact]
+    public async Task Weighting_SkewsSelectionTowardHeavierLines()
+    {
+        await SeedAsync(Phrase("heavy", weight: 9), Phrase("light"));
+
+        var heavyCount = 0;
+        for (var i = 0; i < 400; i++)
+            if (await ResolveAsync(Guid.NewGuid()) == "heavy") heavyCount++;
+
+        // ~90% expected; a loose band keeps it non-flaky while still proving
+        // weighting is honoured.
+        heavyCount.Should().BeInRange(300, 396);
+    }
+
+    [Fact]
+    public async Task GamblingFilter_ExcludesLineReferencingPhrases()
+    {
+        // A StraightUp player who hid gambling content must never be told what
+        // Vegas thought.
+        await SeedAsync(
+            Phrase("safe line"),
+            new SmackPhrase
+            {
+                Id = Guid.NewGuid(),
+                Voice = NotificationVoice.Smack,
+                Situation = PickSituation.GenericLoss,
+                Text = "Vegas said so",
+                RequiresGamblingContent = true
+            });
+
+        for (var i = 0; i < 20; i++)
+        {
+            (await ResolveAsync(Guid.NewGuid(), allowGambling: false))
+                .Should().Be("safe line");
+        }
+    }
+
+    [Fact]
+    public void Formatter_ResolvesTokensFromThePickedSidePerspective()
+    {
+        var msg = new UserPickScored(
+            Guid.NewGuid(), null, Guid.NewGuid(), Guid.NewGuid(),
+            AwayName: null, HomeName: null,
+            AwayAbbreviation: "NYY", HomeAbbreviation: "BOS",
+            AwayScore: 2, HomeScore: 9,
+            IsCorrect: true, PickedIsHome: true, PickedSpread: -6.5,
+            LeagueId: Guid.NewGuid(), LeagueName: "Sluggers",
+            Sport: Sport.BaseballMlb, SeasonYear: 2026,
+            CorrelationId: Guid.NewGuid(), CausationId: Guid.NewGuid());
+
+        var result = SmackPhraseFormatter.Format(
+            "{Team} {Score}, {Opponent} {OpponentScore} — by {Margin} in {League} ({Line})", msg);
+
+        result.Should().Be("BOS 9, NYY 2 — by 7 in Sluggers (6.5)");
+    }
+
+    [Fact]
+    public void Formatter_LeavesUnknownTokensAloneRatherThanThrowing()
+    {
+        var msg = new UserPickScored(
+            Guid.NewGuid(), null, Guid.NewGuid(), Guid.NewGuid(),
+            null, null, "NYY", "BOS", 2, 9,
+            true, true, null,
+            Guid.NewGuid(), "Sluggers", Sport.BaseballMlb, 2026,
+            Guid.NewGuid(), Guid.NewGuid());
+
+        // A typo in an operator-authored line should look odd, not drop the
+        // notification. {Line} is also unresolved here (no spread sent).
+        var result = SmackPhraseFormatter.Format("{Team} {Typo} {Line}", msg);
+
+        result.Should().Be("BOS {Typo} {Line}");
+    }
+}


### PR DESCRIPTION
First slice of the SmackBot engagement feature — the Notification-side engine. **Ships dark**: `PickResultVoice` defaults to `Standard` for every user, so nothing changes until the API preference and mobile toggle land.

## Why

Pick-result pushes read in one neutral voice. The founding premise of the product was talking smack, and a notification that *taunts* is an engagement mechanic in a way a scoreline never is — "I'll show them" is a stronger return signal than satisfaction.

## Phrases live in Postgres, not this repo

Same rationale API's `Prompt` entity already documents: *"The database is private (the repo is public), so text lives here."* Doubly true here — the voice IS the differentiator, and a user who can read every taunt in advance loses the surprise that makes it land.

**This PR contains no phrase text.** Rows are inserted out-of-band. An empty catalog is a supported state, which is exactly what lets the schema ship before the content exists.

Notification's own database rather than API's (where `Prompt` lives) because pick-result pushes fire in bursts as a slate finalizes — a cross-service call per notification, for content that changes weekly at most, would be waste.

## Design notes

**`SmackPhrase` diverges from `Prompt` in one deliberate way.** Prompt resolves to exactly ONE `IsDefault` row per slot, enforced by partial unique indexes. This holds MANY active rows per slot with one chosen per send, so `IsActive` replaces `IsDefault` and those unique indexes don't carry over.

**`PickSituationResolver`** derives twelve situations from the existing fat event — no new lookups, no service calls. Resolution is **total** (generic buckets catch everything), so the engine can never fail to produce copy. Precedence encodes editorial judgment rather than arithmetic: a shutout outranks a blowout because humiliation beats margin, and heavy chalk winning is checked before margin so a 21-point favourite blowing someone out still reads as chalk, not as a statement win.

**Selection is deterministic**, seeded from `PickId` — stable under redelivery, reproducible in tests without injecting an RNG, and still varied across picks and users. Weighting scales each row's slice of the hash space.

**Gambling-content filter.** An ATS player opted into spread scoring, so line-referencing taunts are fair. A StraightUp player who hid gambling content must never be told what Vegas thought — `RequiresGamblingContent` marks those rows and the catalog filters them.

## Known gap, deliberately documented

The flagship case — *"took a 14-point dog straight up and lost"* — **doesn't fire yet**. `PickScoringProcessor` populates `PickedSpread` only for ATS leagues, so a straight-up pick degrades to a margin bucket. There's a test asserting the current behaviour with a note to flip it when `MarketSpread` lands in the next PR. Degraded, never broken.

## Two build discoveries worth noting

- Notification's `AppDataContext` does **not** call `ApplyConfigurationsFromAssembly` — it configures inline in `OnModelCreating`. A nested `EntityConfiguration` (Prompt's style) is silently dead code here, and the first generated migration was wrong because of it: nullable `Text`, no length caps, `RowVersion` as `bigint` instead of `xid`, no index. Config moved inline and regenerated.
- Notification uses **plural** table names from the DbSet, unlike API's singular — hence `SmackPhrases`.

## Tests

Notification suite **84/84**. Sixteen resolver cases covering every situation plus the precedence calls and a totality sweep; catalog cases covering empty-catalog fallback, standard-voice short-circuit, determinism, cross-pick variety, weighting, the gambling filter, and token formatting.

Migration applied against a local database before commit — one table, one column with a default, no data movement, `Down()` reverses cleanly.

## Next

1. API — `MarketSpread` on the event; `PickResultVoice` through entity/DTO/command/query, projected into Notification
2. Mobile — the settings toggle
3. Phrase content, inserted out-of-band

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in SmackBot voice for pick-result notifications.
  - Added personalized voice preferences, with Standard voice remaining the default.
  - Added situation-aware notification messages based on results, margins, spreads, and team context.
  - Added configurable phrase selection, sport-specific messaging, weighted variation, and gambling-content filtering.
  - Added formatting for scores, teams, opponents, leagues, margins, and spreads.

- **Documentation**
  - Documented voice behavior, safety rules, fallback handling, and rollout considerations.

- **Bug Fixes**
  - Existing notifications continue to fall back to standard messaging when no suitable SmackBot phrase is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->