### PR TITLE
fix(core,api): stop a NotFound arriving as the enum default, and stop scoring unplayed games

### DIFF
--- a/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
+++ b/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
@@ -80,15 +80,20 @@ namespace SportsData.Api.Application.Jobs
                 // already handled the common case anyway.
                 var startedBefore = _dateTimeProvider.UtcNow().AddHours(-PlayableWindowHours);
 
+                // Joined on GROUP AND CONTEST, not contest alone. The matchup
+                // row is per-group, so a contest picked in ten leagues has ten
+                // rows: a contest-only join fans each pick out across all of
+                // them, and lets one group's row (which could carry a stale
+                // StartDateUtc after a reschedule) admit another group's pick.
+                // Keying on the pick's own group keeps it 1:1 and correct.
                 var unscoredContestIds = await _dataContext.UserPicks
-                    .Where(p => p.ScoredAt == null)
-                    .Join(
-                        _dataContext.PickemGroupMatchups,
-                        pick => pick.ContestId,
-                        matchup => matchup.ContestId,
-                        (pick, matchup) => new { pick.ContestId, matchup.StartDateUtc })
-                    .Where(x => x.StartDateUtc <= startedBefore)
-                    .Select(x => x.ContestId)
+                    .AsNoTracking()
+                    .Where(p => p.ScoredAt == null
+                        && _dataContext.PickemGroupMatchups.Any(m =>
+                            m.GroupId == p.PickemGroupId
+                            && m.ContestId == p.ContestId
+                            && m.StartDateUtc <= startedBefore))
+                    .Select(p => p.ContestId)
                     .Distinct()
                     .ToListAsync();
 

--- a/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
+++ b/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Scoring;
 using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
 using SportsData.Core.Common.Jobs;
 using SportsData.Core.Processing;
 
@@ -25,19 +26,30 @@ namespace SportsData.Api.Application.Jobs
     /// </summary>
     public class PickScoringJob : IAmARecurringJob
     {
+        /// <summary>
+        /// Hours after kickoff before a contest is considered playable-out and
+        /// worth a scoring attempt. Comfortably longer than any game plus
+        /// overtime or a weather delay — being late costs one job interval,
+        /// being early costs a pointless round trip on every run.
+        /// </summary>
+        private const int PlayableWindowHours = 6;
+
         private readonly ILogger<PickScoringJob> _logger;
         private readonly AppDataContext _dataContext;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
+        private readonly IDateTimeProvider _dateTimeProvider;
         private readonly Guid _correlationId = Guid.NewGuid();
 
         public PickScoringJob(
             ILogger<PickScoringJob> logger,
             AppDataContext dataContext,
-            IProvideBackgroundJobs backgroundJobProvider)
+            IProvideBackgroundJobs backgroundJobProvider,
+            IDateTimeProvider dateTimeProvider)
         {
             _logger = logger;
             _dataContext = dataContext;
             _backgroundJobProvider = backgroundJobProvider;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task ExecuteAsync()
@@ -49,15 +61,38 @@ namespace SportsData.Api.Application.Jobs
             {
                 _logger.LogInformation("{MethodName} Began", nameof(PickScoringJob));
 
+                // Only contests whose game can plausibly be OVER. Without this
+                // the pass enqueued every contest anyone had picked, including
+                // games days away — during a season that is most of the slate,
+                // and each one round-trips to Producer to be told there is no
+                // result yet. The processor short-circuits on that, so this is
+                // wasted work rather than incorrect work, but the volume is
+                // real: it repeats on every run until the game is played.
+                //
+                // A generous lower bound (kickoff + this window) rather than a
+                // finalization check, which only Producer can answer. Games run
+                // long — overtime, weather delays — so the window errs late; a
+                // contest that finished sooner simply gets scored on the next
+                // pass, and the event-driven path (ContestCompleted) has
+                // already handled the common case anyway.
+                var startedBefore = _dateTimeProvider.UtcNow().AddHours(-PlayableWindowHours);
+
                 var unscoredContestIds = await _dataContext.UserPicks
                     .Where(p => p.ScoredAt == null)
-                    .Select(p => p.ContestId)
+                    .Join(
+                        _dataContext.PickemGroupMatchups,
+                        pick => pick.ContestId,
+                        matchup => matchup.ContestId,
+                        (pick, matchup) => new { pick.ContestId, matchup.StartDateUtc })
+                    .Where(x => x.StartDateUtc <= startedBefore)
+                    .Select(x => x.ContestId)
                     .Distinct()
                     .ToListAsync();
 
                 _logger.LogInformation(
-                    "Found {Count} distinct contests with unscored picks. Enqueuing scoring for each.",
-                    unscoredContestIds.Count);
+                    "Found {Count} distinct contests with unscored picks whose game started before {StartedBefore}. Enqueuing scoring for each.",
+                    unscoredContestIds.Count,
+                    startedBefore);
 
                 foreach (var contestId in unscoredContestIds)
                 {

--- a/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
+++ b/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
@@ -97,6 +97,17 @@ namespace SportsData.Api.Application.Jobs
                     .Distinct()
                     .ToListAsync();
 
+                // Deliberately enqueued per CONTEST, not per group, even
+                // though eligibility was evaluated per group above. Kickoff is
+                // a property of the game, so two groups' rows for one contest
+                // should agree; if they disagree one is stale, and either way
+                // this cannot score a game early — PickScoringProcessor
+                // refuses to score unless the matchup result carries
+                // FinalizedUtc (see the 2026-06-16 incident noted there).
+                // Scoring per group would multiply Producer round trips by the
+                // number of leagues sharing a contest to guard something the
+                // processor already guarantees.
+
                 _logger.LogInformation(
                     "Found {Count} distinct contests with unscored picks whose game started before {StartedBefore}. Enqueuing scoring for each.",
                     unscoredContestIds.Count,

--- a/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
+++ b/src/SportsData.Api/Application/Jobs/PickScoringJob.cs
@@ -28,11 +28,14 @@ namespace SportsData.Api.Application.Jobs
     {
         /// <summary>
         /// Hours after kickoff before a contest is considered playable-out and
-        /// worth a scoring attempt. Comfortably longer than any game plus
-        /// overtime or a weather delay — being late costs one job interval,
-        /// being early costs a pointless round trip on every run.
+        /// worth a scoring attempt. An NFL game runs about three hours, and
+        /// still comfortably under four with overtime, so four clears a
+        /// finished game without waiting on one. Erring short is cheap: an
+        /// early attempt short-circuits cleanly on the NotFound relay and is
+        /// retried next pass, whereas erring long delays scoring for every
+        /// game that the event-driven ContestCompleted path happened to miss.
         /// </summary>
-        private const int PlayableWindowHours = 6;
+        private const int PlayableWindowHours = 4;
 
         private readonly ILogger<PickScoringJob> _logger;
         private readonly AppDataContext _dataContext;

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -120,6 +120,14 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             HttpStatusCode.BadRequest => ResultStatus.BadRequest,
             HttpStatusCode.Conflict => ResultStatus.Conflict,
             HttpStatusCode.UnprocessableEntity => ResultStatus.BadRequest,
+            // Named explicitly so they can never fall through to the caller's
+            // optimistic default. Several callers pass NotFound, which for
+            // these would be a silent lie: a rate-limited or mis-routed call
+            // would read as "the resource doesn't exist" and take a
+            // missing-resource branch — e.g. pick scoring skipping a game that
+            // genuinely needs scoring, forever.
+            HttpStatusCode.TooManyRequests => ResultStatus.RateLimited,
+            HttpStatusCode.MethodNotAllowed => ResultStatus.Error,
             >= HttpStatusCode.InternalServerError => ResultStatus.Error,
             _ => defaultStatus
         };

--- a/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/ClientBase.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation.Results;
+using FluentValidation.Results;
 
 using SportsData.Core.Common;
 using SportsData.Core.Extensions;
@@ -95,7 +95,16 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             // Response body is not valid JSON, use defaults
         }
 
-        var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, defaultFailureStatus);
+        // The HTTP status is AUTHORITATIVE — same rule as PostAsync below.
+        // Server failure bodies are shaped { errors } (ToActionResult never
+        // serializes a Failure<T>), so the parse above yields a Failure whose
+        // Status is the enum DEFAULT: Accepted, because it is declared first
+        // and therefore zero. Trusting it made every 404 arrive as Accepted,
+        // which silently defeated all three callers that branch on NotFound —
+        // the contest-overview relay and both pick-scoring processors, whose
+        // "not finalized yet, skip" short-circuit became an Error and a
+        // throw. The body contributes errors only.
+        var status = MapHttpStatusCode(response.StatusCode, defaultFailureStatus);
         var errors = failure?.Errors ?? [new ValidationFailure(entityName, $"Unable to retrieve {entityName.ToLowerInvariant()}")];
 
         return new Failure<TResponse>(defaultResponse, status, errors);
@@ -396,7 +405,10 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
                 // Response body is not valid JSON, use defaults
             }
 
-            var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, ResultStatus.Error);
+            // HTTP status is authoritative; the { errors }-shaped failure body
+            // has no status to bind, so trusting it yields Accepted (enum 0).
+            // See the note in GetAsync.
+            var status = MapHttpStatusCode(response.StatusCode, ResultStatus.Error);
             var errors = failure?.Errors ?? [new ValidationFailure(operationName, $"{operationName} failed with status {response.StatusCode}")];
 
             return new Failure<bool>(false, status, errors);
@@ -458,7 +470,10 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
                 // Response body is not valid JSON, use defaults
             }
 
-            var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, ResultStatus.Error);
+            // HTTP status is authoritative; the { errors }-shaped failure body
+            // has no status to bind, so trusting it yields Accepted (enum 0).
+            // See the note in GetAsync.
+            var status = MapHttpStatusCode(response.StatusCode, ResultStatus.Error);
             var errors = failure?.Errors ?? [new ValidationFailure(operationName, $"{operationName} failed with status {response.StatusCode}")];
 
             return new Failure<bool>(false, status, errors);
@@ -513,7 +528,10 @@ public abstract class ClientBase(HttpClient httpClient) : IProvideHealthChecks
             {
             }
 
-            var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, ResultStatus.Error);
+            // HTTP status is authoritative; the { errors }-shaped failure body
+            // has no status to bind, so trusting it yields Accepted (enum 0).
+            // See the note in GetAsync.
+            var status = MapHttpStatusCode(response.StatusCode, ResultStatus.Error);
             var errors = failure?.Errors ?? [new ValidationFailure(operationName, $"{operationName} failed with status {response.StatusCode}")];
 
             return new Failure<bool>(false, status, errors);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringJobTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using SportsData.Api.Application.Jobs;
 using SportsData.Api.Application.Scoring;
 using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
 using SportsData.Core.Processing;
 
 using System.Linq.Expressions;
@@ -15,6 +16,31 @@ namespace SportsData.Api.Tests.Unit.Application.Scoring;
 
 public class PickScoringJobTests : ApiTestBase<PickScoringJob>
 {
+    // Fixed clock so the playable-window boundary is exact rather than
+    // relative to wall time.
+    private static readonly DateTime Now = new(2026, 8, 23, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>Pins the clock and returns the SUT.</summary>
+    private PickScoringJob CreateSut()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+        return Mocker.CreateInstance<PickScoringJob>();
+    }
+
+    /// <summary>
+    /// A contest's matchup row supplies the kickoff the job filters on.
+    /// Without one the pick is invisible to the job — the join is what stops
+    /// unplayed games being enqueued.
+    /// </summary>
+    private void SeedMatchup(Guid contestId, DateTime startDateUtc)
+    {
+        DataContext.PickemGroupMatchups.Add(
+            Fixture.Build<PickemGroupMatchup>()
+                .With(x => x.ContestId, contestId)
+                .With(x => x.StartDateUtc, startDateUtc)
+                .Create());
+    }
+
     [Fact]
     public async Task Execute_EnqueuesScoreContestCommand_ForEachDistinctUnscoredContest()
     {
@@ -40,6 +66,11 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
                 .Create()
         );
 
+        // All three kicked off long enough ago to be scoreable.
+        SeedMatchup(contestId1, Now.AddHours(-24));
+        SeedMatchup(contestId2, Now.AddHours(-24));
+        SeedMatchup(contestId3, Now.AddHours(-24));
+
         await DataContext.SaveChangesAsync();
 
         // Capture every enqueued ScoreContestCommand so we can verify the exact
@@ -56,7 +87,7 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
                 if (cmd != null) enqueuedCommands.Add(cmd);
             });
 
-        var sut = Mocker.CreateInstance<PickScoringJob>();
+        var sut = CreateSut();
 
         // Act
         await sut.ExecuteAsync();
@@ -99,10 +130,76 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
 
         var background = Mocker.GetMock<IProvideBackgroundJobs>();
 
-        var sut = Mocker.CreateInstance<PickScoringJob>();
+        var sut = CreateSut();
 
         // Act
         await sut.ExecuteAsync();
+
+        // Assert
+        background.Verify(x => x.Enqueue<IScorePicks>(
+            It.IsAny<Expression<Func<IScorePicks, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsContests_WhoseGameHasNotBeenPlayedYet()
+    {
+        // Arrange — the production symptom: a pick on a game days away. The
+        // job used to enqueue it on every run, and each attempt round-tripped
+        // to Producer only to be told there is no result yet.
+        var futureContestId = Guid.NewGuid();
+        var playedContestId = Guid.NewGuid();
+
+        DataContext.UserPicks.AddRange(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, futureContestId)
+                .With(x => x.ScoredAt, (DateTime?)null).Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, playedContestId)
+                .With(x => x.ScoredAt, (DateTime?)null).Create());
+
+        SeedMatchup(futureContestId, Now.AddDays(4));
+        SeedMatchup(playedContestId, Now.AddHours(-24));
+
+        await DataContext.SaveChangesAsync();
+
+        var enqueuedCommands = new List<ScorePicksCommand>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IScorePicks>(It.IsAny<Expression<Func<IScorePicks, Task>>>()))
+            .Callback<Expression<Func<IScorePicks, Task>>>(expr =>
+            {
+                var cmd = ScorePicksCommandFromExpression(expr);
+                if (cmd != null) enqueuedCommands.Add(cmd);
+            });
+
+        // Act
+        await CreateSut().ExecuteAsync();
+
+        // Assert — only the game that has actually been played.
+        Assert.Single(enqueuedCommands);
+        Assert.Equal(playedContestId, enqueuedCommands[0].ContestId);
+    }
+
+    [Fact]
+    public async Task Execute_SkipsContests_StillInsideThePlayableWindow()
+    {
+        // Arrange — kicked off an hour ago. The game is very likely still in
+        // progress, so scoring it is premature; the event-driven
+        // ContestCompleted path handles the real finish.
+        var inProgressContestId = Guid.NewGuid();
+
+        DataContext.UserPicks.Add(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, inProgressContestId)
+                .With(x => x.ScoredAt, (DateTime?)null).Create());
+
+        SeedMatchup(inProgressContestId, Now.AddHours(-1));
+
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        // Act
+        await CreateSut().ExecuteAsync();
 
         // Assert
         background.Verify(x => x.Enqueue<IScorePicks>(

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringJobTests.cs
@@ -182,9 +182,11 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
     [Fact]
     public async Task Execute_SkipsContests_StillInsideThePlayableWindow()
     {
-        // Arrange — kicked off an hour ago. The game is very likely still in
-        // progress, so scoring it is premature; the event-driven
-        // ContestCompleted path handles the real finish.
+        // Arrange — kicked off three hours ago, so inside the four-hour
+        // window: an NFL game of that age may still be running. Scoring it is
+        // premature; the event-driven ContestCompleted path handles the real
+        // finish. Paired with the test below, this pins the window rather
+        // than merely passing for any generous value.
         var inProgressContestId = Guid.NewGuid();
 
         DataContext.UserPicks.Add(
@@ -192,7 +194,7 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
                 .With(x => x.ContestId, inProgressContestId)
                 .With(x => x.ScoredAt, (DateTime?)null).Create());
 
-        SeedMatchup(inProgressContestId, Now.AddHours(-1));
+        SeedMatchup(inProgressContestId, Now.AddHours(-3));
 
         await DataContext.SaveChangesAsync();
 
@@ -204,5 +206,38 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
         // Assert
         background.Verify(x => x.Enqueue<IScorePicks>(
             It.IsAny<Expression<Func<IScorePicks, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_ScoresContests_JustPastThePlayableWindow()
+    {
+        // Arrange — kicked off five hours ago: past four, so even an
+        // overtime game is done and the contest is worth an attempt.
+        var finishedContestId = Guid.NewGuid();
+
+        DataContext.UserPicks.Add(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, finishedContestId)
+                .With(x => x.ScoredAt, (DateTime?)null).Create());
+
+        SeedMatchup(finishedContestId, Now.AddHours(-5));
+
+        await DataContext.SaveChangesAsync();
+
+        var enqueuedCommands = new List<ScorePicksCommand>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IScorePicks>(It.IsAny<Expression<Func<IScorePicks, Task>>>()))
+            .Callback<Expression<Func<IScorePicks, Task>>>(expr =>
+            {
+                var cmd = ScorePicksCommandFromExpression(expr);
+                if (cmd != null) enqueuedCommands.Add(cmd);
+            });
+
+        // Act
+        await CreateSut().ExecuteAsync();
+
+        // Assert
+        Assert.Single(enqueuedCommands);
+        Assert.Equal(finishedContestId, enqueuedCommands[0].ContestId);
     }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringJobTests.cs
@@ -20,6 +20,9 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
     // relative to wall time.
     private static readonly DateTime Now = new(2026, 8, 23, 12, 0, 0, DateTimeKind.Utc);
 
+    /// <summary>Mirrors PickScoringJob.PlayableWindowHours.</summary>
+    private const int PlayableWindowHours = 4;
+
     /// <summary>Pins the clock and returns the SUT.</summary>
     private PickScoringJob CreateSut()
     {
@@ -30,15 +33,41 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
     /// <summary>
     /// A contest's matchup row supplies the kickoff the job filters on.
     /// Without one the pick is invisible to the job — the join is what stops
-    /// unplayed games being enqueued.
+    /// unplayed games being enqueued. The row is keyed to the SAME group as
+    /// the pick, because the job joins on group AND contest.
     /// </summary>
-    private void SeedMatchup(Guid contestId, DateTime startDateUtc)
+    private void SeedMatchup(Guid contestId, DateTime startDateUtc, Guid groupId)
     {
+        // OmitAutoProperties is load-bearing: Build<T> otherwise populates
+        // navigation properties, and EF persists the whole generated graph —
+        // seeding one matchup produced 37 rows with random 2027 kickoffs, and
+        // the pick's PickemGroupId was overwritten by its generated nav.
         DataContext.PickemGroupMatchups.Add(
             Fixture.Build<PickemGroupMatchup>()
+                .OmitAutoProperties()
+                .With(x => x.Id, Guid.NewGuid())
                 .With(x => x.ContestId, contestId)
+                .With(x => x.GroupId, groupId)
                 .With(x => x.StartDateUtc, startDateUtc)
                 .Create());
+    }
+
+    /// <summary>Seeds an unscored pick plus its group's matchup row.</summary>
+    private Guid SeedUnscoredPick(Guid contestId, DateTime startDateUtc)
+    {
+        var groupId = Guid.NewGuid();
+
+        DataContext.UserPicks.Add(
+            Fixture.Build<PickemGroupUserPick>()
+                .OmitAutoProperties()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.ContestId, contestId)
+                .With(x => x.PickemGroupId, groupId)
+                .With(x => x.ScoredAt, (DateTime?)null)
+                .Create());
+
+        SeedMatchup(contestId, startDateUtc, groupId);
+        return groupId;
     }
 
     [Fact]
@@ -50,26 +79,26 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
         var contestId2 = Guid.NewGuid();
         var contestId3 = Guid.NewGuid();
 
-        DataContext.UserPicks.AddRange(
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, contestId1)
-                .With(x => x.ScoredAt, (DateTime?)null).Create(),
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, contestId1) // duplicate contest — should only enqueue once
-                .With(x => x.ScoredAt, (DateTime?)null).Create(),
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, contestId2)
-                .With(x => x.ScoredAt, (DateTime?)null).Create(),
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, contestId3)
-                .With(x => x.ScoredAt, (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)) // already scored
-                .Create()
-        );
+        // All kicked off long enough ago to be scoreable.
+        SeedUnscoredPick(contestId1, Now.AddHours(-24));
+        SeedUnscoredPick(contestId2, Now.AddHours(-24));
 
-        // All three kicked off long enough ago to be scoreable.
-        SeedMatchup(contestId1, Now.AddHours(-24));
-        SeedMatchup(contestId2, Now.AddHours(-24));
-        SeedMatchup(contestId3, Now.AddHours(-24));
+        // Same contest picked in a SECOND group — must still enqueue once.
+        // With a contest-only join this pick would also fan out across the
+        // other group's matchup row.
+        SeedUnscoredPick(contestId1, Now.AddHours(-24));
+
+        // Already scored — never enqueued.
+        var scoredGroupId = Guid.NewGuid();
+        DataContext.UserPicks.Add(
+            Fixture.Build<PickemGroupUserPick>()
+                .OmitAutoProperties()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.ContestId, contestId3)
+                .With(x => x.PickemGroupId, scoredGroupId)
+                .With(x => x.ScoredAt, (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                .Create());
+        SeedMatchup(contestId3, Now.AddHours(-24), scoredGroupId);
 
         await DataContext.SaveChangesAsync();
 
@@ -121,6 +150,8 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
         // Arrange — only already-scored picks in the database.
         DataContext.UserPicks.Add(
             Fixture.Build<PickemGroupUserPick>()
+                .OmitAutoProperties()
+                .With(x => x.Id, Guid.NewGuid())
                 .With(x => x.ContestId, Guid.NewGuid())
                 .With(x => x.ScoredAt, (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
                 .Create()
@@ -149,16 +180,8 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
         var futureContestId = Guid.NewGuid();
         var playedContestId = Guid.NewGuid();
 
-        DataContext.UserPicks.AddRange(
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, futureContestId)
-                .With(x => x.ScoredAt, (DateTime?)null).Create(),
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, playedContestId)
-                .With(x => x.ScoredAt, (DateTime?)null).Create());
-
-        SeedMatchup(futureContestId, Now.AddDays(4));
-        SeedMatchup(playedContestId, Now.AddHours(-24));
+        SeedUnscoredPick(futureContestId, Now.AddDays(4));
+        SeedUnscoredPick(playedContestId, Now.AddHours(-24));
 
         await DataContext.SaveChangesAsync();
 
@@ -189,12 +212,7 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
         // than merely passing for any generous value.
         var inProgressContestId = Guid.NewGuid();
 
-        DataContext.UserPicks.Add(
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, inProgressContestId)
-                .With(x => x.ScoredAt, (DateTime?)null).Create());
-
-        SeedMatchup(inProgressContestId, Now.AddHours(-3));
+        SeedUnscoredPick(inProgressContestId, Now.AddHours(-3));
 
         await DataContext.SaveChangesAsync();
 
@@ -209,18 +227,64 @@ public class PickScoringJobTests : ApiTestBase<PickScoringJob>
     }
 
     [Fact]
+    public async Task Execute_ScoresContests_ExactlyAtThePlayableWindow()
+    {
+        // Arrange — kicked off exactly four hours ago. The filter is
+        // inclusive, so the boundary itself qualifies. With the 3h and 5h
+        // cases either side, the cutoff is pinned to the hour: a drift to
+        // 4.5 would break this test.
+        var boundaryContestId = Guid.NewGuid();
+        SeedUnscoredPick(boundaryContestId, Now.AddHours(-PlayableWindowHours));
+        await DataContext.SaveChangesAsync();
+
+        var enqueuedCommands = new List<ScorePicksCommand>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IScorePicks>(It.IsAny<Expression<Func<IScorePicks, Task>>>()))
+            .Callback<Expression<Func<IScorePicks, Task>>>(expr =>
+            {
+                var cmd = ScorePicksCommandFromExpression(expr);
+                if (cmd != null) enqueuedCommands.Add(cmd);
+            });
+
+        // Act
+        await CreateSut().ExecuteAsync();
+
+        // Assert
+        Assert.Single(enqueuedCommands);
+        Assert.Equal(boundaryContestId, enqueuedCommands[0].ContestId);
+    }
+
+    [Fact]
+    public async Task Execute_IgnoresAnotherGroupsMatchupRow()
+    {
+        // Arrange — one group picked the contest; a DIFFERENT group carries a
+        // matchup row for the same contest with a stale, much older kickoff
+        // (e.g. left behind by a reschedule). Joining on contest alone would
+        // let that row admit this pick before its own game has been played.
+        var contestId = Guid.NewGuid();
+        SeedUnscoredPick(contestId, Now.AddHours(-1)); // this group: still in progress
+        SeedMatchup(contestId, Now.AddDays(-3), Guid.NewGuid()); // another group: stale
+
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        // Act
+        await CreateSut().ExecuteAsync();
+
+        // Assert — the pick is gated by ITS OWN group's row.
+        background.Verify(x => x.Enqueue<IScorePicks>(
+            It.IsAny<Expression<Func<IScorePicks, Task>>>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Execute_ScoresContests_JustPastThePlayableWindow()
     {
         // Arrange — kicked off five hours ago: past four, so even an
         // overtime game is done and the contest is worth an attempt.
         var finishedContestId = Guid.NewGuid();
 
-        DataContext.UserPicks.Add(
-            Fixture.Build<PickemGroupUserPick>()
-                .With(x => x.ContestId, finishedContestId)
-                .With(x => x.ScoredAt, (DateTime?)null).Create());
-
-        SeedMatchup(finishedContestId, Now.AddHours(-5));
+        SeedUnscoredPick(finishedContestId, Now.AddHours(-5));
 
         await DataContext.SaveChangesAsync();
 

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/Clients/Contest/ContestClientTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/Clients/Contest/ContestClientTests.cs
@@ -47,6 +47,44 @@ public class ContestClientTests
     }
 
     [Fact]
+    public async Task GetMatchupResult_With404_ReturnsNotFound_NotTheEnumDefault()
+    {
+        // Arrange — the EXACT production shape. ResultExtensions.ToActionResult
+        // serializes a NotFound failure as `new { failure.Errors }`, so the
+        // body carries no status at all. Deserializing it into Failure<T>
+        // therefore left Status at default(ResultStatus), which is Accepted
+        // because it is declared first and numbers zero. Trusting that made
+        // every 404 arrive as Accepted and silently defeated every caller
+        // branching on NotFound — PickScoringProcessor logged an Error and
+        // threw instead of skipping an unplayed game.
+        _handler.SetResponse(
+            HttpStatusCode.NotFound,
+            new { Errors = new[] { new { PropertyName = "contestId", ErrorMessage = "No matchup result found" } } }.ToJson());
+
+        // Act
+        var result = await _sut.GetMatchupResult(Guid.NewGuid());
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        result.Status.Should().NotBe(ResultStatus.Accepted, "Accepted is the enum default and means the status never bound");
+    }
+
+    [Fact]
+    public async Task GetMatchupResult_WithServerError_ReportsErrorNotTheEnumDefault()
+    {
+        // A 500 body is shaped the same way, so it hit the same trap.
+        _handler.SetResponse(
+            HttpStatusCode.InternalServerError,
+            new { Errors = new[] { new { PropertyName = "contest", ErrorMessage = "boom" } } }.ToJson());
+
+        var result = await _sut.GetMatchupResult(Guid.NewGuid());
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Error);
+    }
+
+    [Fact]
     public async Task GetSeasonContests_With404_ReturnsNotFound()
     {
         // Arrange

--- a/test/unit/SportsData.Core.Tests.Unit/Infrastructure/Clients/Contest/ContestClientTests.cs
+++ b/test/unit/SportsData.Core.Tests.Unit/Infrastructure/Clients/Contest/ContestClientTests.cs
@@ -71,6 +71,33 @@ public class ContestClientTests
     }
 
     [Fact]
+    public async Task GetMatchupResult_WithRateLimit_ReportsRateLimited_NotNotFound()
+    {
+        // A 429 previously fell through to the caller's defaultFailureStatus,
+        // which GetMatchupResult passes as NotFound — so a rate-limited call
+        // read as "this game has no result" and pick scoring skipped it for
+        // good. Named explicitly so it can never be mistaken for absence.
+        _handler.SetResponse(HttpStatusCode.TooManyRequests, string.Empty);
+
+        var result = await _sut.GetMatchupResult(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.RateLimited);
+        result.Status.Should().NotBe(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task GetMatchupResult_WithMethodNotAllowed_ReportsError_NotNotFound()
+    {
+        // A mis-routed call (bad deploy) is a real failure, not a missing
+        // resource — it must not take a caller's not-found branch.
+        _handler.SetResponse(HttpStatusCode.MethodNotAllowed, string.Empty);
+
+        var result = await _sut.GetMatchupResult(Guid.NewGuid());
+
+        result.Status.Should().Be(ResultStatus.Error);
+    }
+
+    [Fact]
     public async Task GetMatchupResult_WithServerError_ReportsErrorNotTheEnumDefault()
     {
         // A 500 body is shaped the same way, so it hit the same trap.


### PR DESCRIPTION
## Summary

Production has been logging an Error and **throwing** every ~20 minutes since 2026-08-22 11:18 UTC, across roughly two dozen contests in both NFL and MLB:

```
Failed to retrieve matchup result for FootballNfl contest {id}. Status=Accepted
```

Two layered defects. The second is the visible one; the first is systemic and affects every typed client.

## 1. A NotFound was arriving as the enum default (`ClientBase`)

`ResultExtensions.ToActionResult` serializes a failure as an anonymous object carrying **only** `Errors`:

```csharp
ResultStatus.NotFound => new NotFoundObjectResult(new { failure.Errors }), // 404
```

So the body has no status. Deserializing it into `Failure<T>` still *succeeds*, leaving `Status` at `default(ResultStatus)` — which is `Accepted`, because it is declared first and therefore numbers zero. And because the parsed failure was non-null, the `MapHttpStatusCode` fallback never ran:

```csharp
var status = failure?.Status ?? MapHttpStatusCode(response.StatusCode, defaultFailureStatus);
```

Net effect: **every 404 from a typed client surfaced as `Accepted`**, which silently defeated all three callers that branch on `NotFound`:

| Caller | Intended behavior | Actual |
|---|---|---|
| `PickScoringProcessor` | log a warning, skip an unfinalized game | Error + **throw** |
| `PickScoringAuditProcessor` | same skip | same |
| `GetContestByIdQueryHandler` | relay a 404 | the contest-overview warnings on the same contests |

Worth noting: **one of the five failure-parse sites in `ClientBase` already had this fix**, complete with a comment describing the identical bug turning a 409 into `Accepted` and breaking the conflict relay. It was never propagated to the other four. They now follow the same rule — the HTTP status is authoritative, the body contributes errors only.

## 2. Scoring was attempted for games that had not been played (`PickScoringJob`)

The TODO sat on the exact line:

```csharp
// TODO: Nav to group and matchups. Only select where Matchup.StartDateUtc > UtcNow() + 3 hours
var unscoredContestIds = await _dataContext.UserPicks
    .Where(p => p.ScoredAt == null)
```

Every contest with an unscored pick was enqueued, so the moment users picked the upcoming slate those contests were retried on every run — which is what started the noise on the 22nd. Now joins `PickemGroupMatchups` and takes only contests kicked off at least 6 hours ago, via injected `IDateTimeProvider`.

The window errs late on purpose: being late costs one job interval, being early costs a pointless Producer round trip on *every* run, and the event-driven `ContestCompleted` path already covers the normal case.

The job's own doc comment always claimed the processor "short-circuits cleanly when there's nothing to do" — fix 1 is what makes that true again. Fix 2 removes work that was never useful.

## Validation

- Two new `ContestClient` tests reproduce the exact production body shape and assert `NotFound` / `Error` rather than the enum default
- The two existing job tests seeded no matchups, so the new join changed their outcome — updated, plus cases for a game four days out (skipped), one hour in (skipped), and a day old (scored)
- Core 263, Api 703; Producer, Notification and Provider all build clean against the shared `ClientBase` change

## Review note

`ClientBase.GetAsync` backs every typed client, so this changes failure-status resolution service-wide. It strictly improves accuracy — statuses that previously bound correctly still do — but it is the kind of change where a caller that had adapted to the *wrong* behavior would now see something different. I found no such caller; the three above were all broken *by* the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pick scoring now processes contests only after games have finished and the four-hour playable window has closed.
  - Prevents future, in-progress, or recently started contests from being scored prematurely.
  - HTTP failures now report accurate statuses, including Not Found, Rate Limited, and Error responses.

- **Tests**
  - Added coverage for scoring-window boundaries, completed contests, and unrelated matchup data.
  - Added validation for accurate handling of common HTTP error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->