### PR TITLE
feat(mobile): rankings parity — home Top 5 card, sport-scoped screen; leaderboard pct fix

### DIFF
--- a/src/UI/sd-mobile/__tests__/components/features/home/RankingsCard.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/home/RankingsCard.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// The api client's transitive import chain pulls in firebase/auth; stub it
+// (same rationale as MatchupCard.live.test.tsx).
+jest.mock('firebase/auth', () => ({
+  getAuth: () => ({ currentUser: null }),
+}));
+
+jest.mock('@/src/services/api/seasonApi', () => ({
+  seasonApi: {
+    getCurrentSeason: jest.fn(),
+  },
+}));
+
+jest.mock('@/src/services/api/rankingsApi', () => {
+  const actual = jest.requireActual('@/src/services/api/rankingsApi');
+  return {
+    ...actual,
+    rankingsApi: {
+      getSeasonRankings: jest.fn(),
+      getWeekRankings: jest.fn(),
+    },
+  };
+});
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { RankingsCard } from '@/src/components/features/home/RankingsCard';
+import { seasonApi } from '@/src/services/api/seasonApi';
+import { rankingsApi } from '@/src/services/api/rankingsApi';
+
+function renderWithProviders(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const entry = (rank: number, name: string, slug: string) => ({
+  rank,
+  franchiseName: name,
+  franchiseSlug: slug,
+  franchiseSeasonId: `fs-${rank}`,
+  wins: 0,
+  losses: 0,
+});
+
+const apPoll = {
+  pollId: 'ap',
+  pollName: 'AP Top 25',
+  seasonYear: 2026,
+  week: 1,
+  pollDateUtc: '2026-08-17T00:00:00Z',
+  hasPoints: true,
+  hasFirstPlaceVotes: true,
+  hasTrends: false,
+  entries: Array.from({ length: 25 }, (_, i) => entry(i + 1, `Team ${i + 1}`, `team-${i + 1}`)),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (seasonApi.getCurrentSeason as jest.Mock).mockResolvedValue({
+    data: { seasonYear: 2026 },
+  });
+});
+
+describe('RankingsCard', () => {
+  it('renders the AP top 5 with a full-rankings affordance', async () => {
+    (rankingsApi.getSeasonRankings as jest.Mock).mockResolvedValue({
+      data: [{ ...apPoll, pollId: 'usa', pollName: 'Coaches Poll' }, apPoll],
+    });
+
+    renderWithProviders(<RankingsCard />);
+
+    // Prefers 'ap' over the first-listed poll.
+    await waitFor(() => expect(screen.getByText('AP TOP 25')).toBeTruthy());
+    expect(screen.getByText('Team 1')).toBeTruthy();
+    expect(screen.getByText('Team 5')).toBeTruthy();
+    expect(screen.queryByText('Team 6')).toBeNull();
+    expect(screen.getByText('Full rankings ›')).toBeTruthy();
+
+    // Rankings were requested for the RESOLVED season, not a literal.
+    expect(rankingsApi.getSeasonRankings).toHaveBeenCalledWith(2026);
+  });
+
+  it('renders nothing when no polls exist for the season', async () => {
+    (rankingsApi.getSeasonRankings as jest.Mock).mockResolvedValue({ data: [] });
+
+    renderWithProviders(<RankingsCard />);
+
+    await waitFor(() => expect(rankingsApi.getSeasonRankings).toHaveBeenCalled());
+    expect(screen.queryByText('Full rankings ›')).toBeNull();
+  });
+
+  it('never falls back to the CFP poll when AP is absent', async () => {
+    (rankingsApi.getSeasonRankings as jest.Mock).mockResolvedValue({
+      data: [{ ...apPoll, pollId: 'cfp', pollName: 'CFP Rankings' }],
+    });
+
+    renderWithProviders(<RankingsCard />);
+
+    await waitFor(() => expect(rankingsApi.getSeasonRankings).toHaveBeenCalled());
+    expect(screen.queryByText('CFP RANKINGS')).toBeNull();
+    expect(screen.queryByText('Team 1')).toBeNull();
+  });
+});

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/rankings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/rankings.tsx
@@ -1,0 +1,255 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, TouchableOpacity, Image, ScrollView } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+
+import { Text } from '@/src/components/ui/AppText';
+import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { rankingsApi, rankingsKeys, type RankingsPoll } from '@/src/services/api/rankingsApi';
+import { useCurrentSeasonYear } from '@/src/hooks/useCurrentSeasonYear';
+
+/**
+ * Full rankings screen — every poll as a tab, all 25 entries. Web parity
+ * with sd-ui's RankingsPage at /app/sport/:sport/:league/rankings.
+ *
+ * Route: /sport/[sport]/[league]/rankings with optional ?season=&week=
+ * search params (the mobile twin of the web's path segments).
+ *
+ * Only football/ncaa has poll data today and the backend week endpoint is
+ * not scope-aware yet, so other tuples get an honest empty state — same
+ * gate as the web page. CFP is filtered app-wide until those rankings
+ * publish (operator call; the bracket surface needs its own pass first).
+ */
+export default function RankingsScreen() {
+  const { sport, league, season: seasonParam, week: weekParam } = useLocalSearchParams<{
+    sport: string;
+    league: string;
+    season?: string;
+    week?: string;
+  }>();
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const [activePollId, setActivePollId] = useState<string | null>(null);
+
+  const isSupported = sport?.toLowerCase() === 'football' && league?.toLowerCase() === 'ncaa';
+
+  const { seasonYear: currentSeasonYear, loading: seasonLoading } = useCurrentSeasonYear(
+    sport ?? 'football',
+    league ?? 'ncaa'
+  );
+
+  const parsedSeason = /^\d{4}$/.test(seasonParam ?? '') ? Number(seasonParam) : undefined;
+  const parsedWeek =
+    parsedSeason && /^\d{1,2}$/.test(weekParam ?? '') && Number(weekParam) > 0
+      ? Number(weekParam)
+      : undefined;
+  const seasonYear = parsedSeason ?? currentSeasonYear;
+
+  const { data, isLoading } = useQuery({
+    queryKey: parsedWeek
+      ? rankingsKeys.week(sport!, league!, seasonYear ?? 0, parsedWeek)
+      : rankingsKeys.season(sport!, league!, seasonYear ?? 0),
+    queryFn: async () =>
+      parsedWeek
+        ? (await rankingsApi.getWeekRankings(seasonYear!, parsedWeek)).data
+        : (await rankingsApi.getSeasonRankings(seasonYear!, sport, league)).data,
+    enabled: isSupported && seasonYear !== null && seasonYear !== undefined,
+  });
+
+  // CFP hidden until those rankings publish — remove this filter to
+  // re-enable; mirrors sd-ui's RankingsWidget.
+  const polls: RankingsPoll[] = (data ?? []).filter((p) => p.pollId !== 'cfp');
+  const activePoll = polls.find((p) => p.pollId === activePollId) ?? polls[0];
+
+  const openTeam = (slug: string) => {
+    router.push({
+      pathname: '/sport/[sport]/[league]/team/[slug]',
+      params: { sport: sport!, league: league!, slug, season: String(seasonYear) },
+    } as never);
+  };
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Rankings' }} />
+      <ScrollView
+        style={{ backgroundColor: theme.background }}
+        contentContainerStyle={styles.content}
+      >
+        {!isSupported ? (
+          <Text style={[styles.empty, { color: theme.textSecondary }]}>
+            Rankings aren't available for this league yet.
+          </Text>
+        ) : isLoading || seasonLoading ? (
+          <LoadingSpinner message="Loading rankings..." />
+        ) : polls.length === 0 ? (
+          <Text style={[styles.empty, { color: theme.textSecondary }]}>
+            No rankings available.
+          </Text>
+        ) : (
+          <>
+            <View style={styles.tabs}>
+              {polls.map((poll) => {
+                const active = poll.pollId === activePoll?.pollId;
+                return (
+                  <TouchableOpacity
+                    key={poll.pollId}
+                    onPress={() => setActivePollId(poll.pollId)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Show ${poll.pollName}`}
+                    style={[
+                      styles.tab,
+                      { borderColor: active ? theme.tint : theme.border },
+                      active && { backgroundColor: theme.card },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.tabLabel,
+                        { color: active ? theme.tint : theme.textSecondary },
+                        active && styles.tabLabelActive,
+                      ]}
+                    >
+                      {poll.pollName}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            {activePoll && (
+              <View
+                style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
+              >
+                {activePoll.entries.map((team, i) => {
+                  const logoSrc =
+                    scheme === 'dark'
+                      ? team.franchiseLogoUrlDark ??
+                        team.franchiseLogoUrlLight ??
+                        team.franchiseLogoUrl
+                      : team.franchiseLogoUrlLight ??
+                        team.franchiseLogoUrlDark ??
+                        team.franchiseLogoUrl;
+                  return (
+                    <TouchableOpacity
+                      key={team.franchiseSeasonId || team.rank}
+                      onPress={() => openTeam(team.franchiseSlug)}
+                      activeOpacity={0.6}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Open ${team.franchiseName}`}
+                      style={[
+                        styles.row,
+                        i > 0 && {
+                          borderTopWidth: StyleSheet.hairlineWidth,
+                          borderTopColor: theme.border,
+                        },
+                      ]}
+                    >
+                      <Text style={[styles.rank, { color: theme.textSecondary }]}>
+                        {team.rank}
+                      </Text>
+                      <View style={styles.logoSlot}>
+                        {logoSrc ? <Image source={{ uri: logoSrc }} style={styles.logo} /> : null}
+                      </View>
+                      <View style={styles.nameCol}>
+                        <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>
+                          {team.franchiseName || 'Unknown'}
+                        </Text>
+                        <Text style={[styles.record, { color: theme.textSecondary }]}>
+                          {team.wins}-{team.losses}
+                          {activePoll.hasPoints && team.points
+                            ? ` · ${team.points} pts`
+                            : ''}
+                          {activePoll.hasFirstPlaceVotes && team.firstPlaceVotes
+                            ? ` · ${team.firstPlaceVotes} first-place`
+                            : ''}
+                        </Text>
+                      </View>
+                      {activePoll.hasTrends && team.trend ? (
+                        <Text style={[styles.trend, { color: theme.textSecondary }]}>
+                          {team.trend}
+                        </Text>
+                      ) : null}
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            )}
+          </>
+        )}
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    padding: 12,
+    paddingBottom: 32,
+  },
+  empty: {
+    textAlign: 'center',
+    paddingVertical: 32,
+  },
+  tabs: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 12,
+  },
+  tab: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  tabLabel: {
+    fontSize: 13,
+  },
+  tabLabelActive: {
+    fontWeight: '700',
+  },
+  card: {
+    borderRadius: 14,
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 9,
+    gap: 8,
+  },
+  rank: {
+    minWidth: 24,
+    textAlign: 'right',
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  logoSlot: {
+    width: 22,
+    alignItems: 'center',
+  },
+  logo: {
+    width: 22,
+    height: 22,
+    resizeMode: 'contain',
+  },
+  nameCol: {
+    flex: 1,
+  },
+  name: {
+    fontWeight: '600',
+  },
+  record: {
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
+  },
+  trend: {
+    fontSize: 13,
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/rankings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/(details)/sport/[sport]/[league]/rankings.tsx
@@ -41,9 +41,11 @@ export default function RankingsScreen() {
     league ?? 'ncaa'
   );
 
+  // week parses independently of season: ?week=1 alone means "week 1 of the
+  // CURRENT season" (the resolved seasonYear below feeds the week fetch).
   const parsedSeason = /^\d{4}$/.test(seasonParam ?? '') ? Number(seasonParam) : undefined;
   const parsedWeek =
-    parsedSeason && /^\d{1,2}$/.test(weekParam ?? '') && Number(weekParam) > 0
+    /^\d{1,2}$/.test(weekParam ?? '') && Number(weekParam) > 0
       ? Number(weekParam)
       : undefined;
   const seasonYear = parsedSeason ?? currentSeasonYear;
@@ -124,14 +126,9 @@ export default function RankingsScreen() {
                 style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
               >
                 {activePoll.entries.map((team, i) => {
-                  const logoSrc =
-                    scheme === 'dark'
-                      ? team.franchiseLogoUrlDark ??
-                        team.franchiseLogoUrlLight ??
-                        team.franchiseLogoUrl
-                      : team.franchiseLogoUrlLight ??
-                        team.franchiseLogoUrlDark ??
-                        team.franchiseLogoUrl;
+                  // The wire carries one logo URL — no theme variants
+                  // (see rankingsApi).
+                  const logoSrc = team.franchiseLogoUrl;
                   return (
                     <TouchableOpacity
                       key={team.franchiseSeasonId || team.rank}
@@ -159,10 +156,12 @@ export default function RankingsScreen() {
                         </Text>
                         <Text style={[styles.record, { color: theme.textSecondary }]}>
                           {team.wins}-{team.losses}
-                          {activePoll.hasPoints && team.points
-                            ? ` · ${team.points} pts`
-                            : ''}
-                          {activePoll.hasFirstPlaceVotes && team.firstPlaceVotes
+                          {activePoll.hasPoints ? ` · ${team.points} pts` : ''}
+                          {/* Zero first-place votes deliberately suppressed —
+                              web parity (sd-ui renders FPV only when > 0). */}
+                          {activePoll.hasFirstPlaceVotes &&
+                          team.firstPlaceVotes != null &&
+                          team.firstPlaceVotes > 0
                             ? ` · ${team.firstPlaceVotes} first-place`
                             : ''}
                         </Text>

--- a/src/UI/sd-mobile/app/(tabs)/index.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/index.tsx
@@ -12,6 +12,7 @@ import { PlayerPickemTeaserCard } from '@/src/components/features/home/PlayerPic
 import { PendingInvitesCard } from '@/src/components/features/home/PendingInvitesCard';
 import { YourLeaguesCard } from '@/src/components/features/home/YourLeaguesCard';
 import { JoinableLeaguesCard } from '@/src/components/features/home/JoinableLeaguesCard';
+import { RankingsCard } from '@/src/components/features/home/RankingsCard';
 
 /**
  * Post-login landing — mirrors web's HomePage (PR #272 / docs/post-login-landing-design.md).
@@ -113,6 +114,11 @@ export default function HomeScreen() {
           {hasLeagues && <YourLeaguesCard leagues={leagues} />}
         </>
       )}
+
+      {/* Tier 2 — current poll Top 10, linking to the full rankings screen.
+          Self-nulls when no poll exists for the current season, so Home
+          never shows a broken card. Web parity: HomePage's RankingsCard. */}
+      <RankingsCard />
 
       {/* Tier 3 — public-league discovery. Rendered for every user (self-nulls
           when nothing is joinable), so a league-less user lands on actionable

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -54,7 +54,11 @@ function StandingRow({
           {isMe ? '  (you)' : ''}
         </Text>
         <Text style={[styles.accuracy, { color: isMe ? 'rgba(255,255,255,0.7)' : theme.textMuted }]}>
-          {standing.totalCorrect}/{standing.totalPicks} ({(standing.pickAccuracy * 100).toFixed(0)}%)
+          {/* pickAccuracy arrives ALREADY percentage-scaled to 2 decimals
+              (the API rounds TotalCorrect/TotalPicks * 100) — web renders it
+              raw, and so do we. The old * 100 here double-scaled it: 12/17
+              showed as 7059%. */}
+          {standing.totalCorrect}/{standing.totalPicks} ({standing.pickAccuracy}%)
         </Text>
       </View>
 

--- a/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
@@ -72,10 +72,8 @@ export function RankingsCard() {
 
       <View>
         {topEntries.map((team, i) => {
-          const logoSrc =
-            scheme === 'dark'
-              ? team.franchiseLogoUrlDark ?? team.franchiseLogoUrlLight ?? team.franchiseLogoUrl
-              : team.franchiseLogoUrlLight ?? team.franchiseLogoUrlDark ?? team.franchiseLogoUrl;
+          // The wire carries one logo URL — no theme variants (see rankingsApi).
+          const logoSrc = team.franchiseLogoUrl;
           return (
             <TouchableOpacity
               key={team.franchiseSeasonId || team.rank}

--- a/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { rankingsApi, rankingsKeys, type RankingsPoll } from '@/src/services/api/rankingsApi';
+import { useCurrentSeasonYear } from '@/src/hooks/useCurrentSeasonYear';
+
+const TOP_N = 5;
+
+/**
+ * Tier 2 home card — Top 5 from the current AP poll, linking to the full
+ * rankings screen for all polls and all 25 entries. Web sibling of sd-ui's
+ * RankingsCard (which shows 10 — mobile gets 5, operator call: home real
+ * estate is tighter here).
+ *
+ * AP only here; the fallback (AP absent) must never surface CFP either —
+ * it's hidden app-wide until those rankings publish (operator call, the
+ * bracket surface needs its own pass first). Renders nothing while loading,
+ * on error, and when no poll exists for the current season, so Home never
+ * shows a broken card.
+ */
+export function RankingsCard() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const router = useRouter();
+  const { seasonYear } = useCurrentSeasonYear();
+
+  const { data } = useQuery({
+    queryKey: rankingsKeys.season('football', 'ncaa', seasonYear ?? 0),
+    queryFn: async () => (await rankingsApi.getSeasonRankings(seasonYear!)).data,
+    enabled: seasonYear !== null,
+  });
+
+  const polls: RankingsPoll[] = data ?? [];
+  const eligible = polls.filter((p) => p.pollId !== 'cfp');
+  const poll = eligible.find((p) => p.pollId === 'ap') ?? eligible[0];
+
+  if (!poll?.entries?.length || seasonYear === null) return null;
+
+  const topEntries = poll.entries.slice(0, TOP_N);
+
+  const openFullRankings = () => {
+    router.push('/sport/football/ncaa/rankings' as never);
+  };
+
+  const openTeam = (slug: string) => {
+    router.push({
+      pathname: '/sport/[sport]/[league]/team/[slug]',
+      params: { sport: 'football', league: 'ncaa', slug, season: String(seasonYear) },
+    } as never);
+  };
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <View style={styles.headerRow}>
+        <Text style={[styles.eyebrow, { color: theme.tint }]}>
+          {(poll.pollName || 'RANKINGS').toUpperCase()}
+        </Text>
+        <TouchableOpacity
+          onPress={openFullRankings}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Open full rankings"
+        >
+          <Text style={[styles.full, { color: theme.tint }]}>Full rankings ›</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View>
+        {topEntries.map((team, i) => {
+          const logoSrc =
+            scheme === 'dark'
+              ? team.franchiseLogoUrlDark ?? team.franchiseLogoUrlLight ?? team.franchiseLogoUrl
+              : team.franchiseLogoUrlLight ?? team.franchiseLogoUrlDark ?? team.franchiseLogoUrl;
+          return (
+            <TouchableOpacity
+              key={team.franchiseSeasonId || team.rank}
+              onPress={() => openTeam(team.franchiseSlug)}
+              activeOpacity={0.6}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${team.franchiseName}`}
+              style={[
+                styles.row,
+                i > 0 && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: theme.border },
+              ]}
+            >
+              <Text style={[styles.rank, { color: theme.textSecondary }]}>{team.rank}</Text>
+              {/* Slot always renders so logo-less rows keep column alignment. */}
+              <View style={styles.logoSlot}>
+                {logoSrc ? <Image source={{ uri: logoSrc }} style={styles.logo} /> : null}
+              </View>
+              <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>
+                {team.franchiseName || 'Unknown'}
+              </Text>
+              <Text style={[styles.record, { color: theme.textSecondary }]}>
+                {team.wins}-{team.losses}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 14,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 12,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  eyebrow: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+  },
+  full: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 7,
+    gap: 8,
+  },
+  rank: {
+    minWidth: 22,
+    textAlign: 'right',
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  logoSlot: {
+    width: 20,
+    alignItems: 'center',
+  },
+  logo: {
+    width: 20,
+    height: 20,
+    resizeMode: 'contain',
+  },
+  name: {
+    flex: 1,
+    fontWeight: '500',
+  },
+  record: {
+    fontSize: 13,
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/src/UI/sd-mobile/src/hooks/useCurrentSeasonYear.ts
+++ b/src/UI/sd-mobile/src/hooks/useCurrentSeasonYear.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { seasonApi } from '@/src/services/api/seasonApi';
+
+/**
+ * Resolves the current (or upcoming) season year for a sport from
+ * /api/{sport}/{league}/seasons/current — the same source the home
+ * countdown uses. Exists so rankings surfaces never hardcode a season
+ * year: sd-ui's 2025-era literals froze its widget to a finished season
+ * at rollover, and this is the mobile twin of the hook that fixed it.
+ *
+ * seasonYear is null while loading and when no season is sourced (a
+ * valid state for an unsupported sport, not an error).
+ */
+export function useCurrentSeasonYear(sport = 'football', league = 'ncaa') {
+  const { data, isLoading } = useQuery({
+    queryKey: ['currentSeason', sport, league],
+    queryFn: async () => (await seasonApi.getCurrentSeason(sport, league)).data,
+    staleTime: 60 * 60 * 1000,
+  });
+
+  return { seasonYear: data?.seasonYear ?? null, loading: isLoading };
+}

--- a/src/UI/sd-mobile/src/services/api/rankingsApi.ts
+++ b/src/UI/sd-mobile/src/services/api/rankingsApi.ts
@@ -1,0 +1,54 @@
+import { apiClient } from './client';
+
+// Matches SportsData.Core.Dtos.Canonical.RankingsByPollIdByWeekDto — the
+// shape /ui/rankings serves (see sd-ui's RankingsWidget for the web twin).
+export interface RankingsEntry {
+  rank: number;
+  franchiseName: string;
+  franchiseSlug: string;
+  franchiseSeasonId: string;
+  franchiseLogoUrl?: string;
+  franchiseLogoUrlDark?: string;
+  franchiseLogoUrlLight?: string;
+  wins: number;
+  losses: number;
+  points?: number;
+  firstPlaceVotes?: number;
+  previousRank?: number;
+  trend?: string | null;
+}
+
+export interface RankingsPoll {
+  pollId: string;
+  pollName: string;
+  seasonYear: number;
+  week: number;
+  pollDateUtc: string;
+  hasPoints: boolean;
+  hasFirstPlaceVotes: boolean;
+  hasTrends: boolean;
+  entries: RankingsEntry[];
+}
+
+export const rankingsKeys = {
+  season: (sport: string, league: string, seasonYear: number) =>
+    ['rankings', sport, league, seasonYear] as const,
+  week: (sport: string, league: string, seasonYear: number, week: number) =>
+    ['rankings', sport, league, seasonYear, 'week', week] as const,
+};
+
+export const rankingsApi = {
+  // Latest published polls for a season. sport/league ride as query params
+  // (the endpoint defaults football/ncaa server-side); the week endpoint is
+  // not scope-aware yet — callers gate non-NCAAFB scopes, mirroring sd-ui's
+  // RankingsPage.
+  getSeasonRankings: (seasonYear: number, sport = 'football', league = 'ncaa') =>
+    apiClient.get<RankingsPoll[]>(
+      `/ui/rankings/${seasonYear}?sport=${sport}&league=${league}`
+    ),
+
+  // A specific week's polls (designated poll per week — see the backend's
+  // poll_rank_asof docs for the date-based semantics).
+  getWeekRankings: (seasonYear: number, week: number) =>
+    apiClient.get<RankingsPoll[]>(`/ui/rankings/${seasonYear}/week/${week}`),
+};

--- a/src/UI/sd-mobile/src/services/api/rankingsApi.ts
+++ b/src/UI/sd-mobile/src/services/api/rankingsApi.ts
@@ -2,20 +2,22 @@ import { apiClient } from './client';
 
 // Matches SportsData.Core.Dtos.Canonical.RankingsByPollIdByWeekDto — the
 // shape /ui/rankings serves (see sd-ui's RankingsWidget for the web twin).
+// NOTE: theme-specific logo variants (dark/light) exist on an inner Producer
+// DTO but are dropped by the ToRankingsByPollDto mapping — the wire carries
+// only FranchiseLogoUrl.
 export interface RankingsEntry {
   rank: number;
   franchiseName: string;
   franchiseSlug: string;
   franchiseSeasonId: string;
-  franchiseLogoUrl?: string;
-  franchiseLogoUrlDark?: string;
-  franchiseLogoUrlLight?: string;
+  franchiseLogoUrl: string;
   wins: number;
   losses: number;
-  points?: number;
-  firstPlaceVotes?: number;
-  previousRank?: number;
+  points: number;
+  firstPlaceVotes?: number | null;
+  previousRank?: number | null;
   trend?: string | null;
+  pollDateUtc?: string | null;
 }
 
 export interface RankingsPoll {

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -262,6 +262,7 @@ export interface Standing {
   isSynthetic?: boolean;
   totalPicks: number;
   totalCorrect: number;
+  /** Percentage-scaled by the API (70.59, not 0.7059) — render raw, never * 100. */
   pickAccuracy: number;
   totalPoints: number;
   currentWeekPoints: number;


### PR DESCRIPTION
## Summary

Mobile twin of the web rankings revival (#649), plus a screenshot-reported leaderboard fix.

### Rankings parity
- **`rankingsApi.ts`** — typed client for `/ui/rankings` (season + week endpoints, react-query keys). Season call carries sport/league; the week endpoint isn't scope-aware yet, so the screen gates non-NCAAFB scopes exactly like sd-ui's `RankingsPage`.
- **`useCurrentSeasonYear`** — season resolved from `/seasons/current` (react-query twin of the web hook); no season literals to die at rollover.
- **Home `RankingsCard`** — AP **Top 5** (web shows 10; mobile real estate is tighter — operator call), self-nulling on error/empty/no-season, rows deep-link to team cards with the resolved season, "Full rankings ›" opens the new screen. Mounted between Your Leagues and the joinable rail (web-parity ordering).
- **Full screen** at `/sport/[sport]/[league]/rankings` (same route family as team/game): poll tabs, all 25 entries with record/points/first-place votes, optional `?season=&week=` params. CFP filtered app-wide until those rankings publish (operator call, matching web).

### Leaderboard percentage fix
`pickAccuracy` arrives **already percentage-scaled** from the API (`Math.Round(correct/total*100, 2)` in `GetLeaderboardQueryHandler`); the standings tab multiplied by 100 again, so `12/17` rendered as `7059%`. Now rendered verbatim like the web (`70.59%`), with a scale warning on the type so it can't silently regress.

## Testing
- `RankingsCard` ×3: AP preference + resolved-season tripwire, empty-poll null render, CFP-never-fallback.
- `tsc --noEmit` clean; full mobile suite **133/133**.
- Expo Go validated locally, both themes (dark-mode team-name color was a first-round catch).
- Ships with the next EAS build per the mobile batching flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NCAA football rankings to the mobile home screen, including the top five teams, records, points, trends, and poll selection.
  * Added a full rankings view with season/week support and links to team details.
  * Added navigation from rankings to complete poll results and team pages.

* **Bug Fixes**
  * Corrected standings accuracy percentages to display the proper values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->