### PR TITLE
fix(notification,web): SmackBot game context + admin review auto-close

### DIFF
--- a/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/UserPickScoredConsumer.cs
@@ -174,7 +174,13 @@ namespace SportsData.Notification.Application.Consumers
             var title = smackLine is not null
                 ? "SmackBot"
                 : msg.IsCorrect == true ? "Nice pick!" : "Tough loss";
-            var body = smackLine ?? ComposeBody(msg, leagueName);
+            // The smack line is the headline, but alone it loses the game —
+            // "Vegas told you so" arrives with ZERO indication of which pick
+            // earned it. The standard context line (league, scoreline, pick
+            // mark) rides underneath so the recipient always knows the game.
+            var body = smackLine is not null
+                ? $"{smackLine}\n{ComposeBody(msg, leagueName)}"
+                : ComposeBody(msg, leagueName);
 
             // Deep link to the scored game. Everything needed rides on the
             // event except the week, which comes from the local matchup

--- a/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
+++ b/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
@@ -218,23 +218,34 @@ function InsightDialog({
                   onChange={(e) => setRejectionNote(e.target.value)}
                   rows={3}
                 />
+                {/* Close on success: the handlers resolve true only when the
+                    action landed (toast confirms it); a failure keeps the
+                    dialog open with the rejection note intact for a retry. */}
                 <div className="insight-admin__actions">
                   <button
-                    onClick={() =>
-                      onApprovePreview?.(matchup.contestId, matchup.id)
-                    }
+                    onClick={async () => {
+                      const ok = await onApprovePreview?.(matchup.contestId, matchup.id);
+                      if (ok) {
+                        setRejectionNote("");
+                        onClose();
+                      }
+                    }}
                     className="admin-approve-button"
                   >
                     Approve Preview
                   </button>
                   <button
-                    onClick={() =>
-                      onRejectPreview?.({
+                    onClick={async () => {
+                      const ok = await onRejectPreview?.({
                         PreviewId: matchup.id,
                         ContestId: matchup.contestId,
                         RejectionNote: rejectionNote.trim(),
-                      })
-                    }
+                      });
+                      if (ok) {
+                        setRejectionNote("");
+                        onClose();
+                      }
+                    }}
                     className="admin-reset-button"
                     disabled={!rejectionNote.trim()}
                   >

--- a/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
+++ b/src/UI/sd-ui/src/components/insights/InsightDialog.jsx
@@ -59,6 +59,9 @@ function InsightDialog({
 
   // Local state for rejection note
   const [rejectionNote, setRejectionNote] = useState("");
+  // In-flight guard: both moderation buttons disable while a request runs,
+  // so a double-click can't double-approve or race approve-vs-reject.
+  const [isModerationPending, setIsModerationPending] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -224,30 +227,41 @@ function InsightDialog({
                 <div className="insight-admin__actions">
                   <button
                     onClick={async () => {
-                      const ok = await onApprovePreview?.(matchup.contestId, matchup.id);
-                      if (ok) {
-                        setRejectionNote("");
-                        onClose();
+                      setIsModerationPending(true);
+                      try {
+                        const ok = await onApprovePreview?.(matchup.contestId, matchup.id);
+                        if (ok) {
+                          setRejectionNote("");
+                          onClose();
+                        }
+                      } finally {
+                        setIsModerationPending(false);
                       }
                     }}
                     className="admin-approve-button"
+                    disabled={isModerationPending}
                   >
                     Approve Preview
                   </button>
                   <button
                     onClick={async () => {
-                      const ok = await onRejectPreview?.({
-                        PreviewId: matchup.id,
-                        ContestId: matchup.contestId,
-                        RejectionNote: rejectionNote.trim(),
-                      });
-                      if (ok) {
-                        setRejectionNote("");
-                        onClose();
+                      setIsModerationPending(true);
+                      try {
+                        const ok = await onRejectPreview?.({
+                          PreviewId: matchup.id,
+                          ContestId: matchup.contestId,
+                          RejectionNote: rejectionNote.trim(),
+                        });
+                        if (ok) {
+                          setRejectionNote("");
+                          onClose();
+                        }
+                      } finally {
+                        setIsModerationPending(false);
                       }
                     }}
                     className="admin-reset-button"
-                    disabled={!rejectionNote.trim()}
+                    disabled={isModerationPending || !rejectionNote.trim()}
                   >
                     Reject Preview
                   </button>

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -685,6 +685,9 @@ function PicksPage() {
     }
   }
 
+  // Both admin-review handlers return success so the dialog can close
+  // itself only when the action actually landed — a failure keeps it open
+  // (with the rejection note intact) for a retry.
   async function handleRejectPreview({ PreviewId, ContestId, RejectionNote }) {
     try {
       console.log("Reject Preview Payload:", {
@@ -701,9 +704,11 @@ function PicksPage() {
         Sport: leagueSport,
       });
       toast.success("Preview rejection sent.");
+      return true;
     } catch (error) {
       console.error("Error rejecting preview:", error);
       toast.error("Failed to reject preview.");
+      return false;
     }
   }
 
@@ -711,9 +716,11 @@ function PicksPage() {
     try {
       await apiWrapper.Previews.approvePreviewByContestId(previewId);
       toast.success("Preview approved.");
+      return true;
     } catch (error) {
       console.error("Error approving preview:", error);
       toast.error("Failed to approve preview.");
+      return false;
     }
   }
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using SportsData.Core.Common;
 using SportsData.Core.Eventing.Events.Picks;
 using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Application.Dispatching;
 using SportsData.Notification.Infrastructure.Data.Entities;
 using SportsData.Notification.Infrastructure.Notifications;
 
@@ -105,6 +106,28 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
 
         body.Should().Be("Sluggers: BOS 3, NYY 2 — you picked BOS ✓");
         _capturedTitle.Should().Be("Nice pick!");
+    }
+
+    [Fact]
+    public async Task Consume_SmackVoice_AppendsGameContextUnderTheSmackLine()
+    {
+        // A smack line alone loses the game — "Vegas told you so" arrives
+        // with zero indication of which pick earned it. The standard context
+        // line must ride underneath.
+        Mocker.GetMock<ISmackPhraseCatalog>()
+            .Setup(x => x.TryResolveAsync(
+                It.IsAny<UserPickScored>(),
+                It.IsAny<NotificationVoice>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Vegas told you so");
+
+        var body = await RunAndCaptureBodyAsync(
+            Msg(Guid.NewGuid(), "BOS", "NYY", awayScore: 2, homeScore: 3,
+                isCorrect: false, pickedIsHome: false, pickedSpread: null));
+
+        _capturedTitle.Should().Be("SmackBot");
+        body.Should().Be("Vegas told you so\nSluggers: BOS 2, NYY 3 — you picked BOS ✗");
     }
 
     [Fact]

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/UserPickScoredConsumerTests.cs
@@ -128,6 +128,12 @@ public class UserPickScoredConsumerTests : NotificationTestBase<UserPickScoredCo
 
         _capturedTitle.Should().Be("SmackBot");
         body.Should().Be("Vegas told you so\nSluggers: BOS 2, NYY 3 — you picked BOS ✗");
+
+        // The audit row must record the SAME composed body that was sent —
+        // the Lab's rating flow and support questions read from it.
+        var row = await DataContext.NotificationUserPicks.SingleAsync();
+        row.Title.Should().Be("SmackBot");
+        row.Body.Should().Be("Vegas told you so\nSluggers: BOS 2, NYY 3 — you picked BOS ✗");
     }
 
     [Fact]


### PR DESCRIPTION
## SmackBot game context (the urgent one — NFL preseason tonight)

A SmackBot-voice push replaced the entire notification body with the smack line — the recipient had **zero** indication of which game earned it ("Vegas told you so" — about *what*?!). Reported live by a league member.

Fix in `UserPickScoredConsumer`: the smack line stays the headline, and the standard context line rides underneath — the exact `ComposeBody` output standard-voice users get (league name, scoreline picked-team-first, pick label with ATS spread when applicable, ✓/✗ mark), fallback shapes included:

```
SmackBot
AWY got waxed by 28.
Sluggers: HOM 59, AWY 20 — you picked AWY ✗
```

The tap-through deep link was already correct; this fixes what the recipient *sees*. Collapsed notifications show the smack line and truncate (the right tease); expanded shows everything. The `NotificationUserPick` audit row records the full composed body.

New consumer test locks the composed shape + SmackBot title. Notification suite **122/122**.

## Admin review auto-close (web)

Approving or rejecting a preview from the insight dialog now closes the dialog automatically — saving a click per review across hundreds of previews. Deliberate nuance: it closes **only when the action landed**. `PicksPage`'s handlers return success; a failure keeps the dialog open with the rejection note intact for a retry (auto-closing on failure would eat the note). Success also clears the note so the next matchup's dialog doesn't inherit a stale rejection reason.

Web lint clean, **26/26** Vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SmackBot pick-result notifications now retain the resolved smack line along with league, score, and pick details.
  * Admin approval and rejection dialogs remain open when an action fails, preserving any entered rejection note.
  * Dialogs now close and clear rejection notes only after actions complete successfully.
  * Approval and rejection controls are disabled while requests are in progress, preventing duplicate actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->