### PR TITLE
feat(api,notification): SmackBot voice preference + MarketSpread on UserPickScored

### DIFF
--- a/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringProcessor.cs
@@ -214,6 +214,18 @@ namespace SportsData.Api.Application.Scoring
                         pickedSpread = pickedIsHome.Value ? result.Spread.Value : -result.Spread.Value;
                     }
 
+                    // The market line regardless of PickType, same signing.
+                    // PickedSpread's ATS gate is display semantics; SmackBot's
+                    // situation taxonomy needs the line even for StraightUp
+                    // picks ("took a 14-point dog straight up"), so it travels
+                    // in its own field and existing copy never changes.
+                    double? marketSpread = null;
+                    if (pickedIsHome.HasValue
+                        && result.Spread is not null && result.Spread.Value != 0)
+                    {
+                        marketSpread = pickedIsHome.Value ? result.Spread.Value : -result.Spread.Value;
+                    }
+
                     // Fat-event for the Notification service (design doc §4 /
                     // §5 v1). Publish BEFORE SaveChanges so the bus-outbox
                     // interceptor commits this together with the pick update;
@@ -238,6 +250,7 @@ namespace SportsData.Api.Application.Scoring
                             pick.IsCorrect,
                             pickedIsHome,
                             pickedSpread,
+                            marketSpread,
                             group.Id,
                             group.Name,
                             group.Sport,

--- a/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommand.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommand.cs
@@ -15,4 +15,10 @@ public class UpdateNotificationPreferencesCommand
     public bool MatchupPreviewEnabled { get; init; } = true;
     public bool ScheduleChangeEnabled { get; init; } = true;
     public bool OddsChangedEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Pick-result voice wire name (see <c>NotificationVoices</c>). Defaults
+    /// to Standard so clients that predate the field keep today's copy.
+    /// </summary>
+    public string PickResultVoice { get; init; } = SportsData.Core.Eventing.Events.Users.NotificationVoices.Standard;
 }

--- a/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandler.cs
@@ -106,6 +106,7 @@ public class UpdateNotificationPreferencesCommandHandler : IUpdateNotificationPr
                 command.MatchupPreviewEnabled,
                 command.ScheduleChangeEnabled,
                 command.OddsChangedEnabled,
+                command.PickResultVoice,
                 Guid.NewGuid(),
                 Guid.NewGuid()),
             cancellationToken);
@@ -150,5 +151,6 @@ public class UpdateNotificationPreferencesCommandHandler : IUpdateNotificationPr
         prefs.MatchupPreviewEnabled = command.MatchupPreviewEnabled;
         prefs.ScheduleChangeEnabled = command.ScheduleChangeEnabled;
         prefs.OddsChangedEnabled = command.OddsChangedEnabled;
+        prefs.PickResultVoice = command.PickResultVoice;
     }
 }

--- a/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandValidator.cs
@@ -3,15 +3,18 @@ using FluentValidation;
 namespace SportsData.Api.Application.User.Commands.UpdateNotificationPreferences;
 
 /// <summary>
-/// No field-level rules today — every property is a non-nullable bool, so any
-/// deserialized command is structurally valid. Kept (and auto-registered) so the
-/// handler's <c>IValidator&lt;T&gt;</c> dependency resolves and there's a home for
-/// future cross-field rules.
+/// PickResultVoice must be a recognised wire name — an unknown voice stored
+/// canonically would silently degrade to Standard copy at dispatch, so reject
+/// it loudly at the API boundary instead. The bools remain structurally valid
+/// by type.
 /// </summary>
 public class UpdateNotificationPreferencesCommandValidator
     : AbstractValidator<UpdateNotificationPreferencesCommand>
 {
     public UpdateNotificationPreferencesCommandValidator()
     {
+        RuleFor(x => x.PickResultVoice)
+            .Must(SportsData.Core.Eventing.Events.Users.NotificationVoices.IsKnown)
+            .WithMessage(x => $"Unknown PickResultVoice '{x.PickResultVoice}'.");
     }
 }

--- a/src/SportsData.Api/Application/User/Dtos/NotificationPreferencesDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/NotificationPreferencesDto.cs
@@ -14,4 +14,7 @@ public class NotificationPreferencesDto
     public bool MatchupPreviewEnabled { get; set; } = true;
     public bool ScheduleChangeEnabled { get; set; } = true;
     public bool OddsChangedEnabled { get; set; } = true;
+
+    /// <summary>Pick-result voice wire name (see <c>NotificationVoices</c>).</summary>
+    public string PickResultVoice { get; set; } = SportsData.Core.Eventing.Events.Users.NotificationVoices.Standard;
 }

--- a/src/SportsData.Api/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetNotificationPreferences/GetNotificationPreferencesQueryHandler.cs
@@ -46,7 +46,8 @@ public class GetNotificationPreferencesQueryHandler : IGetNotificationPreference
                 MembershipEnabled = p.MembershipEnabled,
                 MatchupPreviewEnabled = p.MatchupPreviewEnabled,
                 ScheduleChangeEnabled = p.ScheduleChangeEnabled,
-                OddsChangedEnabled = p.OddsChangedEnabled
+                OddsChangedEnabled = p.OddsChangedEnabled,
+                PickResultVoice = p.PickResultVoice
             })
             .FirstOrDefaultAsync(cancellationToken);
 

--- a/src/SportsData.Api/Infrastructure/Data/Entities/UserNotificationPreferences.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/UserNotificationPreferences.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+using SportsData.Core.Eventing.Events.Users;
 using SportsData.Core.Infrastructure.Data.Entities;
 
 namespace SportsData.Api.Infrastructure.Data.Entities
@@ -36,6 +37,14 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public bool OddsChangedEnabled { get; set; } = true;
 
+        /// <summary>
+        /// Wire name from <c>NotificationVoices</c> ("Standard"/"Smack").
+        /// Stored as a string — the PickType-on-projection precedent — so the
+        /// canonical side needs no dependency on Notification's enum.
+        /// Standard = today's neutral copy; SmackBot is strictly opt-in.
+        /// </summary>
+        public string PickResultVoice { get; set; } = NotificationVoices.Standard;
+
         public class EntityConfiguration : IEntityTypeConfiguration<UserNotificationPreferences>
         {
             public void Configure(EntityTypeBuilder<UserNotificationPreferences> builder)
@@ -46,6 +55,14 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
                 // One row per user.
                 builder.HasIndex(x => x.UserId).IsUnique();
+
+                builder.Property(x => x.PickResultVoice)
+                    .HasMaxLength(40)
+                    .IsRequired()
+                    // DB-side default, not just the CLR initializer: existing
+                    // rows must backfill to Standard when the column is added,
+                    // and out-of-band inserts must never produce ''.
+                    .HasDefaultValue(NotificationVoices.Standard);
 
                 builder.HasOne(x => x.User)
                     .WithMany()

--- a/src/SportsData.Api/Migrations/20260817092825_PickResultVoicePreference.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260817092825_PickResultVoicePreference.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260817092825_PickResultVoicePreference")]
+    partial class PickResultVoicePreference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260817092825_PickResultVoicePreference.cs
+++ b/src/SportsData.Api/Migrations/20260817092825_PickResultVoicePreference.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PickResultVoicePreference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PickResultVoice",
+                table: "UserNotificationPreferences",
+                type: "character varying(40)",
+                maxLength: 40,
+                nullable: false,
+                defaultValue: "Standard");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PickResultVoice",
+                table: "UserNotificationPreferences");
+        }
+    }
+}

--- a/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
+++ b/src/SportsData.Core/Eventing/Events/Picks/UserPickScored.cs
@@ -47,6 +47,13 @@ namespace SportsData.Core.Eventing.Events.Picks
         // away = its negation), the same value scoring ran on. Null for straight-
         // up picks (or ATS with no/zero spread). The consumer formats it.
         double? PickedSpread,
+        // The picked side's market line regardless of league PickType, where
+        // PickedSpread is ATS-only (display semantics). Exists so SmackBot's
+        // situation taxonomy can see "took a 14-point dog STRAIGHT UP" —
+        // PickedSpread stays untouched so existing copy never grows a spread.
+        // Same signing as PickedSpread (negative = favoured). Null when the
+        // matchup carried no line or the side is unresolved.
+        double? MarketSpread,
         Guid LeagueId,
         string LeagueName,
         Sport Sport,

--- a/src/SportsData.Core/Eventing/Events/Users/NotificationVoices.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/NotificationVoices.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace SportsData.Core.Eventing.Events.Users
+{
+    /// <summary>
+    /// Wire names for the pick-result notification voice. The voice travels as
+    /// a STRING on events and in the API contract — same precedent as
+    /// PickType on <c>PickemGroupDataPublished</c> — so Core does not take a
+    /// dependency on Notification's enum and an unknown value degrades rather
+    /// than failing deserialization. Notification parses to its own
+    /// <c>NotificationVoice</c> with a Standard fallback.
+    /// See docs/features/smackbot-voice.md.
+    /// </summary>
+    public static class NotificationVoices
+    {
+        public const string Standard = "Standard";
+
+        public const string Smack = "Smack";
+
+        /// <summary>Every recognised wire name — the API validator's allow-list.</summary>
+        public static readonly string[] All = [Standard, Smack];
+
+        public static bool IsKnown(string? value) =>
+            value is not null && Array.Exists(All, v => string.Equals(v, value, StringComparison.Ordinal));
+    }
+}

--- a/src/SportsData.Core/Eventing/Events/Users/NotificationVoices.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/NotificationVoices.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace SportsData.Core.Eventing.Events.Users
 {
     /// <summary>
@@ -20,7 +18,9 @@ namespace SportsData.Core.Eventing.Events.Users
         /// <summary>Every recognised wire name — the API validator's allow-list.</summary>
         public static readonly string[] All = [Standard, Smack];
 
+        // Ordinal (case-sensitive) by construction — the wire contract is
+        // exact names, and Notification parses the same way.
         public static bool IsKnown(string? value) =>
-            value is not null && Array.Exists(All, v => string.Equals(v, value, StringComparison.Ordinal));
+            value is Standard or Smack;
     }
 }

--- a/src/SportsData.Core/Eventing/Events/Users/UserNotificationPreferencesUpdated.cs
+++ b/src/SportsData.Core/Eventing/Events/Users/UserNotificationPreferencesUpdated.cs
@@ -24,6 +24,10 @@ namespace SportsData.Core.Eventing.Events.Users
         bool MatchupPreviewEnabled,
         bool ScheduleChangeEnabled,
         bool OddsChangedEnabled,
+        // Wire name from NotificationVoices ("Standard"/"Smack"). Nullable so
+        // in-flight messages published before this field existed deserialize
+        // cleanly; consumers treat null/unknown as Standard.
+        string? PickResultVoice,
         Guid CorrelationId,
         Guid CausationId
     ) : EventBase(null, Sport.All, null, CorrelationId, CausationId);

--- a/src/SportsData.Notification/Application/Consumers/UserNotificationPreferencesUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserNotificationPreferencesUpdatedConsumer.cs
@@ -97,6 +97,14 @@ namespace SportsData.Notification.Application.Consumers
             entity.MatchupPreviewEnabled = msg.MatchupPreviewEnabled;
             entity.ScheduleChangeEnabled = msg.ScheduleChangeEnabled;
             entity.OddsChangedEnabled = msg.OddsChangedEnabled;
+
+            // Voice travels as a wire string; parse to the local enum with a
+            // Standard fallback so a null (pre-field event still in flight) or
+            // an unknown future voice degrades to today's copy, never throws.
+            entity.PickResultVoice =
+                Enum.TryParse<NotificationVoice>(msg.PickResultVoice, ignoreCase: false, out var voice)
+                    ? voice
+                    : NotificationVoice.Standard;
         }
 
         private static bool IsUniqueConstraintViolation(DbUpdateException ex)

--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -162,7 +162,10 @@ namespace SportsData.Notification.Application.Consumers
 
             // An AgainstTheSpread player opted into spread-based scoring, so
             // line-referencing copy is fair game. Anyone else has not, so the
-            // catalog filters those rows out.
+            // catalog filters those rows out. Deliberately keyed on
+            // PickedSpread (ATS-only), NOT MarketSpread — MarketSpread exists
+            // on straight-up picks too, but knowing the line and being allowed
+            // to talk about it are different things.
             var allowGamblingContent = msg.PickedSpread is not null;
 
             var smackLine = await _smackPhraseCatalog.TryResolveAsync(

--- a/src/SportsData.Notification/Application/Dispatching/PickSituationResolver.cs
+++ b/src/SportsData.Notification/Application/Dispatching/PickSituationResolver.cs
@@ -75,13 +75,12 @@ public enum PickSituation
 /// </para>
 ///
 /// <para>
-/// SPREAD AVAILABILITY: the spread-dependent situations need the picked
-/// side's line. Today <c>PickedSpread</c> is populated only for
-/// AgainstTheSpread leagues (PickScoringProcessor gates on PickType for
-/// display reasons), so a straight-up pick on a 14-point dog currently falls
-/// through to the generic buckets. A future <c>MarketSpread</c> on the event
-/// closes that gap; this resolver reads whichever is present, so it needs no
-/// change when that lands. Degraded, never broken.
+/// SPREAD AVAILABILITY: <c>PickedSpread</c> is populated only for
+/// AgainstTheSpread leagues (display semantics); <c>MarketSpread</c> carries
+/// the same picked-side-signed line for every league. The resolver reads
+/// whichever is present, so a straight-up pick on a 14-point dog resolves to
+/// the dog buckets. Events published before MarketSpread existed carry null
+/// and degrade to the margin buckets — degraded, never broken.
 /// </para>
 /// </summary>
 public static class PickSituationResolver
@@ -105,15 +104,22 @@ public static class PickSituationResolver
         var margin = pickedScore - opponentScore;
 
         // Negative = favoured, positive = underdog, from the picked side's
-        // perspective. Null when the league is straight-up (see class doc).
-        var line = msg.PickedSpread;
+        // perspective. TWO distinct meanings:
+        //   atsLine (PickedSpread) — non-null iff the pick was SCORED against
+        //     the spread. Cover-relative situations (NarrowMissAts) key on
+        //     this: a straight-up pick has no cover to miss.
+        //   line — the market number for dog/favourite framing, valid in any
+        //     league; MarketSpread supplies it when PickedSpread is null,
+        //     which is what lets "took a 14-point dog STRAIGHT UP" resolve.
+        var atsLine = msg.PickedSpread;
+        var line = atsLine ?? msg.MarketSpread;
 
         return msg.IsCorrect == true
             ? ResolveWin(margin, line)
-            : ResolveLoss(margin, pickedScore, line);
+            : ResolveLoss(margin, pickedScore, line, atsLine);
     }
 
-    private static PickSituation ResolveLoss(int margin, int pickedScore, double? line)
+    private static PickSituation ResolveLoss(int margin, int pickedScore, double? line, double? atsLine)
     {
         // Most-specific first. Humiliation outranks arithmetic: being shut out
         // is the story even if the margin also qualifies as a blowout.
@@ -122,8 +128,10 @@ public static class PickSituationResolver
             return PickSituation.ShutoutLoss;
 
         // An ATS near-miss is a sharper sting than any margin bucket — the
-        // pick was one point from cashing.
-        if (line is { } spread && Math.Abs(margin + spread) <= NarrowAtsMiss)
+        // pick was one point from cashing. Keyed on atsLine, NOT the merged
+        // line: a straight-up 14-point dog losing by exactly 14 has no cover
+        // to miss and must read as BigDogLoss, not a near-miss.
+        if (atsLine is { } spread && Math.Abs(margin + spread) <= NarrowAtsMiss)
             return PickSituation.NarrowMissAts;
 
         // SCOREBOARD vs PICK. IsCorrect means the pick COVERED, not that the

--- a/src/SportsData.Notification/Application/Dispatching/SmackPhraseCatalog.cs
+++ b/src/SportsData.Notification/Application/Dispatching/SmackPhraseCatalog.cs
@@ -177,8 +177,10 @@ public static class SmackPhraseFormatter
         }
 
         // Absolute value: lines read "a 14-point dog" / "favoured by 14", so
-        // the sign is carried by the wording, not the number.
-        if (msg.PickedSpread is { } spread)
+        // the sign is carried by the wording, not the number. Falls back to
+        // MarketSpread so a (non-gambling-gated) line using the token still
+        // resolves for straight-up picks.
+        if ((msg.PickedSpread ?? msg.MarketSpread) is { } spread)
             builder.Replace("{Line}", Math.Abs(spread).ToString("0.#"));
 
         return builder.ToString();

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
@@ -66,7 +66,10 @@ public class UpdateNotificationPreferencesCommandHandlerTests
             MembershipEnabled = false,
             MatchupPreviewEnabled = true,
             ScheduleChangeEnabled = false,
-            OddsChangedEnabled = true
+            OddsChangedEnabled = true,
+            // Non-default voice so a dropped mapping (entity or event) trips
+            // an assertion rather than passing on the default.
+            PickResultVoice = NotificationVoices.Smack
         };
 
     // Assert all eight flags on the persisted entity match the command.
@@ -80,6 +83,7 @@ public class UpdateNotificationPreferencesCommandHandlerTests
         prefs.MatchupPreviewEnabled.Should().Be(c.MatchupPreviewEnabled);
         prefs.ScheduleChangeEnabled.Should().Be(c.ScheduleChangeEnabled);
         prefs.OddsChangedEnabled.Should().Be(c.OddsChangedEnabled);
+        prefs.PickResultVoice.Should().Be(c.PickResultVoice);
     }
 
     // All eight flags on the published event match the command (plus UserId).
@@ -93,7 +97,8 @@ public class UpdateNotificationPreferencesCommandHandlerTests
            && e.MembershipEnabled == c.MembershipEnabled
            && e.MatchupPreviewEnabled == c.MatchupPreviewEnabled
            && e.ScheduleChangeEnabled == c.ScheduleChangeEnabled
-           && e.OddsChangedEnabled == c.OddsChangedEnabled;
+           && e.OddsChangedEnabled == c.OddsChangedEnabled
+           && e.PickResultVoice == c.PickResultVoice;
 
     // The event was published exactly once with the full flag set (payload-specific),
     // AND exactly one UserNotificationPreferencesUpdated was published in total. The
@@ -321,5 +326,38 @@ public class UpdateNotificationPreferencesCommandHandlerTests
 
             return await base.SaveChangesAsync(cancellationToken);
         }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownVoice_IsRejected()
+    {
+        // An unknown voice stored canonically would silently degrade to
+        // Standard copy at dispatch — reject it loudly at the boundary.
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateNotificationPreferencesCommand
+        {
+            PickResultVoice = "SassMaster9000"
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.BadRequest);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultCommand_KeepsStandardVoice()
+    {
+        // A client that predates the field sends no voice; the default must
+        // be Standard so nobody is opted into SmackBot by omission.
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+
+        var result = await handler.ExecuteAsync(userId, new UpdateNotificationPreferencesCommand());
+
+        result.IsSuccess.Should().BeTrue();
+        var prefs = await DataContext.UserNotificationPreferences.AsNoTracking()
+            .FirstAsync(x => x.UserId == userId);
+        prefs.PickResultVoice.Should().Be(NotificationVoices.Standard);
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpdateNotificationPreferences/UpdateNotificationPreferencesCommandHandlerTests.cs
@@ -346,6 +346,29 @@ public class UpdateNotificationPreferencesCommandHandlerTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_VoiceIsCaseSensitive_SmackAcceptedLowercaseRejected()
+    {
+        // Locks the wire contract: Notification parses case-sensitively, so
+        // the API boundary must reject 'smack' — accepting it here would store
+        // a value that silently degrades to Standard at dispatch.
+        var userId = await SeedUserAsync();
+        var handler = Mocker.CreateInstance<UpdateNotificationPreferencesCommandHandler>();
+
+        var accepted = await handler.ExecuteAsync(userId, new UpdateNotificationPreferencesCommand
+        {
+            PickResultVoice = NotificationVoices.Smack
+        });
+        accepted.IsSuccess.Should().BeTrue();
+
+        var rejected = await handler.ExecuteAsync(userId, new UpdateNotificationPreferencesCommand
+        {
+            PickResultVoice = "smack"
+        });
+        rejected.IsSuccess.Should().BeFalse();
+        rejected.Status.Should().Be(ResultStatus.BadRequest);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_DefaultCommand_KeepsStandardVoice()
     {
         // A client that predates the field sends no voice; the default must

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserNotificationPreferencesUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserNotificationPreferencesUpdatedConsumerTests.cs
@@ -130,4 +130,42 @@ public class UserNotificationPreferencesUpdatedConsumerTests
             .FirstAsync(p => p.UserId == userId);
         row.PickResultVoice.Should().Be(expected);
     }
+
+    [Fact]
+    public async Task Consume_PayloadOmittingPickResultVoice_DeserializesAndFallsBackToStandard()
+    {
+        // Contract-compatibility guard: an event serialized BEFORE the
+        // PickResultVoice field existed (in-flight during a rolling deploy)
+        // must deserialize with null in the positional slot and project as
+        // Standard. System.Text.Json is what MassTransit uses on the wire.
+        var userId = Guid.NewGuid();
+        var oldPayload = $$"""
+        {
+            "userId": "{{userId}}",
+            "pickResultEnabled": true,
+            "pickDeadlineReminderEnabled": true,
+            "contestStartReminderEnabled": true,
+            "leagueInviteEnabled": true,
+            "membershipEnabled": true,
+            "matchupPreviewEnabled": true,
+            "scheduleChangeEnabled": true,
+            "oddsChangedEnabled": true,
+            "correlationId": "{{Guid.NewGuid()}}",
+            "causationId": "{{Guid.NewGuid()}}"
+        }
+        """;
+
+        var msg = System.Text.Json.JsonSerializer.Deserialize<UserNotificationPreferencesUpdated>(
+            oldPayload,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        msg!.PickResultVoice.Should().BeNull("the omitted field must land as null, not throw");
+
+        var sut = Mocker.CreateInstance<UserNotificationPreferencesUpdatedConsumer>();
+        await sut.Consume(ContextFor(msg));
+
+        var row = await DataContext.UserNotificationPreferences.AsNoTracking()
+            .FirstAsync(p => p.UserId == userId);
+        row.PickResultVoice.Should().Be(NotificationVoice.Standard);
+    }
 }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserNotificationPreferencesUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserNotificationPreferencesUpdatedConsumerTests.cs
@@ -37,7 +37,8 @@ public class UserNotificationPreferencesUpdatedConsumerTests
     private static UserNotificationPreferencesUpdated MessageFor(
         Guid userId,
         bool pickResult = true,
-        bool oddsChanged = true)
+        bool oddsChanged = true,
+        string voice = "Standard")
         => new(
             userId,
             PickResultEnabled: pickResult,
@@ -48,6 +49,7 @@ public class UserNotificationPreferencesUpdatedConsumerTests
             MatchupPreviewEnabled: true,
             ScheduleChangeEnabled: true,
             OddsChangedEnabled: oddsChanged,
+            PickResultVoice: voice,
             CorrelationId: Guid.NewGuid(),
             CausationId: Guid.NewGuid());
 
@@ -109,5 +111,23 @@ public class UserNotificationPreferencesUpdatedConsumerTests
             .Where(p => p.UserId == userId).ToListAsync();
         rows.Should().HaveCount(1);
         rows[0].PickResultEnabled.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Smack", NotificationVoice.Smack)]
+    [InlineData("Standard", NotificationVoice.Standard)]
+    [InlineData(null, NotificationVoice.Standard)]          // pre-field event in flight
+    [InlineData("SassMaster9000", NotificationVoice.Standard)] // unknown future voice
+    [InlineData("smack", NotificationVoice.Standard)]       // case-sensitive wire contract
+    public async Task Consume_ProjectsVoice_WithStandardFallback(string wireVoice, NotificationVoice expected)
+    {
+        var userId = Guid.NewGuid();
+        var sut = Mocker.CreateInstance<UserNotificationPreferencesUpdatedConsumer>();
+
+        await sut.Consume(ContextFor(MessageFor(userId, voice: wireVoice)));
+
+        var row = await DataContext.UserNotificationPreferences.AsNoTracking()
+            .FirstAsync(p => p.UserId == userId);
+        row.PickResultVoice.Should().Be(expected);
     }
 }

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
@@ -83,6 +83,7 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
             userId, null, contestId ?? Guid.NewGuid(), pickId ?? Guid.NewGuid(), null, null,
             awayAbbr, homeAbbr, awayScore, homeScore,
             isCorrect, pickedIsHome, pickedSpread,
+            pickedSpread, // MarketSpread mirrors the line in these fixtures
             leagueId ?? Guid.NewGuid(), leagueName, Sport.BaseballMlb, 2026,
             correlationId ?? Guid.NewGuid(), Guid.NewGuid());
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/PickSituationResolverTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/PickSituationResolverTests.cs
@@ -25,7 +25,8 @@ public class PickSituationResolverTests
         int opponentScore,
         bool isCorrect,
         double? pickedSpread = null,
-        bool? pickedIsHome = true)
+        bool? pickedIsHome = true,
+        double? marketSpread = null)
         => new(
             Guid.NewGuid(), null, Guid.NewGuid(), Guid.NewGuid(),
             AwayName: null, HomeName: null,
@@ -38,6 +39,9 @@ public class PickSituationResolverTests
             IsCorrect: isCorrect,
             PickedIsHome: pickedIsHome,
             PickedSpread: pickedSpread,
+            // ATS events carry the same line in both fields, mirroring the
+            // publisher; straight-up cases pass marketSpread alone.
+            MarketSpread: marketSpread ?? pickedSpread,
             LeagueId: Guid.NewGuid(), LeagueName: "Sluggers",
             Sport: Sport.FootballNcaa, SeasonYear: 2026,
             CorrelationId: Guid.NewGuid(), CausationId: Guid.NewGuid());
@@ -165,15 +169,35 @@ public class PickSituationResolverTests
     }
 
     [Fact]
-    public void StraightUpBigDogLoss_CurrentlyDegradesToAMarginBucket()
+    public void StraightUpBigDogLoss_ResolvesViaMarketSpread()
     {
-        // DOCUMENTS A KNOWN GAP. The flagship case — "took a 14-point dog
-        // straight up and lost" — can't resolve to BigDogLoss today because
-        // PickScoringProcessor only populates PickedSpread for ATS leagues.
-        // It degrades to a margin bucket rather than failing. Adding
-        // MarketSpread to the event closes this, and THIS TEST SHOULD THEN
-        // FLIP to expect BigDogLoss.
-        PickSituationResolver.Resolve(Pick(10, 24, isCorrect: false, pickedSpread: null))
+        // THE FLAGSHIP CASE — "took a 14-point dog straight up and lost".
+        // PickedSpread is null in a StraightUp league (display semantics);
+        // MarketSpread carries the line, and the dog buckets resolve from it.
+        // This test previously documented the gap; MarketSpread closed it.
+        PickSituationResolver.Resolve(
+                Pick(10, 24, isCorrect: false, pickedSpread: null, marketSpread: 14))
+            .Should().Be(PickSituation.BigDogLoss);
+    }
+
+    [Fact]
+    public void StraightUpDogAtExactlyTheLine_IsNotANearMiss()
+    {
+        // Same 14-point margin as the ATS near-miss case, but scored straight
+        // up: there was no cover to miss, so cover-relative situations must
+        // never fire from MarketSpread alone.
+        PickSituationResolver.Resolve(
+                Pick(10, 24, isCorrect: false, pickedSpread: null, marketSpread: 14))
+            .Should().NotBe(PickSituation.NarrowMissAts);
+    }
+
+    [Fact]
+    public void PreMarketSpreadEvent_StillDegradesToAMarginBucket()
+    {
+        // An event published before MarketSpread existed carries null in both
+        // fields and must keep degrading to the margin buckets, not throw.
+        PickSituationResolver.Resolve(
+                Pick(10, 24, isCorrect: false, pickedSpread: null, marketSpread: null))
             .Should().Be(PickSituation.GenericLoss);
     }
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/SmackPhraseCatalogTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/SmackPhraseCatalogTests.cs
@@ -32,7 +32,7 @@ public class SmackPhraseCatalogTests : NotificationTestBase<SmackPhraseCatalog>
         => new(
             Guid.NewGuid(), null, Guid.NewGuid(), pickId,
             null, null, "NYY", "BOS", 24, 14,
-            IsCorrect: false, PickedIsHome: true, PickedSpread: null,
+            IsCorrect: false, PickedIsHome: true, PickedSpread: null, MarketSpread: null,
             Guid.NewGuid(), "Sluggers", Sport.FootballNcaa, 2026,
             Guid.NewGuid(), Guid.NewGuid());
 
@@ -137,7 +137,7 @@ public class SmackPhraseCatalogTests : NotificationTestBase<SmackPhraseCatalog>
             AwayName: null, HomeName: null,
             AwayAbbreviation: "NYY", HomeAbbreviation: "BOS",
             AwayScore: 2, HomeScore: 9,
-            IsCorrect: true, PickedIsHome: true, PickedSpread: -6.5,
+            IsCorrect: true, PickedIsHome: true, PickedSpread: -6.5, MarketSpread: -6.5,
             LeagueId: Guid.NewGuid(), LeagueName: "Sluggers",
             Sport: Sport.BaseballMlb, SeasonYear: 2026,
             CorrelationId: Guid.NewGuid(), CausationId: Guid.NewGuid());
@@ -154,7 +154,7 @@ public class SmackPhraseCatalogTests : NotificationTestBase<SmackPhraseCatalog>
         var msg = new UserPickScored(
             Guid.NewGuid(), null, Guid.NewGuid(), Guid.NewGuid(),
             null, null, "NYY", "BOS", 2, 9,
-            true, true, null,
+            true, true, null, null,
             Guid.NewGuid(), "Sluggers", Sport.BaseballMlb, 2026,
             Guid.NewGuid(), Guid.NewGuid());
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/SmackPhraseCatalogTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Dispatching/SmackPhraseCatalogTests.cs
@@ -149,6 +149,23 @@ public class SmackPhraseCatalogTests : NotificationTestBase<SmackPhraseCatalog>
     }
 
     [Fact]
+    public void Formatter_ResolvesLineFromMarketSpread_WhenPickedSpreadAbsent()
+    {
+        // Straight-up pick: PickedSpread is null but the market line rides on
+        // MarketSpread; a non-gambling line using {Line} must still resolve.
+        var msg = new UserPickScored(
+            Guid.NewGuid(), null, Guid.NewGuid(), Guid.NewGuid(),
+            null, null, "NYY", "BOS", 2, 9,
+            IsCorrect: true, PickedIsHome: true,
+            PickedSpread: null, MarketSpread: -6.5,
+            LeagueId: Guid.NewGuid(), LeagueName: "Sluggers",
+            Sport: Sport.BaseballMlb, SeasonYear: 2026,
+            CorrelationId: Guid.NewGuid(), CausationId: Guid.NewGuid());
+
+        SmackPhraseFormatter.Format("({Line})", msg).Should().Be("(6.5)");
+    }
+
+    [Fact]
     public void Formatter_LeavesUnknownTokensAloneRatherThanThrowing()
     {
         var msg = new UserPickScored(


### PR DESCRIPTION
Second SmackBot slice (engine: #643). Two independent additions that together make the feature real — **still shipping dark**: nothing changes until a user flips the (not-yet-built) mobile toggle AND the phrase catalog has rows.

## MarketSpread — the flagship case works

`PickScoringProcessor` now sends the picked side's market line **regardless of league PickType**. The ATS gate on `PickedSpread` was display semantics, so that field is untouched and existing copy never grows a spread. The resolver reads `PickedSpread ?? MarketSpread` for dog/favourite framing, so *"took a 14-point dog straight up and lost"* finally resolves to `BigDogLoss` — the documented-gap test from #643 flipped to assert it.

**Subtlety the flip caught:** cover-relative situations key on `PickedSpread` ONLY. A straight-up 14-point dog losing by exactly 14 has *no cover to miss* — the naive merge made it read as `NarrowMissAts`. The resolver now carries the two meanings separately (`atsLine` vs `line`), pinned by an explicit test.

The gambling gate also stays keyed on `PickedSpread`: knowing the line and being allowed to *talk about it* are different things. Straight-up players get the dog situations, but only their `RequiresGamblingContent = false` lines — never "Vegas said 14."

## Voice preference — end to end

`PickResultVoice` flows API entity → command/validator/DTO/query → `UserNotificationPreferencesUpdated` → Notification projection, where the #643 catalog already reads it.

- Travels as a wire **string** (the `PickType` precedent) with the allow-list in one place: `Core.NotificationVoices`
- API validator **rejects** unknown voices loudly (an unknown value stored canonically would silently degrade at dispatch)
- Notification parses with a `Standard` **fallback** — a null from an in-flight pre-field event or an unknown future voice degrades rather than throws; case-sensitive contract, pinned by test

## Migration note

EF does not translate CLR initializers into database defaults — the first generated migration backfilled existing rows to `''`. Regenerated with `HasDefaultValue("Standard")` so existing rows and out-of-band inserts both land on `Standard`. **Applied locally before commit.**

## Tests

Notification **95/95**, API **676/676**, Core **252/252**. New coverage: flagship straight-up big-dog resolution, the not-a-near-miss pin, pre-MarketSpread event degradation, voice projection matrix (Smack/Standard/null/unknown/case-mismatch), unknown-voice rejection, and default-command-keeps-Standard.

## Remaining

Mobile settings toggle (batched for the next EAS build) and phrase content (out-of-band SQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a notification preference for choosing a Standard or Smack voice for pick-result alerts.
  * Added validation and safe fallback to the Standard voice for invalid or older preference values.
  * Pick results now include market-line information across pick types.

* **Bug Fixes**
  * Improved pick-result messaging for underdog, favorite, and near-miss scenarios.
  * Preserved accurate ATS-specific line handling while improving straight-up pick classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->