### PR TITLE
perf(api): watermark audited picks instead of re-auditing every pick nightly

### DIFF
--- a/src/SportsData.Api/Application/Events/ContestFinalizedHandler.cs
+++ b/src/SportsData.Api/Application/Events/ContestFinalizedHandler.cs
@@ -45,15 +45,18 @@ namespace SportsData.Api.Application.Events
         private readonly ILogger<ContestFinalizedHandler> _logger;
         private readonly IProvideBackgroundJobs _backgroundJobProvider;
         private readonly IHubContext<NotificationHub> _hubContext;
+        private readonly IInvalidatePickAudits _auditInvalidator;
 
         public ContestFinalizedHandler(
             ILogger<ContestFinalizedHandler> logger,
             IProvideBackgroundJobs backgroundJobProvider,
-            IHubContext<NotificationHub> hubContext)
+            IHubContext<NotificationHub> hubContext,
+            IInvalidatePickAudits auditInvalidator)
         {
             _logger = logger;
             _backgroundJobProvider = backgroundJobProvider;
             _hubContext = hubContext;
+            _auditInvalidator = auditInvalidator;
         }
 
         public async Task Consume(ConsumeContext<ContestFinalized> context)
@@ -70,6 +73,19 @@ namespace SportsData.Api.Application.Events
             _logger.LogInformation(
                 "ContestFinalized consume: ScorePicksCommand enqueued. ContestId={ContestId}, CorrelationId={CorrelationId}",
                 msg.ContestId, msg.CorrelationId);
+
+            // Clear the audit watermark so the nightly audit re-verifies these
+            // picks. NOT redundant with the scoring enqueued above: that
+            // processor short-circuits when every pick on the contest is
+            // already scored, so a RE-enrichment of settled picks re-scores
+            // nothing. That is exactly how a corrected spread winner or
+            // over/under result arrives — no score changes, so
+            // ContestScoreChanged never fires either. The audit is the only
+            // thing that catches it, and it only looks at unwatermarked picks.
+            await _auditInvalidator.InvalidateForContestAsync(
+                msg.ContestId,
+                nameof(ContestFinalized),
+                context.CancellationToken);
 
             // SignalR broadcast — same Clients.All pattern as the existing
             // ContestStatusChanged / ContestScoreChanged handlers. Web

--- a/src/SportsData.Api/Application/Events/ContestScoreChangedHandler.cs
+++ b/src/SportsData.Api/Application/Events/ContestScoreChangedHandler.cs
@@ -30,16 +30,21 @@ namespace SportsData.Api.Application.Events
         {
             var msg = context.Message;
 
-            await _hubContext.Clients
-                .All // ? simple, global broadcast for now
-                .SendAsync("ContestScoreChanged", msg, context.CancellationToken);
-
-            // A score correction changes exactly the inputs the audit checks,
-            // so any prior audit of these picks is stale.
+            // Durable state BEFORE the ephemeral broadcast. A score correction
+            // changes exactly the inputs the audit checks, so any prior audit
+            // of these picks is stale. If SendAsync were to throw first, the
+            // contest would stay watermarked and the nightly audit would skip
+            // it — a silent, permanent miss traded for a live UI nudge that
+            // clients recover on their next fetch anyway. Idempotent, so a
+            // MassTransit retry is harmless.
             await _auditInvalidator.InvalidateForContestAsync(
                 msg.ContestId,
                 nameof(ContestScoreChanged),
                 context.CancellationToken);
+
+            await _hubContext.Clients
+                .All // ? simple, global broadcast for now
+                .SendAsync("ContestScoreChanged", msg, context.CancellationToken);
         }
     }
 }

--- a/src/SportsData.Api/Application/Events/ContestScoreChangedHandler.cs
+++ b/src/SportsData.Api/Application/Events/ContestScoreChangedHandler.cs
@@ -2,21 +2,28 @@ using MassTransit;
 
 using Microsoft.AspNetCore.SignalR;
 
+using SportsData.Api.Application.Scoring;
 using SportsData.Api.Infrastructure.Notifications;
 using SportsData.Core.Eventing.Events.Contests;
 
 namespace SportsData.Api.Application.Events
 {
     /// <summary>
-    /// Handles ContestScoreChanged events and broadcasts them to connected SignalR clients.
+    /// Handles ContestScoreChanged events: broadcasts them to connected
+    /// SignalR clients, and clears the audit watermark on the contest's picks
+    /// so the nightly audit re-verifies scoring against the corrected scores.
     /// </summary>
     public class ContestScoreChangedHandler : IConsumer<ContestScoreChanged>
     {
         private readonly IHubContext<NotificationHub> _hubContext;
+        private readonly IInvalidatePickAudits _auditInvalidator;
 
-        public ContestScoreChangedHandler(IHubContext<NotificationHub> hubContext)
+        public ContestScoreChangedHandler(
+            IHubContext<NotificationHub> hubContext,
+            IInvalidatePickAudits auditInvalidator)
         {
             _hubContext = hubContext;
+            _auditInvalidator = auditInvalidator;
         }
 
         public async Task Consume(ConsumeContext<ContestScoreChanged> context)
@@ -26,6 +33,13 @@ namespace SportsData.Api.Application.Events
             await _hubContext.Clients
                 .All // ? simple, global broadcast for now
                 .SendAsync("ContestScoreChanged", msg, context.CancellationToken);
+
+            // A score correction changes exactly the inputs the audit checks,
+            // so any prior audit of these picks is stale.
+            await _auditInvalidator.InvalidateForContestAsync(
+                msg.ContestId,
+                nameof(ContestScoreChanged),
+                context.CancellationToken);
         }
     }
 }

--- a/src/SportsData.Api/Application/Jobs/PickScoringAuditJob.cs
+++ b/src/SportsData.Api/Application/Jobs/PickScoringAuditJob.cs
@@ -52,12 +52,22 @@ public class PickScoringAuditJob
         {
             _logger.LogInformation("{JobName} began.", nameof(PickScoringAuditJob));
 
-            // Sport-scoped candidate selection: every distinct ContestId
-            // that has at least one scored pick whose PickemGroup is for
+            // Sport-scoped candidate selection: every distinct ContestId with
+            // at least one scored-but-UNAUDITED pick whose PickemGroup is for
             // this sport. SQL-level filter so we don't pull other sports'
             // contests into memory just to discard them.
+            //
+            // AuditedUtc is the watermark that keeps this bounded. Without it
+            // the job re-audited every pick ever scored on every run — 1,284
+            // contests on 2026-08-24, almost all settled 2025 games, growing
+            // every week forever, each one its own Hangfire job and Producer
+            // round trip. Re-auditing is still driven by DATA CHANGE rather
+            // than by age: the watermark is cleared when a score correction or
+            // a re-enrichment lands, so a fix that arrives a year later is
+            // still caught. (A time window would not have caught the ATS
+            // re-enrichment, which corrected 2025 games in August 2026.)
             var contestIds = await _dataContext.UserPicks
-                .Where(p => p.ScoredAt != null)
+                .Where(p => p.ScoredAt != null && p.AuditedUtc == null)
                 .Join(_dataContext.PickemGroups,
                     p => p.PickemGroupId,
                     g => g.Id,

--- a/src/SportsData.Api/Application/Scoring/PickAuditInvalidator.cs
+++ b/src/SportsData.Api/Application/Scoring/PickAuditInvalidator.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+
+namespace SportsData.Api.Application.Scoring;
+
+public interface IInvalidatePickAudits
+{
+    Task<int> InvalidateForContestAsync(Guid contestId, string reason, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Clears the audit watermark on a contest's picks so the nightly audit
+/// re-verifies them.
+///
+/// This is what keeps the watermark honest. The audit selects only picks with
+/// a null AuditedUtc, so without invalidation a corrected contest would stay
+/// invisible forever. Re-auditing is therefore driven by DATA CHANGE, not by
+/// age — a correction landing a year after the game still triggers a re-audit,
+/// which no time-based window would catch.
+///
+/// Called from the two events that can move a scored pick's inputs:
+///   - ContestScoreChanged — the scores themselves were corrected.
+///   - ContestFinalized — enrichment (re)ran, which is how a spread-winner or
+///     over/under fix arrives WITHOUT any score changing. This path matters
+///     more than it looks: PickScoringProcessor short-circuits when every pick
+///     on the contest is already scored, so a re-enrichment of settled picks
+///     does NOT re-score them. The audit is the only thing that catches it,
+///     and it only looks at unwatermarked picks.
+/// </summary>
+public class PickAuditInvalidator : IInvalidatePickAudits
+{
+    private readonly ILogger<PickAuditInvalidator> _logger;
+    private readonly AppDataContext _dataContext;
+
+    public PickAuditInvalidator(
+        ILogger<PickAuditInvalidator> logger,
+        AppDataContext dataContext)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+    }
+
+    public async Task<int> InvalidateForContestAsync(
+        Guid contestId,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        // Loaded rather than ExecuteUpdate: a contest carries a handful of
+        // picks per league, so the set is small, and the unit tests run on the
+        // EF InMemory provider, which has no ExecuteUpdate support.
+        var picks = await _dataContext.UserPicks
+            .Where(p => p.ContestId == contestId && p.AuditedUtc != null)
+            .ToListAsync(cancellationToken);
+
+        if (picks.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var pick in picks)
+        {
+            // Only the watermark is touched. ModifiedUtc tracks when the
+            // pick's SCORING changed; queueing a re-audit is not that.
+            pick.AuditedUtc = null;
+        }
+
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Pick audit invalidated. ContestId={ContestId}, PickCount={PickCount}, Reason={Reason}",
+            contestId, picks.Count, reason);
+
+        return picks.Count;
+    }
+}

--- a/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
@@ -222,6 +222,20 @@ public class PickScoringAuditProcessor : IPickScoringAudit
             // changed, and a clean audit changes nothing the user can see.
             // The two continue-paths above (missing Group, scoring threw) are
             // left unstamped on purpose so tomorrow retries them.
+            //
+            // KNOWN RACE (accepted, not fixed): a correction that lands after
+            // the GetMatchupResult call above but before this stamp is lost.
+            // The invalidator finds AuditedUtc already null, no-ops, and then
+            // this line watermarks the pick against the stale result — so the
+            // correction is never re-verified until something else invalidates
+            // that contest. Closing it properly needs a durable invalidation
+            // generation captured at audit start and compared here, which is a
+            // new column plus a conditional update; the entity carries no
+            // concurrency token to lean on. Deferred deliberately: it requires
+            // a RE-finalization of an already-scored contest inside a
+            // sub-second window during the 02:00–02:30 UTC run. Moving that
+            // schedule out of the 00:00–06:00 UTC window when games finalize
+            // would shrink the exposure further at zero cost.
             pick.AuditedUtc = now;
 
             if (matches)

--- a/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringAuditProcessor.cs
@@ -137,6 +137,11 @@ public class PickScoringAuditProcessor : IPickScoringAudit
             pick.PointsAwarded = null;
             pick.ScoredAt = null;
             pick.WasAgainstSpread = null;
+            // Back to unscored, so the watermark must clear with it: when the
+            // contest finalizes for real and the pick is re-scored, it has to
+            // be audited again. A stamp left behind here would make the pick
+            // permanently invisible to the audit.
+            pick.AuditedUtc = null;
             pick.ModifiedUtc = now;
             pick.ModifiedBy = CausationId.Api.PickScoringAuditProcessor;
 
@@ -209,6 +214,15 @@ public class PickScoringAuditProcessor : IPickScoringAudit
                 pick.IsCorrect == clone.IsCorrect
                 && pick.PointsAwarded == clone.PointsAwarded
                 && pick.WasAgainstSpread == clone.WasAgainstSpread;
+
+            // Re-scored and compared against current canonical data — that is
+            // a completed audit whether or not anything differed, so the
+            // watermark is stamped on both branches. Deliberately NOT touching
+            // ModifiedUtc here: that field tracks when the pick's SCORING last
+            // changed, and a clean audit changes nothing the user can see.
+            // The two continue-paths above (missing Group, scoring threw) are
+            // left unstamped on purpose so tomorrow retries them.
+            pick.AuditedUtc = now;
 
             if (matches)
             {

--- a/src/SportsData.Api/Application/Scoring/PickScoringService.cs
+++ b/src/SportsData.Api/Application/Scoring/PickScoringService.cs
@@ -87,6 +87,7 @@ public class PickScoringService : IPickScoringService
 
         pick.IsCorrect = pick.FranchiseSeasonId == result.WinnerFranchiseSeasonId;
         pick.ScoredAt = now;
+        pick.AuditedUtc = null;
     }
 
     private void ScoreAgainstSpread(
@@ -138,12 +139,19 @@ public class PickScoringService : IPickScoringService
 
         pick.IsCorrect = spreadWinnerId.HasValue && pick.FranchiseSeasonId == spreadWinnerId.Value;
         pick.ScoredAt = now;
+        pick.AuditedUtc = null;
     }
 
+    // NOTE: every write of ScoredAt above also clears AuditedUtc. Scoring a
+    // pick IS a change to the values the nightly audit verifies, so any prior
+    // audit is stale by definition. Keeping the two together here means a
+    // future caller of ScorePick cannot forget it. (The audit itself scores a
+    // CLONE, so it never trips this on the real pick.)
     private void SetIncorrect(PickemGroupUserPick pick, DateTime now)
     {
         pick.IsCorrect = false;
         pick.ScoredAt = now;
+        pick.AuditedUtc = null;
         pick.PointsAwarded = 0;
     }
 }

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -4,7 +4,6 @@ using FluentValidation;
 
 using SportsData.Api.Application.Admin.Commands.BackfillLeagueScores;
 using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
-using SportsData.Api.Application.Admin.Commands.GenerateGameRecap;
 using SportsData.Api.Application.Admin.Commands.GenerateLoadTest;
 using SportsData.Api.Application.Admin.Commands.RefreshAiExistence;
 using SportsData.Api.Application.Admin.Commands.SendTestPushNotification;
@@ -104,6 +103,7 @@ using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 
 using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.Contests.Commands.GenerateGameRecap;
 
 namespace SportsData.Api.DependencyInjection
 {
@@ -312,6 +312,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IScheduleGroupWeekMatchups, MatchupScheduleProcessor>();
             services.AddScoped<IBootstrapLeagueMatchups, BootstrapLeagueMatchupsProcessor>();
             services.AddScoped<IScorePicks, PickScoringProcessor>();
+            services.AddScoped<IInvalidatePickAudits, PickAuditInvalidator>();
             services.AddScoped<IScoreLeagueWeeks, LeagueWeekScoringProcessor>();
             
             // HATEOAS Ref Generator (external API)

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroupUserPick.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroupUserPick.cs
@@ -42,6 +42,21 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public DateTime? ScoredAt { get; set; }
 
+        /// <summary>
+        /// When the nightly audit last re-verified this pick against canonical
+        /// data. Null means "needs auditing" — that is the ONLY thing the
+        /// audit job selects on, so this is a watermark rather than a log.
+        ///
+        /// Cleared whenever the pick's inputs could have moved: a score
+        /// correction (ContestScoreChanged), a re-enrichment
+        /// (ContestFinalized — which is how a spread-winner or over/under fix
+        /// arrives WITHOUT the score changing), or a re-score. Without the
+        /// watermark the job re-audited every pick ever scored on every run:
+        /// 1,284 contests on 2026-08-24, almost all of them settled 2025
+        /// games, growing every week forever.
+        /// </summary>
+        public DateTime? AuditedUtc { get; set; }
+
         // === Tiebreaker Fields ===
         public TiebreakerType TiebreakerType { get; set; }
 

--- a/src/SportsData.Api/Migrations/20260824103036_PickAuditedWatermark.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260824103036_PickAuditedWatermark.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260824103036_PickAuditedWatermark")]
+    partial class PickAuditedWatermark
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260824103036_PickAuditedWatermark.cs
+++ b/src/SportsData.Api/Migrations/20260824103036_PickAuditedWatermark.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/SportsData.Api/Migrations/20260824103036_PickAuditedWatermark.cs
+++ b/src/SportsData.Api/Migrations/20260824103036_PickAuditedWatermark.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PickAuditedWatermark : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AuditedUtc",
+                table: "UserPick",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AuditedUtc",
+                table: "UserPick");
+        }
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickAuditInvalidatorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickAuditInvalidatorTests.cs
@@ -1,0 +1,96 @@
+using AutoFixture;
+
+using FluentAssertions;
+
+using SportsData.Api.Application.Scoring;
+using SportsData.Api.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Scoring;
+
+/// <summary>
+/// Invalidation is what keeps the audit watermark honest: the nightly audit
+/// only looks at picks with a null AuditedUtc, so a corrected contest that is
+/// never invalidated stays invisible forever.
+/// </summary>
+public class PickAuditInvalidatorTests : ApiTestBase<PickAuditInvalidator>
+{
+    private static readonly DateTime Audited =
+        new(2026, 8, 24, 2, 0, 0, DateTimeKind.Utc);
+
+    private PickemGroupUserPick SeedPick(Guid contestId, DateTime? auditedUtc)
+    {
+        var pick = Fixture.Build<PickemGroupUserPick>()
+            .OmitAutoProperties()
+            .With(x => x.Id, Guid.NewGuid())
+            .With(x => x.ContestId, contestId)
+            .With(x => x.ScoredAt, (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .With(x => x.AuditedUtc, auditedUtc)
+            .Create();
+
+        DataContext.UserPicks.Add(pick);
+        return pick;
+    }
+
+    [Fact]
+    public async Task InvalidateForContest_ClearsTheWatermark_SoTheNightlyAuditPicksItUpAgain()
+    {
+        var contestId = Guid.NewGuid();
+        var pick = SeedPick(contestId, Audited);
+        await DataContext.SaveChangesAsync();
+
+        var count = await Mocker.CreateInstance<PickAuditInvalidator>()
+            .InvalidateForContestAsync(contestId, "ContestScoreChanged");
+
+        count.Should().Be(1);
+        pick.AuditedUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task InvalidateForContest_LeavesOtherContestsAlone()
+    {
+        var target = Guid.NewGuid();
+        var bystander = Guid.NewGuid();
+        SeedPick(target, Audited);
+        var untouched = SeedPick(bystander, Audited);
+        await DataContext.SaveChangesAsync();
+
+        await Mocker.CreateInstance<PickAuditInvalidator>()
+            .InvalidateForContestAsync(target, "ContestFinalized");
+
+        untouched.AuditedUtc.Should().Be(Audited);
+    }
+
+    [Fact]
+    public async Task InvalidateForContest_IsANoOp_WhenNothingWasAudited()
+    {
+        // The common case by far: a contest finalizing for the first time has
+        // no audited picks, and this must not churn writes for it.
+        var contestId = Guid.NewGuid();
+        SeedPick(contestId, null);
+        await DataContext.SaveChangesAsync();
+
+        var count = await Mocker.CreateInstance<PickAuditInvalidator>()
+            .InvalidateForContestAsync(contestId, "ContestFinalized");
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task InvalidateForContest_DoesNotTouchScoring()
+    {
+        // Only the watermark clears — the pick stays scored, because the
+        // audit's job is to VERIFY the scoring, not to discard it.
+        var contestId = Guid.NewGuid();
+        var pick = SeedPick(contestId, Audited);
+        var scoredAt = pick.ScoredAt;
+        await DataContext.SaveChangesAsync();
+
+        await Mocker.CreateInstance<PickAuditInvalidator>()
+            .InvalidateForContestAsync(contestId, "ContestScoreChanged");
+
+        pick.ScoredAt.Should().Be(scoredAt);
+        pick.AuditedUtc.Should().BeNull();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditJobTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Scoring/PickScoringAuditJobTests.cs
@@ -17,6 +17,96 @@ namespace SportsData.Api.Tests.Unit.Application.Scoring;
 public class PickScoringAuditJobTests : ApiTestBase<PickScoringAuditJob>
 {
     [Fact]
+    public async Task Execute_SkipsContests_WhosePicksAreAlreadyAudited()
+    {
+        // The watermark is the whole point: before it, the job re-audited
+        // every pick ever scored on every run — 1,284 contests on
+        // 2026-08-24, almost all of them settled 2025 games.
+        var auditedContest = Guid.NewGuid();
+        var unauditedContest = Guid.NewGuid();
+
+        var group = Fixture.Build<PickemGroup>()
+            .With(g => g.Sport, Sport.FootballNcaa).Create();
+        DataContext.PickemGroups.Add(group);
+
+        var scoredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        DataContext.UserPicks.AddRange(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, auditedContest)
+                .With(x => x.PickemGroupId, group.Id)
+                .With(x => x.Group, group)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)new DateTime(2026, 8, 24, 2, 0, 0, DateTimeKind.Utc))
+                .Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, unauditedContest)
+                .With(x => x.PickemGroupId, group.Id)
+                .With(x => x.Group, group)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)null)
+                .Create());
+
+        await DataContext.SaveChangesAsync();
+
+        var enqueued = new List<AuditContestCommand>();
+        Mocker.GetMock<IProvideBackgroundJobs>()
+            .Setup(x => x.Enqueue<IPickScoringAudit>(It.IsAny<Expression<Func<IPickScoringAudit, Task>>>()))
+            .Callback<Expression<Func<IPickScoringAudit, Task>>>(expr =>
+            {
+                var cmd = AuditContestCommandFromExpression(expr);
+                if (cmd != null) enqueued.Add(cmd);
+            });
+
+        // Act
+        await Mocker.CreateInstance<PickScoringAuditJob>().ExecuteAsync(Sport.FootballNcaa);
+
+        // Assert — only the contest still carrying an unaudited pick.
+        Assert.Single(enqueued);
+        Assert.Equal(unauditedContest, enqueued[0].ContestId);
+    }
+
+    [Fact]
+    public async Task Execute_ReAuditsAContest_WhenOnlyOneOfItsPicksWasInvalidated()
+    {
+        // Invalidation is per contest, but a partially-invalidated contest
+        // must still be picked up — otherwise a correction that cleared some
+        // picks would be half-audited.
+        var contestId = Guid.NewGuid();
+
+        var group = Fixture.Build<PickemGroup>()
+            .With(g => g.Sport, Sport.FootballNcaa).Create();
+        DataContext.PickemGroups.Add(group);
+
+        var scoredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        DataContext.UserPicks.AddRange(
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, contestId)
+                .With(x => x.PickemGroupId, group.Id)
+                .With(x => x.Group, group)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)new DateTime(2026, 8, 24, 2, 0, 0, DateTimeKind.Utc))
+                .Create(),
+            Fixture.Build<PickemGroupUserPick>()
+                .With(x => x.ContestId, contestId)
+                .With(x => x.PickemGroupId, group.Id)
+                .With(x => x.Group, group)
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)null)
+                .Create());
+
+        await DataContext.SaveChangesAsync();
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        await Mocker.CreateInstance<PickScoringAuditJob>().ExecuteAsync(Sport.FootballNcaa);
+
+        background.Verify(x => x.Enqueue<IPickScoringAudit>(
+            It.IsAny<Expression<Func<IPickScoringAudit, Task>>>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Execute_EnqueuesAuditCommand_ForEachDistinctScoredContestOfThisSport()
     {
         // Arrange — five scored picks: two distinct NCAAFB contests
@@ -48,32 +138,38 @@ public class PickScoringAuditJobTests : ApiTestBase<PickScoringAuditJob>
                 .With(x => x.ContestId, ncaaContest1)
                 .With(x => x.PickemGroupId, ncaaGroup.Id)
                 .With(x => x.Group, ncaaGroup)
-                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)null).Create(),
             Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, ncaaContest1) // duplicate contest, same sport
                 .With(x => x.PickemGroupId, ncaaGroup.Id)
                 .With(x => x.Group, ncaaGroup)
-                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)null).Create(),
             Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, ncaaContest2)
                 .With(x => x.PickemGroupId, ncaaGroup.Id)
                 .With(x => x.Group, ncaaGroup)
-                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)null).Create(),
             Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, nflContest)
                 .With(x => x.PickemGroupId, nflGroup.Id)
                 .With(x => x.Group, nflGroup)
-                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)null).Create(),
             Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, mlbContest)
                 .With(x => x.PickemGroupId, mlbGroup.Id)
                 .With(x => x.Group, mlbGroup)
-                .With(x => x.ScoredAt, (DateTime?)scoredAt).Create(),
+                .With(x => x.ScoredAt, (DateTime?)scoredAt)
+                .With(x => x.AuditedUtc, (DateTime?)null).Create(),
             Fixture.Build<PickemGroupUserPick>()
                 .With(x => x.ContestId, ncaaUnscoredContest)
                 .With(x => x.PickemGroupId, ncaaGroup.Id)
                 .With(x => x.Group, ncaaGroup)
-                .With(x => x.ScoredAt, (DateTime?)null).Create()
+                .With(x => x.ScoredAt, (DateTime?)null)
+                .With(x => x.AuditedUtc, (DateTime?)null).Create()
         );
 
         await DataContext.SaveChangesAsync();
@@ -143,7 +239,8 @@ public class PickScoringAuditJobTests : ApiTestBase<PickScoringAuditJob>
                 .With(x => x.ContestId, Guid.NewGuid())
                 .With(x => x.PickemGroupId, ncaaGroup.Id)
                 .With(x => x.Group, ncaaGroup)
-                .With(x => x.ScoredAt, (DateTime?)null).Create()
+                .With(x => x.ScoredAt, (DateTime?)null)
+                .With(x => x.AuditedUtc, (DateTime?)null).Create()
         );
 
         await DataContext.SaveChangesAsync();


### PR DESCRIPTION
## Summary

`PickScoringAuditJob` filtered only on `ScoredAt != null` plus sport, so it **re-audited every pick ever scored, on every run**. Last night:

| Sport | Contests audited |
|---|---|
| BaseballMlb | 763 |
| FootballNcaa | 489 |
| FootballNfl | 32 |

**1,284 contests**, each its own Hangfire job and its own Producer round trip — and almost all of them settled 2025 games that cannot change. The number only ever grows.

Adds `AuditedUtc` to `PickemGroupUserPick`. The job now selects `ScoredAt != null AND AuditedUtc == null`; the processor stamps it on picks it actually verified, and deliberately leaves its two skip-paths (missing `Group`, scoring threw) unstamped so tomorrow retries them.

## Why a watermark and not a time window

A time-based window was considered and rejected. The ATS re-enrichment corrected **2025-season games in August 2026** — no sane window would have caught it. Clearing the watermark on the events that can actually move a scored pick's inputs catches a correction whenever it lands, including a year later, and costs nothing in steady state.

## Invalidation hooks both events

Via a shared `PickAuditInvalidator`:

- **`ContestScoreChanged`** — the scores themselves were corrected.
- **`ContestFinalized`** — enrichment (re)ran.

The second one is easy to miss and is the more important of the two. That same ATS re-enrichment changed `AtsWinnerFranchiseSeasonId` on 29 contests with **no score change**, so `ContestScoreChanged` never fired. And the `ScorePicksCommand` that `ContestFinalizedHandler` already enqueues doesn't cover it either — `PickScoringProcessor` short-circuits when every pick on the contest is already scored:

```csharp
var hasUnscoredPicks = await _dataContext.UserPicks
    .AnyAsync(p => p.ContestId == command.ContestId && p.ScoredAt == null);
if (!hasUnscoredPicks) { /* log + return */ }
```

So re-enriching settled picks re-scores nothing. The audit is the only thing that catches that class of correction, and it only looks at unwatermarked picks.

## Two supporting invariants

- The watermark clears at **all three** places `PickScoringService` writes `ScoredAt`, so "scoring changed ⇒ any prior audit is stale" lives next to the write and a future caller can't forget it. (The audit scores a *clone*, so it never trips this on the real pick.)
- When the audit **un-scores** a pick because the contest isn't actually finalized, it clears the watermark too — a stamp left behind there would make the pick permanently invisible once it was re-scored.

## Migration

Deliberately does **not** backfill `AuditedUtc`. Every existing pick gets exactly one more audit under the new code — the clean verification pass — and the nightly cost drops to near zero after that.

Verified against the local `sdApi.All` database: column added, nullable, **0 of 4,819 scored picks backfilled**.

## Validation

6 new tests: the job skips already-watermarked contests and still picks up a contest where only *some* picks were invalidated; the invalidator clears the watermark, leaves other contests alone, no-ops when nothing was audited, and never touches scoring. Api 712.

## What to expect after deploy

The first nightly run audits everything once — same ~1,284 contests as today — then drops to near zero and only moves when a score correction or a re-enrichment actually lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic re-auditing when finalized results, scores, or scoring corrections change.
  * Added tracking to identify picks that still require auditing.
  * Unfinalized or corrected contests can now return picks to the audit queue.
* **Bug Fixes**
  * Prevented outdated audit results from remaining after scoring changes.
  * Picks affected by temporary audit errors remain eligible for retry.
* **Database**
  * Added storage for pick audit status timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->