### PR TITLE
feat(api,core): SpreadContext in preview payload + validation retry loop

### DIFF
--- a/docs/features/matchup-spread-context.md
+++ b/docs/features/matchup-spread-context.md
@@ -86,14 +86,27 @@ sentences composed client-side from the structured facts:
 The entire section is **gated by `shouldShowGambling`** on both platforms
 — the framing is spread-derived.
 
-## Future (not in v1)
+## Model-payload injection (v1.1)
 
-- Inject the fact chain into the preview/insight model payload
-  (`MatchupPreviewProcessor`) so the LLM narrative can cite it —
-  "model predicts, LLM explains" with pre-verified facts.
+`MatchupForPreviewDto.SpreadContext` carries the same block into the
+preview/insight prompt payload (`MatchupPreviewProcessor` copies it from
+the history fetch; the payload serializer's omit-null and GUID-hygiene
+rules apply — the block is names-and-numbers only, zero GUIDs). Because
+the facts are as-of-capped in Producer, capture/experiment runs on
+completed games stay leak-free.
+
+**Operator note:** the payload provides the facts; the PROMPT (blob-
+stored, never in this repo) decides what the model does with them.
+To activate the narrative angle, update the preview prompt in the
+Prompt Lab to instruct the model to cite `SpreadContext` facts verbatim
+when discussing the line — the model reads facts, never computes them.
+
+## Future
+
+- League-wide base rate ("35+ favorites cover X% overall") as the
+  anchor each team's number stands against.
 - More family members: cover streaks vs. opponent class, totals-based
-  facts ("teams hitting this O/U"), favorite-cover-rate league-wide at
-  this bucket as the base rate.
+  facts ("teams hitting this O/U").
 
 See memory `project_spread_contextualized_history` for the full product
 rationale and origin (2026-08-19, immediately post-#658).

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -219,22 +219,80 @@ namespace SportsData.Api.Application.Previews
                 return;
             }
 
-            // Run semantic validation
-            var validation = MatchupPreviewValidator.Validate(
-                contestId: command.ContestId,
-                homeScore: parsed.HomeScore,
-                awayScore: parsed.AwayScore,
-                homeSpread: assembled.Matchup.HomeSpread ?? 0,
-                predictedStraightUpWinner: parsed.PredictedStraightUpWinner,
-                predictedSpreadWinner: parsed.PredictedSpreadWinner,
-                homeFranchiseSeasonId: assembled.Matchup.HomeFranchiseSeasonId,
-                awayFranchiseSeasonId: assembled.Matchup.AwayFranchiseSeasonId
-            );
+            MatchupPreviewValidator.ValidationResult Validate(MatchupPreviewResponse p) =>
+                MatchupPreviewValidator.Validate(
+                    contestId: command.ContestId,
+                    homeScore: p.HomeScore,
+                    awayScore: p.AwayScore,
+                    homeSpread: assembled.Matchup.HomeSpread ?? 0,
+                    predictedStraightUpWinner: p.PredictedStraightUpWinner,
+                    predictedSpreadWinner: p.PredictedSpreadWinner,
+                    homeFranchiseSeasonId: assembled.Matchup.HomeFranchiseSeasonId,
+                    awayFranchiseSeasonId: assembled.Matchup.AwayFranchiseSeasonId);
+
+            // Truncate to the capture column's 1024-char cap.
+            static string ErrorText(List<string> errors)
+            {
+                var joined = string.Join("; ", errors);
+                return joined.Length <= 1024 ? joined : joined[..1024];
+            }
+
+            var validation = Validate(parsed);
+            var iterations = 1;
 
             if (!validation.IsValid)
             {
-                _logger.LogError("Validation failed. Errors: {Errors}", validation.Errors);
-                return;
+                // One bounded retry with the violations fed back — the
+                // automated twin of the human editor-rejection loop. Without
+                // it, a failed validation silently costs the game its preview
+                // until the next scheduled run rolls fresh dice. First-attempt
+                // errors stay on the capture either way, so the Lab shows the
+                // recovery, and IterationsRequired records the extra call.
+                _logger.LogWarning(
+                    "Preview validation failed for {ContestId} (attempt 1); retrying with feedback. Errors: {Errors}",
+                    command.ContestId, validation.Errors);
+                capture.ResponseValidationErrors = ErrorText(validation.Errors);
+
+                var retryPrompt =
+                    $"{assembled.FullPrompt}\n\nYour previous response:\n{rawResponse}\n\n" +
+                    $"It failed validation for these reasons:\n- {string.Join("\n- ", validation.Errors)}\n\n" +
+                    "Generate a corrected response that resolves every issue and keeps all fields consistent with each other.";
+
+                var retryResponse = await _aiCommunication.GetResponseAsync(retryPrompt, CancellationToken.None);
+                rawResponse = retryResponse.Value;
+                iterations = 2;
+
+                parsed = !retryResponse.IsSuccess || string.IsNullOrWhiteSpace(rawResponse)
+                    ? null
+                    : TryParseResponse(rawResponse);
+
+                if (parsed is null)
+                {
+                    // Persist the capture so the failure is auditable in the
+                    // Lab instead of vanishing with the log line.
+                    capture.Model = _aiCommunication.GetModelName();
+                    capture.RawResponse = string.IsNullOrWhiteSpace(rawResponse) ? null : rawResponse;
+                    await _dataContext.SaveChangesAsync();
+                    _logger.LogError(
+                        "Preview retry response unusable for {ContestId}; no preview written.",
+                        command.ContestId);
+                    return;
+                }
+
+                validation = Validate(parsed);
+                if (!validation.IsValid)
+                {
+                    // Attempt-1 errors were recorded above; append the retry's.
+                    capture.ResponseValidationErrors = ErrorText(
+                        [capture.ResponseValidationErrors!, .. validation.Errors.Select(e => $"Retry: {e}")]);
+                    capture.Model = _aiCommunication.GetModelName();
+                    capture.RawResponse = rawResponse;
+                    await _dataContext.SaveChangesAsync();
+                    _logger.LogError(
+                        "Preview validation failed after retry for {ContestId}; no preview written. Errors: {Errors}",
+                        command.ContestId, validation.Errors);
+                    return;
+                }
             }
 
             // We have a valid response (parsed + valid)
@@ -259,7 +317,7 @@ namespace SportsData.Api.Application.Previews
                 CreatedUtc = _dateTimeProvider.UtcNow(),
                 CreatedBy = command.CorrelationId,
                 PromptId = assembled.PromptId,
-                IterationsRequired = 1,
+                IterationsRequired = iterations,
                 UsedMetrics = assembled.Matchup.AwayMetrics != null
             };
 
@@ -304,6 +362,13 @@ namespace SportsData.Api.Application.Previews
                 matchup.HomePriorSeasonGames = historyResult.Value.HomePriorSeasonGames;
                 matchup.AwayPriorSeason = historyResult.Value.AwayPriorSeason;
                 matchup.HomePriorSeason = historyResult.Value.HomePriorSeason;
+
+                // Spread-conditioned facts ("The Line"): pre-verified numbers
+                // the narrative can cite — the model reads facts, never
+                // computes them. GUID-free by construction, and as-of-capped
+                // in Producer so capture/experiment runs on completed games
+                // stay leak-free.
+                matchup.SpreadContext = historyResult.Value.SpreadContext;
 
                 // Same both-or-nothing rule as current-season metrics:
                 // asymmetric analytics would bias the model toward the

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -230,13 +230,6 @@ namespace SportsData.Api.Application.Previews
                     homeFranchiseSeasonId: assembled.Matchup.HomeFranchiseSeasonId,
                     awayFranchiseSeasonId: assembled.Matchup.AwayFranchiseSeasonId);
 
-            // Truncate to the capture column's 1024-char cap.
-            static string ErrorText(List<string> errors)
-            {
-                var joined = string.Join("; ", errors);
-                return joined.Length <= 1024 ? joined : joined[..1024];
-            }
-
             var validation = Validate(parsed);
             var iterations = 1;
 
@@ -251,7 +244,9 @@ namespace SportsData.Api.Application.Previews
                 _logger.LogWarning(
                     "Preview validation failed for {ContestId} (attempt 1); retrying with feedback. Errors: {Errors}",
                     command.ContestId, validation.Errors);
-                capture.ResponseValidationErrors = ErrorText(validation.Errors);
+                var attempt1Errors = string.Join("; ", validation.Errors);
+                capture.ResponseValidationErrors =
+                    MatchupPreviewValidator.ComposeErrorSections(attempt1Errors, null);
 
                 var retryPrompt =
                     $"{assembled.FullPrompt}\n\nYour previous response:\n{rawResponse}\n\n" +
@@ -271,16 +266,18 @@ namespace SportsData.Api.Application.Previews
                     // Persist the capture so the failure is auditable in the
                     // Lab instead of vanishing with the log line — including
                     // WHY the retry produced nothing (request failure vs blank
-                    // vs unparsable), alongside the attempt-1 errors.
+                    // vs unparsable), alongside the attempt-1 errors. The
+                    // compose helper guarantees the retry section survives
+                    // truncation even when attempt-1 filled the column.
                     var retryDiagnostic = !retryResponse.IsSuccess
                         ? retryResponse is Failure<string> retryFailure
-                            ? $"Retry: AI request failed - {string.Join(", ", retryFailure.Errors.Select(x => x.ErrorMessage))}"
-                            : "Retry: AI request failed"
+                            ? $"AI request failed - {string.Join(", ", retryFailure.Errors.Select(x => x.ErrorMessage))}"
+                            : "AI request failed"
                         : string.IsNullOrWhiteSpace(rawResponse)
-                            ? "Retry: AI returned no content"
-                            : "Retry: response could not be parsed by either deserialization strategy";
-                    capture.ResponseValidationErrors = ErrorText(
-                        [capture.ResponseValidationErrors!, retryDiagnostic]);
+                            ? "AI returned no content"
+                            : "response could not be parsed by either deserialization strategy";
+                    capture.ResponseValidationErrors =
+                        MatchupPreviewValidator.ComposeErrorSections(attempt1Errors, retryDiagnostic);
                     capture.Model = _aiCommunication.GetModelName();
                     capture.RawResponse = string.IsNullOrWhiteSpace(rawResponse) ? null : rawResponse;
                     await _dataContext.SaveChangesAsync();
@@ -293,9 +290,8 @@ namespace SportsData.Api.Application.Previews
                 validation = Validate(parsed);
                 if (!validation.IsValid)
                 {
-                    // Attempt-1 errors were recorded above; append the retry's.
-                    capture.ResponseValidationErrors = ErrorText(
-                        [capture.ResponseValidationErrors!, .. validation.Errors.Select(e => $"Retry: {e}")]);
+                    capture.ResponseValidationErrors = MatchupPreviewValidator.ComposeErrorSections(
+                        attempt1Errors, string.Join("; ", validation.Errors));
                     capture.Model = _aiCommunication.GetModelName();
                     capture.RawResponse = rawResponse;
                     await _dataContext.SaveChangesAsync();

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -269,7 +269,18 @@ namespace SportsData.Api.Application.Previews
                 if (parsed is null)
                 {
                     // Persist the capture so the failure is auditable in the
-                    // Lab instead of vanishing with the log line.
+                    // Lab instead of vanishing with the log line — including
+                    // WHY the retry produced nothing (request failure vs blank
+                    // vs unparsable), alongside the attempt-1 errors.
+                    var retryDiagnostic = !retryResponse.IsSuccess
+                        ? retryResponse is Failure<string> retryFailure
+                            ? $"Retry: AI request failed - {string.Join(", ", retryFailure.Errors.Select(x => x.ErrorMessage))}"
+                            : "Retry: AI request failed"
+                        : string.IsNullOrWhiteSpace(rawResponse)
+                            ? "Retry: AI returned no content"
+                            : "Retry: response could not be parsed by either deserialization strategy";
+                    capture.ResponseValidationErrors = ErrorText(
+                        [capture.ResponseValidationErrors!, retryDiagnostic]);
                     capture.Model = _aiCommunication.GetModelName();
                     capture.RawResponse = string.IsNullOrWhiteSpace(rawResponse) ? null : rawResponse;
                     await _dataContext.SaveChangesAsync();

--- a/src/SportsData.Api/Application/UI/Matchups/MatchupPreviewValidator.cs
+++ b/src/SportsData.Api/Application/UI/Matchups/MatchupPreviewValidator.cs
@@ -4,6 +4,44 @@ public class MatchupPreviewValidator
 {
     public record ValidationResult(bool IsValid, List<string> Errors);
 
+    /// <summary>Matches MatchupPreviewPrompt.ResponseValidationErrors' column cap.</summary>
+    public const int MaxErrorTextLength = 1024;
+
+    /// <summary>
+    /// Compose attempt-1 and retry diagnostics into one capture-column value
+    /// under the 1024-char cap, guaranteeing the RETRY section always
+    /// survives truncation: the retry gets first claim on up to half the
+    /// budget (more when attempt-1 is short), and each section is truncated
+    /// only within its own share. Retry null = attempt-1 only.
+    /// </summary>
+    public static string ComposeErrorSections(string attempt1, string? retry)
+    {
+        var attemptSection = $"Attempt 1: {attempt1}";
+
+        if (retry is null)
+        {
+            return attemptSection.Length <= MaxErrorTextLength
+                ? attemptSection
+                : attemptSection[..MaxErrorTextLength];
+        }
+
+        const string separator = " | ";
+        var retrySection = $"Retry: {retry}";
+
+        if (attemptSection.Length + separator.Length + retrySection.Length <= MaxErrorTextLength)
+            return attemptSection + separator + retrySection;
+
+        var retryBudget = Math.Min(
+            retrySection.Length,
+            Math.Max(MaxErrorTextLength / 2, MaxErrorTextLength - separator.Length - attemptSection.Length));
+        var attemptBudget = MaxErrorTextLength - separator.Length - retryBudget;
+
+        if (attemptSection.Length > attemptBudget) attemptSection = attemptSection[..attemptBudget];
+        if (retrySection.Length > retryBudget) retrySection = retrySection[..retryBudget];
+
+        return attemptSection + separator + retrySection;
+    }
+
     public static ValidationResult Validate(
         Guid contestId,
         int homeScore,

--- a/src/SportsData.Core/Dtos/Canonical/MatchupForPreviewDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/MatchupForPreviewDto.cs
@@ -80,6 +80,16 @@ namespace SportsData.Core.Dtos.Canonical
         public PreviewPriorSeasonSummaryDto? AwayPriorSeason { get; set; }
         public PreviewPriorSeasonSummaryDto? HomePriorSeason { get; set; }
 
+        /// <summary>
+        /// Spread-conditioned facts for the live line (last time each side
+        /// won/lost by the spread's magnitude with opponent-quality context,
+        /// ATS records at the key-number bucket). Names-and-numbers only —
+        /// zero GUIDs, same rule as the other historical blocks. Computed
+        /// preview-safe (as-of the target's start) in Producer; null when
+        /// the contest has no line or the history fetch fails.
+        /// </summary>
+        public PreviewSpreadContextDto? SpreadContext { get; set; }
+
         public string? Spread { get; set; }             // co."Details"
         public double? AwaySpread { get; set; }
         public double? HomeSpread { get; set; }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -108,6 +108,53 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 ConferenceWins = 3,
                 ConferenceLosses = 9,
                 Metrics = new FranchiseSeasonMetricsDto { GamesPlayed = 17, Ypp = 4.9m }
+            },
+            SpreadContext = new PreviewSpreadContextDto
+            {
+                FavoriteTeam = "Arizona Cardinals",
+                UnderdogTeam = "Carolina Panthers",
+                Magnitude = 6.5,
+                SpreadDetails = "ARI -6.5",
+                FavoriteWonByMargin = new PreviewMarginFactDto
+                {
+                    LastGame = new PreviewGameResultDto
+                    {
+                        GameDate = new DateTime(2025, 11, 2, 18, 0, 0, DateTimeKind.Utc),
+                        SeasonYear = 2025,
+                        Phase = "Regular Season",
+                        HomeTeam = "Arizona Cardinals",
+                        AwayTeam = "Tennessee Titans",
+                        HomeScore = 31,
+                        AwayScore = 17,
+                        Winner = "Arizona Cardinals"
+                    },
+                    OpponentSeasonRecord = "3-14",
+                    OpponentPriorSeasonRecord = "5-12",
+                    CountLastFiveSeasons = 9,
+                    SearchFloorSeason = 2002
+                },
+                UnderdogLostByMargin = new PreviewMarginFactDto
+                {
+                    // The headline "never" case: no qualifying game, count 0,
+                    // floor intact.
+                    LastGame = null,
+                    CountLastFiveSeasons = 0,
+                    SearchFloorSeason = 2002
+                },
+                FavoriteAtsAsBigFavorite = new PreviewAtsBucketFactDto
+                {
+                    Threshold = 3,
+                    Games = 12,
+                    Covers = 7,
+                    DataFloorSeason = 2022
+                },
+                UnderdogAtsAsBigUnderdog = new PreviewAtsBucketFactDto
+                {
+                    Threshold = 3,
+                    Games = 15,
+                    Covers = 9,
+                    DataFloorSeason = 2022
+                }
             }
         };
 
@@ -213,6 +260,20 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             Assert.Contains("\"ConferenceLosses\":7", capture.PayloadJson);
             Assert.Contains("\"ConferenceWins\":3", capture.PayloadJson);
             Assert.Contains("\"ConferenceLosses\":9", capture.PayloadJson);
+
+            // Spread-conditioned facts ("The Line") ride in — pre-verified
+            // numbers the narrative can cite. The GUID count assertion above
+            // already proves the block contributes zero ids; the never-case
+            // fact serializes without a LastGame (omit-null) but keeps its
+            // count and search floor.
+            Assert.Contains("\"SpreadContext\"", capture.PayloadJson);
+            Assert.Contains("\"Magnitude\":6.5", capture.PayloadJson);
+            Assert.Contains("\"OpponentSeasonRecord\":\"3-14\"", capture.PayloadJson);
+            Assert.Contains("\"CountLastFiveSeasons\":9", capture.PayloadJson);
+            Assert.Contains("\"CountLastFiveSeasons\":0", capture.PayloadJson);
+            Assert.Contains("\"SearchFloorSeason\":2002", capture.PayloadJson);
+            Assert.Contains("\"Covers\":7", capture.PayloadJson);
+            Assert.Contains("\"DataFloorSeason\":2022", capture.PayloadJson);
             Assert.Null(capture.EditorNote);
             Assert.True(capture.CharCount > PromptText.Length);
             Assert.Equal(capture.CharCount / 4, capture.EstTokens);
@@ -286,6 +347,107 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 .Verify(x => x.GetResponseAsync(
                     $"{PromptText}\n\n{capture.PayloadJson}",
                     It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        // A response whose predictedSpreadWinner contradicts its own predicted
+        // scores against a -38.5 home spread (59-25 = margin 34: home does NOT
+        // cover; naming home is the contradiction the validator flags).
+        private string SpreadResponse(Guid spreadWinner) => $$"""
+            {
+              "overview": "o",
+              "analysis": "a",
+              "prediction": "p",
+              "predictedStraightUpWinner": "{{_homeFranchiseSeasonId}}",
+              "predictedSpreadWinner": "{{spreadWinner}}",
+              "overUnderPrediction": 1,
+              "awayScore": 25,
+              "homeScore": 59
+            }
+            """;
+
+        [Fact]
+        public async Task RealGeneration_RetriesWithFeedback_WhenValidationFails()
+        {
+            // Arrange — big home spread so the first response can contradict
+            // itself; the retry names the correct ATS side and must succeed.
+            var matchup = BuildMatchup("STATUS_SCHEDULED");
+            matchup.HomeSpread = -38.5;
+            matchup.Spread = "ARI -38.5";
+            SetupPipeline(matchup);
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .SetupSequence(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(SpreadResponse(_homeFranchiseSeasonId))) // contradiction
+                .ReturnsAsync(new Success<string>(SpreadResponse(_awayFranchiseSeasonId))); // corrected
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — the retry produced a valid preview and the recovery is
+            // fully auditable: attempt-1 errors on the capture, iteration
+            // count on the preview.
+            var preview = Assert.Single(DataContext.MatchupPreviews);
+            Assert.Equal(2, preview.IterationsRequired);
+            Assert.Equal(_awayFranchiseSeasonId, preview.PredictedSpreadWinner);
+
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Equal(preview.Id, capture.MatchupPreviewId);
+            Assert.Contains("inconsistent", capture.ResponseValidationErrors);
+
+            // The second call carried the violation feedback and the original
+            // (bad) response back to the model.
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(
+                    It.Is<string>(p => p.Contains("It failed validation") && p.Contains("Your previous response")),
+                    It.IsAny<CancellationToken>()), Times.Once);
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task RealGeneration_PersistsAuditableCapture_WhenRetryAlsoFails()
+        {
+            // Arrange — both attempts contradict themselves: no preview may be
+            // written, but the capture must persist with both rounds of errors
+            // (previously a validation failure discarded the capture entirely).
+            var matchup = BuildMatchup("STATUS_SCHEDULED");
+            matchup.HomeSpread = -38.5;
+            matchup.Spread = "ARI -38.5";
+            SetupPipeline(matchup);
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(SpreadResponse(_homeFranchiseSeasonId)));
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert
+            Assert.Empty(DataContext.MatchupPreviews);
+
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Null(capture.MatchupPreviewId);
+            Assert.NotNull(capture.RawResponse);
+            Assert.Contains("Retry:", capture.ResponseValidationErrors);
+
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [Fact]

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Matchups/MatchupPreviewValidatorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Matchups/MatchupPreviewValidatorTests.cs
@@ -136,4 +136,57 @@ public class MatchupPreviewValidatorTests
         result.Errors.Should().Contain(e => e.Contains("Straight-up winner is incorrect"));
         result.Errors.Should().Contain(e => e.Contains("Spread winner is inconsistent"));
     }
+
+    // ─── ComposeErrorSections ─────────────────────────────────────────────
+    // Capture-column diagnostics: the retry section must ALWAYS survive
+    // truncation, no matter how large the attempt-1 section is.
+
+    [Fact]
+    public void ComposeErrorSections_ShortSections_KeepsBothInFull()
+    {
+        var result = MatchupPreviewValidator.ComposeErrorSections("bad spread", "still bad");
+
+        result.Should().Be("Attempt 1: bad spread | Retry: still bad");
+    }
+
+    [Fact]
+    public void ComposeErrorSections_OversizedAttempt1_NeverTruncatesRetryAway()
+    {
+        var attempt1 = new string('a', 2000); // alone would overflow the cap
+        var retry = "AI returned no content";
+
+        var result = MatchupPreviewValidator.ComposeErrorSections(attempt1, retry);
+
+        result.Length.Should().BeLessThanOrEqualTo(MatchupPreviewValidator.MaxErrorTextLength);
+        result.Should().StartWith("Attempt 1: ");
+        result.Should().EndWith($"Retry: {retry}", "a short retry section must survive in full");
+    }
+
+    [Fact]
+    public void ComposeErrorSections_BothOversized_SplitsTheBudget()
+    {
+        var attempt1 = new string('a', 2000);
+        var retry = new string('r', 2000);
+
+        var result = MatchupPreviewValidator.ComposeErrorSections(attempt1, retry);
+
+        result.Length.Should().BeLessThanOrEqualTo(MatchupPreviewValidator.MaxErrorTextLength);
+        result.Should().Contain("Attempt 1: ");
+        result.Should().Contain("Retry: ");
+        // The retry section holds its reserved half of the budget.
+        result.IndexOf("Retry: ", StringComparison.Ordinal).Should().BeLessThan(
+            MatchupPreviewValidator.MaxErrorTextLength / 2 + 1);
+    }
+
+    [Fact]
+    public void ComposeErrorSections_NullRetry_TruncatesAttempt1ToCap()
+    {
+        var attempt1 = new string('a', 2000);
+
+        var result = MatchupPreviewValidator.ComposeErrorSections(attempt1, null);
+
+        result.Length.Should().Be(MatchupPreviewValidator.MaxErrorTextLength);
+        result.Should().StartWith("Attempt 1: ");
+        result.Should().NotContain("Retry:");
+    }
 }


### PR DESCRIPTION
## Summary

Two halves of one arc: **arm** the preview model with the pre-verified spread facts from #659, and **coach** it with its violations when it stumbles.

## Payload injection

`MatchupForPreviewDto` gains `SpreadContext` — the spread-conditioned facts block computed in Producer (#659) — and `MatchupPreviewProcessor.AssemblePromptAsync` copies it from the history fetch it already makes. Properties of the block that make this safe with zero serializer changes:

- **Names-and-numbers only, zero GUIDs** — same rule as the other historical blocks; the payload's GUID-hygiene walk is untouched and the `guidCount == 2` test assertion still proves it.
- **As-of-capped in Producer** — capture/experiment runs on completed games stay leak-free automatically.
- Omit-null serialization handles the no-line case (block simply absent).

The model now receives, pre-verified: "the favorite has won by this margin 6 times in 5 seasons, most recently vs a 7-6 team; the dog took a 45-point beating this year from a 3-9 team; ATS at the 35+ bucket: 2/2 and 1/1 since 2022." The prompt (blob-stored, never in this repo) instructs citation — updated separately via the Prompt Lab.

## Validation retry loop (Generate mode only)

Observed in a real Lab experiment: the model produced "USC covers with a 34-point margin" against a 38.5 spread while echoing USC as `predictedSpreadWinner` — self-contradictory output `MatchupPreviewValidator` rightly rejects. But rejection in Generate mode was a **dead end**: `LogError` + return, the game silently got no preview, and the capture row was discarded with it.

Now:
- **One bounded retry** whose prompt appends the model's own previous response plus the itemized violations — the automated twin of the human editor-rejection loop.
- **Retry succeeds** → preview written with `IterationsRequired = 2` (the column has awaited this loop since day one); attempt-1 errors stay on the capture so the Lab shows the recovery.
- **Retry fails/unparsable** → still no preview (the guard never weakens), but the capture now **persists** with both rounds of errors and the final raw response — prod validation failures become auditable in the Lab instead of vanishing into a log line.
- Experiment mode untouched: records-without-blocking by design (no retry for two-shot experiments).

## Tests

- Payload test asserts the serialized SpreadContext facts (magnitude, opponent records, counts, floors — including the never-happened margin fact keeping its count and floor via omit-null).
- Two new retry facts: recover-on-retry (feedback prompt contains the prior response + violations, `IterationsRequired = 2`, corrected ATS side persisted) and fail-after-retry (no preview, auditable capture with `Retry:` errors, exactly 2 model calls).
- Full API suite **691/691**; Producer builds clean against the Core change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Matchup previews now include relevant spread-conditioned historical insights when available.
  - Preview generation can retry once after validation issues, using corrective feedback to improve results.
  - Successful retries are tracked for greater transparency.

- **Bug Fixes**
  - Failed generation attempts now preserve diagnostic details for review.
  - Invalid results are prevented from producing a preview after repeated validation failures.

- **Documentation**
  - Updated feature documentation to describe spread-context insights and current roadmap items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->