### PR TITLE
chore(eas): .easignore — archive only the mobile app

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,27 @@
+# EAS Build archive filter. When this file exists, EAS uses it INSTEAD of
+# .gitignore — so it must carry both the secret hygiene and the monorepo
+# trimming. EAS archives the whole git repo for monorepo support; the mobile
+# app (src/UI/sd-mobile, ~2 MB) is all the build needs, while the .NET
+# solution + web app + docs pushed the archive to 158 MB.
+#
+# Pattern: ignore everything, then re-include only the path to sd-mobile.
+# (gitignore semantics: to un-ignore a nested dir, each parent level must be
+# un-ignored and its siblings re-ignored.)
+
+/*
+!/src
+/src/*
+!/src/UI
+/src/UI/*
+!/src/UI/sd-mobile
+
+# Hygiene within the app tree — mirror of sd-mobile's own ignores plus
+# secrets. NEVER upload env files: EAS builds take environment from
+# eas.json / EAS environment variables, not local .env.
+src/UI/sd-mobile/node_modules/
+src/UI/sd-mobile/.expo/
+src/UI/sd-mobile/dist/
+src/UI/sd-mobile/web-build/
+src/UI/sd-mobile/coverage/
+src/UI/sd-mobile/.env
+src/UI/sd-mobile/.env.*


### PR DESCRIPTION
## Summary

EAS Build archives the entire monorepo for every mobile build — 158 MB compressed, of which `src/UI/sd-mobile` is 2.3 MB. This whitelist-style `.easignore` re-includes only the app tree, cutting upload size/time ~98%.

Notes:
- `.easignore` **replaces** `.gitignore` for archive filtering, so secret hygiene (`.env*`) is restated here deliberately — EAS builds take environment from `eas.json` / EAS env vars, never a local `.env`.
- No native `android`/`ios` dirs exist (managed workflow), so nothing build-relevant is excluded.
- Takes effect from the working directory at `eas build` time; already exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)