### PR TITLE
feat(producer,core,web,mobile): spread-contextualized history facts ("The Line")

### DIFF
--- a/docs/features/matchup-spread-context.md
+++ b/docs/features/matchup-spread-context.md
@@ -26,7 +26,9 @@ mobile, and (future) the preview/insight model payload.
 
 `SpreadContext` is **null when the target contest has no line** from the
 preferred/fallback odds providers (EspnBet 58 → DraftKings 100 — same
-lateral as the matchup payload, so both surfaces quote the same number).
+lateral as the matchup payload, so both surfaces quote the same number),
+**and also when the selected line is zero** (a pick'em has no favorite to
+condition on).
 
 ## Fact family and data tiers
 

--- a/docs/features/matchup-spread-context.md
+++ b/docs/features/matchup-spread-context.md
@@ -1,0 +1,97 @@
+# Matchup Spread Context ("The Line")
+
+Spread-conditioned historical facts surfaced proactively in the team
+comparison dialog's History tab — answering the questions a user wouldn't
+think to ask. For a USC -38.5 line over San José State:
+
+1. When is the last time USC beat **anyone** by 38.5+? (and who was it —
+   a bowl team or a 3-9 doormat?)
+2. When is the last time anyone beat SJSU by 38.5+?
+3. How has USC done ATS as a 35+ favorite? SJSU as a 35+ underdog?
+
+Product positioning: **a dimension, not a toll booth.** The casual picks
+USC and moves on at full speed; the data geek gets the bigger picture one
+tap away. Facts are **context, never prediction** — every number comes
+from a query, none from prose, which keeps the killer detail
+hallucination-proof.
+
+## Data flow
+
+Computed in Producer inside the existing preview-history pipeline
+(`GetContestPreviewHistoryQueryHandler`) and attached to
+`ContestPreviewHistoryDto.SpreadContext`, so it reaches every consumer of
+`GET contests/{id}/preview-history`: the API relay
+(`/api/{sport}/{league}/contests/{contestId}/history`) feeding web +
+mobile, and (future) the preview/insight model payload.
+
+`SpreadContext` is **null when the target contest has no line** from the
+preferred/fallback odds providers (EspnBet 58 → DraftKings 100 — same
+lateral as the matchup payload, so both surfaces quote the same number).
+
+## Fact family and data tiers
+
+| Fact | Tier | Floor | Source |
+|------|------|-------|--------|
+| `FavoriteWonByMargin` / `UnderdogLostByMargin` | score margins | franchise's earliest corpus season (returned per-fact as `SearchFloorSeason`) | `GetFranchiseMarginFact.sql` |
+| `FavoriteAtsAsBigFavorite` / `UnderdogAtsAsBigUnderdog` | spread values | 2022 (`DataFloorSeason`) | `GetFranchiseAtsBucket.sql` |
+
+Observed coverage (NCAAFB, 2026-08-19): spread **results**
+(`SpreadWinnerFranchiseSeasonId`) exist from 2012 (~840 FBS games/yr);
+spread **values** (`CompetitionOdds.Spread`, providers 58/100) from 2022.
+Margin facts need neither — scores only.
+
+### Margin facts (`PreviewMarginFactDto`)
+
+- Exact-line semantics: "won by ≥ 38.5" uses the real magnitude, no
+  bucketing — that IS the user's question.
+- The qualifying game carries **opponent quality** one level deep: the
+  opponent's record that season and the season before
+  (`FranchiseSeasonRecord`, type `total`). Absent stays null — never a
+  fabricated 0-0.
+- `LastGame == null` means it never happened within the corpus — the
+  headline case. The SQL always returns a row so the count (0) and the
+  franchise's honest search floor survive.
+- `CountLastFiveSeasons` bounds "how unusual is this" to a window.
+
+### ATS bucket facts (`PreviewAtsBucketFactDto`)
+
+- Bucketed on football **key numbers** `[3, 7, 10, 14, 21, 28, 35]`:
+  largest key ≤ magnitude. "As a 35+ favorite" reads naturally and
+  accrues a sample where "as a 38.5-point favorite" would be n=0.
+  Magnitude < 3 ⇒ no ATS facts.
+- `Games` counts **decided** ATS results only (`SpreadWinner` null =
+  push or unsourced ⇒ excluded).
+- Zero games is presented honestly: "no games with a line that large
+  since 2022" — never implied as 0-for-0.
+
+### Preview-safe predicates (all queries)
+
+Finalized + non-cancelled only; strictly before the target's start (no
+answer leak); preseason (`SeasonPhase.TypeCode 1`) excluded, NULL phase
+kept — identical to the head-to-head/prior-season queries.
+
+## Rendering
+
+Web (`TeamComparison.jsx`) and mobile (`StatsComparisonModal.tsx`) render
+"The Line — USC -38.5" at the top of the History tab as deterministic
+sentences composed client-side from the structured facts:
+
+> **Last time USC Trojans won by 38.5+:** Sep 6, 2025 — beat Georgia
+> Southern Eagles 59-20 (they went 3-9; 2-10 the season before). 6 such
+> wins in the last 5 seasons.
+> **San José State Spartans as a 35+ underdog:** covered 1 of 1 (since 2022).
+
+The entire section is **gated by `shouldShowGambling`** on both platforms
+— the framing is spread-derived.
+
+## Future (not in v1)
+
+- Inject the fact chain into the preview/insight model payload
+  (`MatchupPreviewProcessor`) so the LLM narrative can cite it —
+  "model predicts, LLM explains" with pre-verified facts.
+- More family members: cover streaks vs. opponent class, totals-based
+  facts ("teams hitting this O/U"), favorite-cover-rate league-wide at
+  this bucket as the base rate.
+
+See memory `project_spread_contextualized_history` for the full product
+rationale and origin (2026-08-19, immediately post-#658).

--- a/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
@@ -23,6 +23,88 @@ namespace SportsData.Core.Dtos.Canonical
         public PreviewPriorSeasonSummaryDto? AwayPriorSeason { get; set; }
 
         public PreviewPriorSeasonSummaryDto? HomePriorSeason { get; set; }
+
+        /// <summary>
+        /// Spread-conditioned facts for the live line (e.g. "when did the
+        /// favorite last beat ANYONE by this much?"). Null when the target
+        /// contest has no line from the preferred/fallback providers.
+        /// Everything here is spread-derived — consumers must gate display
+        /// behind the gambling-content preference.
+        /// </summary>
+        public PreviewSpreadContextDto? SpreadContext { get; set; }
+    }
+
+    /// <summary>
+    /// Facts conditioned on the target contest's CURRENT spread. Two data
+    /// tiers with different floors: margin facts run on final scores (full
+    /// corpus), ATS-bucket facts need historical spread VALUES (odds era,
+    /// ~2022+). Each fact carries its own floor so consumers never imply a
+    /// completeness the data doesn't have.
+    /// </summary>
+    public class PreviewSpreadContextDto
+    {
+        /// <summary>Favorite's Franchise.DisplayName (matches matchup Away/Home names).</summary>
+        public string FavoriteTeam { get; set; } = default!;
+
+        public string UnderdogTeam { get; set; } = default!;
+
+        /// <summary>Absolute value of the spread (38.5 for "USC -38.5").</summary>
+        public double Magnitude { get; set; }
+
+        /// <summary>Line details text (e.g. "USC -38.5") — self-documents the favorite.</summary>
+        public string? SpreadDetails { get; set; }
+
+        /// <summary>Last time the favorite beat ANY opponent by ≥ Magnitude.</summary>
+        public PreviewMarginFactDto FavoriteWonByMargin { get; set; } = new();
+
+        /// <summary>Last time the underdog lost to ANY opponent by ≥ Magnitude.</summary>
+        public PreviewMarginFactDto UnderdogLostByMargin { get; set; } = new();
+
+        /// <summary>ATS record as a favorite of BucketThreshold+; null when the bucket doesn't apply (small lines).</summary>
+        public PreviewAtsBucketFactDto? FavoriteAtsAsBigFavorite { get; set; }
+
+        public PreviewAtsBucketFactDto? UnderdogAtsAsBigUnderdog { get; set; }
+    }
+
+    /// <summary>
+    /// "When is the last time this team won/lost a game by ≥ X?" —
+    /// score-margin tier, full corpus. A null LastGame means it has not
+    /// happened within the searched window (SearchFloorSeason onward), which
+    /// is itself the headline fact.
+    /// </summary>
+    public class PreviewMarginFactDto
+    {
+        public PreviewGameResultDto? LastGame { get; set; }
+
+        /// <summary>The qualifying game's opponent record THAT season ("3-9"); null when unsourced.</summary>
+        public string? OpponentSeasonRecord { get; set; }
+
+        /// <summary>The opponent's record the season BEFORE the qualifying game ("2-10").</summary>
+        public string? OpponentPriorSeasonRecord { get; set; }
+
+        /// <summary>How many times it happened in the five seasons before the target contest.</summary>
+        public int CountLastFiveSeasons { get; set; }
+
+        /// <summary>Earliest season in the corpus for this franchise — the honest search floor.</summary>
+        public int SearchFloorSeason { get; set; }
+    }
+
+    /// <summary>
+    /// ATS record conditioned on spread size ("as a 35+ underdog") — market
+    /// tier, spread VALUES exist ~2022+. Games counts decided results only
+    /// (pushes / unsourced ATS results excluded).
+    /// </summary>
+    public class PreviewAtsBucketFactDto
+    {
+        /// <summary>Key-number bucket applied (largest of 3/7/10/14/21/28/35 ≤ Magnitude).</summary>
+        public double Threshold { get; set; }
+
+        public int Games { get; set; }
+
+        public int Covers { get; set; }
+
+        /// <summary>Floor season of the spread-value data tier (currently 2022).</summary>
+        public int DataFloorSeason { get; set; }
     }
 
     /// <summary>

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -228,7 +228,10 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                     FranchiseId = franchiseId,
                     Margin = margin,
                     AsOf = asOf,
-                    WindowStartSeason = targetSeasonYear - 5,
+                    // "Last 5 seasons" = the target's (partial, as-of-capped)
+                    // season plus the four before it — exactly five season
+                    // labels. A blowout three weeks ago belongs in the count.
+                    WindowStartSeason = targetSeasonYear - 4,
                     Won = won
                 },
                 cancellationToken: cancellationToken));
@@ -317,9 +320,14 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
         if (stats is null)
             return null;
 
-        var wins = (int)(stats.FirstOrDefault(st => st.Name == StatWins)?.Value ?? 0);
-        var losses = (int)(stats.FirstOrDefault(st => st.Name == StatLosses)?.Value ?? 0);
-        return $"{wins}-{losses}";
+        // Both stats or nothing: defaulting a missing side to 0 fabricates a
+        // record ("0-12"), and absent-stays-null is this feature's honesty rule.
+        var wins = stats.FirstOrDefault(st => st.Name == StatWins)?.Value;
+        var losses = stats.FirstOrDefault(st => st.Name == StatLosses)?.Value;
+        if (wins is null || losses is null)
+            return null;
+
+        return $"{(int)wins}-{(int)losses}";
     }
 
     /// <summary>Overall W-L string for the season BEFORE the given FranchiseSeason (cross-season identity via Franchise).</summary>

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -106,7 +106,240 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                 target.HomeTeamFranchiseSeasonId, target.SeasonYear, cancellationToken);
         }
 
+        dto.SpreadContext = await BuildSpreadContextAsync(connection, query.ContestId, cancellationToken);
+
         return new Success<ContestPreviewHistoryDto>(dto);
+    }
+
+    // ─── Spread-conditioned facts ───────────────────────────────────────────
+
+    /// <summary>Spread-value data exists from this season on (odds-era floor).</summary>
+    private const int MarketDataFloorSeason = 2022;
+
+    /// <summary>
+    /// ATS facts bucket on football key numbers rather than the exact line:
+    /// "as a 35+ favorite" reads naturally and accrues a meaningful sample,
+    /// where "as a 38.5-point favorite" would almost always be n=0.
+    /// </summary>
+    private static readonly double[] AtsKeyNumbers = [3, 7, 10, 14, 21, 28, 35];
+
+    private class SpreadTargetRow
+    {
+        public DateTime StartDateUtc { get; set; }
+        public int SeasonYear { get; set; }
+        public Guid AwayFranchiseId { get; set; }
+        public Guid HomeFranchiseId { get; set; }
+        public string AwayTeam { get; set; } = default!;
+        public string HomeTeam { get; set; } = default!;
+        public double? HomeSpread { get; set; }
+        public string? SpreadDetails { get; set; }
+    }
+
+    private class MarginFactRow
+    {
+        public DateTime? GameDate { get; set; }
+        public int? SeasonYear { get; set; }
+        public string? Phase { get; set; }
+        public string? Note { get; set; }
+        public string? HomeTeam { get; set; }
+        public string? AwayTeam { get; set; }
+        public int? HomeScore { get; set; }
+        public int? AwayScore { get; set; }
+        public string? Winner { get; set; }
+        public string? SpreadWinner { get; set; }
+        public Guid? OpponentFranchiseSeasonId { get; set; }
+        public int CountLastFiveSeasons { get; set; }
+        public int? SearchFloorSeason { get; set; }
+    }
+
+    private class AtsBucketRow
+    {
+        public int Games { get; set; }
+        public int Covers { get; set; }
+    }
+
+    /// <summary>
+    /// Facts conditioned on the target contest's live line: when each side
+    /// last won/lost by the spread's magnitude (score tier, full corpus,
+    /// with the qualifying opponent's records as quality context) and each
+    /// side's ATS record at the nearest key-number bucket (market tier,
+    /// odds era only). Null when the contest has no line — the block is
+    /// spread-derived and meaningless without one.
+    /// </summary>
+    private async Task<PreviewSpreadContextDto?> BuildSpreadContextAsync(
+        System.Data.Common.DbConnection connection,
+        Guid contestId,
+        CancellationToken cancellationToken)
+    {
+        var target = await connection.QueryFirstOrDefaultAsync<SpreadTargetRow>(
+            new CommandDefinition(
+                _sqlProvider.GetContestSpreadTarget(),
+                new { ContestId = contestId },
+                cancellationToken: cancellationToken));
+
+        if (target?.HomeSpread is null || target.HomeSpread.Value == 0)
+            return null;
+
+        var homeFavored = target.HomeSpread.Value < 0;
+        var magnitude = Math.Abs(target.HomeSpread.Value);
+        var favoriteFranchiseId = homeFavored ? target.HomeFranchiseId : target.AwayFranchiseId;
+        var underdogFranchiseId = homeFavored ? target.AwayFranchiseId : target.HomeFranchiseId;
+
+        var context = new PreviewSpreadContextDto
+        {
+            FavoriteTeam = homeFavored ? target.HomeTeam : target.AwayTeam,
+            UnderdogTeam = homeFavored ? target.AwayTeam : target.HomeTeam,
+            Magnitude = magnitude,
+            SpreadDetails = target.SpreadDetails,
+            FavoriteWonByMargin = await BuildMarginFactAsync(
+                connection, favoriteFranchiseId, magnitude, target.StartDateUtc,
+                target.SeasonYear, won: true, cancellationToken),
+            UnderdogLostByMargin = await BuildMarginFactAsync(
+                connection, underdogFranchiseId, magnitude, target.StartDateUtc,
+                target.SeasonYear, won: false, cancellationToken)
+        };
+
+        var threshold = AtsKeyNumbers.Where(k => k <= magnitude).DefaultIfEmpty(0).Max();
+        if (threshold > 0)
+        {
+            context.FavoriteAtsAsBigFavorite = await BuildAtsBucketFactAsync(
+                connection, favoriteFranchiseId, threshold, target.StartDateUtc, asFavorite: true, cancellationToken);
+            context.UnderdogAtsAsBigUnderdog = await BuildAtsBucketFactAsync(
+                connection, underdogFranchiseId, threshold, target.StartDateUtc, asFavorite: false, cancellationToken);
+        }
+
+        return context;
+    }
+
+    private async Task<PreviewMarginFactDto> BuildMarginFactAsync(
+        System.Data.Common.DbConnection connection,
+        Guid franchiseId,
+        double margin,
+        DateTime asOf,
+        int targetSeasonYear,
+        bool won,
+        CancellationToken cancellationToken)
+    {
+        var row = await connection.QueryFirstOrDefaultAsync<MarginFactRow>(
+            new CommandDefinition(
+                _sqlProvider.GetFranchiseMarginFact(),
+                new
+                {
+                    FranchiseId = franchiseId,
+                    Margin = margin,
+                    AsOf = asOf,
+                    WindowStartSeason = targetSeasonYear - 5,
+                    Won = won
+                },
+                cancellationToken: cancellationToken));
+
+        var fact = new PreviewMarginFactDto
+        {
+            CountLastFiveSeasons = row?.CountLastFiveSeasons ?? 0,
+            SearchFloorSeason = row?.SearchFloorSeason ?? targetSeasonYear
+        };
+
+        if (row?.GameDate is null)
+            return fact; // never happened within the corpus — the headline case
+
+        fact.LastGame = new PreviewGameResultDto
+        {
+            GameDate = row.GameDate.Value,
+            SeasonYear = row.SeasonYear ?? 0,
+            Phase = row.Phase,
+            Note = row.Note,
+            HomeTeam = row.HomeTeam!,
+            AwayTeam = row.AwayTeam!,
+            HomeScore = row.HomeScore,
+            AwayScore = row.AwayScore,
+            Winner = row.Winner,
+            SpreadWinner = row.SpreadWinner
+        };
+
+        // Opponent quality is what turns the fact into an argument: a
+        // 40-point win over a 2-10 doormat and one over a bowl team are
+        // different evidence. Records come from FranchiseSeasonRecord —
+        // absent stays null (never a fabricated 0-0).
+        if (row.OpponentFranchiseSeasonId is not null)
+        {
+            fact.OpponentSeasonRecord = await GetOverallRecordAsync(
+                row.OpponentFranchiseSeasonId.Value, cancellationToken);
+            fact.OpponentPriorSeasonRecord = await GetPriorSeasonOverallRecordAsync(
+                row.OpponentFranchiseSeasonId.Value, cancellationToken);
+        }
+
+        return fact;
+    }
+
+    private async Task<PreviewAtsBucketFactDto> BuildAtsBucketFactAsync(
+        System.Data.Common.DbConnection connection,
+        Guid franchiseId,
+        double threshold,
+        DateTime asOf,
+        bool asFavorite,
+        CancellationToken cancellationToken)
+    {
+        var row = await connection.QueryFirstOrDefaultAsync<AtsBucketRow>(
+            new CommandDefinition(
+                _sqlProvider.GetFranchiseAtsBucket(),
+                new
+                {
+                    FranchiseId = franchiseId,
+                    Threshold = threshold,
+                    AsOf = asOf,
+                    AsFavorite = asFavorite
+                },
+                cancellationToken: cancellationToken));
+
+        return new PreviewAtsBucketFactDto
+        {
+            Threshold = threshold,
+            Games = row?.Games ?? 0,
+            Covers = row?.Covers ?? 0,
+            DataFloorSeason = MarketDataFloorSeason
+        };
+    }
+
+    /// <summary>Overall W-L string ("3-9") for one FranchiseSeason; null when unsourced.</summary>
+    private async Task<string?> GetOverallRecordAsync(
+        Guid franchiseSeasonId,
+        CancellationToken cancellationToken)
+    {
+        var stats = await _dbContext.FranchiseSeasonRecords
+            .AsNoTracking()
+            .Where(r => r.FranchiseSeasonId == franchiseSeasonId && r.Type == RecordTypeTotal)
+            .Select(r => r.Stats
+                .Where(st => st.Name == StatWins || st.Name == StatLosses)
+                .Select(st => new { st.Name, st.Value })
+                .ToList())
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (stats is null)
+            return null;
+
+        var wins = (int)(stats.FirstOrDefault(st => st.Name == StatWins)?.Value ?? 0);
+        var losses = (int)(stats.FirstOrDefault(st => st.Name == StatLosses)?.Value ?? 0);
+        return $"{wins}-{losses}";
+    }
+
+    /// <summary>Overall W-L string for the season BEFORE the given FranchiseSeason (cross-season identity via Franchise).</summary>
+    private async Task<string?> GetPriorSeasonOverallRecordAsync(
+        Guid franchiseSeasonId,
+        CancellationToken cancellationToken)
+    {
+        var priorSeasonId = await _dbContext.FranchiseSeasons
+            .AsNoTracking()
+            .Where(current => current.Id == franchiseSeasonId)
+            .SelectMany(current => _dbContext.FranchiseSeasons
+                .Where(prior => prior.FranchiseId == current.FranchiseId
+                             && prior.SeasonYear == current.SeasonYear - 1))
+            .Select(prior => (Guid?)prior.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (priorSeasonId is null)
+            return null;
+
+        return await GetOverallRecordAsync(priorSeasonId.Value, cancellationToken);
     }
 
     // FranchiseSeasonRecord.Type values (ESPN vocabulary): the season

--- a/src/SportsData.Producer/Infrastructure/Sql/GetContestSpreadTarget.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetContestSpreadTarget.sql
@@ -1,0 +1,31 @@
+-- The target contest's live line + franchise identities, feeding the
+-- spread-context facts (PreviewSpreadContextDto). Same preferred-provider
+-- lateral as the matchup payload so both surfaces quote the same number.
+-- HomeSpread is home-relative (negative = home favored). NULL spread rows
+-- mean no line from the preferred/fallback providers -> no spread context.
+SELECT
+    c."StartDateUtc"      AS "StartDateUtc",
+    c."SeasonYear"        AS "SeasonYear",
+    fsAway."FranchiseId"  AS "AwayFranchiseId",
+    fsHome."FranchiseId"  AS "HomeFranchiseId",
+    fAway."DisplayName"   AS "AwayTeam",
+    fHome."DisplayName"   AS "HomeTeam",
+    co."Spread"           AS "HomeSpread",
+    co."Details"          AS "SpreadDetails"
+FROM public."Contest" c
+INNER JOIN public."Competition" comp ON comp."ContestId" = c."Id"
+LEFT JOIN LATERAL (
+    SELECT *
+    FROM public."CompetitionOdds"
+    WHERE "CompetitionId" = comp."Id"
+      AND "ProviderId" IN ('{PreferredOddsProviderId}', '{FallbackOddsProviderId}')
+      AND "Spread" IS NOT NULL
+    ORDER BY CASE WHEN "ProviderId" = '{PreferredOddsProviderId}' THEN 1 ELSE 2 END
+    LIMIT 1
+) co ON TRUE
+INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
+INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
+WHERE c."Id" = @ContestId
+LIMIT 1

--- a/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseAtsBucket.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseAtsBucket.sql
@@ -1,0 +1,37 @@
+-- ATS record for one franchise conditioned on spread size: as a FAVORITE of
+-- @Threshold+ (@AsFavorite = TRUE) or an UNDERDOG of @Threshold+ (FALSE).
+-- Market tier: requires historical spread VALUES (preferred/fallback
+-- providers, present ~2022+), so counts are honest only within that window —
+-- the handler stamps the data-floor season on the DTO. Games counts DECIDED
+-- ATS results only (SpreadWinner null = push or unsourced -> excluded).
+-- Preview-safe: finalized/non-cancelled, strictly before @AsOf, preseason
+-- excluded, NULL phase kept.
+SELECT
+    COUNT(*) AS "Games",
+    COUNT(*) FILTER (
+        WHERE (fsHome."FranchiseId" = @FranchiseId AND c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId")
+           OR (fsAway."FranchiseId" = @FranchiseId AND c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId")
+    ) AS "Covers"
+FROM public."Contest" c
+INNER JOIN public."Competition" comp ON comp."ContestId" = c."Id"
+INNER JOIN LATERAL (
+    SELECT *
+    FROM public."CompetitionOdds"
+    WHERE "CompetitionId" = comp."Id"
+      AND "ProviderId" IN ('{PreferredOddsProviderId}', '{FallbackOddsProviderId}')
+      AND "Spread" IS NOT NULL
+    ORDER BY CASE WHEN "ProviderId" = '{PreferredOddsProviderId}' THEN 1 ELSE 2 END
+    LIMIT 1
+) co ON TRUE
+INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+LEFT JOIN public."SeasonPhase" sp ON sp."Id" = c."SeasonPhaseId"
+WHERE c."FinalizedUtc" IS NOT NULL
+  AND c."CancelledUtc" IS NULL
+  AND c."StartDateUtc" < @AsOf
+  AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+  AND c."SpreadWinnerFranchiseSeasonId" IS NOT NULL
+  AND (
+        (fsHome."FranchiseId" = @FranchiseId AND ((@AsFavorite AND co."Spread" <= -@Threshold) OR (NOT @AsFavorite AND co."Spread" >= @Threshold)))
+     OR (fsAway."FranchiseId" = @FranchiseId AND ((@AsFavorite AND co."Spread" >= @Threshold) OR (NOT @AsFavorite AND co."Spread" <= -@Threshold)))
+  )

--- a/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseMarginFact.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseMarginFact.sql
@@ -1,0 +1,82 @@
+-- Margin fact for one franchise: the most recent game it WON by >= @Margin
+-- (@Won = TRUE) or LOST by >= @Margin (@Won = FALSE), plus how often that
+-- happened in the five seasons before the target, and the franchise's
+-- earliest corpus season (the honest search floor). Score-margin tier: runs
+-- on final scores only, no odds required.
+-- Preview-safe by construction: finalized/non-cancelled, strictly before
+-- @AsOf, preseason (SeasonPhase.TypeCode 1) excluded, NULL phase kept.
+WITH franchise_games AS (
+    SELECT
+        c."StartDateUtc",
+        c."SeasonYear",
+        sp."Name" AS "Phase",
+        c."EventNote" AS "Note",
+        fHome."DisplayName" AS "HomeTeam",
+        fAway."DisplayName" AS "AwayTeam",
+        c."HomeScore",
+        c."AwayScore",
+        CASE
+            WHEN c."WinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."DisplayName"
+            WHEN c."WinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."DisplayName"
+            ELSE NULL
+        END AS "Winner",
+        CASE
+            WHEN c."SpreadWinnerFranchiseSeasonId" = c."HomeTeamFranchiseSeasonId" THEN fHome."DisplayName"
+            WHEN c."SpreadWinnerFranchiseSeasonId" = c."AwayTeamFranchiseSeasonId" THEN fAway."DisplayName"
+            ELSE NULL
+        END AS "SpreadWinner",
+        CASE WHEN fsHome."FranchiseId" = @FranchiseId
+             THEN c."AwayTeamFranchiseSeasonId"
+             ELSE c."HomeTeamFranchiseSeasonId"
+        END AS "OpponentFranchiseSeasonId",
+        CASE WHEN fsHome."FranchiseId" = @FranchiseId
+             THEN c."HomeScore" - c."AwayScore"
+             ELSE c."AwayScore" - c."HomeScore"
+        END AS "OurMargin"
+    FROM public."Contest" c
+    INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+    INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
+    INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+    INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
+    LEFT JOIN public."SeasonPhase" sp ON sp."Id" = c."SeasonPhaseId"
+    WHERE (fsHome."FranchiseId" = @FranchiseId OR fsAway."FranchiseId" = @FranchiseId)
+      AND c."FinalizedUtc" IS NOT NULL
+      AND c."CancelledUtc" IS NULL
+      AND c."HomeScore" IS NOT NULL
+      AND c."AwayScore" IS NOT NULL
+      AND c."StartDateUtc" < @AsOf
+      AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+),
+qualifying AS (
+    SELECT *
+    FROM franchise_games
+    WHERE (@Won AND "OurMargin" >= @Margin)
+       OR (NOT @Won AND "OurMargin" <= -@Margin)
+)
+-- Always exactly one row: "it has never happened" is the headline case and
+-- must still carry the count (0) and the franchise's corpus floor.
+SELECT
+    q."StartDateUtc" AS "GameDate",
+    q."SeasonYear",
+    q."Phase",
+    q."Note",
+    q."HomeTeam",
+    q."AwayTeam",
+    q."HomeScore",
+    q."AwayScore",
+    q."Winner",
+    q."SpreadWinner",
+    q."OpponentFranchiseSeasonId",
+    cnt."CountLastFiveSeasons",
+    fl."SearchFloorSeason"
+FROM (SELECT 1) AS one
+LEFT JOIN LATERAL (
+    SELECT * FROM qualifying ORDER BY "StartDateUtc" DESC LIMIT 1
+) q ON TRUE
+CROSS JOIN LATERAL (
+    SELECT COUNT(*) AS "CountLastFiveSeasons"
+    FROM qualifying WHERE "SeasonYear" >= @WindowStartSeason
+) cnt
+CROSS JOIN LATERAL (
+    SELECT MIN("SeasonYear") AS "SearchFloorSeason" FROM franchise_games
+) fl

--- a/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
+++ b/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
@@ -20,6 +20,9 @@ public class ProducerSqlQueryProvider
         "GetRankingsByPollByWeek.sql",
         "GetContestHeadToHeadResults.sql",
         "GetContestPriorSeasonResults.sql",
+        "GetContestSpreadTarget.sql",
+        "GetFranchiseMarginFact.sql",
+        "GetFranchiseAtsBucket.sql",
         "GetFranchiseSeasonCompetitionResults.sql",
         "GetFranchiseSeasonPreviewStats.sql",
         "GetFranchiseSeasonStatistics.sql",
@@ -104,6 +107,12 @@ public class ProducerSqlQueryProvider
     public string GetContestHeadToHeadResults() => Get("GetContestHeadToHeadResults.sql");
 
     public string GetContestPriorSeasonResults() => Get("GetContestPriorSeasonResults.sql");
+
+    public string GetContestSpreadTarget() => Get("GetContestSpreadTarget.sql");
+
+    public string GetFranchiseMarginFact() => Get("GetFranchiseMarginFact.sql");
+
+    public string GetFranchiseAtsBucket() => Get("GetFranchiseAtsBucket.sql");
 
     public string GetFranchiseSeasonCompetitionResults() => Get("GetFranchiseSeasonCompetitionResults.sql");
 

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -353,7 +353,9 @@ export function StatsComparisonModal({
     homePriorGames.length > 0 ||
     history?.awayPriorSeason != null ||
     history?.homePriorSeason != null ||
-    history?.spreadContext != null;
+    // Spread context only counts when it can actually render — it is
+    // gambling-gated, and a hidden-only history would open an empty tab.
+    (showGambling && history?.spreadContext != null);
 
   // Head-to-head wins among the displayed meetings (ties count for neither).
   const h2hWinsAway = headToHead.filter((g) => g.winner === matchup.away).length;

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -352,7 +352,8 @@ export function StatsComparisonModal({
     awayPriorGames.length > 0 ||
     homePriorGames.length > 0 ||
     history?.awayPriorSeason != null ||
-    history?.homePriorSeason != null;
+    history?.homePriorSeason != null ||
+    history?.spreadContext != null;
 
   // Head-to-head wins among the displayed meetings (ties count for neither).
   const h2hWinsAway = headToHead.filter((g) => g.winner === matchup.away).length;

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -12,8 +12,11 @@ import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type {
+  ContestAtsBucketFact,
   ContestHistoryGame,
+  ContestMarginFact,
   ContestPriorSeasonSummary,
+  ContestSpreadContext,
   Matchup,
   TeamComparisonData,
   TeamStatEntry,
@@ -243,6 +246,72 @@ function priorSeasonRecordLabel(summary: ContestPriorSeasonSummary | null | unde
   return `${summary.seasonYear}: ${summary.wins}-${summary.losses}${conf}`;
 }
 
+// ─── "The Line" — spread-context fact sentences ───────────────────────────────
+// Deterministic sentences composed from server-computed facts — every number
+// comes from a query, never from prose. Mirrors the web dialog's wording.
+
+type LineFact = { head: string; detail: string };
+
+function marginFactSentence(
+  teamName: string,
+  fact: ContestMarginFact | null | undefined,
+  magnitude: number,
+  won: boolean,
+): LineFact | null {
+  if (!fact) return null;
+  if (!fact.lastGame) {
+    return {
+      head: `${teamName} ${won ? 'has never won' : 'has never lost'} a game by ${magnitude}+`,
+      detail: `in our records (back to ${fact.searchFloorSeason}).`,
+    };
+  }
+  const g = fact.lastGame;
+  const isHome = g.homeTeam === teamName;
+  const ourScore = isHome ? g.homeScore : g.awayScore;
+  const theirScore = isHome ? g.awayScore : g.homeScore;
+  const opponent = isHome ? g.awayTeam : g.homeTeam;
+  const when = formatGameDate(g.gameDate);
+  const quality =
+    fact.opponentSeasonRecord || fact.opponentPriorSeasonRecord
+      ? ` (they went ${fact.opponentSeasonRecord ?? '?'}${
+          fact.opponentPriorSeasonRecord ? `; ${fact.opponentPriorSeasonRecord} the season before` : ''
+        })`
+      : '';
+  const times = fact.countLastFiveSeasons;
+  return {
+    head: `Last time ${teamName} ${won ? 'won' : 'lost'} by ${magnitude}+:`,
+    detail: `${when} — ${won ? 'beat' : 'lost to'} ${opponent} ${ourScore ?? '—'}-${theirScore ?? '—'}${quality}. ${times} such ${won ? 'win' : 'loss'}${times === 1 ? '' : won ? 's' : 'es'} in the last 5 seasons.`,
+  };
+}
+
+function atsFactSentence(
+  teamName: string,
+  fact: ContestAtsBucketFact | null | undefined,
+  asFavorite: boolean,
+): LineFact | null {
+  if (!fact) return null;
+  const role = `${fact.threshold}+ ${asFavorite ? 'favorite' : 'underdog'}`;
+  if (fact.games === 0) {
+    return {
+      head: `${teamName} as a ${role}:`,
+      detail: `no games with a line that large since ${fact.dataFloorSeason}.`,
+    };
+  }
+  return {
+    head: `${teamName} as a ${role}:`,
+    detail: `covered ${fact.covers} of ${fact.games} (since ${fact.dataFloorSeason}).`,
+  };
+}
+
+function spreadContextFacts(ctx: ContestSpreadContext): LineFact[] {
+  return [
+    marginFactSentence(ctx.favoriteTeam, ctx.favoriteWonByMargin, ctx.magnitude, true),
+    marginFactSentence(ctx.underdogTeam, ctx.underdogLostByMargin, ctx.magnitude, false),
+    atsFactSentence(ctx.favoriteTeam, ctx.favoriteAtsAsBigFavorite, true),
+    atsFactSentence(ctx.underdogTeam, ctx.underdogAtsAsBigUnderdog, false),
+  ].filter((f): f is LineFact => f != null);
+}
+
 // ─── StatsComparisonModal ─────────────────────────────────────────────────────
 
 export function StatsComparisonModal({
@@ -370,6 +439,21 @@ export function StatsComparisonModal({
                 showsVerticalScrollIndicator={false}
                 contentContainerStyle={styles.historyContent}
               >
+                {showGambling && history?.spreadContext && (
+                  <>
+                    <Text style={[styles.historySectionTitle, { color: theme.text }]}>
+                      The Line
+                      {history.spreadContext.spreadDetails ? ` — ${history.spreadContext.spreadDetails}` : ''}
+                    </Text>
+                    {spreadContextFacts(history.spreadContext).map((f, i) => (
+                      <View key={i} style={[styles.lineFact, { borderBottomColor: theme.border }]}>
+                        <Text style={[styles.lineFactText, { color: theme.text }]}>
+                          <Text style={styles.lineFactHead}>{f.head}</Text> {f.detail}
+                        </Text>
+                      </View>
+                    ))}
+                  </>
+                )}
                 {headToHead.length > 0 && (
                   <>
                     <Text style={[styles.historySectionTitle, { color: theme.text }]}>
@@ -784,6 +868,17 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontStyle: 'italic',
     paddingVertical: 4,
+  },
+  lineFact: {
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  lineFactText: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  lineFactHead: {
+    fontWeight: '700',
   },
 
   barTrack: {

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -352,6 +352,42 @@ export interface ContestPriorSeasonSummary {
 }
 
 /**
+ * "When is the last time this team won/lost by ≥ X?" — score-margin tier.
+ * A null lastGame means it has not happened within the searched window
+ * (searchFloorSeason onward), which is itself the headline fact.
+ */
+export interface ContestMarginFact {
+  lastGame?: ContestHistoryGame | null;
+  opponentSeasonRecord?: string | null;
+  opponentPriorSeasonRecord?: string | null;
+  countLastFiveSeasons: number;
+  searchFloorSeason: number;
+}
+
+/** ATS record conditioned on spread size ("as a 35+ underdog") — market tier (~2022+). */
+export interface ContestAtsBucketFact {
+  threshold: number;
+  games: number;
+  covers: number;
+  dataFloorSeason: number;
+}
+
+/**
+ * Facts conditioned on the target contest's CURRENT spread. Spread-derived —
+ * display must be gated behind the gambling-content preference.
+ */
+export interface ContestSpreadContext {
+  favoriteTeam: string;
+  underdogTeam: string;
+  magnitude: number;
+  spreadDetails?: string | null;
+  favoriteWonByMargin: ContestMarginFact;
+  underdogLostByMargin: ContestMarginFact;
+  favoriteAtsAsBigFavorite?: ContestAtsBucketFact | null;
+  underdogAtsAsBigUnderdog?: ContestAtsBucketFact | null;
+}
+
+/**
  * Historical context for a matchup: recent head-to-head meetings plus each
  * team's late-prior-season form — the same blocks the preview/insight models
  * consume. Away/Home here refer to the LIVE matchup's sides.
@@ -362,6 +398,8 @@ export interface ContestHistory {
   homePriorSeasonGames: ContestHistoryGame[];
   awayPriorSeason?: ContestPriorSeasonSummary | null;
   homePriorSeason?: ContestPriorSeasonSummary | null;
+  /** Null when the contest has no line from the preferred providers. */
+  spreadContext?: ContestSpreadContext | null;
 }
 
 /** Assembled comparison object used by StatsComparisonModal */

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -410,7 +410,9 @@ function MatchupCard({
       const hasHistory = Boolean(
         h && (
           h.headToHead?.length || h.awayPriorSeasonGames?.length || h.homePriorSeasonGames?.length ||
-          h.awayPriorSeason != null || h.homePriorSeason != null || h.spreadContext != null
+          h.awayPriorSeason != null || h.homePriorSeason != null ||
+          // Gambling-gated: spread context only counts when it can render.
+          (showGambling && h.spreadContext != null)
         )
       );
       const hasAnyData =

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -410,7 +410,7 @@ function MatchupCard({
       const hasHistory = Boolean(
         h && (
           h.headToHead?.length || h.awayPriorSeasonGames?.length || h.homePriorSeasonGames?.length ||
-          h.awayPriorSeason != null || h.homePriorSeason != null
+          h.awayPriorSeason != null || h.homePriorSeason != null || h.spreadContext != null
         )
       );
       const hasAnyData =

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.css
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.css
@@ -606,3 +606,21 @@
     flex-wrap: wrap;
   }
 }
+
+/* "The Line" — spread-context facts */
+.line-fact {
+  padding: 0.4rem 0.75rem;
+  border-radius: 8px;
+  background: var(--hover-bg);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.line-fact-head {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.line-fact-detail {
+  color: var(--text-primary);
+}

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -36,7 +36,9 @@ export default function TeamComparison({
     teamBPriorGames.length > 0 ||
     teamAPriorSeason != null ||
     teamBPriorSeason != null ||
-    history?.spreadContext != null;
+    // Spread context only counts when it can actually render — it is
+    // gambling-gated, and a hidden-only history would open an empty tab.
+    (showGambling && history?.spreadContext != null);
 
   // Main tab state. History is the overview and opens first; Statistics and
   // Metrics are the detail tabs. Statistics only leads when there is no

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -623,6 +623,85 @@ export default function TeamComparison({
     </div>
   );
 
+  // ─── Spread-context facts ("The Line") ───────────────────────────────────
+  // Deterministic sentences composed from server-computed facts — every
+  // number comes from a query, never from prose. The whole block is
+  // spread-derived, so it renders only when showGambling allows.
+
+  const spreadContext = history?.spreadContext ?? null;
+
+  const fmtLine = (n) => String(n);
+
+  const marginFactSentence = (teamName, fact, magnitude, won) => {
+    if (!fact) return null;
+    if (!fact.lastGame) {
+      return {
+        head: `${teamName} ${won ? "has never won" : "has never lost"} a game by ${fmtLine(magnitude)}+`,
+        detail: `in our records (back to ${fact.searchFloorSeason}).`,
+      };
+    }
+    const g = fact.lastGame;
+    const isHome = g.homeTeam === teamName;
+    const ourScore = isHome ? g.homeScore : g.awayScore;
+    const theirScore = isHome ? g.awayScore : g.homeScore;
+    const opponent = isHome ? g.awayTeam : g.homeTeam;
+    const when = new Date(g.gameDate).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+    const quality =
+      fact.opponentSeasonRecord || fact.opponentPriorSeasonRecord
+        ? ` (they went ${fact.opponentSeasonRecord ?? "?"}${
+            fact.opponentPriorSeasonRecord ? `; ${fact.opponentPriorSeasonRecord} the season before` : ""
+          })`
+        : "";
+    const times = fact.countLastFiveSeasons;
+    return {
+      head: `Last time ${teamName} ${won ? "won" : "lost"} by ${fmtLine(magnitude)}+:`,
+      detail: `${when} — ${won ? "beat" : "lost to"} ${opponent} ${ourScore}-${theirScore}${quality}. ${times} such ${won ? "win" : "loss"}${times === 1 ? "" : won ? "s" : "es"} in the last 5 seasons.`,
+    };
+  };
+
+  const atsFactSentence = (teamName, fact, asFavorite) => {
+    if (!fact) return null;
+    const role = `${fmtLine(fact.threshold)}+ ${asFavorite ? "favorite" : "underdog"}`;
+    if (fact.games === 0) {
+      return {
+        head: `${teamName} as a ${role}:`,
+        detail: `no games with a line that large since ${fact.dataFloorSeason}.`,
+      };
+    }
+    return {
+      head: `${teamName} as a ${role}:`,
+      detail: `covered ${fact.covers} of ${fact.games} (since ${fact.dataFloorSeason}).`,
+    };
+  };
+
+  const renderSpreadContext = () => {
+    if (!showGambling || !spreadContext) return null;
+    const facts = [
+      marginFactSentence(spreadContext.favoriteTeam, spreadContext.favoriteWonByMargin, spreadContext.magnitude, true),
+      marginFactSentence(spreadContext.underdogTeam, spreadContext.underdogLostByMargin, spreadContext.magnitude, false),
+      atsFactSentence(spreadContext.favoriteTeam, spreadContext.favoriteAtsAsBigFavorite, true),
+      atsFactSentence(spreadContext.underdogTeam, spreadContext.underdogAtsAsBigUnderdog, false),
+    ].filter(Boolean);
+    if (facts.length === 0) return null;
+    return (
+      <div className="history-section">
+        <div className="history-section-title">
+          The Line{spreadContext.spreadDetails ? ` — ${spreadContext.spreadDetails}` : ""}
+        </div>
+        {facts.map((f, i) => (
+          <div className="line-fact" key={i}>
+            <span className="line-fact-head">{f.head}</span>{" "}
+            <span className="line-fact-detail">{f.detail}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
   const renderHistoryTab = () => {
     if (!hasHistoryData) {
       return (
@@ -636,6 +715,7 @@ export default function TeamComparison({
 
     return (
       <div className="history-content">
+        {renderSpreadContext()}
         {headToHead.length > 0 && (
           <div className="history-section">
             <div className="history-section-title">

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -35,7 +35,8 @@ export default function TeamComparison({
     teamAPriorGames.length > 0 ||
     teamBPriorGames.length > 0 ||
     teamAPriorSeason != null ||
-    teamBPriorSeason != null;
+    teamBPriorSeason != null ||
+    history?.spreadContext != null;
 
   // Main tab state. History is the overview and opens first; Statistics and
   // Metrics are the detail tabs. Statistics only leads when there is no


### PR DESCRIPTION
## Summary

Proactively answers the questions a user wouldn't think to ask about a line. For **USC -38.5** over San José State, the History tab now leads with:

> **Last time USC Trojans won by 38.5+:** Sep 6, 2025 — beat Georgia Southern Eagles 59-20 (they went 7-6; 3-9 the season before). 6 such wins in the last 5 seasons.
> **Last time San José State Spartans lost by 38.5+:** Nov 15, 2025 — lost to Nevada Wolf Pack 10-55 …
> **USC Trojans as a 35+ favorite:** covered 2 of 2 (since 2022).
> **San José State Spartans as a 35+ underdog:** covered 1 of 1 (since 2022).

Product framing: a **dimension, not a toll booth** — the casual's pick flow is untouched; the depth sits one tap away. Facts are **context, never prediction**: every number comes from a query, none from prose. Design doc: `docs/features/matchup-spread-context.md`.

## How it works

Producer computes `ContestPreviewHistoryDto.SpreadContext` inside the existing preview-history handler, so it rides the established relay (`/api/{sport}/{league}/contests/{id}/history`) to web and mobile with **zero API changes** — and sits one step from the model payload later (deliberately deferred).

Three new SQL queries:
- **GetContestSpreadTarget** — the target's live line via the same preferred-provider lateral (EspnBet → DraftKings) as the matchup payload, so every surface quotes the same number. No line → `SpreadContext` null → section absent.
- **GetFranchiseMarginFact** — most recent game the franchise won/lost by ≥ the *exact* magnitude, count over the last five seasons, and the franchise's earliest corpus season as the honest search floor. Always returns a row: "it has never happened" is the headline case and keeps its count and floor. The qualifying opponent's records (that season + prior, from `FranchiseSeasonRecord`) provide quality context — absent stays null, never a fabricated 0-0.
- **GetFranchiseAtsBucket** — ATS record bucketed on football key numbers `[3,7,10,14,21,28,35]` (largest ≤ magnitude); decided results only (pushes/unsourced excluded).

**Data tiers, each self-labeling:** margin facts run on the full scores corpus (per-franchise floor, e.g. USC: 2001); spread *results* exist from 2012; spread *values* from 2022 (`DataFloorSeason` on the DTO). The UI never implies completeness the data lacks.

All queries preview-safe (finalized, non-cancelled, strictly before target start, preseason excluded) — identical predicates to the existing history queries.

## Rendering

Web (`TeamComparison.jsx`) and mobile (`StatsComparisonModal.tsx`) compose deterministic sentences client-side from the structured facts and render them as "The Line — USC -38.5" at the top of the History tab. The **entire section is gated by `shouldShowGambling`** on both platforms.

## Validation

- SQL proven against local PG with the live SJSU@USC contest **twice**: raw psql and a Dapper harness using the handler's exact parameter binding — including the never-happened edge case (one row, nulls, count 0, floor intact)
- Producer build + suite green (562 passed; single failure = the pre-existing local-WIP one, unrelated); API builds against the extended DTO
- Web lint clean + 26/26 Vitest; mobile tsc clean + 133/133 Jest
- Validated E2E on the live SJSU @ USC card (both themes; gambling toggle hides the section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spread-based historical context to matchup history, including favorite/underdog details, margin trends, and against-the-spread records.
  * Added a “The Line” section to web and mobile history views when eligible spread data is available.
  * Added safeguards for missing lines and insufficient historical data.
* **Documentation**
  * Documented spread-conditioned matchup history, data availability, visibility rules, and display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->