### PR TITLE
feat(mobile): SmackBot voice toggle in notification settings

### DIFF
--- a/src/UI/sd-mobile/app/settings/notifications.tsx
+++ b/src/UI/sd-mobile/app/settings/notifications.tsx
@@ -21,7 +21,11 @@ const notificationKeys = {
 
 // Field key → user-facing label + one-line description. Grouped into sections
 // below. Order within a section is deliberate (most-valued first).
-type PrefKey = keyof NotificationPreferences;
+// Boolean keys only — pickResultVoice is a string preference with its own
+// hand-rendered row and toggleVoice handler.
+type PrefKey = {
+  [K in keyof NotificationPreferences]: NotificationPreferences[K] extends boolean ? K : never;
+}[keyof NotificationPreferences];
 
 interface ToggleMeta {
   key: PrefKey;
@@ -101,6 +105,8 @@ const ALL_ENABLED: NotificationPreferences = {
   matchupPreviewEnabled: true,
   scheduleChangeEnabled: true,
   oddsChangedEnabled: true,
+  // Voice is opt-IN, unlike the flags: nobody gets smack who didn't ask.
+  pickResultVoice: 'Standard',
 };
 
 export default function NotificationSettingsScreen() {
@@ -158,6 +164,15 @@ export default function NotificationSettingsScreen() {
     if (!prefs || mutation.isPending) return;
     // Full-replacement PATCH — send the whole set with this one flag flipped.
     mutation.mutate({ ...prefs, [key]: !prefs[key] });
+  };
+
+  // Voice is a string, not a flag — the switch maps Smack <-> Standard.
+  const toggleVoice = () => {
+    if (!prefs || mutation.isPending) return;
+    mutation.mutate({
+      ...prefs,
+      pickResultVoice: prefs.pickResultVoice === 'Smack' ? 'Standard' : 'Smack',
+    });
   };
 
   const effective = prefs ?? ALL_ENABLED;
@@ -268,6 +283,41 @@ export default function NotificationSettingsScreen() {
                       />
                     </View>
                   ))}
+
+                  {/* SmackBot voice — a STRING preference (Standard|Smack), so
+                      it's hand-rendered rather than a SECTIONS flag. Lives
+                      under Pick results because it styles that notification;
+                      interaction disabled (state preserved) while pick
+                      results are off. Opt-in only. */}
+                  {section.title === 'Your picks' && (
+                    <View
+                      style={[
+                        styles.row,
+                        {
+                          borderTopColor: theme.border,
+                          borderTopWidth: StyleSheet.hairlineWidth,
+                        },
+                        !effective.pickResultEnabled && styles.rowDimmed,
+                      ]}
+                    >
+                      <View style={styles.rowText}>
+                        <Text style={[styles.rowLabel, { color: theme.text }]}>
+                          SmackBot voice
+                        </Text>
+                        <Text style={[styles.rowDesc, { color: theme.textMuted }]}>
+                          Pick results with attitude — SmackBot mocks the misses
+                          and grudgingly credits the wins.
+                        </Text>
+                      </View>
+                      <Switch
+                        value={effective.pickResultVoice === 'Smack'}
+                        onValueChange={toggleVoice}
+                        disabled={mutation.isPending || !effective.pickResultEnabled}
+                        trackColor={{ true: theme.tint, false: theme.border }}
+                        accessibilityLabel="SmackBot voice for pick results"
+                      />
+                    </View>
+                  )}
                 </View>
               </View>
             ))}
@@ -348,6 +398,7 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   rowText: { flex: 1, gap: 2 },
+  rowDimmed: { opacity: 0.45 },
   rowLabel: { fontSize: 15, fontWeight: '600' },
   rowDesc: { fontSize: 12, lineHeight: 16 },
   registerButton: {

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -369,6 +369,13 @@ export interface NotificationPreferences {
   matchupPreviewEnabled: boolean;
   scheduleChangeEnabled: boolean;
   oddsChangedEnabled: boolean;
+  /**
+   * Wire name of the pick-result copy voice — 'Standard' | 'Smack' today
+   * (server-validated allow-list; typed string for forward-compat). MUST be
+   * carried on every PATCH: the endpoint is full-replacement, so omitting it
+   * silently resets an opted-in user to Standard.
+   */
+  pickResultVoice: string;
 }
 
 // ─── Contest Overview ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Exposes the `PickResultVoice` preference (#644) to users — the last dark piece of the SmackBot arc (#643–#646). Strictly opt-in: default `Standard`, nobody hears smack who didn't ask.

- **`NotificationPreferences` gains `pickResultVoice`** (string wire name, `Standard`/`Smack`, server-validated allow-list). Load-bearing side effect: the PATCH endpoint is full-replacement, so before this field existed client-side, *any* mobile preference save would have silently reset an opted-in user to Standard. The spread in `toggle()` now carries it on every save, and the type carries a warning comment.
- **Hand-rendered "SmackBot voice" row** under Pick results — it's a string preference, not a flag, so it gets its own `toggleVoice` handler mapping the switch to `Smack`/`Standard`. Dimmed and non-interactive while Pick results is off (state preserved). Copy: "Pick results with attitude — SmackBot mocks the misses and grudgingly credits the wins."
- **`PrefKey` narrowed to boolean keys** via a mapped type, keeping the existing toggle machinery type-safe alongside the string field.

## Testing

- Expo Go validated: toggle persists across reload (GET round-trip), survives unrelated flag saves (the full-replacement hazard), dimmed state when Pick results is off.
- Canonical row audit verified in data: first-ever save inserts with `CreatedUtc` only (house convention); subsequent saves stamp `ModifiedUtc`.
- `tsc --noEmit` clean; full mobile suite 133/133.
- Ships with today's EAS build alongside mobile rankings (#651).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a SmackBot voice preference under “Your picks.”
  * Users can switch pick-result announcements between Standard and Smack voices.
  * The voice setting is disabled while pick-result notifications are off or preferences are saving.
* **Improvements**
  * Pick-result notification settings now retain the selected voice preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->