### PR TITLE
feat(web,mobile): Player Pick'em roster builder — admin-gated v1 exploration

### DIFF
--- a/src/UI/sd-mobile/__tests__/utils/pickemLogic.test.ts
+++ b/src/UI/sd-mobile/__tests__/utils/pickemLogic.test.ts
@@ -1,0 +1,107 @@
+import {
+  SLOT_DEFS,
+  assign,
+  canAssign,
+  remove,
+  isRostered,
+} from '@/src/utils/pickem/rosterLogic';
+import {
+  NAME_SORT,
+  sortAthletes,
+  statPartsFor,
+  seasonLine,
+} from '@/src/utils/pickem/athleteStats';
+import type { PickemAthlete } from '@/src/services/api/playerPickemApi';
+
+function qb(
+  lastName: string,
+  currentYds: number | null,
+  prevYds: number | null
+): PickemAthlete {
+  return {
+    athleteId: `qb-${lastName}`,
+    firstName: 'Test',
+    lastName,
+    teamName: 'Team',
+    teamSlug: 'team',
+    position: 'QB',
+    opponentName: 'Opp',
+    opponentSlug: 'opp',
+    opponentDefPerGame: 200,
+    currentSeason:
+      currentYds == null
+        ? null
+        : { seasonYear: 2026, gamesPlayed: 4, stats: { passYds: currentYds } },
+    previousSeason:
+      prevYds == null
+        ? null
+        : { seasonYear: 2025, gamesPlayed: 13, stats: { passYds: prevYds } },
+  };
+}
+
+const qbParts = statPartsFor('QB', ['QB']);
+
+describe('rosterLogic (mobile port)', () => {
+  it('matches the web slot shape with DEF disabled', () => {
+    expect(SLOT_DEFS.map((s) => s.id)).toEqual([
+      'QB', 'RB1', 'RB2', 'WR1', 'WR2', 'TE', 'FLEX', 'K', 'DEF',
+    ]);
+    expect(SLOT_DEFS.find((s) => s.id === 'DEF')?.disabled).toBe(true);
+  });
+
+  it('enforces eligibility, duplicates, and removal', () => {
+    const a = qb('Manning', 1000, 2000);
+    let roster = assign({}, 'QB', a);
+    expect(roster.QB).toBe(a);
+    expect(canAssign(roster, 'FLEX', a)).toBe(false); // QB not FLEX-eligible anyway
+    expect(isRostered(roster, a.athleteId)).toBe(true);
+    roster = remove(roster, 'QB');
+    expect(isRostered(roster, a.athleteId)).toBe(false);
+  });
+});
+
+describe('sortAthletes (mobile port)', () => {
+  it('sorts current-season desc with nulls sinking', () => {
+    const rows = [qb('Out', null, 4000), qb('High', 1300, 1), qb('Low', 800, 9999)];
+    const sorted = sortAthletes(rows, { key: 'passYds', dir: 'desc' }, qbParts);
+    expect(sorted.map((r) => r.lastName)).toEqual(['High', 'Low', 'Out']);
+  });
+
+  it('falls back to previous season when no row has current data', () => {
+    const rows = [qb('Small', null, 1785), qb('Big', null, 4052)];
+    const sorted = sortAthletes(rows, { key: 'passYds', dir: 'desc' }, qbParts);
+    expect(sorted.map((r) => r.lastName)).toEqual(['Big', 'Small']);
+  });
+
+  it('name sort is the default ordering', () => {
+    const rows = [qb('Zeta', 1, 1), qb('Alpha', 2, 2)];
+    expect(sortAthletes(rows, NAME_SORT, qbParts).map((r) => r.lastName)).toEqual([
+      'Alpha', 'Zeta',
+    ]);
+  });
+});
+
+describe('seasonLine', () => {
+  it('renders a compact line and em-dashes missing stats', () => {
+    const a = qb('Manning', 1247, null);
+    const line = seasonLine(qbParts, a.currentSeason, a);
+    expect(line).toContain('1,247 YDS');
+    expect(line).toContain('— CMP%'); // only passYds present in this fixture
+  });
+
+  it('uses whole-season formatters for K ratios', () => {
+    const kParts = statPartsFor('K', ['K']);
+    const kicker: PickemAthlete = {
+      ...qb('Zvada', null, null),
+      position: 'K',
+      currentSeason: {
+        seasonYear: 2026,
+        gamesPlayed: 5,
+        stats: { fgMade: 9, fgAtt: 10, fgPct: 90.0, fgLong: 56, xpMade: 14, xpAtt: 14 },
+      },
+    };
+    const line = seasonLine(kParts, kicker.currentSeason, kicker);
+    expect(line).toContain('9/10 FG');
+    expect(line).toContain('14/14 XP');
+  });
+});

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -530,6 +530,10 @@ export default function ProfileScreen() {
             label="Push Token (FCM)"
             onPress={() => router.push('/admin/push-token')}
           />
+          <SettingsRow
+            label="Player Pick'em (Preview)"
+            onPress={() => router.push('/admin/player-pickem')}
+          />
         </View>
       ) : null}
 

--- a/src/UI/sd-mobile/app/admin/player-pickem.tsx
+++ b/src/UI/sd-mobile/app/admin/player-pickem.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/src/services/api/playerPickemApi';
 import {
   SLOT_DEFS,
+  slotById,
   eligiblePositions,
   assign,
   remove,
@@ -36,6 +37,38 @@ import {
 // until PlayerLineup entities exist server-side. Shares nothing with the
 // web draft; both are local explorations.
 const ROSTER_KEY = 'playerPickemRosterDraft';
+
+/**
+ * A stored draft is untrusted input: JSON.parse happily returns null,
+ * arrays, or strings (all valid JSON), and a raw setRoster of any of
+ * those crashes the screen on the next roster[activeSlotId] read. Accept
+ * only a plain object whose keys are real slot ids and whose values look
+ * like athletes; anything else degrades to the slot-by-slot best effort
+ * or an empty roster.
+ */
+function sanitizeRoster(raw: string): Roster {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return {};
+    }
+    const next: Roster = {};
+    for (const [slotId, val] of Object.entries(parsed)) {
+      if (
+        slotById(slotId) &&
+        val !== null &&
+        typeof val === 'object' &&
+        !Array.isArray(val) &&
+        typeof (val as { athleteId?: unknown }).athleteId === 'string'
+      ) {
+        next[slotId] = val as PickemAthlete;
+      }
+    }
+    return next;
+  } catch {
+    return {};
+  }
+}
 
 const OPP_DEF_LABEL: Record<string, string> = {
   QB: 'Pass Alw/G',
@@ -73,11 +106,7 @@ export default function PlayerPickemScreen() {
     AsyncStorage.getItem(ROSTER_KEY)
       .then((raw) => {
         if (cancelled || !raw) return;
-        try {
-          setRoster(JSON.parse(raw));
-        } catch {
-          // Corrupt draft — start clean rather than crash the screen.
-        }
+        setRoster(sanitizeRoster(raw));
       })
       .finally(() => {
         if (!cancelled) setRosterHydrated(true);
@@ -216,7 +245,10 @@ export default function PlayerPickemScreen() {
         <Text style={[styles.cardMatchup, { color: theme.textMuted }]}>
           {a.opponentName ? `vs ${a.opponentName}` : 'BYE'}
           {a.opponentDefPerGame != null
-            ? ` · Opp ${a.opponentDefPerGame.toFixed(1)} ${oppDefLabel}`
+            // Per-row label: on FLEX the number's meaning depends on the
+            // athlete's position (rush vs pass allowed), so the card says
+            // which it is instead of the slot's generic label.
+            ? ` · Opp ${a.opponentDefPerGame.toFixed(1)} ${OPP_DEF_LABEL[a.position]}`
             : ''}
         </Text>
 
@@ -322,7 +354,14 @@ export default function PlayerPickemScreen() {
           {[
             { key: 'name', label: 'Name' },
             ...parts.map((p) => ({ key: p.key, label: p.label })),
-            { key: 'oppDef', label: `Opp ${oppDefLabel}` },
+            // No opponent-defense sort on FLEX: the value is rush yds
+            // allowed/G for an RB but pass yds allowed/G for a WR/TE —
+            // different units, so a cross-position ranking would lie.
+            // (The per-card display stays; each card's label carries its
+            // own meaning.)
+            ...(activeSlotId === 'FLEX'
+              ? []
+              : [{ key: 'oppDef', label: `Opp ${oppDefLabel}` }]),
           ].map((chip) => {
             const active = sort.key === chip.key;
             const arrow =

--- a/src/UI/sd-mobile/app/admin/player-pickem.tsx
+++ b/src/UI/sd-mobile/app/admin/player-pickem.tsx
@@ -1,0 +1,439 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  FlatList,
+  TouchableOpacity,
+} from 'react-native';
+import { Stack } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { useCurrentUser } from '@/src/hooks/useStandings';
+import {
+  getAthletesByPosition,
+  type PickemAthlete,
+} from '@/src/services/api/playerPickemApi';
+import {
+  SLOT_DEFS,
+  eligiblePositions,
+  assign,
+  remove,
+  isRostered,
+  type Roster,
+} from '@/src/utils/pickem/rosterLogic';
+import {
+  statPartsFor,
+  seasonLine,
+  sortAthletes,
+  NAME_SORT,
+  type SortDescriptor,
+} from '@/src/utils/pickem/athleteStats';
+
+// Selections survive app restarts — rudimentary stand-in for carry-over
+// until PlayerLineup entities exist server-side. Shares nothing with the
+// web draft; both are local explorations.
+const ROSTER_KEY = 'playerPickemRosterDraft';
+
+const OPP_DEF_LABEL: Record<string, string> = {
+  QB: 'Pass Alw/G',
+  RB: 'Rush Alw/G',
+  WR: 'Pass Alw/G',
+  TE: 'Pass Alw/G',
+  K: 'Pts Alw/G',
+  FLEX: 'Def/G',
+};
+
+/**
+ * Player Pick'em roster builder — admin-only v1 exploration, mobile
+ * parity for sd-ui's PlayerRosterBuilder. Same slot shape, same mock
+ * Week 5 contract; the web's mirrored table columns become stacked
+ * '26/'25 lines on a card, and column-header sorting becomes a chip row.
+ */
+export default function PlayerPickemScreen() {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  // Defense-in-depth admin gate — same convention as /admin/push-token:
+  // the profile link is gated, but the route is reachable by direct URL.
+  const { data: me, isLoading: meLoading } = useCurrentUser();
+  const isAdmin = me?.isAdmin === true;
+
+  const [roster, setRoster] = useState<Roster>({});
+  const [rosterHydrated, setRosterHydrated] = useState(false);
+  const [activeSlotId, setActiveSlotId] = useState('QB');
+  const [athletes, setAthletes] = useState<PickemAthlete[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [sort, setSort] = useState<SortDescriptor>(NAME_SORT);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(ROSTER_KEY)
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        try {
+          setRoster(JSON.parse(raw));
+        } catch {
+          // Corrupt draft — start clean rather than crash the screen.
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setRosterHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    // Don't clobber a stored draft with the initial empty roster before
+    // hydration has read it.
+    if (!rosterHydrated) return;
+    AsyncStorage.setItem(ROSTER_KEY, JSON.stringify(roster)).catch(() => {});
+  }, [roster, rosterHydrated]);
+
+  const positions = useMemo(
+    () => eligiblePositions(activeSlotId),
+    [activeSlotId]
+  );
+
+  const parts = useMemo(
+    () => statPartsFor(activeSlotId, positions),
+    [activeSlotId, positions]
+  );
+
+  // Stat sets differ per slot — slot changes reset to the name sort.
+  useEffect(() => {
+    setSort(NAME_SORT);
+  }, [activeSlotId]);
+
+  useEffect(() => {
+    if (positions.length === 0) return;
+    let ignore = false;
+    setLoading(true);
+
+    Promise.all(positions.map((pos) => getAthletesByPosition(pos)))
+      .then((responses) => {
+        if (ignore) return;
+        setAthletes(responses.flatMap((r) => r.athletes));
+      })
+      .finally(() => {
+        if (!ignore) setLoading(false);
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [positions]);
+
+  const sorted = useMemo(
+    () => sortAthletes(athletes, sort, parts),
+    [athletes, sort, parts]
+  );
+
+  const toggleSort = useCallback((key: string) => {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === 'desc' ? 'asc' : 'desc' }
+        : { key, dir: 'desc' }
+    );
+  }, []);
+
+  const activeSlot = SLOT_DEFS.find((s) => s.id === activeSlotId);
+  const occupant = roster[activeSlotId];
+  const oppDefLabel =
+    OPP_DEF_LABEL[activeSlot?.id === 'FLEX' ? 'FLEX' : positions[0]];
+
+  if (meLoading) {
+    return (
+      <>
+        <Stack.Screen options={{ title: "Player Pick'em", headerBackTitle: 'Back' }} />
+        <View style={[styles.gate, { backgroundColor: theme.background }]}>
+          <Text style={{ color: theme.textMuted }}>Loading…</Text>
+        </View>
+      </>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <>
+        <Stack.Screen options={{ title: "Player Pick'em", headerBackTitle: 'Back' }} />
+        <View style={[styles.gate, { backgroundColor: theme.background }]}>
+          <Text style={[styles.gateHeading, { color: theme.text }]}>Unauthorized</Text>
+          <Text style={{ color: theme.textMuted, textAlign: 'center' }}>
+            This screen is restricted to admin users.
+          </Text>
+        </View>
+      </>
+    );
+  }
+
+  const renderAthlete = ({ item: a }: { item: PickemAthlete }) => {
+    const rostered = isRostered(roster, a.athleteId);
+    const addLabel =
+      occupant && occupant.athleteId !== a.athleteId
+        ? `Replace ${occupant.firstName.charAt(0)}. ${occupant.lastName}`
+        : 'Add';
+
+    return (
+      <View style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}>
+        <View style={styles.cardHeader}>
+          <View style={styles.cardIdentity}>
+            <Text style={[styles.cardName, { color: theme.text }]}>
+              {a.lastName}, {a.firstName}
+              {activeSlot?.id === 'FLEX' ? (
+                <Text style={[styles.cardPos, { color: theme.textMuted }]}>
+                  {'  '}{a.position}
+                </Text>
+              ) : null}
+            </Text>
+            <Text style={[styles.cardTeam, { color: theme.textMuted }]}>
+              {a.teamName}
+            </Text>
+          </View>
+          <TouchableOpacity
+            style={[
+              styles.addBtn,
+              { borderColor: rostered ? theme.border : theme.tint },
+            ]}
+            disabled={rostered}
+            onPress={() => setRoster((prev) => assign(prev, activeSlotId, a))}
+          >
+            <Text
+              style={[
+                styles.addBtnText,
+                { color: rostered ? theme.textMuted : theme.tint },
+              ]}
+            >
+              {rostered ? 'Rostered' : addLabel}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <Text style={[styles.cardMatchup, { color: theme.textMuted }]}>
+          {a.opponentName ? `vs ${a.opponentName}` : 'BYE'}
+          {a.opponentDefPerGame != null
+            ? ` · Opp ${a.opponentDefPerGame.toFixed(1)} ${oppDefLabel}`
+            : ''}
+        </Text>
+
+        {/* '26 over '25 in the same stat order — the mobile translation of
+            the web grid's mirrored columns. */}
+        <View style={styles.seasonRow}>
+          <Text style={[styles.seasonTag, { color: theme.text }]}>
+            {a.currentSeason
+              ? `'26 · ${a.currentSeason.gamesPlayed} G`
+              : "'26 · —"}
+          </Text>
+          <Text style={[styles.seasonStats, { color: theme.text }]} numberOfLines={1}>
+            {a.currentSeason
+              ? seasonLine(parts, a.currentSeason, a)
+              : 'No games yet'}
+          </Text>
+        </View>
+        <View style={styles.seasonRow}>
+          <Text style={[styles.seasonTag, { color: theme.textMuted }]}>
+            {a.previousSeason
+              ? `'25 · ${a.previousSeason.gamesPlayed} G`
+              : "'25 · —"}
+          </Text>
+          <Text style={[styles.seasonStats, { color: theme.textMuted }]} numberOfLines={1}>
+            {a.previousSeason
+              ? seasonLine(parts, a.previousSeason, a)
+              : 'No prior season'}
+          </Text>
+        </View>
+      </View>
+    );
+  };
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Player Pick'em", headerBackTitle: 'Back' }} />
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <Text style={[styles.sub, { color: theme.textMuted }]}>
+          Week 5 · 2026 · NCAAFB (FBS) — admin preview, local-only, mock data
+        </Text>
+
+        {/* Wrapping grid, not a horizontal scroller — every slot visible at
+            once so nothing about the lineup shape hides off-screen. */}
+        <View style={styles.slotRow}>
+          {SLOT_DEFS.map((slot) => {
+            const filled = roster[slot.id];
+            const isActive = slot.id === activeSlotId;
+            return (
+              <TouchableOpacity
+                key={slot.id}
+                disabled={slot.disabled}
+                onPress={() => setActiveSlotId(slot.id)}
+                style={[
+                  styles.slot,
+                  { borderColor: theme.border },
+                  filled && { borderColor: theme.tint, borderStyle: 'solid' },
+                  isActive && { borderColor: theme.tint, borderWidth: 2 },
+                  slot.disabled && styles.slotDisabled,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.slotLabel,
+                    { color: filled ? theme.tint : theme.textMuted },
+                  ]}
+                >
+                  {slot.label}
+                </Text>
+                <Text
+                  style={[
+                    styles.slotPlayer,
+                    { color: filled ? theme.text : theme.textMuted },
+                  ]}
+                  numberOfLines={1}
+                >
+                  {filled
+                    ? `${filled.firstName.charAt(0)}. ${filled.lastName}`
+                    : slot.disabled
+                      ? 'Soon'
+                      : '—'}
+                </Text>
+                {filled ? (
+                  <TouchableOpacity
+                    style={[styles.slotRemove, { backgroundColor: theme.card, borderColor: theme.border }]}
+                    accessibilityLabel={`Remove ${filled.firstName} ${filled.lastName}`}
+                    onPress={() => setRoster((prev) => remove(prev, slot.id))}
+                  >
+                    <Text style={{ color: theme.textMuted, fontSize: 10, lineHeight: 12 }}>✕</Text>
+                  </TouchableOpacity>
+                ) : null}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        {/* Sort chips replace the web's clickable column headers. */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.sortRow}
+          contentContainerStyle={styles.sortRowContent}
+        >
+          {[
+            { key: 'name', label: 'Name' },
+            ...parts.map((p) => ({ key: p.key, label: p.label })),
+            { key: 'oppDef', label: `Opp ${oppDefLabel}` },
+          ].map((chip) => {
+            const active = sort.key === chip.key;
+            const arrow =
+              active && chip.key !== 'name'
+                ? sort.dir === 'asc'
+                  ? ' ▲'
+                  : ' ▼'
+                : '';
+            return (
+              <TouchableOpacity
+                key={chip.key}
+                onPress={() =>
+                  chip.key === 'name' ? setSort(NAME_SORT) : toggleSort(chip.key)
+                }
+                style={[
+                  styles.sortChip,
+                  { borderColor: active ? theme.tint : theme.border },
+                ]}
+              >
+                <Text
+                  style={{
+                    color: active ? theme.tint : theme.textMuted,
+                    fontSize: 12,
+                    fontWeight: '600',
+                  }}
+                >
+                  {chip.label}
+                  {arrow}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+
+        {loading ? (
+          <Text style={[styles.status, { color: theme.textMuted }]}>
+            Loading athletes…
+          </Text>
+        ) : (
+          <FlatList
+            data={sorted}
+            keyExtractor={(a) => a.athleteId}
+            renderItem={renderAthlete}
+            contentContainerStyle={styles.listContent}
+            ListEmptyComponent={
+              <Text style={[styles.status, { color: theme.textMuted }]}>
+                No athletes for this position.
+              </Text>
+            }
+          />
+        )}
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  gate: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+  gateHeading: { fontSize: 18, fontWeight: '700', marginBottom: 8 },
+  sub: { fontSize: 12, paddingHorizontal: 16, paddingTop: 10 },
+  slotRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 16,
+    marginTop: 10,
+  },
+  slot: {
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    minWidth: 64,
+  },
+  slotDisabled: { opacity: 0.45 },
+  slotLabel: { fontSize: 11, fontWeight: '700', letterSpacing: 0.8 },
+  slotPlayer: { fontSize: 11, maxWidth: 96 },
+  slotRemove: {
+    position: 'absolute',
+    top: -7,
+    right: -7,
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sortRow: { flexGrow: 0, marginTop: 10 },
+  sortRowContent: { paddingHorizontal: 16, gap: 6 },
+  sortChip: {
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  listContent: { padding: 16, gap: 10 },
+  card: { borderWidth: 1, borderRadius: 10, padding: 12 },
+  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' },
+  cardIdentity: { flexShrink: 1, paddingRight: 8 },
+  cardName: { fontSize: 15, fontWeight: '700' },
+  cardPos: { fontSize: 11, fontWeight: '700' },
+  cardTeam: { fontSize: 12, marginTop: 1 },
+  addBtn: { borderWidth: 1, borderRadius: 6, paddingVertical: 4, paddingHorizontal: 10 },
+  addBtnText: { fontSize: 12, fontWeight: '600' },
+  cardMatchup: { fontSize: 12, marginTop: 6 },
+  seasonRow: { flexDirection: 'row', marginTop: 5, alignItems: 'baseline' },
+  seasonTag: { fontSize: 11, fontWeight: '700', width: 70 },
+  seasonStats: { fontSize: 12, flexShrink: 1 },
+  status: { padding: 16 },
+});

--- a/src/UI/sd-mobile/app/admin/player-pickem.tsx
+++ b/src/UI/sd-mobile/app/admin/player-pickem.tsx
@@ -54,12 +54,21 @@ function sanitizeRoster(raw: string): Roster {
     }
     const next: Roster = {};
     for (const [slotId, val] of Object.entries(parsed)) {
+      const candidate = val as {
+        athleteId?: unknown;
+        firstName?: unknown;
+        lastName?: unknown;
+      };
       if (
         slotById(slotId) &&
         val !== null &&
         typeof val === 'object' &&
         !Array.isArray(val) &&
-        typeof (val as { athleteId?: unknown }).athleteId === 'string'
+        typeof candidate.athleteId === 'string' &&
+        // The slot chip renders firstName.charAt(0) + lastName — an entry
+        // missing either would crash on first paint.
+        typeof candidate.firstName === 'string' &&
+        typeof candidate.lastName === 'string'
       ) {
         next[slotId] = val as PickemAthlete;
       }

--- a/src/UI/sd-mobile/src/services/api/playerPickemApi.ts
+++ b/src/UI/sd-mobile/src/services/api/playerPickemApi.ts
@@ -1,0 +1,158 @@
+// Player Pick'em roster-builder data layer — TS mirror of sd-ui's
+// src/api/playerPickemApi.js (same contract, same mock Week 5 snapshot).
+//
+// MOCK-BACKED FOR NOW. When the Producer endpoint lands via the API
+// proxy, replace the mock with apiClient and delete MOCK_ATHLETES — the
+// screen consumes only this module.
+
+export type SeasonBlock = {
+  seasonYear: number;
+  gamesPlayed: number;
+  stats: Record<string, number>;
+};
+
+export type PickemAthlete = {
+  athleteId: string;
+  firstName: string;
+  lastName: string;
+  teamName: string;
+  teamSlug: string;
+  position: 'QB' | 'RB' | 'WR' | 'TE' | 'K';
+  opponentName: string | null;
+  opponentSlug: string | null;
+  // Opponent's relevant defensive allowance per game: pass yds allowed/G
+  // for QB/WR/TE, rush yds allowed/G for RB, points allowed/G for K.
+  opponentDefPerGame: number | null;
+  // null before the athlete's first game of the season (week 1 everywhere)
+  currentSeason: SeasonBlock | null;
+  previousSeason: SeasonBlock | null;
+};
+
+const MOCK_ATHLETES: Record<string, PickemAthlete[]> = {
+  QB: [
+    {
+      athleteId: 'ea6ec41d-31a1-623e-1a68-d21910f17bb8', firstName: 'Arch', lastName: 'Manning',
+      teamName: 'Texas Longhorns', teamSlug: 'texas-longhorns', position: 'QB',
+      opponentName: 'Oklahoma Sooners', opponentSlug: 'oklahoma-sooners', opponentDefPerGame: 158.9,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 68.6, passYds: 1247, passYdsPerGame: 311.8, passTd: 11, interceptions: 2, rushYds: 186 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { cmpPct: 61.2, passYds: 1785, passYdsPerGame: 148.8, passTd: 15, interceptions: 4, rushYds: 224 } },
+    },
+    {
+      athleteId: '4afaf7e4-f027-c0ea-a5a1-358f3730f057', firstName: 'Sam', lastName: 'Leavitt',
+      teamName: 'Arizona State Sun Devils', teamSlug: 'arizona-state-sun-devils', position: 'QB',
+      opponentName: 'Utah Utes', opponentSlug: 'utah-utes', opponentDefPerGame: 171.2,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 64.1, passYds: 1102, passYdsPerGame: 275.5, passTd: 9, interceptions: 3, rushYds: 147 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 61.7, passYds: 2885, passYdsPerGame: 221.9, passTd: 24, interceptions: 6, rushYds: 443 } },
+    },
+    {
+      athleteId: 'mock-qb-3', firstName: 'LaNorris', lastName: 'Sellers',
+      teamName: 'South Carolina Gamecocks', teamSlug: 'south-carolina-gamecocks', position: 'QB',
+      opponentName: 'Kentucky Wildcats', opponentSlug: 'kentucky-wildcats', opponentDefPerGame: 226.8,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { cmpPct: 66.9, passYds: 1310, passYdsPerGame: 262.0, passTd: 10, interceptions: 2, rushYds: 312 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 65.6, passYds: 2534, passYdsPerGame: 194.9, passTd: 18, interceptions: 7, rushYds: 674 } },
+    },
+    {
+      athleteId: 'mock-qb-4', firstName: 'Garrett', lastName: 'Nussmeier',
+      teamName: 'LSU Tigers', teamSlug: 'lsu-tigers', position: 'QB',
+      opponentName: 'Ole Miss Rebels', opponentSlug: 'ole-miss-rebels', opponentDefPerGame: 243.5,
+      // Hasn't played this season — exercises null-current rendering.
+      currentSeason: null,
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 64.2, passYds: 4052, passYdsPerGame: 311.7, passTd: 29, interceptions: 12, rushYds: 34 } },
+    },
+    {
+      athleteId: 'mock-qb-5', firstName: 'Cade', lastName: 'Klubnik',
+      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'QB',
+      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 65.8, passYds: 1042, passYdsPerGame: 260.5, passTd: 8, interceptions: 1, rushYds: 122 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { cmpPct: 63.4, passYds: 3639, passYdsPerGame: 259.9, passTd: 36, interceptions: 6, rushYds: 463 } },
+    },
+  ],
+  RB: [
+    {
+      athleteId: 'mock-rb-1', firstName: 'Jeremiyah', lastName: 'Love',
+      teamName: 'Notre Dame Fighting Irish', teamSlug: 'notre-dame-fighting-irish', position: 'RB',
+      opponentName: 'USC Trojans', opponentSlug: 'usc-trojans', opponentDefPerGame: 148.6,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { rushAtt: 71, rushYds: 512, rushYdsPerGame: 128.0, rushTd: 7, receptions: 11 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 163, rushYds: 1125, rushYdsPerGame: 86.5, rushTd: 17, receptions: 28 } },
+    },
+    {
+      athleteId: 'mock-rb-2', firstName: 'Nicholas', lastName: 'Singleton',
+      teamName: 'Penn State Nittany Lions', teamSlug: 'penn-state-nittany-lions', position: 'RB',
+      opponentName: 'UCLA Bruins', opponentSlug: 'ucla-bruins', opponentDefPerGame: 176.3,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 82, rushYds: 464, rushYdsPerGame: 92.8, rushTd: 6, receptions: 14 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { rushAtt: 172, rushYds: 1099, rushYdsPerGame: 68.7, rushTd: 12, receptions: 41 } },
+    },
+    {
+      athleteId: 'mock-rb-3', firstName: 'Makhi', lastName: 'Hughes',
+      teamName: 'Oregon Ducks', teamSlug: 'oregon-ducks', position: 'RB',
+      opponentName: 'Indiana Hoosiers', opponentSlug: 'indiana-hoosiers', opponentDefPerGame: 101.9,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 96, rushYds: 538, rushYdsPerGame: 107.6, rushTd: 5, receptions: 9 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 245, rushYds: 1401, rushYdsPerGame: 107.8, rushTd: 15, receptions: 24 } },
+    },
+  ],
+  WR: [
+    {
+      athleteId: 'mock-wr-1', firstName: 'Jeremiah', lastName: 'Smith',
+      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'WR',
+      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 34, recYds: 587, recYdsPerGame: 117.4, recTd: 7 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { receptions: 76, recYds: 1315, recYdsPerGame: 82.2, recTd: 15 } },
+    },
+    {
+      athleteId: 'mock-wr-2', firstName: 'Ryan', lastName: 'Williams',
+      teamName: 'Alabama Crimson Tide', teamSlug: 'alabama-crimson-tide', position: 'WR',
+      opponentName: 'Vanderbilt Commodores', opponentSlug: 'vanderbilt-commodores', opponentDefPerGame: 233.1,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 21, recYds: 356, recYdsPerGame: 89.0, recTd: 4 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 48, recYds: 865, recYdsPerGame: 66.5, recTd: 8 } },
+    },
+    {
+      athleteId: 'mock-wr-3', firstName: 'Antonio', lastName: 'Williams',
+      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'WR',
+      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 26, recYds: 401, recYdsPerGame: 100.3, recTd: 3 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 75, recYds: 904, recYdsPerGame: 69.5, recTd: 11 } },
+    },
+  ],
+  TE: [
+    {
+      athleteId: 'mock-te-1', firstName: 'Max', lastName: 'Klare',
+      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'TE',
+      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 22, recYds: 264, recYdsPerGame: 52.8, recTd: 3 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { receptions: 51, recYds: 685, recYdsPerGame: 57.1, recTd: 4 } },
+    },
+    {
+      athleteId: 'mock-te-2', firstName: 'Eli', lastName: 'Stowers',
+      teamName: 'Vanderbilt Commodores', teamSlug: 'vanderbilt-commodores', position: 'TE',
+      opponentName: 'Alabama Crimson Tide', opponentSlug: 'alabama-crimson-tide', opponentDefPerGame: 187.4,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 25, recYds: 301, recYdsPerGame: 60.2, recTd: 4 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 49, recYds: 638, recYdsPerGame: 49.1, recTd: 5 } },
+    },
+  ],
+  K: [
+    {
+      athleteId: 'mock-k-1', firstName: 'Dominic', lastName: 'Zvada',
+      teamName: 'Michigan Wolverines', teamSlug: 'michigan-wolverines', position: 'K',
+      opponentName: 'Washington Huskies', opponentSlug: 'washington-huskies', opponentDefPerGame: 22.6,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 9, fgAtt: 10, fgPct: 90.0, fgLong: 56, xpMade: 14, xpAtt: 14 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { fgMade: 21, fgAtt: 22, fgPct: 95.5, fgLong: 56, xpMade: 38, xpAtt: 38 } },
+    },
+    {
+      athleteId: 'mock-k-2', firstName: 'Peyton', lastName: 'Woodring',
+      teamName: 'Georgia Bulldogs', teamSlug: 'georgia-bulldogs', position: 'K',
+      opponentName: 'Auburn Tigers', opponentSlug: 'auburn-tigers', opponentDefPerGame: 19.8,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 8, fgAtt: 9, fgPct: 88.9, fgLong: 52, xpMade: 17, xpAtt: 17 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { fgMade: 19, fgAtt: 23, fgPct: 82.6, fgLong: 49, xpMade: 46, xpAtt: 46 } },
+    },
+  ],
+};
+
+function respond(rows: PickemAthlete[]): Promise<{ athletes: PickemAthlete[] }> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve({ athletes: rows }), 250);
+  });
+}
+
+export function getAthletesByPosition(position: string) {
+  return respond(MOCK_ATHLETES[position] ?? []);
+}

--- a/src/UI/sd-mobile/src/utils/pickem/athleteStats.ts
+++ b/src/UI/sd-mobile/src/utils/pickem/athleteStats.ts
@@ -1,0 +1,165 @@
+// Stat-line building + sorting for the mobile roster builder.
+//
+// Mobile renders each athlete as a CARD with two aligned season lines
+// ('26 over '25) instead of the web's mirrored table columns, but the
+// underlying stat sets and the sort semantics mirror sd-ui's
+// gridColumns.js / athleteSort.js — keep them in lockstep.
+
+import type { PickemAthlete, SeasonBlock } from '@/src/services/api/playerPickemApi';
+
+type StatPart = {
+  key: string;
+  label: string;
+  value: (s: SeasonBlock | null, row: PickemAthlete) => number | null;
+  fmt: (v: number) => string;
+  // Whole-season formatter (e.g. "9/10" for FG) wins over fmt(value).
+  fmtSeason?: (s: SeasonBlock | null) => string | null;
+};
+
+const int = (v: number) => Math.round(v).toLocaleString();
+const oneDp = (v: number) => v.toFixed(1);
+
+function stat(s: SeasonBlock | null, key: string): number | null {
+  return s?.stats?.[key] ?? null;
+}
+
+const PER_GAME_KEY: Record<string, string> = {
+  QB: 'passYdsPerGame',
+  RB: 'rushYdsPerGame',
+  WR: 'recYdsPerGame',
+  TE: 'recYdsPerGame',
+};
+
+const TD_KEY: Record<string, string> = {
+  QB: 'passTd',
+  RB: 'rushTd',
+  WR: 'recTd',
+  TE: 'recTd',
+};
+
+export const STAT_PARTS: Record<string, StatPart[]> = {
+  QB: [
+    { key: 'cmpPct', label: 'CMP%', value: (s) => stat(s, 'cmpPct'), fmt: oneDp },
+    { key: 'passYds', label: 'YDS', value: (s) => stat(s, 'passYds'), fmt: int },
+    { key: 'passYdsPerGame', label: 'Y/G', value: (s) => stat(s, 'passYdsPerGame'), fmt: oneDp },
+    { key: 'passTd', label: 'TD', value: (s) => stat(s, 'passTd'), fmt: int },
+    { key: 'interceptions', label: 'INT', value: (s) => stat(s, 'interceptions'), fmt: int },
+    { key: 'rushYds', label: 'RUSH', value: (s) => stat(s, 'rushYds'), fmt: int },
+  ],
+  RB: [
+    { key: 'rushAtt', label: 'ATT', value: (s) => stat(s, 'rushAtt'), fmt: int },
+    { key: 'rushYds', label: 'YDS', value: (s) => stat(s, 'rushYds'), fmt: int },
+    { key: 'rushYdsPerGame', label: 'Y/G', value: (s) => stat(s, 'rushYdsPerGame'), fmt: oneDp },
+    { key: 'rushTd', label: 'TD', value: (s) => stat(s, 'rushTd'), fmt: int },
+    { key: 'receptions', label: 'REC', value: (s) => stat(s, 'receptions'), fmt: int },
+  ],
+  WR: [
+    { key: 'receptions', label: 'REC', value: (s) => stat(s, 'receptions'), fmt: int },
+    { key: 'recYds', label: 'YDS', value: (s) => stat(s, 'recYds'), fmt: int },
+    { key: 'recYdsPerGame', label: 'Y/G', value: (s) => stat(s, 'recYdsPerGame'), fmt: oneDp },
+    { key: 'recTd', label: 'TD', value: (s) => stat(s, 'recTd'), fmt: int },
+  ],
+  K: [
+    {
+      key: 'fg', label: 'FG', value: (s) => stat(s, 'fgMade'), fmt: int,
+      fmtSeason: (s) => (s?.stats ? `${s.stats.fgMade}/${s.stats.fgAtt}` : null),
+    },
+    { key: 'fgPct', label: 'PCT', value: (s) => stat(s, 'fgPct'), fmt: oneDp },
+    { key: 'fgLong', label: 'LNG', value: (s) => stat(s, 'fgLong'), fmt: int },
+    {
+      key: 'xp', label: 'XP', value: (s) => stat(s, 'xpMade'), fmt: int,
+      fmtSeason: (s) => (s?.stats ? `${s.stats.xpMade}/${s.stats.xpAtt}` : null),
+    },
+  ],
+  FLEX: [
+    {
+      key: 'flexYdsPerGame', label: 'Y/G',
+      value: (s, row) => stat(s, PER_GAME_KEY[row.position]), fmt: oneDp,
+    },
+    {
+      key: 'flexTd', label: 'TD',
+      value: (s, row) => stat(s, TD_KEY[row.position]), fmt: int,
+    },
+  ],
+};
+
+STAT_PARTS.TE = STAT_PARTS.WR;
+
+export function statPartsFor(slotId: string, positions: string[]): StatPart[] {
+  return STAT_PARTS[slotId === 'FLEX' ? 'FLEX' : positions[0]] ?? [];
+}
+
+/** One season's compact card line: "68.6 CMP% · 1,247 YDS · 11 TD". */
+export function seasonLine(
+  parts: StatPart[],
+  season: SeasonBlock | null,
+  row: PickemAthlete
+): string {
+  return parts
+    .map((p) => {
+      if (p.fmtSeason) {
+        const s = p.fmtSeason(season);
+        return s == null ? `— ${p.label}` : `${s} ${p.label}`;
+      }
+      const v = p.value(season, row);
+      return v == null ? `— ${p.label}` : `${p.fmt(v)} ${p.label}`;
+    })
+    .join(' · ');
+}
+
+export type SortDescriptor = { key: string; dir?: 'desc' | 'asc' };
+
+export const NAME_SORT: SortDescriptor = { key: 'name' };
+
+function byName(a: PickemAthlete, b: PickemAthlete) {
+  return (
+    a.lastName.localeCompare(b.lastName) ||
+    a.firstName.localeCompare(b.firstName)
+  );
+}
+
+/**
+ * Sort semantics mirror sd-ui's athleteSort.js: order by current-season
+ * values; when EVERY row's current value is null (week 1) fall back to
+ * previous season automatically; nulls sink in both directions; ties
+ * break by name. 'oppDef' sorts the row-level opponent number.
+ */
+export function sortAthletes(
+  rows: PickemAthlete[],
+  sort: SortDescriptor,
+  parts: StatPart[]
+): PickemAthlete[] {
+  const next = [...rows];
+
+  if (sort.key === 'name') {
+    next.sort(byName);
+    return next;
+  }
+
+  let basisOf: (row: PickemAthlete) => number | null;
+  if (sort.key === 'oppDef') {
+    basisOf = (row) => row.opponentDefPerGame;
+  } else {
+    const part = parts.find((p) => p.key === sort.key);
+    if (!part) {
+      next.sort(byName);
+      return next;
+    }
+    const currentOf = (row: PickemAthlete) => part.value(row.currentSeason, row);
+    const useFallback = next.every((row) => currentOf(row) == null);
+    basisOf = useFallback
+      ? (row) => part.value(row.previousSeason, row)
+      : currentOf;
+  }
+
+  const dir = sort.dir === 'asc' ? 1 : -1;
+  next.sort((a, b) => {
+    const av = basisOf(a);
+    const bv = basisOf(b);
+    if (av == null && bv == null) return byName(a, b);
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    return av === bv ? byName(a, b) : (av - bv) * dir;
+  });
+  return next;
+}

--- a/src/UI/sd-mobile/src/utils/pickem/rosterLogic.ts
+++ b/src/UI/sd-mobile/src/utils/pickem/rosterLogic.ts
@@ -1,0 +1,81 @@
+// Pure lineup-slot rules for the Player Pick'em roster builder — TS port
+// of sd-ui's src/components/pickem/players/rosterLogic.js. Keep the two
+// in lockstep; the rules move server-side unchanged when PlayerLineup
+// entities arrive.
+
+import type { PickemAthlete } from '@/src/services/api/playerPickemApi';
+
+export type SlotDef = {
+  id: string;
+  label: string;
+  eligible: string[];
+  disabled?: boolean;
+};
+
+export type Roster = Record<string, PickemAthlete | undefined>;
+
+// v1 fixed shape per docs/features/player-pickem/player-pickem.md open
+// question #1. DEF is a team pick, not an athlete pick — present but
+// disabled until the team-defense picker exists.
+export const SLOT_DEFS: SlotDef[] = [
+  { id: 'QB', label: 'QB', eligible: ['QB'] },
+  { id: 'RB1', label: 'RB', eligible: ['RB'] },
+  { id: 'RB2', label: 'RB', eligible: ['RB'] },
+  { id: 'WR1', label: 'WR', eligible: ['WR'] },
+  { id: 'WR2', label: 'WR', eligible: ['WR'] },
+  { id: 'TE', label: 'TE', eligible: ['TE'] },
+  { id: 'FLEX', label: 'FLEX', eligible: ['RB', 'WR', 'TE'] },
+  { id: 'K', label: 'K', eligible: ['K'] },
+  { id: 'DEF', label: 'DEF', eligible: [], disabled: true },
+];
+
+export function slotById(slotId: string): SlotDef | null {
+  return SLOT_DEFS.find((s) => s.id === slotId) ?? null;
+}
+
+export function eligiblePositions(slotId: string): string[] {
+  return slotById(slotId)?.eligible ?? [];
+}
+
+/**
+ * An athlete may fill a slot iff the slot exists and is enabled, the
+ * athlete's position is eligible for it, and the athlete isn't already
+ * rostered in ANOTHER slot (re-assigning into the same slot is fine —
+ * that's a no-op replace).
+ */
+export function canAssign(
+  roster: Roster,
+  slotId: string,
+  athlete: PickemAthlete
+): boolean {
+  const slot = slotById(slotId);
+  if (!slot || slot.disabled) return false;
+  if (!slot.eligible.includes(athlete.position)) return false;
+
+  return !Object.entries(roster).some(
+    ([id, rostered]) =>
+      id !== slotId && rostered?.athleteId === athlete.athleteId
+  );
+}
+
+/** Returns a new roster with the athlete in the slot (or the same roster
+ *  object if the assignment is illegal — callers can reference-compare). */
+export function assign(
+  roster: Roster,
+  slotId: string,
+  athlete: PickemAthlete
+): Roster {
+  if (!canAssign(roster, slotId, athlete)) return roster;
+  return { ...roster, [slotId]: athlete };
+}
+
+export function remove(roster: Roster, slotId: string): Roster {
+  if (!(slotId in roster)) return roster;
+  const next = { ...roster };
+  delete next[slotId];
+  return next;
+}
+
+export function isRostered(roster: Roster, athleteId: string): boolean {
+  return Object.values(roster).some((a) => a?.athleteId === athleteId);
+}

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -17,6 +17,7 @@ import HomePage from "./components/home/HomePage.jsx";
 import WarRoomPage from "./components/warRoom/WarRoomPage.jsx";
 import SettingsPage from "./components/settings/SettingsPage.jsx";
 import GameMap from "./components/map/GameMap.jsx";
+import PlayerRosterBuilder from "./components/pickem/players/PlayerRosterBuilder";
 import WelcomeDialog from "./components/welcome/WelcomeDialog";
 import TeamCard from "./components/teams/TeamCard";
 import AthleteCard from "./components/athletes/AthleteCard";
@@ -180,6 +181,16 @@ function MainApp() {
               element={
                 <AdminRoute>
                   <GameMap />
+                </AdminRoute>
+              }
+            />
+            {/* Player Pick'em roster builder — admin-only v1 exploration;
+                users see only the home-page teaser until launch. */}
+            <Route
+              path="/pickem/players"
+              element={
+                <AdminRoute>
+                  <PlayerRosterBuilder />
                 </AdminRoute>
               }
             />

--- a/src/UI/sd-ui/src/api/playerPickemApi.js
+++ b/src/UI/sd-ui/src/api/playerPickemApi.js
@@ -1,0 +1,173 @@
+// src/api/playerPickemApi.js
+//
+// Player Pick'em roster-builder data layer.
+//
+// MOCK-BACKED FOR NOW. The response shape below is the contract the real
+// Producer query (athletes-by-position with opponent + opponent-defense
+// join) will serve via the API proxy. When that endpoint lands, delete
+// MOCK_ATHLETES and the fake-latency wrapper and switch getAthletesByPosition
+// to apiClient.get(`/api/${sport}/${league}/pickem/athletes?position=${pos}`)
+// — the page consumes only this module, so nothing else changes.
+//
+// Row contract (one per athlete):
+//   athleteId            Guid
+//   firstName, lastName  identity (grid default-sorts by lastName)
+//   teamName             franchise display name (text only — no marks/logos)
+//   teamSlug             for linking to the team card
+//   position             "QB" | "RB" | "WR" | "TE" | "K"
+//   opponentName         this week's opponent (null on bye)
+//   opponentSlug         opponent team-card link (null on bye)
+//   opponentDefPerGame   opponent's relevant defensive allowance per game:
+//                        pass yds allowed/G for QB/WR/TE, rush yds
+//                        allowed/G for RB, points allowed/G for K.
+//                        Prior-season values until current-season games
+//                        exist.
+//   currentSeason        season block or null (null before the athlete's
+//                        first game of the season — week 1 everywhere)
+//   previousSeason       season block or null (true freshmen)
+//
+// Season block: { seasonYear, gamesPlayed, stats } where stats carries the
+// position-relevant keys (see gridColumns.js). Both seasons use the SAME
+// shape so the grid renders prior season directly beneath current season
+// in the same columns.
+//
+// The mock below is a plausible WEEK 5 snapshot so the with-data design
+// is visible; Nussmeier carries currentSeason: null to exercise the
+// hasn't-played rendering (em-dashes, sinks under stat sorts).
+
+const MOCK_ATHLETES = {
+  QB: [
+    {
+      athleteId: 'ea6ec41d-31a1-623e-1a68-d21910f17bb8', firstName: 'Arch', lastName: 'Manning',
+      teamName: 'Texas Longhorns', teamSlug: 'texas-longhorns', position: 'QB',
+      opponentName: 'Oklahoma Sooners', opponentSlug: 'oklahoma-sooners', opponentDefPerGame: 158.9,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 68.6, passYds: 1247, passYdsPerGame: 311.8, passTd: 11, interceptions: 2, rushYds: 186 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { cmpPct: 61.2, passYds: 1785, passYdsPerGame: 148.8, passTd: 15, interceptions: 4, rushYds: 224 } },
+    },
+    {
+      athleteId: '4afaf7e4-f027-c0ea-a5a1-358f3730f057', firstName: 'Sam', lastName: 'Leavitt',
+      teamName: 'Arizona State Sun Devils', teamSlug: 'arizona-state-sun-devils', position: 'QB',
+      opponentName: 'Utah Utes', opponentSlug: 'utah-utes', opponentDefPerGame: 171.2,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 64.1, passYds: 1102, passYdsPerGame: 275.5, passTd: 9, interceptions: 3, rushYds: 147 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 61.7, passYds: 2885, passYdsPerGame: 221.9, passTd: 24, interceptions: 6, rushYds: 443 } },
+    },
+    {
+      athleteId: 'mock-qb-3', firstName: 'LaNorris', lastName: 'Sellers',
+      teamName: 'South Carolina Gamecocks', teamSlug: 'south-carolina-gamecocks', position: 'QB',
+      opponentName: 'Kentucky Wildcats', opponentSlug: 'kentucky-wildcats', opponentDefPerGame: 226.8,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { cmpPct: 66.9, passYds: 1310, passYdsPerGame: 262.0, passTd: 10, interceptions: 2, rushYds: 312 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 65.6, passYds: 2534, passYdsPerGame: 194.9, passTd: 18, interceptions: 7, rushYds: 674 } },
+    },
+    {
+      athleteId: 'mock-qb-4', firstName: 'Garrett', lastName: 'Nussmeier',
+      teamName: 'LSU Tigers', teamSlug: 'lsu-tigers', position: 'QB',
+      opponentName: 'Ole Miss Rebels', opponentSlug: 'ole-miss-rebels', opponentDefPerGame: 243.5,
+      // Hasn't played this season (injury) — exercises the null-current
+      // rendering and stat-sort sinking.
+      currentSeason: null,
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 64.2, passYds: 4052, passYdsPerGame: 311.7, passTd: 29, interceptions: 12, rushYds: 34 } },
+    },
+    {
+      athleteId: 'mock-qb-5', firstName: 'Cade', lastName: 'Klubnik',
+      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'QB',
+      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 65.8, passYds: 1042, passYdsPerGame: 260.5, passTd: 8, interceptions: 1, rushYds: 122 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { cmpPct: 63.4, passYds: 3639, passYdsPerGame: 259.9, passTd: 36, interceptions: 6, rushYds: 463 } },
+    },
+  ],
+  RB: [
+    {
+      athleteId: 'mock-rb-1', firstName: 'Jeremiyah', lastName: 'Love',
+      teamName: 'Notre Dame Fighting Irish', teamSlug: 'notre-dame-fighting-irish', position: 'RB',
+      opponentName: 'USC Trojans', opponentSlug: 'usc-trojans', opponentDefPerGame: 148.6,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { rushAtt: 71, rushYds: 512, rushYdsPerGame: 128.0, rushTd: 7, receptions: 11 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 163, rushYds: 1125, rushYdsPerGame: 86.5, rushTd: 17, receptions: 28 } },
+    },
+    {
+      athleteId: 'mock-rb-2', firstName: 'Nicholas', lastName: 'Singleton',
+      teamName: 'Penn State Nittany Lions', teamSlug: 'penn-state-nittany-lions', position: 'RB',
+      opponentName: 'UCLA Bruins', opponentSlug: 'ucla-bruins', opponentDefPerGame: 176.3,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 82, rushYds: 464, rushYdsPerGame: 92.8, rushTd: 6, receptions: 14 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { rushAtt: 172, rushYds: 1099, rushYdsPerGame: 68.7, rushTd: 12, receptions: 41 } },
+    },
+    {
+      athleteId: 'mock-rb-3', firstName: 'Makhi', lastName: 'Hughes',
+      teamName: 'Oregon Ducks', teamSlug: 'oregon-ducks', position: 'RB',
+      opponentName: 'Indiana Hoosiers', opponentSlug: 'indiana-hoosiers', opponentDefPerGame: 101.9,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 96, rushYds: 538, rushYdsPerGame: 107.6, rushTd: 5, receptions: 9 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 245, rushYds: 1401, rushYdsPerGame: 107.8, rushTd: 15, receptions: 24 } },
+    },
+  ],
+  WR: [
+    {
+      athleteId: 'mock-wr-1', firstName: 'Jeremiah', lastName: 'Smith',
+      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'WR',
+      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 34, recYds: 587, recYdsPerGame: 117.4, recTd: 7 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { receptions: 76, recYds: 1315, recYdsPerGame: 82.2, recTd: 15 } },
+    },
+    {
+      athleteId: 'mock-wr-2', firstName: 'Ryan', lastName: 'Williams',
+      teamName: 'Alabama Crimson Tide', teamSlug: 'alabama-crimson-tide', position: 'WR',
+      opponentName: 'Vanderbilt Commodores', opponentSlug: 'vanderbilt-commodores', opponentDefPerGame: 233.1,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 21, recYds: 356, recYdsPerGame: 89.0, recTd: 4 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 48, recYds: 865, recYdsPerGame: 66.5, recTd: 8 } },
+    },
+    {
+      athleteId: 'mock-wr-3', firstName: 'Antonio', lastName: 'Williams',
+      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'WR',
+      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye with Clemson
+      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 26, recYds: 401, recYdsPerGame: 100.3, recTd: 3 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 75, recYds: 904, recYdsPerGame: 69.5, recTd: 11 } },
+    },
+  ],
+  TE: [
+    {
+      athleteId: 'mock-te-1', firstName: 'Max', lastName: 'Klare',
+      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'TE',
+      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 22, recYds: 264, recYdsPerGame: 52.8, recTd: 3 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { receptions: 51, recYds: 685, recYdsPerGame: 57.1, recTd: 4 } },
+    },
+    {
+      athleteId: 'mock-te-2', firstName: 'Eli', lastName: 'Stowers',
+      teamName: 'Vanderbilt Commodores', teamSlug: 'vanderbilt-commodores', position: 'TE',
+      opponentName: 'Alabama Crimson Tide', opponentSlug: 'alabama-crimson-tide', opponentDefPerGame: 187.4,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 25, recYds: 301, recYdsPerGame: 60.2, recTd: 4 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 49, recYds: 638, recYdsPerGame: 49.1, recTd: 5 } },
+    },
+  ],
+  K: [
+    {
+      athleteId: 'mock-k-1', firstName: 'Dominic', lastName: 'Zvada',
+      teamName: 'Michigan Wolverines', teamSlug: 'michigan-wolverines', position: 'K',
+      opponentName: 'Washington Huskies', opponentSlug: 'washington-huskies', opponentDefPerGame: 22.6,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 9, fgAtt: 10, fgPct: 90.0, fgLong: 56, xpMade: 14, xpAtt: 14 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { fgMade: 21, fgAtt: 22, fgPct: 95.5, fgLong: 56, xpMade: 38, xpAtt: 38 } },
+    },
+    {
+      athleteId: 'mock-k-2', firstName: 'Peyton', lastName: 'Woodring',
+      teamName: 'Georgia Bulldogs', teamSlug: 'georgia-bulldogs', position: 'K',
+      opponentName: 'Auburn Tigers', opponentSlug: 'auburn-tigers', opponentDefPerGame: 19.8,
+      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 8, fgAtt: 9, fgPct: 88.9, fgLong: 52, xpMade: 17, xpAtt: 17 } },
+      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { fgMade: 19, fgAtt: 23, fgPct: 82.6, fgLong: 49, xpMade: 46, xpAtt: 46 } },
+    },
+  ],
+};
+
+// Small fake latency so loading states are exercised the way the real
+// endpoint will exercise them.
+function respond(rows) {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve({ data: { athletes: rows } }), 250);
+  });
+}
+
+const PlayerPickemApi = {
+  // position: "QB" | "RB" | "WR" | "TE" | "K". FLEX is a UI concept —
+  // the page requests each eligible position and merges.
+  getAthletesByPosition: (sport, league, position) =>
+    respond(MOCK_ATHLETES[position] ?? []),
+};
+
+export default PlayerPickemApi;

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
@@ -1,0 +1,247 @@
+/* PlayerRosterBuilder — admin-gated v1 roster exploration. Slot row
+   borrows the teaser's visual language (dashed empty / accent filled);
+   the grid is a plain data table with a muted previous-season sub-row. */
+
+.roster-builder {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 1rem 1.25rem 2rem;
+  color: var(--text-primary);
+}
+
+.roster-builder-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 800;
+}
+
+.roster-builder-sub {
+  color: var(--text-muted, #8d96a0);
+  font-size: 0.85rem;
+  margin: 4px 0 16px;
+}
+
+/* ── Slot row ─────────────────────────────────────────────────────── */
+
+.roster-slots {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.roster-slot {
+  position: relative;
+}
+
+.roster-slot-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 72px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px dashed
+    color-mix(in srgb, var(--text-muted, #8d96a0) 55%, transparent);
+  background: none;
+  color: var(--text-muted, #8d96a0);
+  cursor: pointer;
+  font: inherit;
+}
+
+.roster-slot-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.roster-slot-player {
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.roster-slot--filled .roster-slot-btn {
+  border-style: solid;
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.roster-slot--active .roster-slot-btn {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  color: var(--text-primary);
+}
+
+.roster-slot--disabled .roster-slot-btn {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.roster-slot-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--accent-subtle);
+  background: var(--bg-card);
+  color: var(--text-muted, #8d96a0);
+  font-size: 0.7rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.roster-slot-remove:hover,
+.roster-slot-remove:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+/* ── Athlete grid ─────────────────────────────────────────────────── */
+
+/* Wide table scrolls inside its own container on narrow viewports —
+   desktop-first, phone degrades gracefully. */
+.roster-grid-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--accent-subtle);
+  border-radius: 10px;
+  background: var(--bg-card);
+}
+
+.roster-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+
+.roster-grid th {
+  text-align: left;
+  padding: 10px 12px;
+  color: var(--text-muted, #8d96a0);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--accent-subtle);
+}
+
+.roster-grid td {
+  padding: 8px 12px;
+}
+
+/* Sortable header cells host a button so keyboard users get them for
+   free; the button restyles to look like the plain header text. */
+.roster-grid-sort {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+}
+
+.roster-grid-sort:hover,
+.roster-grid-sort:focus-visible {
+  color: var(--accent);
+}
+
+/* Team links inherit the browser's default anchor blue otherwise —
+   illegible on the dark background. */
+.roster-grid a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.roster-grid a:hover,
+.roster-grid a:focus-visible {
+  text-decoration: underline;
+}
+
+.roster-grid-num {
+  text-align: right;
+}
+
+.roster-grid-row td {
+  border-top: 1px solid
+    color-mix(in srgb, var(--text-muted, #8d96a0) 18%, transparent);
+}
+
+.roster-grid-row:first-child td {
+  border-top: none;
+}
+
+.roster-grid-player {
+  white-space: nowrap;
+}
+
+/* Team folded under the name — buys column width for the stat cells. */
+.roster-grid-name {
+  display: block;
+  font-weight: 600;
+}
+
+.roster-grid-team {
+  display: block;
+  font-size: 0.75rem;
+  margin-top: 1px;
+}
+
+.roster-grid-pos {
+  margin-left: 6px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-muted, #8d96a0);
+  border: 1px solid var(--accent-subtle);
+  border-radius: 4px;
+  padding: 1px 4px;
+  vertical-align: 1px;
+}
+
+/* Previous-season line rides directly under its primary row. */
+.roster-grid-subrow td {
+  padding-top: 0;
+  padding-bottom: 10px;
+  color: var(--text-muted, #8d96a0);
+  font-size: 0.78rem;
+}
+
+.roster-grid-action {
+  text-align: right;
+}
+
+.roster-grid-add {
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  background: none;
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.roster-grid-add:hover:not(:disabled),
+.roster-grid-add:focus-visible:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.roster-grid-add:disabled {
+  border-color: var(--accent-subtle);
+  color: var(--text-muted, #8d96a0);
+  cursor: default;
+}
+
+.roster-grid-status {
+  padding: 18px 12px;
+  color: var(--text-muted, #8d96a0);
+}
+
+.roster-grid-status--error {
+  color: var(--error, #e05d5d);
+}

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import PlayerPickemApi from '../../../api/playerPickemApi';
 import {
   SLOT_DEFS,
+  slotById,
   eligiblePositions,
   assign,
   remove,
@@ -34,6 +35,37 @@ const OPP_DEF_LABEL = {
 const OPP_DEF_SORT_KEY = 'oppDef';
 
 /**
+ * A stored draft is untrusted input: JSON.parse happily returns null,
+ * arrays, or strings (all valid JSON). Accept only a plain object whose
+ * keys are real slot ids and whose values look like athletes; anything
+ * else degrades to the slot-by-slot best effort or an empty roster.
+ * Mirrors the mobile screen's sanitizer.
+ */
+function sanitizeRoster(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return {};
+    }
+    const next = {};
+    for (const [slotId, val] of Object.entries(parsed)) {
+      if (
+        slotById(slotId) &&
+        val !== null &&
+        typeof val === 'object' &&
+        !Array.isArray(val) &&
+        typeof val.athleteId === 'string'
+      ) {
+        next[slotId] = val;
+      }
+    }
+    return next;
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Player Pick'em roster builder (admin-gated, v1 exploration).
  *
  * Teaser-style slot row up top (fixed v1 shape, DEF disabled); selecting
@@ -46,13 +78,9 @@ const OPP_DEF_SORT_KEY = 'oppDef';
  * mock-backed in playerPickemApi until the Producer endpoint lands.
  */
 function PlayerRosterBuilder() {
-  const [roster, setRoster] = useState(() => {
-    try {
-      return JSON.parse(localStorage.getItem(ROSTER_KEY)) ?? {};
-    } catch {
-      return {};
-    }
-  });
+  const [roster, setRoster] = useState(() =>
+    sanitizeRoster(localStorage.getItem(ROSTER_KEY) ?? 'null')
+  );
   const [activeSlotId, setActiveSlotId] = useState('QB');
   const [athletes, setAthletes] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -163,7 +191,10 @@ function PlayerRosterBuilder() {
         selections are local-only, mock data
       </p>
 
-      <div className="roster-slots" role="tablist" aria-label="Lineup slots">
+      {/* Button group, not tabs: there's no tabpanel relationship here and
+          the remove buttons live between the slot controls, so tablist
+          semantics would promise keyboard behavior this doesn't have. */}
+      <div className="roster-slots" role="group" aria-label="Lineup slots">
         {SLOT_DEFS.map((slot) => {
           const filled = roster[slot.id];
           const isActive = slot.id === activeSlotId;
@@ -181,8 +212,7 @@ function PlayerRosterBuilder() {
             >
               <button
                 type="button"
-                role="tab"
-                aria-selected={isActive}
+                aria-pressed={isActive}
                 className="roster-slot-btn"
                 disabled={slot.disabled}
                 title={slot.disabled ? 'Team defense — coming soon' : undefined}
@@ -249,19 +279,28 @@ function PlayerRosterBuilder() {
                   </th>
                 ))}
                 <th>Opponent</th>
-                <th
-                  className="roster-grid-num"
-                  aria-sort={ariaSort(OPP_DEF_SORT_KEY)}
-                >
-                  <button
-                    type="button"
-                    className="roster-grid-sort"
-                    onClick={() => toggleSort(OPP_DEF_SORT_KEY)}
+                {/* No opponent-defense SORT on FLEX: the value is rush yds
+                    allowed/G for an RB but pass yds allowed/G for a WR/TE —
+                    different units, a cross-position ranking would lie. The
+                    column still displays; the per-row position badge carries
+                    each number's meaning. */}
+                {activeSlot?.id === 'FLEX' ? (
+                  <th className="roster-grid-num">{oppDefLabel}</th>
+                ) : (
+                  <th
+                    className="roster-grid-num"
+                    aria-sort={ariaSort(OPP_DEF_SORT_KEY)}
                   >
-                    {oppDefLabel}
-                    {sortIndicator(OPP_DEF_SORT_KEY)}
-                  </button>
-                </th>
+                    <button
+                      type="button"
+                      className="roster-grid-sort"
+                      onClick={() => toggleSort(OPP_DEF_SORT_KEY)}
+                    >
+                      {oppDefLabel}
+                      {sortIndicator(OPP_DEF_SORT_KEY)}
+                    </button>
+                  </th>
+                )}
                 <th aria-label="Actions" />
               </tr>
             </thead>

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -54,7 +54,11 @@ function sanitizeRoster(raw) {
         val !== null &&
         typeof val === 'object' &&
         !Array.isArray(val) &&
-        typeof val.athleteId === 'string'
+        typeof val.athleteId === 'string' &&
+        // The slot chip renders firstName.charAt(0) + lastName — an entry
+        // missing either would crash on first paint.
+        typeof val.firstName === 'string' &&
+        typeof val.lastName === 'string'
       ) {
         next[slotId] = val;
       }

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -1,0 +1,358 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import PlayerPickemApi from '../../../api/playerPickemApi';
+import {
+  SLOT_DEFS,
+  eligiblePositions,
+  assign,
+  remove,
+  isRostered,
+} from './rosterLogic';
+import { NAME_SORT, sortAthletes } from './athleteSort';
+import { columnsFor, cellText } from './gridColumns';
+import './PlayerRosterBuilder.css';
+
+// Selections survive reloads — rudimentary stand-in for the carry-over
+// behavior until PlayerLineup entities exist server-side.
+const ROSTER_KEY = 'playerPickemRosterDraft';
+
+// Meaning of opponentDefPerGame varies by the position being browsed.
+// FLEX merges positions, so it gets the generic label and the per-row
+// position badge carries the meaning.
+const OPP_DEF_LABEL = {
+  QB: 'Opp Pass Alw/G',
+  RB: 'Opp Rush Alw/G',
+  WR: 'Opp Pass Alw/G',
+  TE: 'Opp Pass Alw/G',
+  K: 'Opp Pts Alw/G',
+  FLEX: 'Opp Def/G',
+};
+
+// Sort key for the opponent-defense column — a row-level number, not a
+// season stat, so its getValue ignores the season block (the current/
+// previous fallback in sortAthletes never distinguishes for it).
+const OPP_DEF_SORT_KEY = 'oppDef';
+
+/**
+ * Player Pick'em roster builder (admin-gated, v1 exploration).
+ *
+ * Teaser-style slot row up top (fixed v1 shape, DEF disabled); selecting
+ * a slot loads the athlete grid below filtered to that slot's eligible
+ * positions. Each athlete renders as a row PAIR in shared stat columns:
+ * current season on the primary row, previous season directly beneath in
+ * the same columns for vertical comparison. Sorting orders the pairs by
+ * the current-season value, falling back to previous-season when no row
+ * has current data (week 1). Roster is local-only (localStorage); data is
+ * mock-backed in playerPickemApi until the Producer endpoint lands.
+ */
+function PlayerRosterBuilder() {
+  const [roster, setRoster] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem(ROSTER_KEY)) ?? {};
+    } catch {
+      return {};
+    }
+  });
+  const [activeSlotId, setActiveSlotId] = useState('QB');
+  const [athletes, setAthletes] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [sort, setSort] = useState(NAME_SORT);
+
+  useEffect(() => {
+    localStorage.setItem(ROSTER_KEY, JSON.stringify(roster));
+  }, [roster]);
+
+  const positions = useMemo(
+    () => eligiblePositions(activeSlotId),
+    [activeSlotId]
+  );
+
+  const columns = useMemo(
+    () => columnsFor(activeSlotId, positions),
+    [activeSlotId, positions]
+  );
+
+  // Stat columns differ per slot — a sort on CMP% means nothing on the
+  // RB grid, so slot changes reset to the name sort.
+  useEffect(() => {
+    setSort(NAME_SORT);
+  }, [activeSlotId]);
+
+  useEffect(() => {
+    if (positions.length === 0) return undefined;
+
+    let ignore = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all(
+      positions.map((pos) =>
+        PlayerPickemApi.getAthletesByPosition('football', 'ncaa', pos)
+      )
+    )
+      .then((responses) => {
+        if (ignore) return;
+        // Raw rows only — display order is derived from the sort state so
+        // toggling a header doesn't refetch.
+        setAthletes(responses.flatMap((r) => r.data.athletes));
+      })
+      .catch(() => {
+        if (!ignore) setError('Could not load athletes.');
+      })
+      .finally(() => {
+        if (!ignore) setLoading(false);
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [positions]);
+
+  const activeCol = columns.find((c) => c.key === sort.key);
+  const getSortValue = useMemo(() => {
+    if (sort.key === OPP_DEF_SORT_KEY) {
+      return (row) => row.opponentDefPerGame;
+    }
+    if (!activeCol) return undefined;
+    return (row, season) => activeCol.value(season, row);
+  }, [sort.key, activeCol]);
+
+  const sortedAthletes = useMemo(
+    () => sortAthletes(athletes, sort, getSortValue),
+    [athletes, sort, getSortValue]
+  );
+
+  // First click on a stat header = descending (big numbers are what a
+  // picker hunts); second click flips; other headers switch columns.
+  const toggleSort = (key) => {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === 'desc' ? 'asc' : 'desc' }
+        : { key, dir: 'desc' }
+    );
+  };
+
+  const sortIndicator = (key) =>
+    sort.key === key ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '';
+
+  const ariaSort = (key) =>
+    sort.key === key
+      ? sort.dir === 'asc'
+        ? 'ascending'
+        : 'descending'
+      : undefined;
+
+  const handleAssign = (athlete) => {
+    setRoster((prev) => assign(prev, activeSlotId, athlete));
+  };
+
+  const handleRemove = (slotId) => {
+    setRoster((prev) => remove(prev, slotId));
+  };
+
+  const activeSlot = SLOT_DEFS.find((s) => s.id === activeSlotId);
+  const oppDefLabel =
+    OPP_DEF_LABEL[activeSlot?.id === 'FLEX' ? 'FLEX' : positions[0]];
+
+  return (
+    <div className="roster-builder">
+      <h2 className="roster-builder-title">Player Pick&rsquo;em Roster</h2>
+      <p className="roster-builder-sub">
+        Week 5 &middot; 2026 &middot; NCAAFB (FBS) &mdash; admin preview,
+        selections are local-only, mock data
+      </p>
+
+      <div className="roster-slots" role="tablist" aria-label="Lineup slots">
+        {SLOT_DEFS.map((slot) => {
+          const filled = roster[slot.id];
+          const isActive = slot.id === activeSlotId;
+          return (
+            <div
+              key={slot.id}
+              className={[
+                'roster-slot',
+                filled ? 'roster-slot--filled' : '',
+                isActive ? 'roster-slot--active' : '',
+                slot.disabled ? 'roster-slot--disabled' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className="roster-slot-btn"
+                disabled={slot.disabled}
+                title={slot.disabled ? 'Team defense — coming soon' : undefined}
+                onClick={() => setActiveSlotId(slot.id)}
+              >
+                <span className="roster-slot-label">{slot.label}</span>
+                <span className="roster-slot-player">
+                  {filled
+                    ? `${filled.firstName.charAt(0)}. ${filled.lastName}`
+                    : slot.disabled
+                      ? 'Soon'
+                      : '—'}
+                </span>
+              </button>
+              {filled ? (
+                <button
+                  type="button"
+                  className="roster-slot-remove"
+                  aria-label={`Remove ${filled.firstName} ${filled.lastName}`}
+                  onClick={() => handleRemove(slot.id)}
+                >
+                  &times;
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      {loading ? (
+        <div className="roster-grid-status">Loading athletes&hellip;</div>
+      ) : error ? (
+        <div className="roster-grid-status roster-grid-status--error">
+          {error}
+        </div>
+      ) : (
+        <div className="roster-grid-wrap">
+          <table className="roster-grid">
+            <thead>
+              <tr>
+                <th aria-sort={sort.key === 'name' ? 'ascending' : undefined}>
+                  <button
+                    type="button"
+                    className="roster-grid-sort"
+                    onClick={() => setSort(NAME_SORT)}
+                  >
+                    Player{sort.key === 'name' ? ' ▲' : ''}
+                  </button>
+                </th>
+                {columns.map((col) => (
+                  <th
+                    key={col.key}
+                    className="roster-grid-num"
+                    aria-sort={ariaSort(col.key)}
+                  >
+                    <button
+                      type="button"
+                      className="roster-grid-sort"
+                      onClick={() => toggleSort(col.key)}
+                    >
+                      {col.label}
+                      {sortIndicator(col.key)}
+                    </button>
+                  </th>
+                ))}
+                <th>Opponent</th>
+                <th
+                  className="roster-grid-num"
+                  aria-sort={ariaSort(OPP_DEF_SORT_KEY)}
+                >
+                  <button
+                    type="button"
+                    className="roster-grid-sort"
+                    onClick={() => toggleSort(OPP_DEF_SORT_KEY)}
+                  >
+                    {oppDefLabel}
+                    {sortIndicator(OPP_DEF_SORT_KEY)}
+                  </button>
+                </th>
+                <th aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {sortedAthletes.map((a) => {
+                const rostered = isRostered(roster, a.athleteId);
+                // Adding into an occupied slot replaces its player — say so
+                // on the button instead of springing it on the user.
+                const occupant = roster[activeSlotId];
+                const addLabel =
+                  occupant && occupant.athleteId !== a.athleteId
+                    ? `Replace ${occupant.firstName.charAt(0)}. ${occupant.lastName}`
+                    : 'Add';
+                return [
+                  <tr key={a.athleteId} className="roster-grid-row">
+                    <td className="roster-grid-player">
+                      <span className="roster-grid-name">
+                        {a.lastName}, {a.firstName}
+                        {activeSlot?.id === 'FLEX' ? (
+                          <span className="roster-grid-pos">{a.position}</span>
+                        ) : null}
+                      </span>
+                      <Link
+                        className="roster-grid-team"
+                        to={`/sport/football/ncaa/team/${a.teamSlug}`}
+                      >
+                        {a.teamName}
+                      </Link>
+                    </td>
+                    {columns.map((col) => (
+                      <td key={col.key} className="roster-grid-num">
+                        {cellText(col, a.currentSeason, a)}
+                      </td>
+                    ))}
+                    <td>
+                      {a.opponentName ? (
+                        a.opponentSlug ? (
+                          <Link to={`/sport/football/ncaa/team/${a.opponentSlug}`}>
+                            {a.opponentName}
+                          </Link>
+                        ) : (
+                          a.opponentName
+                        )
+                      ) : (
+                        'BYE'
+                      )}
+                    </td>
+                    <td className="roster-grid-num">
+                      {a.opponentDefPerGame?.toFixed(1) ?? '—'}
+                    </td>
+                    <td className="roster-grid-action">
+                      <button
+                        type="button"
+                        className="roster-grid-add"
+                        disabled={rostered}
+                        onClick={() => handleAssign(a)}
+                      >
+                        {rostered ? 'Rostered' : addLabel}
+                      </button>
+                    </td>
+                  </tr>,
+                  <tr key={`${a.athleteId}-prev`} className="roster-grid-subrow">
+                    <td>
+                      {a.previousSeason
+                        ? `${a.previousSeason.seasonYear} · ${a.previousSeason.gamesPlayed} G`
+                        : 'No prior season'}
+                    </td>
+                    {columns.map((col) => (
+                      <td key={col.key} className="roster-grid-num">
+                        {a.previousSeason
+                          ? cellText(col, a.previousSeason, a)
+                          : '—'}
+                      </td>
+                    ))}
+                    <td colSpan={3} />
+                  </tr>,
+                ];
+              })}
+              {sortedAthletes.length === 0 ? (
+                <tr>
+                  <td colSpan={columns.length + 4} className="roster-grid-status">
+                    No athletes for this position.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PlayerRosterBuilder;

--- a/src/UI/sd-ui/src/components/pickem/players/athleteSort.js
+++ b/src/UI/sd-ui/src/components/pickem/players/athleteSort.js
@@ -1,0 +1,51 @@
+// Grid ordering for the roster-builder athlete table. Pure so the
+// null-handling, tie-breaks, and the season-fallback rule are
+// unit-testable.
+//
+// Sort descriptor: { key: 'name' } or { key: <columnKey>, dir: 'desc'|'asc' }.
+
+export const NAME_SORT = { key: 'name' };
+
+function byName(a, b) {
+  return (
+    a.lastName.localeCompare(b.lastName) ||
+    a.firstName.localeCompare(b.firstName)
+  );
+}
+
+/**
+ * Sort by a stat column via getValue(row, season) -> number|null.
+ *
+ * Season-fallback rule: order by CURRENT-season values, but when every
+ * row's current value is null (week 1, or a slate that hasn't kicked
+ * off), fall back to the previous season's values automatically — that
+ * is the exact moment last year's numbers ARE the ranking. Rows with a
+ * null value under the chosen basis sink to the bottom in both
+ * directions (a missing number is never the best or worst matchup), and
+ * ties break by name so the order is stable across renders.
+ */
+export function sortAthletes(rows, sort, getValue) {
+  const next = [...rows];
+
+  if (!sort || sort.key === 'name' || typeof getValue !== 'function') {
+    next.sort(byName);
+    return next;
+  }
+
+  const currentOf = (row) => getValue(row, row.currentSeason);
+  const useFallback = next.every((row) => currentOf(row) == null);
+  const basisOf = useFallback
+    ? (row) => getValue(row, row.previousSeason)
+    : currentOf;
+
+  const dir = sort.dir === 'asc' ? 1 : -1;
+  next.sort((a, b) => {
+    const av = basisOf(a);
+    const bv = basisOf(b);
+    if (av == null && bv == null) return byName(a, b);
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    return av === bv ? byName(a, b) : (av - bv) * dir;
+  });
+  return next;
+}

--- a/src/UI/sd-ui/src/components/pickem/players/athleteSort.test.js
+++ b/src/UI/sd-ui/src/components/pickem/players/athleteSort.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { NAME_SORT, sortAthletes } from './athleteSort';
+
+// getValue mirrors the grid's column accessors: read one stat off a
+// season block.
+const passYds = (row, season) => season?.stats?.passYds ?? null;
+
+function qbRow(lastName, currentYds, prevYds) {
+  return {
+    firstName: 'Test',
+    lastName,
+    currentSeason:
+      currentYds == null ? null : { stats: { passYds: currentYds } },
+    previousSeason: prevYds == null ? null : { stats: { passYds: prevYds } },
+  };
+}
+
+describe('sortAthletes', () => {
+  it('name sort orders by last name then first name', () => {
+    const rows = [
+      { firstName: 'B', lastName: 'Zeta' },
+      { firstName: 'A', lastName: 'Alpha' },
+      { firstName: 'A', lastName: 'Zeta' },
+    ];
+    const sorted = sortAthletes(rows, NAME_SORT);
+    expect(sorted.map((r) => `${r.lastName}-${r.firstName}`)).toEqual([
+      'Alpha-A',
+      'Zeta-A',
+      'Zeta-B',
+    ]);
+  });
+
+  it('stat desc orders by CURRENT-season values when any exist', () => {
+    const rows = [
+      qbRow('Low', 800, 4000),
+      qbRow('High', 1300, 1000),
+      qbRow('Mid', 1100, 2000),
+    ];
+    const sorted = sortAthletes(rows, { key: 'passYds', dir: 'desc' }, passYds);
+    expect(sorted.map((r) => r.lastName)).toEqual(['High', 'Mid', 'Low']);
+  });
+
+  it('sinks null-current rows to the bottom in both directions', () => {
+    const rows = [qbRow('Out', null, 4000), qbRow('Playing', 900, 500)];
+    expect(
+      sortAthletes(rows, { key: 'passYds', dir: 'desc' }, passYds)[1].lastName
+    ).toBe('Out');
+    expect(
+      sortAthletes(rows, { key: 'passYds', dir: 'asc' }, passYds)[1].lastName
+    ).toBe('Out');
+  });
+
+  it('falls back to PREVIOUS season when no row has current data (week 1)', () => {
+    const rows = [
+      qbRow('Small', null, 1785),
+      qbRow('Big', null, 4052),
+      qbRow('Mid', null, 2885),
+    ];
+    const sorted = sortAthletes(rows, { key: 'passYds', dir: 'desc' }, passYds);
+    expect(sorted.map((r) => r.lastName)).toEqual(['Big', 'Mid', 'Small']);
+  });
+
+  it('does NOT fall back when even one row has current data', () => {
+    // Mixed slate: one player has kicked off. Prior-year monsters must not
+    // outrank live production.
+    const rows = [qbRow('Vet', null, 4052), qbRow('Live', 320, 900)];
+    const sorted = sortAthletes(rows, { key: 'passYds', dir: 'desc' }, passYds);
+    expect(sorted.map((r) => r.lastName)).toEqual(['Live', 'Vet']);
+  });
+
+  it('ties break by name and the input array is not mutated', () => {
+    const rows = [qbRow('Zeta', 1000, 1), qbRow('Alpha', 1000, 2)];
+    const sorted = sortAthletes(rows, { key: 'passYds', dir: 'desc' }, passYds);
+    expect(sorted.map((r) => r.lastName)).toEqual(['Alpha', 'Zeta']);
+    expect(rows.map((r) => r.lastName)).toEqual(['Zeta', 'Alpha']);
+  });
+
+  it('falls back to name sort when no getValue is supplied', () => {
+    const rows = [qbRow('Zeta', 1, 1), qbRow('Alpha', 2, 2)];
+    const sorted = sortAthletes(rows, { key: 'passYds', dir: 'desc' });
+    expect(sorted.map((r) => r.lastName)).toEqual(['Alpha', 'Zeta']);
+  });
+});

--- a/src/UI/sd-ui/src/components/pickem/players/gridColumns.js
+++ b/src/UI/sd-ui/src/components/pickem/players/gridColumns.js
@@ -1,0 +1,95 @@
+// Per-position stat column definitions for the roster-builder grid.
+//
+// Each column reads a season block ({ seasonYear, gamesPlayed, stats } or
+// null) and formats one cell. The SAME columns render the current-season
+// primary row and the previous-season sub-row, which is the point: prior
+// season sits directly under current season for vertical comparison.
+//
+// FLEX merges RB/WR/TE, whose stat keys differ — its columns resolve the
+// position-appropriate value per row (Y/G means rush for an RB, receiving
+// for a WR/TE).
+
+const int = (v) => (v == null ? null : Math.round(v).toLocaleString());
+const oneDp = (v) => (v == null ? null : v.toFixed(1));
+
+function stat(season, key) {
+  return season?.stats?.[key] ?? null;
+}
+
+const PER_GAME_KEY = {
+  QB: 'passYdsPerGame',
+  RB: 'rushYdsPerGame',
+  WR: 'recYdsPerGame',
+  TE: 'recYdsPerGame',
+};
+
+const TD_KEY = {
+  QB: 'passTd',
+  RB: 'rushTd',
+  WR: 'recTd',
+  TE: 'recTd',
+};
+
+// value(season, row) returns the RAW numeric (sorting); fmt renders it.
+export const COLUMNS = {
+  QB: [
+    { key: 'cmpPct', label: 'CMP%', value: (s) => stat(s, 'cmpPct'), fmt: oneDp },
+    { key: 'passYds', label: 'YDS', value: (s) => stat(s, 'passYds'), fmt: int },
+    { key: 'passYdsPerGame', label: 'Y/G', value: (s) => stat(s, 'passYdsPerGame'), fmt: oneDp },
+    { key: 'passTd', label: 'TD', value: (s) => stat(s, 'passTd'), fmt: int },
+    { key: 'interceptions', label: 'INT', value: (s) => stat(s, 'interceptions'), fmt: int },
+    { key: 'rushYds', label: 'RUSH', value: (s) => stat(s, 'rushYds'), fmt: int },
+  ],
+  RB: [
+    { key: 'rushAtt', label: 'ATT', value: (s) => stat(s, 'rushAtt'), fmt: int },
+    { key: 'rushYds', label: 'YDS', value: (s) => stat(s, 'rushYds'), fmt: int },
+    { key: 'rushYdsPerGame', label: 'Y/G', value: (s) => stat(s, 'rushYdsPerGame'), fmt: oneDp },
+    { key: 'rushTd', label: 'TD', value: (s) => stat(s, 'rushTd'), fmt: int },
+    { key: 'receptions', label: 'REC', value: (s) => stat(s, 'receptions'), fmt: int },
+  ],
+  WR: [
+    { key: 'receptions', label: 'REC', value: (s) => stat(s, 'receptions'), fmt: int },
+    { key: 'recYds', label: 'YDS', value: (s) => stat(s, 'recYds'), fmt: int },
+    { key: 'recYdsPerGame', label: 'Y/G', value: (s) => stat(s, 'recYdsPerGame'), fmt: oneDp },
+    { key: 'recTd', label: 'TD', value: (s) => stat(s, 'recTd'), fmt: int },
+  ],
+  K: [
+    { key: 'fg', label: 'FG', value: (s) => stat(s, 'fgMade'), fmt: int, // sorts by makes
+      fmtSeason: (s) => (s?.stats ? `${s.stats.fgMade}/${s.stats.fgAtt}` : null) },
+    { key: 'fgPct', label: 'PCT', value: (s) => stat(s, 'fgPct'), fmt: oneDp },
+    { key: 'fgLong', label: 'LNG', value: (s) => stat(s, 'fgLong'), fmt: int },
+    { key: 'xp', label: 'XP', value: (s) => stat(s, 'xpMade'), fmt: int,
+      fmtSeason: (s) => (s?.stats ? `${s.stats.xpMade}/${s.stats.xpAtt}` : null) },
+  ],
+  FLEX: [
+    {
+      key: 'flexYdsPerGame',
+      label: 'Y/G',
+      value: (s, row) => stat(s, PER_GAME_KEY[row.position]),
+      fmt: oneDp,
+    },
+    {
+      key: 'flexTd',
+      label: 'TD',
+      value: (s, row) => stat(s, TD_KEY[row.position]),
+      fmt: int,
+    },
+  ],
+};
+
+// TE shares WR's shape.
+COLUMNS.TE = COLUMNS.WR;
+
+export function columnsFor(slotId, positions) {
+  return COLUMNS[slotId === 'FLEX' ? 'FLEX' : positions[0]] ?? [];
+}
+
+/** Render one cell: fmtSeason (whole-season formatter, e.g. "12/14")
+ *  wins over fmt(value); null season/stat renders an em-dash. */
+export function cellText(col, season, row) {
+  if (col.fmtSeason) {
+    return col.fmtSeason(season) ?? '—';
+  }
+  const v = col.value(season, row);
+  return v == null ? '—' : col.fmt(v);
+}

--- a/src/UI/sd-ui/src/components/pickem/players/rosterLogic.js
+++ b/src/UI/sd-ui/src/components/pickem/players/rosterLogic.js
@@ -1,0 +1,75 @@
+// Pure lineup-slot rules for the Player Pick'em roster builder. Kept free
+// of React so the eligibility/duplicate rules are unit-testable and can
+// move server-side unchanged when PlayerLineup entities arrive.
+
+// v1 fixed shape per docs/features/player-pickem/player-pickem.md open
+// question #1 (1 QB / 2 RB / 2 WR / 1 TE / 1 FLEX / 1 K / 1 DEF).
+// DEF is a team pick, not an athlete pick — present but disabled until
+// the team-defense picker exists.
+export const SLOT_DEFS = [
+  { id: 'QB', label: 'QB', eligible: ['QB'] },
+  { id: 'RB1', label: 'RB', eligible: ['RB'] },
+  { id: 'RB2', label: 'RB', eligible: ['RB'] },
+  { id: 'WR1', label: 'WR', eligible: ['WR'] },
+  { id: 'WR2', label: 'WR', eligible: ['WR'] },
+  { id: 'TE', label: 'TE', eligible: ['TE'] },
+  { id: 'FLEX', label: 'FLEX', eligible: ['RB', 'WR', 'TE'] },
+  { id: 'K', label: 'K', eligible: ['K'] },
+  { id: 'DEF', label: 'DEF', eligible: [], disabled: true },
+];
+
+export function slotById(slotId) {
+  return SLOT_DEFS.find((s) => s.id === slotId) ?? null;
+}
+
+export function eligiblePositions(slotId) {
+  return slotById(slotId)?.eligible ?? [];
+}
+
+/**
+ * An athlete may fill a slot iff the slot exists and is enabled, the
+ * athlete's position is eligible for it, and the athlete isn't already
+ * rostered in ANOTHER slot (re-assigning into the same slot is fine —
+ * that's a no-op replace).
+ */
+export function canAssign(roster, slotId, athlete) {
+  const slot = slotById(slotId);
+  if (!slot || slot.disabled) return false;
+  if (!slot.eligible.includes(athlete.position)) return false;
+
+  return !Object.entries(roster).some(
+    ([id, rostered]) =>
+      id !== slotId && rostered?.athleteId === athlete.athleteId
+  );
+}
+
+/** Returns a new roster with the athlete in the slot (or the same roster
+ *  object if the assignment is illegal — callers can reference-compare). */
+export function assign(roster, slotId, athlete) {
+  if (!canAssign(roster, slotId, athlete)) return roster;
+  return { ...roster, [slotId]: athlete };
+}
+
+export function remove(roster, slotId) {
+  if (!(slotId in roster)) return roster;
+  const next = { ...roster };
+  delete next[slotId];
+  return next;
+}
+
+export function isRostered(roster, athleteId) {
+  return Object.values(roster).some((a) => a?.athleteId === athleteId);
+}
+
+/** First empty enabled slot the athlete could legally fill, or null.
+ *  Drives "add from the grid without picking a slot first". */
+export function firstOpenSlotFor(roster, athlete) {
+  const slot = SLOT_DEFS.find(
+    (s) =>
+      !s.disabled &&
+      !roster[s.id] &&
+      s.eligible.includes(athlete.position) &&
+      canAssign(roster, s.id, athlete)
+  );
+  return slot?.id ?? null;
+}

--- a/src/UI/sd-ui/src/components/pickem/players/rosterLogic.test.js
+++ b/src/UI/sd-ui/src/components/pickem/players/rosterLogic.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SLOT_DEFS,
+  eligiblePositions,
+  canAssign,
+  assign,
+  remove,
+  isRostered,
+  firstOpenSlotFor,
+} from './rosterLogic';
+
+const qb = { athleteId: 'qb-1', position: 'QB', firstName: 'Arch', lastName: 'Manning' };
+const rb = { athleteId: 'rb-1', position: 'RB', firstName: 'Jeremiyah', lastName: 'Love' };
+const wr = { athleteId: 'wr-1', position: 'WR', firstName: 'Jeremiah', lastName: 'Smith' };
+const te = { athleteId: 'te-1', position: 'TE', firstName: 'Max', lastName: 'Klare' };
+
+describe('SLOT_DEFS', () => {
+  it('is the fixed v1 shape with DEF present but disabled', () => {
+    expect(SLOT_DEFS.map((s) => s.id)).toEqual([
+      'QB', 'RB1', 'RB2', 'WR1', 'WR2', 'TE', 'FLEX', 'K', 'DEF',
+    ]);
+    expect(SLOT_DEFS.find((s) => s.id === 'DEF').disabled).toBe(true);
+  });
+});
+
+describe('eligiblePositions', () => {
+  it('FLEX accepts RB, WR, and TE', () => {
+    expect(eligiblePositions('FLEX')).toEqual(['RB', 'WR', 'TE']);
+  });
+
+  it('unknown slot yields no positions', () => {
+    expect(eligiblePositions('NOPE')).toEqual([]);
+  });
+});
+
+describe('canAssign / assign', () => {
+  it('fills an eligible empty slot', () => {
+    const roster = assign({}, 'QB', qb);
+    expect(roster.QB).toBe(qb);
+  });
+
+  it('rejects a position mismatch and returns the SAME roster object', () => {
+    const before = {};
+    expect(canAssign(before, 'QB', rb)).toBe(false);
+    expect(assign(before, 'QB', rb)).toBe(before);
+  });
+
+  it('rejects the disabled DEF slot', () => {
+    expect(canAssign({}, 'DEF', rb)).toBe(false);
+  });
+
+  it('rejects an athlete already rostered in another slot', () => {
+    const roster = assign({}, 'RB1', rb);
+    expect(canAssign(roster, 'RB2', rb)).toBe(false);
+    expect(canAssign(roster, 'FLEX', rb)).toBe(false);
+  });
+
+  it('allows re-assigning into the same slot (no-op replace)', () => {
+    const roster = assign({}, 'RB1', rb);
+    expect(canAssign(roster, 'RB1', rb)).toBe(true);
+  });
+
+  it('replaces an occupied slot with a different athlete', () => {
+    const other = { ...wr, athleteId: 'wr-2', lastName: 'Williams' };
+    const roster = assign(assign({}, 'WR1', wr), 'WR1', other);
+    expect(roster.WR1).toBe(other);
+    expect(isRostered(roster, wr.athleteId)).toBe(false);
+  });
+});
+
+describe('remove', () => {
+  it('empties the slot and returns the same object when already empty', () => {
+    const roster = assign({}, 'TE', te);
+    const next = remove(roster, 'TE');
+    expect(next.TE).toBeUndefined();
+    expect(remove(next, 'TE')).toBe(next);
+  });
+});
+
+describe('firstOpenSlotFor', () => {
+  it('prefers the position slot before FLEX', () => {
+    expect(firstOpenSlotFor({}, rb)).toBe('RB1');
+    const oneRb = assign({}, 'RB1', rb);
+    const otherRb = { ...rb, athleteId: 'rb-2' };
+    expect(firstOpenSlotFor(oneRb, otherRb)).toBe('RB2');
+  });
+
+  it('falls through to FLEX when position slots are full', () => {
+    const other = { ...te, athleteId: 'te-2' };
+    const roster = assign({}, 'TE', te);
+    expect(firstOpenSlotFor(roster, other)).toBe('FLEX');
+  });
+
+  it('returns null when nothing is open', () => {
+    let roster = assign({}, 'TE', te);
+    roster = assign(roster, 'FLEX', { ...te, athleteId: 'te-2' });
+    expect(firstOpenSlotFor(roster, { ...te, athleteId: 'te-3' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Top-down first cut of the Player Pick'em roster-creation surface (docs/features/player-pickem/player-pickem.md), web + mobile. **Admin-gated on both platforms** — web behind `AdminRoute` at `/pickem/players`, mobile under the `/admin` route convention with the direct-URL guard — so regular users still see only the "Coming Soon" teaser.

**Mock-backed by design.** `playerPickemApi` on each surface serves a hardcoded Week 5 snapshot and documents, at the top of the file, the exact row contract the real Producer query will serve: athletes-by-position + this week's opponent + opponent defensive allowance + structured `currentSeason`/`previousSeason` blocks. The backend PR swaps those two files and touches nothing else. The hardcoded data is the point of the top-down approach, not an oversight.

## Web

- Teaser-style slot row: fixed v1 shape (1 QB / 2 RB / 2 WR / 1 TE / 1 FLEX / 1 K), DEF present but disabled — team defense is a different picker.
- Each athlete renders as a **row pair**: current season on the primary row, previous season directly beneath **in the same stat columns** — vertical comparison is the insight (`2025 · 12 G` carries games-played so totals read honestly).
- Every stat column sorts (first click descending — big numbers are what a picker hunts). Sort orders by current-season values and **falls back to previous season automatically when no row has current data** — week 1 sorts by last year's numbers without asking; one live row disables the fallback so prior-year monsters can't outrank live production. Byes and not-yet-played athletes sink in both directions.
- Column sets per position: QB 6 (CMP%/YDS/Y/G/TD/INT/RUSH), RB 5, WR/TE 4, K 4 (FG as made/att), FLEX generic Y/G+TD with position badges. Team folds into the player cell to pay for the columns; opponent links to its team card.

## Mobile

- Cards instead of a table: the mirrored columns become two aligned `'26`/`'25` stat lines per card; header sorting becomes a chip row with identical semantics (same fallback rule).
- Slot grid **wraps to two rows** rather than scrolling horizontally — the whole lineup shape stays visible.
- Screen follows the `/admin/push-token` conventions (gate + Unauthorized fallback + profile Developer menu link).

## Scope boundaries (deliberate)

- Roster is **local-only** (localStorage / AsyncStorage with a hydration guard) — a stand-in for carry-over until `PlayerLineup`/`PlayerLineupSlot` entities exist server-side.
- Slot rules (eligibility, no double-rostering across slots, FLEX fall-through, replace-with-warning labels) live in pure modules, ported web→mobile per the existing `liveSituation` convention.
- DEF slot, per-player locking, scoring, and persistence are later verticals per the feature doc.

## Validation

- 20 vitest (web) + 7 jest (mobile) on slot rules, sort fallback, tie-breaks, mutation safety, season-line formatting
- Full suites: 70 web / 173 mobile; `tsc --noEmit` and ESLint clean; web production build compiles
- Operator-reviewed on both surfaces (browser + Expo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only Player Pick’em roster builder for web and mobile.
  * Build, replace, and remove player selections across position-specific roster slots.
  * View sortable player statistics, matchup details, prior-season data, and team links.
  * Roster selections persist between sessions.
  * Added a profile shortcut to the mobile Player Pick’em preview.
  * Added loading, error, authorization, and responsive display states.
* **Bug Fixes**
  * Prevented duplicate player selections and invalid position assignments.
* **Tests**
  * Added coverage for roster rules, eligibility, sorting, formatting, and fallback statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->