### PR TITLE
fix(mobile,web): never wrap a broadcast network name mid-word

### DIFF
--- a/src/UI/sd-mobile/__tests__/utils/textUtils.test.ts
+++ b/src/UI/sd-mobile/__tests__/utils/textUtils.test.ts
@@ -1,0 +1,37 @@
+import { formatBroadcasts } from '@/src/utils/textUtils';
+
+const NBSP = String.fromCharCode(0x00a0);
+
+describe('formatBroadcasts', () => {
+  it('replaces spaces inside network names with non-breaking spaces', () => {
+    const result = formatBroadcasts(
+      'Rangers Sports Network | MLB.TV | Chicago Sports Network'
+    );
+
+    expect(result).toBe(
+      `Rangers${NBSP}Sports${NBSP}Network | MLB.TV | Chicago${NBSP}Sports${NBSP}Network`
+    );
+  });
+
+  it('keeps ordinary breakable spaces around the separators', () => {
+    const result = formatBroadcasts('ESPN | ABC');
+
+    // The join spaces are U+0020 so line wrapping stays legal at the pipe.
+    expect(result).toBe('ESPN | ABC');
+    expect(result).not.toContain(`${NBSP}|`);
+    expect(result).not.toContain(`|${NBSP}`);
+  });
+
+  it('passes a single network through with only internal spaces hardened', () => {
+    expect(formatBroadcasts('Chicago Sports Network')).toBe(
+      `Chicago${NBSP}Sports${NBSP}Network`
+    );
+    expect(formatBroadcasts('ESPN')).toBe('ESPN');
+  });
+
+  it('normalizes ragged separator spacing and drops empty segments', () => {
+    expect(formatBroadcasts('ESPN|ABC')).toBe('ESPN | ABC');
+    expect(formatBroadcasts('ESPN |  | ABC')).toBe('ESPN | ABC');
+    expect(formatBroadcasts('')).toBe('');
+  });
+});

--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -5,6 +5,7 @@ import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
 import type { Matchup, PickType } from '@/src/types/models';
 import { formatToUserTime, getDefaultGameWeekday } from '@/src/utils/timeUtils';
+import { formatBroadcasts } from '@/src/utils/textUtils';
 import { useUserTimeZone } from '@/src/hooks/useUserTimeZone';
 import { FinalScoreResult } from './FinalScoreResult';
 import { formatFootballSituation } from '@/src/utils/liveSituation';
@@ -100,8 +101,10 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail, pickType }
           {formatToUserTime(matchup.startDateUtc, userTz, getDefaultGameWeekday(leagueSport))}
         </Text>
         {matchup.broadcasts ? (
+          // formatBroadcasts pins wrapping to the "|" separators so a
+          // network name never splits across lines ("Chicago Sports\nNetwork")
           <Text style={[styles.statusMeta, { color: theme.textMuted }]}>
-            {matchup.broadcasts}
+            {formatBroadcasts(matchup.broadcasts)}
           </Text>
         ) : null}
         {matchup.venue ? (

--- a/src/UI/sd-mobile/src/utils/textUtils.ts
+++ b/src/UI/sd-mobile/src/utils/textUtils.ts
@@ -1,0 +1,27 @@
+/**
+ * Text-shaping helpers shared by card surfaces.
+ */
+
+// U+00A0 non-breaking space, constructed so no invisible literal hides in
+// source for a formatter or copy-paste to silently normalize away.
+const NBSP = String.fromCharCode(0x00a0);
+
+/**
+ * Reshape a pre-joined broadcast list ("Rangers Sports Network | MLB.TV |
+ * Chicago Sports Network") so line wrapping can only happen at the
+ * separators, never inside a network name. Each name's internal spaces
+ * become non-breaking spaces; the " | " separators keep ordinary spaces
+ * and remain the only legal break points.
+ *
+ * Without this, RN's Text wraps wherever width runs out, producing
+ * orphans like "Chicago Sports\nNetwork" on phone-width cards. A single
+ * name wider than the container still hard-breaks (RN's default), which
+ * is the right fallback for a pathological input.
+ */
+export function formatBroadcasts(broadcasts: string): string {
+  return broadcasts
+    .split('|')
+    .map((name) => name.trim().replace(/ /g, NBSP))
+    .filter(Boolean)
+    .join(' | ');
+}

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { FaCheck } from "react-icons/fa";
 import { contestLink } from '../../utils/sportLinks';
+import { formatBroadcasts } from '../../utils/textUtils';
 import FootballGameStatusInProgress from './FootballGameStatusInProgress';
 import BaseballGameStatusInProgress from './BaseballGameStatusInProgress';
 import FinalScoreResult from './FinalScoreResult';
@@ -240,7 +241,9 @@ function GameStatus({
     <>
       <div className="game-time-location">
         <div>{gameTime}</div>
-        {broadcasts && <div>{broadcasts}</div>}
+        {/* formatBroadcasts pins wrapping to the "|" separators so a
+            network name never splits across lines on narrow viewports */}
+        {broadcasts && <div>{formatBroadcasts(broadcasts)}</div>}
         <div>{venue} | {location}</div>
       </div>
       {/* Bottom-of-status affordance for "open the Contest Overview" —

--- a/src/UI/sd-ui/src/utils/textUtils.js
+++ b/src/UI/sd-ui/src/utils/textUtils.js
@@ -1,0 +1,25 @@
+/**
+ * Text-shaping helpers shared by card surfaces.
+ */
+
+// U+00A0 non-breaking space, constructed so no invisible literal hides in
+// source for a formatter or copy-paste to silently normalize away.
+const NBSP = String.fromCharCode(0x00a0);
+
+/**
+ * Reshape a pre-joined broadcast list ("Rangers Sports Network | MLB.TV |
+ * Chicago Sports Network") so line wrapping can only happen at the
+ * separators, never inside a network name. Each name's internal spaces
+ * become non-breaking spaces; the " | " separators keep ordinary spaces
+ * and remain the only legal break points.
+ *
+ * Mirrors sd-mobile's src/utils/textUtils.ts — on phone-width cards the
+ * raw string wraps mid-name ("Chicago Sports" / "Network").
+ */
+export function formatBroadcasts(broadcasts) {
+  return broadcasts
+    .split('|')
+    .map((name) => name.trim().replace(/ /g, NBSP))
+    .filter(Boolean)
+    .join(' | ');
+}

--- a/src/UI/sd-ui/src/utils/textUtils.test.js
+++ b/src/UI/sd-ui/src/utils/textUtils.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { formatBroadcasts } from './textUtils';
+
+const NBSP = String.fromCharCode(0x00a0);
+
+describe('formatBroadcasts', () => {
+  it('replaces spaces inside network names with non-breaking spaces', () => {
+    const result = formatBroadcasts(
+      'Rangers Sports Network | MLB.TV | Chicago Sports Network'
+    );
+
+    expect(result).toBe(
+      `Rangers${NBSP}Sports${NBSP}Network | MLB.TV | Chicago${NBSP}Sports${NBSP}Network`
+    );
+  });
+
+  it('keeps ordinary breakable spaces around the separators', () => {
+    const result = formatBroadcasts('ESPN | ABC');
+
+    expect(result).toBe('ESPN | ABC');
+    expect(result).not.toContain(`${NBSP}|`);
+    expect(result).not.toContain(`|${NBSP}`);
+  });
+
+  it('passes a single network through with only internal spaces hardened', () => {
+    expect(formatBroadcasts('Chicago Sports Network')).toBe(
+      `Chicago${NBSP}Sports${NBSP}Network`
+    );
+    expect(formatBroadcasts('ESPN')).toBe('ESPN');
+  });
+
+  it('normalizes ragged separator spacing and drops empty segments', () => {
+    expect(formatBroadcasts('ESPN|ABC')).toBe('ESPN | ABC');
+    expect(formatBroadcasts('ESPN |  | ABC')).toBe('ESPN | ABC');
+    expect(formatBroadcasts('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Phone-width scheduled cards wrapped the broadcast list mid-name:

```
Rangers Sports Network | MLB.TV | Chicago Sports
Network
```

The API delivers `broadcasts` as one pre-joined string and both surfaces rendered it
raw, so the text engine broke lines wherever width ran out. New `formatBroadcasts`
helper (mirrored `sd-mobile` TS / `sd-ui` JS) hardens each network name into an
unbreakable unit — internal spaces become non-breaking spaces — while the `|`
separators keep ordinary spaces as the only legal break points:

```
Rangers Sports Network | MLB.TV |
Chicago Sports Network
```

Every network stays visible — no truncation. A single name wider than the container
still hard-breaks, the right fallback for pathological input. The NBSP is built via
`String.fromCharCode(0x00a0)` so no invisible literal sits in source for a formatter
to silently normalize. The helper also normalizes ragged separator input
(missing/doubled pipes) since it re-joins segments anyway.

Web had the identical defect, just masked by desktop width — fixed for parity at
`GameStatus.jsx`.

## Validation

- 4 jest tests (mobile) + 4 vitest tests (web) on the helper
- `tsc --noEmit` clean; ESLint clean on changed `sd-ui` files
- Operator-verified on both surfaces (Expo + browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduled-game broadcast display so network names stay together when text wraps.
  - Standardized spacing around broadcast separators and removed empty entries.
  - Improved handling of empty or single-network broadcast listings.

- **Tests**
  - Added coverage for broadcast formatting, wrapping behavior, spacing normalization, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->