### PR TITLE
feat(web,mobile): collapsible History sections, expanded by default

### DIFF
--- a/src/UI/sd-mobile/__tests__/hooks/useSectionCollapse.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useSectionCollapse.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSectionCollapse } from '@/src/hooks/useSectionCollapse';
+import { useSectionCollapseStore } from '@/src/stores/sectionCollapseStore';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const mockedStorage = AsyncStorage as unknown as {
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+};
+
+describe('useSectionCollapse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStorage.getItem.mockResolvedValue(null);
+    mockedStorage.setItem.mockResolvedValue(undefined);
+    // The store is a module singleton; clear it so each test starts cold.
+    useSectionCollapseStore.setState({ collapsed: {}, hydrated: false });
+  });
+
+  it('starts expanded when nothing has been stored', async () => {
+    // The card surfaces context without being asked, so a section the user
+    // has never touched must not be hidden.
+    const { result } = renderHook(() => useSectionCollapse('history.headToHead'));
+
+    await waitFor(() => expect(mockedStorage.getItem).toHaveBeenCalled());
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it('restores a previous collapse so the choice survives an app restart', async () => {
+    mockedStorage.getItem.mockResolvedValue('true');
+
+    const { result } = renderHook(() => useSectionCollapse('history.lastSeason'));
+
+    await waitFor(() => expect(result.current.collapsed).toBe(true));
+  });
+
+  it('shares state across mounted instances', async () => {
+    // The reported bug. Every MatchupCard renders its comparison modal
+    // eagerly, so with per-instance state each modal read storage once at
+    // list-render time and never saw a later toggle: collapsing on one game
+    // then opening another showed the section expanded again.
+    const gameA = renderHook(() => useSectionCollapse('history.headToHead'));
+    const gameB = renderHook(() => useSectionCollapse('history.headToHead'));
+
+    await waitFor(() => expect(mockedStorage.getItem).toHaveBeenCalled());
+    expect(gameB.result.current.collapsed).toBe(false);
+
+    act(() => gameA.result.current.toggle());
+
+    expect(gameA.result.current.collapsed).toBe(true);
+    expect(gameB.result.current.collapsed).toBe(true);
+  });
+
+  it('persists the new state on toggle', async () => {
+    const { result } = renderHook(() => useSectionCollapse('history.headToHead'));
+    await waitFor(() => expect(mockedStorage.getItem).toHaveBeenCalled());
+
+    act(() => result.current.toggle());
+
+    expect(result.current.collapsed).toBe(true);
+    expect(mockedStorage.setItem).toHaveBeenCalledWith(
+      'section-collapsed:history.headToHead',
+      'true');
+
+    act(() => result.current.toggle());
+
+    expect(result.current.collapsed).toBe(false);
+    expect(mockedStorage.setItem).toHaveBeenLastCalledWith(
+      'section-collapsed:history.headToHead',
+      'false');
+  });
+
+  it('keys sections separately so collapsing one leaves the other alone', async () => {
+    mockedStorage.getItem.mockImplementation((key: string) =>
+      Promise.resolve(key === 'section-collapsed:history.lastSeason' ? 'true' : null));
+
+    const h2h = renderHook(() => useSectionCollapse('history.headToHead'));
+    const lastSeason = renderHook(() => useSectionCollapse('history.lastSeason'));
+
+    await waitFor(() => expect(lastSeason.result.current.collapsed).toBe(true));
+    expect(h2h.result.current.collapsed).toBe(false);
+  });
+
+  it('reads storage once per section, not once per mounted card', async () => {
+    // A slate can render dozens of cards; each one hydrating independently
+    // would be dozens of redundant reads of the same key.
+    renderHook(() => useSectionCollapse('history.headToHead'));
+    renderHook(() => useSectionCollapse('history.headToHead'));
+    renderHook(() => useSectionCollapse('history.headToHead'));
+
+    await waitFor(() => expect(mockedStorage.getItem).toHaveBeenCalled());
+    expect(mockedStorage.getItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a slow read clobber a toggle made while it was in flight', async () => {
+    let resolveRead: (v: string | null) => void = () => {};
+    mockedStorage.getItem.mockReturnValue(
+      new Promise<string | null>((resolve) => { resolveRead = resolve; }));
+
+    const { result } = renderHook(() => useSectionCollapse('history.headToHead'));
+
+    act(() => result.current.toggle());
+    expect(result.current.collapsed).toBe(true);
+
+    // The stored value lands late and disagrees — the user's choice wins.
+    await act(async () => { resolveRead(null); });
+
+    expect(result.current.collapsed).toBe(true);
+  });
+
+  it('falls back to expanded when storage is unreadable', async () => {
+    // A read failure must not hide content — degrade toward showing more.
+    mockedStorage.getItem.mockRejectedValue(new Error('storage unavailable'));
+
+    const { result } = renderHook(() => useSectionCollapse('history.headToHead'));
+
+    await waitFor(() => expect(mockedStorage.getItem).toHaveBeenCalled());
+    expect(result.current.collapsed).toBe(false);
+  });
+});

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -22,6 +22,8 @@ import type {
   TeamStatEntry,
 } from '@/src/types/models';
 import { usePageSheetTopInset } from '@/src/hooks/usePageSheetTopInset';
+import { useSectionCollapse } from '@/src/hooks/useSectionCollapse';
+import { Ionicons } from '@expo/vector-icons';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -178,6 +180,44 @@ function StatRow({
 
 // ─── History pieces ───────────────────────────────────────────────────────────
 
+/**
+ * Section title that doubles as a collapse toggle. Sections stay EXPANDED by
+ * default — the card exists to surface context without being asked — so this
+ * is an escape valve for readers who find a section noisy, not a gate in
+ * front of the content.
+ */
+function CollapsibleSectionHeader({
+  title,
+  collapsed,
+  onToggle,
+  color,
+  mutedColor,
+}: {
+  title: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  color: string;
+  mutedColor: string;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onToggle}
+      style={styles.collapsibleHeader}
+      hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: !collapsed }}
+      accessibilityLabel={`${title}, ${collapsed ? 'collapsed' : 'expanded'}`}
+    >
+      <Text style={[styles.historySectionTitle, { color }]}>{title}</Text>
+      <Ionicons
+        name={collapsed ? 'chevron-down' : 'chevron-up'}
+        size={18}
+        color={mutedColor}
+      />
+    </TouchableOpacity>
+  );
+}
+
 function formatGameDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, {
     year: 'numeric',
@@ -328,6 +368,12 @@ export function StatsComparisonModal({
 
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
 
+  // Collapse state is per device and survives reopening the card — a toggle
+  // that reset every time would have to be redone on every matchup.
+  const { collapsed: h2hCollapsed, toggle: toggleH2h } = useSectionCollapse('history.headToHead');
+  const { collapsed: lastSeasonCollapsed, toggle: toggleLastSeason } =
+    useSectionCollapse('history.lastSeason');
+
   // Collect all category names from teamA stats
   const awayStats = comparison?.teamA?.stats?.data?.statistics ?? {};
   const homeStats = comparison?.teamB?.stats?.data?.statistics ?? {};
@@ -444,7 +490,7 @@ export function StatsComparisonModal({
               >
                 {showGambling && history?.spreadContext && (
                   <>
-                    <Text style={[styles.historySectionTitle, { color: theme.text }]}>
+                    <Text style={[styles.historySectionTitle, { color: theme.tint }]}>
                       The Line
                       {history.spreadContext.spreadDetails ? ` — ${history.spreadContext.spreadDetails}` : ''}
                     </Text>
@@ -459,10 +505,14 @@ export function StatsComparisonModal({
                 )}
                 {headToHead.length > 0 && (
                   <>
-                    <Text style={[styles.historySectionTitle, { color: theme.text }]}>
-                      Head-to-Head — Last {headToHead.length} Meeting{headToHead.length === 1 ? '' : 's'}
-                    </Text>
-                    {headToHead.map((g, i) => (
+                    <CollapsibleSectionHeader
+                      title={`Head-to-Head — Last ${headToHead.length} Meeting${headToHead.length === 1 ? '' : 's'}`}
+                      collapsed={h2hCollapsed}
+                      onToggle={toggleH2h}
+                      color={theme.tint}
+                      mutedColor={theme.tint}
+                    />
+                    {!h2hCollapsed && headToHead.map((g, i) => (
                       <View key={i} style={[styles.h2hRow, { borderBottomColor: theme.border }]}>
                         <View style={styles.h2hMeta}>
                           <Text style={[styles.historyGameDate, { color: theme.textMuted }]}>
@@ -526,10 +576,16 @@ export function StatsComparisonModal({
                   </>
                 )}
 
-                <Text style={[styles.historySectionTitle, { color: theme.text }]}>
-                  Last Season — Final {Math.max(awayPriorGames.length, homePriorGames.length)} Games
-                </Text>
+                <CollapsibleSectionHeader
+                  title={`Last Season — Final ${Math.max(awayPriorGames.length, homePriorGames.length)} Games`}
+                  collapsed={lastSeasonCollapsed}
+                  onToggle={toggleLastSeason}
+                  color={theme.tint}
+                  mutedColor={theme.tint}
+                />
 
+                {!lastSeasonCollapsed && (
+                <>
                 <View style={styles.historyTeamHeader}>
                   <Text style={[styles.historyTeamName, { color: theme.text }]}>{matchup.away}</Text>
                   {priorSeasonRecordLabel(history?.awayPriorSeason) && (
@@ -564,6 +620,8 @@ export function StatsComparisonModal({
                   homePriorGames.map((g, i) => (
                     <PriorSeasonGameRow key={i} game={g} teamName={matchup.home} />
                   ))
+                )}
+                </>
                 )}
               </ScrollView>
             ) : categories.length === 0 ? (
@@ -795,6 +853,12 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     marginTop: 12,
     marginBottom: 6,
+  },
+  collapsibleHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
   },
   h2hRow: {
     paddingVertical: 8,

--- a/src/UI/sd-mobile/src/hooks/useSectionCollapse.ts
+++ b/src/UI/sd-mobile/src/hooks/useSectionCollapse.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect } from 'react';
+import { useSectionCollapseStore } from '@/src/stores/sectionCollapseStore';
+
+/**
+ * Whether a named content section is collapsed, plus a toggle.
+ *
+ * Backed by a shared store rather than local state — see
+ * sectionCollapseStore for why that matters: every MatchupCard mounts its
+ * comparison modal eagerly, so per-instance state went stale the moment one
+ * of them toggled.
+ *
+ * Sections start EXPANDED. Collapsing is an escape valve for readers who
+ * find a section noisy, not a gate in front of the content.
+ */
+export function useSectionCollapse(sectionKey: string) {
+  const collapsed = useSectionCollapseStore((s) => s.collapsed[sectionKey] ?? false);
+  const hydrate = useSectionCollapseStore((s) => s.hydrate);
+  const toggleSection = useSectionCollapseStore((s) => s.toggle);
+
+  useEffect(() => {
+    hydrate(sectionKey);
+  }, [hydrate, sectionKey]);
+
+  const toggle = useCallback(() => toggleSection(sectionKey), [toggleSection, sectionKey]);
+
+  return { collapsed, toggle };
+}

--- a/src/UI/sd-mobile/src/stores/sectionCollapseStore.ts
+++ b/src/UI/sd-mobile/src/stores/sectionCollapseStore.ts
@@ -1,0 +1,73 @@
+import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY_PREFIX = 'section-collapsed:';
+
+/** Keys with a storage read in flight — see hydrate(). */
+const hydrating = new Set<string>();
+
+interface SectionCollapseState {
+  /** Collapsed flags by section key. Absent = expanded (the default). */
+  collapsed: Record<string, boolean>;
+  hydrated: boolean;
+  hydrate: (sectionKey: string) => void;
+  toggle: (sectionKey: string) => void;
+}
+
+/**
+ * Collapse state for named content sections, SHARED across every component
+ * instance and persisted per device.
+ *
+ * Shared is the load-bearing word. Every MatchupCard in a list renders its
+ * own comparison modal eagerly (visible={false} until opened), so per-instance
+ * state meant each modal read storage once at list-render time — before any
+ * toggle had happened — and never heard about a later write. Collapsing a
+ * section on one game then opening another showed it expanded again. A single
+ * store means every mounted modal reflects the change immediately.
+ *
+ * Sections start EXPANDED: the card surfaces context without being asked, so
+ * collapsing is an escape valve, never the starting state. Reads and writes
+ * both degrade toward showing content.
+ */
+export const useSectionCollapseStore = create<SectionCollapseState>((set, get) => ({
+  collapsed: {},
+  hydrated: false,
+
+  hydrate: (sectionKey: string) => {
+    // Only the first mount of a given key touches storage; after that the
+    // store IS the source of truth for this session. The in-flight guard
+    // matters as much as the resolved one: a slate mounts dozens of cards in
+    // the same tick, all before the first read resolves, so without it every
+    // card would issue its own redundant read of the same key.
+    if (Object.prototype.hasOwnProperty.call(get().collapsed, sectionKey)) return;
+    if (hydrating.has(sectionKey)) return;
+    hydrating.add(sectionKey);
+
+    AsyncStorage.getItem(KEY_PREFIX + sectionKey)
+      .then((v) => {
+        hydrating.delete(sectionKey);
+        set((state) =>
+          // A toggle may have landed while the read was in flight — never
+          // clobber a value the user just chose.
+          Object.prototype.hasOwnProperty.call(state.collapsed, sectionKey)
+            ? state
+            : { collapsed: { ...state.collapsed, [sectionKey]: v === 'true' }, hydrated: true });
+      })
+      .catch(() => {
+        hydrating.delete(sectionKey);
+        set((state) =>
+          Object.prototype.hasOwnProperty.call(state.collapsed, sectionKey)
+            ? state
+            : { collapsed: { ...state.collapsed, [sectionKey]: false }, hydrated: true });
+      });
+  },
+
+  toggle: (sectionKey: string) => {
+    const next = !(get().collapsed[sectionKey] ?? false);
+    set((state) => ({ collapsed: { ...state.collapsed, [sectionKey]: next } }));
+
+    // Fire-and-forget: a failed write only means the section returns expanded
+    // next launch, which is the default anyway.
+    AsyncStorage.setItem(KEY_PREFIX + sectionKey, next ? 'true' : 'false').catch(() => {});
+  },
+}));

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.css
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.css
@@ -472,6 +472,12 @@
   text-align: left;
   font-family: inherit;
   cursor: pointer;
+  /* Buttons carry UA padding (1px 6px in Chrome). Only padding-bottom is
+     set by .history-section-title, so without this the two collapsible
+     headings sit inset from "The Line", which is a plain div. Resets the
+     horizontal and top padding while keeping the title's bottom spacing
+     above the rule. */
+  padding: 0 0 0.35rem;
 }
 
 /* The title is already accent, so hover needs a different cue than colour. */

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.css
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.css
@@ -446,10 +446,45 @@
 .history-section-title {
   font-size: 1.05rem;
   font-weight: 600;
-  color: var(--text-primary);
+  /* Accent, not text-primary: these headings separate the History tab into
+     distinct blocks, and on touch there is no hover to lean on — the colour
+     has to carry the affordance on its own. Mobile parity:
+     StatsComparisonModal passes theme.tint for the same reason. */
+  color: var(--accent);
   border-bottom: 1px solid var(--badge-bg);
   padding-bottom: 0.35rem;
   margin-bottom: 0.25rem;
+}
+
+/* Collapse toggle: the section title itself is the control. Sections are
+   expanded by default — this is an escape valve for readers who find a
+   section noisy, not a gate in front of the content. Resets the button
+   element's own styling so it reads as the heading it replaced. */
+.history-section-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--badge-bg);
+  text-align: left;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+/* The title is already accent, so hover needs a different cue than colour. */
+.history-section-toggle:hover .history-section-chevron {
+  opacity: 1;
+}
+
+.history-section-chevron {
+  font-size: 0.85em;
+  color: var(--accent);
+  opacity: 0.75;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
 }
 
 /* Head-to-head rows */

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useSectionCollapse } from "../../hooks/useSectionCollapse";
 import "./TeamComparison.css";
 import "./TeamComparisonTabs.css";
 
@@ -46,6 +47,13 @@ export default function TeamComparison({
   const [activeTab, setActiveTab] = useState(
     hasHistoryData ? "history" : "statistics"
   );
+
+  // Collapse state is per device and survives reopening the dialog — a toggle
+  // that reset every time would have to be redone on every matchup.
+  const { collapsed: h2hCollapsed, toggle: toggleH2h } =
+    useSectionCollapse("history.headToHead");
+  const { collapsed: lastSeasonCollapsed, toggle: toggleLastSeason } =
+    useSectionCollapse("history.lastSeason");
 
   // Helper: choose light or dark text based on background color
   const getContrastTextColor = (bgColor) => {
@@ -721,10 +729,20 @@ export default function TeamComparison({
         {renderSpreadContext()}
         {headToHead.length > 0 && (
           <div className="history-section">
-            <div className="history-section-title">
-              Head-to-Head — Last {headToHead.length} Meeting{headToHead.length === 1 ? "" : "s"}
-            </div>
-            {headToHead.map((game, idx) => {
+            <button
+              type="button"
+              className="history-section-title history-section-toggle"
+              onClick={toggleH2h}
+              aria-expanded={!h2hCollapsed}
+            >
+              <span>
+                Head-to-Head — Last {headToHead.length} Meeting{headToHead.length === 1 ? "" : "s"}
+              </span>
+              <span className="history-section-chevron" aria-hidden="true">
+                {h2hCollapsed ? "▾" : "▴"}
+              </span>
+            </button>
+            {!h2hCollapsed && headToHead.map((game, idx) => {
               return (
                 <div className="h2h-row" key={idx}>
                   <div className="h2h-meta">
@@ -765,13 +783,25 @@ export default function TeamComparison({
         )}
 
         <div className="history-section">
-          <div className="history-section-title">
-            Last Season — Final {Math.max(teamAPriorGames.length, teamBPriorGames.length)} Games
-          </div>
-          <div className="history-teams-grid">
-            {renderPriorSeasonColumn(teamA.name, teamAPriorGames, teamAPriorSeason)}
-            {renderPriorSeasonColumn(teamB.name, teamBPriorGames, teamBPriorSeason)}
-          </div>
+          <button
+            type="button"
+            className="history-section-title history-section-toggle"
+            onClick={toggleLastSeason}
+            aria-expanded={!lastSeasonCollapsed}
+          >
+            <span>
+              Last Season — Final {Math.max(teamAPriorGames.length, teamBPriorGames.length)} Games
+            </span>
+            <span className="history-section-chevron" aria-hidden="true">
+              {lastSeasonCollapsed ? "▾" : "▴"}
+            </span>
+          </button>
+          {!lastSeasonCollapsed && (
+            <div className="history-teams-grid">
+              {renderPriorSeasonColumn(teamA.name, teamAPriorGames, teamAPriorSeason)}
+              {renderPriorSeasonColumn(teamB.name, teamBPriorGames, teamBPriorSeason)}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/UI/sd-ui/src/hooks/useSectionCollapse.js
+++ b/src/UI/sd-ui/src/hooks/useSectionCollapse.js
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+
+const KEY_PREFIX = "section-collapsed:";
+
+/**
+ * Storage disabled (private mode, blocked cookies) degrades toward SHOWING
+ * content — expanded is what the product promises, so a failure must not
+ * hide anything.
+ */
+function readCollapsed(sectionKey) {
+  try {
+    return window.localStorage.getItem(KEY_PREFIX + sectionKey) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remembers whether a named content section is collapsed, per device.
+ *
+ * Sections start EXPANDED. The comparison dialog exists to surface context
+ * without the user having to ask for it, so hiding content by default would
+ * invert that; collapsing is an escape valve for readers who find a section
+ * noisy, not the starting state.
+ *
+ * Persistence is the point. A collapse that resets when the dialog reopens
+ * would have to be redone on every matchup, every week — more irritating
+ * than the scrolling it was meant to fix.
+ *
+ * Device-local on purpose: no round trip, works offline, and it is a display
+ * preference rather than account data. If this graduates to a synced user
+ * setting later, this hook is the single place that changes.
+ *
+ * Mobile parity: sd-mobile/src/hooks/useSectionCollapse.ts — keep the storage
+ * key shape in step so the two surfaces stay conceptually identical.
+ */
+export function useSectionCollapse(sectionKey) {
+  // Read during initialization rather than in an effect. localStorage is
+  // synchronous, so this renders the correct state on the first paint with no
+  // expanded-then-collapsed flicker — and, more importantly, it cannot go
+  // stale. An effect that runs only on mount was the mobile bug: the dialog
+  // there is rendered eagerly by every card, so each instance read once at
+  // list-render time and never saw a later toggle. Web mounts this dialog on
+  // open today, which masks the problem; reading here keeps it correct even
+  // if that ever changes.
+  const [collapsed, setCollapsed] = useState(() => readCollapsed(sectionKey));
+
+  // Re-read if the component is reused for a different section.
+  useEffect(() => {
+    setCollapsed(readCollapsed(sectionKey));
+  }, [sectionKey]);
+
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(KEY_PREFIX + sectionKey, next ? "true" : "false");
+      } catch {
+        // A failed write only means the section returns expanded next visit,
+        // which is the default anyway.
+      }
+      return next;
+    });
+  }, [sectionKey]);
+
+  return { collapsed, toggle };
+}

--- a/src/UI/sd-ui/src/hooks/useSectionCollapse.test.js
+++ b/src/UI/sd-ui/src/hooks/useSectionCollapse.test.js
@@ -39,11 +39,13 @@ describe("useSectionCollapse", () => {
   it("keys sections separately so collapsing one leaves the other alone", () => {
     window.localStorage.setItem("section-collapsed:history.lastSeason", "true");
 
-    const h2h = renderHook(() => useSectionCollapse("history.headToHead"));
-    const lastSeason = renderHook(() => useSectionCollapse("history.lastSeason"));
+    const { result: h2hResult } = renderHook(() =>
+      useSectionCollapse("history.headToHead"));
+    const { result: lastSeasonResult } = renderHook(() =>
+      useSectionCollapse("history.lastSeason"));
 
-    expect(lastSeason.result.current.collapsed).toBe(true);
-    expect(h2h.result.current.collapsed).toBe(false);
+    expect(lastSeasonResult.current.collapsed).toBe(true);
+    expect(h2hResult.current.collapsed).toBe(false);
   });
 
   it("falls back to expanded when storage is unavailable", () => {

--- a/src/UI/sd-ui/src/hooks/useSectionCollapse.test.js
+++ b/src/UI/sd-ui/src/hooks/useSectionCollapse.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSectionCollapse } from "./useSectionCollapse";
+
+describe("useSectionCollapse", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("starts expanded when nothing has been stored", () => {
+    // The dialog surfaces context without being asked, so a section the user
+    // has never touched must not be hidden.
+    const { result } = renderHook(() => useSectionCollapse("history.headToHead"));
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it("restores a previous collapse so the choice survives reopening the dialog", () => {
+    // This is the whole point: a toggle that reset each time would have to be
+    // redone on every matchup, every week.
+    window.localStorage.setItem("section-collapsed:history.lastSeason", "true");
+
+    const { result } = renderHook(() => useSectionCollapse("history.lastSeason"));
+    expect(result.current.collapsed).toBe(true);
+  });
+
+  it("persists the new state on toggle", () => {
+    const { result } = renderHook(() => useSectionCollapse("history.headToHead"));
+
+    act(() => result.current.toggle());
+    expect(result.current.collapsed).toBe(true);
+    expect(window.localStorage.getItem("section-collapsed:history.headToHead")).toBe("true");
+
+    act(() => result.current.toggle());
+    expect(result.current.collapsed).toBe(false);
+    expect(window.localStorage.getItem("section-collapsed:history.headToHead")).toBe("false");
+  });
+
+  it("keys sections separately so collapsing one leaves the other alone", () => {
+    window.localStorage.setItem("section-collapsed:history.lastSeason", "true");
+
+    const h2h = renderHook(() => useSectionCollapse("history.headToHead"));
+    const lastSeason = renderHook(() => useSectionCollapse("history.lastSeason"));
+
+    expect(lastSeason.result.current.collapsed).toBe(true);
+    expect(h2h.result.current.collapsed).toBe(false);
+  });
+
+  it("falls back to expanded when storage is unavailable", () => {
+    // Private mode / blocked storage must not hide content — degrade toward
+    // showing more, not less.
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+
+    const { result } = renderHook(() => useSectionCollapse("history.headToHead"));
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it("does not throw when a write is rejected", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    const { result } = renderHook(() => useSectionCollapse("history.headToHead"));
+
+    expect(() => act(() => result.current.toggle())).not.toThrow();
+    // The in-memory state still flips, so the current session behaves.
+    expect(result.current.collapsed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

User feedback from a 20-year pick'em player: the History tab is "too much," with a suggestion to collapse Head-to-Head **by default**.

Collapsing by default would invert the point of the card — it exists to surface context without the user having to ask for it. So both sections are now collapsible but start **expanded**. Nobody loses anything, and a reader who finds a section noisy can put it away permanently.

- **Head-to-Head** and **Last Season** each get a collapse toggle on the section title
- **The Line** is left alone — it's compact and it's the differentiated content
- State persists per device, keyed per section, so one can be collapsed while the other stays open

Persistence *is* the feature. A toggle that reset each time would have to be redone on every matchup, every week — more irritating than the scrolling it was meant to fix.

## The mobile bug this caught

Found in device testing, not review, and worth understanding because it shaped the design.

`MatchupCard` renders its comparison modal **eagerly for every card in the slate** (`visible={false}` until opened). With per-instance state, each modal read storage once at list-render time — before any toggle had happened — and never heard about a later write. Collapsing a section on one game, then opening another game's dialog, showed it expanded again.

Mobile now uses a shared zustand store (matching `contestUpdatesStore`), so every mounted modal reflects a toggle immediately. Two consequences fell out of that:

- Storage is read **once per section key**, not once per card. That needs an in-flight guard as well as the resolved-value check — a slate mounts dozens of cards in the same tick, all before the first read resolves.
- A toggle made **while a read is in flight** wins, so a late-arriving stored value can't clobber the choice just made.

Web renders the dialog only when open, so it re-reads naturally and never showed the bug. Its hook now reads during state initialization rather than in an effect anyway — that removes an expanded-then-collapsed flicker and keeps it correct if that rendering ever changes.

Both surfaces **degrade toward showing content**: an unreadable store (private mode, blocked cookies, a rejected write) renders expanded rather than hidden, because expanded is what the product promises.

## Accent headers

Section headers now use the accent colour as their base on both surfaces. The web version previously leaned on a hover colour change, which doesn't exist on touch. Applied to all three History headings so they read as one system, and the web hover cue moved to the chevron.

## Explicitly not done: a recency floor

Worth recording, since it looks like an obvious win. Two of the four meetings on the reported card are from **2009 and 2001**, and trimming them would have cut the section's height roughly in half.

Rejected: the tab header shows the all-time series record (**"History (0:4)"**). Dropping old meetings would either corrupt that counter or leave it disagreeing with the rows beneath it. The corpus only spans ~25 years regardless. Those old games aren't there to be read individually — they're what makes the series record true.

## Validation

- 8 mobile hook tests, 6 web: default-expanded, restore-after-restart, per-section keying, storage-failure fallbacks, and — reproducing the reported bug — two mounted instances staying in sync when one toggles
- Mobile 162 with `tsc` clean; web 53 with a clean production build

## Note

The mobile half doesn't reach users until an EAS build, which is still outstanding along with the possession fix from #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collapsible Head-to-Head and Last Season history sections to team comparison views on web and mobile.
  * Added chevron indicators, accessibility labels, accent-colored headers, and independent collapse controls.
  * Collapse preferences persist across modal reopenings and future sessions on supported devices.
  * Sections remain expanded by default when no saved preference exists.

* **Bug Fixes**
  * Added fallback behavior when preference storage is unavailable or fails.
  * Preserved in-progress toggles while saved preferences are loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->