### PR TITLE
fix(api): unbreak main, make the PR gate compile, move the audit cron

### DIFF
--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -103,7 +103,7 @@ using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 
 using SportsData.Api.Application.Common.Enums;
-using SportsData.Api.Application.Contests.Commands.GenerateGameRecap;
+using SportsData.Api.Application.Admin.Commands.GenerateGameRecap;
 
 namespace SportsData.Api.DependencyInjection
 {

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -484,8 +484,23 @@ namespace SportsData.Api.DependencyInjection
             // Per-sport historical audit of previously-scored picks. Catches
             // (a) picks scored against a contest that later finalized to a
             // different result and (b) picks still scored against an
-            // unfinalized contest. Runs before PickScoringJob(9) so any
-            // ScoredAt resets land in time for the daily rescore.
+            // unfinalized contest.
+            //
+            // Timing is pinned between two constraints:
+            //   - AFTER games finalize. Contests finalize and enrich roughly
+            //     00:00–06:00 UTC (evening ET through the latest West Coast
+            //     finishes). The old 02:00–02:30 slot sat inside that window,
+            //     so the audit both competed with live Producer traffic and
+            //     widened the race where a correction landing mid-audit is
+            //     watermarked against a stale result (see the note at the
+            //     stamp site in PickScoringAuditProcessor).
+            //   - BEFORE PickScoringJob at 09:00, because the audit resets
+            //     ScoredAt on picks whose contest turns out not to be
+            //     finalized, and that daily rescore is what picks them back
+            //     up. Running after it would delay every reset a full day.
+            // 08:00 clears the latest finishes with well over an hour of
+            // buffer and still leaves an hour before the rescore — ample,
+            // since the watermark keeps a typical night's work near zero.
             //
             // Stagger by 15 min per sport so a single sport's audit owns
             // its window in Seq — pods are separate so the lack of stagger
@@ -494,17 +509,17 @@ namespace SportsData.Api.DependencyInjection
             recurringJobManager.AddOrUpdate<PickScoringAuditJob>(
                 "PickScoringAudit-FootballNcaa",
                 job => job.ExecuteAsync(Sport.FootballNcaa),
-                "0 2 * * *");
+                Cron.Daily(8));
 
             recurringJobManager.AddOrUpdate<PickScoringAuditJob>(
                 "PickScoringAudit-FootballNfl",
                 job => job.ExecuteAsync(Sport.FootballNfl),
-                "15 2 * * *");
+                Cron.Daily(8, 15));
 
             recurringJobManager.AddOrUpdate<PickScoringAuditJob>(
                 "PickScoringAudit-BaseballMlb",
                 job => job.ExecuteAsync(Sport.BaseballMlb),
-                "30 2 * * *");
+                Cron.Daily(8, 30));
 
             return services;
         }

--- a/src/SportsData.Api/azure-pipelines.yml
+++ b/src/SportsData.Api/azure-pipelines.yml
@@ -66,20 +66,56 @@ stages:
           # warnings escalate to errors (parity with local `dotnet build`).
           # Classic NuGetCommand@2 + MSBuild /t:Restore did not trigger the
           # audit, masking high-severity transitive vulnerabilities.
+          #
+          # SportsData.Api.Tests.Unit is deliberately listed alongside the
+          # solution: it is NOT a member of sports-data-api.sln (which carries
+          # the Integration test project instead), so restoring the solution
+          # alone leaves the project the test step actually runs untouched.
           - task: DotNetCoreCLI@2
             displayName: 'Restore (.NET SDK)'
             inputs:
               command: 'restore'
-              projects: '**/sports-data-api.sln'
+              projects: |
+                **/sports-data-api.sln
+                **/SportsData.Api.Tests.Unit.csproj
               feedsToUse: 'select'
               vstsFeed: '2bb0cd0d-fa6e-42f0-9b7e-9cc1ce065e55/de94ed5a-8390-4547-bdd9-f975a712aa70'
 
+          # Compile the solution. Without this step the stage never compiled the
+          # PR's code at all: it went restore -> `dotnet test --no-build`, so a
+          # compile error could not fail the gate. The check still passed
+          # because this is a self-hosted agent and `--no-build` happily reused
+          # whatever binaries were left in bin/ from an earlier run, which also
+          # means the tests were not necessarily exercising the PR's code.
+          # A broken `using` merged that way in #670 and only surfaced at the
+          # post-merge Docker build, which is the first place compilation was
+          # actually attempted.
+          #
+          # The test project is built explicitly for the reason given on the
+          # restore step -- it is not in the solution -- and it ProjectReferences
+          # SportsData.Api, so building it compiles the service too.
+          #
+          # --no-restore because the step above already restored, and it carries
+          # the private-feed credentials this one does not.
+          - task: DotNetCoreCLI@2
+            displayName: 'Build (.NET SDK)'
+            inputs:
+              command: 'build'
+              projects: |
+                **/sports-data-api.sln
+                **/SportsData.Api.Tests.Unit.csproj
+              arguments: '--configuration $(buildConfiguration) --no-restore'
+
+          # --configuration must match the build above. It was absent before,
+          # so the test step defaulted to Debug while nothing produced Debug
+          # output in this pipeline -- part of why it was silently running
+          # against stale binaries.
           - task: DotNetCoreCLI@2
             displayName: 'Run Unit Tests'
             inputs:
               command: 'test'
               projects: '**/SportsData.Api.Tests.Unit.csproj'
-              arguments: '--no-build --collect:"XPlat Code Coverage"'
+              arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage"'
               publishTestResults: true
               testRunTitle: 'api-tests-unit'
             continueOnError: false


### PR DESCRIPTION
Three commits, one merge. Fixes `main`, and makes the gate capable of catching this
class of break in future.

## 1. Unbreak `main`

`main` has not compiled since #670. `ServiceRegistration.cs` imports
`SportsData.Api.Application.Contests.Commands.GenerateGameRecap`, but the only
`GenerateGameRecap` files tracked in the repo are under
`Application/Admin/Commands/GenerateGameRecap` with the `Admin` namespace. `CS0234`,
and the API image build fails before it can publish.

**Cause.** An in-progress local namespace move was sitting unstaged in
`ServiceRegistration.cs` when #670 staged that file by path. Staging a path takes the
whole file, so the new `using` rode along while the three relocated files — untracked
— did not. It compiled locally because those files are on disk.

Restores the `using` to the namespace actually in the repo. Decides nothing about the
pending move; those files are still untracked locally and it can land on its own.

## 2. Make the PR gate compile

`BuildAndTest` was restore → `dotnet test --no-build`, **with no build task at all**.
A compile error could not fail it — the run on the broken commit passed in 16s.
Compilation was first attempted by the Docker build, gated on `main`, i.e. after merge.

Two problems, and the second explains why the first went unnoticed:

- **No build step.** Added, targeting `Release` to match the tests.
- **`SportsData.Api.Tests.Unit` is not in `sports-data-api.sln`** — the solution
  carries the *Integration* project instead. So restore never touched the project the
  test step runs, and a naive build of just the solution wouldn't either. `--no-build`
  was executing whatever binaries were left in `bin/` on the self-hosted agent from an
  earlier run, which means **the green test results were not necessarily produced by
  the code under review**. Restore and build now list the test project explicitly; it
  `ProjectReference`s `SportsData.Api`, so building it compiles the service.

Also pins `--configuration` on the test step. It was absent, so the step defaulted to
`Debug` while nothing in this pipeline produced `Debug` output — the other half of why
it could only have been running stale binaries.

## 3. Move the audit cron (this PR's original purpose)

02:00/02:15/02:30 UTC sat inside the 00:00–06:00 UTC window when contests finalize and
enrich — competing with live Producer traffic, and widening the race documented at the
stamp site in `PickScoringAuditProcessor`.

Now **08:00 / 08:15 / 08:30 UTC**, same stagger, via the `Cron.Daily` helper the
neighbouring jobs use. Pinned between two constraints, the second easy to miss and the
reason this didn't just move to 10:00:

1. **After games finalize** — latest West Coast finishes ~05:45 UTC; 08:00 clears it
   with over an hour of buffer.
2. **Before `PickScoringJob` at 09:00** — the audit resets `ScoredAt` on picks whose
   contest isn't actually finalized, and that daily rescore is what picks them back up.
   Running after it would delay every reset a full day.

## Validation

Clean worktree at this branch, running the exact pipeline sequence: restore → `build
--no-restore -c Release` → `test -c Release --no-build`. Build 0 errors, **712 passed**
against binaries the sequence itself produced. The `CS0234` repro and its fix were
confirmed the same way against `origin/main`.

Watch this PR's own `sports-data-api` check: it should now take meaningfully longer
than 16s, which is the signal the build step is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rescheduled sport-specific scoring audits to run after game finalization and before daily pick rescoring, improving scoring accuracy.

- **Build & Quality**
  - Updated the automated pipeline to restore and build both the application and unit-test projects.
  - Standardized test execution with the configured build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->