### PR TITLE
feat(web,mobile): live card situation line + possession on team rows

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -988,6 +988,8 @@ namespace SportsData.Api.Application.Admin
                     IsScoringPlay: request.IsScoringPlay,
                     ScoringPlayType: request.ScoringPlayType,
                     BallOnYardLine: request.BallOnYardLine,
+                    Down: request.Down,
+                    Distance: request.Distance,
                     Ref: null,
                     Sport: sport,
                     SeasonYear: null,

--- a/src/SportsData.Api/Application/Admin/SignalRDebug/SignalRDebugRequests.cs
+++ b/src/SportsData.Api/Application/Admin/SignalRDebug/SignalRDebugRequests.cs
@@ -41,7 +41,11 @@ public record DebugFootballPlayRequest(
     // null exercises the clients' neutral "SCORE!" fallback. Optional so
     // existing debug tooling keeps working unchanged.
     string? ScoringPlayType,
-    int? BallOnYardLine);
+    int? BallOnYardLine,
+    // Down and yards-to-go for the situation line ("2nd & 7"). Optional so
+    // existing debug tooling keeps working unchanged.
+    int? Down = null,
+    int? Distance = null);
 
 /// <summary>
 /// Request body for POST /admin/signalr-debug/baseball-play. Drives a

--- a/src/SportsData.Core/Eventing/Events/Contests/Football/FootballPlayCompleted.cs
+++ b/src/SportsData.Core/Eventing/Events/Contests/Football/FootballPlayCompleted.cs
@@ -34,10 +34,23 @@ namespace SportsData.Core.Eventing.Events.Contests.Football
         // Nullable keeps old in-flight messages deserializable, so deploy
         // order doesn't matter.
         string? ScoringPlayType,
-        // Ball position on the field, expressed as 0–100 yards from the
-        // away (visitor) goal line. Matches ESPN's YardLine convention.
+        // Ball position as an ABSOLUTE field coordinate, 0–100 measured
+        // from the HOME team's goal line (home goal = 0, away goal = 100).
+        // Matches ESPN's YardLine convention. So the home team's own yard
+        // numbers read directly (HOME 35 → 35) and the away team's invert
+        // (AWAY 25 → 75) — verified against stored play text across
+        // several games and both home/away orientations. A drive by the
+        // home team increases this value; an away drive decreases it.
         // Null means unknown (e.g. pre-snap, halftime, post-game).
         int? BallOnYardLine,
+        // Down and yards-to-go for the NEXT snap (the play's End* state,
+        // falling back to Start*). Drives the live card's situation line
+        // ("2nd & 7"). Nullable for the same reason as ScoringPlayType:
+        // pre-capture rows and old in-flight messages must stay
+        // deserializable, so deploy order doesn't matter. Down 0 / null
+        // means no snap state (kickoff, extra point, end of period).
+        int? Down,
+        int? Distance,
         Uri? Ref,
         Sport Sport,
         int? SeasonYear,

--- a/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
@@ -170,6 +170,8 @@ namespace SportsData.Producer.Application.Contests
                         IsScoringPlay: play.ScoringPlay,
                         ScoringPlayType: play.ScoringTypeName,
                         BallOnYardLine: play.EndYardLine ?? play.StartYardLine,
+                        Down: play.EndDown ?? play.StartDown,
+                        Distance: play.EndDistance ?? play.StartDistance,
                         Ref: null,
                         Sport: contest.Sport,
                         SeasonYear: contest.SeasonYear,

--- a/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestReplayService.cs
@@ -155,6 +155,12 @@ namespace SportsData.Producer.Application.Contests
                 var emittedCount = 0;
                 foreach (var play in plays)
                 {
+                    // Down and distance travel as a PAIR — see the same
+                    // guard in FootballEventCompetitionPlayDocumentProcessor.
+                    var hasEndSnapState = play.EndDown is not null;
+                    var down = hasEndSnapState ? play.EndDown : play.StartDown;
+                    var distance = hasEndSnapState ? play.EndDistance : play.StartDistance;
+
                     // Merged per-play event — play description + scoreboard
                     // tick in one message so the UI doesn't reassemble.
                     await _eventBus.Publish(new FootballPlayCompleted(
@@ -170,8 +176,8 @@ namespace SportsData.Producer.Application.Contests
                         IsScoringPlay: play.ScoringPlay,
                         ScoringPlayType: play.ScoringTypeName,
                         BallOnYardLine: play.EndYardLine ?? play.StartYardLine,
-                        Down: play.EndDown ?? play.StartDown,
-                        Distance: play.EndDistance ?? play.StartDistance,
+                        Down: down,
+                        Distance: distance,
                         Ref: null,
                         Sport: contest.Sport,
                         SeasonYear: contest.SeasonYear,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -198,6 +198,14 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
     {
         var footballPlay = (FootballCompetitionPlay)play;
 
+        // Down and distance travel as a PAIR: pairing an end-state distance
+        // with a start-state down would describe a snap that never existed.
+        // The END state is what the next snap will be; fall back to the
+        // start pair only when the end down is absent entirely.
+        var hasEndSnapState = footballPlay.EndDown is not null;
+        var down = hasEndSnapState ? footballPlay.EndDown : footballPlay.StartDown;
+        var distance = hasEndSnapState ? footballPlay.EndDistance : footballPlay.StartDistance;
+
         return _publishEndpoint.Publish(new FootballPlayCompleted(
             ContestId: competition.ContestId,
             CompetitionId: competition.Id,
@@ -211,8 +219,8 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
             IsScoringPlay: footballPlay.ScoringPlay,
             ScoringPlayType: footballPlay.ScoringTypeName,
             BallOnYardLine: footballPlay.EndYardLine ?? footballPlay.StartYardLine,
-            Down: footballPlay.EndDown ?? footballPlay.StartDown,
-            Distance: footballPlay.EndDistance ?? footballPlay.StartDistance,
+            Down: down,
+            Distance: distance,
             Ref: null,
             Sport: command.Sport,
             SeasonYear: command.SeasonYear,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -211,6 +211,8 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
             IsScoringPlay: footballPlay.ScoringPlay,
             ScoringPlayType: footballPlay.ScoringTypeName,
             BallOnYardLine: footballPlay.EndYardLine ?? footballPlay.StartYardLine,
+            Down: footballPlay.EndDown ?? footballPlay.StartDown,
+            Distance: footballPlay.EndDistance ?? footballPlay.StartDistance,
             Ref: null,
             Sport: command.Sport,
             SeasonYear: command.SeasonYear,

--- a/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
@@ -123,8 +123,11 @@ describe('MatchupCard — live updates', () => {
     // Last-play description.
     expect(screen.getByText(/homers to deep center/)).toBeTruthy();
 
-    // Score line includes both teams' new scores.
-    expect(screen.getByText(/NYY 4 – 2 BOS/)).toBeTruthy();
+    // The duplicated "NYY 4 – 2 BOS" line is gone — scores live on the
+    // team rows. The batting indicator moved there with it: "Top" means
+    // the away side bats, so exactly one baseball renders.
+    expect(screen.queryByText(/NYY 4 – 2 BOS/)).toBeNull();
+    expect(screen.getAllByText('⚾')).toHaveLength(1);
   });
 
   it('renders football InProgress UI after a FootballPlayCompleted event arrives', () => {
@@ -146,13 +149,23 @@ describe('MatchupCard — live updates', () => {
         possessionFranchiseSeasonId: '00000000-0000-0000-0000-0000000000b1', // away
         isScoringPlay: false,
         ballOnYardLine: 22,
+        down: 2,
+        distance: 7,
       });
     });
 
-    // LIVE + period/clock + new score.
+    // LIVE + period/clock. The scores render on the team rows; the status
+    // block's old "KC 14 – 17 BUF" line duplicated them and now carries
+    // the situation instead.
     expect(screen.getByText('LIVE')).toBeTruthy();
     expect(screen.getByText(/Q3\s*–\s*4:21/)).toBeTruthy();
-    expect(screen.getByText(/KC 14 – 17 BUF/)).toBeTruthy();
+    // ballOnYardLine is absolute from the HOME goal line, so 22 sits in
+    // home (BUF) territory and reads directly.
+    expect(screen.getByText('2nd & 7 · BUF 22')).toBeTruthy();
+    // Possession moved to the team row: exactly one football, and no
+    // leftover pick arrow anywhere on the card.
+    expect(screen.getAllByText('🏈')).toHaveLength(1);
+    expect(screen.queryByText('▶')).toBeNull();
   });
 
   it('renders batter team logo + headshot when the BaseballPlayCompleted carries them', () => {

--- a/src/UI/sd-mobile/__tests__/utils/liveSituation.test.ts
+++ b/src/UI/sd-mobile/__tests__/utils/liveSituation.test.ts
@@ -1,0 +1,147 @@
+import {
+  formatBallSpot,
+  formatDownAndDistance,
+  formatFootballSituation,
+  getPossessionGlyph,
+  getPossessionSide,
+} from '@/src/utils/liveSituation';
+import type { Matchup } from '@/src/types/models';
+
+const baseMatchup = {
+  status: 'STATUS_IN_PROGRESS',
+  awayShort: 'CAR',
+  homeShort: 'JAX',
+  awayFranchiseSeasonId: 'away-fs',
+  homeFranchiseSeasonId: 'home-fs',
+} as unknown as Matchup;
+
+const withLive = (overrides: Partial<Matchup>): Matchup =>
+  ({ ...baseMatchup, ...overrides }) as Matchup;
+
+describe('formatDownAndDistance', () => {
+  it.each([
+    [1, 10, '1st & 10'],
+    [2, 7, '2nd & 7'],
+    [3, 1, '3rd & 1'],
+    [4, 25, '4th & 25'],
+  ])('formats down %i and %i to go', (down, distance, expected) => {
+    expect(formatDownAndDistance(down, distance)).toBe(expected);
+  });
+
+  it('renders goal-to-go rather than "& 0"', () => {
+    expect(formatDownAndDistance(1, 0)).toBe('1st & Goal');
+  });
+
+  it('returns null when there is no snap state', () => {
+    // Down 0 is ESPN's kickoff / extra point / end-of-period value; a
+    // "0th & 0" line would be nonsense.
+    expect(formatDownAndDistance(0, 0)).toBeNull();
+    expect(formatDownAndDistance(null, 10)).toBeNull();
+    expect(formatDownAndDistance(undefined, undefined)).toBeNull();
+  });
+
+  it('keeps the down when distance is unknown', () => {
+    expect(formatDownAndDistance(2, null)).toBe('2nd');
+  });
+});
+
+describe('formatBallSpot', () => {
+  // Convention verified against stored play text: the coordinate is
+  // absolute from the HOME goal line. With JAX at home, a ball "to JAX 27"
+  // stores 27; a ball "to CAR 27" stores 73.
+  it('names the home side below midfield and reads the number directly', () => {
+    expect(formatBallSpot(27, 'CAR', 'JAX')).toBe('JAX 27');
+  });
+
+  it('names the away side above midfield and inverts the number', () => {
+    expect(formatBallSpot(73, 'CAR', 'JAX')).toBe('CAR 27');
+  });
+
+  it('renders midfield as a bare 50', () => {
+    expect(formatBallSpot(50, 'CAR', 'JAX')).toBe('50');
+  });
+
+  it('returns null for unknown or out-of-range positions', () => {
+    expect(formatBallSpot(null, 'CAR', 'JAX')).toBeNull();
+    expect(formatBallSpot(-1, 'CAR', 'JAX')).toBeNull();
+    expect(formatBallSpot(101, 'CAR', 'JAX')).toBeNull();
+  });
+});
+
+describe('formatFootballSituation', () => {
+  it('joins down-and-distance with the ball spot', () => {
+    // The real replayed case: HOU (home) driving, ball at LV 25 stored as
+    // 75. It must read "CAR 25" here — the AWAY side — not "JAX 25".
+    expect(
+      formatFootballSituation(withLive({ down: 1, distance: 10, ballOnYardLine: 75 }))
+    ).toBe('1st & 10 · CAR 25');
+  });
+
+  it('renders either half alone', () => {
+    expect(
+      formatFootballSituation(withLive({ down: 3, distance: 4, ballOnYardLine: null }))
+    ).toBe('3rd & 4');
+    expect(
+      formatFootballSituation(withLive({ down: 0, distance: 0, ballOnYardLine: 35 }))
+    ).toBe('JAX 35');
+  });
+
+  it('returns null when neither half is known so no empty row renders', () => {
+    expect(
+      formatFootballSituation(withLive({ down: null, distance: null, ballOnYardLine: null }))
+    ).toBeNull();
+  });
+});
+
+describe('getPossessionSide', () => {
+  it('resolves football possession by franchise season id', () => {
+    expect(
+      getPossessionSide(withLive({ possessionFranchiseSeasonId: 'home-fs' }), 'FootballNfl')
+    ).toBe('home');
+    expect(
+      getPossessionSide(withLive({ possessionFranchiseSeasonId: 'away-fs' }), 'FootballNfl')
+    ).toBe('away');
+  });
+
+  it('resolves baseball batting from the half inning', () => {
+    expect(getPossessionSide(withLive({ halfInning: 'Top' }), 'BaseballMlb')).toBe('away');
+    expect(getPossessionSide(withLive({ halfInning: 'Bottom' }), 'BaseballMlb')).toBe('home');
+  });
+
+  it('shows nothing once the game is final', () => {
+    // The last play's possession lingers in the live store; a football on
+    // a finished game is simply wrong.
+    expect(
+      getPossessionSide(
+        withLive({ status: 'STATUS_FINAL', possessionFranchiseSeasonId: 'home-fs' }),
+        'FootballNfl'
+      )
+    ).toBeNull();
+  });
+
+  it('still shows possession while a live game is paused', () => {
+    expect(
+      getPossessionSide(
+        withLive({ status: 'STATUS_DELAYED', possessionFranchiseSeasonId: 'away-fs' }),
+        'FootballNfl'
+      )
+    ).toBe('away');
+  });
+
+  it('returns null when possession is unknown or unmatched', () => {
+    expect(
+      getPossessionSide(withLive({ possessionFranchiseSeasonId: null }), 'FootballNfl')
+    ).toBeNull();
+    expect(
+      getPossessionSide(withLive({ possessionFranchiseSeasonId: 'someone-else' }), 'FootballNfl')
+    ).toBeNull();
+  });
+});
+
+describe('getPossessionGlyph', () => {
+  it('uses a baseball for MLB and a football everywhere else', () => {
+    expect(getPossessionGlyph('BaseballMlb')).toBe('⚾');
+    expect(getPossessionGlyph('FootballNcaa')).toBe('🏈');
+    expect(getPossessionGlyph(null)).toBe('🏈');
+  });
+});

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -7,6 +7,7 @@ import type { Matchup, PickType } from '@/src/types/models';
 import { formatToUserTime, getDefaultGameWeekday } from '@/src/utils/timeUtils';
 import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 import { FinalScoreResult } from './FinalScoreResult';
+import { formatFootballSituation } from '@/src/utils/liveSituation';
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
@@ -297,14 +298,10 @@ function FootballInProgress({
   const delayLabel = (
     matchup.statusDescription ?? matchup.status ?? 'PAUSED'
   ).toUpperCase();
-  const awayScore = matchup.awayScore ?? 0;
-  const homeScore = matchup.homeScore ?? 0;
-  const awayHasPossession =
-    !!matchup.possessionFranchiseSeasonId &&
-    matchup.possessionFranchiseSeasonId === matchup.awayFranchiseSeasonId;
-  const homeHasPossession =
-    !!matchup.possessionFranchiseSeasonId &&
-    matchup.possessionFranchiseSeasonId === matchup.homeFranchiseSeasonId;
+  // Possession now renders on the team row (see MatchupCard.TeamRow) — the
+  // scoreline that used to carry it here duplicated the scores already
+  // shown against each team, so this slot became the situation line.
+  const situation = formatFootballSituation(matchup);
   const hasLastPlay =
     typeof matchup.lastPlayDescription === 'string' &&
     matchup.lastPlayDescription.length > 0;
@@ -346,13 +343,13 @@ function FootballInProgress({
         ) : null}
       </View>
 
-      <View style={[styles.scoreRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
-        {awayHasPossession ? <Text style={styles.possessionIcon}>🏈</Text> : null}
-        <Text style={[styles.scoreText, { color: theme.text }]}>
-          {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
-        </Text>
-        {homeHasPossession ? <Text style={styles.possessionIcon}>🏈</Text> : null}
-      </View>
+      {situation ? (
+        <View style={[styles.situationRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
+          <Text style={[styles.situationText, { color: theme.text }]}>
+            {situation}
+          </Text>
+        </View>
+      ) : null}
 
       {matchup.isScoringPlay ? (
         <Text style={styles.scoringPlayText}>
@@ -391,13 +388,10 @@ function BaseballInProgress({
   const delayLabel = (
     matchup.statusDescription ?? matchup.status ?? 'PAUSED'
   ).toUpperCase();
-  const awayScore = matchup.awayScore ?? 0;
-  const homeScore = matchup.homeScore ?? 0;
-  // halfInning "Top" → away batting (gets the ⚾); "Bottom" → home batting.
-  const half = (matchup.halfInning ?? '').toLowerCase();
-  const awayIsBatting = half === 'top';
-  const homeIsBatting = half === 'bottom';
-
+  // The batting indicator moved to the team row alongside football's
+  // possession glyph (see MatchupCard.TeamRow); the scoreline it rode on
+  // duplicated the per-team scores and has been dropped. Baseball's
+  // situation already renders below as inning · count · outs.
   const hasInningRow =
     (typeof matchup.inning === 'number' && matchup.inning > 0) ||
     (typeof matchup.halfInning === 'string' && matchup.halfInning.length > 0);
@@ -428,14 +422,6 @@ function BaseballInProgress({
             <Text style={styles.liveText}>LIVE</Text>
           </>
         )}
-      </View>
-
-      <View style={[styles.scoreRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
-        {awayIsBatting ? <Text style={styles.possessionIcon}>⚾</Text> : null}
-        <Text style={[styles.scoreText, { color: theme.text }]}>
-          {matchup.awayShort} {awayScore} – {homeScore} {matchup.homeShort}
-        </Text>
-        {homeIsBatting ? <Text style={styles.possessionIcon}>⚾</Text> : null}
       </View>
 
       {hasAtBatRow ? (
@@ -478,13 +464,18 @@ function BaseballInProgress({
       ) : null}
 
       {hasInningRow ? (
-        <Text style={[styles.baseballSummary, { color: theme.textMuted }]}>
-          {formattedHalfInning}
-          {' · '}
-          {matchup.balls ?? 0}-{matchup.strikes ?? 0}
-          {' · '}
-          {matchup.outs ?? 0} {outsLabel}
-        </Text>
+        // Baseball's situation line, and — since the scoreline that used to
+        // carry it is gone — the scoring-play flash target, mirroring
+        // football's situationRow.
+        <View style={[styles.situationRow, matchup.isScoringPlay ? styles.scoreRowFlash : null]}>
+          <Text style={[styles.baseballSummary, { color: theme.textMuted }]}>
+            {formattedHalfInning}
+            {' · '}
+            {matchup.balls ?? 0}-{matchup.strikes ?? 0}
+            {' · '}
+            {matchup.outs ?? 0} {outsLabel}
+          </Text>
+        </View>
       ) : null}
 
       {hasRunnersRow ? (
@@ -577,8 +568,9 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '500',
   },
-  // Score
-  scoreRow: {
+  // Live situation line ("2nd & 7 · JAX 27"). Occupies the slot the
+  // duplicated scoreline used to hold.
+  situationRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
@@ -587,9 +579,14 @@ const styles = StyleSheet.create({
     paddingVertical: 2,
     borderRadius: 6,
   },
-  // Brief yellow highlight on the score row when isScoringPlay is true.
-  // The store auto-clears the flag after 2s (see contestUpdatesStore),
-  // so this style toggles off automatically without an Animated value.
+  situationText: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  // Brief yellow highlight on the situation row when isScoringPlay is
+  // true. The store auto-clears the flag after 2s (see
+  // contestUpdatesStore), so this style toggles off automatically
+  // without an Animated value.
   scoreRowFlash: {
     backgroundColor: 'rgba(250, 204, 21, 0.25)',
   },
@@ -609,9 +606,6 @@ const styles = StyleSheet.create({
   suCheck: {
     fontSize: 15,
     fontWeight: '800',
-  },
-  possessionIcon: {
-    fontSize: 14,
   },
   scoringPlayText: {
     fontSize: 13,

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -236,7 +236,13 @@ function TeamRow({
           {hasPossession && (
             <Text
               style={styles.possessionIndicator}
-              accessibilityLabel={`${name} has possession`}
+              // The ⚾ means the team is batting, not that it "has
+              // possession" — announce what the glyph actually signifies.
+              accessibilityLabel={
+                possessionGlyph === '⚾'
+                  ? `${name} is batting`
+                  : `${name} has possession`
+              }
             >
               {possessionGlyph}
             </Text>
@@ -583,8 +589,11 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
         ? live.scoringPlayType
         : matchup.scoringPlayType,
       ballOnYardLine: live.ballOnYardLine ?? matchup.ballOnYardLine,
-      down: live.down ?? matchup.down,
-      distance: live.distance ?? matchup.distance,
+      // Omitted (older messages) falls back to fetched data; an explicit
+      // null CLEARS the snap state (?? would resurrect a stale down at
+      // kickoff / period breaks). Same contract as scoringPlayType above.
+      down: live.down !== undefined ? live.down : matchup.down,
+      distance: live.distance !== undefined ? live.distance : matchup.distance,
       // Baseball live fields
       inning: live.inning ?? matchup.inning,
       halfInning: live.halfInning ?? matchup.halfInning,

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -13,6 +13,7 @@ import { useUserOptions } from '@/src/hooks/useUserOptions';
 import { shouldShowGambling } from '@/src/lib/gamblingContent';
 import { useTeamFinalizedGames } from '@/src/hooks/useTeamFinalizedGames';
 import { resolveSportLeague } from '@/src/utils/sportLinks';
+import { getPossessionGlyph, getPossessionSide } from '@/src/utils/liveSituation';
 import { InsightModal } from './InsightModal';
 import { StatsComparisonModal } from './StatsComparisonModal';
 import { GameStatus } from './GameStatus';
@@ -84,22 +85,23 @@ function TeamRow({
   matchup,
   side,
   isWinning,
-  isPicked,
-  isPickCorrect,
   isFinal,
   isScheduleOpen,
   onToggleSchedule,
   canShowSchedule,
+  hasPossession,
+  possessionGlyph,
 }: {
   matchup: Matchup;
   side: 'home' | 'away';
   isWinning: boolean;
-  isPicked: boolean;
-  isPickCorrect: boolean | null;
   isFinal: boolean;
   isScheduleOpen: boolean;
   onToggleSchedule: () => void;
   canShowSchedule: boolean;
+  /** This side has the ball (football) / is batting (baseball). */
+  hasPossession: boolean;
+  possessionGlyph: string;
 }) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -138,16 +140,11 @@ function TeamRow({
   const isActive = !isFinal || isWinning || isTie;
   const record = formatRecord(wins, losses, confWins, confLosses);
 
-  // Pick indicator styling — uses the same theme.pickCorrect /
-  // theme.pickIncorrect tokens as PickButton and the card border, so all
-  // three result cues stay in lockstep across themes and match web's
-  // --pick-correct / --pick-incorrect palette.
-  let pickIndicatorColor: string | null = null;
-  if (isPicked && isFinal) {
-    pickIndicatorColor = isPickCorrect ? theme.pickCorrect : theme.pickIncorrect;
-  } else if (isPicked) {
-    pickIndicatorColor = theme.tint;
-  }
+  // NOTE: there is deliberately no pick indicator on the team row. A
+  // marker here (previously a blue ▶) sits exactly where every sports app
+  // puts possession, so during a live game it read as "this team has the
+  // ball". The pick is already stated unambiguously by the pick buttons
+  // at the foot of the card, and the result by the card border.
 
   return (
     // Background lives at the call site so the team row gets theme.card,
@@ -230,15 +227,18 @@ function TeamRow({
         ) : null}
       </View>
 
-      {/* Score + pick indicator — only render when there's content to show.
-          Pre-game with no pick, the empty box was reserving minWidth + the
-          parent row's gap, which squeezed the team name in the compact
-          layout and forced truncation ("Cleveland Guar..."). */}
-      {(pickIndicatorColor || score != null) && (
+      {/* Score + possession — only render when there's content to show.
+          Pre-game with nothing to show, the empty box was reserving
+          minWidth + the parent row's gap, which squeezed the team name in
+          the compact layout and forced truncation ("Cleveland Guar..."). */}
+      {(hasPossession || score != null) && (
         <View style={styles.scoreBox}>
-          {pickIndicatorColor && (
-            <Text style={[styles.pickIndicator, { color: pickIndicatorColor }]}>
-              {isPicked && isFinal ? (isPickCorrect ? '✓' : '✗') : '▶'}
+          {hasPossession && (
+            <Text
+              style={styles.possessionIndicator}
+              accessibilityLabel={`${name} has possession`}
+            >
+              {possessionGlyph}
             </Text>
           )}
           {score != null && (
@@ -583,6 +583,8 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
         ? live.scoringPlayType
         : matchup.scoringPlayType,
       ballOnYardLine: live.ballOnYardLine ?? matchup.ballOnYardLine,
+      down: live.down ?? matchup.down,
+      distance: live.distance ?? matchup.distance,
       // Baseball live fields
       inning: live.inning ?? matchup.inning,
       halfInning: live.halfInning ?? matchup.halfInning,
@@ -624,9 +626,13 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
   // lowercased and compared against bare 'final' / 'completed', which
   // never matched the wire's STATUS_FINAL shape — so isFinal was always
   // false and the entire scored-card visual pipeline (PickButton
-  // green/red, team-row indicator ✓/✗, card border tint, winning-team
-  // score color) silently no-op'd.
+  // green/red, card border tint, winning-team score color) silently
+  // no-op'd.
   const isFinal = enrichedMatchup.status === 'STATUS_FINAL';
+
+  // Computed from the ENRICHED matchup: possession arrives over SignalR,
+  // not in the REST payload, so the pre-merge matchup would never have it.
+  const possessionSide = getPossessionSide(enrichedMatchup, leagueSport);
 
   // Optimistic local pick — shows selection instantly before server confirms
   const [optimisticFranchiseId, setOptimisticFranchiseId] = useState<string | null>(null);
@@ -650,6 +656,7 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
 
   const year = seasonYear ?? new Date(matchup.startDateUtc).getFullYear();
   const sportLeague = resolveSportLeague(leagueSport);
+  const possessionGlyph = getPossessionGlyph(leagueSport);
 
   // Point-in-time anchor for the MiniSchedule — THIS game's kickoff, not the
   // week's end. The endpoint filters FinalizedUtc <= asOfDate, and a game's
@@ -851,12 +858,12 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
             matchup={enrichedMatchup}
             side="away"
             isWinning={awayIsWinning}
-            isPicked={pickedAway}
-            isPickCorrect={isPickCorrect}
             isFinal={isFinal}
             isScheduleOpen={showAwaySchedule}
             onToggleSchedule={() => setShowAwaySchedule((v) => !v)}
             canShowSchedule={!!sportLeague}
+            hasPossession={possessionSide === 'away'}
+            possessionGlyph={possessionGlyph}
           />
         </TouchableOpacity>
         {showAwaySchedule && (
@@ -882,12 +889,12 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
             matchup={enrichedMatchup}
             side="home"
             isWinning={homeIsWinning}
-            isPicked={pickedHome}
-            isPickCorrect={isPickCorrect}
             isFinal={isFinal}
             isScheduleOpen={showHomeSchedule}
             onToggleSchedule={() => setShowHomeSchedule((v) => !v)}
             canShowSchedule={!!sportLeague}
+            hasPossession={possessionSide === 'home'}
+            possessionGlyph={possessionGlyph}
           />
         </TouchableOpacity>
         {showHomeSchedule && (
@@ -1092,9 +1099,8 @@ const styles = StyleSheet.create({
   scoreWinner: {
     fontSize: 22,
   },
-  pickIndicator: {
-    fontSize: 14,
-    fontWeight: '800',
+  possessionIndicator: {
+    fontSize: 13,
   },
 
   // Status styles live in GameStatus.tsx

--- a/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
+++ b/src/UI/sd-mobile/src/stores/contestUpdatesStore.ts
@@ -31,6 +31,10 @@ export interface ContestLiveRecord {
    *  to fetched data; explicit null means "no published type" and clears. */
   scoringPlayType?: string | null;
   ballOnYardLine?: number | null;
+  /** Down / yards-to-go for the situation line; same merge semantics as
+   *  scoringPlayType (omitted = fall back, explicit null = clear). */
+  down?: number | null;
+  distance?: number | null;
 
   // Baseball fields
   inning?: number;
@@ -171,6 +175,8 @@ export const useContestUpdatesStore = create<ContestUpdatesState>((set) => ({
           // to fetched data), explicit null clears a stale type.
           scoringPlayType: data.scoringPlayType,
           ballOnYardLine: data.ballOnYardLine,
+          down: data.down,
+          distance: data.distance,
           lastPlayId: data.playId,
           lastPlayDescription: data.playDescription,
           lastPlayAt: now,

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -95,8 +95,14 @@ export interface Matchup {
   /** Canonical scoring-type NAME slug ('touchdown', 'field-goal', 'safety',
    *  'defensive-two-point-conversion') or null - NOT a display name. */
   scoringPlayType?: string | null;
-  /** 0–100 yards from the away (visitor) goal line. Null pre-snap / halftime / post-game. */
+  /** Absolute field coordinate, 0–100 from the HOME goal line (home goal
+   *  = 0, away goal = 100), so home yard numbers read directly and away
+   *  numbers invert. Null pre-snap / halftime / post-game. */
   ballOnYardLine?: number | null;
+  /** Down and yards-to-go for the next snap ("2nd & 7"). Null/0 means no
+   *  snap state — kickoff, extra point, end of period. */
+  down?: number | null;
+  distance?: number | null;
 
   // Live game state — baseball (populated by BaseballPlayCompleted via contestUpdatesStore)
   inning?: number | null;

--- a/src/UI/sd-mobile/src/types/signalR.ts
+++ b/src/UI/sd-mobile/src/types/signalR.ts
@@ -37,10 +37,19 @@ export interface FootballPlayCompletedPayload {
    *  the type wasn't captured; absent entirely on pre-upgrade messages. */
   scoringPlayType?: string | null;
   /**
-   * 0–100 yards from the away (visitor) goal line. Null at pre-snap,
-   * halftime, or post-game — match ESPN's YardLine convention.
+   * Absolute field coordinate, 0–100 measured from the HOME goal line
+   * (home goal = 0, away goal = 100) — ESPN's YardLine convention. Home
+   * yard numbers read directly, away numbers invert. Null at pre-snap,
+   * halftime, or post-game.
    */
   ballOnYardLine: number | null;
+  /**
+   * Down and yards-to-go for the next snap, driving the live card's
+   * situation line ("2nd & 7"). Null/0 means no snap state (kickoff,
+   * extra point, end of period); absent entirely on pre-upgrade messages.
+   */
+  down?: number | null;
+  distance?: number | null;
 }
 
 /**

--- a/src/UI/sd-mobile/src/utils/liveSituation.ts
+++ b/src/UI/sd-mobile/src/utils/liveSituation.ts
@@ -1,0 +1,121 @@
+import type { Matchup } from '@/src/types/models';
+
+/**
+ * Live-game situation helpers shared by the team rows (possession glyph)
+ * and the status block (situation line). Kept in one place so the two
+ * surfaces can never disagree about who has the ball.
+ */
+
+/** Statuses where a possession / batting indicator is meaningful. Mirrors
+ *  GameStatus's DELAY_STATUSES plus the actively-live states: a delayed
+ *  game still has a team with the ball. FINAL deliberately excluded — the
+ *  last play's possession lingers in the live store, and showing a
+ *  football on a finished game is just wrong. */
+const LIVE_STATUSES = new Set([
+  'STATUS_IN_PROGRESS',
+  'STATUS_HALFTIME',
+  'STATUS_DELAYED',
+  'STATUS_RAIN_DELAY',
+  'STATUS_SUSPENDED',
+]);
+
+export function isLiveStatus(status: string | null | undefined): boolean {
+  return !!status && LIVE_STATUSES.has(status);
+}
+
+/**
+ * Which side currently has the ball (football) or is batting (baseball).
+ * Football reads possessionFranchiseSeasonId; baseball derives it from
+ * halfInning ("Top" → away bats, "Bottom" → home bats).
+ * Returns null when the game isn't live or the state is unknown.
+ */
+export function getPossessionSide(
+  matchup: Matchup,
+  leagueSport?: string | null
+): 'home' | 'away' | null {
+  if (!isLiveStatus(matchup.status)) return null;
+
+  if (leagueSport === 'BaseballMlb') {
+    const half = (matchup.halfInning ?? '').toLowerCase();
+    if (half === 'top') return 'away';
+    if (half === 'bottom') return 'home';
+    return null;
+  }
+
+  const possessionId = matchup.possessionFranchiseSeasonId;
+  if (!possessionId) return null;
+  if (possessionId === matchup.awayFranchiseSeasonId) return 'away';
+  if (possessionId === matchup.homeFranchiseSeasonId) return 'home';
+  return null;
+}
+
+/** Glyph for the possession indicator, by sport. */
+export function getPossessionGlyph(leagueSport?: string | null): string {
+  return leagueSport === 'BaseballMlb' ? '⚾' : '🏈';
+}
+
+/**
+ * "2nd & 7" — null when there is no snap state. Down 0 covers kickoffs,
+ * extra points, and end-of-period, where ESPN reports down 0 and a
+ * "0th & 0" line would be nonsense. Distance 0 on a valid down is
+ * "goal" (1st & Goal from the 3).
+ */
+export function formatDownAndDistance(
+  down: number | null | undefined,
+  distance: number | null | undefined
+): string | null {
+  if (down == null || down <= 0) return null;
+
+  const ordinals = ['1st', '2nd', '3rd', '4th'];
+  const downLabel = ordinals[down - 1] ?? `${down}th`;
+
+  if (distance == null) return downLabel;
+  if (distance <= 0) return `${downLabel} & Goal`;
+  return `${downLabel} & ${distance}`;
+}
+
+/**
+ * "LV 25" — the ball spot in the conventional team-relative form.
+ *
+ * ballOnYardLine is an ABSOLUTE field coordinate measured from the HOME
+ * team's goal line (home goal = 0, away goal = 100). Verified against
+ * stored play text across several games and both orientations: with PHI
+ * at home, "to PHI 32" stores 32; with PHI away, "to PHI 6" stores 94.
+ * So a spot below 50 is in HOME territory and reads directly, and one
+ * above 50 is in AWAY territory and reads inverted. Midfield is just
+ * "50". Needs no possession knowledge — which side of the field the ball
+ * sits on is what names the spot.
+ */
+export function formatBallSpot(
+  ballOnYardLine: number | null | undefined,
+  awayShort: string | null | undefined,
+  homeShort: string | null | undefined
+): string | null {
+  if (ballOnYardLine == null) return null;
+  if (ballOnYardLine < 0 || ballOnYardLine > 100) return null;
+  if (ballOnYardLine === 50) return '50';
+
+  if (ballOnYardLine < 50) {
+    return homeShort ? `${homeShort} ${ballOnYardLine}` : null;
+  }
+  return awayShort ? `${awayShort} ${100 - ballOnYardLine}` : null;
+}
+
+/**
+ * The football situation line: "2nd & 7 · JAX 27". Either half can be
+ * missing — a spot with no down still tells you where the ball is, and a
+ * down with no spot still tells you the snap. Null when neither exists,
+ * so the caller renders nothing rather than an empty row.
+ */
+export function formatFootballSituation(matchup: Matchup): string | null {
+  const downAndDistance = formatDownAndDistance(matchup.down, matchup.distance);
+  const spot = formatBallSpot(
+    matchup.ballOnYardLine,
+    matchup.awayShort,
+    matchup.homeShort
+  );
+
+
+  const parts = [downAndDistance, spot].filter(Boolean);
+  return parts.length > 0 ? parts.join(' · ') : null;
+}

--- a/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/BaseballGameStatusInProgress.jsx
@@ -23,10 +23,6 @@ import { contestLink } from '../../utils/sportLinks';
  * markup is deferred to a follow-up effort per docs/matchup-card.md.
  */
 function BaseballGameStatusInProgress({
-  awayShort,
-  homeShort,
-  awayScore,
-  homeScore,
   inning,
   halfInning,
   balls,
@@ -57,11 +53,8 @@ function BaseballGameStatusInProgress({
   league,
 }) {
   const delayLabel = (statusDescription || status || 'PAUSED').toUpperCase();
-  // Top of the inning → away team is batting; Bottom → home batting.
-  // Empty/unknown halfInning produces no indicator (graceful degrade).
-  const half = (halfInning ?? '').toLowerCase();
-  const awayIsBatting = half === 'top';
-  const homeIsBatting = half === 'bottom';
+  // Which side is batting is derived in utils/liveSituation and rendered
+  // on the team row now, so this block no longer needs it.
 
   // Suppress rows whose source fields are absent. Inning is the only
   // truthiness check that needs care because PeriodNumber=0 isn't a
@@ -94,12 +87,10 @@ function BaseballGameStatusInProgress({
       ) : (
         <span className="status-label live-indicator">LIVE</span>
       )}
-      <span className={`score-display ${isScoringPlay ? 'score-flash' : ''}`}>
-        {awayIsBatting && <span className="possession-indicator" aria-label="batting">⚾</span>}
-        {awayShort} {awayScore} - {homeScore} {homeShort}
-        {homeIsBatting && <span className="possession-indicator" aria-label="batting">⚾</span>}
-      </span>
-
+      {/* The batting indicator moved to the team row alongside football's
+          possession glyph, and the scoreline it rode on duplicated the
+          per-team scores. Baseball's situation already renders below as
+          inning · count · outs. */}
       {hasAtBatRow && (
         <span className="live-state-atbat">
           {atBatShortName && (
@@ -138,7 +129,10 @@ function BaseballGameStatusInProgress({
       )}
 
       {hasInningRow && (
-        <span className="live-state-summary">
+        // Baseball's situation line, and — since the scoreline that used
+        // to carry it is gone — the scoring-play flash target, mirroring
+        // football's situation-display.
+        <span className={`live-state-summary ${isScoringPlay ? 'score-flash' : ''}`}>
           {formattedHalfInning}
           {' · '}
           {balls ?? 0}-{strikes ?? 0}

--- a/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
+++ b/src/UI/sd-ui/src/components/matchups/FootballGameStatusInProgress.jsx
@@ -1,12 +1,18 @@
 import { Link } from "react-router-dom";
 import { contestLink } from '../../utils/sportLinks';
+import { formatFootballSituation } from '../../utils/liveSituation';
 
 /**
- * Football per-play live block. Renders LIVE label, period+clock, score
- * with 🏈 next to the team in possession, scoring flash + a typed
+ * Football per-play live block. Renders LIVE label, period+clock, the
+ * situation line ("2nd & 7 · LV 25"), scoring flash + a typed
  * celebration label (🎉 TOUCHDOWN! / FIELD GOAL! / SAFETY! / neutral
  * SCORE! when the type is unknown - issue #45), and a last-play
  * description row (mirrors baseball).
+ *
+ * Possession renders on the TEAM ROW, not here: a marker beside the team
+ * name is where every sports app puts it, and the scoreline that used to
+ * carry it duplicated the scores already shown against each team. That
+ * slot is now the situation line.
  *
  * Class names are intentionally kept (`.game-result`, `.final-score`,
  * `.score-display`, etc.) — the broader status-neutral rename is a
@@ -15,13 +21,12 @@ import { contestLink } from '../../utils/sportLinks';
 function FootballGameStatusInProgress({
   awayShort,
   homeShort,
-  awayScore,
-  homeScore,
   period,
   clock,
-  awayFranchiseSeasonId,
-  homeFranchiseSeasonId,
-  possessionFranchiseSeasonId,
+  // Down / yards-to-go and ball spot for the situation line.
+  down,
+  distance,
+  ballOnYardLine,
   isScoringPlay,
   // Nullable canonical scoring-type NAME slug ('touchdown', 'field-goal',
   // 'safety', 'defensive-two-point-conversion') - NOT a display name. The
@@ -38,16 +43,13 @@ function FootballGameStatusInProgress({
   league,
 }) {
   const delayLabel = (statusDescription || status || 'PAUSED').toUpperCase();
-  // Guard against null/undefined possession — without the != null check,
-  // a missing possessionFranchiseSeasonId could match a missing
-  // awayFranchiseSeasonId / homeFranchiseSeasonId via `===` and falsely
-  // mark a team as having possession.
-  const awayHasPossession =
-    possessionFranchiseSeasonId != null
-    && possessionFranchiseSeasonId === awayFranchiseSeasonId;
-  const homeHasPossession =
-    possessionFranchiseSeasonId != null
-    && possessionFranchiseSeasonId === homeFranchiseSeasonId;
+  const situation = formatFootballSituation({
+    down,
+    distance,
+    ballOnYardLine,
+    awayShort,
+    homeShort,
+  });
 
   const hasLastPlayRow =
     typeof lastPlayDescription === 'string' && lastPlayDescription.length > 0;
@@ -86,11 +88,11 @@ function FootballGameStatusInProgress({
       {period && clock && (
         <span className="game-clock">{period} - {clock}</span>
       )}
-      <span className={`score-display ${isScoringPlay ? 'score-flash' : ''}`}>
-        {awayHasPossession && <span className="possession-indicator">🏈</span>}
-        {awayShort} {awayScore} - {homeScore} {homeShort}
-        {homeHasPossession && <span className="possession-indicator">🏈</span>}
-      </span>
+      {situation && (
+        <span className={`situation-display ${isScoringPlay ? 'score-flash' : ''}`}>
+          {situation}
+        </span>
+      )}
       {isScoringPlay && (
         <span className="touchdown-indicator">
           {scoring.emoji ? '🎉 ' : ''}

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -60,7 +60,12 @@ function GameStatus({
   clock,
   awayFranchiseSeasonId,
   homeFranchiseSeasonId,
-  possessionFranchiseSeasonId,
+  // Football live snap state. possessionFranchiseSeasonId is consumed by
+  // the TEAM ROWS (MatchupCard) rather than here — the status block now
+  // carries the situation line built from down / distance / ball spot.
+  down,
+  distance,
+  ballOnYardLine,
   isScoringPlay,
   scoringPlayType,
   // Baseball-specific live fields (populated by ContestUpdatesContext
@@ -195,13 +200,11 @@ function GameStatus({
       <FootballGameStatusInProgress
         awayShort={awayShort}
         homeShort={homeShort}
-        awayScore={awayScore}
-        homeScore={homeScore}
         period={period}
         clock={clock}
-        awayFranchiseSeasonId={awayFranchiseSeasonId}
-        homeFranchiseSeasonId={homeFranchiseSeasonId}
-        possessionFranchiseSeasonId={possessionFranchiseSeasonId}
+        down={down}
+        distance={distance}
+        ballOnYardLine={ballOnYardLine}
         isScoringPlay={isScoringPlay}
         scoringPlayType={scoringPlayType}
         isDelayed={isDelayed}

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -127,6 +127,16 @@
   gap: 1rem;
 }
 
+/* Score + possession glyph at the row's far right. The glyph sits to the
+   LEFT of the score — ESPN's placement, and where the eye already goes
+   during a live game. */
+.matchup-card .team-score-box {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
 /* Per-team score at the row's far right (mobile parity). Neutral while the
    game is live; the winner's score takes the accent once FINAL. */
 .matchup-card .team-score {
@@ -380,6 +390,17 @@
   gap: 8px;
 }
 
+/* Live football situation ("2nd & 7 · LV 25"), in the slot the duplicated
+   scoreline used to occupy. */
+.situation-display {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* SU quick-scan indicator: a checkmark hugging the winning team's
    short directly in the score line. .score-display-team groups the
    team short + (optional) check so flex gap stays between team groups
@@ -452,7 +473,9 @@
   }
 }
 
-.score-display.score-flash {
+.score-display.score-flash,
+.situation-display.score-flash,
+.live-state-summary.score-flash {
   animation: flash-score 2s ease-in-out;
   font-weight: 700;
 }

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.jsx
@@ -16,6 +16,7 @@ import { useTheme } from "../../contexts/ThemeContext";
 import PickButton from "./PickButton";
 import { SpreadAndOverUnderDisplay } from "./BettingDisplays";
 import { shouldShowGambling } from "../../utils/gamblingContent";
+import { getPossessionGlyph, getPossessionSide } from "../../utils/liveSituation";
 import DeetsMeter from "./DeetsMeter";
 import ConfidencePicker from "./ConfidencePicker";
 
@@ -110,6 +111,12 @@ function MatchupCard({
   const bothScored = matchup.awayScore != null && matchup.homeScore != null;
   const awayIsWinner = isFinalStatus && bothScored && matchup.awayScore > matchup.homeScore;
   const homeIsWinner = isFinalStatus && bothScored && matchup.homeScore > matchup.awayScore;
+
+  // Possession renders on the team rows (mobile parity). Live-only — the
+  // helper returns null once the game is FINAL, so the last play's
+  // possession can't linger on a finished card.
+  const possessionSide = getPossessionSide(matchup, leagueSport);
+  const possessionGlyph = getPossessionGlyph(leagueSport);
 
   // Game details. The (Day) parenthetical shows only when the game falls
   // off the sport's expected day (NCAAFB: Sat, NFL: Sun, others: always
@@ -215,6 +222,8 @@ function MatchupCard({
           asOfDate={scheduleAsOfDate}
           score={matchup.awayScore}
           isWinner={awayIsWinner}
+          hasPossession={possessionSide === 'away'}
+          possessionGlyph={possessionGlyph}
         />
 
         {/* Home Team Row */}
@@ -240,6 +249,8 @@ function MatchupCard({
           asOfDate={scheduleAsOfDate}
           score={matchup.homeScore}
           isWinner={homeIsWinner}
+          hasPossession={possessionSide === 'home'}
+          possessionGlyph={possessionGlyph}
         />
 
         {/* Spread and Over/Under — gated: see utils/gamblingContent.js */}
@@ -270,7 +281,9 @@ function MatchupCard({
           clock={matchup.clock}
           awayFranchiseSeasonId={matchup.awayFranchiseSeasonId}
           homeFranchiseSeasonId={matchup.homeFranchiseSeasonId}
-          possessionFranchiseSeasonId={matchup.possessionFranchiseSeasonId}
+          down={matchup.down}
+          distance={matchup.distance}
+          ballOnYardLine={matchup.ballOnYardLine}
           isScoringPlay={matchup.isScoringPlay}
           scoringPlayType={matchup.scoringPlayType}
           // Baseball-shaped live fields (populated by ContestUpdatesContext

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -27,6 +27,11 @@ import TeamLogo from "../common/TeamLogo";
  *   TeamRow scoreBox.
  * @param {boolean} [props.isWinner] - True when the game is FINAL and this
  *   team scored strictly more; accents the score.
+ * @param {boolean} [props.hasPossession] - This team has the ball (football)
+ *   or is batting (baseball). Renders beside the score during live games
+ *   only — the placement every sports app uses. Mobile parity:
+ *   MatchupCard.tsx's TeamRow.
+ * @param {string} [props.possessionGlyph] - Sport-appropriate glyph.
  */
 function TeamRow({
   teamName,
@@ -49,7 +54,9 @@ function TeamRow({
   probablePitcher,
   asOfDate,
   score,
-  isWinner
+  isWinner,
+  hasPossession = false,
+  possessionGlyph = '🏈'
 }) {
   // resolveSportLeague returns null for unknown/missing enums so unsupported
   // sports don't silently render as an NCAA football route. Fall back to a
@@ -116,9 +123,22 @@ function TeamRow({
             )}
           </div>
         </div>
-        {score != null && (
-          <div className={`team-score${isWinner ? " team-score--winner" : ""}`}>
-            {score}
+        {(hasPossession || score != null) && (
+          <div className="team-score-box">
+            {hasPossession && (
+              <span
+                className="possession-indicator"
+                aria-label={`${teamName} has possession`}
+                title={`${teamName} has possession`}
+              >
+                {possessionGlyph}
+              </span>
+            )}
+            {score != null && (
+              <div className={`team-score${isWinner ? " team-score--winner" : ""}`}>
+                {score}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
+++ b/src/UI/sd-ui/src/components/matchups/TeamRow.jsx
@@ -62,6 +62,11 @@ function TeamRow({
   // sports don't silently render as an NCAA football route. Fall back to a
   // non-linked team name in that case.
   const sportLeague = resolveSportLeague(leagueSport);
+  // The ⚾ means the team is batting, not that it "has possession" —
+  // announce what the glyph actually signifies for each sport.
+  const possessionLabel = leagueSport === 'BaseballMlb'
+    ? `${teamName} is batting`
+    : `${teamName} has possession`;
   return (
     <>
       <div className="team-row">
@@ -128,8 +133,8 @@ function TeamRow({
             {hasPossession && (
               <span
                 className="possession-indicator"
-                aria-label={`${teamName} has possession`}
-                title={`${teamName} has possession`}
+                aria-label={possessionLabel}
+                title={possessionLabel}
               >
                 {possessionGlyph}
               </span>

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -257,8 +257,12 @@ function PicksPage() {
           clock: liveUpdate.clock ?? matchup.clock,
           possessionFranchiseSeasonId: liveUpdate.possessionFranchiseSeasonId ?? matchup.possessionFranchiseSeasonId,
           ballOnYardLine: liveUpdate.ballOnYardLine ?? matchup.ballOnYardLine,
-          down: liveUpdate.down ?? matchup.down,
-          distance: liveUpdate.distance ?? matchup.distance,
+          // Omitted (older messages) falls back to fetched data; an
+          // explicit null CLEARS the snap state (?? would resurrect a
+          // stale down at kickoff / period breaks). Same contract as
+          // scoringPlayType above.
+          down: liveUpdate.down !== undefined ? liveUpdate.down : matchup.down,
+          distance: liveUpdate.distance !== undefined ? liveUpdate.distance : matchup.distance,
           isScoringPlay: liveUpdate.isScoringPlay ?? matchup.isScoringPlay,
           // Omitted (older messages) falls back to fetched data; an
           // explicit null CLEARS a stale type (?? would resurrect it).

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -256,6 +256,9 @@ function PicksPage() {
           period: liveUpdate.period ?? matchup.period,
           clock: liveUpdate.clock ?? matchup.clock,
           possessionFranchiseSeasonId: liveUpdate.possessionFranchiseSeasonId ?? matchup.possessionFranchiseSeasonId,
+          ballOnYardLine: liveUpdate.ballOnYardLine ?? matchup.ballOnYardLine,
+          down: liveUpdate.down ?? matchup.down,
+          distance: liveUpdate.distance ?? matchup.distance,
           isScoringPlay: liveUpdate.isScoringPlay ?? matchup.isScoringPlay,
           // Omitted (older messages) falls back to fetched data; an
           // explicit null CLEARS a stale type (?? would resurrect it).

--- a/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
+++ b/src/UI/sd-ui/src/contexts/ContestUpdatesContext.jsx
@@ -101,6 +101,10 @@ export const ContestUpdatesProvider = ({ children }) => {
         // and must CLEAR any stale value (label falls back to SCORE!).
         scoringPlayType: data.scoringPlayType,
         ballOnYardLine: data.ballOnYardLine,
+        // Down / yards-to-go for the situation line; same merge semantics
+        // as scoringPlayType (omitted = fall back, explicit null = clear).
+        down: data.down,
+        distance: data.distance,
         lastPlayId: data.playId,
         lastPlayDescription: data.playDescription,
         lastPlayAt: Date.now(),

--- a/src/UI/sd-ui/src/utils/liveSituation.js
+++ b/src/UI/sd-ui/src/utils/liveSituation.js
@@ -1,0 +1,108 @@
+/**
+ * Live-game situation helpers shared by the team rows (possession glyph)
+ * and the status block (situation line), so the two surfaces can never
+ * disagree about who has the ball.
+ *
+ * Mobile parity: sd-mobile/src/utils/liveSituation.ts — keep the two in
+ * step; the formatting rules and the yard-line convention below are the
+ * shared contract.
+ */
+
+/** Statuses where a possession / batting indicator is meaningful: the
+ *  actively-live states plus the paused-live ones (a delayed game still
+ *  has a team with the ball). FINAL is deliberately excluded — the last
+ *  play's possession lingers in the live context, and showing a football
+ *  on a finished game is simply wrong. */
+const LIVE_STATUSES = new Set([
+  'STATUS_IN_PROGRESS',
+  'STATUS_HALFTIME',
+  'STATUS_DELAYED',
+  'STATUS_RAIN_DELAY',
+  'STATUS_SUSPENDED',
+]);
+
+export function isLiveStatus(status) {
+  return !!status && LIVE_STATUSES.has(status);
+}
+
+/**
+ * Which side currently has the ball (football) or is batting (baseball).
+ * Football reads possessionFranchiseSeasonId; baseball derives it from
+ * halfInning ("Top" → away bats, "Bottom" → home bats). Returns null when
+ * the game isn't live or the state is unknown.
+ */
+export function getPossessionSide(matchup, leagueSport) {
+  if (!matchup || !isLiveStatus(matchup.status)) return null;
+
+  if (leagueSport === 'BaseballMlb') {
+    const half = (matchup.halfInning ?? '').toLowerCase();
+    if (half === 'top') return 'away';
+    if (half === 'bottom') return 'home';
+    return null;
+  }
+
+  const possessionId = matchup.possessionFranchiseSeasonId;
+  if (possessionId == null) return null;
+  if (possessionId === matchup.awayFranchiseSeasonId) return 'away';
+  if (possessionId === matchup.homeFranchiseSeasonId) return 'home';
+  return null;
+}
+
+/** Glyph for the possession indicator, by sport. */
+export function getPossessionGlyph(leagueSport) {
+  return leagueSport === 'BaseballMlb' ? '⚾' : '🏈';
+}
+
+/**
+ * "2nd & 7" — null when there is no snap state. Down 0 covers kickoffs,
+ * extra points, and end-of-period, where ESPN reports down 0 and a
+ * "0th & 0" line would be nonsense. Distance 0 on a valid down is
+ * goal-to-go (1st & Goal from the 3).
+ */
+export function formatDownAndDistance(down, distance) {
+  if (down == null || down <= 0) return null;
+
+  const ordinals = ['1st', '2nd', '3rd', '4th'];
+  const downLabel = ordinals[down - 1] ?? `${down}th`;
+
+  if (distance == null) return downLabel;
+  if (distance <= 0) return `${downLabel} & Goal`;
+  return `${downLabel} & ${distance}`;
+}
+
+/**
+ * "LV 25" — the ball spot in the conventional team-relative form.
+ *
+ * ballOnYardLine is an ABSOLUTE field coordinate measured from the HOME
+ * team's goal line (home goal = 0, away goal = 100). Verified against
+ * stored play text across several games and both orientations: with PHI
+ * at home, "to PHI 32" stores 32; with PHI away, "to PHI 6" stores 94.
+ * So a spot below 50 is in HOME territory and reads directly, and one
+ * above 50 is in AWAY territory and reads inverted. Midfield is just
+ * "50". Needs no possession knowledge — which side of the field the ball
+ * sits on is what names the spot.
+ */
+export function formatBallSpot(ballOnYardLine, awayShort, homeShort) {
+  if (ballOnYardLine == null) return null;
+  if (ballOnYardLine < 0 || ballOnYardLine > 100) return null;
+  if (ballOnYardLine === 50) return '50';
+
+  if (ballOnYardLine < 50) {
+    return homeShort ? `${homeShort} ${ballOnYardLine}` : null;
+  }
+  return awayShort ? `${awayShort} ${100 - ballOnYardLine}` : null;
+}
+
+/**
+ * The football situation line: "2nd & 7 · LV 25". Either half can be
+ * missing — a spot with no down still tells you where the ball is, and a
+ * down with no spot still tells you the snap. Null when neither exists,
+ * so the caller renders nothing rather than an empty row.
+ */
+export function formatFootballSituation({ down, distance, ballOnYardLine, awayShort, homeShort }) {
+  const downAndDistance = formatDownAndDistance(down, distance);
+  const spot = formatBallSpot(ballOnYardLine, awayShort, homeShort);
+
+  const parts = [downAndDistance, spot].filter(Boolean);
+  return parts.length > 0 ? parts.join(' · ') : null;
+}

--- a/src/UI/sd-ui/src/utils/liveSituation.test.js
+++ b/src/UI/sd-ui/src/utils/liveSituation.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatBallSpot,
+  formatDownAndDistance,
+  formatFootballSituation,
+  getPossessionGlyph,
+  getPossessionSide,
+} from './liveSituation';
+
+const baseMatchup = {
+  status: 'STATUS_IN_PROGRESS',
+  awayShort: 'CAR',
+  homeShort: 'JAX',
+  awayFranchiseSeasonId: 'away-fs',
+  homeFranchiseSeasonId: 'home-fs',
+};
+
+const withLive = (overrides) => ({ ...baseMatchup, ...overrides });
+
+describe('formatDownAndDistance', () => {
+  it.each([
+    [1, 10, '1st & 10'],
+    [2, 7, '2nd & 7'],
+    [3, 1, '3rd & 1'],
+    [4, 25, '4th & 25'],
+  ])('formats down %i and %i to go', (down, distance, expected) => {
+    expect(formatDownAndDistance(down, distance)).toBe(expected);
+  });
+
+  it('renders goal-to-go rather than "& 0"', () => {
+    expect(formatDownAndDistance(1, 0)).toBe('1st & Goal');
+  });
+
+  it('returns null when there is no snap state', () => {
+    // Down 0 is ESPN's kickoff / extra point / end-of-period value.
+    expect(formatDownAndDistance(0, 0)).toBeNull();
+    expect(formatDownAndDistance(null, 10)).toBeNull();
+    expect(formatDownAndDistance(undefined, undefined)).toBeNull();
+  });
+
+  it('keeps the down when distance is unknown', () => {
+    expect(formatDownAndDistance(2, null)).toBe('2nd');
+  });
+});
+
+describe('formatBallSpot', () => {
+  // Convention verified against stored play text: absolute from the HOME
+  // goal line. With JAX at home, "to JAX 27" stores 27; "to CAR 27"
+  // stores 73.
+  it('names the home side below midfield and reads the number directly', () => {
+    expect(formatBallSpot(27, 'CAR', 'JAX')).toBe('JAX 27');
+  });
+
+  it('names the away side above midfield and inverts the number', () => {
+    expect(formatBallSpot(73, 'CAR', 'JAX')).toBe('CAR 27');
+  });
+
+  it('renders midfield as a bare 50', () => {
+    expect(formatBallSpot(50, 'CAR', 'JAX')).toBe('50');
+  });
+
+  it('returns null for unknown or out-of-range positions', () => {
+    expect(formatBallSpot(null, 'CAR', 'JAX')).toBeNull();
+    expect(formatBallSpot(-1, 'CAR', 'JAX')).toBeNull();
+    expect(formatBallSpot(101, 'CAR', 'JAX')).toBeNull();
+  });
+});
+
+describe('formatFootballSituation', () => {
+  it('joins down-and-distance with the ball spot', () => {
+    // The real replayed case: home team driving, ball at the AWAY 25
+    // stored as 75. Must read "CAR 25", not "JAX 25".
+    expect(
+      formatFootballSituation(withLive({ down: 1, distance: 10, ballOnYardLine: 75 }))
+    ).toBe('1st & 10 · CAR 25');
+  });
+
+  it('renders either half alone', () => {
+    expect(
+      formatFootballSituation(withLive({ down: 3, distance: 4, ballOnYardLine: null }))
+    ).toBe('3rd & 4');
+    expect(
+      formatFootballSituation(withLive({ down: 0, distance: 0, ballOnYardLine: 35 }))
+    ).toBe('JAX 35');
+  });
+
+  it('returns null when neither half is known so no empty row renders', () => {
+    expect(
+      formatFootballSituation(withLive({ down: null, distance: null, ballOnYardLine: null }))
+    ).toBeNull();
+  });
+});
+
+describe('getPossessionSide', () => {
+  it('resolves football possession by franchise season id', () => {
+    expect(
+      getPossessionSide(withLive({ possessionFranchiseSeasonId: 'home-fs' }), 'FootballNfl')
+    ).toBe('home');
+    expect(
+      getPossessionSide(withLive({ possessionFranchiseSeasonId: 'away-fs' }), 'FootballNfl')
+    ).toBe('away');
+  });
+
+  it('resolves baseball batting from the half inning', () => {
+    expect(getPossessionSide(withLive({ halfInning: 'Top' }), 'BaseballMlb')).toBe('away');
+    expect(getPossessionSide(withLive({ halfInning: 'Bottom' }), 'BaseballMlb')).toBe('home');
+  });
+
+  it('shows nothing once the game is final', () => {
+    expect(
+      getPossessionSide(
+        withLive({ status: 'STATUS_FINAL', possessionFranchiseSeasonId: 'home-fs' }),
+        'FootballNfl'
+      )
+    ).toBeNull();
+  });
+
+  it('still shows possession while a live game is paused', () => {
+    expect(
+      getPossessionSide(
+        withLive({ status: 'STATUS_DELAYED', possessionFranchiseSeasonId: 'away-fs' }),
+        'FootballNfl'
+      )
+    ).toBe('away');
+  });
+
+  it('does not match a null possession against a null franchise id', () => {
+    // Both null would pass a bare === check and falsely mark possession.
+    expect(
+      getPossessionSide(
+        {
+          ...baseMatchup,
+          possessionFranchiseSeasonId: null,
+          awayFranchiseSeasonId: null,
+        },
+        'FootballNfl'
+      )
+    ).toBeNull();
+  });
+});
+
+describe('getPossessionGlyph', () => {
+  it('uses a baseball for MLB and a football everywhere else', () => {
+    expect(getPossessionGlyph('BaseballMlb')).toBe('⚾');
+    expect(getPossessionGlyph('FootballNcaa')).toBe('🏈');
+    expect(getPossessionGlyph(null)).toBe('🏈');
+  });
+});


### PR DESCRIPTION
## Summary

Reworks the live game card on both surfaces after a side-by-side review against ESPN's mobile scores view.

**The problem:** the team row carried a blue ▶ marking the user's pick — sitting in exactly the slot, and using exactly the shape, that every sports app uses for possession. During live games it read as "this team has the ball." Meanwhile the *real* possession cue was encoded as the **position** of a football emoji inside a `CAR 20 - 6 JAX` line that duplicated the scores already shown against each team.

| | before | after |
|---|---|---|
| Team row | blue ▶ = your pick | 🏈 / ⚾ = possession (live only) |
| Status block | `CAR 20 - 6 JAX` (duplicate) | `2nd & 7 · LV 25` |

## Changes

- **Team rows** — pick indicator removed outright (mobile only; web never had one). Picks are already stated by the pick buttons at the foot of the card, the result by the card border. Possession/batting renders there now, live games only.
- **Status block** — duplicated scoreline gone from both sports. Football gets the situation line; baseball's existing `Top 3 · 1-2 · 1 out` moves up into that slot.
- **Plumbing** — `Down`/`Distance` added to `FootballPlayCompleted` and both publishers (live processor + replay service). Already persisted on `FootballCompetitionPlay`, so **no new sourcing**. Nullable per the `ScoringPlayType` precedent, so old in-flight messages stay deserializable and deploy order doesn't matter. The API relay forwards the whole message → no API change. The ball spot needs no new data either; `ballOnYardLine` already flows.

## Yard-line convention corrected ⚠️

The existing comments claimed `ballOnYardLine` was measured from the **away** goal line. It is actually absolute from the **home** goal line. Caught by local replay: a play reading "to LV 25" rendered "HOU 25".

Verified against stored play text across several games and both orientations — with PHI at home, "to PHI 32" stores 32; with PHI away, "to PHI 6" stores 94; home drives increase the value, away drives decrease it. So home yard numbers read directly and away numbers invert. The misleading comments in `FootballPlayCompleted`, `models.ts`, and `signalR.ts` are fixed at the source. The two other consumers (admin live page, SignalR debug card) only display the raw integer, so neither carried the bad assumption.

## Also fixed while here

- Removing the baseball scoreline orphaned MLB's scoring-play flash (it was the only flash target) — moved to the baseball situation line on both surfaces.
- Web's `PicksPage` live merge was dropping `ballOnYardLine` entirely, so that page would have shown down-and-distance with no ball spot.

## Design note

Situation logic lives in `utils/liveSituation` — a `.ts` for mobile, a `.js` mirror for web (separate apps, no shared code) — so the team row and the status block can never disagree about who has the ball. Both files cross-reference each other.

## Validation

- 20 new util tests per surface: ordinals, goal-to-go, no-snap-state cases, the verified yard-line convention (including the real replayed case as a regression test), possession resolution for both sports, and the FINAL guard that stops a stale possession glyph lingering on a finished game
- Mobile 153/153 with tsc clean; web 46/46 with a clean production build; Api 701/701; Producer 579 (the lone failure is the known pre-existing local-WIP one)
- Validated locally on both surfaces via game replay

## Deferred by design

Live pick/ATS status on the card ("JAX +2.5 — covering by 2"), and the cold-start / commercial-break staleness where a card holds the last play's state because live football data arrives only over SignalR and never in the REST payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live football games now show down, distance, ball position, and possession indicators.
  * Possession and batting indicators appear alongside team rows for clearer game context.
  * Live baseball and football status areas no longer duplicate score information.
* **Bug Fixes**
  * Live play updates now consistently preserve football situation details, including fallback handling and explicit clearing of unavailable data.
  * Scoring highlights now appear on relevant live-game situation details.
  * Football ball-position displays now use a consistent home-goal-line reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->