### PR TITLE
fix(producer): track ESPN home/away re-designations on existing contests

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
@@ -253,6 +253,39 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
             entity.Id,
             dto.HomeAway);
 
+        // Sync the mutable designations: a neutral-site home/away flip (2026
+        // Wisconsin/Notre Dame at Lambeau), order, and winner must track
+        // ESPN. Previously HomeAway was logged above but never WRITTEN,
+        // leaving competitor rows frozen at first ingestion.
+        var designationChanges = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(dto.HomeAway) &&
+            !string.Equals(entity.HomeAway, dto.HomeAway, StringComparison.OrdinalIgnoreCase))
+        {
+            designationChanges.Add($"HomeAway: {entity.HomeAway} -> {dto.HomeAway}");
+            entity.HomeAway = dto.HomeAway;
+        }
+
+        if (entity.Order != dto.Order)
+        {
+            designationChanges.Add($"Order: {entity.Order} -> {dto.Order}");
+            entity.Order = dto.Order;
+        }
+
+        if (entity.Winner != dto.Winner)
+        {
+            designationChanges.Add($"Winner: {entity.Winner} -> {dto.Winner}");
+            entity.Winner = dto.Winner;
+        }
+
+        if (designationChanges.Count > 0)
+        {
+            _logger.LogWarning(
+                "CompetitionCompetitor designations changed. CompetitorId={CompetitorId}, Changes={Changes}",
+                entity.Id,
+                string.Join(", ", designationChanges));
+        }
+
         // Sport-specific inline-data ingestion runs on update too — the
         // payload's mutable extras (e.g. Probables) may have changed
         // since the last fetch.

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
@@ -461,6 +461,7 @@ public abstract class EventDocumentProcessorBase<TDataContext> : DocumentProcess
         // pair from the document on every update.
         var previousHomeId = contest.HomeTeamFranchiseSeasonId;
         var previousAwayId = contest.AwayTeamFranchiseSeasonId;
+        var previousShortName = contest.ShortName;
 
         var teamsResolved = await AddTeams(command, dto, contest);
         if (teamsResolved &&
@@ -471,9 +472,11 @@ public abstract class EventDocumentProcessorBase<TDataContext> : DocumentProcess
             {
                 // Scores, winner, and ATS denorms were computed under the old
                 // sides; an automated swap would corrupt them. Revert and flag
-                // — this state needs an operator, not automation.
+                // — this state needs an operator, not automation. ShortName
+                // too: AddTeams backfills an empty one from the (new) sides.
                 contest.HomeTeamFranchiseSeasonId = previousHomeId;
                 contest.AwayTeamFranchiseSeasonId = previousAwayId;
+                contest.ShortName = previousShortName;
                 _logger.LogError(
                     "ESPN home/away changed on a FINALIZED contest; refusing to swap. ContestId={ContestId}",
                     contest.Id);

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorBase.cs
@@ -452,6 +452,50 @@ public abstract class EventDocumentProcessorBase<TDataContext> : DocumentProcess
             }
         }
 
+        // Home/away designations can change after creation — e.g. a
+        // neutral-site re-designation (2026 Wisconsin/Notre Dame at Lambeau:
+        // Wisconsin was originally the "home" team; ESPN later flipped the
+        // event to Notre Dame). The odds pipeline keeps updating the
+        // HOME-RELATIVE spread against ESPN's CURRENT designation, so a stale
+        // pair silently inverts every spread-derived surface. Re-resolve the
+        // pair from the document on every update.
+        var previousHomeId = contest.HomeTeamFranchiseSeasonId;
+        var previousAwayId = contest.AwayTeamFranchiseSeasonId;
+
+        var teamsResolved = await AddTeams(command, dto, contest);
+        if (teamsResolved &&
+            (contest.HomeTeamFranchiseSeasonId != previousHomeId ||
+             contest.AwayTeamFranchiseSeasonId != previousAwayId))
+        {
+            if (contest.FinalizedUtc is not null)
+            {
+                // Scores, winner, and ATS denorms were computed under the old
+                // sides; an automated swap would corrupt them. Revert and flag
+                // — this state needs an operator, not automation.
+                contest.HomeTeamFranchiseSeasonId = previousHomeId;
+                contest.AwayTeamFranchiseSeasonId = previousAwayId;
+                _logger.LogError(
+                    "ESPN home/away changed on a FINALIZED contest; refusing to swap. ContestId={ContestId}",
+                    contest.Id);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Contest home/away changed; applying swap. ContestId={ContestId}, " +
+                    "OldHome={OldHome}, NewHome={NewHome}, OldAway={OldAway}, NewAway={NewAway}",
+                    contest.Id,
+                    previousHomeId, contest.HomeTeamFranchiseSeasonId,
+                    previousAwayId, contest.AwayTeamFranchiseSeasonId);
+
+                // The names carry the sides ("X at Y") — refresh from the
+                // document, which is already flipped ESPN-side.
+                if (!string.IsNullOrWhiteSpace(dto.Name))
+                    contest.Name = dto.Name;
+                if (!string.IsNullOrWhiteSpace(dto.ShortName))
+                    contest.ShortName = dto.ShortName;
+            }
+        }
+
         _logger.LogInformation(
             "Re-sourcing {Count} competitions for updated Contest. ContestId={ContestId}",
             dto.Competitions.Count(),

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
@@ -22,6 +22,8 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
     public class EventCompetitionCompetitorDocumentProcessorTests
         : ProducerTestBase<FootballEventCompetitionCompetitorDocumentProcessor<FootballDataContext>>
     {
+        private static readonly DateTime FixedTestNow = new(2026, 5, 4, 12, 0, 0, DateTimeKind.Utc);
+
         [Fact]
         public async Task WhenJsonIsValid_DtoDeserializes()
         {
@@ -62,8 +64,8 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             {
                 Id = competitionId,
                 ContestId = Guid.NewGuid(),
-                Date = DateTime.UtcNow,
-                CreatedUtc = DateTime.UtcNow,
+                Date = FixedTestNow,
+                CreatedUtc = FixedTestNow,
                 CreatedBy = Guid.NewGuid()
             });
 
@@ -82,7 +84,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 IsActive = true,
                 SeasonYear = 2024,
                 FranchiseId = Guid.NewGuid(),
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = FixedTestNow,
                 CreatedBy = Guid.NewGuid(),
                 ExternalIds =
                 [
@@ -106,7 +108,7 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 HomeAway = "away",
                 Order = 5,
                 Winner = true,
-                CreatedUtc = DateTime.UtcNow,
+                CreatedUtc = FixedTestNow,
                 CreatedBy = Guid.NewGuid(),
                 ExternalIds =
                 [
@@ -138,7 +140,10 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 
             // assert — designations now track the document
             var saved = await FootballDataContext.CompetitionCompetitors
-                .FirstAsync(x => x.Id == competitorIdentity.CanonicalId);
+                .AsNoTracking()
+                .Where(x => x.Id == competitorIdentity.CanonicalId)
+                .Select(x => new { x.HomeAway, x.Order, x.Winner })
+                .FirstAsync();
             saved.HomeAway.Should().Be("home");
             saved.Order.Should().Be(0);
             saved.Winner.Should().BeFalse();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
@@ -1,14 +1,24 @@
-﻿using FluentAssertions;
+﻿using AutoFixture;
 
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
+using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Common
 {
+    [Collection("Sequential")]
     public class EventCompetitionCompetitorDocumentProcessorTests
         : ProducerTestBase<FootballEventCompetitionCompetitorDocumentProcessor<FootballDataContext>>
     {
@@ -26,6 +36,112 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 
             // factual assertions based on the test JSON
 
+        }
+
+        [Fact]
+        public async Task WhenEntityAlreadyExists_AndDesignationsChanged_ShouldSyncHomeAwayOrderWinner()
+        {
+            // A neutral-site home/away re-designation must flow onto the
+            // existing competitor row — previously the update path logged
+            // dto.HomeAway but never wrote it, freezing rows at first
+            // ingestion. Fixture: homeAway=home, order=0, winner=false.
+
+            // arrange
+            var generator = new ExternalRefIdentityGenerator();
+            Mocker.Use<IGenerateExternalRefIdentities>(generator);
+            var sut = Mocker.CreateInstance<FootballEventCompetitionCompetitorDocumentProcessor<FootballDataContext>>();
+
+            var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitor.json");
+            var dto = json.FromJson<EspnEventCompetitionCompetitorDto>();
+
+            var competitorIdentity = generator.Generate(dto!.Ref);
+            var teamIdentity = generator.Generate(dto.Team.Ref);
+
+            var competitionId = Guid.NewGuid();
+            await FootballDataContext.Competitions.AddAsync(new FootballCompetition
+            {
+                Id = competitionId,
+                ContestId = Guid.NewGuid(),
+                Date = DateTime.UtcNow,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            });
+
+            var franchiseSeasonId = Guid.NewGuid();
+            await FootballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+            {
+                Id = franchiseSeasonId,
+                Abbreviation = "TST",
+                DisplayName = "Test FS",
+                DisplayNameShort = "TFS",
+                Slug = teamIdentity.CanonicalId.ToString(),
+                Location = "Test Location",
+                Name = "Test Franchise Season",
+                ColorCodeHex = "#FFFFFF",
+                ColorCodeAltHex = "#000000",
+                IsActive = true,
+                SeasonYear = 2024,
+                FranchiseId = Guid.NewGuid(),
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds =
+                [
+                    new FranchiseSeasonExternalId
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        SourceUrl = teamIdentity.CleanUrl,
+                        SourceUrlHash = teamIdentity.UrlHash,
+                        Value = teamIdentity.UrlHash
+                    }
+                ]
+            });
+
+            // Existing competitor row with STALE designations (opposite of the doc).
+            await FootballDataContext.CompetitionCompetitors.AddAsync(new FootballCompetitionCompetitor
+            {
+                Id = competitorIdentity.CanonicalId,
+                CompetitionId = competitionId,
+                FranchiseSeasonId = franchiseSeasonId,
+                HomeAway = "away",
+                Order = 5,
+                Winner = true,
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds =
+                [
+                    new CompetitionCompetitorExternalId
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        SourceUrl = competitorIdentity.CleanUrl,
+                        SourceUrlHash = competitorIdentity.UrlHash,
+                        Value = competitorIdentity.UrlHash
+                    }
+                ]
+            });
+            await FootballDataContext.SaveChangesAsync();
+
+            var command = Fixture.Build<ProcessDocumentCommand>()
+                .With(x => x.Document, json)
+                .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitor)
+                .With(x => x.SeasonYear, 2024)
+                .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+                .With(x => x.Sport, Sport.FootballNcaa)
+                .With(x => x.ParentId, competitionId.ToString())
+                .With(x => x.UrlHash, competitorIdentity.UrlHash)
+                .OmitAutoProperties()
+                .Create();
+
+            // act
+            await sut.ProcessAsync(command);
+
+            // assert — designations now track the document
+            var saved = await FootballDataContext.CompetitionCompetitors
+                .FirstAsync(x => x.Id == competitorIdentity.CanonicalId);
+            saved.HomeAway.Should().Be("home");
+            saved.Order.Should().Be(0);
+            saved.Winner.Should().BeFalse();
         }
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
@@ -510,6 +510,134 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
             Times.Once);
     }
 
+    /// <summary>Resolve the FranchiseSeason seeded for the given side's team ref.</summary>
+    private async Task<Guid> GetSeededFranchiseSeasonIdAsync(
+        ExternalRefIdentityGenerator generator, EspnEventDto dto, string homeAway)
+    {
+        var team = dto.Competitions.First().Competitors
+            .First(c => c.HomeAway.Equals(homeAway, StringComparison.OrdinalIgnoreCase)).Team;
+        var hash = generator.Generate(team.Ref).UrlHash;
+        return (await FootballDataContext.FranchiseSeasons
+            .FirstAsync(fs => fs.ExternalIds.Any(e => e.SourceUrlHash == hash))).Id;
+    }
+
+    private FootballContest BuildExistingContest(Guid homeFsId, Guid awayFsId, string urlHash) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "Stale Name At Old Home",
+        ShortName = "STALE @ OLD",
+        SeasonYear = 2024,
+        Sport = Sport.FootballNcaa,
+        StartDateUtc = DateTime.UtcNow,
+        HomeTeamFranchiseSeasonId = homeFsId,
+        AwayTeamFranchiseSeasonId = awayFsId,
+        CreatedUtc = DateTime.UtcNow,
+        CreatedBy = Guid.NewGuid(),
+        ExternalIds = new List<ContestExternalId>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Provider = SourceDataProvider.Espn,
+                Value = "401583027",
+                SourceUrlHash = urlHash,
+                SourceUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334?lang=en"
+            }
+        }
+    };
+
+    [Fact]
+    public async Task WhenEntityAlreadyExists_AndHomeAwayFlipped_ShouldSwapTeamsAndRefreshNames()
+    {
+        // ESPN can re-designate home/away after creation (e.g. the 2026
+        // Wisconsin/Notre Dame neutral-site flip). The odds pipeline tracks
+        // ESPN's CURRENT home-relative spread, so a stale pair inverts every
+        // spread-derived surface. The update path must re-resolve the sides.
+
+        // arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent.json");
+        var dto = json.FromJson<EspnEventDto>();
+
+        await SetupFranchiseSeasonsAsync(generator, dto!);
+        var resolvedHomeId = await GetSeededFranchiseSeasonIdAsync(generator, dto!, "home");
+        var resolvedAwayId = await GetSeededFranchiseSeasonIdAsync(generator, dto!, "away");
+
+        var eventUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334?lang=en";
+        // Seed the contest with the sides deliberately SWAPPED relative to the doc.
+        var contest = BuildExistingContest(resolvedAwayId, resolvedHomeId, eventUrl.UrlHash());
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.Document, json)
+            .With(x => x.DocumentType, DocumentType.Event)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.UrlHash, contest.ExternalIds.First().SourceUrlHash)
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(command);
+
+        // assert — sides corrected to the document's designation, names refreshed
+        var saved = await FootballDataContext.Contests.FirstAsync(c => c.Id == contest.Id);
+        saved.HomeTeamFranchiseSeasonId.Should().Be(resolvedHomeId);
+        saved.AwayTeamFranchiseSeasonId.Should().Be(resolvedAwayId);
+        saved.Name.Should().Be(dto!.Name, "the name carries the sides and must track the document");
+        saved.ShortName.Should().Be(dto.ShortName);
+    }
+
+    [Fact]
+    public async Task WhenEntityAlreadyExists_AndHomeAwayFlipped_ButFinalized_ShouldNotSwap()
+    {
+        // Scores/winner/ATS denorms on a finalized contest were computed
+        // under the old sides — an automated swap would corrupt them. The
+        // processor must refuse and leave the row for an operator.
+
+        // arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent.json");
+        var dto = json.FromJson<EspnEventDto>();
+
+        await SetupFranchiseSeasonsAsync(generator, dto!);
+        var resolvedHomeId = await GetSeededFranchiseSeasonIdAsync(generator, dto!, "home");
+        var resolvedAwayId = await GetSeededFranchiseSeasonIdAsync(generator, dto!, "away");
+
+        var eventUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334?lang=en";
+        var contest = BuildExistingContest(resolvedAwayId, resolvedHomeId, eventUrl.UrlHash());
+        contest.FinalizedUtc = DateTime.UtcNow;
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.Document, json)
+            .With(x => x.DocumentType, DocumentType.Event)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.UrlHash, contest.ExternalIds.First().SourceUrlHash)
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(command);
+
+        // assert — untouched: still swapped, name still stale
+        var saved = await FootballDataContext.Contests.FirstAsync(c => c.Id == contest.Id);
+        saved.HomeTeamFranchiseSeasonId.Should().Be(resolvedAwayId);
+        saved.AwayTeamFranchiseSeasonId.Should().Be(resolvedHomeId);
+        saved.Name.Should().Be("Stale Name At Old Home");
+    }
+
     [Fact]
     public async Task WhenEntityAlreadyExists_AndStartDateUnchanged_ShouldNotPublishContestStartTimeUpdated()
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
@@ -517,8 +517,11 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
         var team = dto.Competitions.First().Competitors
             .First(c => c.HomeAway.Equals(homeAway, StringComparison.OrdinalIgnoreCase)).Team;
         var hash = generator.Generate(team.Ref).UrlHash;
-        return (await FootballDataContext.FranchiseSeasons
-            .FirstAsync(fs => fs.ExternalIds.Any(e => e.SourceUrlHash == hash))).Id;
+        return await FootballDataContext.FranchiseSeasons
+            .AsNoTracking()
+            .Where(fs => fs.ExternalIds.Any(e => e.SourceUrlHash == hash))
+            .Select(fs => fs.Id)
+            .FirstAsync();
     }
 
     private FootballContest BuildExistingContest(Guid homeFsId, Guid awayFsId, string urlHash) => new()
@@ -528,10 +531,10 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
         ShortName = "STALE @ OLD",
         SeasonYear = 2024,
         Sport = Sport.FootballNcaa,
-        StartDateUtc = DateTime.UtcNow,
+        StartDateUtc = FixedTestNow,
         HomeTeamFranchiseSeasonId = homeFsId,
         AwayTeamFranchiseSeasonId = awayFsId,
-        CreatedUtc = DateTime.UtcNow,
+        CreatedUtc = FixedTestNow,
         CreatedBy = Guid.NewGuid(),
         ExternalIds = new List<ContestExternalId>
         {
@@ -586,7 +589,11 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
         await sut.ProcessAsync(command);
 
         // assert — sides corrected to the document's designation, names refreshed
-        var saved = await FootballDataContext.Contests.FirstAsync(c => c.Id == contest.Id);
+        var saved = await FootballDataContext.Contests
+            .AsNoTracking()
+            .Where(c => c.Id == contest.Id)
+            .Select(c => new { c.HomeTeamFranchiseSeasonId, c.AwayTeamFranchiseSeasonId, c.Name, c.ShortName })
+            .FirstAsync();
         saved.HomeTeamFranchiseSeasonId.Should().Be(resolvedHomeId);
         saved.AwayTeamFranchiseSeasonId.Should().Be(resolvedAwayId);
         saved.Name.Should().Be(dto!.Name, "the name carries the sides and must track the document");
@@ -614,7 +621,7 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
 
         var eventUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334?lang=en";
         var contest = BuildExistingContest(resolvedAwayId, resolvedHomeId, eventUrl.UrlHash());
-        contest.FinalizedUtc = DateTime.UtcNow;
+        contest.FinalizedUtc = FixedTestNow;
         await FootballDataContext.Contests.AddAsync(contest);
         await FootballDataContext.SaveChangesAsync();
 
@@ -631,11 +638,66 @@ public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballData
         // act
         await sut.ProcessAsync(command);
 
-        // assert — untouched: still swapped, name still stale
-        var saved = await FootballDataContext.Contests.FirstAsync(c => c.Id == contest.Id);
+        // assert — untouched: still swapped, names still stale
+        var saved = await FootballDataContext.Contests
+            .AsNoTracking()
+            .Where(c => c.Id == contest.Id)
+            .Select(c => new { c.HomeTeamFranchiseSeasonId, c.AwayTeamFranchiseSeasonId, c.Name, c.ShortName })
+            .FirstAsync();
         saved.HomeTeamFranchiseSeasonId.Should().Be(resolvedAwayId);
         saved.AwayTeamFranchiseSeasonId.Should().Be(resolvedHomeId);
         saved.Name.Should().Be("Stale Name At Old Home");
+        saved.ShortName.Should().Be("STALE @ OLD");
+    }
+
+    [Fact]
+    public async Task WhenFinalizedWithEmptyShortName_AndHomeAwayFlipped_ShouldNotBackfillShortName()
+    {
+        // AddTeams backfills an empty ShortName from the (new) sides BEFORE
+        // the finality gate runs — the finalized branch must restore it so a
+        // finalized contest is never mutated by a refused swap.
+
+        // arrange
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var sut = Mocker.CreateInstance<FootballEventDocumentProcessor<FootballDataContext>>();
+
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEvent.json");
+        var dto = json.FromJson<EspnEventDto>();
+
+        await SetupFranchiseSeasonsAsync(generator, dto!);
+        var resolvedHomeId = await GetSeededFranchiseSeasonIdAsync(generator, dto!, "home");
+        var resolvedAwayId = await GetSeededFranchiseSeasonIdAsync(generator, dto!, "away");
+
+        var eventUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334?lang=en";
+        var contest = BuildExistingContest(resolvedAwayId, resolvedHomeId, eventUrl.UrlHash());
+        contest.ShortName = string.Empty;
+        contest.FinalizedUtc = FixedTestNow;
+        await FootballDataContext.Contests.AddAsync(contest);
+        await FootballDataContext.SaveChangesAsync();
+
+        var command = Fixture.Build<ProcessDocumentCommand>()
+            .With(x => x.Document, json)
+            .With(x => x.DocumentType, DocumentType.Event)
+            .With(x => x.SeasonYear, 2024)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.UrlHash, contest.ExternalIds.First().SourceUrlHash)
+            .OmitAutoProperties()
+            .Create();
+
+        // act
+        await sut.ProcessAsync(command);
+
+        // assert — entirely untouched, including the empty ShortName
+        var saved = await FootballDataContext.Contests
+            .AsNoTracking()
+            .Where(c => c.Id == contest.Id)
+            .Select(c => new { c.HomeTeamFranchiseSeasonId, c.AwayTeamFranchiseSeasonId, c.ShortName })
+            .FirstAsync();
+        saved.HomeTeamFranchiseSeasonId.Should().Be(resolvedAwayId);
+        saved.AwayTeamFranchiseSeasonId.Should().Be(resolvedHomeId);
+        saved.ShortName.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

ESPN can flip home/away after an event is created — observed on the 2026 Wisconsin/Notre Dame neutral-site game at Lambeau (Wisconsin originally designated home; ESPN later flipped the event to Notre Dame, `neutralSite: true`). Our pipeline never revisited the designation, while the odds pipeline kept updating the **home-relative** spread against ESPN's *current* designation. The stale pair silently inverted every spread-derived surface: the matchup showed **"WIS -20.5"** for what is actually Notre Dame's line.

## The two holes

1. **`EventDocumentProcessorBase.ProcessUpdate`** refreshed only `StartDateUtc` — never re-resolved `Home/AwayTeamFranchiseSeasonId`, `Name`, or `ShortName`, despite the DTO carrying the competitors' current `homeAway` (the create path resolves them via `AddTeams`).
2. **`EventCompetitionCompetitorDocumentProcessorBase.ProcessUpdate`** *logged* `dto.HomeAway` in its update message but never wrote it (nor `Order`/`Winner`) — competitor rows were frozen at first ingestion.

(`EventCompetitionDocumentProcessorBase` — the initial suspect — was already correct: its update does a full `SetValues` sweep.)

## The fix

- **Event update path**: re-resolve the pair from the document on every update, reusing `AddTeams`.
  - Changed + **not finalized** → apply the swap, refresh `Name`/`ShortName` from the document (already flipped ESPN-side), warn with old→new ids.
  - Changed + **finalized** → revert and log an error: scores/winner/ATS denorms were computed under the old sides; automated swapping would corrupt them. Operator territory.
- **Competitor update path**: sync `HomeAway`, `Order`, `Winner` with per-field change detection and one consolidated warning.

**Healing is automatic**: ESPN republishes event documents frequently, so this contest — and any other silently flipped game we haven't noticed — corrects itself on the first republish after deploy. Producer's matchup/preview queries read live so API surfaces follow; picks reference `FranchiseSeasonId`, so their meaning never changed.

## Validation

- 3 new tests: swap-applied (sides corrected + names refreshed), finalized-refuses (row untouched), competitor designations-sync (`away/5/true → home/0/false` from the fixture). Existing update-path tests now implicitly exercise re-resolution and pass unchanged.
- Full Producer suite: 565 passed / 18 skipped; single failure is the pre-existing local-WIP one, unrelated.
- **E2E validated locally**: rebuilt the compose stack from this branch, re-requested event `401858438` through the pipeline — contest `dab8ad91…` flipped to ND-home with the corrected name, and the matchup surface now pairs the line correctly (**ND -20.5**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected synchronization of competitor home/away designations, ordering, and winner status from incoming event data.
  - Updated non-finalized contests when teams’ home/away assignments change, including refreshed team names.
  - Preserved finalized contest assignments when conflicting designation changes are received.

- **Tests**
  - Added coverage for competitor field synchronization and home/away changes in finalized and non-finalized contests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->