### PR TITLE
feat(web,api,producer): athlete details page

### DIFF
--- a/src/SportsData.Api/Application/Athletes/AthletesController.cs
+++ b/src/SportsData.Api/Application/Athletes/AthletesController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
+
+namespace SportsData.Api.Application.Athletes;
+
+[ApiController]
+[Route("api/{sport}/{league}/athletes")]
+public class AthletesController : ApiControllerBase
+{
+    /// <summary>
+    /// Full athlete drill-down for the web athlete page: athlete record,
+    /// every season, and per-season statistic documents. GUID route — the
+    /// slug convention assumes uniqueness athlete slugs don't have.
+    /// </summary>
+    [HttpGet("{athleteId:guid}")]
+    public async Task<ActionResult<AthleteDetailDto>> GetAthleteDetails(
+        [FromRoute] string sport,
+        [FromRoute] string league,
+        [FromRoute] Guid athleteId,
+        [FromServices] IGetAthleteDetailsQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(
+            new GetAthleteDetailsQuery(sport, league, athleteId),
+            cancellationToken);
+        return result.ToActionResult();
+    }
+}

--- a/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQuery.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQuery.cs
@@ -1,0 +1,8 @@
+namespace SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
+
+/// <summary>GUID-keyed — athlete slugs are not unique (~15% collide),
+/// unlike the franchise slugs the rest of the sport routes key on.</summary>
+public record GetAthleteDetailsQuery(
+    string Sport,
+    string League,
+    Guid AthleteId);

--- a/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQueryHandler.cs
@@ -38,6 +38,17 @@ public class GetAthleteDetailsQueryHandler : IGetAthleteDetailsQueryHandler
         GetAthleteDetailsQuery query,
         CancellationToken cancellationToken = default)
     {
+        if (query.AthleteId == Guid.Empty)
+        {
+            // The :guid route constraint admits Guid.Empty. It can never
+            // identify a record, so it is a malformed request (400), not a
+            // miss (404).
+            return new Failure<AthleteDetailDto>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(query.AthleteId), "AthleteId is required")]);
+        }
+
         Sport mode;
         try
         {
@@ -59,6 +70,12 @@ public class GetAthleteDetailsQueryHandler : IGetAthleteDetailsQueryHandler
         {
             var client = _franchiseClientFactory.Resolve(mode);
             return await client.GetAthleteDetails(query.AthleteId, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller went away — that is not a server error. Without this
+            // the generic catch below would log it and return Error.
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQueryHandler.cs
@@ -1,0 +1,81 @@
+using FluentValidation.Results;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Mapping;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Franchise;
+
+namespace SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
+
+public interface IGetAthleteDetailsQueryHandler
+{
+    Task<Result<AthleteDetailDto>> ExecuteAsync(
+        GetAthleteDetailsQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Relay to Producer's athlete drill-down. Resolved through the franchise
+/// client factory — the athlete read lives on the same Producer instance
+/// the franchise reads target, and the dormant Player service's client is
+/// dead code, so a dedicated athlete client would be a factory chain with
+/// one method.
+/// </summary>
+public class GetAthleteDetailsQueryHandler : IGetAthleteDetailsQueryHandler
+{
+    private readonly ILogger<GetAthleteDetailsQueryHandler> _logger;
+    private readonly IFranchiseClientFactory _franchiseClientFactory;
+
+    public GetAthleteDetailsQueryHandler(
+        ILogger<GetAthleteDetailsQueryHandler> logger,
+        IFranchiseClientFactory franchiseClientFactory)
+    {
+        _logger = logger;
+        _franchiseClientFactory = franchiseClientFactory;
+    }
+
+    public async Task<Result<AthleteDetailDto>> ExecuteAsync(
+        GetAthleteDetailsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        Sport mode;
+        try
+        {
+            mode = ModeMapper.ResolveMode(query.Sport, query.League);
+        }
+        catch (NotSupportedException)
+        {
+            // Bad route segments — surface as 400 (Validation), not 500.
+            return new Failure<AthleteDetailDto>(
+                default!,
+                ResultStatus.Validation,
+                [
+                    new ValidationFailure(nameof(query.Sport), $"Unsupported sport: '{query.Sport}'"),
+                    new ValidationFailure(nameof(query.League), $"Unsupported league: '{query.League}'")
+                ]);
+        }
+
+        try
+        {
+            var client = _franchiseClientFactory.Resolve(mode);
+            return await client.GetAthleteDetails(query.AthleteId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // CWE-117: route segments are user-controlled — strip CR/LF before
+            // plain-text log sinks (Seq is already safe via JSON escaping).
+            _logger.LogError(
+                ex,
+                "Error retrieving athlete details for sport={Sport}, league={League}, athleteId={AthleteId}",
+                SanitizeForLog(query.Sport), SanitizeForLog(query.League), query.AthleteId);
+
+            return new Failure<AthleteDetailDto>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure("AthleteDetails", "Error retrieving athlete details. Please try again later.")]);
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        value is null ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -3,6 +3,7 @@ using Hangfire;
 using FluentValidation;
 
 using SportsData.Api.Application.Admin.Commands.BackfillLeagueScores;
+using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
 using SportsData.Api.Application.Admin.Commands.GenerateGameRecap;
 using SportsData.Api.Application.Admin.Commands.GenerateLoadTest;
 using SportsData.Api.Application.Admin.Commands.RefreshAiExistence;
@@ -315,6 +316,9 @@ namespace SportsData.Api.DependencyInjection
             
             // HATEOAS Ref Generator (external API)
             services.AddSingleton<IGenerateApiResourceRefs, ApiResourceRefGenerator>();
+
+            // Athlete Queries
+            services.AddScoped<IGetAthleteDetailsQueryHandler, GetAthleteDetailsQueryHandler>();
 
             // TeamCard Queries
             services.AddScoped<IGetTeamCardQueryHandler, GetTeamCardQueryHandler>();

--- a/src/SportsData.Core/Dtos/Canonical/AthleteDetailDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/AthleteDetailDto.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Core.Dtos.Canonical;
+
+/// <summary>
+/// Full athlete drill-down for the web athlete page: the Athlete record,
+/// every AthleteSeason (newest first), and each season's statistic
+/// documents with their categories and stats. Deliberately verbose — this
+/// page exists to spot-check sourced data without opening the database, so
+/// provenance fields (doc CreatedUtc, split identifiers) that a normal
+/// product surface would omit are part of the contract here: they are what
+/// make duplicate docs and stale vintages visible.
+/// </summary>
+public class AthleteDetailDto
+{
+    public Guid Id { get; set; }
+    public string? DisplayName { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public string? ShortName { get; set; }
+    public string? Slug { get; set; }
+    public string? Jersey { get; set; }
+    public string? HeightDisplay { get; set; }
+    public string? WeightDisplay { get; set; }
+    public DateTime? DoB { get; set; }
+    public string? BirthLocation { get; set; }
+    public string? ExperienceDisplayValue { get; set; }
+    public int ExperienceYears { get; set; }
+    public int? DebutYear { get; set; }
+    public string? DraftDisplayText { get; set; }
+    public bool IsActive { get; set; }
+    public string? StatusName { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? ModifiedUtc { get; set; }
+
+    public List<AthleteSeasonDetailDto> Seasons { get; set; } = [];
+}
+
+public class AthleteSeasonDetailDto
+{
+    public Guid AthleteSeasonId { get; set; }
+    public int? SeasonYear { get; set; }
+    public string? TeamName { get; set; }
+    public string? TeamSlug { get; set; }
+    public string? Position { get; set; }
+    public string? PositionAbbreviation { get; set; }
+    public string? Jersey { get; set; }
+    public string? ExperienceDisplayValue { get; set; }
+    public bool IsActive { get; set; }
+    public string? StatusName { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? ModifiedUtc { get; set; }
+
+    public List<AthleteSeasonStatisticDetailDto> Statistics { get; set; } = [];
+}
+
+/// <summary>One sourced statistics DOCUMENT (a season can carry several —
+/// splits, and historically duplicates; surfacing them all is the point).</summary>
+public class AthleteSeasonStatisticDetailDto
+{
+    public Guid Id { get; set; }
+    public string? SplitId { get; set; }
+    public string? SplitName { get; set; }
+    public string? SplitType { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? ModifiedUtc { get; set; }
+
+    public List<AthleteStatisticCategoryDto> Categories { get; set; } = [];
+}
+
+public class AthleteStatisticCategoryDto
+{
+    public string? Name { get; set; }
+    public string? DisplayName { get; set; }
+    public string? Summary { get; set; }
+
+    public List<AthleteStatisticStatDto> Stats { get; set; } = [];
+}
+
+public class AthleteStatisticStatDto
+{
+    public string? DisplayName { get; set; }
+    public string? Abbreviation { get; set; }
+    public string? DisplayValue { get; set; }
+    public string? PerGameDisplayValue { get; set; }
+}

--- a/src/SportsData.Core/Dtos/Canonical/TeamRosterDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/TeamRosterDto.cs
@@ -11,6 +11,9 @@ public class TeamRosterDto
 public class TeamRosterEntryDto
 {
     public Guid AthleteSeasonId { get; set; }
+
+    /// <summary>The athlete's canonical id — the athlete detail page's route key.</summary>
+    public Guid AthleteId { get; set; }
     public string? DisplayName { get; set; }
     public string? ShortName { get; set; }
     public string? Slug { get; set; }

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -36,6 +36,8 @@ public interface IProvideFranchises : IProvideHealthChecks
     Task<Dictionary<Guid, string>> GetConferenceIdsBySlugs(int seasonYear, List<string> slugs, CancellationToken cancellationToken = default);
     Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, MarkDirection direction, CancellationToken cancellationToken = default);
     Task<Result<TeamRosterDto>> GetTeamRoster(string slug, int seasonYear, CancellationToken cancellationToken = default);
+    /// <summary>Full athlete drill-down (athlete record + every season + statistics). Keyed by GUID — athlete slugs are not unique (~15% collide).</summary>
+    Task<Result<AthleteDetailDto>> GetAthleteDetails(Guid athleteId, CancellationToken cancellationToken = default);
     Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default);
     Task<Result<bool>> UpdateLogoDarkBg(Guid logoId, bool isForDarkBg, string logoType, CancellationToken cancellationToken = default);
     /// <summary>Fan out ESPN sourcing for every FranchiseSeason in the year, optionally narrowed to specific child document types. Returns the batch correlation id (the Seq handle).</summary>
@@ -336,6 +338,15 @@ public class FranchiseClient : ClientBase, IProvideFranchises
             new TeamRosterDto(),
             cancellationToken);
         return new Success<TeamRosterDto>(result);
+    }
+
+    public async Task<Result<AthleteDetailDto>> GetAthleteDetails(Guid athleteId, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(
+            $"athletes/{athleteId}",
+            new AthleteDetailDto(),
+            entityName: "AthleteDetail",
+            cancellationToken: cancellationToken);
     }
 
     public async Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default)

--- a/src/SportsData.Producer/Application/Athletes/AthleteController.cs
+++ b/src/SportsData.Producer/Application/Athletes/AthleteController.cs
@@ -1,8 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Core.DependencyInjection;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
 using SportsData.Core.Processing;
 using SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
+using SportsData.Producer.Application.Athletes.Queries.GetAthleteById;
 
 namespace SportsData.Producer.Application.Athletes;
 
@@ -20,6 +23,21 @@ public class AthleteSeasonStatisticsSourcingRequest
 [ApiController]
 public class AthleteController : ControllerBase
 {
+    /// <summary>
+    /// Full athlete drill-down: athlete record + every season + statistic
+    /// documents. GUID-keyed — athlete slugs are not unique (~15% collide),
+    /// so slug routing is not an option here.
+    /// </summary>
+    [HttpGet("{athleteId:guid}")]
+    public async Task<ActionResult<AthleteDetailDto>> GetAthleteById(
+        [FromRoute] Guid athleteId,
+        [FromServices] IGetAthleteByIdQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(new GetAthleteByIdQuery(athleteId), cancellationToken);
+        return result.ToActionResult();
+    }
+
     /// <summary>
     /// Fans out season-type-scoped statistics DocumentRequests for every
     /// ACTIVE athlete rostered in the season year (immediate driver: the

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteById.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteById.cs
@@ -1,6 +1,0 @@
-﻿namespace SportsData.Producer.Application.Athletes.Queries
-{
-    public class GetAthleteById
-    {
-    }
-}

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteById/GetAthleteByIdQuery.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteById/GetAthleteByIdQuery.cs
@@ -1,0 +1,5 @@
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteById;
+
+/// <summary>Keyed by GUID, not slug — athlete slugs are not unique
+/// (~15% collide across the corpus), unlike franchise slugs.</summary>
+public record GetAthleteByIdQuery(Guid AthleteId);

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteById/GetAthleteByIdQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteById/GetAthleteByIdQueryHandler.cs
@@ -1,0 +1,215 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteById;
+
+public interface IGetAthleteByIdQueryHandler
+{
+    Task<Result<AthleteDetailDto>> ExecuteAsync(
+        GetAthleteByIdQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Full athlete drill-down: the Athlete record, every AthleteSeason
+/// (newest first), and each season's statistic documents down to the stat
+/// rows. Built as three sequential projected queries (athlete, seasons,
+/// statistics) rather than one Include chain — the stat graph is three
+/// levels deep and a single query would explode into a cartesian join.
+/// Provenance fields (doc CreatedUtc, split identifiers) are part of the
+/// contract: the page this serves exists to spot-check sourced data, so
+/// duplicates and stale vintages must be visible, not smoothed over.
+/// </summary>
+public class GetAthleteByIdQueryHandler : IGetAthleteByIdQueryHandler
+{
+    private readonly ILogger<GetAthleteByIdQueryHandler> _logger;
+    private readonly TeamSportDataContext _dataContext;
+
+    public GetAthleteByIdQueryHandler(
+        ILogger<GetAthleteByIdQueryHandler> logger,
+        TeamSportDataContext dataContext)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<AthleteDetailDto>> ExecuteAsync(
+        GetAthleteByIdQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var athleteRow = await _dataContext.Athletes
+            .AsNoTracking()
+            .Where(a => a.Id == query.AthleteId)
+            .Select(a => new
+            {
+                a.Id,
+                a.DisplayName,
+                a.FirstName,
+                a.LastName,
+                a.ShortName,
+                a.Slug,
+                a.Jersey,
+                a.HeightDisplay,
+                a.WeightDisplay,
+                a.DoB,
+                BirthCity = a.BirthLocation == null ? null : a.BirthLocation.City,
+                BirthState = a.BirthLocation == null ? null : a.BirthLocation.State,
+                BirthCountry = a.BirthLocation == null ? null : a.BirthLocation.Country,
+                a.ExperienceDisplayValue,
+                a.ExperienceYears,
+                a.DebutYear,
+                a.DraftDisplayText,
+                a.IsActive,
+                StatusName = a.Status == null ? null : a.Status.Name,
+                a.CreatedUtc,
+                a.ModifiedUtc
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (athleteRow is null)
+        {
+            return new Failure<AthleteDetailDto>(
+                default!,
+                ResultStatus.NotFound,
+                []);
+        }
+
+        var birthParts = new[] { athleteRow.BirthCity, athleteRow.BirthState, athleteRow.BirthCountry }
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .ToArray();
+
+        var athlete = new AthleteDetailDto
+        {
+            Id = athleteRow.Id,
+            DisplayName = athleteRow.DisplayName,
+            FirstName = athleteRow.FirstName,
+            LastName = athleteRow.LastName,
+            ShortName = athleteRow.ShortName,
+            Slug = athleteRow.Slug,
+            Jersey = athleteRow.Jersey,
+            HeightDisplay = athleteRow.HeightDisplay,
+            WeightDisplay = athleteRow.WeightDisplay,
+            DoB = athleteRow.DoB,
+            BirthLocation = birthParts.Length == 0 ? null : string.Join(", ", birthParts),
+            ExperienceDisplayValue = athleteRow.ExperienceDisplayValue,
+            ExperienceYears = athleteRow.ExperienceYears,
+            DebutYear = athleteRow.DebutYear,
+            DraftDisplayText = athleteRow.DraftDisplayText,
+            IsActive = athleteRow.IsActive,
+            StatusName = athleteRow.StatusName,
+            CreatedUtc = athleteRow.CreatedUtc,
+            ModifiedUtc = athleteRow.ModifiedUtc
+        };
+
+        var seasons = await _dataContext.AthleteSeasons
+            .AsNoTracking()
+            .Where(s => s.AthleteId == query.AthleteId)
+            .Select(s => new
+            {
+                Dto = new AthleteSeasonDetailDto
+                {
+                    AthleteSeasonId = s.Id,
+                    Position = s.Position.Name,
+                    PositionAbbreviation = s.Position.Abbreviation,
+                    Jersey = s.Jersey,
+                    ExperienceDisplayValue = s.ExperienceDisplayValue,
+                    IsActive = s.IsActive,
+                    StatusName = s.Status == null ? null : s.Status.Name,
+                    CreatedUtc = s.CreatedUtc,
+                    ModifiedUtc = s.ModifiedUtc
+                },
+                s.FranchiseSeasonId
+            })
+            .ToListAsync(cancellationToken);
+
+        // FranchiseSeason has no navigation from AthleteSeason — resolve the
+        // team identity (name/slug/year) with a keyed lookup instead.
+        var franchiseSeasonIds = seasons
+            .Where(s => s.FranchiseSeasonId.HasValue)
+            .Select(s => s.FranchiseSeasonId!.Value)
+            .Distinct()
+            .ToList();
+
+        var teamsById = await _dataContext.FranchiseSeasons
+            .AsNoTracking()
+            .Where(fs => franchiseSeasonIds.Contains(fs.Id))
+            .Select(fs => new { fs.Id, fs.SeasonYear, fs.DisplayName, fs.Slug })
+            .ToDictionaryAsync(fs => fs.Id, cancellationToken);
+
+        var seasonIds = seasons.Select(s => s.Dto.AthleteSeasonId).ToList();
+
+        var statistics = await _dataContext.AthleteSeasonStatistics
+            .AsNoTracking()
+            // Two nested collection projections (Categories -> Stats): the
+            // context throws on MultipleCollectionIncludeWarning, and split
+            // queries avoid the row-explosion join anyway.
+            .AsSplitQuery()
+            .Where(st => seasonIds.Contains(st.AthleteSeasonId))
+            .Select(st => new
+            {
+                st.AthleteSeasonId,
+                Dto = new AthleteSeasonStatisticDetailDto
+                {
+                    Id = st.Id,
+                    SplitId = st.SplitId,
+                    SplitName = st.SplitName,
+                    SplitType = st.SplitType,
+                    CreatedUtc = st.CreatedUtc,
+                    ModifiedUtc = st.ModifiedUtc,
+                    Categories = st.Categories
+                        .OrderBy(c => c.DisplayName)
+                        .Select(c => new AthleteStatisticCategoryDto
+                        {
+                            Name = c.Name,
+                            DisplayName = c.DisplayName,
+                            Summary = c.Summary,
+                            Stats = c.Stats
+                                .OrderBy(x => x.DisplayName)
+                                .Select(x => new AthleteStatisticStatDto
+                                {
+                                    DisplayName = x.DisplayName,
+                                    Abbreviation = x.Abbreviation,
+                                    DisplayValue = x.DisplayValue,
+                                    PerGameDisplayValue = x.PerGameDisplayValue
+                                })
+                                .ToList()
+                        })
+                        .ToList()
+                }
+            })
+            .ToListAsync(cancellationToken);
+
+        var statsBySeason = statistics
+            .GroupBy(s => s.AthleteSeasonId)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.Dto).ToList());
+
+        foreach (var season in seasons)
+        {
+            if (season.FranchiseSeasonId.HasValue &&
+                teamsById.TryGetValue(season.FranchiseSeasonId.Value, out var team))
+            {
+                season.Dto.SeasonYear = team.SeasonYear;
+                season.Dto.TeamName = team.DisplayName;
+                season.Dto.TeamSlug = team.Slug;
+            }
+
+            if (statsBySeason.TryGetValue(season.Dto.AthleteSeasonId, out var docs))
+            {
+                // Newest doc first — vintage ordering is the spot-check signal.
+                season.Dto.Statistics = docs
+                    .OrderByDescending(d => d.CreatedUtc)
+                    .ToList();
+            }
+        }
+
+        athlete.Seasons = seasons
+            .Select(s => s.Dto)
+            .OrderByDescending(s => s.SeasonYear ?? 0)
+            .ToList();
+
+        return new Success<AthleteDetailDto>(athlete);
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -7,6 +7,7 @@ using SportsData.Core.Config;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 using SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
+using SportsData.Producer.Application.Athletes.Queries.GetAthleteById;
 using SportsData.Producer.Application.Competitions;
 using SportsData.Producer.Application.Competitions.Reconcile;
 using SportsData.Producer.Application.Consumers;
@@ -278,6 +279,9 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IRefreshCompetitionMediaCommandHandler, RefreshCompetitionMediaCommandHandler>();
             services.AddScoped<IEnqueueCompetitionMediaRefreshCommandHandler, EnqueueCompetitionMediaRefreshCommandHandler>();
             services.AddScoped<IRefreshAllCompetitionMediaCommandHandler, RefreshAllCompetitionMediaCommandHandler>();
+
+            // Athlete Queries
+            services.AddScoped<IGetAthleteByIdQueryHandler, GetAthleteByIdQueryHandler>();
 
             // Athlete Commands
             services.AddScoped<IRequestAthleteSeasonStatisticsSourcingCommandHandler, RequestAthleteSeasonStatisticsSourcingCommandHandler>();

--- a/src/SportsData.Producer/Infrastructure/Sql/GetTeamRoster.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetTeamRoster.sql
@@ -1,5 +1,6 @@
 SELECT
     asl."Id" AS "AthleteSeasonId",
+    asl."AthleteId",
     asl."DisplayName",
     asl."ShortName",
     asl."Slug",

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -19,6 +19,7 @@ import SettingsPage from "./components/settings/SettingsPage.jsx";
 import GameMap from "./components/map/GameMap.jsx";
 import WelcomeDialog from "./components/welcome/WelcomeDialog";
 import TeamCard from "./components/teams/TeamCard";
+import AthleteCard from "./components/athletes/AthleteCard";
 import ConfirmationDialog from "./components/common/ConfirmationDialog";
 import VenuePage from "components/venues/VenuePage";
 import VenuesPage from "components/venues/VenuesPage";
@@ -191,6 +192,12 @@ function MainApp() {
             <Route
               path="/sport/:sport/:league/team/:slug/:seasonYear"
               element={<TeamCard />}
+            />
+            {/* GUID route — athlete slugs are not unique (~15% collide),
+                so athletes key on id where teams key on slug. */}
+            <Route
+              path="/sport/:sport/:league/athlete/:athleteId"
+              element={<AthleteCard />}
             />
             {/* Rankings — sport-scoped like team/venue/contest. Three
                 explicit routes because the literal /week segment can't be

--- a/src/UI/sd-ui/src/api/apiWrapper.js
+++ b/src/UI/sd-ui/src/api/apiWrapper.js
@@ -1,3 +1,4 @@
+import Athletes from "./athleteApi";
 import Matchups from "./matchupsApi";
 import Leaderboard from "./leaderboardApi";
 import Auth from "./authApi";
@@ -18,6 +19,7 @@ import LogoAdmin from "./logoAdminApi";
 import Imports from "./importsApi";
 
 const apiWrapper = {
+  Athletes,
   Matchups,
   Leaderboard,
   Auth,

--- a/src/UI/sd-ui/src/api/athleteApi.js
+++ b/src/UI/sd-ui/src/api/athleteApi.js
@@ -1,0 +1,10 @@
+// src/api/athleteApi.js
+import apiClient from "./apiClient";
+
+const AthleteApi = {
+  // GUID route — athlete slugs are not unique, unlike team slugs.
+  getDetails: (sport, league, athleteId) =>
+    apiClient.get(`/api/${sport}/${league}/athletes/${athleteId}`),
+};
+
+export default AthleteApi;

--- a/src/UI/sd-ui/src/components/athletes/AthleteCard.css
+++ b/src/UI/sd-ui/src/components/athletes/AthleteCard.css
@@ -1,0 +1,235 @@
+.athlete-card {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  color: var(--text-primary);
+}
+
+.athlete-card.error {
+  color: var(--error-text);
+}
+
+/* ---- header ---- */
+
+.athlete-header {
+  margin-bottom: 1.5rem;
+}
+
+.athlete-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.athlete-title h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.athlete-subtitle {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+/* ---- sections ---- */
+
+.athlete-section {
+  margin-bottom: 2rem;
+}
+
+.athlete-section h2 {
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 0.4rem;
+  margin-bottom: 0.9rem;
+}
+
+.athlete-empty {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* ---- fact grid ---- */
+
+.athlete-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.6rem 1.5rem;
+  margin: 0;
+}
+
+.athlete-facts > div {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.athlete-facts dt {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  white-space: nowrap;
+}
+
+.athlete-facts dd {
+  margin: 0;
+  font-size: 0.92rem;
+  overflow-wrap: anywhere;
+}
+
+.athlete-facts.compact {
+  margin-bottom: 0.9rem;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+/* ---- season blocks ---- */
+
+.season-block {
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  background: var(--bg-card);
+  margin-bottom: 0.75rem;
+}
+
+.season-block > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.7rem 1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.season-block > summary::-webkit-details-marker {
+  display: none;
+}
+
+.season-block[open] > summary {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.season-year {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.season-team {
+  font-weight: 600;
+}
+
+.season-meta {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.season-doc-count {
+  margin-left: auto;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.season-body {
+  padding: 0.9rem 1rem 1rem;
+}
+
+/* ---- statistic documents ---- */
+
+.stat-doc {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 0.75rem 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.stat-doc-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.stat-doc-split {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.stat-doc-provenance {
+  color: var(--text-secondary);
+}
+
+.stat-category h4 {
+  margin: 0.7rem 0 0.35rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+}
+
+.stat-summary {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 400;
+}
+
+.stat-table-wrap {
+  overflow-x: auto;
+}
+
+.stat-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.stat-table thead th {
+  text-align: left;
+  padding: 0.35rem 0.6rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.stat-table tbody td {
+  padding: 0.3rem 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.stat-table .stat-value {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- status badge (matches TeamRoster) ---- */
+
+.athlete-card .status-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.athlete-card .status-badge.active {
+  background-color: var(--success-bg);
+  color: var(--success-text);
+}
+
+.athlete-card .status-badge.inactive {
+  background-color: var(--error-bg);
+  color: var(--error-text);
+}

--- a/src/UI/sd-ui/src/components/athletes/AthleteCard.jsx
+++ b/src/UI/sd-ui/src/components/athletes/AthleteCard.jsx
@@ -28,13 +28,20 @@ function AthleteCard() {
   const isAdmin = userDto?.isAdmin === true;
 
   useEffect(() => {
+    // Navigating between athletes can leave an in-flight request that
+    // resolves AFTER the newer one; without this guard the stale response
+    // would overwrite the current athlete.
+    let ignore = false;
+
     const fetchAthlete = async () => {
       setLoading(true);
       setError(null);
       try {
         const response = await apiWrapper.Athletes.getDetails(sport, league, athleteId);
+        if (ignore) return;
         setAthlete(response.data?.value ?? response.data ?? null);
       } catch (err) {
+        if (ignore) return;
         console.error("Failed to fetch athlete details:", err);
         setError(
           err?.response?.status === 404
@@ -42,7 +49,7 @@ function AthleteCard() {
             : "Failed to load athlete details."
         );
       } finally {
-        setLoading(false);
+        if (!ignore) setLoading(false);
       }
     };
 
@@ -51,6 +58,10 @@ function AthleteCard() {
     } else {
       setLoading(false);
     }
+
+    return () => {
+      ignore = true;
+    };
   }, [sport, league, athleteId]);
 
   if (loading) return <div className="athlete-card">Loading athlete...</div>;
@@ -59,7 +70,11 @@ function AthleteCard() {
 
   const currentSeason = athlete.seasons?.[0];
 
-  const formatDate = (value) => (value ? new Date(value).toLocaleDateString() : "-");
+  // A birth date is a calendar date, but the API serializes it as a UTC
+  // timestamp — formatting in local time would show the previous day for
+  // anyone west of UTC. Read the UTC components.
+  const formatDate = (value) =>
+    value ? new Date(value).toLocaleDateString(undefined, { timeZone: "UTC" }) : "-";
   const formatUtc = (value) => (value ? new Date(value).toISOString().replace("T", " ").slice(0, 19) + "Z" : "-");
 
   // Admins see every sourced doc; users see the newest per split (the API

--- a/src/UI/sd-ui/src/components/athletes/AthleteCard.jsx
+++ b/src/UI/sd-ui/src/components/athletes/AthleteCard.jsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import apiWrapper from "../../api/apiWrapper";
+import { useUserDto } from "../../contexts/UserContext";
+import { teamLink } from "../../utils/sportLinks";
+import "./AthleteCard.css";
+
+/**
+ * Athlete drill-down: the Athlete record, every AthleteSeason, and each
+ * season's sourced statistic documents. Deliberately a research surface —
+ * provenance fields (doc created timestamps, split identifiers, record
+ * ids) are shown on purpose so sourced data can be spot-checked without
+ * opening the database. Duplicate docs and stale vintages are the thing
+ * this page exists to make visible.
+ */
+function AthleteCard() {
+  const { sport = "football", league = "ncaa", athleteId } = useParams();
+  const { userDto } = useUserDto();
+  const [athlete, setAthlete] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Provenance (record ids, created/modified, doc identity + vintage,
+  // duplicate docs) is the admin spot-check surface. Regular users get a
+  // clean player page: no internal ids, and only the newest statistic doc
+  // per split — duplicates would read as a rendering bug, but for admins
+  // they ARE the signal.
+  const isAdmin = userDto?.isAdmin === true;
+
+  useEffect(() => {
+    const fetchAthlete = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await apiWrapper.Athletes.getDetails(sport, league, athleteId);
+        setAthlete(response.data?.value ?? response.data ?? null);
+      } catch (err) {
+        console.error("Failed to fetch athlete details:", err);
+        setError(
+          err?.response?.status === 404
+            ? "Athlete not found."
+            : "Failed to load athlete details."
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (athleteId) {
+      fetchAthlete();
+    } else {
+      setLoading(false);
+    }
+  }, [sport, league, athleteId]);
+
+  if (loading) return <div className="athlete-card">Loading athlete...</div>;
+  if (error) return <div className="athlete-card error">{error}</div>;
+  if (!athlete) return <div className="athlete-card">No athlete data available.</div>;
+
+  const currentSeason = athlete.seasons?.[0];
+
+  const formatDate = (value) => (value ? new Date(value).toLocaleDateString() : "-");
+  const formatUtc = (value) => (value ? new Date(value).toISOString().replace("T", " ").slice(0, 19) + "Z" : "-");
+
+  // Admins see every sourced doc; users see the newest per split (the API
+  // returns docs newest-first, so first-seen wins).
+  const visibleStatDocs = (statistics) => {
+    if (!statistics) return [];
+    if (isAdmin) return statistics;
+    const newestBySplit = new Map();
+    for (const doc of statistics) {
+      const key = doc.splitId ?? doc.splitName ?? "";
+      if (!newestBySplit.has(key)) newestBySplit.set(key, doc);
+    }
+    return [...newestBySplit.values()];
+  };
+
+  return (
+    <div className="athlete-card">
+      <header className="athlete-header">
+        <div className="athlete-title">
+          <h1>{athlete.displayName ?? athlete.shortName ?? "Unknown Athlete"}</h1>
+          <span className={`status-badge ${athlete.isActive ? "active" : "inactive"}`}>
+            {athlete.statusName ?? (athlete.isActive ? "Active" : "Inactive")}
+          </span>
+        </div>
+        <div className="athlete-subtitle">
+          {currentSeason?.positionAbbreviation && <span>{currentSeason.positionAbbreviation}</span>}
+          {athlete.jersey && <span>#{athlete.jersey}</span>}
+          {currentSeason?.teamSlug && (
+            <Link to={teamLink(currentSeason.teamSlug, currentSeason.seasonYear, sport, league)}>
+              {currentSeason.teamName ?? currentSeason.teamSlug}
+            </Link>
+          )}
+        </div>
+      </header>
+
+      <section className="athlete-section">
+        <h2>Athlete Record</h2>
+        <dl className="athlete-facts">
+          <div><dt>Name</dt><dd>{athlete.firstName ?? "-"} {athlete.lastName ?? ""}</dd></div>
+          <div><dt>Height</dt><dd>{athlete.heightDisplay ?? "-"}</dd></div>
+          <div><dt>Weight</dt><dd>{athlete.weightDisplay ?? "-"}</dd></div>
+          <div><dt>Born</dt><dd>{formatDate(athlete.doB)}</dd></div>
+          <div><dt>Birthplace</dt><dd>{athlete.birthLocation ?? "-"}</dd></div>
+          <div><dt>Experience</dt><dd>{athlete.experienceDisplayValue ?? "-"}</dd></div>
+          <div><dt>Debut</dt><dd>{athlete.debutYear ?? "-"}</dd></div>
+          <div><dt>Draft</dt><dd>{athlete.draftDisplayText ?? "-"}</dd></div>
+          {isAdmin && (
+            <>
+              <div><dt>Slug</dt><dd className="mono">{athlete.slug ?? "-"}</dd></div>
+              <div><dt>Athlete Id</dt><dd className="mono">{athlete.id}</dd></div>
+              <div><dt>Created</dt><dd className="mono">{formatUtc(athlete.createdUtc)}</dd></div>
+              <div><dt>Modified</dt><dd className="mono">{formatUtc(athlete.modifiedUtc)}</dd></div>
+            </>
+          )}
+        </dl>
+      </section>
+
+      <section className="athlete-section">
+        <h2>Seasons ({athlete.seasons?.length ?? 0})</h2>
+        {(!athlete.seasons || athlete.seasons.length === 0) && (
+          <p className="athlete-empty">No season records.</p>
+        )}
+        {athlete.seasons?.map((season, index) => (
+          <details
+            key={season.athleteSeasonId}
+            className="season-block"
+            open={index === 0}
+          >
+            <summary>
+              <span className="season-year">{season.seasonYear ?? "—"}</span>
+              <span className="season-team">
+                {season.teamName ?? "(no team)"}
+              </span>
+              <span className="season-meta">
+                {season.positionAbbreviation ?? season.position ?? "-"}
+                {season.jersey ? ` · #${season.jersey}` : ""}
+                {season.experienceDisplayValue ? ` · ${season.experienceDisplayValue}` : ""}
+              </span>
+              <span className={`status-badge ${season.isActive ? "active" : "inactive"}`}>
+                {season.statusName ?? (season.isActive ? "Active" : "Inactive")}
+              </span>
+              {isAdmin && (
+                <span className="season-doc-count">
+                  {season.statistics?.length ?? 0} stat doc{(season.statistics?.length ?? 0) === 1 ? "" : "s"}
+                </span>
+              )}
+            </summary>
+
+            <div className="season-body">
+              <dl className="athlete-facts compact">
+                {season.teamSlug && (
+                  <div>
+                    <dt>Team</dt>
+                    <dd>
+                      <Link to={teamLink(season.teamSlug, season.seasonYear, sport, league)}>
+                        {season.teamName ?? season.teamSlug}
+                      </Link>
+                    </dd>
+                  </div>
+                )}
+                {isAdmin && (
+                  <>
+                    <div><dt>Season Row Id</dt><dd className="mono">{season.athleteSeasonId}</dd></div>
+                    <div><dt>Created</dt><dd className="mono">{formatUtc(season.createdUtc)}</dd></div>
+                    <div><dt>Modified</dt><dd className="mono">{formatUtc(season.modifiedUtc)}</dd></div>
+                  </>
+                )}
+              </dl>
+
+              {visibleStatDocs(season.statistics).length === 0 && (
+                <p className="athlete-empty">
+                  {isAdmin ? "No statistics sourced for this season." : "No statistics for this season."}
+                </p>
+              )}
+
+              {visibleStatDocs(season.statistics).map((doc) => (
+                <div key={doc.id} className="stat-doc">
+                  <div className="stat-doc-header">
+                    <span className="stat-doc-split">
+                      {doc.splitName || doc.splitType || "Season"}
+                      {isAdmin && doc.splitId ? ` (split ${doc.splitId})` : ""}
+                    </span>
+                    {isAdmin && (
+                      <span className="stat-doc-provenance mono">
+                        doc {doc.id?.slice(0, 8)} · sourced {formatUtc(doc.createdUtc)}
+                      </span>
+                    )}
+                  </div>
+                  {doc.categories?.map((category) => (
+                    <div key={category.name} className="stat-category">
+                      <h4>
+                        {category.displayName ?? category.name}
+                        {category.summary ? <span className="stat-summary"> — {category.summary}</span> : null}
+                      </h4>
+                      <div className="stat-table-wrap">
+                        <table className="stat-table">
+                          <thead>
+                            <tr>
+                              <th>Stat</th>
+                              <th>Abbr</th>
+                              <th>Total</th>
+                              <th>Per Game</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {category.stats?.map((stat) => (
+                              <tr key={`${category.name}-${stat.abbreviation}-${stat.displayName}`}>
+                                <td>{stat.displayName}</td>
+                                <td className="mono">{stat.abbreviation}</td>
+                                <td className="stat-value">{stat.displayValue ?? "-"}</td>
+                                <td className="stat-value">{stat.perGameDisplayValue ?? "-"}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </details>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+export default AthleteCard;

--- a/src/UI/sd-ui/src/components/teams/TeamRoster.css
+++ b/src/UI/sd-ui/src/components/teams/TeamRoster.css
@@ -34,6 +34,17 @@
   color: var(--text-primary);
 }
 
+.roster-athlete-link {
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.roster-athlete-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
 .status-badge {
   display: inline-block;
   padding: 0.15rem 0.5rem;

--- a/src/UI/sd-ui/src/components/teams/TeamRoster.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamRoster.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import apiWrapper from "../../api/apiWrapper";
+import { athleteLink } from "../../utils/sportLinks";
 import "./TeamRoster.css";
 
 function TeamRoster({ slug, seasonYear, sport, league }) {
@@ -52,7 +54,19 @@ function TeamRoster({ slug, seasonYear, sport, league }) {
           {roster.map((player) => (
             <tr key={player.athleteSeasonId}>
               <td>{player.jersey ?? "-"}</td>
-              <td>{player.displayName ?? player.shortName ?? "-"}</td>
+              <td>
+                {player.athleteId ? (
+                  <Link
+                    className="roster-athlete-link"
+                    to={athleteLink(player.athleteId, sport, league)}
+                    aria-label={`View ${player.displayName ?? player.shortName ?? "athlete"} details`}
+                  >
+                    {player.displayName ?? player.shortName ?? "-"}
+                  </Link>
+                ) : (
+                  player.displayName ?? player.shortName ?? "-"
+                )}
+              </td>
               <td title={player.position}>{player.positionAbbreviation ?? player.position ?? "-"}</td>
               <td>{player.heightDisplay ?? "-"}</td>
               <td>{player.weightDisplay ?? "-"}</td>

--- a/src/UI/sd-ui/src/utils/sportLinks.js
+++ b/src/UI/sd-ui/src/utils/sportLinks.js
@@ -42,6 +42,14 @@ export function teamLink(slug, seasonYear, sport = DEFAULT_SPORT, league = DEFAU
   return `/app/sport/${sport}/${league}/team/${slug}${seasonYear ? `/${seasonYear}` : ''}`;
 }
 
+/**
+ * Athlete detail page. Keyed by athlete GUID, not slug — athlete slugs
+ * collide (~15% of the corpus), unlike team slugs.
+ */
+export function athleteLink(athleteId, sport = DEFAULT_SPORT, league = DEFAULT_LEAGUE) {
+  return `/app/sport/${sport}/${league}/athlete/${athleteId}`;
+}
+
 export function contestLink(contestId, sport = DEFAULT_SPORT, league = DEFAULT_LEAGUE) {
   return `/app/sport/${sport}/${league}/contest/${contestId}`;
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetAthleteDetailsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetAthleteDetailsQueryHandlerTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Franchise;
+using SportsData.Tests.Shared;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Athletes;
+
+public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetailsQueryHandler>
+{
+    private readonly Mock<IFranchiseClientFactory> _franchiseClientFactoryMock;
+    private readonly Mock<IProvideFranchises> _franchiseClientMock;
+
+    public GetAthleteDetailsQueryHandlerTests()
+    {
+        _franchiseClientFactoryMock = Mocker.GetMock<IFranchiseClientFactory>();
+        _franchiseClientMock = new Mock<IProvideFranchises>();
+        _franchiseClientFactoryMock
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_franchiseClientMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RelaysTheClientResult()
+    {
+        var athleteId = Guid.NewGuid();
+        var dto = new AthleteDetailDto { Id = athleteId, DisplayName = "Arch Manning" };
+
+        _franchiseClientMock
+            .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<AthleteDetailDto>(dto));
+
+        var handler = Mocker.CreateInstance<GetAthleteDetailsQueryHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new GetAthleteDetailsQuery("football", "ncaa", athleteId));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.DisplayName.Should().Be("Arch Manning");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NotFoundFromClient_PassesThrough()
+    {
+        var athleteId = Guid.NewGuid();
+
+        _franchiseClientMock
+            .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<AthleteDetailDto>(default!, ResultStatus.NotFound, []));
+
+        var handler = Mocker.CreateInstance<GetAthleteDetailsQueryHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new GetAthleteDetailsQuery("football", "ncaa", athleteId));
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnsupportedSportLeague_Returns400Validation()
+    {
+        var handler = Mocker.CreateInstance<GetAthleteDetailsQueryHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new GetAthleteDetailsQuery("cricket", "ipl", Guid.NewGuid()));
+
+        result.Status.Should().Be(ResultStatus.Validation);
+        _franchiseClientMock.Verify(
+            x => x.GetAthleteDetails(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ClientThrows_ReturnsErrorNotException()
+    {
+        var athleteId = Guid.NewGuid();
+
+        _franchiseClientMock
+            .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("producer unreachable"));
+
+        var handler = Mocker.CreateInstance<GetAthleteDetailsQueryHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new GetAthleteDetailsQuery("football", "ncaa", athleteId));
+
+        result.Status.Should().Be(ResultStatus.Error);
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetAthleteDetailsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetAthleteDetailsQueryHandlerTests.cs
@@ -77,6 +77,42 @@ public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetails
     }
 
     [Fact]
+    public async Task ExecuteAsync_EmptyAthleteId_Returns400Validation()
+    {
+        var handler = Mocker.CreateInstance<GetAthleteDetailsQueryHandler>();
+
+        // The :guid route constraint admits Guid.Empty; it can never identify
+        // a record, so it is malformed input, not a miss.
+        var result = await handler.ExecuteAsync(
+            new GetAthleteDetailsQuery("football", "ncaa", Guid.Empty));
+
+        result.Status.Should().Be(ResultStatus.Validation);
+        _franchiseClientMock.Verify(
+            x => x.GetAthleteDetails(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallerCancels_PropagatesCancellation()
+    {
+        var athleteId = Guid.NewGuid();
+        using var cts = new CancellationTokenSource();
+
+        _franchiseClientMock
+            .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var handler = Mocker.CreateInstance<GetAthleteDetailsQueryHandler>();
+        await cts.CancelAsync();
+
+        // A cancelled request must not be reported as a server error.
+        var act = async () => await handler.ExecuteAsync(
+            new GetAthleteDetailsQuery("football", "ncaa", athleteId), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ClientThrows_ReturnsErrorNotException()
     {
         var athleteId = Guid.NewGuid();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteByIdQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteByIdQueryHandlerTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+
+using SportsData.Core.Common;
+using SportsData.Producer.Application.Athletes.Queries.GetAthleteById;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Athletes;
+
+/// <summary>
+/// The athlete drill-down must return the full graph — athlete record,
+/// seasons newest-first, per-season statistic documents newest-first with
+/// categories and stats — and only THIS athlete's rows. Provenance fields
+/// (doc CreatedUtc, split identifiers) are contract, not decoration: the
+/// page exists to make duplicate docs and stale vintages visible.
+/// </summary>
+public class GetAthleteByIdQueryHandlerTests
+    : ProducerTestBase<GetAthleteByIdQueryHandler>
+{
+    private static readonly DateTime FixedNow = new(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+
+    private async Task<Guid> SeedAthleteGraphAsync()
+    {
+        var athleteId = Guid.NewGuid();
+        var positionId = Guid.NewGuid();
+
+        await FootballDataContext.AthletePositions.AddAsync(new AthletePosition
+        {
+            Id = positionId,
+            Name = "Quarterback",
+            DisplayName = "Quarterback",
+            Abbreviation = "QB",
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        await FootballDataContext.Athletes.AddAsync(new FootballAthlete
+        {
+            Id = athleteId,
+            FirstName = "Arch",
+            LastName = "Manning",
+            DisplayName = "Arch Manning",
+            ShortName = "A. Manning",
+            Slug = "arch-manning",
+            Jersey = "16",
+            HeightDisplay = "6' 4\"",
+            WeightDisplay = "222 lbs",
+            IsActive = true,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        // Two seasons on two different franchise seasons, seeded 2024 FIRST
+        // so newest-first ordering is proven, not accidental.
+        var fs2024 = Guid.NewGuid();
+        var fs2025 = Guid.NewGuid();
+        foreach (var (fsId, year) in new[] { (fs2024, 2024), (fs2025, 2025) })
+        {
+            await FootballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+            {
+                Id = fsId,
+                FranchiseId = Guid.NewGuid(),
+                SeasonYear = year,
+                Slug = "texas-longhorns",
+                Location = "Texas",
+                Name = "Longhorns",
+                Abbreviation = "TEX",
+                DisplayName = "Texas Longhorns",
+                DisplayNameShort = "Texas",
+                ColorCodeHex = "000000",
+                IsActive = true,
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+
+        var season2024 = Guid.NewGuid();
+        var season2025 = Guid.NewGuid();
+        foreach (var (seasonId, fsId) in new[] { (season2024, fs2024), (season2025, fs2025) })
+        {
+            await FootballDataContext.AthleteSeasons.AddAsync(new FootballAthleteSeason
+            {
+                Id = seasonId,
+                AthleteId = athleteId,
+                FranchiseSeasonId = fsId,
+                PositionId = positionId,
+                FirstName = "Arch",
+                LastName = "Manning",
+                Jersey = "16",
+                IsActive = true,
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+
+        // 2025 carries TWO statistic docs (older + newer — the duplicate-doc
+        // shape this page must expose), the newer one with a category + stats.
+        var olderDoc = Guid.NewGuid();
+        var newerDoc = Guid.NewGuid();
+        await FootballDataContext.AthleteSeasonStatistics.AddRangeAsync(
+            new AthleteSeasonStatistic
+            {
+                Id = olderDoc,
+                AthleteSeasonId = season2025,
+                SplitId = "0",
+                SplitName = "All Splits",
+                SplitType = "",
+                CreatedUtc = FixedNow.AddDays(-30),
+                CreatedBy = Guid.NewGuid()
+            },
+            new AthleteSeasonStatistic
+            {
+                Id = newerDoc,
+                AthleteSeasonId = season2025,
+                SplitId = "0",
+                SplitName = "All Splits",
+                SplitType = "season",
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+
+        var categoryId = Guid.NewGuid();
+        await FootballDataContext.AthleteSeasonStatisticCategories.AddAsync(
+            new AthleteSeasonStatisticCategory
+            {
+                Id = categoryId,
+                AthleteSeasonStatisticId = newerDoc,
+                Name = "passing",
+                DisplayName = "Passing",
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+
+        await FootballDataContext.AthleteSeasonStatisticStats.AddAsync(
+            new AthleteSeasonStatisticStat
+            {
+                Id = Guid.NewGuid(),
+                AthleteSeasonStatisticCategoryId = categoryId,
+                Name = "passingYards",
+                DisplayName = "Passing Yards",
+                ShortDisplayName = "YDS",
+                Abbreviation = "YDS",
+                DisplayValue = "1,628",
+                PerGameDisplayValue = "232.6",
+                Value = 1628m,
+                CreatedUtc = FixedNow,
+                CreatedBy = Guid.NewGuid()
+            });
+
+        // A DIFFERENT athlete with a season — must not leak into the result.
+        var otherAthleteId = Guid.NewGuid();
+        await FootballDataContext.Athletes.AddAsync(new FootballAthlete
+        {
+            Id = otherAthleteId,
+            FirstName = "Other",
+            LastName = "Athlete",
+            DisplayName = "Other Athlete",
+            ShortName = "O. Athlete",
+            IsActive = true,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.AthleteSeasons.AddAsync(new FootballAthleteSeason
+        {
+            Id = Guid.NewGuid(),
+            AthleteId = otherAthleteId,
+            FranchiseSeasonId = fs2025,
+            PositionId = positionId,
+            IsActive = true,
+            CreatedUtc = FixedNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        await FootballDataContext.SaveChangesAsync();
+        return athleteId;
+    }
+
+    [Fact]
+    public async Task ReturnsFullGraph_SeasonsNewestFirst_DocsNewestFirst()
+    {
+        var athleteId = await SeedAthleteGraphAsync();
+        var sut = Mocker.CreateInstance<GetAthleteByIdQueryHandler>();
+
+        var result = await sut.ExecuteAsync(new GetAthleteByIdQuery(athleteId));
+
+        result.IsSuccess.Should().BeTrue();
+        var dto = result.Value;
+
+        dto.DisplayName.Should().Be("Arch Manning");
+        dto.Slug.Should().Be("arch-manning");
+
+        // Only this athlete's seasons, newest year first.
+        dto.Seasons.Should().HaveCount(2);
+        dto.Seasons.Select(s => s.SeasonYear).Should().ContainInOrder(2025, 2024);
+        dto.Seasons.Should().OnlyContain(s => s.TeamName == "Texas Longhorns" && s.TeamSlug == "texas-longhorns");
+        dto.Seasons.Should().OnlyContain(s => s.Position == "Quarterback" && s.PositionAbbreviation == "QB");
+
+        // Both 2025 docs surface (duplicates are the spot-check signal),
+        // newest sourced first; the 2024 season has none.
+        var s2025 = dto.Seasons[0];
+        s2025.Statistics.Should().HaveCount(2);
+        s2025.Statistics[0].CreatedUtc.Should().BeAfter(s2025.Statistics[1].CreatedUtc);
+        dto.Seasons[1].Statistics.Should().BeEmpty();
+
+        // The newer doc carries the category/stat graph.
+        var passing = s2025.Statistics[0].Categories.Should().ContainSingle().Subject;
+        passing.DisplayName.Should().Be("Passing");
+        var yards = passing.Stats.Should().ContainSingle().Subject;
+        yards.DisplayName.Should().Be("Passing Yards");
+        yards.DisplayValue.Should().Be("1,628");
+        yards.PerGameDisplayValue.Should().Be("232.6");
+    }
+
+    [Fact]
+    public async Task UnknownAthlete_ReturnsNotFound()
+    {
+        await SeedAthleteGraphAsync();
+        var sut = Mocker.CreateInstance<GetAthleteByIdQueryHandler>();
+
+        var result = await sut.ExecuteAsync(new GetAthleteByIdQuery(Guid.NewGuid()));
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an athlete drill-down page reachable from every Roster tab row: the Athlete record, every `AthleteSeason`, and each season's sourced statistic documents down to the stat rows.

Primary purpose is **operational** — spot-checking sourced athlete data (the 2025 stats backfill, duplicate docs, stale vintages) without opening the database. Regular users get a clean player page from the same surface.

**Routed by athlete GUID, not slug**: ~19k of 246k athlete slugs collide (~15%), so the slug convention the team routes use doesn't hold for athletes.

## Changes

**Core**
- `AthleteDetailDto` (+ season / statistic / category / stat children). Deliberately verbose: provenance fields (doc `CreatedUtc`, split identifiers, record ids) are contract, since they're what make duplicate docs and stale vintages visible.
- `TeamRosterEntryDto` gains `AthleteId` — roster rows previously exposed only `AthleteSeasonId`, so there was no link key.
- `IProvideFranchises.GetAthleteDetails` — the athlete read targets the same Producer instance as the franchise reads, and the Player service client is dead code, so a dedicated client/factory chain would carry exactly one method.

**Producer**
- `GetAthleteById` slice fills the previously-empty stub. Three sequential projected queries (athlete → seasons → statistics) rather than one Include chain: the stat graph is three levels deep and a single query would explode into a cartesian join. `AsSplitQuery` on the nested collection projection — the context throws on `MultipleCollectionIncludeWarning`.
- `GET api/athletes/{athleteId:guid}`; seasons newest-first, statistic docs newest-first.
- `GetTeamRoster.sql` selects `AthleteId`.

**Api** — `GET api/{sport}/{league}/athletes/{athleteId}` relay, mirroring the finalized-games handler: ModeMapper 400 on bad route segments, CWE-117 log sanitizing, 404 passthrough.

**Web**
- `AthleteCard` at `/app/sport/:sport/:league/athlete/:athleteId`; roster names become links; `athleteLink()` joins `sportLinks.js`.
- **Admin/user split** on the standard `userDto.isAdmin` gate. Admins see all ids, created/modified timestamps, doc identity + vintage, and every sourced doc. Regular users get a clean player page: no internal ids, and only the newest stat doc per split — duplicates would read as a rendering bug to a user, but for an admin they *are* the signal. The DTO stays single-shape; record ids and sourcing timestamps aren't secrets.

## Validation

- 2 new Producer handler tests: full graph, season + doc ordering, no cross-athlete leakage, NotFound
- 4 new Api handler tests: relay, NotFound passthrough, unsupported sport/league → 400, client throw → Error
- Producer suite 579 passed (the lone failure is the known pre-existing local-WIP one); web Vitest 26/26; CRA production build clean
- Validated E2E locally against real data (Arch Manning, multi-season)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added athlete detail pages with profiles, status, team history, seasons, and statistics.
  - Added sport- and league-specific URLs using unique athlete IDs.
  - Team roster athlete names now link to detail pages.
  - Added loading, not-found, and error states.
  - Administrators can view additional data provenance and identifiers.

- **Bug Fixes**
  - Improved handling of unsupported leagues, unavailable athletes, and provider errors.

- **Tests**
  - Added coverage for retrieval, ordering, filtering, error handling, and missing athletes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->