### PR TITLE
feat(api,core): SmackBot Lab composition + typed NotificationClient

### DIFF
--- a/src/SportsData.Api/Application/Admin/SmackLab/GetSmackLabLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/SmackLab/GetSmackLabLeaguesQueryHandler.cs
@@ -37,7 +37,11 @@ public class GetSmackLabLeaguesQueryHandler : IGetSmackLabLeaguesQueryHandler
 
     public async Task<Result<List<SmackLabLeagueDto>>> ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var leagues = await _db.UserPicks
+        // Anonymous projection end-to-end on the server: EF cannot translate
+        // an OrderBy over a constructor-projected record's property (nor the
+        // enum ToStrings), so the DTO is shaped in memory AFTER the ordered
+        // rows come back.
+        var rows = await _db.UserPicks
             .AsNoTracking()
             .Where(p => p.IsCorrect != null)
             .GroupBy(p => p.PickemGroupId)
@@ -46,14 +50,21 @@ public class GetSmackLabLeaguesQueryHandler : IGetSmackLabLeaguesQueryHandler
                 _db.PickemGroups.AsNoTracking(),
                 x => x.LeagueId,
                 grp => grp.Id,
-                (x, grp) => new SmackLabLeagueDto(
+                (x, grp) => new
+                {
                     grp.Id,
                     grp.Name,
-                    grp.Sport.ToString(),
-                    grp.PickType.ToString(),
-                    x.ScoredPickCount))
-            .OrderByDescending(l => l.ScoredPickCount)
+                    grp.Sport,
+                    grp.PickType,
+                    x.ScoredPickCount
+                })
+            .OrderByDescending(x => x.ScoredPickCount)
             .ToListAsync(cancellationToken);
+
+        var leagues = rows
+            .Select(x => new SmackLabLeagueDto(
+                x.Id, x.Name, x.Sport.ToString(), x.PickType.ToString(), x.ScoredPickCount))
+            .ToList();
 
         return new Success<List<SmackLabLeagueDto>>(leagues);
     }

--- a/src/SportsData.Api/Application/Admin/SmackLab/GetSmackLabLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/SmackLab/GetSmackLabLeaguesQueryHandler.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.SmackLab;
+
+/// <summary>
+/// A league eligible for the SmackBot Lab: it has at least one scored pick to
+/// preview. ScoredPickCount sizes the work before the operator selects it.
+/// </summary>
+public record SmackLabLeagueDto(
+    Guid LeagueId,
+    string Name,
+    string Sport,
+    string PickType,
+    int ScoredPickCount);
+
+public interface IGetSmackLabLeaguesQueryHandler
+{
+    Task<Result<List<SmackLabLeagueDto>>> ExecuteAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Leagues with scored picks, most recently active first. Scored means
+/// <c>IsCorrect</c> is populated — the same marker PickScoringProcessor
+/// writes; unscored picks have nothing to preview.
+/// </summary>
+public class GetSmackLabLeaguesQueryHandler : IGetSmackLabLeaguesQueryHandler
+{
+    private readonly AppDataContext _db;
+
+    public GetSmackLabLeaguesQueryHandler(AppDataContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<Result<List<SmackLabLeagueDto>>> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var leagues = await _db.UserPicks
+            .AsNoTracking()
+            .Where(p => p.IsCorrect != null)
+            .GroupBy(p => p.PickemGroupId)
+            .Select(g => new { LeagueId = g.Key, ScoredPickCount = g.Count() })
+            .Join(
+                _db.PickemGroups.AsNoTracking(),
+                x => x.LeagueId,
+                grp => grp.Id,
+                (x, grp) => new SmackLabLeagueDto(
+                    grp.Id,
+                    grp.Name,
+                    grp.Sport.ToString(),
+                    grp.PickType.ToString(),
+                    x.ScoredPickCount))
+            .OrderByDescending(l => l.ScoredPickCount)
+            .ToListAsync(cancellationToken);
+
+        return new Success<List<SmackLabLeagueDto>>(leagues);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/SmackLab/GetSmackLabPicksQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/SmackLab/GetSmackLabPicksQueryHandler.cs
@@ -1,0 +1,185 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Infrastructure.Clients.Notification.Dtos;
+
+namespace SportsData.Api.Application.Admin.SmackLab;
+
+/// <summary>
+/// A scored pick prepared for the Lab: the preview fact payload (what
+/// Notification's resolver and formatter consume) plus display context for
+/// the operator's table row.
+/// </summary>
+public record SmackLabPickDto(
+    SmackPreviewPickDto Facts,
+    string PickerName,
+    string MatchupLabel,
+    string PickLabel,
+    bool? IsCorrect);
+
+public interface IGetSmackLabPicksQueryHandler
+{
+    Task<Result<List<SmackLabPickDto>>> ExecuteAsync(Guid leagueId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Composes preview fact payloads for every scored pick in a league.
+///
+/// <para>
+/// FIDELITY: the facts must match what a live send saw, so the derivation of
+/// PickedIsHome / PickedSpread / MarketSpread mirrors
+/// <c>PickScoringProcessor</c> exactly — FranchiseSeasonId compared against
+/// the matchup result's per-side ids; PickedSpread gated to ATS leagues with
+/// a non-zero line; MarketSpread ungated. Contest facts come from the same
+/// <c>GetMatchupResult</c> call scoring used, fetched once per distinct
+/// contest rather than per pick.
+/// </para>
+/// </summary>
+public class GetSmackLabPicksQueryHandler : IGetSmackLabPicksQueryHandler
+{
+    private readonly AppDataContext _db;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly ILogger<GetSmackLabPicksQueryHandler> _logger;
+
+    public GetSmackLabPicksQueryHandler(
+        AppDataContext db,
+        IContestClientFactory contestClientFactory,
+        ILogger<GetSmackLabPicksQueryHandler> logger)
+    {
+        _db = db;
+        _contestClientFactory = contestClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<Result<List<SmackLabPickDto>>> ExecuteAsync(
+        Guid leagueId,
+        CancellationToken cancellationToken = default)
+    {
+        var league = await _db.PickemGroups
+            .AsNoTracking()
+            .Where(g => g.Id == leagueId)
+            .Select(g => new { g.Id, g.Name, g.Sport, g.PickType })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (league is null)
+        {
+            return new Failure<List<SmackLabPickDto>>(
+                [], ResultStatus.NotFound,
+                [new FluentValidation.Results.ValidationFailure(nameof(leagueId), "League not found.")]);
+        }
+
+        var picks = await _db.UserPicks
+            .AsNoTracking()
+            .Where(p => p.PickemGroupId == leagueId && p.IsCorrect != null)
+            .Select(p => new
+            {
+                p.Id,
+                p.UserId,
+                p.ContestId,
+                p.FranchiseSeasonId,
+                p.IsCorrect
+            })
+            .ToListAsync(cancellationToken);
+
+        if (picks.Count == 0)
+            return new Success<List<SmackLabPickDto>>([]);
+
+        var userNames = await _db.Users
+            .AsNoTracking()
+            .Where(u => picks.Select(p => p.UserId).Distinct().Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName, u.Username })
+            .ToDictionaryAsync(u => u.Id, cancellationToken);
+
+        // One matchup-result fetch per distinct contest — the same call
+        // scoring ran on, so scores/spread/abbreviations are the values the
+        // live send composed copy from. A contest whose result fetch fails is
+        // skipped (logged) rather than failing the whole league.
+        var contestClient = _contestClientFactory.Resolve(league.Sport);
+        var results = new Dictionary<Guid, Core.Dtos.Canonical.MatchupResult>();
+        foreach (var contestId in picks.Select(p => p.ContestId).Distinct())
+        {
+            var response = await contestClient.GetMatchupResult(contestId, cancellationToken);
+            if (response.IsSuccess && response.Value.FinalizedUtc is not null)
+            {
+                results[contestId] = response.Value;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "SmackLab: no finalized matchup result for ContestId {ContestId}; its picks are skipped.",
+                    contestId);
+            }
+        }
+
+        var dtos = new List<SmackLabPickDto>(picks.Count);
+        foreach (var pick in picks)
+        {
+            if (!results.TryGetValue(pick.ContestId, out var result))
+                continue;
+
+            // ── Derivation parity with PickScoringProcessor ──────────────
+            bool? pickedIsHome = pick.FranchiseSeasonId.HasValue
+                ? pick.FranchiseSeasonId == result.HomeFranchiseSeasonId ? true
+                  : pick.FranchiseSeasonId == result.AwayFranchiseSeasonId ? false
+                  : (bool?)null
+                : null;
+
+            double? pickedSpread = null;
+            if (pickedIsHome.HasValue
+                && league.PickType == PickType.AgainstTheSpread
+                && result.Spread is not null && result.Spread.Value != 0)
+            {
+                pickedSpread = pickedIsHome.Value ? result.Spread.Value : -result.Spread.Value;
+            }
+
+            double? marketSpread = null;
+            if (pickedIsHome.HasValue
+                && result.Spread is not null && result.Spread.Value != 0)
+            {
+                marketSpread = pickedIsHome.Value ? result.Spread.Value : -result.Spread.Value;
+            }
+            // ─────────────────────────────────────────────────────────────
+
+            var facts = new SmackPreviewPickDto
+            {
+                PickId = pick.Id,
+                ContestId = pick.ContestId,
+                LeagueId = league.Id,
+                UserId = pick.UserId,
+                AwayAbbreviation = result.AwayAbbreviation,
+                HomeAbbreviation = result.HomeAbbreviation,
+                AwayScore = result.AwayScore,
+                HomeScore = result.HomeScore,
+                IsCorrect = pick.IsCorrect,
+                PickedIsHome = pickedIsHome,
+                PickedSpread = pickedSpread,
+                MarketSpread = marketSpread,
+                LeagueName = league.Name,
+                Sport = league.Sport
+            };
+
+            var pickerName = userNames.TryGetValue(pick.UserId, out var user)
+                ? user.DisplayName ?? user.Username
+                : "(unknown)";
+
+            var pickLabel = pickedIsHome switch
+            {
+                true => result.HomeAbbreviation ?? "home",
+                false => result.AwayAbbreviation ?? "away",
+                null => "O/U"
+            };
+
+            dtos.Add(new SmackLabPickDto(
+                facts,
+                pickerName,
+                $"{result.AwayAbbreviation ?? "AWY"} {result.AwayScore} @ {result.HomeAbbreviation ?? "HOM"} {result.HomeScore}",
+                pickLabel,
+                pick.IsCorrect));
+        }
+
+        return new Success<List<SmackLabPickDto>>(dtos);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/SmackLabController.cs
+++ b/src/SportsData.Api/Application/Admin/SmackLabController.cs
@@ -1,0 +1,106 @@
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Api.Application.Admin.SmackLab;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Notification;
+using SportsData.Core.Infrastructure.Clients.Notification.Dtos;
+
+namespace SportsData.Api.Application.Admin;
+
+/// <summary>
+/// SmackBot Lab's API surface (web admin → here → Notification). Two
+/// composition reads own the canonical-data half (leagues with scored picks,
+/// per-league preview facts); the rest are thin relays through
+/// <see cref="IProvideNotifications"/> — the typed client stamps Notification's
+/// X-Api-Key server-to-server, so the browser only ever holds the admin token
+/// this controller already requires. See docs/features/smackbot-lab.md.
+/// </summary>
+[ApiController]
+[Route("admin/smack-lab")]
+[AdminApiToken]
+public class SmackLabController : ControllerBase
+{
+    private readonly ILogger<SmackLabController> _logger;
+
+    public SmackLabController(ILogger<SmackLabController> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>Leagues with at least one scored pick to preview.</summary>
+    [HttpGet("leagues")]
+    public async Task<ActionResult<List<SmackLabLeagueDto>>> GetLeagues(
+        [FromServices] IGetSmackLabLeaguesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(cancellationToken);
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Every scored pick in a league, composed into the preview fact payload
+    /// plus operator display context.
+    /// </summary>
+    [HttpGet("leagues/{leagueId:guid}/picks")]
+    public async Task<ActionResult<List<SmackLabPickDto>>> GetPicks(
+        [FromServices] IGetSmackLabPicksQueryHandler handler,
+        [FromRoute] Guid leagueId,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(leagueId, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    // ─── Relays to Notification (typed client only — no ad-hoc HTTP) ─────
+
+    [HttpPost("preview")]
+    public async Task<ActionResult<List<SmackPreviewResultDto>>> Preview(
+        [FromServices] IProvideNotifications notifications,
+        [FromBody] SmackPreviewRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        var result = await notifications.PreviewSmack(request, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpGet("phrases")]
+    public async Task<ActionResult<List<SmackPhraseDto>>> GetPhrases(
+        [FromServices] IProvideNotifications notifications,
+        CancellationToken cancellationToken)
+    {
+        var result = await notifications.GetSmackPhrases(cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpPost("phrases")]
+    public async Task<ActionResult<SmackPhraseDto>> CreatePhrase(
+        [FromServices] IProvideNotifications notifications,
+        [FromBody] SmackPhraseUpsertDto request,
+        CancellationToken cancellationToken)
+    {
+        var result = await notifications.CreateSmackPhrase(request, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    /// <summary>Relays the xmin echo; a stale RowVersion returns 409.</summary>
+    [HttpPut("phrases/{phraseId:guid}")]
+    public async Task<ActionResult<SmackPhraseDto>> UpdatePhrase(
+        [FromServices] IProvideNotifications notifications,
+        [FromRoute] Guid phraseId,
+        [FromBody] SmackPhraseUpsertDto request,
+        CancellationToken cancellationToken)
+    {
+        var result = await notifications.UpdateSmackPhrase(phraseId, request, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [HttpPost("ratings")]
+    public async Task<IActionResult> RatePreview(
+        [FromServices] IProvideNotifications notifications,
+        [FromBody] SmackRatingRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        var result = await notifications.RateSmackPreview(request, cancellationToken);
+        return result.ToActionResult().Result ?? Ok();
+    }
+}

--- a/src/SportsData.Api/Application/Admin/SmackLabController.cs
+++ b/src/SportsData.Api/Application/Admin/SmackLabController.cs
@@ -94,6 +94,17 @@ public class SmackLabController : ControllerBase
         return result.ToActionResult();
     }
 
+    /// <summary>Stored ratings for a league — the Lab re-hydrates stars from these.</summary>
+    [HttpGet("leagues/{leagueId:guid}/ratings")]
+    public async Task<ActionResult<List<SmackRatingDto>>> GetRatings(
+        [FromServices] IProvideNotifications notifications,
+        [FromRoute] Guid leagueId,
+        CancellationToken cancellationToken)
+    {
+        var result = await notifications.GetSmackRatings(leagueId, cancellationToken);
+        return result.ToActionResult();
+    }
+
     [HttpPost("ratings")]
     public async Task<IActionResult> RatePreview(
         [FromServices] IProvideNotifications notifications,

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -337,6 +337,10 @@ namespace SportsData.Api.DependencyInjection
             // User Queries
             services.AddScoped<IGetMeQueryHandler, GetMeQueryHandler>();
             services.AddScoped<IGetNotificationPreferencesQueryHandler, GetNotificationPreferencesQueryHandler>();
+
+            // SmackBot Lab composition (docs/features/smackbot-lab.md)
+            services.AddScoped<Application.Admin.SmackLab.IGetSmackLabLeaguesQueryHandler, Application.Admin.SmackLab.GetSmackLabLeaguesQueryHandler>();
+            services.AddScoped<Application.Admin.SmackLab.IGetSmackLabPicksQueryHandler, Application.Admin.SmackLab.GetSmackLabPicksQueryHandler>();
             services.AddScoped<IGetUserOptionsQueryHandler, GetUserOptionsQueryHandler>();
 
             services.AddScoped<IUserService, UserService>();

--- a/src/SportsData.Core/Common/Result.cs
+++ b/src/SportsData.Core/Common/Result.cs
@@ -32,6 +32,12 @@ namespace SportsData.Core.Common
         RateLimited,
         Success,
         Unauthorized,
-        Validation
+        Validation,
+
+        // Appended (not alphabetical) deliberately: enum members number by
+        // position, and inserting mid-enum would renumber everything after it
+        // — a silent remap anywhere a ResultStatus is ever serialized
+        // numerically across a rolling deploy.
+        Conflict
     }
 }

--- a/src/SportsData.Core/Config/CommonConfigKeys.cs
+++ b/src/SportsData.Core/Config/CommonConfigKeys.cs
@@ -77,6 +77,12 @@ namespace SportsData.Core.Config
         public static string GetNotificationProviderUri(Sport mode) =>
             $"{nameof(CommonConfig)}:{nameof(NotificationClientConfig)}:{mode}:{nameof(NotificationClientConfig.ApiUrl)}";
 
+        public static string GetNotificationProviderUri() =>
+            $"{nameof(CommonConfig)}:{nameof(NotificationClientConfig)}:{nameof(NotificationClientConfig.ApiUrl)}";
+
+        public static string GetNotificationClientSecretKey() =>
+            $"{nameof(CommonConfig)}:{nameof(NotificationClientConfig)}:{nameof(NotificationClientConfig.SecretKey)}";
+
         public static string GetPlayerProviderUri(Sport mode) =>
             $"{nameof(CommonConfig)}:{nameof(PlayerClientConfig)}:{mode}:{nameof(PlayerClientConfig.ApiUrl)}";
 

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -23,6 +23,7 @@ using SportsData.Core.Http.Policies;
 using SportsData.Core.Infrastructure.Blobs;
 using SportsData.Core.Infrastructure.Clients;
 using SportsData.Core.Infrastructure.Clients.Contest;
+using SportsData.Core.Infrastructure.Clients.Notification;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 using SportsData.Core.Infrastructure.Clients.Provider;
 using SportsData.Core.Infrastructure.Clients.Season;
@@ -615,6 +616,27 @@ namespace SportsData.Core.DependencyInjection
             {
                 var franchiseClientName = $"{HttpClients.FranchiseClient}";
                 services.AddHttpClient(franchiseClientName, client => client.BaseAddress = new Uri(franchiseApiUrl));
+            }
+
+            // Notification is a single mode-agnostic service (mode=All), so no
+            // per-sport factory — one typed client, registered only when the
+            // slot is configured. The admin key is stamped as a default header
+            // here so call sites (and browsers) never see it.
+            var notificationApiUrl = configuration[CommonConfigKeys.GetNotificationProviderUri()];
+            if (!string.IsNullOrEmpty(notificationApiUrl))
+            {
+                var notificationSecret = configuration[CommonConfigKeys.GetNotificationClientSecretKey()];
+                services
+                    .AddHttpClient<IProvideNotifications, NotificationClient>(HttpClients.NotificationClient, c =>
+                    {
+                        c.BaseAddress = new Uri(notificationApiUrl);
+                        c.Timeout = TimeSpan.FromSeconds(30);
+                        if (!string.IsNullOrEmpty(notificationSecret))
+                        {
+                            c.DefaultRequestHeaders.Add("X-Api-Key", notificationSecret);
+                        }
+                    })
+                    .AddPolicyHandlerFromRegistry("HttpRetry");
             }
 
             var seasonApiUrl = configuration[CommonConfigKeys.GetSeasonProviderUri()];

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -638,6 +638,17 @@ namespace SportsData.Core.DependencyInjection
                     })
                     .AddPolicyHandlerFromRegistry("HttpRetry");
             }
+            else
+            {
+                // No ApiUrl: consumers (e.g. SmackLabController) still resolve
+                // IProvideNotifications and receive a controlled
+                // misconfiguration Failure per call, rather than the container
+                // failing dependency resolution into a raw 500. A missing
+                // SecretKey (above) is likewise a controlled failure: the
+                // server rejects with 401 and the client maps it to an
+                // Unauthorized envelope.
+                services.AddSingleton<IProvideNotifications, UnconfiguredNotificationClient>();
+            }
 
             var seasonApiUrl = configuration[CommonConfigKeys.GetSeasonProviderUri()];
             if (!string.IsNullOrEmpty(seasonApiUrl))

--- a/src/SportsData.Core/Extensions/ResultExtensions.cs
+++ b/src/SportsData.Core/Extensions/ResultExtensions.cs
@@ -46,6 +46,7 @@ namespace SportsData.Core.Extensions
                     ResultStatus.Unauthorized => new UnauthorizedObjectResult(new { failure.Errors }), // 401 Unauthorized
                     ResultStatus.Forbid => new ForbidResult(), // 403 Forbidden
                     ResultStatus.NotFound => new NotFoundObjectResult(new { failure.Errors }), // 404 Not Found
+                    ResultStatus.Conflict => new ConflictObjectResult(new { failure.Errors }), // 409 Conflict
                     _ => new ObjectResult(new { failure.Errors }) { StatusCode = 500 } // 500 Internal Server Error
                 };
             }

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -190,8 +190,35 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             Content = new StringContent(request.ToJson(), Encoding.UTF8, "application/json")
         };
 
-        using var response = await HttpClient.SendAsync(message, cancellationToken);
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        HttpResponseMessage response;
+        string content;
+        try
+        {
+            response = await HttpClient.SendAsync(message, cancellationToken);
+            content = await response.Content.ReadAsStringAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller-requested cancellation propagates; only TIMEOUTS (the
+            // client's own token) convert to a failure below.
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            return new Failure<TResponse>(
+                defaultResponse,
+                ResultStatus.Error,
+                [new ValidationFailure(entityName, $"{entityName} request failed: {ex.Message}")]);
+        }
+        catch (TaskCanceledException)
+        {
+            return new Failure<TResponse>(
+                defaultResponse,
+                ResultStatus.Error,
+                [new ValidationFailure(entityName, $"{entityName} request timed out")]);
+        }
+
+        using var _ = response;
 
         if (response.IsSuccessStatusCode)
         {
@@ -228,7 +255,12 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             // Response body is not valid JSON, use defaults
         }
 
-        var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, defaultFailureStatus);
+        // The HTTP status is AUTHORITATIVE. Server failure bodies are shaped
+        // { errors } (ToActionResult never serializes a Failure<T>), so the
+        // parse above yields a Failure whose Status is the enum DEFAULT —
+        // trusting it turned a 409 into ResultStatus.Accepted and broke the
+        // conflict relay. The body contributes errors only.
+        var status = MapHttpStatusCode(response.StatusCode, defaultFailureStatus);
         var errors = failure?.Errors ?? [new ValidationFailure(entityName, content.Length > 0 && content.Length <= 300 ? content : $"{entityName} request failed")];
 
         return new Failure<TResponse>(defaultResponse, status, errors);

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -109,6 +109,7 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             HttpStatusCode.Unauthorized => ResultStatus.Unauthorized,
             HttpStatusCode.Forbidden => ResultStatus.Forbid,
             HttpStatusCode.BadRequest => ResultStatus.BadRequest,
+            HttpStatusCode.Conflict => ResultStatus.Conflict,
             HttpStatusCode.UnprocessableEntity => ResultStatus.BadRequest,
             >= HttpStatusCode.InternalServerError => ResultStatus.Error,
             _ => defaultStatus
@@ -133,6 +134,104 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             entityName,
             defaultFailureStatus,
             cancellationToken);
+    }
+
+    /// <summary>
+    /// Performs an HTTP POST with a JSON body where the caller needs the
+    /// response BODY as a Result — the body-returning sibling of
+    /// <see cref="PostWithResultAsync{TRequest}(string, TRequest, string, CancellationToken)"/>,
+    /// with the same error mapping as <see cref="GetAsync{TResponse, TDto}"/>.
+    /// </summary>
+    protected Task<Result<TResponse>> PostAsync<TResponse, TDto, TRequest>(
+        string url,
+        TRequest request,
+        Func<TDto, TResponse> mapToResponse,
+        TResponse defaultResponse,
+        string entityName = "Response",
+        ResultStatus defaultFailureStatus = ResultStatus.BadRequest,
+        CancellationToken cancellationToken = default)
+        where TDto : class
+        where TRequest : class
+        => SendWithBodyAsync(HttpMethod.Post, url, request, mapToResponse, defaultResponse, entityName, defaultFailureStatus, cancellationToken);
+
+    /// <summary>
+    /// Performs an HTTP PUT with a JSON body where the caller needs the
+    /// response BODY as a Result. Same error mapping as
+    /// <see cref="GetAsync{TResponse, TDto}"/>; a 409 surfaces via
+    /// <see cref="MapHttpStatusCode"/> so optimistic-concurrency conflicts are
+    /// distinguishable from other failures.
+    /// </summary>
+    protected Task<Result<TResponse>> PutAsync<TResponse, TDto, TRequest>(
+        string url,
+        TRequest request,
+        Func<TDto, TResponse> mapToResponse,
+        TResponse defaultResponse,
+        string entityName = "Response",
+        ResultStatus defaultFailureStatus = ResultStatus.BadRequest,
+        CancellationToken cancellationToken = default)
+        where TDto : class
+        where TRequest : class
+        => SendWithBodyAsync(HttpMethod.Put, url, request, mapToResponse, defaultResponse, entityName, defaultFailureStatus, cancellationToken);
+
+    private async Task<Result<TResponse>> SendWithBodyAsync<TResponse, TDto, TRequest>(
+        HttpMethod method,
+        string url,
+        TRequest request,
+        Func<TDto, TResponse> mapToResponse,
+        TResponse defaultResponse,
+        string entityName,
+        ResultStatus defaultFailureStatus,
+        CancellationToken cancellationToken)
+        where TDto : class
+        where TRequest : class
+    {
+        using var message = new HttpRequestMessage(method, url)
+        {
+            Content = new StringContent(request.ToJson(), Encoding.UTF8, "application/json")
+        };
+
+        using var response = await HttpClient.SendAsync(message, cancellationToken);
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            try
+            {
+                var dto = content.FromJson<TDto>();
+
+                if (dto is null)
+                {
+                    return new Failure<TResponse>(
+                        defaultResponse,
+                        ResultStatus.BadRequest,
+                        [new ValidationFailure(entityName, $"Unable to deserialize {entityName.ToLowerInvariant()} response")]);
+                }
+
+                return new Success<TResponse>(mapToResponse(dto));
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return new Failure<TResponse>(
+                    defaultResponse,
+                    ResultStatus.BadRequest,
+                    [new ValidationFailure(entityName, $"Unable to deserialize {entityName.ToLowerInvariant()} response")]);
+            }
+        }
+
+        Failure<TResponse>? failure = null;
+        try
+        {
+            failure = content.FromJson<Failure<TResponse>>();
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            // Response body is not valid JSON, use defaults
+        }
+
+        var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, defaultFailureStatus);
+        var errors = failure?.Errors ?? [new ValidationFailure(entityName, content.Length > 0 && content.Length <= 300 ? content : $"{entityName} request failed")];
+
+        return new Failure<TResponse>(defaultResponse, status, errors);
     }
 
     /// <summary>

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -190,7 +190,9 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             Content = new StringContent(request.ToJson(), Encoding.UTF8, "application/json")
         };
 
-        HttpResponseMessage response;
+        // response outlives the try so the body-read can fault without
+        // leaking it: every catch disposes what SendAsync handed back.
+        HttpResponseMessage? response = null;
         string content;
         try
         {
@@ -201,10 +203,12 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
         {
             // Caller-requested cancellation propagates; only TIMEOUTS (the
             // client's own token) convert to a failure below.
+            response?.Dispose();
             throw;
         }
         catch (HttpRequestException ex)
         {
+            response?.Dispose();
             return new Failure<TResponse>(
                 defaultResponse,
                 ResultStatus.Error,
@@ -212,6 +216,7 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
         }
         catch (TaskCanceledException)
         {
+            response?.Dispose();
             return new Failure<TResponse>(
                 defaultResponse,
                 ResultStatus.Error,

--- a/src/SportsData.Core/Infrastructure/Clients/Notification/Dtos/SmackLabDtos.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Notification/Dtos/SmackLabDtos.cs
@@ -93,6 +93,19 @@ namespace SportsData.Core.Infrastructure.Clients.Notification.Dtos
         public uint? RowVersion { get; set; }
     }
 
+    /// <summary>
+    /// A stored rating, read back so the Lab can re-hydrate stars on reload.
+    /// RenderedText travels so the client can refuse to show a rating against
+    /// a line that has since changed — the rating graded THAT text.
+    /// </summary>
+    public record SmackRatingDto(
+        Guid PickId,
+        string Voice,
+        string Situation,
+        Guid? PhraseId,
+        string RenderedText,
+        int Stars);
+
     public class SmackRatingRequestDto
     {
         public Guid PickId { get; set; }

--- a/src/SportsData.Core/Infrastructure/Clients/Notification/Dtos/SmackLabDtos.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Notification/Dtos/SmackLabDtos.cs
@@ -1,0 +1,111 @@
+#nullable enable
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.Picks;
+
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Core.Infrastructure.Clients.Notification.Dtos
+{
+    /// <summary>
+    /// Wire contracts for the SmackBot Lab, shared by Notification's
+    /// SmackAdminController (server) and <see cref="NotificationClient"/>
+    /// (API-side caller) so the two cannot drift — the same pattern as
+    /// SeasonContestDto shared by Producer and ContestClient.
+    /// See docs/features/smackbot-lab.md.
+    /// </summary>
+    public class SmackPreviewPickDto
+    {
+        public Guid PickId { get; set; }
+        public Guid ContestId { get; set; }
+        public Guid LeagueId { get; set; }
+        public Guid UserId { get; set; }
+        public string? AwayAbbreviation { get; set; }
+        public string? HomeAbbreviation { get; set; }
+        public int AwayScore { get; set; }
+        public int HomeScore { get; set; }
+        public bool? IsCorrect { get; set; }
+        public bool? PickedIsHome { get; set; }
+        public double? PickedSpread { get; set; }
+        public double? MarketSpread { get; set; }
+        public string? LeagueName { get; set; }
+        public Sport Sport { get; set; }
+
+        /// <summary>
+        /// The catalog takes the event shape; identifiers that only matter for
+        /// dispatch (correlation/causation) are synthesized. PickId is REAL —
+        /// deterministic phrase selection hashes it, so a preview picks the
+        /// same line a live send would.
+        /// </summary>
+        public UserPickScored ToEvent() => new(
+            UserId, null, ContestId, PickId,
+            null, null, AwayAbbreviation, HomeAbbreviation,
+            AwayScore, HomeScore, IsCorrect, PickedIsHome,
+            PickedSpread, MarketSpread,
+            LeagueId, LeagueName ?? "your league", Sport, null,
+            Guid.NewGuid(), Guid.NewGuid());
+    }
+
+    public class SmackPreviewRequestDto
+    {
+        /// <summary>Wire voice name; unknown values preview as Standard.</summary>
+        public string? Voice { get; set; }
+
+        public List<SmackPreviewPickDto>? Picks { get; set; }
+    }
+
+    public record SmackPreviewResultDto(
+        Guid PickId,
+        string Situation,
+        Guid? PhraseId,
+        string? Text,
+        bool UsedStandardFallback);
+
+    public record SmackPhraseDto(
+        Guid Id,
+        string Voice,
+        string Situation,
+        string? Sport,
+        string Text,
+        bool IsActive,
+        bool RequiresGamblingContent,
+        int Weight,
+        string? Description,
+        uint RowVersion);
+
+    public class SmackPhraseUpsertDto
+    {
+        public string Voice { get; set; } = "Smack";
+        public string? Situation { get; set; }
+        public string? Sport { get; set; }
+        public string? Text { get; set; }
+        public bool IsActive { get; set; } = true;
+        public bool RequiresGamblingContent { get; set; }
+        public int Weight { get; set; } = 1;
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// xmin echo for optimistic concurrency. Ignored on create; REQUIRED
+        /// on update — a stale value earns 409 rather than clobbering a newer
+        /// edit.
+        /// </summary>
+        public uint? RowVersion { get; set; }
+    }
+
+    public class SmackRatingRequestDto
+    {
+        public Guid PickId { get; set; }
+        public Guid ContestId { get; set; }
+        public Guid LeagueId { get; set; }
+        public Guid PickerUserId { get; set; }
+        public string Voice { get; set; } = "Smack";
+        public string? Situation { get; set; }
+        public Guid? PhraseId { get; set; }
+        public string? RenderedText { get; set; }
+        public int Stars { get; set; }
+
+        /// <summary>Training features — serialize the preview pick payload here.</summary>
+        public string? FactsJson { get; set; }
+    }
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Notification/NotificationClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Notification/NotificationClient.cs
@@ -1,26 +1,110 @@
-﻿//using Microsoft.Extensions.Logging;
+#nullable enable
 
-//using SportsData.Core.Middleware.Health;
+using Microsoft.Extensions.Logging;
 
-//using System.Net.Http;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Notification.Dtos;
 
-//namespace SportsData.Core.Infrastructure.Clients.Notification
-//{
-//    public interface IProvideNotifications : IProvideHealthChecks
-//    {
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
-//    }
+namespace SportsData.Core.Infrastructure.Clients.Notification
+{
+    /// <summary>
+    /// Typed client for the Notification service — the ONLY sanctioned way
+    /// for another service to call it (no ad-hoc HttpClient use). Current
+    /// surface is the SmackBot Lab admin family; the X-Api-Key header that
+    /// Notification's <c>[ApiKeyAuth]</c> endpoints require is stamped at
+    /// registration from <c>CommonConfig:NotificationClientConfig:SecretKey</c>,
+    /// so the key never appears at call sites (or in a browser).
+    /// </summary>
+    public interface IProvideNotifications
+    {
+        Task<Result<List<SmackPreviewResultDto>>> PreviewSmack(
+            SmackPreviewRequestDto request, CancellationToken cancellationToken = default);
 
-//    public class NotificationClient : ClientBase, IProvideNotifications
-//    {
-//        private readonly ILogger<NotificationClient> _logger;
+        Task<Result<List<SmackPhraseDto>>> GetSmackPhrases(CancellationToken cancellationToken = default);
 
-//        public NotificationClient(
-//            ILogger<NotificationClient> logger,
-//            IHttpClientFactory clientFactory) :
-//            base(HttpClients.NotificationClient, clientFactory)
-//        {
-//            _logger = logger;
-//        }
-//    }
-//}
+        Task<Result<SmackPhraseDto>> CreateSmackPhrase(
+            SmackPhraseUpsertDto request, CancellationToken cancellationToken = default);
+
+        Task<Result<SmackPhraseDto>> UpdateSmackPhrase(
+            Guid phraseId, SmackPhraseUpsertDto request, CancellationToken cancellationToken = default);
+
+        Task<Result<bool>> RateSmackPreview(
+            SmackRatingRequestDto request, CancellationToken cancellationToken = default);
+    }
+
+    public class NotificationClient : ClientBase, IProvideNotifications
+    {
+        private readonly ILogger<NotificationClient> _logger;
+
+        public NotificationClient(
+            ILogger<NotificationClient> logger,
+            HttpClient httpClient)
+            : base(httpClient)
+        {
+            _logger = logger;
+        }
+
+        public async Task<Result<List<SmackPreviewResultDto>>> PreviewSmack(
+            SmackPreviewRequestDto request, CancellationToken cancellationToken = default)
+        {
+            return await PostAsync<List<SmackPreviewResultDto>, List<SmackPreviewResultDto>, SmackPreviewRequestDto>(
+                "admin/smack/preview",
+                request,
+                previews => previews,
+                [],
+                "SmackPreview",
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<Result<List<SmackPhraseDto>>> GetSmackPhrases(
+            CancellationToken cancellationToken = default)
+        {
+            return await GetAsync<List<SmackPhraseDto>, List<SmackPhraseDto>>(
+                "admin/smack/phrases",
+                phrases => phrases,
+                [],
+                "SmackPhrases",
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<Result<SmackPhraseDto>> CreateSmackPhrase(
+            SmackPhraseUpsertDto request, CancellationToken cancellationToken = default)
+        {
+            return await PostAsync<SmackPhraseDto, SmackPhraseDto, SmackPhraseUpsertDto>(
+                "admin/smack/phrases",
+                request,
+                phrase => phrase,
+                default!,
+                "SmackPhrase",
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<Result<SmackPhraseDto>> UpdateSmackPhrase(
+            Guid phraseId, SmackPhraseUpsertDto request, CancellationToken cancellationToken = default)
+        {
+            return await PutAsync<SmackPhraseDto, SmackPhraseDto, SmackPhraseUpsertDto>(
+                $"admin/smack/phrases/{phraseId}",
+                request,
+                phrase => phrase,
+                default!,
+                "SmackPhrase",
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<Result<bool>> RateSmackPreview(
+            SmackRatingRequestDto request, CancellationToken cancellationToken = default)
+        {
+            return await PostWithResultAsync(
+                "admin/smack/ratings",
+                request,
+                "SmackRating",
+                cancellationToken);
+        }
+    }
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Notification/NotificationClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Notification/NotificationClient.cs
@@ -36,6 +36,49 @@ namespace SportsData.Core.Infrastructure.Clients.Notification
 
         Task<Result<bool>> RateSmackPreview(
             SmackRatingRequestDto request, CancellationToken cancellationToken = default);
+
+        Task<Result<List<SmackRatingDto>>> GetSmackRatings(
+            Guid leagueId, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Registered when <c>CommonConfig:NotificationClientConfig:ApiUrl</c> is
+    /// absent, so consumers of <see cref="IProvideNotifications"/> resolve and
+    /// get a CONTROLLED failure instead of a DI exception surfacing as a raw
+    /// 500. Every method returns the same misconfiguration Failure.
+    /// </summary>
+    public class UnconfiguredNotificationClient : IProvideNotifications
+    {
+        private const string Message =
+            "Notification client is not configured - set CommonConfig:NotificationClientConfig:ApiUrl.";
+
+        private static Failure<T> Fail<T>(T defaultValue) => new(
+            defaultValue,
+            ResultStatus.Error,
+            [new FluentValidation.Results.ValidationFailure("NotificationClient", Message)]);
+
+        public Task<Result<List<SmackPreviewResultDto>>> PreviewSmack(
+            SmackPreviewRequestDto request, CancellationToken cancellationToken = default)
+            => Task.FromResult<Result<List<SmackPreviewResultDto>>>(Fail<List<SmackPreviewResultDto>>([]));
+
+        public Task<Result<List<SmackPhraseDto>>> GetSmackPhrases(CancellationToken cancellationToken = default)
+            => Task.FromResult<Result<List<SmackPhraseDto>>>(Fail<List<SmackPhraseDto>>([]));
+
+        public Task<Result<SmackPhraseDto>> CreateSmackPhrase(
+            SmackPhraseUpsertDto request, CancellationToken cancellationToken = default)
+            => Task.FromResult<Result<SmackPhraseDto>>(Fail<SmackPhraseDto>(default!));
+
+        public Task<Result<SmackPhraseDto>> UpdateSmackPhrase(
+            Guid phraseId, SmackPhraseUpsertDto request, CancellationToken cancellationToken = default)
+            => Task.FromResult<Result<SmackPhraseDto>>(Fail<SmackPhraseDto>(default!));
+
+        public Task<Result<bool>> RateSmackPreview(
+            SmackRatingRequestDto request, CancellationToken cancellationToken = default)
+            => Task.FromResult<Result<bool>>(Fail(false));
+
+        public Task<Result<List<SmackRatingDto>>> GetSmackRatings(
+            Guid leagueId, CancellationToken cancellationToken = default)
+            => Task.FromResult<Result<List<SmackRatingDto>>>(Fail<List<SmackRatingDto>>([]));
     }
 
     public class NotificationClient : ClientBase, IProvideNotifications
@@ -94,6 +137,17 @@ namespace SportsData.Core.Infrastructure.Clients.Notification
                 phrase => phrase,
                 default!,
                 "SmackPhrase",
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<Result<List<SmackRatingDto>>> GetSmackRatings(
+            Guid leagueId, CancellationToken cancellationToken = default)
+        {
+            return await GetAsync<List<SmackRatingDto>, List<SmackRatingDto>>(
+                $"admin/smack/ratings?leagueId={leagueId}",
+                ratings => ratings,
+                [],
+                "SmackRatings",
                 cancellationToken: cancellationToken);
         }
 

--- a/src/SportsData.Core/Infrastructure/Clients/Notification/NotificationClientConfig.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Notification/NotificationClientConfig.cs
@@ -3,5 +3,13 @@
     public class NotificationClientConfig
     {
         public required string ApiUrl { get; set; }
+
+        /// <summary>
+        /// The X-Api-Key value Notification's [ApiKeyAuth] admin endpoints
+        /// require — same secret as CommonConfig:Notification:AdminApiKey on
+        /// the Notification side. Stamped as a default header at client
+        /// registration so call sites never handle it.
+        /// </summary>
+        public string? SecretKey { get; set; }
     }
 }

--- a/src/SportsData.Notification/Controllers/SmackAdminController.cs
+++ b/src/SportsData.Notification/Controllers/SmackAdminController.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Picks;
+using SportsData.Core.Infrastructure.Clients.Notification.Dtos;
 using SportsData.Notification.Application.Dispatching;
 using SportsData.Notification.Infrastructure.Auth;
 using SportsData.Notification.Infrastructure.Data;
@@ -339,106 +340,5 @@ namespace SportsData.Notification.Controllers
 
         private static bool IsUniqueConstraintViolation(DbUpdateException ex)
             => ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505";
-    }
-
-    // ─── Wire contracts ───────────────────────────────────────────────────
-
-    /// <summary>
-    /// The pick facts the resolver and formatter need — the UserPickScored
-    /// shape minus event plumbing. API composes these from canonical data
-    /// (the same derivation PickScoringProcessor performs for live sends).
-    /// </summary>
-    public class SmackPreviewPickDto
-    {
-        public Guid PickId { get; set; }
-        public Guid ContestId { get; set; }
-        public Guid LeagueId { get; set; }
-        public Guid UserId { get; set; }
-        public string? AwayAbbreviation { get; set; }
-        public string? HomeAbbreviation { get; set; }
-        public int AwayScore { get; set; }
-        public int HomeScore { get; set; }
-        public bool? IsCorrect { get; set; }
-        public bool? PickedIsHome { get; set; }
-        public double? PickedSpread { get; set; }
-        public double? MarketSpread { get; set; }
-        public string? LeagueName { get; set; }
-        public Sport Sport { get; set; }
-
-        /// <summary>
-        /// The catalog takes the event shape; identifiers that only matter for
-        /// dispatch (correlation/causation) are synthesized. PickId is REAL —
-        /// deterministic phrase selection hashes it, so the preview picks the
-        /// same line a live send would.
-        /// </summary>
-        public UserPickScored ToEvent() => new(
-            UserId, null, ContestId, PickId,
-            null, null, AwayAbbreviation, HomeAbbreviation,
-            AwayScore, HomeScore, IsCorrect, PickedIsHome,
-            PickedSpread, MarketSpread,
-            LeagueId, LeagueName ?? "your league", Sport, null,
-            Guid.NewGuid(), Guid.NewGuid());
-    }
-
-    public class SmackPreviewRequestDto
-    {
-        /// <summary>Wire voice name; unknown values preview as Standard.</summary>
-        public string? Voice { get; set; }
-
-        public List<SmackPreviewPickDto>? Picks { get; set; }
-    }
-
-    public record SmackPreviewResultDto(
-        Guid PickId,
-        string Situation,
-        Guid? PhraseId,
-        string? Text,
-        bool UsedStandardFallback);
-
-    public record SmackPhraseDto(
-        Guid Id,
-        string Voice,
-        string Situation,
-        string? Sport,
-        string Text,
-        bool IsActive,
-        bool RequiresGamblingContent,
-        int Weight,
-        string? Description,
-        uint RowVersion);
-
-    public class SmackPhraseUpsertDto
-    {
-        public string Voice { get; set; } = "Smack";
-        public string? Situation { get; set; }
-        public string? Sport { get; set; }
-        public string? Text { get; set; }
-        public bool IsActive { get; set; } = true;
-        public bool RequiresGamblingContent { get; set; }
-        public int Weight { get; set; } = 1;
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// xmin echo for optimistic concurrency. Ignored on create; REQUIRED
-        /// on update — a stale value earns 409 rather than clobbering a newer
-        /// edit.
-        /// </summary>
-        public uint? RowVersion { get; set; }
-    }
-
-    public class SmackRatingRequestDto
-    {
-        public Guid PickId { get; set; }
-        public Guid ContestId { get; set; }
-        public Guid LeagueId { get; set; }
-        public Guid PickerUserId { get; set; }
-        public string Voice { get; set; } = "Smack";
-        public string? Situation { get; set; }
-        public Guid? PhraseId { get; set; }
-        public string? RenderedText { get; set; }
-        public int Stars { get; set; }
-
-        /// <summary>Training features — serialize the preview pick payload here.</summary>
-        public string? FactsJson { get; set; }
     }
 }

--- a/src/SportsData.Notification/Controllers/SmackAdminController.cs
+++ b/src/SportsData.Notification/Controllers/SmackAdminController.cs
@@ -197,6 +197,35 @@ namespace SportsData.Notification.Controllers
         // ─── Ratings ──────────────────────────────────────────────────────
 
         /// <summary>
+        /// Stored ratings for a league, so the Lab re-hydrates stars on
+        /// reload. The client matches on (PickId, Voice) AND RenderedText —
+        /// a rating graded a specific line, and must not display against a
+        /// phrase that has since been edited.
+        /// </summary>
+        [HttpGet("ratings")]
+        public async Task<ActionResult<List<SmackRatingDto>>> GetRatings(
+            [FromQuery] Guid leagueId,
+            CancellationToken cancellationToken)
+        {
+            if (leagueId == Guid.Empty)
+                return BadRequest("leagueId is required.");
+
+            var ratings = await _dataContext.SmackPreviewRatings
+                .AsNoTracking()
+                .Where(r => r.LeagueId == leagueId)
+                .Select(r => new SmackRatingDto(
+                    r.PickId,
+                    r.Voice.ToString(),
+                    r.Situation.ToString(),
+                    r.PhraseId,
+                    r.RenderedText,
+                    r.Stars))
+                .ToListAsync(cancellationToken);
+
+            return Ok(ratings);
+        }
+
+        /// <summary>
         /// Upserts on (PickId, Voice): re-rating after a phrase edit
         /// overwrites rather than duplicates, so the training set holds one
         /// current opinion per previewed pick.

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/SmackLab/GetSmackLabLeaguesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/SmackLab/GetSmackLabLeaguesQueryHandlerTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.Admin.SmackLab;
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Admin.SmackLab;
+
+/// <summary>
+/// Pins the ordering/filtering behaviour. Honest caveat: the first cut of
+/// this query ordered by a constructor-projected record property and threw
+/// ONLY against real PostgreSQL — the InMemory provider is laxer about
+/// translation, so these tests guard the logic, not SQL translatability.
+/// Real translation proof stays with local E2E against Postgres.
+/// </summary>
+public class GetSmackLabLeaguesQueryHandlerTests : ApiTestBase<GetSmackLabLeaguesQueryHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 8, 17, 12, 0, 0, DateTimeKind.Utc);
+
+    private async Task<Guid> SeedLeagueWithPicksAsync(string name, int scored, int unscored)
+    {
+        var league = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            PickType = PickType.AgainstTheSpread,
+            CommissionerUserId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        DataContext.PickemGroups.Add(league);
+
+        for (var i = 0; i < scored + unscored; i++)
+        {
+            DataContext.UserPicks.Add(new PickemGroupUserPick
+            {
+                Id = Guid.NewGuid(),
+                PickemGroupId = league.Id,
+                UserId = Guid.NewGuid(),
+                ContestId = Guid.NewGuid(),
+                Week = 1,
+                IsCorrect = i < scored ? (i % 2 == 0) : null,
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+        await DataContext.SaveChangesAsync();
+        return league.Id;
+    }
+
+    [Fact]
+    public async Task ReturnsOnlyLeaguesWithScoredPicks_CountedAndOrdered()
+    {
+        var small = await SeedLeagueWithPicksAsync("Small", scored: 2, unscored: 3);
+        var big = await SeedLeagueWithPicksAsync("Big", scored: 5, unscored: 0);
+        await SeedLeagueWithPicksAsync("Unscored only", scored: 0, unscored: 4);
+
+        var result = await Mocker.CreateInstance<GetSmackLabLeaguesQueryHandler>()
+            .ExecuteAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2, "a league with no scored picks has nothing to preview");
+        result.Value[0].LeagueId.Should().Be(big, "most scored picks first");
+        result.Value[0].ScoredPickCount.Should().Be(5);
+        result.Value[1].LeagueId.Should().Be(small);
+        result.Value[1].ScoredPickCount.Should().Be(2, "unscored picks must not inflate the count");
+        result.Value[1].Sport.Should().Be(nameof(Sport.FootballNcaa));
+        result.Value[1].PickType.Should().Be(nameof(PickType.AgainstTheSpread));
+    }
+
+    [Fact]
+    public async Task NoScoredPicksAnywhere_ReturnsEmptyListNotError()
+    {
+        await SeedLeagueWithPicksAsync("Fresh league", scored: 0, unscored: 2);
+
+        var result = await Mocker.CreateInstance<GetSmackLabLeaguesQueryHandler>()
+            .ExecuteAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/SmackLab/GetSmackLabPicksQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/SmackLab/GetSmackLabPicksQueryHandlerTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.Admin.SmackLab;
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.Admin.SmackLab;
+
+/// <summary>
+/// The Lab's fact payloads must match what a live send saw — the derivation
+/// here mirrors PickScoringProcessor, so the sign conventions and gates are
+/// the behaviour worth pinning.
+/// </summary>
+public class GetSmackLabPicksQueryHandlerTests : ApiTestBase<GetSmackLabPicksQueryHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 8, 17, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Guid _homeFranchiseSeasonId = Guid.NewGuid();
+    private readonly Guid _awayFranchiseSeasonId = Guid.NewGuid();
+    private readonly Mock<IProvideContests> _contestClient = new();
+
+    public GetSmackLabPicksQueryHandlerTests()
+    {
+        Mocker.GetMock<IContestClientFactory>()
+            .Setup(f => f.Resolve(It.IsAny<Sport>()))
+            .Returns(_contestClient.Object);
+    }
+
+    private void StubResult(Guid contestId, double? spread = null, bool finalized = true)
+    {
+        _contestClient
+            .Setup(c => c.GetMatchupResult(contestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<MatchupResult>(new MatchupResult
+            {
+                ContestId = contestId,
+                HomeFranchiseSeasonId = _homeFranchiseSeasonId,
+                AwayFranchiseSeasonId = _awayFranchiseSeasonId,
+                HomeScore = 24,
+                AwayScore = 20,
+                Spread = spread,
+                HomeAbbreviation = "HOM",
+                AwayAbbreviation = "AWY",
+                FinalizedUtc = finalized ? FixedNow : null
+            }));
+    }
+
+    private async Task<Guid> SeedLeagueAsync(PickType pickType)
+    {
+        var league = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = "Sluggers",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            PickType = pickType,
+            CommissionerUserId = Guid.NewGuid(),
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        DataContext.PickemGroups.Add(league);
+        await DataContext.SaveChangesAsync();
+        return league.Id;
+    }
+
+    private async Task<Guid> SeedScoredPickAsync(
+        Guid leagueId,
+        Guid contestId,
+        Guid? franchiseSeasonId,
+        bool isCorrect = false)
+    {
+        var userId = Guid.NewGuid();
+        DataContext.Users.Add(new UserEntity
+        {
+            Id = userId,
+            FirebaseUid = $"fb-{userId:N}",
+            Email = $"{userId:N}@example.com",
+            SignInProvider = "password",
+            DisplayName = "Rater McTester",
+            Username = $"u{userId:N}"[..12],
+            CreatedUtc = FixedNow,
+            CreatedBy = userId
+        });
+
+        var pick = new PickemGroupUserPick
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            UserId = userId,
+            ContestId = contestId,
+            Week = 1,
+            FranchiseSeasonId = franchiseSeasonId,
+            IsCorrect = isCorrect,
+            CreatedUtc = FixedNow,
+            CreatedBy = userId
+        };
+        DataContext.UserPicks.Add(pick);
+        await DataContext.SaveChangesAsync();
+        return pick.Id;
+    }
+
+    [Fact]
+    public async Task UnknownLeague_ReturnsNotFound()
+    {
+        var handler = Mocker.CreateInstance<GetSmackLabPicksQueryHandler>();
+
+        var result = await handler.ExecuteAsync(Guid.NewGuid());
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task AtsAwayPick_CarriesNegatedSpread_InBothFields()
+    {
+        // MatchupResult.Spread is home-perspective; an away pick negates it —
+        // the exact PickScoringProcessor convention. ATS league ⇒ both
+        // PickedSpread (display) and MarketSpread (situation) populate.
+        var leagueId = await SeedLeagueAsync(PickType.AgainstTheSpread);
+        var contestId = Guid.NewGuid();
+        StubResult(contestId, spread: -6.5);
+        await SeedScoredPickAsync(leagueId, contestId, _awayFranchiseSeasonId);
+
+        var result = await Mocker.CreateInstance<GetSmackLabPicksQueryHandler>()
+            .ExecuteAsync(leagueId);
+
+        var facts = result.Value.Single().Facts;
+        facts.PickedIsHome.Should().BeFalse();
+        facts.PickedSpread.Should().Be(6.5);
+        facts.MarketSpread.Should().Be(6.5);
+        facts.AwayAbbreviation.Should().Be("AWY");
+        facts.HomeScore.Should().Be(24);
+    }
+
+    [Fact]
+    public async Task StraightUpPick_GetsMarketSpreadOnly()
+    {
+        // The gate that makes the flagship taunt possible: SU leagues carry
+        // the line in MarketSpread while PickedSpread stays null so standard
+        // copy never grows a spread.
+        var leagueId = await SeedLeagueAsync(PickType.StraightUp);
+        var contestId = Guid.NewGuid();
+        StubResult(contestId, spread: 14);
+        await SeedScoredPickAsync(leagueId, contestId, _homeFranchiseSeasonId);
+
+        var result = await Mocker.CreateInstance<GetSmackLabPicksQueryHandler>()
+            .ExecuteAsync(leagueId);
+
+        var facts = result.Value.Single().Facts;
+        facts.PickedSpread.Should().BeNull();
+        facts.MarketSpread.Should().Be(14);
+    }
+
+    [Fact]
+    public async Task OverUnderPick_HasNoSideAndNoSpreads()
+    {
+        var leagueId = await SeedLeagueAsync(PickType.OverUnder);
+        var contestId = Guid.NewGuid();
+        StubResult(contestId, spread: -3);
+        await SeedScoredPickAsync(leagueId, contestId, franchiseSeasonId: null);
+
+        var result = await Mocker.CreateInstance<GetSmackLabPicksQueryHandler>()
+            .ExecuteAsync(leagueId);
+
+        var dto = result.Value.Single();
+        dto.Facts.PickedIsHome.Should().BeNull();
+        dto.Facts.PickedSpread.Should().BeNull();
+        dto.Facts.MarketSpread.Should().BeNull("no side means no picked-side perspective to sign the line from");
+        dto.PickLabel.Should().Be("O/U");
+    }
+
+    [Fact]
+    public async Task UnfinalizedContest_PicksAreSkippedNotFailed()
+    {
+        var leagueId = await SeedLeagueAsync(PickType.StraightUp);
+        var goodContest = Guid.NewGuid();
+        var unfinalized = Guid.NewGuid();
+        StubResult(goodContest);
+        StubResult(unfinalized, finalized: false);
+        await SeedScoredPickAsync(leagueId, goodContest, _homeFranchiseSeasonId);
+        await SeedScoredPickAsync(leagueId, unfinalized, _homeFranchiseSeasonId);
+
+        var result = await Mocker.CreateInstance<GetSmackLabPicksQueryHandler>()
+            .ExecuteAsync(leagueId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1, "one contest lacked a finalized result and its pick is skipped");
+    }
+
+    [Fact]
+    public async Task UnscoredPicks_AreExcluded()
+    {
+        var leagueId = await SeedLeagueAsync(PickType.StraightUp);
+        var contestId = Guid.NewGuid();
+        StubResult(contestId);
+        await SeedScoredPickAsync(leagueId, contestId, _homeFranchiseSeasonId);
+
+        // Unscored pick (IsCorrect null) in the same league.
+        DataContext.UserPicks.Add(new PickemGroupUserPick
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = leagueId,
+            UserId = Guid.NewGuid(),
+            ContestId = contestId,
+            Week = 1,
+            FranchiseSeasonId = _homeFranchiseSeasonId,
+            IsCorrect = null,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+
+        var result = await Mocker.CreateInstance<GetSmackLabPicksQueryHandler>()
+            .ExecuteAsync(leagueId);
+
+        result.Value.Should().HaveCount(1, "there is nothing to preview for an unscored pick");
+    }
+}

--- a/test/unit/SportsData.Notification.Tests.Unit/Controllers/SmackAdminControllerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Controllers/SmackAdminControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Notification.Application.Dispatching;
+using SportsData.Core.Infrastructure.Clients.Notification.Dtos;
 using SportsData.Notification.Controllers;
 using SportsData.Notification.Infrastructure.Data.Entities;
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Controllers/SmackAdminControllerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Controllers/SmackAdminControllerTests.cs
@@ -406,4 +406,40 @@ public class SmackAdminControllerTests : NotificationTestBase<SmackAdminControll
             Stars = 2
         }, CancellationToken.None)).Should().BeOfType<BadRequestObjectResult>();
     }
+
+    [Fact]
+    public async Task GetRatings_ReturnsLeagueRowsOnly_AndRequiresLeagueId()
+    {
+        var leagueId = Guid.NewGuid();
+        var sut = Sut();
+
+        (await sut.GetRatings(Guid.Empty, CancellationToken.None))
+            .Result.Should().BeOfType<BadRequestObjectResult>();
+
+        await sut.RatePreview(new SmackRatingRequestDto
+        {
+            PickId = Guid.NewGuid(),
+            LeagueId = leagueId,
+            Situation = nameof(PickSituation.GenericLoss),
+            RenderedText = "in-league line",
+            Stars = 3
+        }, CancellationToken.None);
+        await sut.RatePreview(new SmackRatingRequestDto
+        {
+            PickId = Guid.NewGuid(),
+            LeagueId = Guid.NewGuid(), // different league — must not return
+            Situation = nameof(PickSituation.GenericLoss),
+            RenderedText = "other league line",
+            Stars = 1
+        }, CancellationToken.None);
+
+        var result = await sut.GetRatings(leagueId, CancellationToken.None);
+        var rows = (result.Result as OkObjectResult)!.Value
+            as List<SportsData.Core.Infrastructure.Clients.Notification.Dtos.SmackRatingDto>;
+
+        rows.Should().HaveCount(1);
+        rows![0].RenderedText.Should().Be("in-league line");
+        rows[0].Stars.Should().Be(3);
+        rows[0].Voice.Should().Be("Smack");
+    }
 }


### PR DESCRIPTION
Fourth SmackBot slice (#643 engine, #644 preference, #645 Lab server side). API's half of the Lab, plus the service boundary it rides on.

## The NotificationClient

The commented-out stub in Core is now real, per the rule that **every cross-service call goes through a typed client** — no ad-hoc HTTP. `IProvideNotifications` registers in `AddClients` only when `CommonConfig:NotificationClientConfig:ApiUrl` is configured, and the `X-Api-Key` that Notification's `[ApiKeyAuth]` endpoints require is stamped **once at registration** from the `SecretKey` slot — call sites and browsers never see it.

Config note: the `Prod.All` manifest entries for this client turned out to be a **ContestClientConfig copy-paste pointing at the three producer services** — fixed in `sports-data-provision` (`8d26ba1`, applied by pipeline). Correct values: `http://notification-svc/` (no `/api/` prefix — admin routes serve at the root; trailing slash load-bearing for relative resolution) + keyvault `NotificationAdminApiKey-Prod` (the same secret Notification reads, so the sides can't drift).

## Core plumbing that fell out

- **`ClientBase`** gains typed-response `PostAsync`/`PutAsync` mirroring `GetAsync`'s error mapping (existing helpers were GET-with-body or bool-only POST).
- **`ResultStatus.Conflict` + 409** in `ToActionResult`, so a stale phrase edit's 409 survives Notification → client → API → browser. `Conflict` is **appended at the enum tail, not inserted alphabetically**: members number by position, and a mid-enum insert silently renumbers everything after it anywhere a `ResultStatus` serializes numerically across a rolling deploy. The enum carries a comment saying exactly this so nobody "fixes" the ordering.
- The Lab **wire contracts move to `Core.Infrastructure.Clients.Notification.Dtos`**, shared by Notification's controller and the client so they cannot drift — the `SeasonContestDto` pattern.

## SmackLabController (`admin/smack-lab`, `[AdminApiToken]`)

- `GET leagues` — leagues with ≥1 scored pick (`IsCorrect` populated, the marker `PickScoringProcessor` writes)
- `GET leagues/{id}/picks` — preview facts with **derivation parity to `PickScoringProcessor`**: same `FranchiseSeasonId` side-matching, same ATS gate on `PickedSpread`, same home-perspective negation for away picks, same `MarketSpread`. Contest facts come from the same `GetMatchupResult` call scoring ran on, fetched once per distinct contest; unfinalized contests are skipped (logged), never fail the league.
- `preview` / `phrases` CRUD / `ratings` — thin relays through the typed client.

## Tests

6 new handler cases pinning the sign conventions: ATS away-pick negation, straight-up market-only spread, O/U no-side, unfinalized-skip, unscored-excluded, unknown-league 404. Suites: API **683/683**, Notification **118/118**, Core **252/252**; Producer and Provider build clean against the Core changes.

No migration. Final slice after this: the web page at `/app/admin/smack-lab` — local E2E before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SmackBot Lab administration tools for browsing leagues and scored picks.
  - Added preview, phrase management, and preview-rating capabilities.
  - Added configurable notification service connectivity with optional API authentication.
  - Added support for conflict responses and improved notification request handling.

- **Bug Fixes**
  - Improved handling of missing leagues, unfinalized contests, unscored picks, and failed service responses.

- **Tests**
  - Added coverage for pick scoring, spread behavior, filtering, ratings, and missing-data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->