### PR TITLE
feat(web): rankings visibility — sport-scoped page, home Top 10 card

### DIFF
--- a/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetPollBySeasonWeekId/GetPollBySeasonWeekIdQueryHandler.cs
+++ b/src/SportsData.Producer/Application/FranchiseSeasonRankings/Queries/GetPollBySeasonWeekId/GetPollBySeasonWeekIdQueryHandler.cs
@@ -35,25 +35,57 @@ public class GetPollBySeasonWeekIdQueryHandler : IGetPollBySeasonWeekIdQueryHand
     {
         try
         {
-            var pollEntries = await _dataContext.FranchiseSeasonRankings
+            // Read from the SeasonPoll* store — the store the weekly rankings
+            // sourcing job feeds directly. The FranchiseSeasonRanking store
+            // this used to read only fills when TeamSeason docs are re-sourced
+            // with a TeamSeasonRank inclusion filter, so it silently went
+            // stale between backfills (2025's final AP poll never landed
+            // there).
+            var week = await _dataContext.SeasonPollWeeks
                 .AsNoTracking()
-                .Where(x => x.SeasonWeekId == query.SeasonWeekId && x.Type == query.PollSlug)
-                .OrderBy(x => x.Rank.Current)
+                .Where(x => x.SeasonWeekId == query.SeasonWeekId && x.SeasonPoll.Slug == query.PollSlug)
+                .Select(x => new
+                {
+                    x.Id,
+                    x.ShortHeadline,
+                    x.DateUtc,
+                    x.SeasonPoll.SeasonYear
+                })
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (week is null)
+            {
+                return new Failure<FranchiseSeasonPollDto>(
+                    default!,
+                    ResultStatus.NotFound,
+                    [new ValidationFailure("pollSlug", $"No rankings found for poll '{query.PollSlug}' in season week {query.SeasonWeekId}")]);
+            }
+
+            var pollEntries = await _dataContext.SeasonPollWeekEntries
+                .AsNoTracking()
+                .Where(x => x.SeasonPollWeekId == week.Id &&
+                            !x.IsOtherReceivingVotes &&
+                            !x.IsDroppedOut)
+                .OrderBy(x => x.Current)
                 .Select(x => new FranchiseSeasonPollDto.FranchiseSeasonPollEntryDto
                 {
                     FranchiseLogoUrl = x.FranchiseSeason.Logos
                         .Select(l => l.Uri.OriginalString)
                         .FirstOrDefault() ?? string.Empty,
-                    FranchiseName = x.Franchise.DisplayNameShort,
-                    FranchiseSlug = x.Franchise.Slug,
-                    Rank = x.Rank.Current,
-                    FirstPlaceVotes = x.Rank.FirstPlaceVotes,
+                    FranchiseName = x.FranchiseSeason.DisplayNameShort,
+                    FranchiseSlug = x.FranchiseSeason.Slug,
+                    Rank = x.Current,
+                    FirstPlaceVotes = x.FirstPlaceVotes,
                     FranchiseSeasonId = x.FranchiseSeasonId,
-                    Points = (int)x.Rank.Points,
-                    Trend = x.Rank.Trend,
-                    Losses = x.FranchiseSeason.Losses,
-                    PreviousRank = x.Rank.Previous,
-                    Wins = x.FranchiseSeason.Wins
+                    Points = (int)x.Points,
+                    // Empty string / zero are the entry's "absent" sentinels;
+                    // the DTO contract uses null (HasTrends keys on it).
+                    Trend = x.Trend == "" ? null : x.Trend,
+                    PreviousRank = x.Previous == 0 ? null : x.Previous,
+                    // Preseason entries carry NULL records; fall back to the
+                    // FranchiseSeason totals like the Dapper queries do.
+                    Losses = x.Losses ?? x.FranchiseSeason.Losses,
+                    Wins = x.Wins ?? x.FranchiseSeason.Wins
                 })
                 .ToListAsync(cancellationToken);
 
@@ -65,12 +97,6 @@ public class GetPollBySeasonWeekIdQueryHandler : IGetPollBySeasonWeekIdQueryHand
                     [new ValidationFailure("pollSlug", $"No rankings found for poll '{query.PollSlug}' in season week {query.SeasonWeekId}")]);
             }
 
-            var firstEntry = await _dataContext.FranchiseSeasonRankings
-                .AsNoTracking()
-                .Where(x => x.SeasonWeekId == query.SeasonWeekId && x.Type == query.PollSlug)
-                .Select(x => new { x.ShortHeadline, x.Date, x.SeasonYear })
-                .FirstAsync(cancellationToken);
-
             var seasonWeekNumber = await _dataContext.SeasonWeeks
                 .AsNoTracking()
                 .Where(x => x.Id == query.SeasonWeekId)
@@ -81,13 +107,13 @@ public class GetPollBySeasonWeekIdQueryHandler : IGetPollBySeasonWeekIdQueryHand
             {
                 Entries = pollEntries,
                 PollId = query.PollSlug,
-                PollName = firstEntry.ShortHeadline,
-                SeasonYear = firstEntry.SeasonYear,
+                PollName = week.ShortHeadline,
+                SeasonYear = week.SeasonYear,
                 Week = seasonWeekNumber,
                 HasFirstPlaceVotes = pollEntries.Sum(x => x.FirstPlaceVotes) > 0,
                 HasPoints = pollEntries.Sum(x => x.Points) > 0,
                 HasTrends = pollEntries.Any(x => x.Trend != null),
-                PollDateUtc = firstEntry.Date ?? DateTime.MinValue
+                PollDateUtc = week.DateUtc ?? DateTime.MinValue
             };
 
             return new Success<FranchiseSeasonPollDto>(dto);

--- a/src/SportsData.Producer/Infrastructure/Data/Common/BaseDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Common/BaseDataContext.cs
@@ -40,6 +40,8 @@ namespace SportsData.Producer.Infrastructure.Data.Common
 
         public DbSet<SeasonPollWeek> SeasonPollWeeks { get; set; }
 
+        public DbSet<SeasonPollWeekEntry> SeasonPollWeekEntries { get; set; }
+
         public DbSet<SeasonWeek> SeasonWeeks { get; set; }
 
         public DbSet<SeasonExternalId> SeasonExternalIds { get; set; }

--- a/src/SportsData.Producer/Infrastructure/Sql/GetPollByTypeAndSeason.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetPollByTypeAndSeason.sql
@@ -1,38 +1,45 @@
--- Returns poll entries for the most recent week of a given poll type and season.
--- Single query: finds the most recent week, then returns all entries with logos.
+-- Returns poll entries for the most recent published week of a poll type
+-- and season, read from the SeasonPoll* store — the store the weekly
+-- rankings sourcing job (SeasonRanking → SeasonTypeWeekRankings docs)
+-- feeds directly. The prior version read FranchiseSeasonRanking, which
+-- only fills when TeamSeason docs are re-sourced with a TeamSeasonRank
+-- inclusion filter — so the weekly job never refreshed the UI.
+-- Single query: find the most recent week, then return its ranked
+-- entries (others-receiving-votes and dropped-out rows excluded).
 WITH most_recent AS (
-  SELECT fsr."SeasonWeekId", fsr."Date", fsr."ShortHeadline"
-  FROM public."FranchiseSeasonRanking" fsr
-  INNER JOIN public."SeasonWeek" sw ON sw."Id" = fsr."SeasonWeekId"
-  INNER JOIN public."Season" s ON s."Id" = sw."SeasonId"
-  WHERE s."Year" = @SeasonYear AND fsr."Type" = @PollId AND fsr."Date" IS NOT NULL
-  ORDER BY fsr."Date" DESC
+  SELECT spw."Id" AS "SeasonPollWeekId", spw."DateUtc", spw."ShortHeadline", spw."SeasonWeekId"
+  FROM public."SeasonPollWeek" spw
+  INNER JOIN public."SeasonPoll" sp ON sp."Id" = spw."SeasonPollId"
+  WHERE sp."SeasonYear" = @SeasonYear AND sp."Slug" = @PollId AND spw."DateUtc" IS NOT NULL
+  ORDER BY spw."DateUtc" DESC
   LIMIT 1
 ),
 week_info AS (
-  SELECT sw."Number" AS "WeekNumber", mr."SeasonWeekId", mr."Date" AS "PollDate", mr."ShortHeadline"
+  -- SeasonWeekId is nullable on SeasonPollWeek; a missing link renders as
+  -- week 0 rather than dropping the poll.
+  SELECT COALESCE(sw."Number", 0) AS "WeekNumber", mr."SeasonPollWeekId", mr."DateUtc" AS "PollDate", mr."ShortHeadline"
   FROM most_recent mr
-  INNER JOIN public."SeasonWeek" sw ON sw."Id" = mr."SeasonWeekId"
+  LEFT JOIN public."SeasonWeek" sw ON sw."Id" = mr."SeasonWeekId"
 )
 SELECT
     wi."WeekNumber",
     wi."PollDate" AS "PollDateUtc",
     wi."ShortHeadline" AS "PollName",
     fs."Id" AS "FranchiseSeasonId",
-    f."Id" AS "FranchiseId",
-    f."Slug" AS "FranchiseSlug",
-    f."DisplayNameShort" AS "FranchiseName",
-    fs."Wins",
-    fs."Losses",
-    fsrd."Current" AS "Rank",
-    fsrd."Previous" AS "PreviousRank",
-    fsrd."Points",
-    fsrd."FirstPlaceVotes",
-    fsrd."Trend"
-FROM public."FranchiseSeasonRankingDetail" fsrd
-INNER JOIN public."FranchiseSeasonRanking" fsr ON fsr."Id" = fsrd."FranchiseSeasonRankingId"
-INNER JOIN public."FranchiseSeason" fs ON fs."Id" = fsr."FranchiseSeasonId"
-INNER JOIN public."Franchise" f ON f."Id" = fsr."FranchiseId"
-INNER JOIN week_info wi ON fsr."SeasonWeekId" = wi."SeasonWeekId"
-WHERE fsr."Type" = @PollId
-ORDER BY fsrd."Current" ASC
+    fs."FranchiseId",
+    fs."Slug" AS "FranchiseSlug",
+    fs."DisplayNameShort" AS "FranchiseName",
+    -- Entry-level record when ESPN published one (mid-season), otherwise
+    -- the FranchiseSeason record (preseason entries carry NULLs).
+    COALESCE(spwe."Wins", fs."Wins") AS "Wins",
+    COALESCE(spwe."Losses", fs."Losses") AS "Losses",
+    spwe."Current" AS "Rank",
+    NULLIF(spwe."Previous", 0) AS "PreviousRank",
+    spwe."Points",
+    spwe."FirstPlaceVotes",
+    NULLIF(spwe."Trend", '') AS "Trend"
+FROM public."SeasonPollWeekEntry" spwe
+INNER JOIN public."FranchiseSeason" fs ON fs."Id" = spwe."FranchiseSeasonId"
+INNER JOIN week_info wi ON spwe."SeasonPollWeekId" = wi."SeasonPollWeekId"
+WHERE NOT spwe."IsOtherReceivingVotes" AND NOT spwe."IsDroppedOut"
+ORDER BY spwe."Current" ASC

--- a/src/SportsData.Producer/Infrastructure/Sql/GetRankingsByPollByWeek.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetRankingsByPollByWeek.sql
@@ -1,19 +1,22 @@
+-- Poll entries for a specific season/week/poll, read from the SeasonPoll*
+-- store (see GetPollByTypeAndSeason.sql for why not FranchiseSeasonRanking).
 SELECT
     fs."Id" as "FranchiseSeasonId",
     fsl."Uri" as "FranchiseLogoUrl",
     fs."Slug" as "FranchiseSlug",
     fs."DisplayNameShort" as "FranchiseName",
-    fs."Wins",
-    fs."Losses",
-    fsrd."Current" as "Rank",
-    fsrd."Previous" as "PreviousRank",
-    fsrd."Points",
-    fsrd."FirstPlaceVotes",
-    fsrd."Trend",
-    fsrd."Date" as "PollDateUtc"
-FROM public."FranchiseSeasonRankingDetail" fsrd
-INNER JOIN public."FranchiseSeasonRanking" fsr on fsr."Id" = fsrd."FranchiseSeasonRankingId"
-INNER JOIN public."FranchiseSeason" fs on fs."Id" = fsr."FranchiseSeasonId"
+    COALESCE(spwe."Wins", fs."Wins") as "Wins",
+    COALESCE(spwe."Losses", fs."Losses") as "Losses",
+    spwe."Current" as "Rank",
+    NULLIF(spwe."Previous", 0) as "PreviousRank",
+    spwe."Points",
+    spwe."FirstPlaceVotes",
+    NULLIF(spwe."Trend", '') as "Trend",
+    spw."DateUtc" as "PollDateUtc"
+FROM public."SeasonPollWeekEntry" spwe
+INNER JOIN public."SeasonPollWeek" spw on spw."Id" = spwe."SeasonPollWeekId"
+INNER JOIN public."SeasonPoll" sp on sp."Id" = spw."SeasonPollId"
+INNER JOIN public."FranchiseSeason" fs on fs."Id" = spwe."FranchiseSeasonId"
 -- Logo selection: prefer sportdeets-mark + requested direction, then any
 -- sportdeets-mark, then anything else. Matches the pattern in
 -- GetMatchupsByContestIds.sql and LogoSelectionService.
@@ -30,7 +33,10 @@ LEFT JOIN LATERAL (
     fsl."Uri"
   LIMIT 1
 ) as fsl on true
-INNER JOIN public."SeasonWeek" sw on sw."Id" = fsr."SeasonWeekId"
-INNER JOIN public."Season" s on s."Id" = sw."SeasonId"
-WHERE fsr."Type" = @PollType and sw."Number" = @WeekNumber and s."Year" = @SeasonYear
-ORDER BY fsrd."Current" asc
+INNER JOIN public."SeasonWeek" sw on sw."Id" = spw."SeasonWeekId"
+WHERE sp."Slug" = @PollType
+  and sp."SeasonYear" = @SeasonYear
+  and sw."Number" = @WeekNumber
+  and NOT spwe."IsOtherReceivingVotes"
+  and NOT spwe."IsDroppedOut"
+ORDER BY spwe."Current" asc

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -39,6 +39,7 @@ import AdminModelsPage from "./components/admin/AdminModelsPage";
 import AdminSmackLabPage from "./components/admin/AdminSmackLabPage";
 import AdminRoute from "./routes/AdminRoute";
 import SeasonOverview from "./components/season/SeasonOverview";
+import RankingsPage from "./components/rankings/RankingsPage";
 
 function MainApp() {
   const navigate = useNavigate();
@@ -190,6 +191,22 @@ function MainApp() {
             <Route
               path="/sport/:sport/:league/team/:slug/:seasonYear"
               element={<TeamCard />}
+            />
+            {/* Rankings — sport-scoped like team/venue/contest. Three
+                explicit routes because the literal /week segment can't be
+                made optional inside one pattern: bare (current season,
+                latest polls), season, and season+week. */}
+            <Route
+              path="/sport/:sport/:league/rankings"
+              element={<RankingsPage />}
+            />
+            <Route
+              path="/sport/:sport/:league/rankings/:seasonYear"
+              element={<RankingsPage />}
+            />
+            <Route
+              path="/sport/:sport/:league/rankings/:seasonYear/week/:week"
+              element={<RankingsPage />}
             />
             <Route
               path="/sport/:sport/:league/venue/:slug"

--- a/src/UI/sd-ui/src/api/rankingsApi.js
+++ b/src/UI/sd-ui/src/api/rankingsApi.js
@@ -1,8 +1,13 @@
 import apiClient from "./apiClient";
 
 const RankingsApi = {
-  getSeasonRankings: (seasonYear) =>
-    apiClient.get(`/ui/rankings/${seasonYear}`),
+  // sport/league ride as query params — the season endpoint accepts them
+  // (defaulting football/ncaa server-side). The week endpoints below are
+  // not scope-aware yet (multi-sport TODO in
+  // GetRankingsByPollWeekQueryHandler); RankingsPage gates non-NCAAFB
+  // scopes until that lands.
+  getSeasonRankings: (seasonYear, sport = "football", league = "ncaa") =>
+    apiClient.get(`/ui/rankings/${seasonYear}?sport=${sport}&league=${league}`),
   getCurrentRankings: (seasonYear, seasonWeek) =>
     apiClient.get(`/ui/rankings/${seasonYear}/week/${seasonWeek}`),
   getCurrentPoll: (seasonYear, seasonWeek, pollName) =>

--- a/src/UI/sd-ui/src/components/home/HomePage.jsx
+++ b/src/UI/sd-ui/src/components/home/HomePage.jsx
@@ -4,6 +4,7 @@ import PrimarySlotOffSeasonCountdown from "./PrimarySlotOffSeasonCountdown";
 import PlayerPickemTeaserCard from "./PlayerPickemTeaserCard";
 import PendingInvitesCard from "./PendingInvitesCard";
 import YourLeaguesCard from "./YourLeaguesCard";
+import RankingsCard from "./RankingsCard";
 import JoinableLeaguesCard from "./JoinableLeaguesCard";
 
 /**
@@ -75,6 +76,13 @@ function HomePage() {
           <YourLeaguesCard />
         </section>
       )}
+
+      {/* Tier 2 — current poll Top 10, linking to /app/rankings for the
+          full surface. Self-nulls when no poll exists for the current
+          season (e.g. a sport gap), so Home never shows a broken card. */}
+      <section className="home-tier home-tier--context">
+        <RankingsCard />
+      </section>
 
       {/* Tier 3 — public-league discovery. THE content driver for
           league-less users: actionable joins instead of a bare countdown.

--- a/src/UI/sd-ui/src/components/home/RankingsCard.css
+++ b/src/UI/sd-ui/src/components/home/RankingsCard.css
@@ -1,0 +1,109 @@
+/* RankingsCard — Tier 2 compact Top 10 from the current poll. Visual
+   family: YourLeaguesCard (eyebrow, full-bleed rows, hairline
+   separators). */
+.rankings-card {
+  background-color: var(--bg-card);
+  border: 1px solid var(--accent-subtle);
+  border-radius: 14px;
+  box-shadow: var(--shadow-md);
+  padding: 1rem 1.25rem;
+  max-width: 880px;
+  box-sizing: border-box;
+  margin: 0 auto;
+  color: var(--text-primary);
+}
+
+.rankings-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.rankings-card__eyebrow {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+}
+
+.rankings-card__full {
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 0.12s ease;
+}
+
+.rankings-card__full:hover,
+.rankings-card__full:focus-visible {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.rankings-card__full:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.rankings-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.rankings-card__item + .rankings-card__item {
+  border-top: 1px solid var(--border-primary);
+}
+
+.rankings-card__row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.15rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  transition: background-color 0.12s ease;
+}
+
+.rankings-card__row:hover,
+.rankings-card__row:focus-visible {
+  background-color: var(--hover-bg);
+}
+
+.rankings-card__rank {
+  min-width: 1.4rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.rankings-card__logo {
+  min-width: 20px;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.rankings-card__logo img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+
+.rankings-card__name {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.rankings-card__record {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  font-size: 0.9em;
+}

--- a/src/UI/sd-ui/src/components/home/RankingsCard.jsx
+++ b/src/UI/sd-ui/src/components/home/RankingsCard.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTheme } from "../../contexts/ThemeContext";
+import apiWrapper from "../../api/apiWrapper";
+import useCurrentSeasonYear from "../../hooks/useCurrentSeasonYear";
+import { teamLink, rankingsLink } from "../../utils/sportLinks";
+import "./RankingsCard.css";
+
+/**
+ * Tier 2 — compact Top 10 from the current AP poll (falls back to the
+ * first poll returned when 'ap' is absent), linking to the full
+ * /app/rankings page for all polls and all 25 entries.
+ *
+ * Renders null while loading, on error, and when no poll exists for the
+ * current season — the home page never shows a broken or empty card.
+ */
+function RankingsCard() {
+  const { theme } = useTheme();
+  const { seasonYear, loading: seasonLoading } = useCurrentSeasonYear();
+  const [poll, setPoll] = useState(null);
+
+  useEffect(() => {
+    if (seasonLoading || seasonYear === null) return;
+
+    let cancelled = false;
+    apiWrapper.Rankings.getSeasonRankings(seasonYear)
+      .then((apiResult) => {
+        if (cancelled) return;
+        const data = apiResult?.data || apiResult;
+        const polls = Array.isArray(data) ? data : [];
+        // AP only on the home card; the fallback (AP absent) must never
+        // surface CFP either — it's hidden app-wide until it publishes.
+        const eligible = polls.filter((p) => p.pollId !== "cfp");
+        setPoll(eligible.find((p) => p.pollId === "ap") || eligible[0] || null);
+      })
+      .catch(() => {
+        // Self-nulling card: rankings being unavailable must not break Home.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [seasonLoading, seasonYear]);
+
+  if (!poll?.entries?.length) return null;
+
+  const top10 = poll.entries.slice(0, 10);
+
+  return (
+    <div className="rankings-card">
+      <div className="rankings-card__header">
+        <div className="rankings-card__eyebrow">
+          {(poll.pollName || "RANKINGS").toUpperCase()}
+        </div>
+        <Link to={rankingsLink()} className="rankings-card__full">
+          Full rankings ›
+        </Link>
+      </div>
+      <ol className="rankings-card__list">
+        {top10.map((team) => {
+          const logoSrc =
+            theme === "dark"
+              ? team.franchiseLogoUrlDark || team.franchiseLogoUrlLight || team.franchiseLogoUrl
+              : team.franchiseLogoUrlLight || team.franchiseLogoUrlDark || team.franchiseLogoUrl;
+          return (
+            <li key={team.franchiseSeasonId || team.rank} className="rankings-card__item">
+              <Link
+                to={teamLink(team.franchiseSlug || "", seasonYear)}
+                className="rankings-card__row"
+                aria-label={`Open ${team.franchiseName}`}
+              >
+                <span className="rankings-card__rank">{team.rank}</span>
+                {/* Span always renders so rows without a logo keep column
+                    alignment, matching YourLeaguesCard's icon handling. */}
+                <span className="rankings-card__logo" aria-hidden="true">
+                  {logoSrc ? <img src={logoSrc} alt="" /> : null}
+                </span>
+                <span className="rankings-card__name">
+                  {team.franchiseName || "Unknown"}
+                </span>
+                <span className="rankings-card__record">
+                  {team.wins}-{team.losses}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+export default RankingsCard;

--- a/src/UI/sd-ui/src/components/home/RankingsCard.test.jsx
+++ b/src/UI/sd-ui/src/components/home/RankingsCard.test.jsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import RankingsCard from "./RankingsCard";
+import apiWrapper from "../../api/apiWrapper";
+import SeasonApi from "../../api/seasonApi";
+
+// apiWrapper is a default export → wrap the mock in { default }.
+vi.mock("../../api/apiWrapper", () => ({
+  default: {
+    Rankings: {
+      getSeasonRankings: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../../api/seasonApi", () => ({
+  default: {
+    getCurrentSeason: vi.fn(),
+  },
+}));
+
+vi.mock("../../contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: "dark" }),
+}));
+
+const entry = (rank, name, slug) => ({
+  rank,
+  franchiseName: name,
+  franchiseSlug: slug,
+  franchiseSeasonId: `fs-${rank}`,
+  franchiseLogoUrlDark: `https://example.com/${slug}-dark.png`,
+  wins: 0,
+  losses: 0,
+});
+
+const apPoll = {
+  pollId: "ap",
+  pollName: "AP Top 25",
+  entries: Array.from({ length: 25 }, (_, i) =>
+    entry(i + 1, `Team ${i + 1}`, `team-${i + 1}`)
+  ),
+};
+
+function renderCard() {
+  return render(
+    <MemoryRouter>
+      <RankingsCard />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  SeasonApi.getCurrentSeason.mockResolvedValue({ data: { seasonYear: 2026 } });
+});
+
+test("renders the top 10 of the AP poll with a full-rankings link", async () => {
+  apiWrapper.Rankings.getSeasonRankings.mockResolvedValue({
+    data: [{ ...apPoll, pollId: "usa", pollName: "Coaches Poll" }, apPoll],
+  });
+
+  renderCard();
+
+  await waitFor(() => {
+    expect(screen.getByText("AP TOP 25")).toBeInTheDocument();
+  });
+
+  // Prefers 'ap' over the first-listed poll, shows exactly 10 rows.
+  expect(screen.getByText("Team 1")).toBeInTheDocument();
+  expect(screen.getByText("Team 10")).toBeInTheDocument();
+  expect(screen.queryByText("Team 11")).not.toBeInTheDocument();
+
+  const fullLink = screen.getByRole("link", { name: /full rankings/i });
+  expect(fullLink).toHaveAttribute("href", "/app/sport/football/ncaa/rankings");
+
+  // Rankings were requested for the RESOLVED season, not a literal.
+  expect(apiWrapper.Rankings.getSeasonRankings).toHaveBeenCalledWith(2026);
+
+  // Team rows deep-link with the resolved season year.
+  expect(screen.getByRole("link", { name: "Open Team 1" })).toHaveAttribute(
+    "href",
+    "/app/sport/football/ncaa/team/team-1/2026"
+  );
+});
+
+test("renders nothing when no polls exist for the season", async () => {
+  apiWrapper.Rankings.getSeasonRankings.mockResolvedValue({ data: [] });
+
+  const { container } = renderCard();
+
+  await waitFor(() => {
+    expect(apiWrapper.Rankings.getSeasonRankings).toHaveBeenCalled();
+  });
+  expect(container).toBeEmptyDOMElement();
+});
+
+test("renders nothing when no current season is sourced", async () => {
+  SeasonApi.getCurrentSeason.mockRejectedValue(new Error("404"));
+
+  const { container } = renderCard();
+
+  // The rankings fetch must be skipped entirely — no season, no request.
+  await waitFor(() => {
+    expect(SeasonApi.getCurrentSeason).toHaveBeenCalled();
+  });
+  expect(apiWrapper.Rankings.getSeasonRankings).not.toHaveBeenCalled();
+  expect(container).toBeEmptyDOMElement();
+});

--- a/src/UI/sd-ui/src/components/layout/Navigation.jsx
+++ b/src/UI/sd-ui/src/components/layout/Navigation.jsx
@@ -10,8 +10,7 @@ import {
   FaBars,
   FaTimes,
   FaRocket,
-  FaMapMarkedAlt,
-  FaListOl
+  FaMapMarkedAlt
 } from "react-icons/fa";
 import Wordmark from '../brand/Wordmark';
 import { useUserDto } from '../../contexts/UserContext';
@@ -55,10 +54,6 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
             <NavLink to="/app/leaderboard" className="nav-link" onClick={handleNavLinkClick}>
               <FaTrophy className="nav-icon" />
               <span>Leaderboard</span>
-            </NavLink>
-            <NavLink to="/app/sport/football/ncaa/rankings" className="nav-link" onClick={handleNavLinkClick}>
-              <FaListOl className="nav-icon" />
-              <span>Rankings</span>
             </NavLink>
             {isAdmin && (
               <NavLink to="/app/map" className="nav-link" onClick={handleNavLinkClick}>
@@ -132,12 +127,6 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
                 <NavLink to="/app/leaderboard" className="nav-link">
                   <FaTrophy className="nav-icon" />
                   <span>Leaderboard</span>
-                </NavLink>
-              </td>
-              <td>
-                <NavLink to="/app/sport/football/ncaa/rankings" className="nav-link">
-                  <FaListOl className="nav-icon" />
-                  <span>Rankings</span>
                 </NavLink>
               </td>
               {isAdmin && (

--- a/src/UI/sd-ui/src/components/layout/Navigation.jsx
+++ b/src/UI/sd-ui/src/components/layout/Navigation.jsx
@@ -10,7 +10,8 @@ import {
   FaBars,
   FaTimes,
   FaRocket,
-  FaMapMarkedAlt
+  FaMapMarkedAlt,
+  FaListOl
 } from "react-icons/fa";
 import Wordmark from '../brand/Wordmark';
 import { useUserDto } from '../../contexts/UserContext';
@@ -54,6 +55,10 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
             <NavLink to="/app/leaderboard" className="nav-link" onClick={handleNavLinkClick}>
               <FaTrophy className="nav-icon" />
               <span>Leaderboard</span>
+            </NavLink>
+            <NavLink to="/app/sport/football/ncaa/rankings" className="nav-link" onClick={handleNavLinkClick}>
+              <FaListOl className="nav-icon" />
+              <span>Rankings</span>
             </NavLink>
             {isAdmin && (
               <NavLink to="/app/map" className="nav-link" onClick={handleNavLinkClick}>
@@ -127,6 +132,12 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
                 <NavLink to="/app/leaderboard" className="nav-link">
                   <FaTrophy className="nav-icon" />
                   <span>Leaderboard</span>
+                </NavLink>
+              </td>
+              <td>
+                <NavLink to="/app/sport/football/ncaa/rankings" className="nav-link">
+                  <FaListOl className="nav-icon" />
+                  <span>Rankings</span>
                 </NavLink>
               </td>
               {isAdmin && (

--- a/src/UI/sd-ui/src/components/rankings/RankingsPage.css
+++ b/src/UI/sd-ui/src/components/rankings/RankingsPage.css
@@ -1,0 +1,11 @@
+.rankings-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem 2rem;
+}
+
+@media (max-width: 600px) {
+  .rankings-page {
+    padding: 0.75rem 0.5rem 1.5rem;
+  }
+}

--- a/src/UI/sd-ui/src/components/rankings/RankingsPage.css
+++ b/src/UI/sd-ui/src/components/rankings/RankingsPage.css
@@ -9,3 +9,9 @@
     padding: 0.75rem 0.5rem 1.5rem;
   }
 }
+
+.rankings-page__unsupported {
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 2rem 1rem;
+}

--- a/src/UI/sd-ui/src/components/rankings/RankingsPage.jsx
+++ b/src/UI/sd-ui/src/components/rankings/RankingsPage.jsx
@@ -8,16 +8,42 @@ import "./RankingsPage.css";
  *   /app/sport/:sport/:league/rankings/:seasonYear        that season's latest polls
  *   /app/sport/:sport/:league/rankings/:seasonYear/week/:week  a specific week
  *
+ * Only football/ncaa has poll data today, and the backend week endpoint is
+ * not yet scope-aware (multi-sport TODO in GetRankingsByPollWeekQueryHandler)
+ * — so any other tuple gets an honest empty state here rather than silently
+ * rendering NCAAFB data under an NFL/MLB URL.
+ *
  * Params are validated here (year/week must be positive integers) so the
  * widget only ever receives clean values — garbage segments fall back to
  * the no-param behavior rather than producing a broken API call.
  */
+const SUPPORTED_SCOPES = [{ sport: "football", league: "ncaa" }];
+
 function RankingsPage() {
   const { sport, league, seasonYear, week } = useParams();
 
-  const parsedYear = /^\d{4}$/.test(seasonYear ?? "") ? Number(seasonYear) : undefined;
+  const isSupported = SUPPORTED_SCOPES.some(
+    (s) => s.sport === sport?.toLowerCase() && s.league === league?.toLowerCase()
+  );
+
+  if (!isSupported) {
+    return (
+      <div className="rankings-page">
+        <p className="rankings-page__unsupported">
+          Rankings aren't available for this league yet.
+        </p>
+      </div>
+    );
+  }
+
+  const parsedYear =
+    /^\d{4}$/.test(seasonYear ?? "") && Number(seasonYear) > 0
+      ? Number(seasonYear)
+      : undefined;
   const parsedWeek =
-    parsedYear && /^\d{1,2}$/.test(week ?? "") ? Number(week) : undefined;
+    parsedYear && /^\d{1,2}$/.test(week ?? "") && Number(week) > 0
+      ? Number(week)
+      : undefined;
 
   return (
     <div className="rankings-page">

--- a/src/UI/sd-ui/src/components/rankings/RankingsPage.jsx
+++ b/src/UI/sd-ui/src/components/rankings/RankingsPage.jsx
@@ -1,0 +1,34 @@
+import { useParams } from "react-router-dom";
+import RankingsWidget from "../widgets/RankingsWidget";
+import "./RankingsPage.css";
+
+/**
+ * Sport-scoped rankings surface:
+ *   /app/sport/:sport/:league/rankings                    current season, latest polls
+ *   /app/sport/:sport/:league/rankings/:seasonYear        that season's latest polls
+ *   /app/sport/:sport/:league/rankings/:seasonYear/week/:week  a specific week
+ *
+ * Params are validated here (year/week must be positive integers) so the
+ * widget only ever receives clean values — garbage segments fall back to
+ * the no-param behavior rather than producing a broken API call.
+ */
+function RankingsPage() {
+  const { sport, league, seasonYear, week } = useParams();
+
+  const parsedYear = /^\d{4}$/.test(seasonYear ?? "") ? Number(seasonYear) : undefined;
+  const parsedWeek =
+    parsedYear && /^\d{1,2}$/.test(week ?? "") ? Number(week) : undefined;
+
+  return (
+    <div className="rankings-page">
+      <RankingsWidget
+        sport={sport}
+        league={league}
+        seasonYear={parsedYear}
+        week={parsedWeek}
+      />
+    </div>
+  );
+}
+
+export default RankingsPage;

--- a/src/UI/sd-ui/src/components/rankings/RankingsPage.test.jsx
+++ b/src/UI/sd-ui/src/components/rankings/RankingsPage.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import RankingsPage from "./RankingsPage";
+
+// Capture the props RankingsPage hands to the widget — these tests pin the
+// param validation and scope gating, not the widget's rendering.
+const { widgetSpy } = vi.hoisted(() => ({ widgetSpy: vi.fn() }));
+vi.mock("../widgets/RankingsWidget", () => ({
+  default: (props) => {
+    widgetSpy(props);
+    return <div data-testid="rankings-widget" />;
+  },
+}));
+
+function renderAt(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/sport/:sport/:league/rankings" element={<RankingsPage />} />
+        <Route path="/sport/:sport/:league/rankings/:seasonYear" element={<RankingsPage />} />
+        <Route
+          path="/sport/:sport/:league/rankings/:seasonYear/week/:week"
+          element={<RankingsPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  widgetSpy.mockClear();
+});
+
+test("valid season and week pass through as numbers", () => {
+  renderAt("/sport/football/ncaa/rankings/2026/week/1");
+
+  expect(widgetSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sport: "football",
+      league: "ncaa",
+      seasonYear: 2026,
+      week: 1,
+    })
+  );
+});
+
+test("zero-valued params are rejected, not forwarded", () => {
+  renderAt("/sport/football/ncaa/rankings/0000/week/00");
+
+  expect(widgetSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ seasonYear: undefined, week: undefined })
+  );
+});
+
+test("unsupported scope gets an honest empty state, no widget", () => {
+  renderAt("/sport/baseball/mlb/rankings");
+
+  expect(screen.getByText(/aren't available for this league yet/i)).toBeInTheDocument();
+  expect(widgetSpy).not.toHaveBeenCalled();
+});

--- a/src/UI/sd-ui/src/components/widgets/RankingsWidget.jsx
+++ b/src/UI/sd-ui/src/components/widgets/RankingsWidget.jsx
@@ -40,7 +40,7 @@ function RankingsWidget({
       try {
         const apiResult = week
           ? await apiWrapper.Rankings.getCurrentRankings(seasonYear, week)
-          : await apiWrapper.Rankings.getSeasonRankings(seasonYear);
+          : await apiWrapper.Rankings.getSeasonRankings(seasonYear, sport, league);
         if (cancelled) return;
         const data = apiResult?.data || apiResult;
         const polls = Array.isArray(data) ? data : [];
@@ -60,7 +60,9 @@ function RankingsWidget({
     return () => {
       cancelled = true;
     };
-  }, [seasonLoading, seasonYear, week]);
+    // sport/league in the deps: a route change between scopes with the
+    // same resolved season must refetch, not retain the prior scope's polls.
+  }, [seasonLoading, seasonYear, week, sport, league]);
 
   const activePoll = pollsData && pollsData.length > activeTabIndex ? pollsData[activeTabIndex] : null;
 

--- a/src/UI/sd-ui/src/components/widgets/RankingsWidget.jsx
+++ b/src/UI/sd-ui/src/components/widgets/RankingsWidget.jsx
@@ -3,32 +3,64 @@ import { useTheme } from "../../contexts/ThemeContext";
 import apiWrapper from "../../api/apiWrapper";
 import CFPBracket from "./CFPBracket";
 import { teamLink } from '../../utils/sportLinks';
+import useCurrentSeasonYear from "../../hooks/useCurrentSeasonYear";
 import "./RankingsWidget.css";
 
-function RankingsWidget() {
+function RankingsWidget({
+  sport = "football",
+  league = "ncaa",
+  seasonYear: seasonYearProp,
+  week,
+}) {
   const { theme } = useTheme();
+  // Season comes from the route when given, otherwise /seasons/current —
+  // never a literal. The 2025-era hardcode froze this widget to a
+  // finished season at rollover.
+  const { seasonYear: currentSeasonYear, loading: currentSeasonLoading } =
+    useCurrentSeasonYear(sport, league);
+  const seasonYear = seasonYearProp ?? currentSeasonYear;
+  const seasonLoading = seasonYearProp ? false : currentSeasonLoading;
   const [pollsData, setPollsData] = useState(null);
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (seasonLoading) return;
+    if (seasonYear === null) {
+      setPollsData([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
     async function fetchRankings() {
       setLoading(true);
       setError(null);
       try {
-        const apiResult = await apiWrapper.Rankings.getSeasonRankings(2025);
+        const apiResult = week
+          ? await apiWrapper.Rankings.getCurrentRankings(seasonYear, week)
+          : await apiWrapper.Rankings.getSeasonRankings(seasonYear);
+        if (cancelled) return;
         const data = apiResult?.data || apiResult;
-        setPollsData(Array.isArray(data) ? data : []);
+        const polls = Array.isArray(data) ? data : [];
+        // CFP hidden until those rankings publish (operator call,
+        // 2026-08-18) — the bracket needs its own pass first (mock
+        // championship site/date are stale). Remove this filter to
+        // re-enable; the cfp-layout render path below is intact.
+        setPollsData(polls.filter((p) => p.pollId !== "cfp"));
         setActiveTabIndex(0);
       } catch (err) {
-        setError("Failed to load rankings");
+        if (!cancelled) setError("Failed to load rankings");
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
     fetchRankings();
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [seasonLoading, seasonYear, week]);
 
   const activePoll = pollsData && pollsData.length > activeTabIndex ? pollsData[activeTabIndex] : null;
 
@@ -76,7 +108,7 @@ function RankingsWidget() {
   return (
     <div className="rankings-widget">
       <h2>College Football Rankings</h2>
-      {loading ? (
+      {loading || seasonLoading ? (
         <div>Loading rankings...</div>
       ) : error ? (
         <div className="error">{error}</div>
@@ -144,7 +176,7 @@ function RankingsWidget() {
                                 ) : null;
                               })()}
                               <a
-                                href={teamLink(team.franchiseSlug || '', 2025)}
+                                href={teamLink(team.franchiseSlug || '', seasonYear, sport, league)}
                                 className="team-link"
                                 style={{ color: '#61dafb', textDecoration: 'underline', fontWeight: 500 }}
                               >

--- a/src/UI/sd-ui/src/hooks/useCurrentSeasonYear.js
+++ b/src/UI/sd-ui/src/hooks/useCurrentSeasonYear.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import SeasonApi from "../api/seasonApi";
+
+/**
+ * Resolves the current (or upcoming) season year for a sport from
+ * /api/{sport}/{league}/seasons/current — the same source the home-page
+ * countdown uses. Exists so rankings surfaces never hardcode a season
+ * year again: the 2025 literals in the old RankingsWidget silently froze
+ * it to a finished season at rollover.
+ *
+ * Returns { seasonYear, loading }. seasonYear stays null when no season
+ * is sourced (a valid state for an unsupported sport, not an error).
+ */
+export default function useCurrentSeasonYear(sport = "football", league = "ncaa") {
+  const [seasonYear, setSeasonYear] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    SeasonApi.getCurrentSeason(sport, league)
+      .then((res) => {
+        if (!cancelled) setSeasonYear(res.data?.seasonYear ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setSeasonYear(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sport, league]);
+
+  return { seasonYear, loading };
+}

--- a/src/UI/sd-ui/src/utils/sportLinks.js
+++ b/src/UI/sd-ui/src/utils/sportLinks.js
@@ -45,3 +45,14 @@ export function teamLink(slug, seasonYear, sport = DEFAULT_SPORT, league = DEFAU
 export function contestLink(contestId, sport = DEFAULT_SPORT, league = DEFAULT_LEAGUE) {
   return `/app/sport/${sport}/${league}/contest/${contestId}`;
 }
+
+/**
+ * Rankings surface, sport-scoped like teamLink/contestLink.
+ * No args → current season, latest polls (/app/sport/football/ncaa/rankings).
+ * A week without a seasonYear is meaningless and is ignored.
+ */
+export function rankingsLink(seasonYear, week, sport = DEFAULT_SPORT, league = DEFAULT_LEAGUE) {
+  const seasonSegment = seasonYear ? `/${seasonYear}` : '';
+  const weekSegment = seasonYear && week ? `/week/${week}` : '';
+  return `/app/sport/${sport}/${league}/rankings${seasonSegment}${weekSegment}`;
+}


### PR DESCRIPTION
## Summary

Revives poll visibility for the 2026 NCAAFB season. The 2025 rankings widget survived in the tree but was orphaned by the home-page tier rework (#272) and hardcoded `seasonYear = 2025` in both its data fetch and its team links.

### Routes (sport-scoped, matching the team/venue/contest family)
- `/app/sport/football/ncaa/rankings` — current season, latest polls (nav + home card target; no year embedded, links never go stale)
- `/app/sport/football/ncaa/rankings/{seasonYear}` — explicit season
- `/app/sport/football/ncaa/rankings/{seasonYear}/week/{week}` — specific week, served by the existing `/ui/rankings/{year}/week/{week}` endpoint

Three explicit routes because the literal `/week` segment can't be made optional inside one pattern. `RankingsPage` validates year/week params before they reach the widget — malformed segments fall back to default behavior instead of a broken API call.

### Season resolution
New `useCurrentSeasonYear` hook resolves the season from `/api/{sport}/{league}/seasons/current` (the same source the home countdown uses). No rankings surface embeds a season literal anymore; a test tripwire asserts the fetch uses the resolved season.

### Surfaces
- **RankingsWidget** — now takes `sport/league/seasonYear/week` props; CFP poll filtered app-wide until those rankings publish (operator call — the bracket needs its own pass before November); render path for the CFP layout left intact for re-enable.
- **RankingsCard** (home Tier 2) — AP Top 10 (fallback never surfaces CFP), rank/logo/name/record rows deep-linking to team cards, "Full rankings ›" link. Self-nulls on error, empty data, or missing season so Home never shows a broken card.
- `rankingsLink()` added to `sportLinks.js` beside `teamLink`/`contestLink`; nav entry in both variants; HomePage Tier 2 section.

## Testing
- vitest 23/23 (3 new RankingsCard tests: AP preference + resolved-season assertions, empty-poll null render, no-season → no fetch), eslint clean.
- E2E-validated locally against the real 2026 preseason AP poll (sourced to prod yesterday, copied down today): home card, nav, full page tabs (AP + Coaches, no CFP), historical week route (`/rankings/2025/week/12`), team-link routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rankings pages with support for current-season, season-specific, and week-specific views.
  * Added a homepage rankings card showing the top 10 teams, records, logos, and links to full rankings.
  * Added sport- and league-aware rankings navigation.

* **Bug Fixes**
  * Improved rankings data accuracy by excluding dropped teams and “other receiving votes” entries.
  * Added graceful handling for unavailable seasons, polls, and ranking data.
  * Corrected historical season and weekly team links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->