### PR TITLE
feat(api): allow Provider resourceIndex family through admin ops proxy

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -51,7 +51,8 @@ public class AdminOpsProxyController : ControllerBase
 
         private static readonly string[] ProviderPrefixes =
         [
-            "documents"
+            "documents",
+            "resourceIndex"
         ];
 
         public static bool IsAllowed(string service, string path)

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Admin/AdminOpsProxyAllowlistTests.cs
@@ -20,6 +20,8 @@ public class AdminOpsProxyAllowlistTests
     [InlineData("producer", "contests")]
     [InlineData("PRODUCER", "Franchise-Seasons/x")]
     [InlineData("provider", "documents/replay")]
+    [InlineData("provider", "resourceIndex/create")]
+    [InlineData("provider", "resourceindex/00000000-0000-0000-0000-000000000000/process")]
     public void AllowedFamilies_PassPerService(string service, string path)
     {
         AdminOpsProxyController.Allowlist.IsAllowed(service, path).Should().BeTrue();
@@ -27,6 +29,8 @@ public class AdminOpsProxyAllowlistTests
 
     [Theory]
     [InlineData("producer", "documents/replay", "provider-only family on producer")]
+    [InlineData("producer", "resourceIndex/create", "provider-only family on producer")]
+    [InlineData("provider", "resourceIndexes/anything", "no segment boundary after prefix")]
     [InlineData("provider", "franchise-seasons/x", "producer-only family on provider")]
     [InlineData("producer", "hangfire", "ops dashboards are never proxied")]
     [InlineData("producer", "test/outbox", "the deleted test surface stays dead")]


### PR DESCRIPTION
## Summary

One allowlist line: adds the `resourceIndex` family to the ops proxy's Provider prefixes, so ad-hoc sourcing runs can be driven through `POST /admin/ops/provider/{sport}/{league}/resourceIndex/...` (admin token required) instead of port-forwarding to the internal Provider.

### Why now

The 2026 NCAAFB preseason AP poll released today, and nothing sourced it. Root cause: the Sunday rankings job was a seeded recurring `ResourceIndex` (`SeederBase`), but Provider seeding is one-shot (`LoadSeedData` bails on a non-empty `ResourceIndexJobs` table) with a hardcoded `[2025]` season list — so a `/seasons/2026/rankings` resource never existed. This PR is the access path; the ad-hoc create + process trigger for 2026 goes through the proxy, and a proper cron-based job (replacing the seeder approach) follows separately.

### Scope

- `AdminOpsProxyController.Allowlist`: `ProviderPrefixes` gains `"resourceIndex"`. All existing proxy hardening (canonical-path check, traversal/percent-escape rejection, segment-boundary matching, header stripping) applies unchanged.
- Tests: `resourceIndex/create` and `resourceindex/{guid}/process` allowed on provider, denied on producer; `resourceIndexes/anything` denied (segment boundary).

## Testing

- API unit tests: 689/689 passing (25 allowlist tests including the 4 new cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider access now supports `resourceIndex` paths in addition to document paths.

* **Bug Fixes**
  * Improved access controls to prevent producer access to provider-only resource paths and improperly formatted paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->