### PR TITLE
feat(core,producer,api): athlete season-statistics backfill + 2026-row purge

### DIFF
--- a/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
+++ b/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
@@ -231,19 +231,28 @@ Remediation shipped:
   `seasons/{year}/types/{seasonType}/athletes/{id}/statistics` URL
   (`EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef`) — never the
   athlete document's own (prior-season) ref. The #657 season guard then
-  attaches each doc to the roster row matching the ref's season, so the
-  fan-out is idempotent and safe to re-run. ~24.6k active 2025 rows ≈ 7h
-  at the 1s ESPN delay. Bruno: `athletes-source-statistics`.
+  attaches each doc to the roster row matching the season parsed from the
+  ref, so the fan-out is idempotent and safe to re-run. Precision note:
+  the guard engages only when the ref's season PARSES — always true for
+  these synthesized URLs, but an unparseable ref would fall through to
+  the spawning-row attach, which is why any nonzero step-4 result in the
+  purge script's post-backfill verification must be treated as a FAILED
+  backfill and investigated, not shrugged off. ~24.6k active 2025 rows
+  ≈ 7h at the 1s ESPN delay. Bruno: `athletes-source-statistics`.
 - **Purge script** —
   `sql/pgsql/athleteSeasonStatistics_2026_purge.sql`: deletes ALL stat
   docs attached to 2026 roster rows (~15.3k roster rows' worth; the
   script reports athletes and roster rows separately since transfers can
   split one athlete across two rows in a season). Scope is provably safe
-  while zero 2026 games have finalized — the script's step-0 guard
-  asserts exactly that and aborts the run if it ever fails. Child-first,
-  single transaction. Run order: deploy → purge → backfill → **re-run
-  the script's verification steps 4-5 after the batch completes** (2025
-  coverage should approach the active-roster count; 2026 stays zero).
+  while zero 2026 games have finalized — the guard runs INSIDE the purge
+  transaction and raises an exception if that ever fails, aborting the
+  transaction (nothing is deleted). Statistic writers are not stopped
+  during the run: post-#657 they no longer write to 2026 rows, and a
+  racing insert is caught by step 4 — nonzero after the purge means
+  re-run the (idempotent) script before backfilling. Run order: deploy →
+  purge → step 4 reads zero → backfill → **re-run steps 4-5 after the
+  batch completes** (step 4 still zero; 2025 coverage should approach
+  the active-roster count).
 
 ## Open questions
 

--- a/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
+++ b/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
@@ -217,8 +217,10 @@ URI must carry `?limit=200`:
 Root cause re-verified on a second specimen: Arch Manning's 2026 athlete
 document points its statistics ref at `seasons/2025/types/3/...`, while
 his 2024 document correctly points at `seasons/2024/types/3/...`. ESPN
-will presumably flip the 2026 ref once the season has data (the 2026
-statistics URL currently 404s).
+will presumably flip the 2026 ref once the season has data. (External
+observation, 2026-08-21: `GET .../college-football/seasons/2026/types/3/
+athletes/4870906/statistics` returned HTTP 404 — expected to change once
+2026 games exist.)
 
 Remediation shipped:
 
@@ -233,10 +235,15 @@ Remediation shipped:
   fan-out is idempotent and safe to re-run. ~24.6k active 2025 rows ≈ 7h
   at the 1s ESPN delay. Bruno: `athletes-source-statistics`.
 - **Purge script** —
-  `sql/pgsql/athleteSeasonStatistics_2026_purge.sql`: deletes the
-  ~15,263 athletes' worth of mislabeled stat docs attached to 2026 rows
-  (child-first, single transaction, pre/post counts + Manning spot
-  check). Run order: deploy → purge → backfill.
+  `sql/pgsql/athleteSeasonStatistics_2026_purge.sql`: deletes ALL stat
+  docs attached to 2026 roster rows (~15.3k roster rows' worth; the
+  script reports athletes and roster rows separately since transfers can
+  split one athlete across two rows in a season). Scope is provably safe
+  while zero 2026 games have finalized — the script's step-0 guard
+  asserts exactly that and aborts the run if it ever fails. Child-first,
+  single transaction. Run order: deploy → purge → backfill → **re-run
+  the script's verification steps 4-5 after the batch completes** (2025
+  coverage should approach the active-roster count; 2026 stays zero).
 
 ## Open questions
 

--- a/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
+++ b/docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
@@ -212,6 +212,32 @@ URI must carry `?limit=200`:
   `.../seasons/2026/types/2/leaders?lang=en&region=us&limit=200`
   (add the `types/3` row once postseason begins)
 
+## Follow-up (2026-08-21): purge + backfill built (recommendations #2 and #4)
+
+Root cause re-verified on a second specimen: Arch Manning's 2026 athlete
+document points its statistics ref at `seasons/2025/types/3/...`, while
+his 2024 document correctly points at `seasons/2024/types/3/...`. ESPN
+will presumably flip the 2026 ref once the season has data (the 2026
+statistics URL currently 404s).
+
+Remediation shipped:
+
+- **Backfill endpoint** — `POST
+  api/athletes/seasonYear/{seasonYear}/statistics/source` (Producer,
+  ops-proxy family `athletes`): fans out one DocumentRequested per ACTIVE
+  AthleteSeason for the year, targeting a SYNTHESIZED
+  `seasons/{year}/types/{seasonType}/athletes/{id}/statistics` URL
+  (`EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef`) — never the
+  athlete document's own (prior-season) ref. The #657 season guard then
+  attaches each doc to the roster row matching the ref's season, so the
+  fan-out is idempotent and safe to re-run. ~24.6k active 2025 rows ≈ 7h
+  at the 1s ESPN delay. Bruno: `athletes-source-statistics`.
+- **Purge script** —
+  `sql/pgsql/athleteSeasonStatistics_2026_purge.sql`: deletes the
+  ~15,263 athletes' worth of mislabeled stat docs attached to 2026 rows
+  (child-first, single transaction, pre/post counts + Manning spot
+  check). Run order: deploy → purge → backfill.
+
 ## Open questions
 
 - Whether ESPN's `types/3` statistics ref flips to `types/2` early in a

--- a/sql/pgsql/athleteSeasonStatistics_2026_purge.sql
+++ b/sql/pgsql/athleteSeasonStatistics_2026_purge.sql
@@ -4,29 +4,49 @@
 -- Context: docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
 -- ESPN's 2026 athlete documents hand out the PRIOR season's statistics ref
 -- until the new season has data, so every stat doc attached to a 2026
--- AthleteSeason row actually contains 2025 numbers (~15,263 athletes).
--- The season guard (#657) prevents re-pollution; the type-scoped backfill
--- endpoint re-sources the same data onto the correct 2025 rows.
+-- AthleteSeason row actually contains 2025 numbers. The season guard (#657)
+-- prevents re-pollution; the type-scoped backfill endpoint re-sources the
+-- same data onto the correct 2025 rows.
 --
--- Run order: deploy the backfill PR -> run THIS purge -> trigger the
--- backfill (Bruno: athletes-source-statistics).
+-- WHY the purge scope is "everything on a 2026 row" rather than an
+-- identity-matched subset: no 2026 games have been played, so a 2026
+-- roster row cannot legitimately carry ANY season statistics. Step 0
+-- asserts that invariant before anything is deleted — once real 2026
+-- games finalize, this script is no longer safe to run as-is and step 0
+-- will say so.
+--
+-- Run order: deploy the backfill PR -> step 0-3 (this purge) -> trigger
+-- the backfill (Bruno: athletes-source-statistics) -> AFTER the batch
+-- completes, re-run steps 4-5 as the post-backfill verification.
 --
 -- The FK chain AthleteSeasonStatistic -> Category -> Stat is ON DELETE
 -- CASCADE, but the deletes below are explicit child-first anyway so each
 -- level reports its own row count.
 -- =============================================================================
 
--- 1) Pre-counts: what will be deleted
-select count(distinct ass."AthleteSeasonId") as athletes_2026_with_stats,
-       count(distinct ass."Id")              as statistic_docs
+-- 0) PRE-FLIGHT GUARD: the purge is only valid while no 2026 game has been
+--    finalized. Expect zero — if this returns ANY rows, STOP: the blanket
+--    2026 purge is no longer provably safe and needs an identity-scoped
+--    variant instead.
+select count(*) as finalized_2026_contests_MUST_BE_ZERO
+from public."Contest"
+where "SeasonYear" = 2026
+  and "FinalizedUtc" is not null;
+
+-- 1) Pre-counts: what will be deleted. Athletes and roster rows counted
+--    separately (mid-season transfers can give one athlete two roster rows
+--    in a single season, so the two metrics legitimately differ).
+select count(distinct aths."AthleteId")       as athletes_2026_with_stats,
+       count(distinct ass."AthleteSeasonId")  as roster_rows_2026_with_stats,
+       count(distinct ass."Id")               as statistic_docs
 from public."AthleteSeasonStatistic" ass
 join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
 join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
 where fs."SeasonYear" = 2026;
 
--- 2) Sanity: 2025 rows BEFORE backfill (expect ~1,942 athletes; re-run
---    after the backfill and expect it near the active-2025 roster count)
-select count(distinct ass."AthleteSeasonId") as athletes_2025_with_stats
+-- 2) Baseline: 2025 coverage BEFORE backfill (expect ~1.9k athletes).
+select count(distinct aths."AthleteId")      as athletes_2025_with_stats,
+       count(distinct ass."AthleteSeasonId") as roster_rows_2025_with_stats
 from public."AthleteSeasonStatistic" ass
 join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
 join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
@@ -57,15 +77,32 @@ where ass."Id" = p."Id";
 
 commit;
 
--- 4) Verify: expect zero
+-- =============================================================================
+-- POST-BACKFILL VERIFICATION — run steps 4-5 twice: once immediately after
+-- the purge (4 should be zero; 5's 2025 row still sparse), and AGAIN after
+-- the backfill batch completes in Seq (5's 2025 coverage should approach
+-- the active-2025 roster count; 2026 stays zero until real 2026 games).
+-- =============================================================================
+
+-- 4) Expect zero after the purge, and STILL zero after the backfill (the
+--    season guard must not attach anything to 2026 rows).
 select count(*) as remaining_2026_stat_docs
 from public."AthleteSeasonStatistic" ass
 join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
 join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
 where fs."SeasonYear" = 2026;
 
--- 5) Post-backfill spot check: Arch Manning's 2025 row should carry his
---    real 2025 stats; his 2026 row should be empty until 2026 games exist.
+-- 5) Coverage by season + Arch Manning spot check: after the backfill his
+--    2025 row should carry his real 2025 stats; his 2026 row stays empty.
+select fs."SeasonYear",
+       count(distinct aths."AthleteId") as athletes_with_stats
+from public."AthleteSeasonStatistic" ass
+join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
+join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
+where fs."SeasonYear" in (2024, 2025, 2026)
+group by fs."SeasonYear"
+order by fs."SeasonYear" desc;
+
 select fs."SeasonYear", count(ass."Id") as stat_docs
 from public."AthleteSeason" aths
 join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"

--- a/sql/pgsql/athleteSeasonStatistics_2026_purge.sql
+++ b/sql/pgsql/athleteSeasonStatistics_2026_purge.sql
@@ -10,32 +10,34 @@
 --
 -- WHY the purge scope is "everything on a 2026 row" rather than an
 -- identity-matched subset: no 2026 games have been played, so a 2026
--- roster row cannot legitimately carry ANY season statistics. Step 0
--- asserts that invariant before anything is deleted — once real 2026
--- games finalize, this script is no longer safe to run as-is and step 0
--- will say so.
+-- roster row cannot legitimately carry ANY season statistics. Step 2's
+-- guard ENFORCES that invariant inside the purge transaction — it raises
+-- an exception (aborting the transaction) if any finalized 2026 contest
+-- exists. Once real 2026 games finalize, this script refuses to run and
+-- an identity-scoped variant is needed instead.
 --
--- Run order: deploy the backfill PR -> step 0-3 (this purge) -> trigger
--- the backfill (Bruno: athletes-source-statistics) -> AFTER the batch
--- completes, re-run steps 4-5 as the post-backfill verification.
+-- Concurrency: this script does not stop Producer's statistic writers.
+-- That is deliberate — post-#657 a statistics document whose ref parses
+-- to a prior season attaches to THAT season's roster row, so organic
+-- processing no longer writes to 2026 rows. If a writer nonetheless
+-- races the purge (insert lands after _purge_stat_docs is materialized),
+-- step 4 catches it: a nonzero result means RE-RUN this script (it is
+-- idempotent) before triggering the backfill.
+--
+-- Run order: deploy the backfill PR -> steps 1-3 (this purge) -> step 4
+-- must be zero (nonzero => re-run the purge) -> trigger the backfill
+-- (Bruno: athletes-source-statistics) -> AFTER the batch completes,
+-- re-run steps 4-5 as the post-backfill verification.
 --
 -- The FK chain AthleteSeasonStatistic -> Category -> Stat is ON DELETE
 -- CASCADE, but the deletes below are explicit child-first anyway so each
 -- level reports its own row count.
 -- =============================================================================
 
--- 0) PRE-FLIGHT GUARD: the purge is only valid while no 2026 game has been
---    finalized. Expect zero — if this returns ANY rows, STOP: the blanket
---    2026 purge is no longer provably safe and needs an identity-scoped
---    variant instead.
-select count(*) as finalized_2026_contests_MUST_BE_ZERO
-from public."Contest"
-where "SeasonYear" = 2026
-  and "FinalizedUtc" is not null;
-
 -- 1) Pre-counts: what will be deleted. Athletes and roster rows counted
 --    separately (mid-season transfers can give one athlete two roster rows
---    in a single season, so the two metrics legitimately differ).
+--    in a single season, so the two metrics legitimately differ). Also the
+--    2025 baseline for comparison after the backfill (expect ~1.9k).
 select count(distinct aths."AthleteId")       as athletes_2026_with_stats,
        count(distinct ass."AthleteSeasonId")  as roster_rows_2026_with_stats,
        count(distinct ass."Id")               as statistic_docs
@@ -44,7 +46,6 @@ join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
 join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
 where fs."SeasonYear" = 2026;
 
--- 2) Baseline: 2025 coverage BEFORE backfill (expect ~1.9k athletes).
 select count(distinct aths."AthleteId")      as athletes_2025_with_stats,
        count(distinct ass."AthleteSeasonId") as roster_rows_2025_with_stats
 from public."AthleteSeasonStatistic" ass
@@ -52,8 +53,25 @@ join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
 join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
 where fs."SeasonYear" = 2025;
 
--- 3) The purge (single transaction, child-first)
+-- 2+3) The purge: guard + delete in ONE transaction. The guard RAISES if
+--      any finalized 2026 contest exists, which aborts the transaction —
+--      the deletes below then refuse to run and the COMMIT rolls back.
 begin;
+
+do $$
+declare finalized_2026 int;
+begin
+    select count(*) into finalized_2026
+    from public."Contest"
+    where "SeasonYear" = 2026
+      and "FinalizedUtc" is not null;
+
+    if finalized_2026 > 0 then
+        raise exception
+            'PURGE ABORTED: % finalized 2026 contest(s) exist. A 2026 roster row can now legitimately carry stats — the blanket purge is unsafe. Use an identity-scoped variant instead.',
+            finalized_2026;
+    end if;
+end $$;
 
 create temp table _purge_stat_docs on commit drop as
 select ass."Id"
@@ -78,14 +96,17 @@ where ass."Id" = p."Id";
 commit;
 
 -- =============================================================================
--- POST-BACKFILL VERIFICATION — run steps 4-5 twice: once immediately after
--- the purge (4 should be zero; 5's 2025 row still sparse), and AGAIN after
--- the backfill batch completes in Seq (5's 2025 coverage should approach
--- the active-2025 roster count; 2026 stays zero until real 2026 games).
+-- VERIFICATION — run steps 4-5 twice:
+--   (a) immediately after the purge: step 4 MUST be zero. Nonzero means a
+--       concurrent writer raced the purge — re-run the script (idempotent)
+--       and do NOT trigger the backfill until step 4 reads zero.
+--   (b) again after the backfill batch completes in Seq: step 4 must STILL
+--       be zero (the season guard must not attach anything to 2026 rows —
+--       nonzero here = failed backfill, investigate before proceeding);
+--       step 5's 2025 coverage should approach the active-roster count.
 -- =============================================================================
 
--- 4) Expect zero after the purge, and STILL zero after the backfill (the
---    season guard must not attach anything to 2026 rows).
+-- 4) Remaining 2026-row stat docs — must be zero at both checkpoints.
 select count(*) as remaining_2026_stat_docs
 from public."AthleteSeasonStatistic" ass
 join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"

--- a/sql/pgsql/athleteSeasonStatistics_2026_purge.sql
+++ b/sql/pgsql/athleteSeasonStatistics_2026_purge.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- Purge mislabeled 2026-row athlete season statistics (NCAAFB)
+-- =============================================================================
+-- Context: docs/features/player-pickem/athlete-season-stats-audit-2026-08.md
+-- ESPN's 2026 athlete documents hand out the PRIOR season's statistics ref
+-- until the new season has data, so every stat doc attached to a 2026
+-- AthleteSeason row actually contains 2025 numbers (~15,263 athletes).
+-- The season guard (#657) prevents re-pollution; the type-scoped backfill
+-- endpoint re-sources the same data onto the correct 2025 rows.
+--
+-- Run order: deploy the backfill PR -> run THIS purge -> trigger the
+-- backfill (Bruno: athletes-source-statistics).
+--
+-- The FK chain AthleteSeasonStatistic -> Category -> Stat is ON DELETE
+-- CASCADE, but the deletes below are explicit child-first anyway so each
+-- level reports its own row count.
+-- =============================================================================
+
+-- 1) Pre-counts: what will be deleted
+select count(distinct ass."AthleteSeasonId") as athletes_2026_with_stats,
+       count(distinct ass."Id")              as statistic_docs
+from public."AthleteSeasonStatistic" ass
+join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
+join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
+where fs."SeasonYear" = 2026;
+
+-- 2) Sanity: 2025 rows BEFORE backfill (expect ~1,942 athletes; re-run
+--    after the backfill and expect it near the active-2025 roster count)
+select count(distinct ass."AthleteSeasonId") as athletes_2025_with_stats
+from public."AthleteSeasonStatistic" ass
+join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
+join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
+where fs."SeasonYear" = 2025;
+
+-- 3) The purge (single transaction, child-first)
+begin;
+
+create temp table _purge_stat_docs on commit drop as
+select ass."Id"
+from public."AthleteSeasonStatistic" ass
+join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
+join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
+where fs."SeasonYear" = 2026;
+
+delete from public."AthleteSeasonStatisticStat" s
+using public."AthleteSeasonStatisticCategory" c, _purge_stat_docs p
+where s."AthleteSeasonStatisticCategoryId" = c."Id"
+  and c."AthleteSeasonStatisticId" = p."Id";
+
+delete from public."AthleteSeasonStatisticCategory" c
+using _purge_stat_docs p
+where c."AthleteSeasonStatisticId" = p."Id";
+
+delete from public."AthleteSeasonStatistic" ass
+using _purge_stat_docs p
+where ass."Id" = p."Id";
+
+commit;
+
+-- 4) Verify: expect zero
+select count(*) as remaining_2026_stat_docs
+from public."AthleteSeasonStatistic" ass
+join public."AthleteSeason" aths on aths."Id" = ass."AthleteSeasonId"
+join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
+where fs."SeasonYear" = 2026;
+
+-- 5) Post-backfill spot check: Arch Manning's 2025 row should carry his
+--    real 2025 stats; his 2026 row should be empty until 2026 games exist.
+select fs."SeasonYear", count(ass."Id") as stat_docs
+from public."AthleteSeason" aths
+join public."FranchiseSeason" fs on fs."Id" = aths."FranchiseSeasonId"
+left join public."AthleteSeasonStatistic" ass on ass."AthleteSeasonId" = aths."Id"
+where aths."AthleteId" = 'ea6ec41d-31a1-623e-1a68-d21910f17bb8'
+group by fs."SeasonYear"
+order by fs."SeasonYear" desc;

--- a/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminOpsProxyController.cs
@@ -44,6 +44,7 @@ public class AdminOpsProxyController : ControllerBase
         // segment (base/api + api/... = /api/api/...) and 404 upstream.
         private static readonly string[] ProducerPrefixes =
         [
+            "athletes",
             "franchise-seasons",
             "competitions",
             "contests"

--- a/src/SportsData.Core/Common/CausationId.cs
+++ b/src/SportsData.Core/Common/CausationId.cs
@@ -37,6 +37,7 @@ namespace SportsData.Core.Common
             public static Guid FranchiseSeasonCreated = new Guid("10000000-0000-0000-0000-000000000012");
             public static Guid FranchiseSeasonEnrichmentProcessor = new Guid("10000001-0000-0000-0000-00000000001F");
             public static Guid FranchiseSeasonService = new Guid("10000A00-0000-0000-0000-000000000007");
+            public static Guid AthleteSeasonStatisticsSourcing = new Guid("10000A00-0000-0000-0000-000000000008");
             public static Guid GroupSeasonDocumentProcessor = new Guid("10000000-0000-0000-0000-000000000013");
             public static Guid ImageRequestedProcessor = new Guid("10000000-0000-0000-0000-000000000014");
             public static Guid PositionDocumentProcessor = new Guid("10000000-0000-0000-0000-000000000015");

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
@@ -762,6 +762,37 @@ public static class EspnUriMapper
         return new Uri(result, UriKind.Absolute);
     }
 
+    /// <summary>
+    /// Builds the season-type-scoped statistics ref from a season-scoped
+    /// athlete ref: .../seasons/{year}/athletes/{id} becomes
+    /// .../seasons/{year}/types/{seasonType}/athletes/{id}/statistics.
+    /// The explicit /types/{n}/ scope is the whole point — ESPN's athlete
+    /// document hands out the PRIOR season's statistics ref until the new
+    /// season has data, so backfills must synthesize the URL themselves
+    /// rather than follow the document.
+    /// </summary>
+    public static Uri AthleteSeasonRefToSeasonTypeStatisticsRef(Uri athleteSeasonRef, int seasonType)
+    {
+        if (athleteSeasonRef == null) throw new ArgumentNullException(nameof(athleteSeasonRef));
+
+        var path = athleteSeasonRef.GetLeftPart(UriPartial.Path);
+        var parts = path.Split('/');
+
+        // Expect: ... / seasons / {year} / athletes / {athleteId}
+        var seasonsIndex = Array.IndexOf(parts, "seasons");
+        var athletesIndex = Array.IndexOf(parts, "athletes");
+
+        if (seasonsIndex < 0 || seasonsIndex + 1 >= parts.Length ||
+            athletesIndex != seasonsIndex + 2 || athletesIndex + 1 >= parts.Length ||
+            !int.TryParse(parts[athletesIndex + 1], out _))
+            throw new InvalidOperationException($"Unexpected ESPN AthleteSeason ref format: {athleteSeasonRef}");
+
+        var prefix = string.Join('/', parts.Take(seasonsIndex + 2)); // .../seasons/{year}
+        var athleteId = parts[athletesIndex + 1];
+
+        return new Uri($"{prefix}/types/{seasonType}/athletes/{athleteId}/statistics", UriKind.Absolute);
+    }
+
     public static Uri CoachSeasonRecordRefToCoachSeasonRef(Uri recordRef)
         => TrimRecordSegment(recordRef, nameof(recordRef));
 

--- a/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
+++ b/src/SportsData.Core/Infrastructure/DataSources/Espn/EspnUriMapper.cs
@@ -783,6 +783,7 @@ public static class EspnUriMapper
         var athletesIndex = Array.IndexOf(parts, "athletes");
 
         if (seasonsIndex < 0 || seasonsIndex + 1 >= parts.Length ||
+            !int.TryParse(parts[seasonsIndex + 1], out _) ||
             athletesIndex != seasonsIndex + 2 || athletesIndex + 1 >= parts.Length ||
             !int.TryParse(parts[athletesIndex + 1], out _))
             throw new InvalidOperationException($"Unexpected ESPN AthleteSeason ref format: {athleteSeasonRef}");

--- a/src/SportsData.Producer/Application/Athletes/AthleteController.cs
+++ b/src/SportsData.Producer/Application/Athletes/AthleteController.cs
@@ -1,6 +1,51 @@
-﻿namespace SportsData.Producer.Application.Athletes
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Core.DependencyInjection;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
+
+namespace SportsData.Producer.Application.Athletes;
+
+/// <summary>
+/// Body for the season-statistics sourcing endpoint. SeasonType scopes the
+/// synthesized statistics URL: 2 = regular season, 3 = through postseason
+/// (default — full-season totals).
+/// </summary>
+public class AthleteSeasonStatisticsSourcingRequest
 {
-    public class AthleteController
+    public int SeasonType { get; set; } = 3;
+}
+
+[Route("api/athletes")]
+[ApiController]
+public class AthleteController : ControllerBase
+{
+    /// <summary>
+    /// Fans out season-type-scoped statistics DocumentRequests for every
+    /// ACTIVE athlete rostered in the season year (immediate driver: the
+    /// 2025 NCAAFB season-stats backfill). ~25k athletes per season, so it
+    /// runs as a background job; the returned correlation id is the Seq
+    /// handle for the whole batch, same contract as the franchise-season
+    /// sourcing endpoint.
+    /// </summary>
+    [HttpPost("seasonYear/{seasonYear}/statistics/source")]
+    public ActionResult<Guid> RequestAthleteSeasonStatisticsSourcing(
+        [FromRoute] int seasonYear,
+        [FromBody] AthleteSeasonStatisticsSourcingRequest request,
+        [FromServices] IProvideBackgroundJobs backgroundJobProvider,
+        [FromServices] IAppMode appMode)
     {
+        var correlationId = Guid.NewGuid();
+
+        var command = new RequestAthleteSeasonStatisticsSourcingCommand(
+            seasonYear,
+            appMode.CurrentSport,
+            request.SeasonType,
+            correlationId);
+
+        backgroundJobProvider.Enqueue<IRequestAthleteSeasonStatisticsSourcingCommandHandler>(
+            h => h.ExecuteAsync(command, CancellationToken.None));
+
+        return Accepted(correlationId);
     }
 }

--- a/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommand.cs
+++ b/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommand.cs
@@ -1,0 +1,12 @@
+using SportsData.Core.Common;
+
+namespace SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
+
+/// <param name="SeasonType">ESPN season type scope for the statistics URL:
+/// 2 = regular season, 3 = through postseason (default — full-season
+/// totals, what the lineup picker wants for "last season").</param>
+public record RequestAthleteSeasonStatisticsSourcingCommand(
+    int SeasonYear,
+    Sport Sport,
+    int SeasonType = 3,
+    Guid? CorrelationId = null);

--- a/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommandHandler.cs
@@ -1,0 +1,173 @@
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Core.Infrastructure.DataSources.Espn;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
+
+public interface IRequestAthleteSeasonStatisticsSourcingCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        RequestAthleteSeasonStatisticsSourcingCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Fans out a DocumentRequested per ACTIVE AthleteSeason for a season year,
+/// targeting an explicitly season-type-scoped statistics URL synthesized
+/// from the roster row's own ESPN ref (immediate driver: the 2025 NCAAFB
+/// season-stats backfill). The URL must be synthesized rather than taken
+/// from ESPN's athlete document because that document hands out the PRIOR
+/// season's statistics ref until the new season has data — the root cause
+/// of the mislabeled-2026-stats mess this backfill repairs. The
+/// AthleteSeasonStatisticsDocumentProcessor's season guard then attaches
+/// each document to the athlete's roster row for the season embedded in
+/// the ref, so requests are safe to re-run and safe even if a target row
+/// is missing (logged skip).
+/// </summary>
+public class RequestAthleteSeasonStatisticsSourcingCommandHandler : IRequestAthleteSeasonStatisticsSourcingCommandHandler
+{
+    private readonly ILogger<RequestAthleteSeasonStatisticsSourcingCommandHandler> _logger;
+    private readonly TeamSportDataContext _dataContext;
+    private readonly IEventBus _eventBus;
+    private readonly IGenerateExternalRefIdentities _externalRefIdentityGenerator;
+    private readonly IValidator<RequestAthleteSeasonStatisticsSourcingCommand> _validator;
+    private readonly IMessageDeliveryScope _deliveryScope;
+
+    public RequestAthleteSeasonStatisticsSourcingCommandHandler(
+        ILogger<RequestAthleteSeasonStatisticsSourcingCommandHandler> logger,
+        TeamSportDataContext dataContext,
+        IEventBus eventBus,
+        IGenerateExternalRefIdentities externalRefIdentityGenerator,
+        IValidator<RequestAthleteSeasonStatisticsSourcingCommand> validator,
+        IMessageDeliveryScope deliveryScope)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _eventBus = eventBus;
+        _externalRefIdentityGenerator = externalRefIdentityGenerator;
+        _validator = validator;
+        _deliveryScope = deliveryScope;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        RequestAthleteSeasonStatisticsSourcingCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+
+        // Active roster rows for the season, with their season-scoped ESPN
+        // athlete ref. Projected, not Include'd — this is the only shape the
+        // fan-out needs, and at ~25k rows per season the narrow select
+        // matters.
+        var targets = await _dataContext.AthleteSeasons
+            .AsNoTracking()
+            .Where(a =>
+                a.IsActive &&
+                a.FranchiseSeasonId != null &&
+                _dataContext.FranchiseSeasons.Any(fs =>
+                    fs.Id == a.FranchiseSeasonId &&
+                    fs.SeasonYear == command.SeasonYear))
+            .Select(a => new
+            {
+                a.Id,
+                SourceUrl = a.ExternalIds
+                    .Where(x => x.Provider == SourceDataProvider.Espn)
+                    .Select(x => x.SourceUrl)
+                    .FirstOrDefault()
+            })
+            .ToListAsync(cancellationToken);
+
+        if (targets.Count == 0)
+        {
+            _logger.LogWarning(
+                "No active athlete seasons found to source statistics for. SeasonYear={SeasonYear}, Sport={Sport}",
+                command.SeasonYear, command.Sport);
+            return new Success<Guid>(Guid.Empty, ResultStatus.NotFound);
+        }
+
+        // Caller-minted correlation id, same contract as the franchise
+        // sourcing endpoint: the 202 response carries the Seq handle for the
+        // whole batch before this background job runs.
+        var correlationId = command.CorrelationId ?? Guid.NewGuid();
+        var requested = 0;
+        var skipped = 0;
+        var failed = 0;
+
+        // Direct delivery, NOT the bus-outbox: this handler only READS and
+        // writes no entity, so SaveChangesAsync would never flush the outbox
+        // and the events would be silently dropped. See
+        // RequestFranchiseSeasonSourcingCommandHandler.
+        using (_deliveryScope.Use(DeliveryMode.Direct))
+        {
+            foreach (var target in targets)
+            {
+                Uri statisticsRef;
+                try
+                {
+                    if (string.IsNullOrWhiteSpace(target.SourceUrl) ||
+                        !Uri.TryCreate(target.SourceUrl, UriKind.Absolute, out var athleteSeasonRef))
+                        throw new InvalidOperationException("No usable ESPN SourceUrl");
+
+                    statisticsRef = EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef(
+                        athleteSeasonRef, command.SeasonType);
+                }
+                catch (Exception ex)
+                {
+                    // Log-and-continue: one athlete's missing/garbage ref must
+                    // not stop the rest. The count surfaces in the summary.
+                    _logger.LogWarning(
+                        "Skipping athlete season {AthleteSeasonId}: {Reason}. SeasonYear={SeasonYear}",
+                        target.Id, ex.Message, command.SeasonYear);
+                    skipped++;
+                    continue;
+                }
+
+                var identity = _externalRefIdentityGenerator.Generate(statisticsRef);
+
+                try
+                {
+                    await _eventBus.Publish(new DocumentRequested(
+                        Id: identity.UrlHash,
+                        ParentId: target.Id.ToString(),
+                        Uri: new Uri(identity.CleanUrl),
+                        Ref: null,
+                        Sport: command.Sport,
+                        SeasonYear: command.SeasonYear,
+                        DocumentType: DocumentType.AthleteSeasonStatistics,
+                        SourceDataProvider: SourceDataProvider.Espn,
+                        CorrelationId: correlationId,
+                        CausationId: CausationId.Producer.AthleteSeasonStatisticsSourcing,
+                        IncludeLinkedDocumentTypes: null
+                    ), cancellationToken);
+
+                    requested++;
+                }
+                catch (Exception ex)
+                {
+                    // Same log-and-continue contract: under at-least-once a
+                    // re-run publishes the same idempotent DocumentRequested
+                    // for the failed ones.
+                    _logger.LogError(ex,
+                        "Failed to publish statistics sourcing request for athlete season {AthleteSeasonId}. SeasonYear={SeasonYear}",
+                        target.Id, command.SeasonYear);
+                    failed++;
+                }
+            }
+        }
+
+        _logger.LogInformation(
+            "AthleteSeason statistics sourcing requested. SeasonYear={SeasonYear}, SeasonType={SeasonType}, Sport={Sport}, Requested={Requested}, Skipped={Skipped}, Failed={Failed}, CorrelationId={CorrelationId}",
+            command.SeasonYear, command.SeasonType, command.Sport, requested, skipped, failed, correlationId);
+
+        return new Success<Guid>(correlationId, ResultStatus.Accepted);
+    }
+}

--- a/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommandHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommandHandler.cs
@@ -110,15 +110,20 @@ public class RequestAthleteSeasonStatisticsSourcingCommandHandler : IRequestAthl
         {
             foreach (var target in targets)
             {
-                Uri statisticsRef;
+                ExternalRefIdentity identity;
                 try
                 {
                     if (string.IsNullOrWhiteSpace(target.SourceUrl) ||
                         !Uri.TryCreate(target.SourceUrl, UriKind.Absolute, out var athleteSeasonRef))
                         throw new InvalidOperationException("No usable ESPN SourceUrl");
 
-                    statisticsRef = EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef(
+                    var statisticsRef = EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef(
                         athleteSeasonRef, command.SeasonType);
+
+                    // Inside the same boundary as the URL synthesis: an
+                    // identity failure for one athlete's ref is that athlete's
+                    // problem, not the batch's.
+                    identity = _externalRefIdentityGenerator.Generate(statisticsRef);
                 }
                 catch (Exception ex)
                 {
@@ -130,8 +135,6 @@ public class RequestAthleteSeasonStatisticsSourcingCommandHandler : IRequestAthl
                     skipped++;
                     continue;
                 }
-
-                var identity = _externalRefIdentityGenerator.Generate(statisticsRef);
 
                 try
                 {

--- a/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommandValidator.cs
+++ b/src/SportsData.Producer/Application/Athletes/Commands/RequestAthleteSeasonStatisticsSourcing/RequestAthleteSeasonStatisticsSourcingCommandValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
+
+/// <summary>
+/// Same season-year bounds as the sibling franchise-season sourcing
+/// validator (2000 floor inclusive; at most one year out). SeasonType is
+/// restricted to the two scopes ESPN publishes athlete statistics under:
+/// 2 (regular season) and 3 (through postseason).
+/// </summary>
+public class RequestAthleteSeasonStatisticsSourcingCommandValidator
+    : AbstractValidator<RequestAthleteSeasonStatisticsSourcingCommand>
+{
+    public RequestAthleteSeasonStatisticsSourcingCommandValidator(IDateTimeProvider dateTimeProvider)
+    {
+        RuleFor(x => x.Sport)
+            .IsInEnum()
+            .WithMessage("Sport must be a valid enum value");
+
+        RuleFor(x => x.SeasonYear)
+            .GreaterThanOrEqualTo(2000)
+            .WithMessage("Season year must be 2000 or later")
+            .Must(year => year <= dateTimeProvider.UtcNow().Year + 1)
+            .WithMessage("Season year cannot be more than one year in the future");
+
+        RuleFor(x => x.SeasonType)
+            .InclusiveBetween(2, 3)
+            .WithMessage("SeasonType must be 2 (regular season) or 3 (through postseason)");
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Common;
 using SportsData.Core.Config;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
+using SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
 using SportsData.Producer.Application.Competitions;
 using SportsData.Producer.Application.Competitions.Reconcile;
 using SportsData.Producer.Application.Consumers;
@@ -277,6 +278,10 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IRefreshCompetitionMediaCommandHandler, RefreshCompetitionMediaCommandHandler>();
             services.AddScoped<IEnqueueCompetitionMediaRefreshCommandHandler, EnqueueCompetitionMediaRefreshCommandHandler>();
             services.AddScoped<IRefreshAllCompetitionMediaCommandHandler, RefreshAllCompetitionMediaCommandHandler>();
+
+            // Athlete Commands
+            services.AddScoped<IRequestAthleteSeasonStatisticsSourcingCommandHandler, RequestAthleteSeasonStatisticsSourcingCommandHandler>();
+            services.AddScoped<FluentValidation.IValidator<RequestAthleteSeasonStatisticsSourcingCommand>, RequestAthleteSeasonStatisticsSourcingCommandValidator>();
 
             // FranchiseSeason Commands
             services.AddScoped<IEnqueueFranchiseSeasonMetricsGenerationCommandHandler, EnqueueFranchiseSeasonMetricsGenerationCommandHandler>();

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
@@ -1031,6 +1031,7 @@ namespace SportsData.Core.Tests.Unit.Infrastructure.DataSources.Espn
         [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/types/3/athletes/4870906")]
         [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/")]
         [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/abc")]
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/not-a-year/athletes/4870906")]
         public void AthleteSeasonRefToSeasonTypeStatisticsRef_Should_Throw_For_Unexpected_Format(string url)
         {
             var input = new Uri(url);

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/DataSources/Espn/EspnUriMapperTests.cs
@@ -997,5 +997,54 @@ namespace SportsData.Core.Tests.Unit.Infrastructure.DataSources.Espn
         }
 
         #endregion
+
+        #region AthleteSeasonRefToSeasonTypeStatisticsRef
+
+        // Happy path: the /types/{n}/ scope is INSERTED between the season
+        // and athlete segments, query string stripped, scheme preserved.
+        // Covers negative ESPN athlete ids (valid) and both season types.
+        [Theory]
+        [InlineData(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/4870906?lang=en&region=us",
+            3,
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/types/3/athletes/4870906/statistics")]
+        [InlineData(
+            "https://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/-6952?lang=en&region=us",
+            2,
+            "https://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/types/2/athletes/-6952/statistics")]
+        public void AthleteSeasonRefToSeasonTypeStatisticsRef_Should_Insert_Type_Scope_And_Append_Statistics(
+            string athleteSeasonRef,
+            int seasonType,
+            string expectedStatisticsRef)
+        {
+            var input = new Uri(athleteSeasonRef);
+            var result = EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef(input, seasonType);
+            result.Should().Be(new Uri(expectedStatisticsRef));
+        }
+
+        // Non-athlete-season shapes must throw rather than synthesize a
+        // garbage URL: no seasons segment, no athletes segment, athletes not
+        // directly under seasons/{year}, missing id, non-numeric id.
+        [Theory]
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/athletes/4870906")]
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/teams/61")]
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/types/3/athletes/4870906")]
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/")]
+        [InlineData("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/abc")]
+        public void AthleteSeasonRefToSeasonTypeStatisticsRef_Should_Throw_For_Unexpected_Format(string url)
+        {
+            var input = new Uri(url);
+            var act = () => EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef(input, 3);
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void AthleteSeasonRefToSeasonTypeStatisticsRef_Should_Throw_For_Null()
+        {
+            var act = () => EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef(null!, 3);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        #endregion
     }
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/RequestAthleteSeasonStatisticsSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/RequestAthleteSeasonStatisticsSourcingCommandHandlerTests.cs
@@ -262,6 +262,36 @@ public class RequestAthleteSeasonStatisticsSourcingCommandHandlerTests
     }
 
     [Fact]
+    public async Task PublishFailure_ForOneAthlete_DoesNotAbandonTheBatch()
+    {
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/1");
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/2");
+
+        var handler = CreateHandler();
+
+        // The broker hiccups on athlete 1's publish; athlete 2 must still go
+        // out (logged failure, not an abandoned batch — under at-least-once
+        // a re-run republishes the same idempotent request for the failure).
+        Mocker.GetMock<IEventBus>()
+            .Setup(x => x.Publish(
+                It.Is<DocumentRequested>(e => e.Uri.ToString().Contains("/athletes/1/")),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("broker boom"));
+
+        var result = await handler.ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(SeasonYear, Sport.FootballNcaa));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e => e.Uri.ToString().Contains("/athletes/2/")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task NoActiveAthleteSeasons_ReturnsNotFound_PublishesNothing()
     {
         var result = await CreateHandler().ExecuteAsync(

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/RequestAthleteSeasonStatisticsSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/RequestAthleteSeasonStatisticsSourcingCommandHandlerTests.cs
@@ -1,0 +1,256 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.Documents;
+using SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Athletes;
+
+/// <summary>
+/// Bulk statistics backfill fan-out: one DocumentRequested per ACTIVE
+/// athlete season with a usable ESPN ref, targeting a SYNTHESIZED
+/// season-type-scoped statistics URL (never the athlete document's own
+/// statistics ref — ESPN points that at the prior season until the new one
+/// has data, which is the mislabeling this backfill repairs).
+/// </summary>
+public class RequestAthleteSeasonStatisticsSourcingCommandHandlerTests
+    : ProducerTestBase<RequestAthleteSeasonStatisticsSourcingCommandHandler>
+{
+    private const int SeasonYear = 2025;
+
+    // Fixed clock: deterministic seed data, per the no-DateTime.UtcNow rule.
+    private static readonly DateTime FixedNow = new(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+
+#nullable enable
+    private async Task<AthleteSeason> SeedAthleteSeasonAsync(
+        string? sourceUrl,
+        bool isActive = true,
+        int seasonYear = SeasonYear)
+    {
+        var fsId = Guid.NewGuid();
+        await FootballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+        {
+            Id = fsId,
+            FranchiseId = Guid.NewGuid(),
+            SeasonYear = seasonYear,
+            Slug = $"fs-{fsId:N}"[..20],
+            Location = "Testville",
+            Name = "Test Team",
+            Abbreviation = "TST",
+            DisplayName = "Test Team",
+            DisplayNameShort = "Test",
+            ColorCodeHex = "000000",
+            IsActive = true,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        var athleteSeasonId = Guid.NewGuid();
+        var athleteSeason = new FootballAthleteSeason
+        {
+            Id = athleteSeasonId,
+            AthleteId = Guid.NewGuid(),
+            FranchiseSeasonId = fsId,
+            PositionId = Guid.NewGuid(),
+            FirstName = "Test",
+            LastName = "Athlete",
+            IsActive = isActive,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        };
+
+        if (sourceUrl is not null)
+        {
+            athleteSeason.ExternalIds.Add(new AthleteSeasonExternalId
+            {
+                Id = Guid.NewGuid(),
+                AthleteSeasonId = athleteSeasonId,
+                Provider = SourceDataProvider.Espn,
+                Value = athleteSeasonId.ToString(),
+                SourceUrlHash = athleteSeasonId.ToString("N"),
+                SourceUrl = sourceUrl,
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+
+        await FootballDataContext.AthleteSeasons.AddAsync(athleteSeason);
+        await FootballDataContext.SaveChangesAsync();
+        return athleteSeason;
+    }
+
+    private RequestAthleteSeasonStatisticsSourcingCommandHandler CreateHandler()
+    {
+        // Real validator with a fixed clock — bounds behavior is part of the
+        // contract, not something to mock away.
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(FixedNow);
+        Mocker.Use<FluentValidation.IValidator<RequestAthleteSeasonStatisticsSourcingCommand>>(
+            new RequestAthleteSeasonStatisticsSourcingCommandValidator(Mocker.Get<IDateTimeProvider>()));
+        Mocker.GetMock<IGenerateExternalRefIdentities>()
+            .Setup(x => x.Generate(It.IsAny<Uri>()))
+            .Returns((Uri u) => new ExternalRefIdentity(
+                Guid.NewGuid(),
+                u.ToString().GetHashCode().ToString("X"),
+                u.ToString()));
+        // Direct delivery is required (read-only handler; the bus-outbox would
+        // never flush). Return a real disposable so `using` is safe.
+        Mocker.GetMock<IMessageDeliveryScope>()
+            .Setup(x => x.Use(It.IsAny<DeliveryMode>()))
+            .Returns(new NoopDisposable());
+        return Mocker.CreateInstance<RequestAthleteSeasonStatisticsSourcingCommandHandler>();
+    }
+
+    [Fact]
+    public async Task PublishesOneRequestPerActiveAthleteSeason_WithSynthesizedTypeScopedUrl()
+    {
+        var seeded = await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/4870906");
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/5078810");
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(SeasonYear, Sport.FootballNcaa));
+
+        result.IsSuccess.Should().BeTrue();
+        var published = new List<DocumentRequested>();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e =>
+                    CaptureAndMatch(published, e) &&
+                    e.DocumentType == DocumentType.AthleteSeasonStatistics &&
+                    e.Sport == Sport.FootballNcaa &&
+                    e.SeasonYear == SeasonYear),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+
+        // The URL is SYNTHESIZED with the explicit /types/3/ scope — never
+        // taken from the athlete document's (prior-season) statistics ref.
+        published.Select(e => e.Uri.ToString()).Should().BeEquivalentTo(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/types/3/athletes/4870906/statistics",
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/types/3/athletes/5078810/statistics");
+
+        // ParentId carries the spawning roster row; the processor's season
+        // guard re-verifies it against the ref's season regardless.
+        published.Select(e => e.ParentId).Should().Contain(seeded.Id.ToString());
+
+        // One batch, one correlation id — the Seq handle for the run.
+        published.Select(e => e.CorrelationId).Distinct().Should().ContainSingle();
+
+        // Direct delivery, not the bus-outbox — this handler saves nothing,
+        // so the outbox would silently swallow the events.
+        Mocker.GetMock<IMessageDeliveryScope>()
+            .Verify(x => x.Use(DeliveryMode.Direct), Times.Once);
+    }
+
+    [Fact]
+    public async Task InactiveOtherSeasonAndReflessRows_AreExcludedOrSkipped()
+    {
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/1");
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/2",
+            isActive: false);
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/3",
+            seasonYear: 2024);
+        await SeedAthleteSeasonAsync(sourceUrl: null); // no ESPN ref: logged skip
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(SeasonYear, Sport.FootballNcaa));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e =>
+                    e.Uri.ToString().Contains("/athletes/1/")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SeasonType2_ScopesTheSynthesizedUrlToRegularSeason()
+    {
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/4870906");
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(SeasonYear, Sport.FootballNcaa, SeasonType: 2));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e => e.Uri.ToString().Contains("/types/2/")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvalidSeasonType_FailsValidation_PublishesNothing()
+    {
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(SeasonYear, Sport.FootballNcaa, SeasonType: 1));
+
+        result.Status.Should().Be(ResultStatus.Validation);
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SuppliedCorrelationId_IsUsedOnEveryPublishedEvent()
+    {
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/1");
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/2");
+
+        // The controller mints the id, returns it in the 202, and enqueues
+        // the handler — the operator's Seq handle must match the response.
+        var suppliedId = Guid.NewGuid();
+
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(
+                SeasonYear, Sport.FootballNcaa, 3, suppliedId));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e => e.CorrelationId == suppliedId),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task NoActiveAthleteSeasons_ReturnsNotFound_PublishesNothing()
+    {
+        var result = await CreateHandler().ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(SeasonYear, Sport.FootballNcaa));
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    private static bool CaptureAndMatch(List<DocumentRequested> sink, DocumentRequested e)
+    {
+        sink.Add(e);
+        return true;
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/RequestAthleteSeasonStatisticsSourcingCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/RequestAthleteSeasonStatisticsSourcingCommandHandlerTests.cs
@@ -232,6 +232,36 @@ public class RequestAthleteSeasonStatisticsSourcingCommandHandlerTests
     }
 
     [Fact]
+    public async Task IdentityGenerationFailure_ForOneAthlete_DoesNotAbandonTheBatch()
+    {
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/1");
+        await SeedAthleteSeasonAsync(
+            "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2025/athletes/2");
+
+        var handler = CreateHandler();
+
+        // One athlete's ref blows up identity generation; the other must
+        // still publish (logged skip, not an abandoned batch).
+        Mocker.GetMock<IGenerateExternalRefIdentities>()
+            .Setup(x => x.Generate(It.Is<Uri>(u => u.ToString().Contains("/athletes/1/"))))
+            .Throws(new InvalidOperationException("identity boom"));
+
+        var result = await handler.ExecuteAsync(
+            new RequestAthleteSeasonStatisticsSourcingCommand(SeasonYear, Sport.FootballNcaa));
+
+        result.IsSuccess.Should().BeTrue();
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(e => e.Uri.ToString().Contains("/athletes/2/")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(It.IsAny<DocumentRequested>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task NoActiveAthleteSeasons_ReturnsNotFound_PublishesNothing()
     {
         var result = await CreateHandler().ExecuteAsync(


### PR DESCRIPTION
## Summary

Repairs the mislabeled athlete season stats from the [player pick'em audit](docs/features/player-pickem/athlete-season-stats-audit-2026-08.md): ESPN's season-scoped athlete document hands out the **prior season's** statistics ref until the new season has data — re-verified on Arch Manning, whose 2026 doc points at `seasons/2025/types/3/.../statistics` while his 2024 doc correctly points at 2024. Result: ~15,263 athletes' 2025 numbers attached to 2026 roster rows, 2025 rows nearly empty.

Two-part remediation (the #657 season guard already prevents re-pollution):

1. **Purge** the mislabeled 2026-row stat docs — `sql/pgsql/athleteSeasonStatistics_2026_purge.sql` (single transaction, child-first, pre/post counts, Manning spot check).
2. **Backfill** 2025 stats onto the correct rows via a new bulk endpoint.

## Changes

**Core**
- `EspnUriMapper.AthleteSeasonRefToSeasonTypeStatisticsRef` — synthesizes `seasons/{year}/types/{seasonType}/athletes/{id}/statistics` from the roster row's own season-scoped athlete ref. Synthesis is the point: following ESPN's document ref is the root cause being repaired. Throws on unexpected URL shapes.
- `CausationId.Producer.AthleteSeasonStatisticsSourcing`

**Producer**
- `POST api/athletes/seasonYear/{seasonYear}/statistics/source` (body `{"seasonType": 2|3}`, default 3): one `DocumentRequested` (AthleteSeasonStatistics) per **active** AthleteSeason for the year — ~24.6k for 2025, ≈7h at the 1s ESPN delay. Mirrors the franchise-season sourcing slice: background job, 202 + caller-minted correlation id as the Seq handle, direct delivery (read-only handler; the bus-outbox would never flush), log-and-continue per athlete.
- The #657 season guard attaches each document to the roster row matching the ref's season, so the fan-out is idempotent and safe to re-run; athletes without a roster row for the target season are logged skips (expected — 2025 roster sourcing was partial).

**Api** — `athletes` added to the ops-proxy Producer allowlist.

## Run order (post-merge)

Deploy → run the purge script → trigger the backfill via the ops proxy (Bruno request ready locally) → watch the correlation id in Seq → re-run the audit counts (2025 athletes-with-stats should rise from ~1,942 toward the active-roster count; 2026 should be zero until real 2026 games).

## Validation

- 6 new handler tests: synthesized URL shape, active/season/ref-less filtering, type-2 scoping, validation bounds, supplied correlation id, empty-result NotFound
- 8 new EspnUriMapper tests: happy paths (incl. negative ESPN athlete ids), malformed-shape throws, null
- Producer suite 575 passed (lone failure is the known pre-existing local-WIP one); Core suite 252 passed; Producer + Api build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to request athlete season-statistics sourcing by year and season type.
  * Requests are processed asynchronously and return a tracking ID.
  * Statistics requests now target season-specific source URLs for active athlete-season records.
  * Added validation for supported sports, season years, and season types.

* **Bug Fixes**
  * Added a documented remediation process to remove mislabeled 2026 statistics and support accurate backfill verification.

* **Tests**
  * Added coverage for URL generation, validation, filtering, correlation IDs, and not-found scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->