### PR TITLE
feat(api,web,mobile): matchup history in the team comparison dialog

### DIFF
--- a/src/SportsData.Api/Application/Contests/ContestsController.cs
+++ b/src/SportsData.Api/Application/Contests/ContestsController.cs
@@ -34,6 +34,8 @@ public class ContestsController : ControllerBase
     /// </summary>
     [HttpGet("{contestId:guid}/history")]
     [ProducesResponseType(typeof(ContestPreviewHistoryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ContestPreviewHistoryDto>> GetContestHistory(
         [FromServices] IGetContestHistoryQueryHandler handler,
         [FromRoute] string sport,

--- a/src/SportsData.Api/Application/Contests/ContestsController.cs
+++ b/src/SportsData.Api/Application/Contests/ContestsController.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Api.Application.Contests.Queries.GetContestById;
 using SportsData.Api.Application.Contests.Queries.GetContestById.Dtos;
+using SportsData.Api.Application.Contests.Queries.GetContestHistory;
+using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
 
 namespace SportsData.Api.Application.Contests;
@@ -21,7 +23,27 @@ public class ContestsController : ControllerBase
     {
         var query = new GetContestByIdQuery(sport, league, contestId);
         var result = await handler.ExecuteAsync(query, cancellationToken);
-        
+
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Historical context for a matchup: last N head-to-head meetings and
+    /// each team's late-prior-season form — the same blocks the
+    /// preview/insight models consume.
+    /// </summary>
+    [HttpGet("{contestId:guid}/history")]
+    [ProducesResponseType(typeof(ContestPreviewHistoryDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ContestPreviewHistoryDto>> GetContestHistory(
+        [FromServices] IGetContestHistoryQueryHandler handler,
+        [FromRoute] string sport,
+        [FromRoute] string league,
+        [FromRoute] Guid contestId,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetContestHistoryQuery(sport, league, contestId);
+        var result = await handler.ExecuteAsync(query, cancellationToken);
+
         return result.ToActionResult();
     }
 }

--- a/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/GetContestHistoryQuery.cs
+++ b/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/GetContestHistoryQuery.cs
@@ -1,0 +1,6 @@
+namespace SportsData.Api.Application.Contests.Queries.GetContestHistory;
+
+public record GetContestHistoryQuery(
+    string Sport,
+    string League,
+    Guid ContestId);

--- a/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/GetContestHistoryQueryHandler.cs
+++ b/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/GetContestHistoryQueryHandler.cs
@@ -3,6 +3,7 @@ using FluentValidation.Results;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Mapping;
 using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.Clients.Contest;
 
 namespace SportsData.Api.Application.Contests.Queries.GetContestHistory;
@@ -40,7 +41,7 @@ public class GetContestHistoryQueryHandler : IGetContestHistoryQueryHandler
         {
             _logger.LogWarning(ex,
                 "Unsupported sport/league combination. Sport={Sport}, League={League}",
-                query.Sport, query.League);
+                query.Sport.Sanitize(), query.League.Sanitize());
             return new Failure<ContestPreviewHistoryDto>(
                 default!,
                 ResultStatus.BadRequest,

--- a/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/GetContestHistoryQueryHandler.cs
+++ b/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/GetContestHistoryQueryHandler.cs
@@ -1,0 +1,54 @@
+using FluentValidation.Results;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Mapping;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.Contests.Queries.GetContestHistory;
+
+/// <summary>
+/// Historical context for a matchup, relayed from Producer's
+/// preview-history query: last N head-to-head meetings (cross-season) and
+/// each team's late-prior-season form. Same data the preview/insight
+/// models consume — preview-safe semantics (finalized only, preseason
+/// excluded, no as-of leakage) are baked in Producer-side.
+/// </summary>
+public class GetContestHistoryQueryHandler : IGetContestHistoryQueryHandler
+{
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly ILogger<GetContestHistoryQueryHandler> _logger;
+
+    public GetContestHistoryQueryHandler(
+        IContestClientFactory contestClientFactory,
+        ILogger<GetContestHistoryQueryHandler> logger)
+    {
+        _contestClientFactory = contestClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<Result<ContestPreviewHistoryDto>> ExecuteAsync(
+        GetContestHistoryQuery query,
+        CancellationToken cancellationToken)
+    {
+        Sport mode;
+        try
+        {
+            mode = ModeMapper.ResolveMode(query.Sport, query.League);
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogWarning(ex,
+                "Unsupported sport/league combination. Sport={Sport}, League={League}",
+                query.Sport, query.League);
+            return new Failure<ContestPreviewHistoryDto>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure("Sport/League", ex.Message)]);
+        }
+
+        return await _contestClientFactory
+            .Resolve(mode)
+            .GetContestPreviewHistory(query.ContestId, cancellationToken);
+    }
+}

--- a/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/IGetContestHistoryQueryHandler.cs
+++ b/src/SportsData.Api/Application/Contests/Queries/GetContestHistory/IGetContestHistoryQueryHandler.cs
@@ -1,0 +1,11 @@
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+
+namespace SportsData.Api.Application.Contests.Queries.GetContestHistory;
+
+public interface IGetContestHistoryQueryHandler
+{
+    Task<Result<ContestPreviewHistoryDto>> ExecuteAsync(
+        GetContestHistoryQuery query,
+        CancellationToken cancellationToken);
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -28,6 +28,7 @@ using SportsData.Api.Application.Franchises.Seasons.Queries.GetFranchiseSeasons;
 using SportsData.Api.Application.Franchises.Seasons.Queries.GetFranchiseSeasonById;
 using SportsData.Api.Application.Franchises.Seasons.Contests;
 using SportsData.Api.Application.Contests.Queries.GetContestById;
+using SportsData.Api.Application.Contests.Queries.GetContestHistory;
 using SportsData.Api.Application.Venues.Queries.GetVenues;
 using SportsData.Api.Application.Venues.Queries.GetVenueById;
 using SportsData.Api.Application.UI.Conferences.Queries.GetConferenceNamesAndSlugs;
@@ -249,6 +250,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetFranchiseSeasonByIdQueryHandler, GetFranchiseSeasonByIdQueryHandler>();
             services.AddScoped<IGetSeasonContestsQueryHandler, GetSeasonContestsQueryHandler>();
             services.AddScoped<IGetContestByIdQueryHandler, GetContestByIdQueryHandler>();
+            services.AddScoped<IGetContestHistoryQueryHandler, GetContestHistoryQueryHandler>();
 
             // Venues Queries
             services.AddScoped<IGetVenuesQueryHandler, GetVenuesQueryHandler>();

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -701,6 +701,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
         statsData.teamB.logoUri !== homeLogoUri
       ) {
         setStatsData({
+          ...statsData,
           teamA: { ...statsData.teamA, logoUri: awayLogoUri },
           teamB: { ...statsData.teamB, logoUri: homeLogoUri },
         });
@@ -710,15 +711,26 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
 
     setStatsLoading(true);
     try {
+      // History resolves independently — a failure (or an unresolvable
+      // sport/league) must not take the stats down with it.
+      const historyPromise = sportLeague
+        ? matchupsApi
+            .getContestHistory(sportLeague.sport, sportLeague.league, matchup.contestId)
+            .then((res) => res.data)
+            .catch(() => null)
+        : Promise.resolve(null);
+
       const [awayStats, homeStats, awayMetrics, homeMetrics] = await Promise.all([
         teamCardApi.getStatistics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId),
         teamCardApi.getStatistics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId),
         teamCardApi.getMetrics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId),
         teamCardApi.getMetrics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId),
       ]);
+      const history = await historyPromise;
       setStatsData({
         teamA: { name: matchup.away, logoUri: awayLogoUri, stats: awayStats, metrics: awayMetrics },
         teamB: { name: matchup.home, logoUri: homeLogoUri, stats: homeStats, metrics: homeMetrics },
+        history,
       });
     } catch (err) {
       console.warn('[MatchupCard] stats fetch error', err);
@@ -943,6 +955,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
       matchup={matchup}
       comparison={statsData}
       isLoading={statsLoading}
+      showGambling={showGambling}
     />
     <InsightModal
       visible={showPreview}

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -711,8 +711,9 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
 
     setStatsLoading(true);
     try {
-      // History resolves independently — a failure (or an unresolvable
-      // sport/league) must not take the stats down with it.
+      // Every request soft-fails independently: week 1 the stats endpoints
+      // 404 (no current-season data) while history is the whole point of the
+      // modal — one slot rejecting must never discard the others.
       const historyPromise = sportLeague
         ? matchupsApi
             .getContestHistory(sportLeague.sport, sportLeague.league, matchup.contestId)
@@ -720,13 +721,13 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
             .catch(() => null)
         : Promise.resolve(null);
 
-      const [awayStats, homeStats, awayMetrics, homeMetrics] = await Promise.all([
-        teamCardApi.getStatistics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId),
-        teamCardApi.getStatistics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId),
-        teamCardApi.getMetrics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId),
-        teamCardApi.getMetrics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId),
+      const [history, awayStats, homeStats, awayMetrics, homeMetrics] = await Promise.all([
+        historyPromise,
+        teamCardApi.getStatistics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId).catch(() => null),
+        teamCardApi.getStatistics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId).catch(() => null),
+        teamCardApi.getMetrics(matchup.awaySlug, year, matchup.awayFranchiseSeasonId).catch(() => null),
+        teamCardApi.getMetrics(matchup.homeSlug, year, matchup.homeFranchiseSeasonId).catch(() => null),
       ]);
-      const history = await historyPromise;
       setStatsData({
         teamA: { name: matchup.away, logoUri: awayLogoUri, stats: awayStats, metrics: awayMetrics },
         teamB: { name: matchup.home, logoUri: homeLogoUri, stats: homeStats, metrics: homeMetrics },

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -279,7 +279,11 @@ export function StatsComparisonModal({
   const awayPriorGames = history?.awayPriorSeasonGames ?? [];
   const homePriorGames = history?.homePriorSeasonGames ?? [];
   const hasHistory =
-    headToHead.length > 0 || awayPriorGames.length > 0 || homePriorGames.length > 0;
+    headToHead.length > 0 ||
+    awayPriorGames.length > 0 ||
+    homePriorGames.length > 0 ||
+    history?.awayPriorSeason != null ||
+    history?.homePriorSeason != null;
 
   // Head-to-head wins among the displayed meetings (ties count for neither).
   const h2hWinsAway = headToHead.filter((g) => g.winner === matchup.away).length;

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -11,7 +11,13 @@ import {
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
-import type { Matchup, TeamComparisonData, TeamStatEntry } from '@/src/types/models';
+import type {
+  ContestHistoryGame,
+  ContestPriorSeasonSummary,
+  Matchup,
+  TeamComparisonData,
+  TeamStatEntry,
+} from '@/src/types/models';
 import { usePageSheetTopInset } from '@/src/hooks/usePageSheetTopInset';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -22,6 +28,8 @@ interface StatsComparisonModalProps {
   matchup: Matchup;
   comparison: TeamComparisonData | null;
   isLoading: boolean;
+  /** Gambling-content gate (spread / ATS / O-U lines in history rows). */
+  showGambling: boolean;
 }
 
 // ─── Team header ──────────────────────────────────────────────────────────────
@@ -165,6 +173,76 @@ function StatRow({
   );
 }
 
+// ─── History pieces ───────────────────────────────────────────────────────────
+
+function formatGameDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * One game of a team's prior-season tail, from that team's perspective.
+ * Historical team names come from Franchise.DisplayName — the same source as
+ * Matchup.away/home — so exact string matching identifies "our" side.
+ */
+function PriorSeasonGameRow({ game, teamName }: { game: ContestHistoryGame; teamName: string }) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const isHome = game.homeTeam === teamName;
+  const isAway = game.awayTeam === teamName;
+  if (!isHome && !isAway) {
+    // Defensive: name matched neither side — render the neutral line.
+    return (
+      <View style={[styles.historyGameRow, { borderBottomColor: theme.border }]}>
+        <Text style={[styles.historyGameDetail, { color: theme.text }]} numberOfLines={1}>
+          {game.awayTeam} {game.awayScore ?? '—'} @ {game.homeTeam} {game.homeScore ?? '—'}
+        </Text>
+        <Text style={[styles.historyGameDate, { color: theme.textMuted }]}>
+          {formatGameDate(game.gameDate)}
+        </Text>
+      </View>
+    );
+  }
+
+  const ourScore = isHome ? game.homeScore : game.awayScore;
+  const theirScore = isHome ? game.awayScore : game.homeScore;
+  const outcome = game.winner == null ? 'T' : game.winner === teamName ? 'W' : 'L';
+  const badgeColors =
+    outcome === 'W'
+      ? { color: theme.successText, backgroundColor: theme.successBg }
+      : outcome === 'L'
+        ? { color: theme.errorText, backgroundColor: theme.errorBg }
+        : { color: theme.textMuted, backgroundColor: 'transparent' };
+
+  return (
+    <View style={[styles.historyGameRow, { borderBottomColor: theme.border }]}>
+      <Text style={[styles.historyResultBadge, badgeColors]}>{outcome}</Text>
+      <Text style={[styles.historyGameScore, { color: theme.text }]}>
+        {ourScore ?? '—'}-{theirScore ?? '—'}
+      </Text>
+      <Text style={[styles.historyGameDetail, { color: theme.text }]} numberOfLines={1}>
+        {isHome ? 'vs' : '@'} {isHome ? game.awayTeam : game.homeTeam}
+      </Text>
+      <Text style={[styles.historyGameDate, { color: theme.textMuted }]}>
+        {formatGameDate(game.gameDate)}
+      </Text>
+    </View>
+  );
+}
+
+function priorSeasonRecordLabel(summary: ContestPriorSeasonSummary | null | undefined): string | null {
+  if (!summary) return null;
+  const conf =
+    summary.conferenceWins != null && summary.conferenceLosses != null
+      ? ` (${summary.conferenceWins}-${summary.conferenceLosses} conf)`
+      : '';
+  return `${summary.seasonYear}: ${summary.wins}-${summary.losses}${conf}`;
+}
+
 // ─── StatsComparisonModal ─────────────────────────────────────────────────────
 
 export function StatsComparisonModal({
@@ -173,6 +251,7 @@ export function StatsComparisonModal({
   matchup,
   comparison,
   isLoading,
+  showGambling,
 }: StatsComparisonModalProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -192,6 +271,25 @@ export function StatsComparisonModal({
   const awayRows: TeamStatEntry[] = currentCategory ? (awayStats[currentCategory] ?? []) : [];
   const homeRows: TeamStatEntry[] = currentCategory ? (homeStats[currentCategory] ?? []) : [];
   const rowCount = Math.max(awayRows.length, homeRows.length);
+
+  // Historical blocks (head-to-head + prior-season form) — present whenever
+  // the franchises have played before, including week 1 when stats are empty.
+  const history = comparison?.history ?? null;
+  const headToHead = history?.headToHead ?? [];
+  const awayPriorGames = history?.awayPriorSeasonGames ?? [];
+  const homePriorGames = history?.homePriorSeasonGames ?? [];
+  const hasHistory =
+    headToHead.length > 0 || awayPriorGames.length > 0 || homePriorGames.length > 0;
+
+  // Head-to-head wins among the displayed meetings (ties count for neither).
+  const h2hWinsAway = headToHead.filter((g) => g.winner === matchup.away).length;
+  const h2hWinsHome = headToHead.filter((g) => g.winner === matchup.home).length;
+
+  // History is the overview and leads (matches the web dialog); Stats is the
+  // detail tab. Null until the user picks, so the default can settle after
+  // the data arrives.
+  const [mainTabChoice, setMainTabChoice] = useState<'history' | 'stats' | null>(null);
+  const mainTab = mainTabChoice ?? (hasHistory ? 'history' : 'stats');
 
   return (
     <Modal
@@ -222,7 +320,7 @@ export function StatsComparisonModal({
               Loading stats…
             </Text>
           </View>
-        ) : comparison == null || categories.length === 0 ? (
+        ) : comparison == null || (categories.length === 0 && !hasHistory) ? (
           <View style={styles.loadingContainer}>
             <Text style={[styles.emptyText, { color: theme.textMuted }]}>
               Stats not available.
@@ -246,54 +344,195 @@ export function StatsComparisonModal({
               />
             </View>
 
-            {/* Category tabs */}
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              style={[styles.tabScroll, { borderBottomColor: theme.border }]}
-              contentContainerStyle={styles.tabScrollContent}
-            >
-              {categories.map((cat) => (
+            {/* Main tabs — History is the overview and leads; Stats carries
+                the category detail. Only shown when history exists. */}
+            {hasHistory && (
+              <View style={[styles.mainTabsRow, { borderBottomColor: theme.border }]}>
                 <CategoryTab
-                  key={cat}
-                  label={cat}
-                  active={currentCategory === cat}
-                  onPress={() => setActiveCategory(cat)}
+                  label={`History (${h2hWinsAway}:${h2hWinsHome})`}
+                  active={mainTab === 'history'}
+                  onPress={() => setMainTabChoice('history')}
                 />
-              ))}
-            </ScrollView>
+                <CategoryTab
+                  label="Stats"
+                  active={mainTab === 'stats'}
+                  onPress={() => setMainTabChoice('stats')}
+                />
+              </View>
+            )}
 
-            {/* Stat rows */}
-            <ScrollView showsVerticalScrollIndicator={false}>
-              {rowCount === 0 ? (
-                <Text style={[styles.emptyText, { color: theme.textMuted, padding: 24 }]}>
-                  No {currentCategory} stats available.
+            {mainTab === 'history' && hasHistory ? (
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={styles.historyContent}
+              >
+                {headToHead.length > 0 && (
+                  <>
+                    <Text style={[styles.historySectionTitle, { color: theme.text }]}>
+                      Head-to-Head — Last {headToHead.length} Meeting{headToHead.length === 1 ? '' : 's'}
+                    </Text>
+                    {headToHead.map((g, i) => (
+                      <View key={i} style={[styles.h2hRow, { borderBottomColor: theme.border }]}>
+                        <View style={styles.h2hMeta}>
+                          <Text style={[styles.historyGameDate, { color: theme.textMuted }]}>
+                            {formatGameDate(g.gameDate)}
+                          </Text>
+                          {g.phase && g.phase !== 'Regular Season' && (
+                            <Text style={[styles.h2hPhase, { color: theme.textMuted }]}>{g.phase}</Text>
+                          )}
+                          {!!g.note && (
+                            <Text style={[styles.h2hPhase, { color: theme.textMuted }]} numberOfLines={1}>
+                              {g.note}
+                            </Text>
+                          )}
+                        </View>
+                        {/* Winner is marked by weight alone — team-color text
+                            is illegible when a team's color sits near the
+                            background (matches the web dialog). */}
+                        <View style={styles.h2hLine}>
+                          <Text
+                            style={[
+                              styles.h2hTeam,
+                              { color: theme.text },
+                              g.winner === g.awayTeam && styles.h2hWinner,
+                            ]}
+                            numberOfLines={1}
+                          >
+                            {g.awayTeam} {g.awayScore ?? '—'}
+                          </Text>
+                          <Text style={[styles.h2hAt, { color: theme.textMuted }]}>@</Text>
+                          <Text
+                            style={[
+                              styles.h2hTeam,
+                              { color: theme.text },
+                              g.winner === g.homeTeam && styles.h2hWinner,
+                            ]}
+                            numberOfLines={1}
+                          >
+                            {g.homeTeam} {g.homeScore ?? '—'}
+                          </Text>
+                        </View>
+                        {showGambling && (g.spread || g.spreadWinner || g.overUnderResult) && (
+                          <View style={styles.h2hMeta}>
+                            {!!g.spread && (
+                              <Text style={[styles.h2hMarket, { color: theme.textMuted }]}>{g.spread}</Text>
+                            )}
+                            {!!g.spreadWinner && (
+                              <Text style={[styles.h2hMarket, { color: theme.textMuted }]}>
+                                ATS: {g.spreadWinner}
+                              </Text>
+                            )}
+                            {!!g.overUnderResult && (
+                              <Text style={[styles.h2hMarket, { color: theme.textMuted }]}>
+                                {g.overUnderResult}
+                                {g.overUnder != null ? ` ${g.overUnder}` : ''}
+                              </Text>
+                            )}
+                          </View>
+                        )}
+                      </View>
+                    ))}
+                  </>
+                )}
+
+                <Text style={[styles.historySectionTitle, { color: theme.text }]}>
+                  Last Season — Final {Math.max(awayPriorGames.length, homePriorGames.length)} Games
                 </Text>
-              ) : (
-                Array.from({ length: rowCount }, (_, i) => {
-                  const away = awayRows[i];
-                  const home = homeRows[i];
-                  // Use label from entry if available, else stat index
-                  const label =
-                    (away as any)?.label ??
-                    (away as any)?.name ??
-                    (home as any)?.label ??
-                    (home as any)?.name ??
-                    `Stat ${i + 1}`;
 
-                  if (!away && !home) return null;
+                <View style={styles.historyTeamHeader}>
+                  <Text style={[styles.historyTeamName, { color: theme.text }]}>{matchup.away}</Text>
+                  {priorSeasonRecordLabel(history?.awayPriorSeason) && (
+                    <Text style={[styles.historySeasonRecord, { color: theme.textMuted }]}>
+                      {priorSeasonRecordLabel(history?.awayPriorSeason)}
+                    </Text>
+                  )}
+                </View>
+                {awayPriorGames.length === 0 ? (
+                  <Text style={[styles.historyEmptyNote, { color: theme.textMuted }]}>
+                    No prior-season games on record.
+                  </Text>
+                ) : (
+                  awayPriorGames.map((g, i) => (
+                    <PriorSeasonGameRow key={i} game={g} teamName={matchup.away} />
+                  ))
+                )}
 
-                  return (
-                    <StatRow
-                      key={i}
-                      label={label}
-                      awayEntry={away ?? { displayValue: '—' }}
-                      homeEntry={home ?? { displayValue: '—' }}
+                <View style={styles.historyTeamHeader}>
+                  <Text style={[styles.historyTeamName, { color: theme.text }]}>{matchup.home}</Text>
+                  {priorSeasonRecordLabel(history?.homePriorSeason) && (
+                    <Text style={[styles.historySeasonRecord, { color: theme.textMuted }]}>
+                      {priorSeasonRecordLabel(history?.homePriorSeason)}
+                    </Text>
+                  )}
+                </View>
+                {homePriorGames.length === 0 ? (
+                  <Text style={[styles.historyEmptyNote, { color: theme.textMuted }]}>
+                    No prior-season games on record.
+                  </Text>
+                ) : (
+                  homePriorGames.map((g, i) => (
+                    <PriorSeasonGameRow key={i} game={g} teamName={matchup.home} />
+                  ))
+                )}
+              </ScrollView>
+            ) : categories.length === 0 ? (
+              <View style={styles.loadingContainer}>
+                <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+                  Stats not available.
+                </Text>
+              </View>
+            ) : (
+              <>
+                {/* Category tabs */}
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  style={[styles.tabScroll, { borderBottomColor: theme.border }]}
+                  contentContainerStyle={styles.tabScrollContent}
+                >
+                  {categories.map((cat) => (
+                    <CategoryTab
+                      key={cat}
+                      label={cat}
+                      active={currentCategory === cat}
+                      onPress={() => setActiveCategory(cat)}
                     />
-                  );
-                })
-              )}
-            </ScrollView>
+                  ))}
+                </ScrollView>
+
+                {/* Stat rows */}
+                <ScrollView showsVerticalScrollIndicator={false}>
+                  {rowCount === 0 ? (
+                    <Text style={[styles.emptyText, { color: theme.textMuted, padding: 24 }]}>
+                      No {currentCategory} stats available.
+                    </Text>
+                  ) : (
+                    Array.from({ length: rowCount }, (_, i) => {
+                      const away = awayRows[i];
+                      const home = homeRows[i];
+                      // Use label from entry if available, else stat index
+                      const label =
+                        (away as any)?.label ??
+                        (away as any)?.name ??
+                        (home as any)?.label ??
+                        (home as any)?.name ??
+                        `Stat ${i + 1}`;
+
+                      if (!away && !home) return null;
+
+                      return (
+                        <StatRow
+                          key={i}
+                          label={label}
+                          awayEntry={away ?? { displayValue: '—' }}
+                          homeEntry={home ?? { displayValue: '—' }}
+                        />
+                      );
+                    })
+                  )}
+                </ScrollView>
+              </>
+            )}
           </View>
         )}
       </View>
@@ -444,6 +683,105 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     lineHeight: 14,
   },
+  // Main tabs (History | Stats)
+  mainTabsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+
+  // History tab
+  historyContent: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 24,
+    gap: 4,
+  },
+  historySectionTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    marginTop: 12,
+    marginBottom: 6,
+  },
+  h2hRow: {
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 2,
+  },
+  h2hMeta: {
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'baseline',
+  },
+  h2hPhase: {
+    fontSize: 11,
+    fontStyle: 'italic',
+  },
+  h2hLine: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+  },
+  h2hTeam: {
+    fontSize: 14,
+    flexShrink: 1,
+  },
+  h2hWinner: {
+    fontWeight: '700',
+  },
+  h2hAt: {
+    fontSize: 12,
+  },
+  h2hMarket: {
+    fontSize: 11,
+  },
+  historyTeamHeader: {
+    marginTop: 10,
+    marginBottom: 4,
+    gap: 1,
+  },
+  historyTeamName: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  historySeasonRecord: {
+    fontSize: 12,
+  },
+  historyGameRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 8,
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  historyResultBadge: {
+    width: 20,
+    textAlign: 'center',
+    fontSize: 12,
+    fontWeight: '700',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  historyGameScore: {
+    fontSize: 13,
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+  },
+  historyGameDetail: {
+    flex: 1,
+    fontSize: 13,
+  },
+  historyGameDate: {
+    fontSize: 11,
+  },
+  historyEmptyNote: {
+    fontSize: 12,
+    fontStyle: 'italic',
+    paddingVertical: 4,
+  },
+
   barTrack: {
     width: '100%',
     height: 4,

--- a/src/UI/sd-mobile/src/services/api/matchupsApi.ts
+++ b/src/UI/sd-mobile/src/services/api/matchupsApi.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { LeagueMatchupsResponse, PreviewResponse } from '@/src/types/models';
+import type { ContestHistory, LeagueMatchupsResponse, PreviewResponse } from '@/src/types/models';
 
 export const matchupsApi = {
   // GET /ui/leagues/{leagueId}/matchups/{week}
@@ -9,4 +9,17 @@ export const matchupsApi = {
   // GET /ui/matchup/{contestId}/preview
   getPreview: (contestId: string) =>
     apiClient.get<PreviewResponse>(`/ui/matchup/${encodeURIComponent(contestId)}/preview`),
+
+  /**
+   * GET /api/{sport}/{league}/contests/{contestId}/history
+   *
+   * Historical context for a matchup: last N head-to-head meetings and each
+   * team's late-prior-season form — the same blocks the preview/insight
+   * models consume. Preview-safe semantics (finalized only, preseason
+   * excluded, no as-of leakage) are baked in server-side.
+   */
+  getContestHistory: (sport: string, league: string, contestId: string) =>
+    apiClient.get<ContestHistory>(
+      `/api/${sport}/${league}/contests/${encodeURIComponent(contestId)}/history`,
+    ),
 };

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -321,6 +321,49 @@ export type TeamStatistics = Record<string, TeamStatEntry[]>;
 /** Shape of metrics?.data from team card API */
 export type TeamMetrics = Record<string, unknown>;
 
+/**
+ * One historical game from GET /api/{sport}/{league}/contests/{id}/history.
+ * Team fields are Franchise.DisplayName strings — the same source as
+ * Matchup.away/home, so exact string matching identifies "our" side.
+ */
+export interface ContestHistoryGame {
+  gameDate: string;
+  seasonYear: number;
+  phase?: string | null;
+  note?: string | null;
+  homeTeam: string;
+  awayTeam: string;
+  homeScore?: number | null;
+  awayScore?: number | null;
+  winner?: string | null;
+  spreadWinner?: string | null;
+  spread?: string | null;
+  overUnder?: number | null;
+  overUnderResult?: string | null;
+}
+
+/** A team's prior season in summary (record; conference record when published). */
+export interface ContestPriorSeasonSummary {
+  seasonYear: number;
+  wins: number;
+  losses: number;
+  conferenceWins?: number | null;
+  conferenceLosses?: number | null;
+}
+
+/**
+ * Historical context for a matchup: recent head-to-head meetings plus each
+ * team's late-prior-season form — the same blocks the preview/insight models
+ * consume. Away/Home here refer to the LIVE matchup's sides.
+ */
+export interface ContestHistory {
+  headToHead: ContestHistoryGame[];
+  awayPriorSeasonGames: ContestHistoryGame[];
+  homePriorSeasonGames: ContestHistoryGame[];
+  awayPriorSeason?: ContestPriorSeasonSummary | null;
+  homePriorSeason?: ContestPriorSeasonSummary | null;
+}
+
 /** Assembled comparison object used by StatsComparisonModal */
 export interface TeamComparisonData {
   teamA: {
@@ -335,6 +378,8 @@ export interface TeamComparisonData {
     stats?: { data?: { statistics?: TeamStatistics } } | null;
     metrics?: { data?: TeamMetrics } | null;
   };
+  /** Matchup history; null when the fetch failed or nothing exists. */
+  history?: ContestHistory | null;
 }
 
 // ─── User ────────────────────────────────────────────────────────────────────

--- a/src/UI/sd-ui/src/api/contestApi.js
+++ b/src/UI/sd-ui/src/api/contestApi.js
@@ -13,6 +13,12 @@ const ContestApi = {
     apiClient.get(`/ui/contest/${contestId}/playlog`, {
       params: { sport, league }
     }),
+  // Historical context for a matchup: last N head-to-head meetings and each
+  // team's late-prior-season form — the same blocks the preview/insight
+  // models consume. Preview-safe semantics (finalized only, preseason
+  // excluded, no as-of leakage) are baked in server-side.
+  getHistory: (sport, league, contestId) =>
+    apiClient.get(`/api/${sport}/${league}/contests/${contestId}/history`),
   refresh: (contestId, sport, league) =>
     apiClient.post(`/ui/contest/${contestId}/refresh`, null, {
       params: { sport, league }

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -408,7 +408,10 @@ function MatchupCard({
       // value in week 1.
       const h = comparisonData.history;
       const hasHistory = Boolean(
-        h && (h.headToHead?.length || h.awayPriorSeasonGames?.length || h.homePriorSeasonGames?.length)
+        h && (
+          h.headToHead?.length || h.awayPriorSeasonGames?.length || h.homePriorSeasonGames?.length ||
+          h.awayPriorSeason != null || h.homePriorSeason != null
+        )
       );
       const hasAnyData =
         comparisonData.teamA?.stats || comparisonData.teamB?.stats ||

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -403,10 +403,18 @@ function MatchupCard({
       // Stats takes a different path (handler still returns Failure(NotFound) for
       // null), so a truthy check on `?.stats` is sufficient there.
       const hasMeaningfulMetrics = (m) => Boolean(m && m.gamesPlayed && m.gamesPlayed > 0);
+      // History (head-to-head + prior-season form) counts as data: early in a
+      // season it's the ONLY populated block, and it's the dialog's whole
+      // value in week 1.
+      const h = comparisonData.history;
+      const hasHistory = Boolean(
+        h && (h.headToHead?.length || h.awayPriorSeasonGames?.length || h.homePriorSeasonGames?.length)
+      );
       const hasAnyData =
         comparisonData.teamA?.stats || comparisonData.teamB?.stats ||
         hasMeaningfulMetrics(comparisonData.teamA?.metrics) ||
-        hasMeaningfulMetrics(comparisonData.teamB?.metrics);
+        hasMeaningfulMetrics(comparisonData.teamB?.metrics) ||
+        hasHistory;
 
       if (!hasAnyData) {
         return (
@@ -439,6 +447,8 @@ function MatchupCard({
           teamB={comparisonData.teamB}
           teamAColor={matchup.awayColor}
           teamBColor={matchup.homeColor}
+          history={comparisonData.history}
+          showGambling={showGambling}
         />
       );
     })()}

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.css
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.css
@@ -207,20 +207,14 @@
 }
 
 .team-comparison-content {
-   padding: 2rem 2.5rem 0 2.5rem;
+   /* Bottom padding matters since the footer CTA was removed — without it
+      the last rows of every tab end exactly on the dialog's edge. */
+   padding: 2rem 2.5rem 2rem 2.5rem;
    flex: 1;
    overflow-y: auto;
    display: flex;
    flex-direction: column;
    gap: 1.5rem;
-}
-
-.team-comparison-footer {
-   padding: 1rem 2.5rem 1.5rem 2.5rem;
-   border-top: 1px solid var(--badge-bg);
-   background: var(--bg-input);
-   border-radius: 0 0 14px 14px;
-   flex-shrink: 0;
 }
 
 @media (max-width: 600px) {
@@ -231,11 +225,7 @@
   }
 
   .team-comparison-content {
-    padding: 1rem 0.5rem 0 0.5rem;
-  }
-
-  .team-comparison-footer {
-    padding: 0.75rem 0.5rem 1rem 0.5rem;
+    padding: 1rem 0.5rem 1rem 0.5rem;
   }
 
   .team-comparison-table {
@@ -403,24 +393,23 @@
   }
 }
 
-.close-btn {
-  display: block;
-  width: 100%;
-  max-width: 200px;
-  margin: 0 auto;
-  padding: 0.75rem 1.5rem;
-  border-radius: 8px;
+/* Close affordance — same X as InsightDialog (top-right, no footer CTA) */
+.close-x-button {
+  position: absolute;
+  top: 10px;
+  right: 14px;
+  background: none;
   border: none;
-  background: var(--accent);
-  color: var(--text-on-accent);
-  font-weight: bold;
-  font-size: 1rem;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: var(--text-secondary);
   cursor: pointer;
-  transition: background 0.2s;
+  transition: color 0.2s ease;
+  z-index: 2;
 }
-.close-btn:hover {
-  background: var(--accent-hover);
-  color: var(--text-primary);
+
+.close-x-button:hover {
+  color: var(--accent);
 }
 
 /* Metrics tab styles - reuses stat-row styles above */
@@ -437,3 +426,183 @@
   min-width: 100%;
 }
 
+
+/* ─── History tab ─────────────────────────────────────────────────────── */
+.history-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.history-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.history-section-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--badge-bg);
+  padding-bottom: 0.35rem;
+  margin-bottom: 0.25rem;
+}
+
+/* Head-to-head rows */
+.h2h-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  background: var(--hover-bg);
+}
+
+.h2h-meta {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.h2h-phase,
+.h2h-note {
+  font-style: italic;
+}
+
+.h2h-line {
+  display: flex;
+  gap: 0.6rem;
+  align-items: baseline;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.h2h-at {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.h2h-winner {
+  font-weight: 700;
+}
+
+.h2h-market {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+/* Prior-season two-column grid */
+.history-teams-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+.history-team-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.history-team-col-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  margin-bottom: 0.25rem;
+}
+
+.history-team-name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.history-season-record {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.history-game-line {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  padding: 0.25rem 0.4rem;
+  border-radius: 6px;
+  background: var(--hover-bg);
+  min-width: 0;
+}
+
+.history-result-badge {
+  flex: 0 0 auto;
+  width: 1.35rem;
+  text-align: center;
+  font-weight: 700;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  line-height: 1.35rem;
+}
+
+.history-result-badge.win {
+  background: rgba(46, 160, 67, 0.25);
+  color: #3fb950;
+}
+
+.history-result-badge.loss {
+  background: rgba(248, 81, 73, 0.2);
+  color: #f85149;
+}
+
+.history-result-badge.tie {
+  background: var(--badge-bg);
+  color: var(--text-secondary);
+}
+
+.history-game-score {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.history-game-detail {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-game-line .history-game-date {
+  flex: 0 0 auto;
+}
+
+.history-game-date {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.history-empty-note {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* Phone degradation: columns stack, H2H line wraps */
+@media (max-width: 600px) {
+  .history-teams-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .h2h-line {
+    flex-wrap: wrap;
+  }
+}

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -31,7 +31,11 @@ export default function TeamComparison({
   const teamAPriorSeason = history?.awayPriorSeason ?? null;
   const teamBPriorSeason = history?.homePriorSeason ?? null;
   const hasHistoryData =
-    headToHead.length > 0 || teamAPriorGames.length > 0 || teamBPriorGames.length > 0;
+    headToHead.length > 0 ||
+    teamAPriorGames.length > 0 ||
+    teamBPriorGames.length > 0 ||
+    teamAPriorSeason != null ||
+    teamBPriorSeason != null;
 
   // Main tab state. History is the overview and opens first; Statistics and
   // Metrics are the detail tabs. Statistics only leads when there is no

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -19,9 +19,26 @@ export default function TeamComparison({
   teamB,
   teamAColor = "#61dafb",
   teamBColor = "#61dafb",
+  history = null,
+  showGambling = false,
 }) {
-  // Main tab state
-  const [activeTab, setActiveTab] = useState("statistics");
+  // Historical blocks (head-to-head + prior-season form). Present whenever
+  // the franchises have played before — including week 1, when it's the only
+  // populated tab.
+  const headToHead = history?.headToHead ?? [];
+  const teamAPriorGames = history?.awayPriorSeasonGames ?? [];
+  const teamBPriorGames = history?.homePriorSeasonGames ?? [];
+  const teamAPriorSeason = history?.awayPriorSeason ?? null;
+  const teamBPriorSeason = history?.homePriorSeason ?? null;
+  const hasHistoryData =
+    headToHead.length > 0 || teamAPriorGames.length > 0 || teamBPriorGames.length > 0;
+
+  // Main tab state. History is the overview and opens first; Statistics and
+  // Metrics are the detail tabs. Statistics only leads when there is no
+  // history to show.
+  const [activeTab, setActiveTab] = useState(
+    hasHistoryData ? "history" : "statistics"
+  );
 
   // Helper: choose light or dark text based on background color
   const getContrastTextColor = (bgColor) => {
@@ -524,6 +541,155 @@ export default function TeamComparison({
     );
   };
 
+  // ─── History tab ─────────────────────────────────────────────────────────
+  // Historical team names come from Franchise.DisplayName — the same source
+  // as teamA.name / teamB.name (matchup Away/Home) — so exact string matching
+  // identifies "our" side of a historical row.
+
+  const formatGameDate = (iso) =>
+    new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+
+  // W/L/T + score + opponent from one team's perspective; null when the team
+  // name matches neither side (defensive — shouldn't happen).
+  const gameResultForTeam = (game, teamName) => {
+    const isHome = game.homeTeam === teamName;
+    const isAway = game.awayTeam === teamName;
+    if (!isHome && !isAway) return null;
+    const ourScore = isHome ? game.homeScore : game.awayScore;
+    const theirScore = isHome ? game.awayScore : game.homeScore;
+    const outcome =
+      game.winner == null ? "T" : game.winner === teamName ? "W" : "L";
+    return {
+      outcome,
+      ourScore,
+      theirScore,
+      opponent: isHome ? game.awayTeam : game.homeTeam,
+      venue: isHome ? "vs" : "@",
+    };
+  };
+
+  const renderPriorSeasonColumn = (teamName, games, summary) => (
+    <div className="history-team-col">
+      <div className="history-team-col-header">
+        <span className="history-team-name">{teamName}</span>
+        {summary && (
+          <span className="history-season-record">
+            {summary.seasonYear}: {summary.wins}-{summary.losses}
+            {summary.conferenceWins != null && summary.conferenceLosses != null
+              ? ` (${summary.conferenceWins}-${summary.conferenceLosses} conf)`
+              : ""}
+          </span>
+        )}
+      </div>
+      {games.length === 0 ? (
+        <div className="history-empty-note">No prior-season games on record.</div>
+      ) : (
+        games.map((game, idx) => {
+          const r = gameResultForTeam(game, teamName);
+          if (!r) {
+            return (
+              <div className="history-game-line" key={idx}>
+                <span className="history-game-date">{formatGameDate(game.gameDate)}</span>
+                <span className="history-game-detail">
+                  {game.awayTeam} {game.awayScore ?? "—"} @ {game.homeTeam} {game.homeScore ?? "—"}
+                </span>
+              </div>
+            );
+          }
+          return (
+            <div className="history-game-line" key={idx}>
+              <span className={`history-result-badge ${r.outcome === "W" ? "win" : r.outcome === "L" ? "loss" : "tie"}`}>
+                {r.outcome}
+              </span>
+              <span className="history-game-score">
+                {r.ourScore ?? "—"}-{r.theirScore ?? "—"}
+              </span>
+              <span className="history-game-detail">
+                {r.venue} {r.opponent}
+              </span>
+              <span className="history-game-date">{formatGameDate(game.gameDate)}</span>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+
+  const renderHistoryTab = () => {
+    if (!hasHistoryData) {
+      return (
+        <div className="metrics-placeholder">
+          <p style={{ textAlign: "center", color: "var(--text-secondary)", fontSize: "1.1rem", padding: "2rem" }}>
+            No matchup history is available for these teams.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="history-content">
+        {headToHead.length > 0 && (
+          <div className="history-section">
+            <div className="history-section-title">
+              Head-to-Head — Last {headToHead.length} Meeting{headToHead.length === 1 ? "" : "s"}
+            </div>
+            {headToHead.map((game, idx) => {
+              return (
+                <div className="h2h-row" key={idx}>
+                  <div className="h2h-meta">
+                    <span className="history-game-date">{formatGameDate(game.gameDate)}</span>
+                    {game.phase && game.phase !== "Regular Season" && (
+                      <span className="h2h-phase">{game.phase}</span>
+                    )}
+                    {game.note && <span className="h2h-note">{game.note}</span>}
+                  </div>
+                  {/* Winner is marked by weight alone — team-color text is
+                      illegible whenever a team's color sits near the card
+                      background (e.g. LSU purple on dark). */}
+                  <div className="h2h-line">
+                    <span className={`h2h-team${game.winner === game.awayTeam ? " h2h-winner" : ""}`}>
+                      {game.awayTeam} {game.awayScore ?? "—"}
+                    </span>
+                    <span className="h2h-at">@</span>
+                    <span className={`h2h-team${game.winner === game.homeTeam ? " h2h-winner" : ""}`}>
+                      {game.homeTeam} {game.homeScore ?? "—"}
+                    </span>
+                  </div>
+                  {showGambling && (game.spread || game.spreadWinner || game.overUnderResult) && (
+                    <div className="h2h-market">
+                      {game.spread && <span>{game.spread}</span>}
+                      {game.spreadWinner && <span>ATS: {game.spreadWinner}</span>}
+                      {game.overUnderResult && (
+                        <span>
+                          {game.overUnderResult}
+                          {game.overUnder != null ? ` ${game.overUnder}` : ""}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="history-section">
+          <div className="history-section-title">
+            Last Season — Final {Math.max(teamAPriorGames.length, teamBPriorGames.length)} Games
+          </div>
+          <div className="history-teams-grid">
+            {renderPriorSeasonColumn(teamA.name, teamAPriorGames, teamAPriorSeason)}
+            {renderPriorSeasonColumn(teamB.name, teamBPriorGames, teamBPriorSeason)}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   if (!open) return null;
 
   // Helper to determine which team is favored (higher value wins by default)
@@ -627,6 +793,10 @@ export default function TeamComparison({
   const { totalFavoredA, totalFavoredB } = calculateOverallFavorability();
   const { metricsFavoredA, metricsFavoredB } = calculateMetricsFavorability();
 
+  // Head-to-head wins among the displayed meetings (ties count for neither).
+  const h2hWinsA = headToHead.filter((g) => g.winner === teamA.name).length;
+  const h2hWinsB = headToHead.filter((g) => g.winner === teamB.name).length;
+
   // Get main tab styling based on overall favorability
   const getMainTabStyling = (tabType, isActive) => {
     if (!isActive) return {}; // Only apply styling to active tabs
@@ -656,6 +826,22 @@ export default function TeamComparison({
           color: getContrastTextColor(normAColor),
         };
       } else if (metricsFavoredB > metricsFavoredA) {
+        return {
+          background: /^#|rgb/.test(normBColor)
+            ? normBColor
+            : getMutedColor(normBColor),
+          color: getContrastTextColor(normBColor),
+        };
+      }
+    } else if (tabType === "history") {
+      if (h2hWinsA > h2hWinsB) {
+        return {
+          background: /^#|rgb/.test(normAColor)
+            ? normAColor
+            : getMutedColor(normAColor),
+          color: getContrastTextColor(normAColor),
+        };
+      } else if (h2hWinsB > h2hWinsA) {
         return {
           background: /^#|rgb/.test(normBColor)
             ? normBColor
@@ -715,6 +901,10 @@ export default function TeamComparison({
         className="team-comparison-dialog"
         onClick={(e) => e.stopPropagation()}
       >
+        {/* Same close affordance as InsightDialog — X top-right, no footer CTA */}
+        <button className="close-x-button" onClick={onClose} aria-label="Close">
+          &times;
+        </button>
         <div className="team-comparison-content">
           <div className="team-comparison-header">
             <div className="team-col">
@@ -728,8 +918,38 @@ export default function TeamComparison({
             </div>
           </div>
 
-          {/* Main tabs */}
+          {/* Main tabs — History is the overview and leads; Statistics and
+              Metrics carry the detail. */}
           <div className="main-tabs">
+            {hasHistoryData && (
+              <button
+                className={`main-tab ${activeTab === "history" ? "active" : ""}`}
+                onClick={() => setActiveTab("history")}
+                style={getMainTabStyling("history", activeTab === "history")}
+              >
+                <div className="main-tab-content">
+                  <div className="tab-text">History ({h2hWinsA}:{h2hWinsB})</div>
+                  {(h2hWinsA > 0 || h2hWinsB > 0) && (
+                    <div className="tab-gradient-bar">
+                      <div
+                        className="gradient-segment team-a"
+                        style={{
+                          width: `${(h2hWinsA / (h2hWinsA + h2hWinsB)) * 100}%`,
+                          backgroundColor: normAColor
+                        }}
+                      ></div>
+                      <div
+                        className="gradient-segment team-b"
+                        style={{
+                          width: `${(h2hWinsB / (h2hWinsA + h2hWinsB)) * 100}%`,
+                          backgroundColor: normBColor
+                        }}
+                      ></div>
+                    </div>
+                  )}
+                </div>
+              </button>
+            )}
             <button
               className={`main-tab ${
                 activeTab === "statistics" ? "active" : ""
@@ -779,14 +999,14 @@ export default function TeamComparison({
                 <div className="tab-text">Metrics ({metricsFavoredA}:{metricsFavoredB})</div>
                 {(metricsFavoredA > 0 || metricsFavoredB > 0) && (
                   <div className="tab-gradient-bar">
-                    <div 
+                    <div
                       className="gradient-segment team-a"
                       style={{
                         width: `${(metricsFavoredA / (metricsFavoredA + metricsFavoredB)) * 100}%`,
                         backgroundColor: normAColor
                       }}
                     ></div>
-                    <div 
+                    <div
                       className="gradient-segment team-b"
                       style={{
                         width: `${(metricsFavoredB / (metricsFavoredA + metricsFavoredB)) * 100}%`,
@@ -803,14 +1023,10 @@ export default function TeamComparison({
           <div className="tab-content">
             {activeTab === "statistics" && renderStatisticsTab()}
             {activeTab === "metrics" && renderMetricsTab()}
+            {activeTab === "history" && renderHistoryTab()}
           </div>
         </div>
 
-        <div className="team-comparison-footer">
-          <button className="close-btn" onClick={onClose}>
-            Close
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/src/UI/sd-ui/src/hooks/useTeamComparison.js
+++ b/src/UI/sd-ui/src/hooks/useTeamComparison.js
@@ -26,7 +26,8 @@ export const useTeamComparison = (matchup, seasonYear, leagueSport) => {
     if (!seasonYear || !sportLeague) {
       setComparisonData({
         teamA: { name: matchup.away, logoUri: matchup.awayLogoUri, stats: null, metrics: null },
-        teamB: { name: matchup.home, logoUri: matchup.homeLogoUri, stats: null, metrics: null }
+        teamB: { name: matchup.home, logoUri: matchup.homeLogoUri, stats: null, metrics: null },
+        history: null
       });
       setComparisonLoading(false);
       return;
@@ -41,11 +42,12 @@ export const useTeamComparison = (matchup, seasonYear, leagueSport) => {
         apiWrapper.TeamCard.getStatistics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
         apiWrapper.TeamCard.getStatistics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId),
         apiWrapper.TeamCard.getMetrics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
-        apiWrapper.TeamCard.getMetrics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId)
+        apiWrapper.TeamCard.getMetrics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId),
+        apiWrapper.Contest.getHistory(sport, league, matchup.contestId)
       ]);
 
       const valueOrNull = (r) => (r.status === 'fulfilled' ? (r.value?.data ?? null) : null);
-      const [awayStats, homeStats, awayMetrics, homeMetrics] = results.map(valueOrNull);
+      const [awayStats, homeStats, awayMetrics, homeMetrics, history] = results.map(valueOrNull);
 
       setComparisonData({
         teamA: {
@@ -59,7 +61,8 @@ export const useTeamComparison = (matchup, seasonYear, leagueSport) => {
           logoUri: matchup.homeLogoUri,
           stats: homeStats,
           metrics: homeMetrics
-        }
+        },
+        history
       });
     } catch (e) {
       setComparisonData(null);

--- a/src/UI/sd-ui/src/hooks/useTeamComparison.js
+++ b/src/UI/sd-ui/src/hooks/useTeamComparison.js
@@ -20,10 +20,9 @@ export const useTeamComparison = (matchup, seasonYear, leagueSport) => {
     setShowComparison(true);
 
     const sportLeague = resolveSportLeague(leagueSport);
-    // Without a seasonYear OR a resolvable sport/league we can't build season-
-    // specific stats/metrics URLs. Show the dialog's empty-state card rather
-    // than issuing requests with an undefined year segment or a wrong sport.
-    if (!seasonYear || !sportLeague) {
+    // Without a resolvable sport/league we can't build ANY URL — show the
+    // dialog's empty-state card rather than issuing wrong-sport requests.
+    if (!sportLeague) {
       setComparisonData({
         teamA: { name: matchup.away, logoUri: matchup.awayLogoUri, stats: null, metrics: null },
         teamB: { name: matchup.home, logoUri: matchup.homeLogoUri, stats: null, metrics: null },
@@ -36,13 +35,22 @@ export const useTeamComparison = (matchup, seasonYear, leagueSport) => {
     try {
       const { sport, league } = sportLeague;
 
+      // Stats/metrics URLs are season-specific; history only needs the
+      // contest. A missing seasonYear therefore skips the four season slots
+      // but still fetches history.
+      const seasonRequests = seasonYear
+        ? [
+            apiWrapper.TeamCard.getStatistics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
+            apiWrapper.TeamCard.getStatistics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId),
+            apiWrapper.TeamCard.getMetrics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
+            apiWrapper.TeamCard.getMetrics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId)
+          ]
+        : [Promise.resolve(null), Promise.resolve(null), Promise.resolve(null), Promise.resolve(null)];
+
       // allSettled so a missing/failed stat block for one team doesn't kill the
       // dialog — each slot independently resolves to its data or null.
       const results = await Promise.allSettled([
-        apiWrapper.TeamCard.getStatistics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
-        apiWrapper.TeamCard.getStatistics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId),
-        apiWrapper.TeamCard.getMetrics(sport, league, matchup.awaySlug, seasonYear, matchup.awayFranchiseSeasonId),
-        apiWrapper.TeamCard.getMetrics(sport, league, matchup.homeSlug, seasonYear, matchup.homeFranchiseSeasonId),
+        ...seasonRequests,
         apiWrapper.Contest.getHistory(sport, league, matchup.contestId)
       ]);
 


### PR DESCRIPTION
## Summary

The team comparison dialog (comparison button on MatchupCard) had nothing to show until several weeks into a season — current-season stats/metrics are empty at week 1. It now surfaces the historical blocks the preview/insight models already consume: **last N head-to-head meetings** (cross-season) and **each team's final games of the prior season**, with prior-season records.

## API

`GET /api/{sport}/{league}/contests/{contestId}/history` — a thin vertical slice (`Application/Contests/Queries/GetContestHistory/`) relaying Producer's existing preview-history query via `ContestClient.GetContestPreviewHistory`. Preview-safe semantics (finalized/non-cancelled only, preseason excluded, no as-of leakage) are baked in Producer-side; the relay adds nothing but sport/league→mode resolution.

## Web — TeamComparison dialog

- **New History tab, first in order and default-open** — overview first; Statistics and Metrics are the detail tabs. Tab label shows head-to-head wins (`History (1:2)`) with the same team-color gradient bar as its siblings.
- **Head-to-Head**: date, phase/bowl note, score line with the winner marked **by weight alone** — team-color text is illegible whenever a team's color sits near the card background (LSU purple on dark). Spread / ATS / O-U context renders only when `shouldShowGambling` allows.
- **Last Season — Final 5 Games**: two-column grid (away | home) with record summaries (`2025: 7-6 (4-4 conf)`) and W/L-badged game lines; stacks at the 600px phone breakpoint.
- **Week-1 behavior**: history counts as data in the dialog's empty-state check, and with no stats the dialog opens straight onto History.
- **Consistency**: footer "Close" CTA replaced with the same top-right ✕ as InsightDialog; the content container gains the bottom padding the footer had been masking (fixes flush-bottom rows on every tab).

## Mobile — StatsComparisonModal

- Same endpoint via `matchupsApi.getContestHistory`, sport-aware through `resolveSportLeague`; the history fetch fails soft (`.catch(() => null)`) so it can never take stats down with it.
- **History | Stats** main tabs, History leading and default when data exists; single-column layout for phones: head-to-head rows (winner by weight, market line gated by `showGambling` threaded from MatchupCard) and each team's prior-season record + final-5 with theme-token W/L badges.
- Week-1 parity (history counts as data) and the theme-toggle logo refresh preserves cached history.
- New types: `ContestHistoryGame`, `ContestPriorSeasonSummary`, `ContestHistory`; `TeamComparisonData.history`.

Historical rows are matched to teams by `Franchise.DisplayName` — the same source both matchup names and history names come from, on web and mobile alike.

## Validation

- API: `dotnet build` zero errors
- Web: lint clean, 26/26 Vitest; validated E2E in both themes (incl. iterations on winner-marking legibility, close affordance, bottom padding)
- Mobile: `tsc --noEmit` clean, 133/133 Jest; ships with the next EAS build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added historical matchup comparisons, including head-to-head results and prior-season records.
  * Added History and Statistics views with scores, outcomes, dates, records, and optional betting details.
  * History is shown by default when available, with support for history-only comparisons.
  * Added an API endpoint for retrieving contest history.
* **UI Improvements**
  * Added responsive history layouts, result badges, game details, and improved close-button styling.
  * Preserved comparison data while refreshing theme-dependent visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->