### PR TITLE
feat(producer,api,core,web,mobile): athlete matchup summaries feed — roster builder goes live

### DIFF
--- a/src/SportsData.Api/Application/Athletes/AthletesController.cs
+++ b/src/SportsData.Api/Application/Athletes/AthletesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 
 using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
+using SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
@@ -11,6 +12,28 @@ namespace SportsData.Api.Application.Athletes;
 [Route("api/{sport}/{league}/athletes")]
 public class AthletesController : ApiControllerBase
 {
+    /// <summary>
+    /// Roster-builder grid feed for Player Pick'em: active FBS athletes at
+    /// a position with the week's opponent, opponent defensive allowance
+    /// per game, and current/previous season stat blocks. Literal route
+    /// segment — declared before the guid route it would otherwise shadow.
+    /// </summary>
+    [HttpGet("pickem")]
+    public async Task<ActionResult<AthleteMatchupSummariesDto>> GetPickemAthletes(
+        [FromRoute] string sport,
+        [FromRoute] string league,
+        [FromQuery] string position,
+        [FromQuery] int seasonYear,
+        [FromQuery] int week,
+        [FromServices] IGetPickemAthletesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(
+            new GetPickemAthletesQuery(sport, league, position, seasonYear, week),
+            cancellationToken);
+        return result.ToActionResult();
+    }
+
     /// <summary>
     /// Full athlete drill-down for the web athlete page: athlete record,
     /// every season, and per-season statistic documents. GUID route — the

--- a/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetAthleteDetails/GetAthleteDetailsQueryHandler.cs
@@ -3,7 +3,7 @@ using FluentValidation.Results;
 using SportsData.Core.Common;
 using SportsData.Core.Common.Mapping;
 using SportsData.Core.Dtos.Canonical;
-using SportsData.Core.Infrastructure.Clients.Franchise;
+using SportsData.Core.Infrastructure.Clients.Athlete;
 
 namespace SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
 
@@ -15,23 +15,25 @@ public interface IGetAthleteDetailsQueryHandler
 }
 
 /// <summary>
-/// Relay to Producer's athlete drill-down. Resolved through the franchise
-/// client factory — the athlete read lives on the same Producer instance
-/// the franchise reads target, and the dormant Player service's client is
-/// dead code, so a dedicated athlete client would be a factory chain with
-/// one method.
+/// Relay to Producer's athlete drill-down via the athlete client. This
+/// originally rode the franchise client factory ("a dedicated athlete
+/// client would be a factory chain with one method") — the pickem grid
+/// feed made it two methods and athlete reads became their own aggregate
+/// root. The client still resolves to the same Producer instance the
+/// franchise reads target; the dormant Player service's client stays
+/// untouched.
 /// </summary>
 public class GetAthleteDetailsQueryHandler : IGetAthleteDetailsQueryHandler
 {
     private readonly ILogger<GetAthleteDetailsQueryHandler> _logger;
-    private readonly IFranchiseClientFactory _franchiseClientFactory;
+    private readonly IAthleteClientFactory _athleteClientFactory;
 
     public GetAthleteDetailsQueryHandler(
         ILogger<GetAthleteDetailsQueryHandler> logger,
-        IFranchiseClientFactory franchiseClientFactory)
+        IAthleteClientFactory athleteClientFactory)
     {
         _logger = logger;
-        _franchiseClientFactory = franchiseClientFactory;
+        _athleteClientFactory = athleteClientFactory;
     }
 
     public async Task<Result<AthleteDetailDto>> ExecuteAsync(
@@ -68,7 +70,7 @@ public class GetAthleteDetailsQueryHandler : IGetAthleteDetailsQueryHandler
 
         try
         {
-            var client = _franchiseClientFactory.Resolve(mode);
+            var client = _athleteClientFactory.Resolve(mode);
             return await client.GetAthleteDetails(query.AthleteId, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQuery.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQuery.cs
@@ -1,0 +1,8 @@
+namespace SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
+
+public record GetPickemAthletesQuery(
+    string Sport,
+    string League,
+    string Position,
+    int SeasonYear,
+    int Week);

--- a/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryHandler.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using FluentValidation.Results;
 
 using SportsData.Core.Common;
@@ -25,19 +26,31 @@ public class GetPickemAthletesQueryHandler : IGetPickemAthletesQueryHandler
 {
     private readonly ILogger<GetPickemAthletesQueryHandler> _logger;
     private readonly IAthleteClientFactory _athleteClientFactory;
+    private readonly IValidator<GetPickemAthletesQuery> _validator;
 
     public GetPickemAthletesQueryHandler(
         ILogger<GetPickemAthletesQueryHandler> logger,
-        IAthleteClientFactory athleteClientFactory)
+        IAthleteClientFactory athleteClientFactory,
+        IValidator<GetPickemAthletesQuery> validator)
     {
         _logger = logger;
         _athleteClientFactory = athleteClientFactory;
+        _validator = validator;
     }
 
     public async Task<Result<AthleteMatchupSummariesDto>> ExecuteAsync(
         GetPickemAthletesQuery query,
         CancellationToken cancellationToken = default)
     {
+        var validation = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<AthleteMatchupSummariesDto>(
+                default!,
+                ResultStatus.Validation,
+                validation.Errors);
+        }
+
         Sport mode;
         try
         {

--- a/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryHandler.cs
@@ -1,0 +1,86 @@
+using FluentValidation.Results;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Mapping;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Athlete;
+
+namespace SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
+
+public interface IGetPickemAthletesQueryHandler
+{
+    Task<Result<AthleteMatchupSummariesDto>> ExecuteAsync(
+        GetPickemAthletesQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Relay to Producer's roster-builder grid feed via the athlete client —
+/// athlete reads are their own aggregate root even though they resolve to
+/// the same Producer instance as franchise reads. Position validation
+/// lives in the Producer handler — this relay only validates the route
+/// segments it owns.
+/// </summary>
+public class GetPickemAthletesQueryHandler : IGetPickemAthletesQueryHandler
+{
+    private readonly ILogger<GetPickemAthletesQueryHandler> _logger;
+    private readonly IAthleteClientFactory _athleteClientFactory;
+
+    public GetPickemAthletesQueryHandler(
+        ILogger<GetPickemAthletesQueryHandler> logger,
+        IAthleteClientFactory athleteClientFactory)
+    {
+        _logger = logger;
+        _athleteClientFactory = athleteClientFactory;
+    }
+
+    public async Task<Result<AthleteMatchupSummariesDto>> ExecuteAsync(
+        GetPickemAthletesQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        Sport mode;
+        try
+        {
+            mode = ModeMapper.ResolveMode(query.Sport, query.League);
+        }
+        catch (NotSupportedException)
+        {
+            return new Failure<AthleteMatchupSummariesDto>(
+                default!,
+                ResultStatus.Validation,
+                [
+                    new ValidationFailure(nameof(query.Sport), $"Unsupported sport: '{query.Sport}'"),
+                    new ValidationFailure(nameof(query.League), $"Unsupported league: '{query.League}'")
+                ]);
+        }
+
+        try
+        {
+            var client = _athleteClientFactory.Resolve(mode);
+            return await client.GetAthleteMatchupSummaries(
+                query.Position, query.SeasonYear, query.Week, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // CWE-117: route/query values are user-controlled — strip CR/LF
+            // before plain-text log sinks.
+            _logger.LogError(
+                ex,
+                "Error retrieving pickem athletes for sport={Sport}, league={League}, position={Position}, seasonYear={SeasonYear}, week={Week}",
+                SanitizeForLog(query.Sport), SanitizeForLog(query.League), SanitizeForLog(query.Position),
+                query.SeasonYear, query.Week);
+
+            return new Failure<AthleteMatchupSummariesDto>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure("PickemAthletes", "Error retrieving athletes. Please try again later.")]);
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        value is null ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryValidator.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
+
+/// <summary>
+/// Numeric-bounds gate in front of the Producer relay — without it a
+/// request like seasonYear=0&amp;week=-1 rides all the way to Producer just
+/// to come back as a validation failure. Bounds mirror Producer's
+/// GetAthleteMatchupSummariesQueryValidator. Sport/league route segments
+/// are validated by ModeMapper in the handler; position membership is
+/// validated by Producer, whose whitelist and stat mapping are one
+/// dictionary.
+/// </summary>
+public class GetPickemAthletesQueryValidator : AbstractValidator<GetPickemAthletesQuery>
+{
+    public GetPickemAthletesQueryValidator(IDateTimeProvider dateTimeProvider)
+    {
+        RuleFor(x => x.Position)
+            .NotEmpty()
+            .WithMessage("Position is required");
+
+        RuleFor(x => x.SeasonYear)
+            .GreaterThanOrEqualTo(2000)
+            .WithMessage("Season year must be 2000 or later")
+            .Must(year => year <= dateTimeProvider.UtcNow().Year + 1)
+            .WithMessage("Season year cannot be more than one year in the future");
+
+        RuleFor(x => x.Week)
+            .InclusiveBetween(1, 30)
+            .WithMessage("Week must be between 1 and 30");
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -322,6 +322,7 @@ namespace SportsData.Api.DependencyInjection
             // Athlete Queries
             services.AddScoped<IGetAthleteDetailsQueryHandler, GetAthleteDetailsQueryHandler>();
             services.AddScoped<IGetPickemAthletesQueryHandler, GetPickemAthletesQueryHandler>();
+            services.AddScoped<FluentValidation.IValidator<GetPickemAthletesQuery>, GetPickemAthletesQueryValidator>();
 
             // TeamCard Queries
             services.AddScoped<IGetTeamCardQueryHandler, GetTeamCardQueryHandler>();

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 
 using SportsData.Api.Application.Admin.Commands.BackfillLeagueScores;
 using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
+using SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
 using SportsData.Api.Application.Admin.Commands.GenerateLoadTest;
 using SportsData.Api.Application.Admin.Commands.RefreshAiExistence;
 using SportsData.Api.Application.Admin.Commands.SendTestPushNotification;
@@ -320,6 +321,7 @@ namespace SportsData.Api.DependencyInjection
 
             // Athlete Queries
             services.AddScoped<IGetAthleteDetailsQueryHandler, GetAthleteDetailsQueryHandler>();
+            services.AddScoped<IGetPickemAthletesQueryHandler, GetPickemAthletesQueryHandler>();
 
             // TeamCard Queries
             services.AddScoped<IGetTeamCardQueryHandler, GetTeamCardQueryHandler>();

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -595,6 +595,11 @@ namespace SportsData.Core.DependencyInjection
             services.AddSingleton<IVenueClientFactory, VenueClientFactory>();
             services.AddSingleton<IFranchiseClientFactory, FranchiseClientFactory>();
             services.AddSingleton<IAthleteClientFactory, AthleteClientFactory>();
+            // Named registration only — BaseAddress is per-sport-mode and is
+            // set by AthleteClientFactory at resolve time, so it cannot live
+            // here. The name gives future athlete-specific handler/policy
+            // configuration a place to attach.
+            services.AddHttpClient(HttpClients.AthleteClient);
             services.AddSingleton<IContestClientFactory, ContestClientFactory>();
             services.AddSingleton<ISeasonClientFactory, SeasonClientFactory>();
 

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -24,6 +24,7 @@ using SportsData.Core.Infrastructure.Blobs;
 using SportsData.Core.Infrastructure.Clients;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Infrastructure.Clients.Notification;
+using SportsData.Core.Infrastructure.Clients.Athlete;
 using SportsData.Core.Infrastructure.Clients.Franchise;
 using SportsData.Core.Infrastructure.Clients.Provider;
 using SportsData.Core.Infrastructure.Clients.Season;
@@ -593,6 +594,7 @@ namespace SportsData.Core.DependencyInjection
             // Client factories handle resolution by sport/league mode
             services.AddSingleton<IVenueClientFactory, VenueClientFactory>();
             services.AddSingleton<IFranchiseClientFactory, FranchiseClientFactory>();
+            services.AddSingleton<IAthleteClientFactory, AthleteClientFactory>();
             services.AddSingleton<IContestClientFactory, ContestClientFactory>();
             services.AddSingleton<ISeasonClientFactory, SeasonClientFactory>();
 

--- a/src/SportsData.Core/Dtos/Canonical/AthleteMatchupSummaryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/AthleteMatchupSummaryDto.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Core.Dtos.Canonical
+{
+    /// <summary>
+    /// One athlete's week-matchup summary: identity, team, the week's
+    /// opponent with its defensive allowance, and structured current/
+    /// previous season stat blocks. Canonical athlete data — the API's
+    /// pick'em surfaces consume it, but nothing in it is game-specific.
+    /// The serialized shape is frozen by sd-ui/src/api/playerPickemApi.js
+    /// and sd-mobile/src/services/api/playerPickemApi.ts — field renames
+    /// are breaking changes.
+    /// </summary>
+    public class AthleteMatchupSummaryDto
+    {
+        public Guid AthleteId { get; set; }
+        public required string FirstName { get; set; }
+        public required string LastName { get; set; }
+        public required string TeamName { get; set; }
+        public required string TeamSlug { get; set; }
+        /// <summary>"QB" | "RB" | "WR" | "TE" | "K" (position abbreviation).</summary>
+        public required string Position { get; set; }
+
+        /// <summary>Null on a bye week.</summary>
+        public string? OpponentName { get; set; }
+        public string? OpponentSlug { get; set; }
+
+        /// <summary>
+        /// The week opponent's relevant defensive allowance per game,
+        /// aggregated from what THEIR opponents actually gained against
+        /// them (ESPN's own yardsAllowed team stats are zero-filled):
+        /// net pass yds allowed/G for QB/WR/TE, rush yds allowed/G for
+        /// RB, points allowed/G for K. Prior-season values when the
+        /// opponent has no current-season games yet.
+        /// </summary>
+        public decimal? OpponentDefPerGame { get; set; }
+
+        /// <summary>Null before the athlete's first game of the season.</summary>
+        public AthleteSeasonStatBlockDto? CurrentSeason { get; set; }
+
+        /// <summary>Null for athletes with no prior-season record (true freshmen).</summary>
+        public AthleteSeasonStatBlockDto? PreviousSeason { get; set; }
+    }
+
+    /// <summary>
+    /// One season of position-relevant stats. Both seasons use the SAME
+    /// shape so consumers can render prior season directly beneath current
+    /// season in the same columns. Keys are the consumer contract's stat
+    /// keys (cmpPct, passYds, rushAtt, receptions, fgMade, ...).
+    /// </summary>
+    public class AthleteSeasonStatBlockDto
+    {
+        public int SeasonYear { get; set; }
+        public int GamesPlayed { get; set; }
+        public Dictionary<string, decimal> Stats { get; set; } = new Dictionary<string, decimal>();
+    }
+
+    public class AthleteMatchupSummariesDto
+    {
+        public List<AthleteMatchupSummaryDto> Athletes { get; set; } = new List<AthleteMatchupSummaryDto>();
+    }
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClient.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Middleware.Health;
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SportsData.Core.Infrastructure.Clients.Athlete;
+
+public interface IProvideAthletes : IProvideHealthChecks
+{
+    /// <summary>Full athlete drill-down (athlete record + every season + statistics). Keyed by GUID — athlete slugs are not unique (~15% collide).</summary>
+    Task<Result<AthleteDetailDto>> GetAthleteDetails(Guid athleteId, CancellationToken cancellationToken = default);
+
+    /// <summary>Athletes at a position with their week opponent, the opponent's defensive allowance per game, and current/previous season stat blocks.</summary>
+    Task<Result<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(string position, int seasonYear, int week, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Athlete-domain reads. These are served by the same Producer instance
+/// the franchise reads target (Producer's AthleteController) — the
+/// factory reuses the franchise ApiUrl configuration — but the CLIENT is
+/// its own aggregate root: athlete reads do not belong on the franchise
+/// domain, and the dormant Player service's client stays untouched.
+/// </summary>
+public class AthleteClient : ClientBase, IProvideAthletes
+{
+    private readonly ILogger<AthleteClient> _logger;
+
+    public AthleteClient(
+        ILogger<AthleteClient> logger,
+        HttpClient httpClient) :
+        base(httpClient)
+    {
+        _logger = logger;
+    }
+
+    public async Task<Result<AthleteDetailDto>> GetAthleteDetails(Guid athleteId, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(
+            $"athletes/{athleteId}",
+            new AthleteDetailDto(),
+            entityName: "AthleteDetail",
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<Result<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(
+        string position,
+        int seasonYear,
+        int week,
+        CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(
+            $"athletes/matchup-summaries?position={Uri.EscapeDataString(position)}&seasonYear={seasonYear}&week={week}",
+            new AthleteMatchupSummariesDto(),
+            entityName: "AthleteMatchupSummaries",
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClientFactory.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClientFactory.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using SportsData.Core.Common;
+using SportsData.Core.Config;
+
+using System;
+using System.Net.Http;
+
+namespace SportsData.Core.Infrastructure.Clients.Athlete;
+
+public interface IAthleteClientFactory
+{
+    IProvideAthletes Resolve(Sport mode);
+}
+
+public class AthleteClientFactory : ClientFactoryBase<AthleteClient, IProvideAthletes>, IAthleteClientFactory
+{
+    protected override string HttpClientName => HttpClients.AthleteClient;
+
+    public AthleteClientFactory(
+        ILoggerFactory loggerFactory,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration)
+        : base(loggerFactory, httpClientFactory, configuration)
+    {
+    }
+
+    protected override Uri? GetBaseAddressForMode(Sport mode)
+    {
+        // Deliberately the FRANCHISE ApiUrl keys: athlete endpoints live on
+        // the same Producer instance the franchise reads target, and a
+        // parallel AthleteClientConfig would mean provisioning identical
+        // URLs in AppConfig for every environment/mode for no routing gain.
+        // If athlete reads ever move to their own service, this is the one
+        // method to change.
+        var modeSpecificKey = CommonConfigKeys.GetFranchiseProviderUri(mode);
+        var url = Configuration?[modeSpecificKey];
+
+        if (string.IsNullOrEmpty(url))
+        {
+            var defaultKey = CommonConfigKeys.GetFranchiseProviderUri();
+            url = Configuration?[defaultKey];
+        }
+
+        return string.IsNullOrEmpty(url) ? null : new Uri(url);
+    }
+
+    protected override AthleteClient CreateClient(ILogger<AthleteClient> logger, HttpClient httpClient)
+        => new(logger, httpClient);
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Franchise/FranchiseClient.cs
@@ -36,8 +36,6 @@ public interface IProvideFranchises : IProvideHealthChecks
     Task<Dictionary<Guid, string>> GetConferenceIdsBySlugs(int seasonYear, List<string> slugs, CancellationToken cancellationToken = default);
     Task<RankingsByPollIdByWeekDto> GetRankingsByPollByWeek(string poll, int seasonYear, int weekNumber, MarkDirection direction, CancellationToken cancellationToken = default);
     Task<Result<TeamRosterDto>> GetTeamRoster(string slug, int seasonYear, CancellationToken cancellationToken = default);
-    /// <summary>Full athlete drill-down (athlete record + every season + statistics). Keyed by GUID — athlete slugs are not unique (~15% collide).</summary>
-    Task<Result<AthleteDetailDto>> GetAthleteDetails(Guid athleteId, CancellationToken cancellationToken = default);
     Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default);
     Task<Result<bool>> UpdateLogoDarkBg(Guid logoId, bool isForDarkBg, string logoType, CancellationToken cancellationToken = default);
     /// <summary>Fan out ESPN sourcing for every FranchiseSeason in the year, optionally narrowed to specific child document types. Returns the batch correlation id (the Seq handle).</summary>
@@ -338,15 +336,6 @@ public class FranchiseClient : ClientBase, IProvideFranchises
             new TeamRosterDto(),
             cancellationToken);
         return new Success<TeamRosterDto>(result);
-    }
-
-    public async Task<Result<AthleteDetailDto>> GetAthleteDetails(Guid athleteId, CancellationToken cancellationToken = default)
-    {
-        return await GetAsync(
-            $"athletes/{athleteId}",
-            new AthleteDetailDto(),
-            entityName: "AthleteDetail",
-            cancellationToken: cancellationToken);
     }
 
     public async Task<Result<FranchiseLogosDto>> GetFranchiseLogos(string slug, CancellationToken cancellationToken = default)

--- a/src/SportsData.Core/Infrastructure/Clients/HttpClients.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/HttpClients.cs
@@ -2,6 +2,7 @@
 {
     public static class HttpClients
     {
+        public const string AthleteClient = "AthleteClient";
         public const string ContestClient = "ContestClient";
         public const string FranchiseClient = "FranchiseClient";
         public const string NotificationClient = "NotificationClient";

--- a/src/SportsData.Producer/Application/Athletes/AthleteController.cs
+++ b/src/SportsData.Producer/Application/Athletes/AthleteController.cs
@@ -6,6 +6,7 @@ using SportsData.Core.Extensions;
 using SportsData.Core.Processing;
 using SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
 using SportsData.Producer.Application.Athletes.Queries.GetAthleteById;
+using SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSummaries;
 
 namespace SportsData.Producer.Application.Athletes;
 
@@ -35,6 +36,27 @@ public class AthleteController : ControllerBase
         CancellationToken cancellationToken)
     {
         var result = await handler.ExecuteAsync(new GetAthleteByIdQuery(athleteId), cancellationToken);
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Active FBS athletes at a position with the week's opponent, the
+    /// opponent's defensive allowance per game, and current/previous
+    /// season stat blocks. Consumed by the API's pick'em relay, but the
+    /// data is game-agnostic athlete/matchup data.
+    /// Example: GET /api/athletes/matchup-summaries?position=QB&amp;seasonYear=2026&amp;week=1
+    /// </summary>
+    [HttpGet("matchup-summaries")]
+    public async Task<ActionResult<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(
+        [FromQuery] string position,
+        [FromQuery] int seasonYear,
+        [FromQuery] int week,
+        [FromServices] IGetAthleteMatchupSummariesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(
+            new GetAthleteMatchupSummariesQuery(position, seasonYear, week),
+            cancellationToken);
         return result.ToActionResult();
     }
 

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQuery.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQuery.cs
@@ -1,0 +1,9 @@
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSummaries;
+
+/// <summary>
+/// Athletes-by-position for the Player Pick'em roster builder grid.
+/// </summary>
+/// <param name="Position">Position abbreviation: QB, RB, WR, TE, or K.</param>
+/// <param name="SeasonYear">The season being played (current-season blocks and opponent lookup).</param>
+/// <param name="Week">The week whose opponent/matchup context is attached.</param>
+public record GetAthleteMatchupSummariesQuery(string Position, int SeasonYear, int Week);

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
@@ -1,0 +1,457 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSummaries;
+
+public interface IGetAthleteMatchupSummariesQueryHandler
+{
+    Task<Result<AthleteMatchupSummariesDto>> ExecuteAsync(
+        GetAthleteMatchupSummariesQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Athlete week-matchup summaries: every ACTIVE FBS athlete at a position,
+/// with the week's opponent, the opponent's relevant defensive allowance
+/// per game, and structured current/previous season stat blocks.
+///
+/// Built as set-based projected queries (athletes, prior seasons, stat
+/// docs, stat rows, contests, opponent aggregates) — never per-athlete
+/// round trips; a WR request touches ~700 athletes.
+///
+/// Two data realities shape this handler:
+///   - ESPN's team-stat "yardsAllowed"/"pointsAllowed" are zero-filled,
+///     so defensive allowances are AGGREGATED from what each opponent's
+///     opponents actually gained against them (the OTHER side's
+///     CompetitionCompetitor statistics in each played game). When an
+///     opponent has no current-season games yet (week 1 everywhere), the
+///     aggregate falls back to their prior-season franchise season.
+///   - Athlete statistic docs are duplicated per re-source (~162k
+///     athlete-seasons carry more than one); the NEWEST doc per
+///     athlete-season wins.
+/// </summary>
+public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummariesQueryHandler
+{
+    private const string GamesPlayedKey = "gamesPlayed";
+    private const string GeneralCategory = "general";
+
+    // Consumer-contract stat keys (the serialized shape downstream UIs
+    // depend on — see AthleteMatchupSummaryDto) → the ESPN category/stat
+    // names that carry them. gamesPlayed is added for every position at
+    // query time.
+    private static readonly Dictionary<string, Dictionary<string, (string Category, string Stat)>> StatMap;
+
+    // The week opponent's defensive allowance metric per position. K is
+    // points-allowed and comes from contest scores, not team stats.
+    private static readonly Dictionary<string, (string Category, string Stat)> OppAllowedMap = new()
+    {
+        ["QB"] = ("passing", "netPassingYards"),
+        ["WR"] = ("passing", "netPassingYards"),
+        ["TE"] = ("passing", "netPassingYards"),
+        ["RB"] = ("rushing", "rushingYards"),
+    };
+
+    static GetAthleteMatchupSummariesQueryHandler()
+    {
+        var qb = new Dictionary<string, (string, string)>
+        {
+            ["cmpPct"] = ("passing", "completionPct"),
+            ["passYds"] = ("passing", "passingYards"),
+            ["passYdsPerGame"] = ("passing", "passingYardsPerGame"),
+            ["passTd"] = ("passing", "passingTouchdowns"),
+            ["interceptions"] = ("passing", "interceptions"),
+            ["rushYds"] = ("rushing", "rushingYards"),
+        };
+        var rb = new Dictionary<string, (string, string)>
+        {
+            ["rushAtt"] = ("rushing", "rushingAttempts"),
+            ["rushYds"] = ("rushing", "rushingYards"),
+            ["rushYdsPerGame"] = ("rushing", "rushingYardsPerGame"),
+            ["rushTd"] = ("rushing", "rushingTouchdowns"),
+            ["receptions"] = ("receiving", "receptions"),
+        };
+        var wr = new Dictionary<string, (string, string)>
+        {
+            ["receptions"] = ("receiving", "receptions"),
+            ["recYds"] = ("receiving", "receivingYards"),
+            ["recYdsPerGame"] = ("receiving", "receivingYardsPerGame"),
+            ["recTd"] = ("receiving", "receivingTouchdowns"),
+        };
+        var k = new Dictionary<string, (string, string)>
+        {
+            ["fgMade"] = ("kicking", "fieldGoalsMade"),
+            ["fgAtt"] = ("kicking", "fieldGoalAttempts"),
+            ["fgPct"] = ("kicking", "fieldGoalPct"),
+            ["fgLong"] = ("kicking", "longFieldGoalMade"),
+            ["xpMade"] = ("kicking", "extraPointsMade"),
+            ["xpAtt"] = ("kicking", "extraPointAttempts"),
+        };
+        StatMap = new Dictionary<string, Dictionary<string, (string, string)>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["QB"] = qb,
+            ["RB"] = rb,
+            ["WR"] = wr,
+            ["TE"] = wr, // TE shares WR's stat shape
+            ["K"] = k,
+        };
+    }
+
+    private readonly ILogger<GetAthleteMatchupSummariesQueryHandler> _logger;
+    private readonly TeamSportDataContext _dataContext;
+
+    public GetAthleteMatchupSummariesQueryHandler(
+        ILogger<GetAthleteMatchupSummariesQueryHandler> logger,
+        TeamSportDataContext dataContext)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<AthleteMatchupSummariesDto>> ExecuteAsync(
+        GetAthleteMatchupSummariesQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        if (!StatMap.TryGetValue(query.Position, out var statKeys))
+        {
+            return new Failure<AthleteMatchupSummariesDto>(
+                default!,
+                ResultStatus.BadRequest,
+                [new ValidationFailure(nameof(query.Position),
+                    $"Unsupported position '{query.Position}'. Expected one of: {string.Join(", ", StatMap.Keys)}.")]);
+        }
+
+        var position = query.Position.ToUpperInvariant();
+
+        // The UI contract says "K"; ESPN's position row is "PK" (Place
+        // Kicker). Translate at the boundary so both sides keep their
+        // native vocabulary.
+        var dbPosition = position == "K" ? "PK" : position;
+
+        // ── 1. Active FBS athletes at the position for the season ─────────
+        // Explicit join: AthleteSeason carries FranchiseSeasonId with no
+        // navigation property.
+        var athletes = await (
+                from a in _dataContext.AthleteSeasons.AsNoTracking()
+                join fs in _dataContext.FranchiseSeasons.AsNoTracking()
+                    on a.FranchiseSeasonId equals fs.Id
+                where a.IsActive &&
+                      a.Position.Abbreviation == dbPosition &&
+                      a.Status != null && a.Status.Name == "Active" &&
+                      fs.SeasonYear == query.SeasonYear &&
+                      fs.GroupSeasonMap != null &&
+                      fs.GroupSeasonMap.Contains("fbs")
+                select new
+                {
+                    AthleteSeasonId = a.Id,
+                    a.AthleteId,
+                    a.FirstName,
+                    a.LastName,
+                    FranchiseSeasonId = fs.Id,
+                    // DisplayName, not Name: Name is the bare mascot and
+                    // NCAAFB has ten different Tigers.
+                    TeamName = fs.DisplayName,
+                    TeamSlug = fs.Slug,
+                })
+            .ToListAsync(cancellationToken);
+
+        if (athletes.Count == 0)
+        {
+            return new Success<AthleteMatchupSummariesDto>(new AthleteMatchupSummariesDto());
+        }
+
+        var athleteIds = athletes.Select(a => a.AthleteId).ToList();
+        var teamFsIds = athletes.Select(a => a.FranchiseSeasonId).Distinct().ToList();
+
+        // ── 2. Prior-season athlete rows for the sub-row stat block ───────
+        var priorYear = query.SeasonYear - 1;
+        var priorSeasons = await (
+                from a in _dataContext.AthleteSeasons.AsNoTracking()
+                join fs in _dataContext.FranchiseSeasons.AsNoTracking()
+                    on a.FranchiseSeasonId equals fs.Id
+                where athleteIds.Contains(a.AthleteId) &&
+                      fs.SeasonYear == priorYear
+                select new { a.AthleteId, AthleteSeasonId = a.Id })
+            .ToListAsync(cancellationToken);
+
+        // A transfer mid-cycle can leave two prior rows; keep one.
+        var priorByAthlete = priorSeasons
+            .GroupBy(p => p.AthleteId)
+            .ToDictionary(g => g.Key, g => g.First().AthleteSeasonId);
+
+        // ── 3. Newest statistic doc per athlete-season (dupes are real) ───
+        var allSeasonIds = athletes.Select(a => a.AthleteSeasonId)
+            .Concat(priorByAthlete.Values)
+            .ToList();
+
+        var statDocs = await _dataContext.AthleteSeasonStatistics
+            .AsNoTracking()
+            .Where(s => allSeasonIds.Contains(s.AthleteSeasonId))
+            .Select(s => new { s.Id, s.AthleteSeasonId, s.CreatedUtc })
+            .ToListAsync(cancellationToken);
+
+        var newestDocBySeason = statDocs
+            .GroupBy(s => s.AthleteSeasonId)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(s => s.CreatedUtc).First().Id);
+
+        var docIds = newestDocBySeason.Values.ToList();
+        var seasonByDoc = newestDocBySeason.ToDictionary(kv => kv.Value, kv => kv.Key);
+
+        // ── 4. Stat rows for those docs, filtered to the contract's keys ──
+        var wantedCats = statKeys.Values.Select(v => v.Category)
+            .Append(GeneralCategory).Distinct().ToList();
+        var wantedStats = statKeys.Values.Select(v => v.Stat)
+            .Append(GamesPlayedKey).Distinct().ToList();
+
+        var statRows = await _dataContext.AthleteSeasonStatisticCategories
+            .AsNoTracking()
+            .Where(c => docIds.Contains(c.AthleteSeasonStatisticId) && wantedCats.Contains(c.Name))
+            .SelectMany(c => c.Stats
+                .Where(s => wantedStats.Contains(s.Name) && s.Value != null)
+                .Select(s => new
+                {
+                    c.AthleteSeasonStatisticId,
+                    Category = c.Name,
+                    Stat = s.Name,
+                    Value = s.Value!.Value,
+                }))
+            .ToListAsync(cancellationToken);
+
+        // (athleteSeasonId, category, stat) → value. Same-named stats recur
+        // across categories (scoring repeats rushingTouchdowns), so the
+        // category is part of the key.
+        var statLookup = new Dictionary<(Guid, string, string), decimal>();
+        foreach (var row in statRows)
+        {
+            statLookup[(seasonByDoc[row.AthleteSeasonStatisticId], row.Category, row.Stat)] = row.Value;
+        }
+
+        // ── 5. The week's opponent per team ───────────────────────────────
+        // Week resolves through SeasonWeek.Number, NOT Contest.Week: the
+        // schedule import leaves Week null until the companion doc
+        // hydrates it (all 1,527 local 2026 contests were null), while
+        // SeasonWeekId is populated on every one of them.
+        var weekContests = await (
+                from c in _dataContext.Contests.AsNoTracking()
+                join sw in _dataContext.SeasonWeeks.AsNoTracking()
+                    on c.SeasonWeekId equals sw.Id
+                where c.SeasonYear == query.SeasonYear &&
+                      sw.Number == query.Week &&
+                      c.CancelledUtc == null &&
+                      (teamFsIds.Contains(c.HomeTeamFranchiseSeasonId) ||
+                       teamFsIds.Contains(c.AwayTeamFranchiseSeasonId))
+                select new { c.HomeTeamFranchiseSeasonId, c.AwayTeamFranchiseSeasonId })
+            .ToListAsync(cancellationToken);
+
+        var opponentByTeam = new Dictionary<Guid, Guid>();
+        foreach (var c in weekContests)
+        {
+            // Both sides may be FBS; register each direction we care about.
+            if (teamFsIds.Contains(c.HomeTeamFranchiseSeasonId))
+                opponentByTeam[c.HomeTeamFranchiseSeasonId] = c.AwayTeamFranchiseSeasonId;
+            if (teamFsIds.Contains(c.AwayTeamFranchiseSeasonId))
+                opponentByTeam[c.AwayTeamFranchiseSeasonId] = c.HomeTeamFranchiseSeasonId;
+        }
+
+        var opponentFsIds = opponentByTeam.Values.Distinct().ToList();
+
+        var opponentInfo = await _dataContext.FranchiseSeasons
+            .AsNoTracking()
+            .Where(f => opponentFsIds.Contains(f.Id))
+            // DisplayName, not Name — same ten-Tigers problem as above.
+            .Select(f => new { f.Id, Name = f.DisplayName, f.Slug, f.FranchiseId })
+            .ToListAsync(cancellationToken);
+        var opponentById = opponentInfo.ToDictionary(o => o.Id);
+
+        // ── 6. Opponent defensive allowance per game ──────────────────────
+        // Current-season aggregate first; opponents with no games yet fall
+        // back to their prior-season franchise season.
+        var allowedByOpponent = position == "K"
+            ? await ComputePointsAllowedAsync(opponentFsIds, cancellationToken)
+            : await ComputeYardsAllowedAsync(opponentFsIds, OppAllowedMap[position], cancellationToken);
+
+        var missing = opponentFsIds.Where(id => !allowedByOpponent.ContainsKey(id)).ToList();
+        if (missing.Count > 0)
+        {
+            var priorFsByFranchise = await _dataContext.FranchiseSeasons
+                .AsNoTracking()
+                .Where(f => f.SeasonYear == priorYear &&
+                            opponentInfo.Select(o => o.FranchiseId).Contains(f.FranchiseId))
+                .Select(f => new { f.Id, f.FranchiseId })
+                .ToListAsync(cancellationToken);
+
+            var priorFsLookup = priorFsByFranchise
+                .GroupBy(f => f.FranchiseId)
+                .ToDictionary(g => g.Key, g => g.First().Id);
+
+            var missingPriorIds = missing
+                .Where(id => priorFsLookup.ContainsKey(opponentById[id].FranchiseId))
+                .Select(id => priorFsLookup[opponentById[id].FranchiseId])
+                .Distinct()
+                .ToList();
+
+            var priorAllowed = position == "K"
+                ? await ComputePointsAllowedAsync(missingPriorIds, cancellationToken)
+                : await ComputeYardsAllowedAsync(missingPriorIds, OppAllowedMap[position], cancellationToken);
+
+            foreach (var id in missing)
+            {
+                if (priorFsLookup.TryGetValue(opponentById[id].FranchiseId, out var priorId) &&
+                    priorAllowed.TryGetValue(priorId, out var value))
+                {
+                    allowedByOpponent[id] = value;
+                }
+            }
+        }
+
+        // ── 7. Assemble ───────────────────────────────────────────────────
+        var dto = new AthleteMatchupSummariesDto();
+        foreach (var a in athletes.OrderBy(x => x.LastName ?? string.Empty).ThenBy(x => x.FirstName ?? string.Empty))
+        {
+            Guid? oppId = opponentByTeam.TryGetValue(a.FranchiseSeasonId, out var o) ? o : null;
+            var opp = oppId.HasValue && opponentById.TryGetValue(oppId.Value, out var info) ? info : null;
+
+            dto.Athletes.Add(new AthleteMatchupSummaryDto
+            {
+                AthleteId = a.AthleteId,
+                FirstName = a.FirstName ?? string.Empty,
+                LastName = a.LastName ?? string.Empty,
+                TeamName = a.TeamName ?? a.TeamSlug ?? string.Empty,
+                TeamSlug = a.TeamSlug ?? string.Empty,
+                Position = position,
+                OpponentName = opp?.Name,
+                OpponentSlug = opp?.Slug,
+                OpponentDefPerGame = oppId.HasValue && allowedByOpponent.TryGetValue(oppId.Value, out var allowed)
+                    ? allowed
+                    : null,
+                CurrentSeason = BuildSeasonBlock(a.AthleteSeasonId, query.SeasonYear, statKeys, statLookup),
+                PreviousSeason = priorByAthlete.TryGetValue(a.AthleteId, out var priorSeasonId)
+                    ? BuildSeasonBlock(priorSeasonId, priorYear, statKeys, statLookup)
+                    : null,
+            });
+        }
+
+        _logger.LogInformation(
+            "Athlete matchup summaries: {Count} {Position} rows for {SeasonYear} week {Week}; {WithOpp} with opponents, {WithAllowed} with allowance data.",
+            dto.Athletes.Count, position, query.SeasonYear, query.Week,
+            dto.Athletes.Count(x => x.OpponentName != null),
+            dto.Athletes.Count(x => x.OpponentDefPerGame != null));
+
+        return new Success<AthleteMatchupSummariesDto>(dto);
+    }
+
+    /// <summary>
+    /// Null when the athlete-season has no statistic doc or shows zero
+    /// games played — that is "hasn't played", which the grid renders as
+    /// em-dashes and sinks under stat sorts.
+    /// </summary>
+    private static AthleteSeasonStatBlockDto? BuildSeasonBlock(
+        Guid athleteSeasonId,
+        int seasonYear,
+        Dictionary<string, (string Category, string Stat)> statKeys,
+        Dictionary<(Guid, string, string), decimal> statLookup)
+    {
+        if (!statLookup.TryGetValue((athleteSeasonId, GeneralCategory, GamesPlayedKey), out var games) || games <= 0)
+        {
+            return null;
+        }
+
+        var block = new AthleteSeasonStatBlockDto
+        {
+            SeasonYear = seasonYear,
+            GamesPlayed = (int)games,
+        };
+
+        foreach (var (key, (category, stat)) in statKeys)
+        {
+            if (statLookup.TryGetValue((athleteSeasonId, category, stat), out var value))
+            {
+                block.Stats[key] = value;
+            }
+        }
+
+        return block;
+    }
+
+    /// <summary>
+    /// Per-game average of a stat gained AGAINST each franchise season —
+    /// the other side's team statistics across that team's played games.
+    /// </summary>
+    private async Task<Dictionary<Guid, decimal>> ComputeYardsAllowedAsync(
+        List<Guid> franchiseSeasonIds,
+        (string Category, string Stat) metric,
+        CancellationToken cancellationToken)
+    {
+        if (franchiseSeasonIds.Count == 0) return new Dictionary<Guid, decimal>();
+
+        var rows = await (
+                from cc in _dataContext.CompetitionCompetitors.AsNoTracking()
+                where franchiseSeasonIds.Contains(cc.FranchiseSeasonId)
+                join s in _dataContext.CompetitionCompetitorStatistics.AsNoTracking()
+                    on cc.CompetitionId equals s.CompetitionId
+                where s.FranchiseSeasonId != cc.FranchiseSeasonId
+                join cat in _dataContext.CompetitionCompetitorStatisticCategories.AsNoTracking()
+                    on s.Id equals cat.CompetitionCompetitorStatisticId
+                where cat.Name == metric.Category
+                join st in _dataContext.CompetitionCompetitorStatisticStats.AsNoTracking()
+                    on cat.Id equals st.CompetitionCompetitorStatisticCategoryId
+                where st.Name == metric.Stat && st.Value != null
+                select new { cc.FranchiseSeasonId, Value = st.Value!.Value })
+            .ToListAsync(cancellationToken);
+
+        return rows
+            .GroupBy(r => r.FranchiseSeasonId)
+            .ToDictionary(g => g.Key, g => Math.Round(g.Average(r => r.Value), 1));
+    }
+
+    /// <summary>
+    /// Per-game points allowed from finalized contest scores — the K
+    /// opponent metric. Contest scores are authoritative and exist even
+    /// where per-game team statistics have gaps.
+    /// </summary>
+    private async Task<Dictionary<Guid, decimal>> ComputePointsAllowedAsync(
+        List<Guid> franchiseSeasonIds,
+        CancellationToken cancellationToken)
+    {
+        if (franchiseSeasonIds.Count == 0) return new Dictionary<Guid, decimal>();
+
+        var contests = await _dataContext.Contests
+            .AsNoTracking()
+            .Where(c =>
+                c.FinalizedUtc != null &&
+                c.HomeScore != null && c.AwayScore != null &&
+                (franchiseSeasonIds.Contains(c.HomeTeamFranchiseSeasonId) ||
+                 franchiseSeasonIds.Contains(c.AwayTeamFranchiseSeasonId)))
+            .Select(c => new
+            {
+                c.HomeTeamFranchiseSeasonId,
+                c.AwayTeamFranchiseSeasonId,
+                c.HomeScore,
+                c.AwayScore,
+            })
+            .ToListAsync(cancellationToken);
+
+        var pointsAllowed = new Dictionary<Guid, List<int>>();
+        foreach (var c in contests)
+        {
+            if (franchiseSeasonIds.Contains(c.HomeTeamFranchiseSeasonId))
+            {
+                pointsAllowed.TryAdd(c.HomeTeamFranchiseSeasonId, []);
+                pointsAllowed[c.HomeTeamFranchiseSeasonId].Add(c.AwayScore!.Value);
+            }
+            if (franchiseSeasonIds.Contains(c.AwayTeamFranchiseSeasonId))
+            {
+                pointsAllowed.TryAdd(c.AwayTeamFranchiseSeasonId, []);
+                pointsAllowed[c.AwayTeamFranchiseSeasonId].Add(c.HomeScore!.Value);
+            }
+        }
+
+        return pointsAllowed.ToDictionary(
+            kv => kv.Key,
+            kv => Math.Round((decimal)kv.Value.Average(), 1));
+    }
+}

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
@@ -103,29 +104,47 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
 
     private readonly ILogger<GetAthleteMatchupSummariesQueryHandler> _logger;
     private readonly TeamSportDataContext _dataContext;
+    private readonly IValidator<GetAthleteMatchupSummariesQuery> _validator;
 
     public GetAthleteMatchupSummariesQueryHandler(
         ILogger<GetAthleteMatchupSummariesQueryHandler> logger,
-        TeamSportDataContext dataContext)
+        TeamSportDataContext dataContext,
+        IValidator<GetAthleteMatchupSummariesQuery> validator)
     {
         _logger = logger;
         _dataContext = dataContext;
+        _validator = validator;
     }
 
     public async Task<Result<AthleteMatchupSummariesDto>> ExecuteAsync(
         GetAthleteMatchupSummariesQuery query,
         CancellationToken cancellationToken = default)
     {
-        if (!StatMap.TryGetValue(query.Position, out var statKeys))
+        var validation = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validation.IsValid)
         {
             return new Failure<AthleteMatchupSummariesDto>(
                 default!,
-                ResultStatus.BadRequest,
+                ResultStatus.Validation,
+                validation.Errors);
+        }
+
+        // Resolve the CANONICAL whitelist key rather than echoing the raw
+        // input: the position used everywhere downstream (including logs)
+        // is provably one of the dictionary's compile-time constants, and
+        // the whitelist and the stat mapping stay one dictionary.
+        var position = StatMap.Keys.FirstOrDefault(
+            k => string.Equals(k, query.Position, StringComparison.OrdinalIgnoreCase));
+        if (position is null)
+        {
+            return new Failure<AthleteMatchupSummariesDto>(
+                default!,
+                ResultStatus.Validation,
                 [new ValidationFailure(nameof(query.Position),
                     $"Unsupported position '{query.Position}'. Expected one of: {string.Join(", ", StatMap.Keys)}.")]);
         }
 
-        var position = query.Position.ToUpperInvariant();
+        var statKeys = StatMap[position];
 
         // The UI contract says "K"; ESPN's position row is "PK" (Place
         // Kicker). Translate at the boundary so both sides keep their
@@ -235,12 +254,20 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
         // schedule import leaves Week null until the companion doc
         // hydrates it (all 1,527 local 2026 contests were null), while
         // SeasonWeekId is populated on every one of them.
+        //
+        // Scoped to the REGULAR SEASON phase (TypeCode 2): week numbers
+        // restart per phase, so an unscoped Number match would let a
+        // postseason "week 1" overwrite the real week-1 opponent.
+        const int regularSeasonTypeCode = 2;
         var weekContests = await (
                 from c in _dataContext.Contests.AsNoTracking()
                 join sw in _dataContext.SeasonWeeks.AsNoTracking()
                     on c.SeasonWeekId equals sw.Id
+                join sp in _dataContext.SeasonPhases.AsNoTracking()
+                    on sw.SeasonPhaseId equals sp.Id
                 where c.SeasonYear == query.SeasonYear &&
                       sw.Number == query.Week &&
+                      sp.TypeCode == regularSeasonTypeCode &&
                       c.CancelledUtc == null &&
                       (teamFsIds.Contains(c.HomeTeamFranchiseSeasonId) ||
                        teamFsIds.Contains(c.AwayTeamFranchiseSeasonId))
@@ -288,8 +315,14 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
                 .GroupBy(f => f.FranchiseId)
                 .ToDictionary(g => g.Key, g => g.First().Id);
 
+            // TryGetValue throughout: a Contest can reference a
+            // FranchiseSeasonId with no FranchiseSeason row (unsourced
+            // opponent), and this block runs on every week-1 request — a
+            // direct index would turn that data gap into a 500 instead of
+            // a row with a null allowance.
             var missingPriorIds = missing
-                .Where(id => priorFsLookup.ContainsKey(opponentById[id].FranchiseId))
+                .Where(id => opponentById.TryGetValue(id, out var info) &&
+                             priorFsLookup.ContainsKey(info.FranchiseId))
                 .Select(id => priorFsLookup[opponentById[id].FranchiseId])
                 .Distinct()
                 .ToList();
@@ -300,7 +333,8 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
 
             foreach (var id in missing)
             {
-                if (priorFsLookup.TryGetValue(opponentById[id].FranchiseId, out var priorId) &&
+                if (opponentById.TryGetValue(id, out var info) &&
+                    priorFsLookup.TryGetValue(info.FranchiseId, out var priorId) &&
                     priorAllowed.TryGetValue(priorId, out var value))
                 {
                     allowedByOpponent[id] = value;

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryValidator.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSummaries;
+
+/// <summary>
+/// Season-year bounds match the sibling sourcing validators (2000 floor;
+/// at most one year out). Week 1–30 comfortably covers any phase's week
+/// numbering. Position is validated against the handler's supported set
+/// inside the handler itself — the whitelist and the stat mapping are one
+/// dictionary, and splitting them would let the two drift.
+/// </summary>
+public class GetAthleteMatchupSummariesQueryValidator
+    : AbstractValidator<GetAthleteMatchupSummariesQuery>
+{
+    public GetAthleteMatchupSummariesQueryValidator(IDateTimeProvider dateTimeProvider)
+    {
+        RuleFor(x => x.Position)
+            .NotEmpty()
+            .WithMessage("Position is required");
+
+        RuleFor(x => x.SeasonYear)
+            .GreaterThanOrEqualTo(2000)
+            .WithMessage("Season year must be 2000 or later")
+            .Must(year => year <= dateTimeProvider.UtcNow().Year + 1)
+            .WithMessage("Season year cannot be more than one year in the future");
+
+        RuleFor(x => x.Week)
+            .InclusiveBetween(1, 30)
+            .WithMessage("Week must be between 1 and 30");
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -284,6 +284,7 @@ namespace SportsData.Producer.DependencyInjection
             // Athlete Queries
             services.AddScoped<IGetAthleteByIdQueryHandler, GetAthleteByIdQueryHandler>();
             services.AddScoped<IGetAthleteMatchupSummariesQueryHandler, GetAthleteMatchupSummariesQueryHandler>();
+            services.AddScoped<IValidator<GetAthleteMatchupSummariesQuery>, GetAthleteMatchupSummariesQueryValidator>();
 
             // Athlete Commands
             services.AddScoped<IRequestAthleteSeasonStatisticsSourcingCommandHandler, RequestAthleteSeasonStatisticsSourcingCommandHandler>();

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -8,6 +8,7 @@ using SportsData.Core.DependencyInjection;
 using SportsData.Core.Processing;
 using SportsData.Producer.Application.Athletes.Commands.RequestAthleteSeasonStatisticsSourcing;
 using SportsData.Producer.Application.Athletes.Queries.GetAthleteById;
+using SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSummaries;
 using SportsData.Producer.Application.Competitions;
 using SportsData.Producer.Application.Competitions.Reconcile;
 using SportsData.Producer.Application.Consumers;
@@ -282,6 +283,7 @@ namespace SportsData.Producer.DependencyInjection
 
             // Athlete Queries
             services.AddScoped<IGetAthleteByIdQueryHandler, GetAthleteByIdQueryHandler>();
+            services.AddScoped<IGetAthleteMatchupSummariesQueryHandler, GetAthleteMatchupSummariesQueryHandler>();
 
             // Athlete Commands
             services.AddScoped<IRequestAthleteSeasonStatisticsSourcingCommandHandler, RequestAthleteSeasonStatisticsSourcingCommandHandler>();

--- a/src/UI/sd-mobile/__tests__/utils/pickemLogic.test.ts
+++ b/src/UI/sd-mobile/__tests__/utils/pickemLogic.test.ts
@@ -8,6 +8,8 @@ import {
 import {
   NAME_SORT,
   sortAthletes,
+  filterAthletes,
+  filterByOpponent,
   statPartsFor,
   seasonLine,
 } from '@/src/utils/pickem/athleteStats';
@@ -78,6 +80,30 @@ describe('sortAthletes (mobile port)', () => {
     expect(sortAthletes(rows, NAME_SORT, qbParts).map((r) => r.lastName)).toEqual([
       'Alpha', 'Zeta',
     ]);
+  });
+});
+
+describe('filterAthletes (mobile port)', () => {
+  it('matches names and team case-insensitively; empty filter is identity', () => {
+    const rows = [
+      { ...qb('Manning', 1, 1), teamName: 'Texas Longhorns' },
+      { ...qb('Nussmeier', 1, 1), teamName: 'LSU Tigers' },
+    ];
+    expect(filterAthletes(rows, 'tigers')).toHaveLength(1);
+    expect(filterAthletes(rows, 'MANNING')).toHaveLength(1);
+    expect(filterAthletes(rows, '')).toBe(rows);
+  });
+});
+
+describe('filterByOpponent (mobile port)', () => {
+  it('matches the week opponent; byes never match; empty is identity', () => {
+    const rows = [
+      { ...qb('Love', 1, 1), opponentName: 'UMass Minutemen' },
+      { ...qb('OnBye', 1, 1), opponentName: null },
+    ];
+    expect(filterByOpponent(rows, 'umass')).toHaveLength(1);
+    expect(filterByOpponent(rows, 'x')).toHaveLength(0);
+    expect(filterByOpponent(rows, '')).toBe(rows);
   });
 });
 

--- a/src/UI/sd-mobile/app/admin/player-pickem.tsx
+++ b/src/UI/sd-mobile/app/admin/player-pickem.tsx
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   ScrollView,
   FlatList,
+  TextInput,
   TouchableOpacity,
 } from 'react-native';
 import { Stack } from 'expo-router';
@@ -29,6 +30,8 @@ import {
   statPartsFor,
   seasonLine,
   sortAthletes,
+  filterAthletes,
+  filterByOpponent,
   NAME_SORT,
   type SortDescriptor,
 } from '@/src/utils/pickem/athleteStats';
@@ -79,6 +82,11 @@ function sanitizeRoster(raw: string): Roster {
   }
 }
 
+// Fixed to opening week for the admin preview; a week selector (and
+// deriving the current week server-side) is future work.
+const SEASON_YEAR = 2026;
+const WEEK = 1;
+
 const OPP_DEF_LABEL: Record<string, string> = {
   QB: 'Pass Alw/G',
   RB: 'Rush Alw/G',
@@ -109,6 +117,8 @@ export default function PlayerPickemScreen() {
   const [athletes, setAthletes] = useState<PickemAthlete[]>([]);
   const [loading, setLoading] = useState(false);
   const [sort, setSort] = useState<SortDescriptor>(NAME_SORT);
+  const [filterText, setFilterText] = useState('');
+  const [opponentText, setOpponentText] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -142,9 +152,11 @@ export default function PlayerPickemScreen() {
     [activeSlotId, positions]
   );
 
-  // Stat sets differ per slot — slot changes reset to the name sort.
+  // Stat sets differ per slot — slot changes reset sort and filter.
   useEffect(() => {
     setSort(NAME_SORT);
+    setFilterText('');
+    setOpponentText('');
   }, [activeSlotId]);
 
   useEffect(() => {
@@ -152,7 +164,7 @@ export default function PlayerPickemScreen() {
     let ignore = false;
     setLoading(true);
 
-    Promise.all(positions.map((pos) => getAthletesByPosition(pos)))
+    Promise.all(positions.map((pos) => getAthletesByPosition(pos, SEASON_YEAR, WEEK)))
       .then((responses) => {
         if (ignore) return;
         setAthletes(responses.flatMap((r) => r.athletes));
@@ -167,8 +179,13 @@ export default function PlayerPickemScreen() {
   }, [positions]);
 
   const sorted = useMemo(
-    () => sortAthletes(athletes, sort, parts),
-    [athletes, sort, parts]
+    () =>
+      sortAthletes(
+        filterByOpponent(filterAthletes(athletes, filterText), opponentText),
+        sort,
+        parts
+      ),
+    [athletes, filterText, opponentText, sort, parts]
   );
 
   const toggleSort = useCallback((key: string) => {
@@ -266,8 +283,8 @@ export default function PlayerPickemScreen() {
         <View style={styles.seasonRow}>
           <Text style={[styles.seasonTag, { color: theme.text }]}>
             {a.currentSeason
-              ? `'26 · ${a.currentSeason.gamesPlayed} G`
-              : "'26 · —"}
+              ? `'${a.currentSeason.seasonYear % 100} · ${a.currentSeason.gamesPlayed} G`
+              : `'${SEASON_YEAR % 100} · —`}
           </Text>
           <Text style={[styles.seasonStats, { color: theme.text }]} numberOfLines={1}>
             {a.currentSeason
@@ -278,8 +295,8 @@ export default function PlayerPickemScreen() {
         <View style={styles.seasonRow}>
           <Text style={[styles.seasonTag, { color: theme.textMuted }]}>
             {a.previousSeason
-              ? `'25 · ${a.previousSeason.gamesPlayed} G`
-              : "'25 · —"}
+              ? `'${a.previousSeason.seasonYear % 100} · ${a.previousSeason.gamesPlayed} G`
+              : `'${(SEASON_YEAR - 1) % 100} · —`}
           </Text>
           <Text style={[styles.seasonStats, { color: theme.textMuted }]} numberOfLines={1}>
             {a.previousSeason
@@ -296,7 +313,7 @@ export default function PlayerPickemScreen() {
       <Stack.Screen options={{ title: "Player Pick'em", headerBackTitle: 'Back' }} />
       <View style={[styles.container, { backgroundColor: theme.background }]}>
         <Text style={[styles.sub, { color: theme.textMuted }]}>
-          Week 5 · 2026 · NCAAFB (FBS) — admin preview, local-only, mock data
+          {`Week ${WEEK} · ${SEASON_YEAR} · NCAAFB (FBS) — admin preview, local-only`}
         </Text>
 
         {/* Wrapping grid, not a horizontal scroller — every slot visible at
@@ -351,6 +368,35 @@ export default function PlayerPickemScreen() {
               </TouchableOpacity>
             );
           })}
+        </View>
+
+        <View style={styles.filterRow}>
+          <TextInput
+            style={[
+              styles.filterInput,
+              { borderColor: theme.border, color: theme.text, backgroundColor: theme.card },
+            ]}
+            placeholder="Player or team…"
+            placeholderTextColor={theme.textMuted}
+            value={filterText}
+            onChangeText={setFilterText}
+            autoCorrect={false}
+            clearButtonMode="while-editing"
+          />
+          {/* The matchup hunt: "UMass is horrible, show me the RBs
+              playing them this weekend." */}
+          <TextInput
+            style={[
+              styles.filterInput,
+              { borderColor: theme.border, color: theme.text, backgroundColor: theme.card },
+            ]}
+            placeholder="Opponent…"
+            placeholderTextColor={theme.textMuted}
+            value={opponentText}
+            onChangeText={setOpponentText}
+            autoCorrect={false}
+            clearButtonMode="while-editing"
+          />
         </View>
 
         {/* Sort chips replace the web's clickable column headers. */}
@@ -461,6 +507,20 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginHorizontal: 16,
+    marginTop: 10,
+  },
+  filterInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 7,
+    paddingHorizontal: 10,
+    fontSize: 13,
   },
   sortRow: { flexGrow: 0, marginTop: 10 },
   sortRowContent: { paddingHorizontal: 16, gap: 6 },

--- a/src/UI/sd-mobile/src/services/api/playerPickemApi.ts
+++ b/src/UI/sd-mobile/src/services/api/playerPickemApi.ts
@@ -1,9 +1,8 @@
 // Player Pick'em roster-builder data layer — TS mirror of sd-ui's
-// src/api/playerPickemApi.js (same contract, same mock Week 5 snapshot).
-//
-// MOCK-BACKED FOR NOW. When the Producer endpoint lands via the API
-// proxy, replace the mock with apiClient and delete MOCK_ATHLETES — the
-// screen consumes only this module.
+// src/api/playerPickemApi.js, served by the API's relay to Producer's
+// athletes/pickem feed.
+
+import { apiClient } from './client';
 
 export type SeasonBlock = {
   seasonYear: number;
@@ -20,139 +19,28 @@ export type PickemAthlete = {
   position: 'QB' | 'RB' | 'WR' | 'TE' | 'K';
   opponentName: string | null;
   opponentSlug: string | null;
-  // Opponent's relevant defensive allowance per game: pass yds allowed/G
-  // for QB/WR/TE, rush yds allowed/G for RB, points allowed/G for K.
+  // Opponent's relevant defensive allowance per game: net pass yds
+  // allowed/G for QB/WR/TE, rush yds allowed/G for RB, points allowed/G
+  // for K — aggregated server-side from what the opponent's opponents
+  // actually gained; prior-season values until the opponent has
+  // current-season games.
   opponentDefPerGame: number | null;
   // null before the athlete's first game of the season (week 1 everywhere)
   currentSeason: SeasonBlock | null;
   previousSeason: SeasonBlock | null;
 };
 
-const MOCK_ATHLETES: Record<string, PickemAthlete[]> = {
-  QB: [
-    {
-      athleteId: 'ea6ec41d-31a1-623e-1a68-d21910f17bb8', firstName: 'Arch', lastName: 'Manning',
-      teamName: 'Texas Longhorns', teamSlug: 'texas-longhorns', position: 'QB',
-      opponentName: 'Oklahoma Sooners', opponentSlug: 'oklahoma-sooners', opponentDefPerGame: 158.9,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 68.6, passYds: 1247, passYdsPerGame: 311.8, passTd: 11, interceptions: 2, rushYds: 186 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { cmpPct: 61.2, passYds: 1785, passYdsPerGame: 148.8, passTd: 15, interceptions: 4, rushYds: 224 } },
-    },
-    {
-      athleteId: '4afaf7e4-f027-c0ea-a5a1-358f3730f057', firstName: 'Sam', lastName: 'Leavitt',
-      teamName: 'Arizona State Sun Devils', teamSlug: 'arizona-state-sun-devils', position: 'QB',
-      opponentName: 'Utah Utes', opponentSlug: 'utah-utes', opponentDefPerGame: 171.2,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 64.1, passYds: 1102, passYdsPerGame: 275.5, passTd: 9, interceptions: 3, rushYds: 147 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 61.7, passYds: 2885, passYdsPerGame: 221.9, passTd: 24, interceptions: 6, rushYds: 443 } },
-    },
-    {
-      athleteId: 'mock-qb-3', firstName: 'LaNorris', lastName: 'Sellers',
-      teamName: 'South Carolina Gamecocks', teamSlug: 'south-carolina-gamecocks', position: 'QB',
-      opponentName: 'Kentucky Wildcats', opponentSlug: 'kentucky-wildcats', opponentDefPerGame: 226.8,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { cmpPct: 66.9, passYds: 1310, passYdsPerGame: 262.0, passTd: 10, interceptions: 2, rushYds: 312 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 65.6, passYds: 2534, passYdsPerGame: 194.9, passTd: 18, interceptions: 7, rushYds: 674 } },
-    },
-    {
-      athleteId: 'mock-qb-4', firstName: 'Garrett', lastName: 'Nussmeier',
-      teamName: 'LSU Tigers', teamSlug: 'lsu-tigers', position: 'QB',
-      opponentName: 'Ole Miss Rebels', opponentSlug: 'ole-miss-rebels', opponentDefPerGame: 243.5,
-      // Hasn't played this season — exercises null-current rendering.
-      currentSeason: null,
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 64.2, passYds: 4052, passYdsPerGame: 311.7, passTd: 29, interceptions: 12, rushYds: 34 } },
-    },
-    {
-      athleteId: 'mock-qb-5', firstName: 'Cade', lastName: 'Klubnik',
-      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'QB',
-      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 65.8, passYds: 1042, passYdsPerGame: 260.5, passTd: 8, interceptions: 1, rushYds: 122 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { cmpPct: 63.4, passYds: 3639, passYdsPerGame: 259.9, passTd: 36, interceptions: 6, rushYds: 463 } },
-    },
-  ],
-  RB: [
-    {
-      athleteId: 'mock-rb-1', firstName: 'Jeremiyah', lastName: 'Love',
-      teamName: 'Notre Dame Fighting Irish', teamSlug: 'notre-dame-fighting-irish', position: 'RB',
-      opponentName: 'USC Trojans', opponentSlug: 'usc-trojans', opponentDefPerGame: 148.6,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { rushAtt: 71, rushYds: 512, rushYdsPerGame: 128.0, rushTd: 7, receptions: 11 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 163, rushYds: 1125, rushYdsPerGame: 86.5, rushTd: 17, receptions: 28 } },
-    },
-    {
-      athleteId: 'mock-rb-2', firstName: 'Nicholas', lastName: 'Singleton',
-      teamName: 'Penn State Nittany Lions', teamSlug: 'penn-state-nittany-lions', position: 'RB',
-      opponentName: 'UCLA Bruins', opponentSlug: 'ucla-bruins', opponentDefPerGame: 176.3,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 82, rushYds: 464, rushYdsPerGame: 92.8, rushTd: 6, receptions: 14 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { rushAtt: 172, rushYds: 1099, rushYdsPerGame: 68.7, rushTd: 12, receptions: 41 } },
-    },
-    {
-      athleteId: 'mock-rb-3', firstName: 'Makhi', lastName: 'Hughes',
-      teamName: 'Oregon Ducks', teamSlug: 'oregon-ducks', position: 'RB',
-      opponentName: 'Indiana Hoosiers', opponentSlug: 'indiana-hoosiers', opponentDefPerGame: 101.9,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 96, rushYds: 538, rushYdsPerGame: 107.6, rushTd: 5, receptions: 9 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 245, rushYds: 1401, rushYdsPerGame: 107.8, rushTd: 15, receptions: 24 } },
-    },
-  ],
-  WR: [
-    {
-      athleteId: 'mock-wr-1', firstName: 'Jeremiah', lastName: 'Smith',
-      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'WR',
-      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 34, recYds: 587, recYdsPerGame: 117.4, recTd: 7 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { receptions: 76, recYds: 1315, recYdsPerGame: 82.2, recTd: 15 } },
-    },
-    {
-      athleteId: 'mock-wr-2', firstName: 'Ryan', lastName: 'Williams',
-      teamName: 'Alabama Crimson Tide', teamSlug: 'alabama-crimson-tide', position: 'WR',
-      opponentName: 'Vanderbilt Commodores', opponentSlug: 'vanderbilt-commodores', opponentDefPerGame: 233.1,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 21, recYds: 356, recYdsPerGame: 89.0, recTd: 4 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 48, recYds: 865, recYdsPerGame: 66.5, recTd: 8 } },
-    },
-    {
-      athleteId: 'mock-wr-3', firstName: 'Antonio', lastName: 'Williams',
-      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'WR',
-      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 26, recYds: 401, recYdsPerGame: 100.3, recTd: 3 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 75, recYds: 904, recYdsPerGame: 69.5, recTd: 11 } },
-    },
-  ],
-  TE: [
-    {
-      athleteId: 'mock-te-1', firstName: 'Max', lastName: 'Klare',
-      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'TE',
-      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 22, recYds: 264, recYdsPerGame: 52.8, recTd: 3 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { receptions: 51, recYds: 685, recYdsPerGame: 57.1, recTd: 4 } },
-    },
-    {
-      athleteId: 'mock-te-2', firstName: 'Eli', lastName: 'Stowers',
-      teamName: 'Vanderbilt Commodores', teamSlug: 'vanderbilt-commodores', position: 'TE',
-      opponentName: 'Alabama Crimson Tide', opponentSlug: 'alabama-crimson-tide', opponentDefPerGame: 187.4,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 25, recYds: 301, recYdsPerGame: 60.2, recTd: 4 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 49, recYds: 638, recYdsPerGame: 49.1, recTd: 5 } },
-    },
-  ],
-  K: [
-    {
-      athleteId: 'mock-k-1', firstName: 'Dominic', lastName: 'Zvada',
-      teamName: 'Michigan Wolverines', teamSlug: 'michigan-wolverines', position: 'K',
-      opponentName: 'Washington Huskies', opponentSlug: 'washington-huskies', opponentDefPerGame: 22.6,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 9, fgAtt: 10, fgPct: 90.0, fgLong: 56, xpMade: 14, xpAtt: 14 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { fgMade: 21, fgAtt: 22, fgPct: 95.5, fgLong: 56, xpMade: 38, xpAtt: 38 } },
-    },
-    {
-      athleteId: 'mock-k-2', firstName: 'Peyton', lastName: 'Woodring',
-      teamName: 'Georgia Bulldogs', teamSlug: 'georgia-bulldogs', position: 'K',
-      opponentName: 'Auburn Tigers', opponentSlug: 'auburn-tigers', opponentDefPerGame: 19.8,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 8, fgAtt: 9, fgPct: 88.9, fgLong: 52, xpMade: 17, xpAtt: 17 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { fgMade: 19, fgAtt: 23, fgPct: 82.6, fgLong: 49, xpMade: 46, xpAtt: 46 } },
-    },
-  ],
-};
+type PickemAthletesResponse = { athletes: PickemAthlete[] };
 
-function respond(rows: PickemAthlete[]): Promise<{ athletes: PickemAthlete[] }> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve({ athletes: rows }), 250);
-  });
-}
-
-export function getAthletesByPosition(position: string) {
-  return respond(MOCK_ATHLETES[position] ?? []);
+export async function getAthletesByPosition(
+  position: string,
+  seasonYear: number,
+  week: number,
+  sport = 'football',
+  league = 'ncaa',
+): Promise<PickemAthletesResponse> {
+  const response = await apiClient.get<PickemAthletesResponse>(
+    `/api/${sport}/${league}/athletes/pickem?position=${encodeURIComponent(position)}&seasonYear=${seasonYear}&week=${week}`,
+  );
+  return response.data;
 }

--- a/src/UI/sd-mobile/src/utils/pickem/athleteStats.ts
+++ b/src/UI/sd-mobile/src/utils/pickem/athleteStats.ts
@@ -107,6 +107,35 @@ export function seasonLine(
     .join(' · ');
 }
 
+/**
+ * Case-insensitive substring match on last name, first name, or team
+ * name. Empty/whitespace filter returns the SAME array so memo deps stay
+ * cheap. Mirrors sd-ui's athleteSort.filterAthletes.
+ */
+export function filterAthletes(rows: PickemAthlete[], text: string): PickemAthlete[] {
+  const needle = text.trim().toLowerCase();
+  if (!needle) return rows;
+  return rows.filter(
+    (r) =>
+      r.lastName.toLowerCase().includes(needle) ||
+      r.firstName.toLowerCase().includes(needle) ||
+      r.teamName.toLowerCase().includes(needle)
+  );
+}
+
+/**
+ * Case-insensitive substring match on the WEEK OPPONENT's name — the
+ * matchup-hunting filter ("show me every RB playing UMass"). Bye-week
+ * rows never match a non-empty filter. Mirrors sd-ui's filterByOpponent.
+ */
+export function filterByOpponent(rows: PickemAthlete[], text: string): PickemAthlete[] {
+  const needle = text.trim().toLowerCase();
+  if (!needle) return rows;
+  return rows.filter((r) =>
+    (r.opponentName ?? '').toLowerCase().includes(needle)
+  );
+}
+
 export type SortDescriptor = { key: string; dir?: 'desc' | 'asc' };
 
 export const NAME_SORT: SortDescriptor = { key: 'name' };

--- a/src/UI/sd-ui/src/api/playerPickemApi.js
+++ b/src/UI/sd-ui/src/api/playerPickemApi.js
@@ -1,13 +1,7 @@
 // src/api/playerPickemApi.js
 //
-// Player Pick'em roster-builder data layer.
-//
-// MOCK-BACKED FOR NOW. The response shape below is the contract the real
-// Producer query (athletes-by-position with opponent + opponent-defense
-// join) will serve via the API proxy. When that endpoint lands, delete
-// MOCK_ATHLETES and the fake-latency wrapper and switch getAthletesByPosition
-// to apiClient.get(`/api/${sport}/${league}/pickem/athletes?position=${pos}`)
-// — the page consumes only this module, so nothing else changes.
+// Player Pick'em roster-builder data layer, served by the API's relay to
+// Producer's athletes/pickem feed.
 //
 // Row contract (one per athlete):
 //   athleteId            Guid
@@ -18,156 +12,27 @@
 //   opponentName         this week's opponent (null on bye)
 //   opponentSlug         opponent team-card link (null on bye)
 //   opponentDefPerGame   opponent's relevant defensive allowance per game:
-//                        pass yds allowed/G for QB/WR/TE, rush yds
-//                        allowed/G for RB, points allowed/G for K.
-//                        Prior-season values until current-season games
-//                        exist.
-//   currentSeason        season block or null (null before the athlete's
-//                        first game of the season — week 1 everywhere)
-//   previousSeason       season block or null (true freshmen)
+//                        net pass yds allowed/G for QB/WR/TE, rush yds
+//                        allowed/G for RB, points allowed/G for K —
+//                        aggregated server-side from what the opponent's
+//                        opponents actually gained; prior-season values
+//                        until the opponent has current-season games.
+//   currentSeason        { seasonYear, gamesPlayed, stats } or null (null
+//                        before the athlete's first game — week 1 everywhere)
+//   previousSeason       same shape or null (true freshmen)
 //
-// Season block: { seasonYear, gamesPlayed, stats } where stats carries the
-// position-relevant keys (see gridColumns.js). Both seasons use the SAME
-// shape so the grid renders prior season directly beneath current season
-// in the same columns.
-//
-// The mock below is a plausible WEEK 5 snapshot so the with-data design
-// is visible; Nussmeier carries currentSeason: null to exercise the
-// hasn't-played rendering (em-dashes, sinks under stat sorts).
+// stats keys are position-scoped (cmpPct, passYds, rushAtt, receptions,
+// fgMade, ...) — see gridColumns.js for the render mapping.
 
-const MOCK_ATHLETES = {
-  QB: [
-    {
-      athleteId: 'ea6ec41d-31a1-623e-1a68-d21910f17bb8', firstName: 'Arch', lastName: 'Manning',
-      teamName: 'Texas Longhorns', teamSlug: 'texas-longhorns', position: 'QB',
-      opponentName: 'Oklahoma Sooners', opponentSlug: 'oklahoma-sooners', opponentDefPerGame: 158.9,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 68.6, passYds: 1247, passYdsPerGame: 311.8, passTd: 11, interceptions: 2, rushYds: 186 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { cmpPct: 61.2, passYds: 1785, passYdsPerGame: 148.8, passTd: 15, interceptions: 4, rushYds: 224 } },
-    },
-    {
-      athleteId: '4afaf7e4-f027-c0ea-a5a1-358f3730f057', firstName: 'Sam', lastName: 'Leavitt',
-      teamName: 'Arizona State Sun Devils', teamSlug: 'arizona-state-sun-devils', position: 'QB',
-      opponentName: 'Utah Utes', opponentSlug: 'utah-utes', opponentDefPerGame: 171.2,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 64.1, passYds: 1102, passYdsPerGame: 275.5, passTd: 9, interceptions: 3, rushYds: 147 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 61.7, passYds: 2885, passYdsPerGame: 221.9, passTd: 24, interceptions: 6, rushYds: 443 } },
-    },
-    {
-      athleteId: 'mock-qb-3', firstName: 'LaNorris', lastName: 'Sellers',
-      teamName: 'South Carolina Gamecocks', teamSlug: 'south-carolina-gamecocks', position: 'QB',
-      opponentName: 'Kentucky Wildcats', opponentSlug: 'kentucky-wildcats', opponentDefPerGame: 226.8,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { cmpPct: 66.9, passYds: 1310, passYdsPerGame: 262.0, passTd: 10, interceptions: 2, rushYds: 312 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 65.6, passYds: 2534, passYdsPerGame: 194.9, passTd: 18, interceptions: 7, rushYds: 674 } },
-    },
-    {
-      athleteId: 'mock-qb-4', firstName: 'Garrett', lastName: 'Nussmeier',
-      teamName: 'LSU Tigers', teamSlug: 'lsu-tigers', position: 'QB',
-      opponentName: 'Ole Miss Rebels', opponentSlug: 'ole-miss-rebels', opponentDefPerGame: 243.5,
-      // Hasn't played this season (injury) — exercises the null-current
-      // rendering and stat-sort sinking.
-      currentSeason: null,
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { cmpPct: 64.2, passYds: 4052, passYdsPerGame: 311.7, passTd: 29, interceptions: 12, rushYds: 34 } },
-    },
-    {
-      athleteId: 'mock-qb-5', firstName: 'Cade', lastName: 'Klubnik',
-      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'QB',
-      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { cmpPct: 65.8, passYds: 1042, passYdsPerGame: 260.5, passTd: 8, interceptions: 1, rushYds: 122 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { cmpPct: 63.4, passYds: 3639, passYdsPerGame: 259.9, passTd: 36, interceptions: 6, rushYds: 463 } },
-    },
-  ],
-  RB: [
-    {
-      athleteId: 'mock-rb-1', firstName: 'Jeremiyah', lastName: 'Love',
-      teamName: 'Notre Dame Fighting Irish', teamSlug: 'notre-dame-fighting-irish', position: 'RB',
-      opponentName: 'USC Trojans', opponentSlug: 'usc-trojans', opponentDefPerGame: 148.6,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { rushAtt: 71, rushYds: 512, rushYdsPerGame: 128.0, rushTd: 7, receptions: 11 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 163, rushYds: 1125, rushYdsPerGame: 86.5, rushTd: 17, receptions: 28 } },
-    },
-    {
-      athleteId: 'mock-rb-2', firstName: 'Nicholas', lastName: 'Singleton',
-      teamName: 'Penn State Nittany Lions', teamSlug: 'penn-state-nittany-lions', position: 'RB',
-      opponentName: 'UCLA Bruins', opponentSlug: 'ucla-bruins', opponentDefPerGame: 176.3,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 82, rushYds: 464, rushYdsPerGame: 92.8, rushTd: 6, receptions: 14 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { rushAtt: 172, rushYds: 1099, rushYdsPerGame: 68.7, rushTd: 12, receptions: 41 } },
-    },
-    {
-      athleteId: 'mock-rb-3', firstName: 'Makhi', lastName: 'Hughes',
-      teamName: 'Oregon Ducks', teamSlug: 'oregon-ducks', position: 'RB',
-      opponentName: 'Indiana Hoosiers', opponentSlug: 'indiana-hoosiers', opponentDefPerGame: 101.9,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { rushAtt: 96, rushYds: 538, rushYdsPerGame: 107.6, rushTd: 5, receptions: 9 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { rushAtt: 245, rushYds: 1401, rushYdsPerGame: 107.8, rushTd: 15, receptions: 24 } },
-    },
-  ],
-  WR: [
-    {
-      athleteId: 'mock-wr-1', firstName: 'Jeremiah', lastName: 'Smith',
-      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'WR',
-      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 34, recYds: 587, recYdsPerGame: 117.4, recTd: 7 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 16, stats: { receptions: 76, recYds: 1315, recYdsPerGame: 82.2, recTd: 15 } },
-    },
-    {
-      athleteId: 'mock-wr-2', firstName: 'Ryan', lastName: 'Williams',
-      teamName: 'Alabama Crimson Tide', teamSlug: 'alabama-crimson-tide', position: 'WR',
-      opponentName: 'Vanderbilt Commodores', opponentSlug: 'vanderbilt-commodores', opponentDefPerGame: 233.1,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 21, recYds: 356, recYdsPerGame: 89.0, recTd: 4 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 48, recYds: 865, recYdsPerGame: 66.5, recTd: 8 } },
-    },
-    {
-      athleteId: 'mock-wr-3', firstName: 'Antonio', lastName: 'Williams',
-      teamName: 'Clemson Tigers', teamSlug: 'clemson-tigers', position: 'WR',
-      opponentName: null, opponentSlug: null, opponentDefPerGame: null, // bye with Clemson
-      currentSeason: { seasonYear: 2026, gamesPlayed: 4, stats: { receptions: 26, recYds: 401, recYdsPerGame: 100.3, recTd: 3 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 75, recYds: 904, recYdsPerGame: 69.5, recTd: 11 } },
-    },
-  ],
-  TE: [
-    {
-      athleteId: 'mock-te-1', firstName: 'Max', lastName: 'Klare',
-      teamName: 'Ohio State Buckeyes', teamSlug: 'ohio-state-buckeyes', position: 'TE',
-      opponentName: 'Illinois Fighting Illini', opponentSlug: 'illinois-fighting-illini', opponentDefPerGame: 201.7,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 22, recYds: 264, recYdsPerGame: 52.8, recTd: 3 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 12, stats: { receptions: 51, recYds: 685, recYdsPerGame: 57.1, recTd: 4 } },
-    },
-    {
-      athleteId: 'mock-te-2', firstName: 'Eli', lastName: 'Stowers',
-      teamName: 'Vanderbilt Commodores', teamSlug: 'vanderbilt-commodores', position: 'TE',
-      opponentName: 'Alabama Crimson Tide', opponentSlug: 'alabama-crimson-tide', opponentDefPerGame: 187.4,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { receptions: 25, recYds: 301, recYdsPerGame: 60.2, recTd: 4 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { receptions: 49, recYds: 638, recYdsPerGame: 49.1, recTd: 5 } },
-    },
-  ],
-  K: [
-    {
-      athleteId: 'mock-k-1', firstName: 'Dominic', lastName: 'Zvada',
-      teamName: 'Michigan Wolverines', teamSlug: 'michigan-wolverines', position: 'K',
-      opponentName: 'Washington Huskies', opponentSlug: 'washington-huskies', opponentDefPerGame: 22.6,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 9, fgAtt: 10, fgPct: 90.0, fgLong: 56, xpMade: 14, xpAtt: 14 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 13, stats: { fgMade: 21, fgAtt: 22, fgPct: 95.5, fgLong: 56, xpMade: 38, xpAtt: 38 } },
-    },
-    {
-      athleteId: 'mock-k-2', firstName: 'Peyton', lastName: 'Woodring',
-      teamName: 'Georgia Bulldogs', teamSlug: 'georgia-bulldogs', position: 'K',
-      opponentName: 'Auburn Tigers', opponentSlug: 'auburn-tigers', opponentDefPerGame: 19.8,
-      currentSeason: { seasonYear: 2026, gamesPlayed: 5, stats: { fgMade: 8, fgAtt: 9, fgPct: 88.9, fgLong: 52, xpMade: 17, xpAtt: 17 } },
-      previousSeason: { seasonYear: 2025, gamesPlayed: 14, stats: { fgMade: 19, fgAtt: 23, fgPct: 82.6, fgLong: 49, xpMade: 46, xpAtt: 46 } },
-    },
-  ],
-};
-
-// Small fake latency so loading states are exercised the way the real
-// endpoint will exercise them.
-function respond(rows) {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve({ data: { athletes: rows } }), 250);
-  });
-}
+import apiClient from './apiClient';
 
 const PlayerPickemApi = {
   // position: "QB" | "RB" | "WR" | "TE" | "K". FLEX is a UI concept —
   // the page requests each eligible position and merges.
-  getAthletesByPosition: (sport, league, position) =>
-    respond(MOCK_ATHLETES[position] ?? []),
+  getAthletesByPosition: (sport, league, position, seasonYear, week) =>
+    apiClient.get(
+      `/api/${sport}/${league}/athletes/pickem?position=${encodeURIComponent(position)}&seasonYear=${seasonYear}&week=${week}`
+    ),
 };
 
 export default PlayerPickemApi;

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
@@ -101,6 +101,81 @@
   border-color: var(--accent);
 }
 
+/* ── Toolbar (filter + count) ─────────────────────────────────────── */
+
+.roster-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.roster-filter {
+  flex: 1;
+  max-width: 320px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--accent-subtle);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.85rem;
+}
+
+.roster-filter:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.roster-toolbar-count {
+  color: var(--text-muted, #8d96a0);
+  font-size: 0.8rem;
+  flex: 1;
+}
+
+/* Pushed right so it visually pairs with the opponent columns. */
+.roster-filter--opponent {
+  flex: 0 1 auto;
+  max-width: 220px;
+}
+
+/* ── Pager ────────────────────────────────────────────────────────── */
+
+.roster-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--accent-subtle);
+}
+
+.roster-pager-btn {
+  border: 1px solid var(--accent-subtle);
+  background: none;
+  color: var(--accent);
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.roster-pager-btn:hover:not(:disabled),
+.roster-pager-btn:focus-visible:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.roster-pager-btn:disabled {
+  color: var(--text-muted, #8d96a0);
+  cursor: default;
+}
+
+.roster-pager-label {
+  color: var(--text-muted, #8d96a0);
+  font-size: 0.8rem;
+}
+
 /* ── Athlete grid ─────────────────────────────────────────────────── */
 
 /* Wide table scrolls inside its own container on narrow viewports —

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -9,13 +9,28 @@ import {
   remove,
   isRostered,
 } from './rosterLogic';
-import { NAME_SORT, sortAthletes } from './athleteSort';
+import {
+  NAME_SORT,
+  sortAthletes,
+  filterAthletes,
+  filterByOpponent,
+} from './athleteSort';
 import { columnsFor, cellText } from './gridColumns';
 import './PlayerRosterBuilder.css';
 
 // Selections survive reloads — rudimentary stand-in for the carry-over
 // behavior until PlayerLineup entities exist server-side.
 const ROSTER_KEY = 'playerPickemRosterDraft';
+
+// Fixed to opening week for the admin preview; a week selector (and
+// deriving the current week server-side) is future work.
+const SEASON_YEAR = 2026;
+const WEEK = 1;
+
+// Full-depth FBS position lists run to ~2,000 rows (WR); the grid pages
+// client-side — the payload is already in the browser, so filtering and
+// paging never refetch.
+const PAGE_SIZE = 25;
 
 // Meaning of opponentDefPerGame varies by the position being browsed.
 // FLEX merges positions, so it gets the generic label and the per-row
@@ -90,6 +105,9 @@ function PlayerRosterBuilder() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [sort, setSort] = useState(NAME_SORT);
+  const [filterText, setFilterText] = useState('');
+  const [opponentText, setOpponentText] = useState('');
+  const [page, setPage] = useState(0);
 
   useEffect(() => {
     localStorage.setItem(ROSTER_KEY, JSON.stringify(roster));
@@ -106,10 +124,20 @@ function PlayerRosterBuilder() {
   );
 
   // Stat columns differ per slot — a sort on CMP% means nothing on the
-  // RB grid, so slot changes reset to the name sort.
+  // RB grid, so slot changes reset sort, filter, and page together.
   useEffect(() => {
     setSort(NAME_SORT);
+    setFilterText('');
+    setOpponentText('');
+    setPage(0);
   }, [activeSlotId]);
+
+  // Any change to what's shown restarts at the first page — a filter or
+  // re-sort that leaves you stranded on page 40 of a smaller result set
+  // reads as an empty grid.
+  useEffect(() => {
+    setPage(0);
+  }, [filterText, opponentText, sort]);
 
   useEffect(() => {
     if (positions.length === 0) return undefined;
@@ -120,7 +148,7 @@ function PlayerRosterBuilder() {
 
     Promise.all(
       positions.map((pos) =>
-        PlayerPickemApi.getAthletesByPosition('football', 'ncaa', pos)
+        PlayerPickemApi.getAthletesByPosition('football', 'ncaa', pos, SEASON_YEAR, WEEK)
       )
     )
       .then((responses) => {
@@ -151,8 +179,19 @@ function PlayerRosterBuilder() {
   }, [sort.key, activeCol]);
 
   const sortedAthletes = useMemo(
-    () => sortAthletes(athletes, sort, getSortValue),
-    [athletes, sort, getSortValue]
+    () =>
+      sortAthletes(
+        filterByOpponent(filterAthletes(athletes, filterText), opponentText),
+        sort,
+        getSortValue
+      ),
+    [athletes, filterText, opponentText, sort, getSortValue]
+  );
+
+  const pageCount = Math.max(1, Math.ceil(sortedAthletes.length / PAGE_SIZE));
+  const pagedAthletes = useMemo(
+    () => sortedAthletes.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [sortedAthletes, page]
   );
 
   // First click on a stat header = descending (big numbers are what a
@@ -191,8 +230,8 @@ function PlayerRosterBuilder() {
     <div className="roster-builder">
       <h2 className="roster-builder-title">Player Pick&rsquo;em Roster</h2>
       <p className="roster-builder-sub">
-        Week 5 &middot; 2026 &middot; NCAAFB (FBS) &mdash; admin preview,
-        selections are local-only, mock data
+        Week {WEEK} &middot; {SEASON_YEAR} &middot; NCAAFB (FBS) &mdash; admin
+        preview, selections are local-only
       </p>
 
       {/* Button group, not tabs: there's no tabpanel relationship here and
@@ -244,6 +283,31 @@ function PlayerRosterBuilder() {
             </div>
           );
         })}
+      </div>
+
+      <div className="roster-toolbar">
+        <input
+          type="search"
+          className="roster-filter"
+          placeholder="Filter by player or team…"
+          aria-label="Filter athletes by name or team"
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+        />
+        <span className="roster-toolbar-count">
+          {sortedAthletes.length.toLocaleString()} athletes
+        </span>
+        {/* Right-aligned so it sits over the opponent columns — the
+            matchup hunt: "UMass is horrible, show me the RBs playing
+            them this weekend." */}
+        <input
+          type="search"
+          className="roster-filter roster-filter--opponent"
+          placeholder="Filter by opponent…"
+          aria-label="Filter athletes by week opponent"
+          value={opponentText}
+          onChange={(e) => setOpponentText(e.target.value)}
+        />
       </div>
 
       {loading ? (
@@ -309,7 +373,7 @@ function PlayerRosterBuilder() {
               </tr>
             </thead>
             <tbody>
-              {sortedAthletes.map((a) => {
+              {pagedAthletes.map((a) => {
                 const rostered = isRostered(roster, a.athleteId);
                 // Adding into an occupied slot replaces its player — say so
                 // on the button instead of springing it on the user.
@@ -386,12 +450,37 @@ function PlayerRosterBuilder() {
               {sortedAthletes.length === 0 ? (
                 <tr>
                   <td colSpan={columns.length + 4} className="roster-grid-status">
-                    No athletes for this position.
+                    {filterText || opponentText
+                      ? 'No athletes match the filters.'
+                      : 'No athletes for this position.'}
                   </td>
                 </tr>
               ) : null}
             </tbody>
           </table>
+          {pageCount > 1 ? (
+            <div className="roster-pager">
+              <button
+                type="button"
+                className="roster-pager-btn"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                &lsaquo; Prev
+              </button>
+              <span className="roster-pager-label">
+                Page {page + 1} of {pageCount}
+              </span>
+              <button
+                type="button"
+                className="roster-pager-btn"
+                disabled={page >= pageCount - 1}
+                onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+              >
+                Next &rsaquo;
+              </button>
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/src/UI/sd-ui/src/components/pickem/players/athleteSort.js
+++ b/src/UI/sd-ui/src/components/pickem/players/athleteSort.js
@@ -6,6 +6,36 @@
 
 export const NAME_SORT = { key: 'name' };
 
+/**
+ * Case-insensitive substring match on the WEEK OPPONENT's name — the
+ * matchup-hunting filter ("show me every RB playing UMass"). Bye-week
+ * rows have no opponent and never match a non-empty filter. Empty/
+ * whitespace filter returns the SAME array so memo deps stay cheap.
+ */
+export function filterByOpponent(rows, text) {
+  const needle = (text ?? '').trim().toLowerCase();
+  if (!needle) return rows;
+  return rows.filter((r) =>
+    (r.opponentName ?? '').toLowerCase().includes(needle)
+  );
+}
+
+/**
+ * Case-insensitive substring match on last name, first name, or team
+ * name. Empty/whitespace filter returns the SAME array so memo deps stay
+ * cheap.
+ */
+export function filterAthletes(rows, text) {
+  const needle = (text ?? '').trim().toLowerCase();
+  if (!needle) return rows;
+  return rows.filter(
+    (r) =>
+      r.lastName.toLowerCase().includes(needle) ||
+      r.firstName.toLowerCase().includes(needle) ||
+      (r.teamName ?? '').toLowerCase().includes(needle)
+  );
+}
+
 function byName(a, b) {
   return (
     a.lastName.localeCompare(b.lastName) ||

--- a/src/UI/sd-ui/src/components/pickem/players/athleteSort.test.js
+++ b/src/UI/sd-ui/src/components/pickem/players/athleteSort.test.js
@@ -1,5 +1,55 @@
 import { describe, it, expect } from 'vitest';
-import { NAME_SORT, sortAthletes } from './athleteSort';
+import {
+  NAME_SORT,
+  sortAthletes,
+  filterAthletes,
+  filterByOpponent,
+} from './athleteSort';
+
+describe('filterByOpponent', () => {
+  const rows = [
+    { lastName: 'Love', opponentName: 'UMass Minutemen' },
+    { lastName: 'Singleton', opponentName: 'UCLA Bruins' },
+    { lastName: 'OnBye', opponentName: null },
+  ];
+
+  it('matches the week opponent case-insensitively', () => {
+    const hits = filterByOpponent(rows, 'umass');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].lastName).toBe('Love');
+  });
+
+  it('bye rows never match a non-empty filter', () => {
+    expect(filterByOpponent(rows, 'u')).toHaveLength(2);
+  });
+
+  it('returns the SAME array for an empty filter', () => {
+    expect(filterByOpponent(rows, '')).toBe(rows);
+  });
+});
+
+describe('filterAthletes', () => {
+  const rows = [
+    { firstName: 'Arch', lastName: 'Manning', teamName: 'Texas Longhorns' },
+    { firstName: 'Garrett', lastName: 'Nussmeier', teamName: 'LSU Tigers' },
+    { firstName: 'Cade', lastName: 'Klubnik', teamName: 'Clemson Tigers' },
+  ];
+
+  it('matches last name, first name, and team name case-insensitively', () => {
+    expect(filterAthletes(rows, 'manning')).toHaveLength(1);
+    expect(filterAthletes(rows, 'ARCH')).toHaveLength(1);
+    expect(filterAthletes(rows, 'tigers')).toHaveLength(2);
+  });
+
+  it('returns the SAME array for an empty or whitespace filter', () => {
+    expect(filterAthletes(rows, '')).toBe(rows);
+    expect(filterAthletes(rows, '   ')).toBe(rows);
+  });
+
+  it('returns empty for no match', () => {
+    expect(filterAthletes(rows, 'zzz')).toHaveLength(0);
+  });
+});
 
 // getValue mirrors the grid's column accessors: read one stat off a
 // season block.

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetAthleteDetailsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetAthleteDetailsQueryHandlerTests.cs
@@ -5,7 +5,7 @@ using Moq;
 using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
-using SportsData.Core.Infrastructure.Clients.Franchise;
+using SportsData.Core.Infrastructure.Clients.Athlete;
 using SportsData.Tests.Shared;
 
 using Xunit;
@@ -14,16 +14,16 @@ namespace SportsData.Api.Tests.Unit.Application.Athletes;
 
 public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetailsQueryHandler>
 {
-    private readonly Mock<IFranchiseClientFactory> _franchiseClientFactoryMock;
-    private readonly Mock<IProvideFranchises> _franchiseClientMock;
+    private readonly Mock<IAthleteClientFactory> _athleteClientFactoryMock;
+    private readonly Mock<IProvideAthletes> _athleteClientMock;
 
     public GetAthleteDetailsQueryHandlerTests()
     {
-        _franchiseClientFactoryMock = Mocker.GetMock<IFranchiseClientFactory>();
-        _franchiseClientMock = new Mock<IProvideFranchises>();
-        _franchiseClientFactoryMock
+        _athleteClientFactoryMock = Mocker.GetMock<IAthleteClientFactory>();
+        _athleteClientMock = new Mock<IProvideAthletes>();
+        _athleteClientFactoryMock
             .Setup(x => x.Resolve(It.IsAny<Sport>()))
-            .Returns(_franchiseClientMock.Object);
+            .Returns(_athleteClientMock.Object);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetails
         var athleteId = Guid.NewGuid();
         var dto = new AthleteDetailDto { Id = athleteId, DisplayName = "Arch Manning" };
 
-        _franchiseClientMock
+        _athleteClientMock
             .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<AthleteDetailDto>(dto));
 
@@ -50,7 +50,7 @@ public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetails
     {
         var athleteId = Guid.NewGuid();
 
-        _franchiseClientMock
+        _athleteClientMock
             .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Failure<AthleteDetailDto>(default!, ResultStatus.NotFound, []));
 
@@ -71,7 +71,7 @@ public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetails
             new GetAthleteDetailsQuery("cricket", "ipl", Guid.NewGuid()));
 
         result.Status.Should().Be(ResultStatus.Validation);
-        _franchiseClientMock.Verify(
+        _athleteClientMock.Verify(
             x => x.GetAthleteDetails(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -87,7 +87,7 @@ public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetails
             new GetAthleteDetailsQuery("football", "ncaa", Guid.Empty));
 
         result.Status.Should().Be(ResultStatus.Validation);
-        _franchiseClientMock.Verify(
+        _athleteClientMock.Verify(
             x => x.GetAthleteDetails(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -98,7 +98,7 @@ public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetails
         var athleteId = Guid.NewGuid();
         using var cts = new CancellationTokenSource();
 
-        _franchiseClientMock
+        _athleteClientMock
             .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
@@ -117,7 +117,7 @@ public class GetAthleteDetailsQueryHandlerTests : UnitTestBase<GetAthleteDetails
     {
         var athleteId = Guid.NewGuid();
 
-        _franchiseClientMock
+        _athleteClientMock
             .Setup(x => x.GetAthleteDetails(athleteId, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("producer unreachable"));
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetPickemAthletesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetPickemAthletesQueryHandlerTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+
+using FluentValidation;
+
+using Moq;
+
+using SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Athlete;
+using SportsData.Tests.Shared;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Athletes;
+
+public class GetPickemAthletesQueryHandlerTests : UnitTestBase<GetPickemAthletesQueryHandler>
+{
+    private readonly Mock<IAthleteClientFactory> _athleteClientFactoryMock;
+    private readonly Mock<IProvideAthletes> _athleteClientMock;
+
+    public GetPickemAthletesQueryHandlerTests()
+    {
+        _athleteClientFactoryMock = Mocker.GetMock<IAthleteClientFactory>();
+        _athleteClientMock = new Mock<IProvideAthletes>();
+        _athleteClientFactoryMock
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_athleteClientMock.Object);
+
+        // Real validator — an auto-mocked IValidator returns a null
+        // ValidationResult and NREs before the code under test runs.
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.Setup(x => x.UtcNow())
+            .Returns(new DateTime(2026, 8, 26, 0, 0, 0, DateTimeKind.Utc));
+        Mocker.Use<IValidator<GetPickemAthletesQuery>>(
+            new GetPickemAthletesQueryValidator(dateTimeProvider.Object));
+    }
+
+    [Fact]
+    public async Task ValidRequest_RelaysTheClientResult()
+    {
+        var payload = new AthleteMatchupSummariesDto();
+        _athleteClientMock
+            .Setup(x => x.GetAthleteMatchupSummaries("QB", 2026, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<AthleteMatchupSummariesDto>(payload));
+
+        var handler = Mocker.CreateInstance<GetPickemAthletesQueryHandler>();
+        var result = await handler.ExecuteAsync(
+            new GetPickemAthletesQuery("football", "ncaa", "QB", 2026, 1));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(payload);
+    }
+
+    [Theory]
+    [InlineData("QB", 0, 1)]    // season year nonsense
+    [InlineData("QB", 2026, -1)] // negative week
+    [InlineData("QB", 2026, 31)] // week above range
+    [InlineData("", 2026, 1)]    // empty position
+    public async Task InvalidNumericInputs_FailValidation_WithoutCallingProducer(
+        string position, int seasonYear, int week)
+    {
+        var handler = Mocker.CreateInstance<GetPickemAthletesQueryHandler>();
+        var result = await handler.ExecuteAsync(
+            new GetPickemAthletesQuery("football", "ncaa", position, seasonYear, week));
+
+        result.Status.Should().Be(ResultStatus.Validation);
+        _athleteClientMock.Verify(
+            x => x.GetAthleteMatchupSummaries(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UnsupportedSportLeague_FailsValidation()
+    {
+        var handler = Mocker.CreateInstance<GetPickemAthletesQueryHandler>();
+        var result = await handler.ExecuteAsync(
+            new GetPickemAthletesQuery("curling", "olympic", "QB", 2026, 1));
+
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
@@ -1,5 +1,9 @@
 using FluentAssertions;
 
+using FluentValidation;
+
+using Moq;
+
 using SportsData.Core.Common;
 using SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSummaries;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -10,14 +14,27 @@ using Xunit;
 namespace SportsData.Producer.Tests.Unit.Application.Athletes;
 
 /// <summary>
-/// The roster-builder grid feed. Seeds are handcrafted (no AutoFixture
-/// graphs) because the handler's joins span seven tables and stray
-/// auto-populated navigation properties would seed phantom rows.
+/// The athlete matchup-summaries feed. Seeds are handcrafted (no
+/// AutoFixture graphs) because the handler's joins span seven tables and
+/// stray auto-populated navigation properties would seed phantom rows.
 /// </summary>
 public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetAthleteMatchupSummariesQueryHandler>
 {
     private static readonly Guid QbPositionId = Guid.NewGuid();
+    private static readonly Guid KickerPositionId = Guid.NewGuid();
     private static readonly Guid ActiveStatusId = Guid.NewGuid();
+
+    public GetAthleteMatchupSummariesQueryHandlerTests()
+    {
+        // The handler takes the REAL validator — an auto-mocked IValidator
+        // returns a null ValidationResult and NREs before the code under
+        // test runs.
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.Setup(x => x.UtcNow())
+            .Returns(new DateTime(2026, 8, 26, 0, 0, 0, DateTimeKind.Utc));
+        Mocker.Use<IValidator<GetAthleteMatchupSummariesQuery>>(
+            new GetAthleteMatchupSummariesQueryValidator(dateTimeProvider.Object));
+    }
 
     private void SeedPositionAndStatus()
     {
@@ -27,6 +44,14 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
             Name = "Quarterback",
             DisplayName = "Quarterback",
             Abbreviation = "QB",
+        });
+        // ESPN's kicker abbreviation is PK; the handler translates the UI's K.
+        FootballDataContext.AthletePositions.Add(new AthletePosition
+        {
+            Id = KickerPositionId,
+            Name = "Place Kicker",
+            DisplayName = "Place Kicker",
+            Abbreviation = "PK",
         });
         FootballDataContext.AthleteStatuses.Add(new AthleteStatus
         {
@@ -59,7 +84,7 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
     }
 
     private AthleteSeason SeedAthleteSeason(
-        Guid athleteId, FranchiseSeason fs, string firstName, string lastName)
+        Guid athleteId, FranchiseSeason fs, string firstName, string lastName, Guid? positionId = null)
     {
         // TPH: the football DB stores FootballAthleteSeason rows.
         var season = new FootballAthleteSeason
@@ -67,7 +92,7 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
             Id = Guid.NewGuid(),
             AthleteId = athleteId,
             FranchiseSeasonId = fs.Id,
-            PositionId = QbPositionId,
+            PositionId = positionId ?? QbPositionId,
             StatusId = ActiveStatusId,
             FirstName = firstName,
             LastName = lastName,
@@ -137,15 +162,28 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
         FootballDataContext.AthleteSeasonStatisticCategories.AddRange(general, passing);
     }
 
-    private void SeedWeekContest(FranchiseSeason home, FranchiseSeason away, int seasonYear, int week)
+    private void SeedWeekContest(
+        FranchiseSeason home, FranchiseSeason away, int seasonYear, int week, int phaseTypeCode = 2)
     {
-        // Week resolves via SeasonWeek.Number — the handler deliberately
-        // ignores Contest.Week, which the schedule import leaves null.
-        var seasonWeek = new SeasonWeek
+        // Week resolves via SeasonWeek.Number scoped to the regular-season
+        // phase — the handler deliberately ignores Contest.Week, which the
+        // schedule import leaves null, and week numbers restart per phase.
+        var phase = new SeasonPhase
         {
             Id = Guid.NewGuid(),
             SeasonId = Guid.NewGuid(),
-            SeasonPhaseId = Guid.NewGuid(),
+            TypeCode = phaseTypeCode,
+            Name = phaseTypeCode == 2 ? "Regular Season" : "Postseason",
+            Abbreviation = phaseTypeCode == 2 ? "reg" : "post",
+            Slug = phaseTypeCode == 2 ? "regular-season" : "post-season",
+            Year = seasonYear,
+        };
+        FootballDataContext.SeasonPhases.Add(phase);
+        var seasonWeek = new SeasonWeek
+        {
+            Id = Guid.NewGuid(),
+            SeasonId = phase.SeasonId,
+            SeasonPhaseId = phase.Id,
             Number = week,
         };
         FootballDataContext.SeasonWeeks.Add(seasonWeek);
@@ -161,8 +199,94 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
             StartDateUtc = new DateTime(seasonYear, 9, 6, 0, 0, 0, DateTimeKind.Utc),
             HomeTeamFranchiseSeasonId = home.Id,
             AwayTeamFranchiseSeasonId = away.Id,
-            SeasonPhaseId = seasonWeek.SeasonPhaseId,
+            SeasonPhaseId = phase.Id,
         });
+    }
+
+    /// <summary>Finalized contest with scores — feeds the K points-allowed metric.</summary>
+    private void SeedFinalizedContest(
+        FranchiseSeason home, FranchiseSeason away, int seasonYear, int homeScore, int awayScore)
+    {
+        FootballDataContext.Contests.Add(new FootballContest
+        {
+            Id = Guid.NewGuid(),
+            Name = $"{away.Name} at {home.Name}",
+            ShortName = "final",
+            Sport = Sport.FootballNcaa,
+            SeasonYear = seasonYear,
+            StartDateUtc = new DateTime(seasonYear, 9, 13, 0, 0, 0, DateTimeKind.Utc),
+            HomeTeamFranchiseSeasonId = home.Id,
+            AwayTeamFranchiseSeasonId = away.Id,
+            SeasonPhaseId = Guid.NewGuid(),
+            HomeScore = homeScore,
+            AwayScore = awayScore,
+            FinalizedUtc = new DateTime(seasonYear, 9, 14, 0, 0, 0, DateTimeKind.Utc),
+        });
+    }
+
+    /// <summary>Kicking statistic doc (FG made/att + XP) for the K column set.</summary>
+    private void SeedKickingStatDoc(Guid athleteSeasonId, DateTime createdUtc, decimal gamesPlayed)
+    {
+        var doc = new AthleteSeasonStatistic
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonId = athleteSeasonId,
+            SplitId = "0",
+            SplitName = "Season",
+            SplitAbbreviation = "Any",
+            SplitType = "season",
+            CreatedUtc = createdUtc,
+        };
+        var general = new AthleteSeasonStatisticCategory
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonStatisticId = doc.Id,
+            Name = "general",
+            DisplayName = "General",
+            ShortDisplayName = "General",
+            Abbreviation = "gen",
+        };
+        general.Stats.Add(new AthleteSeasonStatisticStat
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonStatisticCategoryId = general.Id,
+            Name = "gamesPlayed",
+            DisplayName = "Games Played",
+            ShortDisplayName = "GP",
+            Abbreviation = "GP",
+            DisplayValue = gamesPlayed.ToString(),
+            Value = gamesPlayed,
+        });
+        var kicking = new AthleteSeasonStatisticCategory
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonStatisticId = doc.Id,
+            Name = "kicking",
+            DisplayName = "Kicking",
+            ShortDisplayName = "Kicking",
+            Abbreviation = "kick",
+        };
+        (string name, decimal value)[] stats =
+        [
+            ("fieldGoalsMade", 9), ("fieldGoalAttempts", 10), ("fieldGoalPct", 90.0m),
+            ("longFieldGoalMade", 56), ("extraPointsMade", 14), ("extraPointAttempts", 14),
+        ];
+        foreach (var (name, value) in stats)
+        {
+            kicking.Stats.Add(new AthleteSeasonStatisticStat
+            {
+                Id = Guid.NewGuid(),
+                AthleteSeasonStatisticCategoryId = kicking.Id,
+                Name = name,
+                DisplayName = name,
+                ShortDisplayName = name,
+                Abbreviation = name,
+                DisplayValue = value.ToString(),
+                Value = value,
+            });
+        }
+        FootballDataContext.AthleteSeasonStatistics.Add(doc);
+        FootballDataContext.AthleteSeasonStatisticCategories.AddRange(general, kicking);
     }
 
     /// <summary>One played game: <paramref name="gainer"/> gained
@@ -211,13 +335,79 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
     }
 
     [Fact]
-    public async Task UnknownPosition_ReturnsBadRequest()
+    public async Task UnknownPosition_ReturnsValidationFailure()
     {
         var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
 
         var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("PUNTER", 2026, 1));
 
-        result.Status.Should().Be(ResultStatus.BadRequest);
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Theory]
+    [InlineData(2026, 0)]   // week below range
+    [InlineData(2026, 31)]  // week above range
+    [InlineData(1999, 1)]   // season before data exists
+    [InlineData(2028, 1)]   // season more than a year out (clock fixed at 2026)
+    public async Task OutOfRangeNumericInputs_ReturnValidationFailure(int seasonYear, int week)
+    {
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", seasonYear, week));
+
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task KickerRequest_TranslatesKToPk_AndUsesPointsAllowed()
+    {
+        SeedPositionAndStatus();
+        var michigan = SeedFranchiseSeason(2026, "michigan-wolverines", "Michigan Wolverines");
+        var opponent = SeedFranchiseSeason(2026, "washington-huskies", "Washington Huskies");
+        var kicker = SeedAthleteSeason(Guid.NewGuid(), michigan, "Dominic", "Zvada", KickerPositionId);
+        SeedKickingStatDoc(kicker.Id, new DateTime(2026, 9, 20, 0, 0, 0, DateTimeKind.Utc), gamesPlayed: 5);
+
+        SeedWeekContest(home: michigan, away: opponent, seasonYear: 2026, week: 5);
+
+        // Opponent allowed 21 and 17 points in two finalized games -> 19.0/G.
+        var somebody = SeedFranchiseSeason(2026, "somebody-state", "Somebody State");
+        SeedFinalizedContest(home: opponent, away: somebody, seasonYear: 2026, homeScore: 30, awayScore: 21);
+        SeedFinalizedContest(home: somebody, away: opponent, seasonYear: 2026, homeScore: 17, awayScore: 24);
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("K", 2026, 5));
+
+        result.IsSuccess.Should().BeTrue();
+        var row = result.Value.Athletes.Should().ContainSingle().Subject;
+        row.Position.Should().Be("K"); // UI vocabulary preserved
+        row.CurrentSeason!.Stats["fgMade"].Should().Be(9);
+        row.CurrentSeason.Stats["fgLong"].Should().Be(56);
+        row.CurrentSeason.Stats["xpMade"].Should().Be(14);
+        row.OpponentDefPerGame.Should().Be(19.0m); // points allowed, not yards
+    }
+
+    [Fact]
+    public async Task PostseasonWeekWithSameNumber_DoesNotOverrideRegularSeasonOpponent()
+    {
+        SeedPositionAndStatus();
+        var texas = SeedFranchiseSeason(2026, "texas-longhorns", "Texas Longhorns");
+        var regularOpponent = SeedFranchiseSeason(2026, "oklahoma-sooners", "Oklahoma Sooners");
+        var bowlOpponent = SeedFranchiseSeason(2026, "georgia-bulldogs", "Georgia Bulldogs");
+        SeedAthleteSeason(Guid.NewGuid(), texas, "Arch", "Manning");
+
+        // Same week NUMBER in two phases — only the regular-season game may win.
+        SeedWeekContest(home: texas, away: regularOpponent, seasonYear: 2026, week: 1, phaseTypeCode: 2);
+        SeedWeekContest(home: texas, away: bowlOpponent, seasonYear: 2026, week: 1, phaseTypeCode: 3);
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", 2026, 1));
+
+        var row = result.Value.Athletes.Should().ContainSingle().Subject;
+        row.OpponentName.Should().Be("Oklahoma Sooners");
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
@@ -1,0 +1,358 @@
+using FluentAssertions;
+
+using SportsData.Core.Common;
+using SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSummaries;
+using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Athletes;
+
+/// <summary>
+/// The roster-builder grid feed. Seeds are handcrafted (no AutoFixture
+/// graphs) because the handler's joins span seven tables and stray
+/// auto-populated navigation properties would seed phantom rows.
+/// </summary>
+public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetAthleteMatchupSummariesQueryHandler>
+{
+    private static readonly Guid QbPositionId = Guid.NewGuid();
+    private static readonly Guid ActiveStatusId = Guid.NewGuid();
+
+    private void SeedPositionAndStatus()
+    {
+        FootballDataContext.AthletePositions.Add(new AthletePosition
+        {
+            Id = QbPositionId,
+            Name = "Quarterback",
+            DisplayName = "Quarterback",
+            Abbreviation = "QB",
+        });
+        FootballDataContext.AthleteStatuses.Add(new AthleteStatus
+        {
+            Id = ActiveStatusId,
+            ExternalId = "1",
+            Name = "Active",
+        });
+    }
+
+    private FranchiseSeason SeedFranchiseSeason(
+        int seasonYear, string slug, string name, Guid? franchiseId = null, string groupSeasonMap = "NCAAF|NCAA|fbs|sec")
+    {
+        var fs = new FranchiseSeason
+        {
+            Id = Guid.NewGuid(),
+            FranchiseId = franchiseId ?? Guid.NewGuid(),
+            SeasonYear = seasonYear,
+            Slug = slug,
+            Name = name,
+            Location = name,
+            Abbreviation = slug[..3].ToUpperInvariant(),
+            DisplayName = name,
+            DisplayNameShort = name,
+            ColorCodeHex = "000000",
+            GroupSeasonMap = groupSeasonMap,
+            IsActive = true,
+        };
+        FootballDataContext.FranchiseSeasons.Add(fs);
+        return fs;
+    }
+
+    private AthleteSeason SeedAthleteSeason(
+        Guid athleteId, FranchiseSeason fs, string firstName, string lastName)
+    {
+        // TPH: the football DB stores FootballAthleteSeason rows.
+        var season = new FootballAthleteSeason
+        {
+            Id = Guid.NewGuid(),
+            AthleteId = athleteId,
+            FranchiseSeasonId = fs.Id,
+            PositionId = QbPositionId,
+            StatusId = ActiveStatusId,
+            FirstName = firstName,
+            LastName = lastName,
+            IsActive = true,
+        };
+        FootballDataContext.AthleteSeasons.Add(season);
+        return season;
+    }
+
+    private void SeedStatDoc(
+        Guid athleteSeasonId,
+        DateTime createdUtc,
+        decimal gamesPlayed,
+        decimal passYds)
+    {
+        var doc = new AthleteSeasonStatistic
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonId = athleteSeasonId,
+            SplitId = "0",
+            SplitName = "Season",
+            SplitAbbreviation = "Any",
+            SplitType = "season",
+            CreatedUtc = createdUtc,
+        };
+        var general = new AthleteSeasonStatisticCategory
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonStatisticId = doc.Id,
+            Name = "general",
+            DisplayName = "General",
+            ShortDisplayName = "General",
+            Abbreviation = "gen",
+        };
+        general.Stats.Add(new AthleteSeasonStatisticStat
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonStatisticCategoryId = general.Id,
+            Name = "gamesPlayed",
+            DisplayName = "Games Played",
+            ShortDisplayName = "GP",
+            Abbreviation = "GP",
+            DisplayValue = gamesPlayed.ToString(),
+            Value = gamesPlayed,
+        });
+        var passing = new AthleteSeasonStatisticCategory
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonStatisticId = doc.Id,
+            Name = "passing",
+            DisplayName = "Passing",
+            ShortDisplayName = "Passing",
+            Abbreviation = "pass",
+        };
+        passing.Stats.Add(new AthleteSeasonStatisticStat
+        {
+            Id = Guid.NewGuid(),
+            AthleteSeasonStatisticCategoryId = passing.Id,
+            Name = "passingYards",
+            DisplayName = "Passing Yards",
+            ShortDisplayName = "YDS",
+            Abbreviation = "YDS",
+            DisplayValue = passYds.ToString(),
+            Value = passYds,
+        });
+        FootballDataContext.AthleteSeasonStatistics.Add(doc);
+        FootballDataContext.AthleteSeasonStatisticCategories.AddRange(general, passing);
+    }
+
+    private void SeedWeekContest(FranchiseSeason home, FranchiseSeason away, int seasonYear, int week)
+    {
+        // Week resolves via SeasonWeek.Number — the handler deliberately
+        // ignores Contest.Week, which the schedule import leaves null.
+        var seasonWeek = new SeasonWeek
+        {
+            Id = Guid.NewGuid(),
+            SeasonId = Guid.NewGuid(),
+            SeasonPhaseId = Guid.NewGuid(),
+            Number = week,
+        };
+        FootballDataContext.SeasonWeeks.Add(seasonWeek);
+        FootballDataContext.Contests.Add(new FootballContest
+        {
+            Id = Guid.NewGuid(),
+            Name = $"{away.Name} at {home.Name}",
+            ShortName = "game",
+            Sport = Sport.FootballNcaa,
+            SeasonYear = seasonYear,
+            Week = null,
+            SeasonWeekId = seasonWeek.Id,
+            StartDateUtc = new DateTime(seasonYear, 9, 6, 0, 0, 0, DateTimeKind.Utc),
+            HomeTeamFranchiseSeasonId = home.Id,
+            AwayTeamFranchiseSeasonId = away.Id,
+            SeasonPhaseId = seasonWeek.SeasonPhaseId,
+        });
+    }
+
+    /// <summary>One played game: <paramref name="gainer"/> gained
+    /// <paramref name="passYds"/> against <paramref name="defense"/>.</summary>
+    private void SeedPlayedGame(FranchiseSeason defense, FranchiseSeason gainer, decimal passYds)
+    {
+        var competitionId = Guid.NewGuid();
+        FootballDataContext.CompetitionCompetitors.Add(new FootballCompetitionCompetitor
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            FranchiseSeasonId = defense.Id,
+            HomeAway = "home",
+        });
+        var stat = new CompetitionCompetitorStatistic
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            FranchiseSeasonId = gainer.Id,
+        };
+        var passing = new CompetitionCompetitorStatisticCategory
+        {
+            Id = Guid.NewGuid(),
+            CompetitionCompetitorStatisticId = stat.Id,
+            Name = "passing",
+        };
+        passing.Stats.Add(new CompetitionCompetitorStatisticStat
+        {
+            Id = Guid.NewGuid(),
+            CompetitionCompetitorStatisticCategoryId = passing.Id,
+            Name = "netPassingYards",
+            DisplayName = "Net Passing Yards",
+            ShortDisplayName = "YDS",
+            Abbreviation = "YDS",
+            Value = passYds,
+        });
+        FootballDataContext.CompetitionCompetitors.Add(new FootballCompetitionCompetitor
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = stat.CompetitionId,
+            FranchiseSeasonId = gainer.Id,
+            HomeAway = "away",
+        });
+        FootballDataContext.CompetitionCompetitorStatistics.Add(stat);
+        FootballDataContext.CompetitionCompetitorStatisticCategories.Add(passing);
+    }
+
+    [Fact]
+    public async Task UnknownPosition_ReturnsBadRequest()
+    {
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("PUNTER", 2026, 1));
+
+        result.Status.Should().Be(ResultStatus.BadRequest);
+    }
+
+    [Fact]
+    public async Task MapsStats_ResolvesOpponent_AndAggregatesAllowance()
+    {
+        SeedPositionAndStatus();
+        var texas = SeedFranchiseSeason(2026, "texas-longhorns", "Texas Longhorns");
+        var opponent = SeedFranchiseSeason(2026, "oklahoma-sooners", "Oklahoma Sooners");
+        var athleteId = Guid.NewGuid();
+        var season2026 = SeedAthleteSeason(athleteId, texas, "Arch", "Manning");
+        SeedStatDoc(season2026.Id, new DateTime(2026, 9, 20, 0, 0, 0, DateTimeKind.Utc), gamesPlayed: 4, passYds: 1247);
+
+        var texas2025 = SeedFranchiseSeason(2025, "texas-longhorns", "Texas Longhorns", texas.FranchiseId);
+        var season2025 = SeedAthleteSeason(athleteId, texas2025, "Arch", "Manning");
+        SeedStatDoc(season2025.Id, new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc), gamesPlayed: 13, passYds: 3163);
+
+        SeedWeekContest(home: opponent, away: texas, seasonYear: 2026, week: 6);
+
+        // Opponent has two played games this season: allowed 300 and 200
+        // net passing yards -> 250.0 per game.
+        var somebody = SeedFranchiseSeason(2026, "somebody-state", "Somebody State");
+        SeedPlayedGame(defense: opponent, gainer: somebody, passYds: 300);
+        SeedPlayedGame(defense: opponent, gainer: somebody, passYds: 200);
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", 2026, 6));
+
+        result.IsSuccess.Should().BeTrue();
+        var row = result.Value.Athletes.Should().ContainSingle().Subject;
+        row.LastName.Should().Be("Manning");
+        row.TeamSlug.Should().Be("texas-longhorns");
+        row.OpponentName.Should().Be("Oklahoma Sooners");
+        row.OpponentSlug.Should().Be("oklahoma-sooners");
+        row.OpponentDefPerGame.Should().Be(250.0m);
+
+        row.CurrentSeason.Should().NotBeNull();
+        row.CurrentSeason!.SeasonYear.Should().Be(2026);
+        row.CurrentSeason.GamesPlayed.Should().Be(4);
+        row.CurrentSeason.Stats["passYds"].Should().Be(1247);
+
+        row.PreviousSeason.Should().NotBeNull();
+        row.PreviousSeason!.SeasonYear.Should().Be(2025);
+        row.PreviousSeason.GamesPlayed.Should().Be(13);
+        row.PreviousSeason.Stats["passYds"].Should().Be(3163);
+    }
+
+    [Fact]
+    public async Task WeekOne_NoCurrentDoc_NullBlock_AndPriorSeasonAllowanceFallback()
+    {
+        SeedPositionAndStatus();
+        var texas = SeedFranchiseSeason(2026, "texas-longhorns", "Texas Longhorns");
+        var opponent = SeedFranchiseSeason(2026, "ohio-state-buckeyes", "Ohio State Buckeyes");
+        var athleteId = Guid.NewGuid();
+        SeedAthleteSeason(athleteId, texas, "Arch", "Manning");
+        // No 2026 stat doc — hasn't played.
+
+        SeedWeekContest(home: texas, away: opponent, seasonYear: 2026, week: 1);
+
+        // Opponent's 2026 season has no games; their 2025 season allowed
+        // 180 net passing yards in its one recorded game.
+        var opponent2025 = SeedFranchiseSeason(2025, "ohio-state-buckeyes", "Ohio State Buckeyes", opponent.FranchiseId);
+        var somebody = SeedFranchiseSeason(2025, "somebody-state", "Somebody State");
+        SeedPlayedGame(defense: opponent2025, gainer: somebody, passYds: 180);
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", 2026, 1));
+
+        result.IsSuccess.Should().BeTrue();
+        var row = result.Value.Athletes.Should().ContainSingle().Subject;
+        row.CurrentSeason.Should().BeNull();
+        row.OpponentName.Should().Be("Ohio State Buckeyes");
+        row.OpponentDefPerGame.Should().Be(180.0m);
+    }
+
+    [Fact]
+    public async Task DuplicateStatDocs_NewestWins()
+    {
+        SeedPositionAndStatus();
+        var texas = SeedFranchiseSeason(2026, "texas-longhorns", "Texas Longhorns");
+        var athleteId = Guid.NewGuid();
+        var season = SeedAthleteSeason(athleteId, texas, "Arch", "Manning");
+        // Stale doc from an earlier source run, then the corrected one.
+        SeedStatDoc(season.Id, new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), gamesPlayed: 3, passYds: 900);
+        SeedStatDoc(season.Id, new DateTime(2026, 9, 20, 0, 0, 0, DateTimeKind.Utc), gamesPlayed: 4, passYds: 1247);
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", 2026, 1));
+
+        var row = result.Value.Athletes.Should().ContainSingle().Subject;
+        row.CurrentSeason!.GamesPlayed.Should().Be(4);
+        row.CurrentSeason.Stats["passYds"].Should().Be(1247);
+    }
+
+    [Fact]
+    public async Task ByeWeek_OpponentFieldsAreNull()
+    {
+        SeedPositionAndStatus();
+        var texas = SeedFranchiseSeason(2026, "texas-longhorns", "Texas Longhorns");
+        SeedAthleteSeason(Guid.NewGuid(), texas, "Arch", "Manning");
+        // No contest for the requested week.
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", 2026, 9));
+
+        var row = result.Value.Athletes.Should().ContainSingle().Subject;
+        row.OpponentName.Should().BeNull();
+        row.OpponentSlug.Should().BeNull();
+        row.OpponentDefPerGame.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task NonFbsAndInactiveAthletes_AreExcluded()
+    {
+        SeedPositionAndStatus();
+        var fcs = SeedFranchiseSeason(2026, "fcs-school", "FCS School", groupSeasonMap: "NCAAF|NCAA|fcs|southland");
+        SeedAthleteSeason(Guid.NewGuid(), fcs, "Fcs", "Quarterback");
+
+        var texas = SeedFranchiseSeason(2026, "texas-longhorns", "Texas Longhorns");
+        var inactive = SeedAthleteSeason(Guid.NewGuid(), texas, "Not", "Playing");
+        inactive.IsActive = false;
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", 2026, 1));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Athletes.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the roster builder's mock data (#674) with the real vertical. Producer gains a game-agnostic athlete matchup-summaries feed; the API relays it under its pick'em domain; both admin-gated UIs now serve real data, with filters and pagination added from operator E2E.

## Producer: `GET /api/athletes/matchup-summaries?position=QB&seasonYear=2026&week=1`

Every ACTIVE FBS athlete at a position, with the week's opponent, the opponent's relevant defensive allowance per game, and structured current/previous season stat blocks. Six set-based queries — no per-athlete round trips (a WR request covers ~2,000 athletes in one pass).

Three data realities shaped the handler, all verified against a local copy of production data:

1. **ESPN's `yardsAllowed`/`pointsAllowed` team stats are zero-filled.** Defensive allowances are therefore **aggregated from what each opponent's opponents actually gained against them** (spot-check: Texas 2025 = 237.6 net pass yds allowed/G over 12 recorded games). K uses points allowed from finalized contest scores. Opponents with no current-season games (week 1 everywhere) fall back to their prior-season franchise season.
2. **Week resolves via `SeasonWeek.Number`, not `Contest.Week`** — the schedule import leaves `Week` null until the companion doc hydrates it (all 1,527 local 2026 contests), while `SeasonWeekId` is populated on every one.
3. **Kickers are `PK` in ESPN's position table** — the boundary translates so the UI contract keeps `K`.

Also: newest statistic doc per athlete-season wins (~162k athlete-seasons carry re-source duplicates), and team/opponent names use `DisplayName` — `Name` is the bare mascot, and NCAAFB has ten different Tigers.

## Domain boundaries

- **New `AthleteClient` + `AthleteClientFactory` aggregate root.** `GetAthleteDetails` moves here from `FranchiseClient`, where it was parked when it was one lone method (#665). The factory deliberately reuses the franchise ApiUrl config keys — same Producer instance — so **no AppConfig provisioning is needed for deploy**; the dormant Player client is untouched.
- **Producer carries no pick'em vocabulary.** The shared DTO is `AthleteMatchupSummaryDto` in `Dtos/Canonical` — game-agnostic expanded athlete data. The API's relay (`GetPickemAthletes` at `/api/{sport}/{league}/athletes/pickem`, unchanged for the UIs) owns the game domain and translates at the boundary.

## UI (both surfaces, admin-gated)

- Mocks swapped for the real call; season 2026 / week 1 pinned (week selector is future work)
- Filter by player/team; **filter by week opponent** ("UMass is horrible — show me the RBs playing them this weekend")
- 25-row pagination on web with live athlete count (mobile's FlatList already virtualizes)
- Full team names throughout

## Deliberately deferred

Roster slimming. Full FBS depth ships (WR = 2,015 rows); a stats-bearing-only filter (WR would drop to 725) would hide true freshmen in week 1, violating the unrestricted-selection principle. The cut waits on an ESPN depth-chart/starter-marker investigation.

## Validation

- Producer: 6 handler tests (stat mapping + opponent + aggregation, week-1 prior-season fallback, newest-doc-wins, bye week, FBS/inactive exclusion, bad position); full suite 598 green
- Api 712; web 26 vitest + ESLint clean; mobile tsc + 9 jest
- Operator E2E against a local copy of production data on both surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live athlete data for Pick’em selection, including matchup details, opponent defensive allowances, and current/prior season statistics.
  - Added athlete search by name, team, and opponent.
  - Added pagination, result counts, clearer empty states, and support for multiple positions and bye-week matchups.
  - Added season and week-aware athlete data retrieval with input validation.

- **Bug Fixes**
  - Athlete details now load through the correct data source.
  - Filters and pagination reset appropriately when changing roster slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->