### PR TITLE
fix(producer): season-guard athlete season statistics attachment

### DIFF
--- a/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
+++ b/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
@@ -1,0 +1,188 @@
+# Athlete Season Stats Audit — 2026-08-19
+
+Findings from the first athlete-stat audit gating Player Pick'em go-live
+(see `docs/features/player-pickem/player-pickem.md`). Scope: NCAAFB
+(`sdProducer.FootballNcaa`), motivated by the week-1 lineup picker: "list all
+active FBS QBs and show their stats for this season and last."
+
+## TL;DR
+
+1. The 2026 roster/QB list is healthy. The stats attached to it are not:
+   every stat doc on a 2026 `AthleteSeason` row actually contains **2025
+   season numbers**, because ESPN's 2026 athlete document links to the
+   prior season's statistics endpoint and we attach whatever comes back to
+   the spawning roster row.
+2. Stats attached to **2025** rows are nearly empty (~1,942 athletes vs
+   ~16k for every other year since 2004), and 2025 **per-game** athlete
+   stats were never sourced at all.
+3. ~162k AthleteSeason rows carry duplicate "Season" stat docs.
+4. Net effect: the only broad copy of 2025 season totals in the system is
+   mislabeled under 2026 — and it will be silently joined (and eventually
+   confused) by real 2026 docs once games start on Aug 28.
+
+## Evidence
+
+### Roster coverage (fine)
+
+Active FBS QBs by season (`AthleteSeason` joined to `FranchiseSeason` with
+`GroupSeasonMap like '%fbs%'`, position `QB`, `IsActive`):
+
+| Season | Active FBS QBs |
+|-------:|---------------:|
+| 2024   | 518 |
+| 2025   | 472 |
+| 2026   | **852** (852 distinct athletes — no dupes; ~6.3/team = full rosters) |
+
+2025's low count means *last* season's roster sourcing was partial, not
+that 2026 is inflated.
+
+### Season-stat coverage by roster year (broken)
+
+Distinct athletes with `AthleteSeasonStatistic` rows, by the roster row's
+`SeasonYear`: every year 2004–2024 lands ~8k–16k. Then:
+
+| Roster year | Athletes with stats | Doc `CreatedUtc` |
+|------------:|--------------------:|------------------|
+| 2025 | **1,942** | 69 on 2025-12-21, 38 on 2026-07-24, 1,835 on 2026-08-16 |
+| 2026 | **15,263** | 9,240 on 2026-04-14, 6,015 on 2026-08-17 |
+
+15k athletes have "2026 stats" before a single 2026 game has been played.
+
+### Case study: Sam Leavitt (`AthleteId 4afaf7e4-f027-c0ea-a5a1-358f3730f057`)
+
+| Roster year | Team | Stat docs | Contents |
+|------------:|------|----------:|----------|
+| 2023 | Spartans | 2 (dupes) | — |
+| 2024 | Sun Devils | 2 (dupes) | 13 GP, 2,885 yds, 24 TD |
+| 2025 | Sun Devils | **0** | (played 7 games, then injured) |
+| 2026 | Tigers | 1 | **7 GP, 1,628 yds, 10 TD ← his 2025 partial season** |
+
+His actual 2025 production is filed under 2026; his 2025 row is empty.
+
+### Per-game stats (missing for 2025)
+
+`AthleteCompetition` coverage: 2023 (21,801 athletes / 1,784 games) and
+2024 (22,335 / 1,827). **Nothing for 2025.** Performance scoring and
+backtesting need game logs; last season has none.
+
+### Duplicate docs
+
+162,608 AthleteSeasons have two "Season" (`SplitId=0`) stat docs; 19 have
+three. Observed pairs differ only in `SplitType` (`''` vs `'season'`) and
+creation date (e.g., 2026-02-21 vs 2026-02-25) — re-sourcing passes that
+produced different doc identities for the same logical resource. Exact
+identity drift (URL shape change vs DTO parse change) should be confirmed
+against the Provider document store before dedup.
+
+## Root cause (confirmed against ESPN + code)
+
+ESPN's season-scoped athlete document for 2026:
+
+```
+GET .../college-football/seasons/2026/athletes/5078810
+→ statistics.$ref = .../seasons/2025/types/3/athletes/5078810/statistics
+```
+
+ESPN itself hands out the **previous season's** statistics ref until the
+new season has data. Our pipeline:
+
+1. `AthleteSeasonDocumentProcessor.ProcessStatistics` spawns the child
+   request straight from `dto.Statistics` — no season check.
+2. `AthleteSeasonStatisticsDocumentProcessor.ProcessInternal` resolves the
+   target row via `TryGetOrDeriveParentId` — i.e., **the spawning
+   AthleteSeason (2026)** — and never compares it to the season year
+   embedded in the doc's own `$ref` (2025). The URI-derivation fallback
+   (`EspnUriMapper.AthleteSeasonStatisticsRefToAthleteSeasonRef`) would
+   have parsed the *correct* season from the ref; the explicit ParentId
+   short-circuits it.
+3. `AthleteSeasonStatistic` persists no season/provenance column, so once
+   attached, the data's true season is invisible to queries. (It IS
+   recoverable: entity `Id` is the canonical identity generated from the
+   ESPN URL, so regenerating identities for candidate season URLs
+   identifies which docs came from which season.)
+
+### The in-season time bomb
+
+Doc replacement keys on the URL-derived identity. When ESPN flips the 2026
+athlete doc's statistics ref to `seasons/2026/...`, that is a **new
+identity** → a new doc **inserted alongside** the 2025-numbers doc on the
+same 2026 row. Nothing overwrites the stale doc; queries that sum or pick
+arbitrarily will mix seasons.
+
+## Recommendations
+
+Pre-kickoff (Aug 28) sourcing work:
+
+1. **Season-guard the attach.** In `AthleteSeasonStatisticsDocumentProcessor`,
+   parse the season year from the doc's `$ref` and attach to that athlete's
+   AthleteSeason **for that year** (resolving by `AthleteId` + season),
+   not the spawning row. If no such row exists, log and skip.
+2. **Backfill 2025 season stats** by requesting explicitly 2025-scoped
+   statistics URLs for athletes with 2025 roster rows (642 of the 852
+   active 2026 FBS QBs have one; all positions need it).
+3. **Backfill 2025 per-game stats** (`AthleteCompetition*`) — required for
+   performance scoring backtests and "recent form" UX regardless.
+4. **Relabel or purge the mislabeled 2026-row docs** using identity
+   regeneration to prove provenance (docs whose identity matches a
+   `seasons/2025/...` URL belong on the 2025 row).
+5. **Dedup the 162k doubled docs** after confirming the identity drift
+   mechanism in the Provider store; keep newest per (AthleteSeason, split).
+
+Read-model guidance for the lineup picker:
+
+- **Resolve "this season and last" by athlete, not by roster row.** Walk
+  the athlete's seasons newest-first and take the two most recent that
+  have stats, labeling each with its true season. Week 1 of 2026 then
+  shows "2025: 1,628 yds (7 GP)" for a player like Leavitt and "no
+  college stats" for a freshman.
+- **Default-sort the picker by last-season production** (yards / games
+  played). 852 QBs includes every walk-on; production sort is a
+  poor-man's depth chart until a real one is sourced.
+- `AthleteSeasonInjury` holds 60 rows total — do not build injury badges
+  on it yet.
+
+## Follow-up (2026-08-19): the league-season leaders endpoint
+
+```
+GET .../college-football/seasons/2025/types/3/leaders?limit=200
+```
+
+drives ESPN's own "All Conferences Player Passing Stats 2025" UI (verified:
+top passing leader 4,379 yds = Drew Mestemaker, matching the site
+row-for-row). Payload: 13 categories (passingYards, rushingYards,
+receivingYards, sacks, interceptions, passingTouchdowns,
+quarterbackRating, receptions, totalTackles, …), default 25 leaders per
+category, **`limit` raises it** (tested 200). Each leader row carries
+`value` plus season-scoped `$ref`s for athlete, team, and — critically —
+a **correctly-scoped statistics ref**
+(`seasons/2025/types/3/athletes/{id}/statistics/0`).
+
+Two implications, both verified:
+
+1. **The per-athlete backfill URL is proven.** Synthesizing
+   `seasons/2025/types/3/athletes/{espnId}/statistics/0` for a non-leader
+   (Leavitt, 5078810) returns his true 2025 season (7 GP, 1,628 yds,
+   10 TD). We hold ESPN athlete ids for every roster row
+   (`AthleteSeasonExternalId.SourceUrl`), so recommendation #2 needs no
+   new discovery mechanism — generate the URLs directly.
+2. **Leaders is the picker's relevance signal.** A leaders sweep
+   (13 categories × limit≈200) is ESPN's own answer to "who actually
+   plays" — better than home-grown production sorting, and it resolves
+   the depth-chart open question for v1. Candidate new `DocumentType`
+   (league-season leaders); we already model the per-game and per-team
+   variants (`EventCompetitionLeaders`, `TeamSeasonLeaders`), so the DTO
+   shape is familiar.
+
+`types/3` semantics partially resolved by the same check: the leaders and
+statistics values under `types/3` match ESPN's displayed full-season 2025
+totals (i.e., cumulative through postseason), which is exactly what the
+picker wants for "last season."
+
+## Open questions
+
+- Whether ESPN's `types/3` statistics ref flips to `types/2` early in a
+  season (regular-season-only totals) before postseason exists — affects
+  in-season re-source behavior.
+- Whether the Provider (Mongo) cached the 2026-row statistics docs under
+  hashes that will collide or diverge when ESPN flips the ref — affects
+  replay behavior.

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/AthleteSeasonStatisticsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/AthleteSeasonStatisticsDocumentProcessor.cs
@@ -67,6 +67,55 @@ namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Co
                 return;
             }
 
+            // Season guard: ESPN hands out the PRIOR season's statistics ref on a
+            // new season's athlete document until the new season has data (e.g. a
+            // seasons/2026 athlete doc links seasons/2025/.../statistics). ParentId
+            // is the spawning roster row, so trusting it blindly files last
+            // season's numbers under the new season. Attach by the season in the
+            // doc's own ref instead.
+            if (EspnUriMapper.TryExtractSeasonYear(dto.Ref, out var refSeasonYear))
+            {
+                var parentSeasonYear = await _dataContext.FranchiseSeasons
+                    .AsNoTracking()
+                    .Where(f => f.Id == athleteSeason.FranchiseSeasonId)
+                    .Select(f => (int?)f.SeasonYear)
+                    .FirstOrDefaultAsync();
+
+                if (parentSeasonYear.HasValue && parentSeasonYear.Value != refSeasonYear)
+                {
+                    var redirected = await _dataContext.AthleteSeasons
+                        .AsNoTracking()
+                        .Where(a => a.AthleteId == athleteSeason.AthleteId && a.Id != athleteSeasonIdValue)
+                        .Join(
+                            _dataContext.FranchiseSeasons.Where(f => f.SeasonYear == refSeasonYear),
+                            a => a.FranchiseSeasonId,
+                            f => f.Id,
+                            (a, f) => new { a.Id, a.CreatedUtc })
+                        .OrderByDescending(x => x.CreatedUtc)
+                        .FirstOrDefaultAsync();
+
+                    if (redirected is null)
+                    {
+                        _logger.LogWarning(
+                            "AthleteSeasonStatistics ref is for season {RefSeasonYear} but spawning AthleteSeason {AthleteSeasonId} is season {ParentSeasonYear} and the athlete has no roster row for the ref's season. Skipping to avoid mislabeled stats. AthleteId={AthleteId}, Ref={Ref}",
+                            refSeasonYear, athleteSeasonIdValue, parentSeasonYear.Value, athleteSeason.AthleteId, dto.Ref);
+                        return;
+                    }
+
+                    _logger.LogInformation(
+                        "Redirecting AthleteSeasonStatistics from spawning AthleteSeason {SpawningId} (season {ParentSeasonYear}) to AthleteSeason {TargetId} matching the ref's season {RefSeasonYear}",
+                        athleteSeasonIdValue, parentSeasonYear.Value, redirected.Id, refSeasonYear);
+
+                    athleteSeasonIdValue = redirected.Id;
+                }
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Unable to extract season year from AthleteSeasonStatistics ref; attaching to spawning AthleteSeason {AthleteSeasonId} unverified. Ref={Ref}",
+                    athleteSeasonIdValue, dto.Ref);
+            }
+
             var identity = _externalRefIdentityGenerator.Generate(dto.Ref);
 
             // ESPN replaces statistics wholesale — delete existing then insert fresh.

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
@@ -554,6 +554,7 @@ public class AthleteSeasonStatisticsDocumentProcessorTests :
         var rowStatistics = await FootballDataContext.AthleteSeasonStatistics
             .AsNoTracking()
             .Where(x => x.AthleteSeasonId == spawningRow.Id)
+            .Select(x => new { x.Id, x.SplitName })
             .ToListAsync();
 
         rowStatistics.Should().HaveCount(1, "2023 data must not be filed under the athlete's 2026 row");

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
@@ -428,4 +428,146 @@ public class AthleteSeasonStatisticsDocumentProcessorTests :
         rushingYardsStat!.PerGameValue.Should().Be(17.0m, "JSON has perGameValue of 17");
         rushingYardsStat.PerGameDisplayValue.Should().Be("17", "JSON has perGameDisplayValue of '17'");
     }
+
+    // ─── Season guard ─────────────────────────────────────────────────────
+    // ESPN hands out the PRIOR season's statistics ref on a new season's
+    // athlete document (a seasons/2026 athlete doc links seasons/2025
+    // statistics), so the spawning ParentId row can be the wrong season for
+    // the data. The test JSON's ref is season 2023.
+
+    private FranchiseSeason SeedFranchiseSeason(int seasonYear) =>
+        Fixture.Build<FranchiseSeason>()
+            .With(x => x.Id, Guid.NewGuid())
+            .With(x => x.SeasonYear, seasonYear)
+            .With(x => x.Abbreviation, "AB")
+            .With(x => x.ColorCodeHex, "#FFFFFF")
+            .With(x => x.DisplayName, "Team")
+            .With(x => x.DisplayNameShort, "T")
+            .With(x => x.Location, "Loc")
+            .With(x => x.Slug, $"team-{Guid.NewGuid():N}")
+            .OmitAutoProperties()
+            .Create();
+
+    // OmitAutoProperties: auto-populated Athlete/Position navs would let EF
+    // nav-fixup overwrite the deliberately shared AthleteId.
+    private FootballAthleteSeason SeedAthleteSeason(Guid athleteId, Guid franchiseSeasonId) =>
+        Fixture.Build<FootballAthleteSeason>()
+            .With(x => x.Id, Guid.NewGuid())
+            .With(x => x.AthleteId, athleteId)
+            .With(x => x.FranchiseSeasonId, franchiseSeasonId)
+            .With(x => x.CreatedUtc, DateTime.UtcNow)
+            .With(x => x.Statistics, new List<AthleteSeasonStatistic>())
+            .OmitAutoProperties()
+            .Create();
+
+    [Fact]
+    public async Task ProcessAsync_RedirectsToRefSeasonRow_WhenSpawningRowSeasonDiffers()
+    {
+        // Arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<AthleteSeasonStatisticsDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaAthleteSeasonStatistics.json");
+
+        var athleteId = Guid.NewGuid();
+        var fs2026 = SeedFranchiseSeason(2026);
+        var fs2023 = SeedFranchiseSeason(2023);
+        var spawningRow = SeedAthleteSeason(athleteId, fs2026.Id); // wrong season for the data
+        var refSeasonRow = SeedAthleteSeason(athleteId, fs2023.Id); // matches the ref's season
+
+        await FootballDataContext.FranchiseSeasons.AddRangeAsync(fs2026, fs2023);
+        await FootballDataContext.AthleteSeasons.AddRangeAsync(spawningRow, refSeasonRow);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.DocumentType, DocumentType.AthleteSeasonStatistics)
+            .With(x => x.Document, json)
+            .With(x => x.ParentId, spawningRow.Id.ToString())
+            .Create();
+
+        // Act
+        await sut.ProcessAsync(command);
+
+        // Assert — data landed on the ref-season row, not the spawning row
+        (await FootballDataContext.AthleteSeasonStatistics
+            .Where(x => x.AthleteSeasonId == refSeasonRow.Id).CountAsync())
+            .Should().Be(1, "the doc's ref says season 2023, so its data belongs on the 2023 row");
+        (await FootballDataContext.AthleteSeasonStatistics
+            .Where(x => x.AthleteSeasonId == spawningRow.Id).CountAsync())
+            .Should().Be(0, "the spawning 2026 row must not receive 2023 data");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Skips_WhenRefSeasonDiffers_AndAthleteHasNoRowForThatSeason()
+    {
+        // Arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<AthleteSeasonStatisticsDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaAthleteSeasonStatistics.json");
+
+        var fs2026 = SeedFranchiseSeason(2026);
+        var spawningRow = SeedAthleteSeason(Guid.NewGuid(), fs2026.Id);
+
+        await FootballDataContext.FranchiseSeasons.AddAsync(fs2026);
+        await FootballDataContext.AthleteSeasons.AddAsync(spawningRow);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2026)
+            .With(x => x.DocumentType, DocumentType.AthleteSeasonStatistics)
+            .With(x => x.Document, json)
+            .With(x => x.ParentId, spawningRow.Id.ToString())
+            .Create();
+
+        // Act
+        await sut.ProcessAsync(command);
+
+        // Assert — mislabeling is worse than missing; nothing persisted
+        (await FootballDataContext.AthleteSeasonStatistics
+            .Where(x => x.AthleteSeasonId == spawningRow.Id).CountAsync())
+            .Should().Be(0, "2023 data must not be filed under the athlete's 2026 row");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_AttachesToSpawningRow_WhenItsSeasonMatchesTheRef()
+    {
+        // Arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<AthleteSeasonStatisticsDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaAthleteSeasonStatistics.json");
+
+        var fs2023 = SeedFranchiseSeason(2023);
+        var spawningRow = SeedAthleteSeason(Guid.NewGuid(), fs2023.Id);
+
+        await FootballDataContext.FranchiseSeasons.AddAsync(fs2023);
+        await FootballDataContext.AthleteSeasons.AddAsync(spawningRow);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, 2023)
+            .With(x => x.DocumentType, DocumentType.AthleteSeasonStatistics)
+            .With(x => x.Document, json)
+            .With(x => x.ParentId, spawningRow.Id.ToString())
+            .Create();
+
+        // Act
+        await sut.ProcessAsync(command);
+
+        // Assert
+        (await FootballDataContext.AthleteSeasonStatistics
+            .Where(x => x.AthleteSeasonId == spawningRow.Id).CountAsync())
+            .Should().Be(1, "matching seasons attach normally");
+    }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
@@ -448,6 +448,8 @@ public class AthleteSeasonStatisticsDocumentProcessorTests :
             .OmitAutoProperties()
             .Create();
 
+    private static readonly DateTime SeedCreatedUtc = new(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
     // OmitAutoProperties: auto-populated Athlete/Position navs would let EF
     // nav-fixup overwrite the deliberately shared AthleteId.
     private FootballAthleteSeason SeedAthleteSeason(Guid athleteId, Guid franchiseSeasonId) =>
@@ -455,7 +457,7 @@ public class AthleteSeasonStatisticsDocumentProcessorTests :
             .With(x => x.Id, Guid.NewGuid())
             .With(x => x.AthleteId, athleteId)
             .With(x => x.FranchiseSeasonId, franchiseSeasonId)
-            .With(x => x.CreatedUtc, DateTime.UtcNow)
+            .With(x => x.CreatedUtc, SeedCreatedUtc)
             .With(x => x.Statistics, new List<AthleteSeasonStatistic>())
             .OmitAutoProperties()
             .Create();
@@ -510,12 +512,29 @@ public class AthleteSeasonStatisticsDocumentProcessorTests :
         var sut = Mocker.CreateInstance<AthleteSeasonStatisticsDocumentProcessor<FootballDataContext>>();
 
         var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaAthleteSeasonStatistics.json");
+        var dto = json.FromJson<EspnAthleteSeasonStatisticsDto>();
 
         var fs2026 = SeedFranchiseSeason(2026);
         var spawningRow = SeedAthleteSeason(Guid.NewGuid(), fs2026.Id);
 
+        // Seed the exact record the replace path would delete (same canonical
+        // id as the incoming doc) — the skip must fire BEFORE delete-and-replace,
+        // leaving this record untouched.
+        var dtoIdentity = generator.Generate(dto!.Ref);
+        var preexisting = new AthleteSeasonStatistic
+        {
+            Id = dtoIdentity.CanonicalId,
+            AthleteSeasonId = spawningRow.Id,
+            SplitId = "0",
+            SplitName = "Preexisting Split",
+            SplitAbbreviation = "PRE",
+            SplitType = "season",
+            CreatedUtc = SeedCreatedUtc
+        };
+
         await FootballDataContext.FranchiseSeasons.AddAsync(fs2026);
         await FootballDataContext.AthleteSeasons.AddAsync(spawningRow);
+        await FootballDataContext.AthleteSeasonStatistics.AddAsync(preexisting);
         await FootballDataContext.SaveChangesAsync();
 
         var command = Fixture.Build<ProcessDocumentCommand>()
@@ -530,10 +549,17 @@ public class AthleteSeasonStatisticsDocumentProcessorTests :
         // Act
         await sut.ProcessAsync(command);
 
-        // Assert — mislabeling is worse than missing; nothing persisted
-        (await FootballDataContext.AthleteSeasonStatistics
-            .Where(x => x.AthleteSeasonId == spawningRow.Id).CountAsync())
-            .Should().Be(0, "2023 data must not be filed under the athlete's 2026 row");
+        // Assert — mislabeling is worse than missing; nothing new persisted,
+        // and the preexisting record survived the skip untouched
+        var rowStatistics = await FootballDataContext.AthleteSeasonStatistics
+            .AsNoTracking()
+            .Where(x => x.AthleteSeasonId == spawningRow.Id)
+            .ToListAsync();
+
+        rowStatistics.Should().HaveCount(1, "2023 data must not be filed under the athlete's 2026 row");
+        rowStatistics[0].Id.Should().Be(dtoIdentity.CanonicalId);
+        rowStatistics[0].SplitName.Should().Be("Preexisting Split",
+            "the skip must fire before delete-and-replace so existing data is never destroyed");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

ESPN hands out the **prior season's** statistics ref on a new season's athlete document until the new season has data — verified live: the `seasons/2026` athlete doc for Sam Leavitt (5078810) links `seasons/2025/types/3/athletes/5078810/statistics`. `AthleteSeasonStatisticsDocumentProcessor` trusted ParentId (the spawning roster row), so last season's numbers were filed under the new season. Current damage in `sdProducer.FootballNcaa`: 15,263 athletes carry "2026" stat docs containing 2025 data, while 2025 roster rows hold stats for only ~1,942 athletes.

Full findings, evidence, and the remediation plan are in the audit doc included here: `docs/features/player-pickem/athlete-season-stats-audit-2026-08.md` (design record for this fix and the upcoming 2025 backfill; part of the athlete-stat audit gating Player Pick'em).

## The fix

The processor now extracts the season year from the doc's **own `$ref`** (existing `EspnUriMapper.TryExtractSeasonYear`) and compares it to the spawning row's season via FranchiseSeason:

- **Match** (or parent season indeterminate, e.g. no FranchiseSeason row): attach as before.
- **Mismatch, athlete has a roster row for the ref's season**: redirect the attach to that row (newest-first for the in-season transfer case), with an info log.
- **Mismatch, no such row**: warn and skip — mislabeled is worse than missing. The skip happens **before** the delete-and-replace, so existing data is never destroyed.

This also defuses the week-1 failure mode: when ESPN flips the ref to `seasons/2026/...` (new URL → new doc identity), a second doc would have been inserted alongside the stale 2025-numbers doc on the same row, mixing seasons in every downstream query.

## Not in this PR (per the audit's plan)

- 2025 season-stats backfill via explicitly season-scoped URLs (next PR — unblocked by this one, since `DocumentRequested.ParentId` can target the correct row directly)
- Relabel/purge of the existing mislabeled 2026-row docs; dedup of the 162k doubled docs

## Tests

- 3 new facts: redirect / skip / match-attaches-normally. `OmitAutoProperties` seeding so the deliberately shared `AthleteId` survives EF nav fixup.
- 7 existing tests pass unchanged (their fixtures seed no FranchiseSeason → exercise the indeterminate-parent path).
- Full Producer suite: 562 passed / 18 skipped / 1 failure = the pre-existing local-WIP failure (`Process_LogsEntryAndCompletion`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved athlete statistics season matching to prevent stats from one season appearing in another.
  - Statistics are now associated with the correct season when available, or skipped when no matching season record exists.
  - Preserved normal processing when statistics and roster seasons already match.

- **Documentation**
  - Added an audit documenting historical athlete statistics issues, data gaps, duplicate records, and recommended cleanup and backfill actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->