### PR TITLE
feat(producer,web,mobile): NFL support for the roster builder

### DIFF
--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
@@ -4,6 +4,7 @@ using FluentValidation.Results;
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
+using SportsData.Core.DependencyInjection;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Producer.Infrastructure.Data.Common;
 
@@ -105,15 +106,18 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
     private readonly ILogger<GetAthleteMatchupSummariesQueryHandler> _logger;
     private readonly TeamSportDataContext _dataContext;
     private readonly IValidator<GetAthleteMatchupSummariesQuery> _validator;
+    private readonly IAppMode _appMode;
 
     public GetAthleteMatchupSummariesQueryHandler(
         ILogger<GetAthleteMatchupSummariesQueryHandler> logger,
         TeamSportDataContext dataContext,
-        IValidator<GetAthleteMatchupSummariesQuery> validator)
+        IValidator<GetAthleteMatchupSummariesQuery> validator,
+        IAppMode appMode)
     {
         _logger = logger;
         _dataContext = dataContext;
         _validator = validator;
+        _appMode = appMode;
     }
 
     public async Task<Result<AthleteMatchupSummariesDto>> ExecuteAsync(
@@ -151,9 +155,17 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
         // native vocabulary.
         var dbPosition = position == "K" ? "PK" : position;
 
-        // ── 1. Active FBS athletes at the position for the season ─────────
+        // ── 1. Active athletes at the position for the season ─────────────
         // Explicit join: AthleteSeason carries FranchiseSeasonId with no
         // navigation property.
+        //
+        // Classification is sport-specific: NCAAFB spans FBS/FCS/etc. and
+        // only FBS athletes are in scope, so its GroupSeasonMap must carry
+        // the fbs node. Other sports (NFL) have no classification concept
+        // and their GroupSeasonMap is empty — an unconditional fbs filter
+        // would return zero athletes there.
+        var requireFbs = _appMode.CurrentSport == Sport.FootballNcaa;
+
         var athletes = await (
                 from a in _dataContext.AthleteSeasons.AsNoTracking()
                 join fs in _dataContext.FranchiseSeasons.AsNoTracking()
@@ -162,8 +174,8 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
                       a.Position.Abbreviation == dbPosition &&
                       a.Status != null && a.Status.Name == "Active" &&
                       fs.SeasonYear == query.SeasonYear &&
-                      fs.GroupSeasonMap != null &&
-                      fs.GroupSeasonMap.Contains("fbs")
+                      (!requireFbs ||
+                       (fs.GroupSeasonMap != null && fs.GroupSeasonMap.Contains("fbs")))
                 select new
                 {
                     AthleteSeasonId = a.Id,

--- a/src/UI/sd-mobile/app/admin/player-pickem.tsx
+++ b/src/UI/sd-mobile/app/admin/player-pickem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   StyleSheet,
@@ -38,8 +38,15 @@ import {
 
 // Selections survive app restarts — rudimentary stand-in for carry-over
 // until PlayerLineup entities exist server-side. Shares nothing with the
-// web draft; both are local explorations.
-const ROSTER_KEY = 'playerPickemRosterDraft';
+// web draft; both are local explorations. Keyed per league so an NCAAFB
+// draft never bleeds into the NFL view.
+const rosterKey = (league: string) => `playerPickemRosterDraft.${league}`;
+
+// NCAAFB is the product; NFL rides along for closed-testing coverage.
+const LEAGUES = [
+  { id: 'ncaa', label: 'NCAAFB (FBS)' },
+  { id: 'nfl', label: 'NFL' },
+] as const;
 
 /**
  * A stored draft is untrusted input: JSON.parse happily returns null,
@@ -111,8 +118,13 @@ export default function PlayerPickemScreen() {
   const { data: me, isLoading: meLoading } = useCurrentUser();
   const isAdmin = me?.isAdmin === true;
 
+  const [league, setLeague] = useState<string>('ncaa');
   const [roster, setRoster] = useState<Roster>({});
   const [rosterHydrated, setRosterHydrated] = useState(false);
+  // Which league the current roster state belongs to — guards the save
+  // effect during a league switch so the old league's roster is never
+  // written over the new league's stored draft.
+  const rosterLeagueRef = useRef('ncaa');
   const [activeSlotId, setActiveSlotId] = useState('QB');
   const [athletes, setAthletes] = useState<PickemAthlete[]>([]);
   const [loading, setLoading] = useState(false);
@@ -121,11 +133,13 @@ export default function PlayerPickemScreen() {
   const [opponentText, setOpponentText] = useState('');
 
   useEffect(() => {
+    // Initial hydration AND league switches load that league's draft.
     let cancelled = false;
-    AsyncStorage.getItem(ROSTER_KEY)
+    AsyncStorage.getItem(rosterKey(league))
       .then((raw) => {
-        if (cancelled || !raw) return;
-        setRoster(sanitizeRoster(raw));
+        if (cancelled) return;
+        setRoster(raw ? sanitizeRoster(raw) : {});
+        rosterLeagueRef.current = league;
       })
       .finally(() => {
         if (!cancelled) setRosterHydrated(true);
@@ -133,14 +147,15 @@ export default function PlayerPickemScreen() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [league]);
 
   useEffect(() => {
     // Don't clobber a stored draft with the initial empty roster before
-    // hydration has read it.
-    if (!rosterHydrated) return;
-    AsyncStorage.setItem(ROSTER_KEY, JSON.stringify(roster)).catch(() => {});
-  }, [roster, rosterHydrated]);
+    // hydration has read it, and don't write the OLD league's roster to
+    // the NEW league's key mid-switch.
+    if (!rosterHydrated || rosterLeagueRef.current !== league) return;
+    AsyncStorage.setItem(rosterKey(league), JSON.stringify(roster)).catch(() => {});
+  }, [roster, rosterHydrated, league]);
 
   const positions = useMemo(
     () => eligiblePositions(activeSlotId),
@@ -152,19 +167,22 @@ export default function PlayerPickemScreen() {
     [activeSlotId, positions]
   );
 
-  // Stat sets differ per slot — slot changes reset sort and filter.
+  // Stat sets differ per slot — slot and league changes reset sort and
+  // filters.
   useEffect(() => {
     setSort(NAME_SORT);
     setFilterText('');
     setOpponentText('');
-  }, [activeSlotId]);
+  }, [activeSlotId, league]);
 
   useEffect(() => {
     if (positions.length === 0) return;
     let ignore = false;
     setLoading(true);
 
-    Promise.all(positions.map((pos) => getAthletesByPosition(pos, SEASON_YEAR, WEEK)))
+    Promise.all(
+      positions.map((pos) => getAthletesByPosition(pos, SEASON_YEAR, WEEK, 'football', league))
+    )
       .then((responses) => {
         if (ignore) return;
         setAthletes(responses.flatMap((r) => r.athletes));
@@ -176,7 +194,7 @@ export default function PlayerPickemScreen() {
     return () => {
       ignore = true;
     };
-  }, [positions]);
+  }, [positions, league]);
 
   const sorted = useMemo(
     () =>
@@ -313,8 +331,36 @@ export default function PlayerPickemScreen() {
       <Stack.Screen options={{ title: "Player Pick'em", headerBackTitle: 'Back' }} />
       <View style={[styles.container, { backgroundColor: theme.background }]}>
         <Text style={[styles.sub, { color: theme.textMuted }]}>
-          {`Week ${WEEK} · ${SEASON_YEAR} · NCAAFB (FBS) — admin preview, local-only`}
+          {`Week ${WEEK} · ${SEASON_YEAR} · ${
+            LEAGUES.find((l) => l.id === league)?.label ?? league
+          } — admin preview, local-only`}
         </Text>
+
+        <View style={styles.leagueRow}>
+          {LEAGUES.map((l) => {
+            const active = l.id === league;
+            return (
+              <TouchableOpacity
+                key={l.id}
+                onPress={() => setLeague(l.id)}
+                style={[
+                  styles.leagueChip,
+                  { borderColor: active ? theme.tint : theme.border },
+                ]}
+              >
+                <Text
+                  style={{
+                    color: active ? theme.tint : theme.textMuted,
+                    fontSize: 12,
+                    fontWeight: '600',
+                  }}
+                >
+                  {l.label}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
 
         {/* Wrapping grid, not a horizontal scroller — every slot visible at
             once so nothing about the lineup shape hides off-screen. */}
@@ -507,6 +553,18 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  leagueRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginHorizontal: 16,
+    marginTop: 10,
+  },
+  leagueChip: {
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingVertical: 5,
+    paddingHorizontal: 12,
   },
   filterRow: {
     flexDirection: 'row',

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
@@ -21,6 +21,31 @@
   margin: 4px 0 16px;
 }
 
+/* ── League toggle ────────────────────────────────────────────────── */
+
+.roster-leagues {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.roster-league-btn {
+  border: 1px solid var(--accent-subtle);
+  background: none;
+  color: var(--text-muted, #8d96a0);
+  border-radius: 8px;
+  padding: 5px 14px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.roster-league-btn--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
 /* ── Slot row ─────────────────────────────────────────────────────── */
 
 .roster-slots {

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -124,18 +124,22 @@ function PlayerRosterBuilder() {
   const [opponentText, setOpponentText] = useState('');
   const [page, setPage] = useState(0);
 
-  // Load the new league's draft on switch (declared before the save
-  // effect so it runs first in the same pass).
+  // Load the new league's draft on switch.
   useEffect(() => {
     if (rosterLeagueRef.current === league) return;
     setRoster(sanitizeRoster(localStorage.getItem(rosterKey(league)) ?? 'null'));
     rosterLeagueRef.current = league;
   }, [league]);
 
+  // Save under the league the roster BELONGS to (the ref), never the
+  // currently selected league. During a switch the two disagree for one
+  // render while state is still the old league's lineup; keying the
+  // write by the ref makes effect ordering irrelevant — the switch pass
+  // doesn't run this effect at all (roster hasn't changed), and once the
+  // loaded roster commits, ref and league agree again.
   useEffect(() => {
-    if (rosterLeagueRef.current !== league) return;
-    localStorage.setItem(rosterKey(league), JSON.stringify(roster));
-  }, [roster, league]);
+    localStorage.setItem(rosterKey(rosterLeagueRef.current), JSON.stringify(roster));
+  }, [roster]);
 
   const positions = useMemo(
     () => eligiblePositions(activeSlotId),

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PlayerPickemApi from '../../../api/playerPickemApi';
 import {
@@ -19,8 +19,16 @@ import { columnsFor, cellText } from './gridColumns';
 import './PlayerRosterBuilder.css';
 
 // Selections survive reloads — rudimentary stand-in for the carry-over
-// behavior until PlayerLineup entities exist server-side.
-const ROSTER_KEY = 'playerPickemRosterDraft';
+// behavior until PlayerLineup entities exist server-side. Keyed per
+// league so an NCAAFB draft never bleeds into the NFL view.
+const rosterKey = (league) => `playerPickemRosterDraft.${league}`;
+
+// NCAAFB is the product; NFL rides along for closed-testing coverage
+// (and who knows).
+const LEAGUES = [
+  { id: 'ncaa', label: 'NCAAFB (FBS)' },
+  { id: 'nfl', label: 'NFL' },
+];
 
 // Fixed to opening week for the admin preview; a week selector (and
 // deriving the current week server-side) is future work.
@@ -93,13 +101,20 @@ function sanitizeRoster(raw) {
  * current season on the primary row, previous season directly beneath in
  * the same columns for vertical comparison. Sorting orders the pairs by
  * the current-season value, falling back to previous-season when no row
- * has current data (week 1). Roster is local-only (localStorage); data is
- * mock-backed in playerPickemApi until the Producer endpoint lands.
+ * has current data (week 1). Roster is local-only (localStorage), keyed
+ * per league. NCAAFB is the product; the NFL toggle exists for
+ * closed-testing coverage.
  */
 function PlayerRosterBuilder() {
+  const [league, setLeague] = useState('ncaa');
   const [roster, setRoster] = useState(() =>
-    sanitizeRoster(localStorage.getItem(ROSTER_KEY) ?? 'null')
+    sanitizeRoster(localStorage.getItem(rosterKey('ncaa')) ?? 'null')
   );
+  // Which league the current roster state belongs to. Guards the save
+  // effect during a league switch — without it, the old league's roster
+  // would be written over the new league's stored draft before the load
+  // effect has swapped it in.
+  const rosterLeagueRef = useRef('ncaa');
   const [activeSlotId, setActiveSlotId] = useState('QB');
   const [athletes, setAthletes] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -109,9 +124,18 @@ function PlayerRosterBuilder() {
   const [opponentText, setOpponentText] = useState('');
   const [page, setPage] = useState(0);
 
+  // Load the new league's draft on switch (declared before the save
+  // effect so it runs first in the same pass).
   useEffect(() => {
-    localStorage.setItem(ROSTER_KEY, JSON.stringify(roster));
-  }, [roster]);
+    if (rosterLeagueRef.current === league) return;
+    setRoster(sanitizeRoster(localStorage.getItem(rosterKey(league)) ?? 'null'));
+    rosterLeagueRef.current = league;
+  }, [league]);
+
+  useEffect(() => {
+    if (rosterLeagueRef.current !== league) return;
+    localStorage.setItem(rosterKey(league), JSON.stringify(roster));
+  }, [roster, league]);
 
   const positions = useMemo(
     () => eligiblePositions(activeSlotId),
@@ -124,13 +148,14 @@ function PlayerRosterBuilder() {
   );
 
   // Stat columns differ per slot — a sort on CMP% means nothing on the
-  // RB grid, so slot changes reset sort, filter, and page together.
+  // RB grid, so slot and league changes reset sort, filter, and page
+  // together.
   useEffect(() => {
     setSort(NAME_SORT);
     setFilterText('');
     setOpponentText('');
     setPage(0);
-  }, [activeSlotId]);
+  }, [activeSlotId, league]);
 
   // Any change to what's shown restarts at the first page — a filter or
   // re-sort that leaves you stranded on page 40 of a smaller result set
@@ -148,7 +173,7 @@ function PlayerRosterBuilder() {
 
     Promise.all(
       positions.map((pos) =>
-        PlayerPickemApi.getAthletesByPosition('football', 'ncaa', pos, SEASON_YEAR, WEEK)
+        PlayerPickemApi.getAthletesByPosition('football', league, pos, SEASON_YEAR, WEEK)
       )
     )
       .then((responses) => {
@@ -167,7 +192,7 @@ function PlayerRosterBuilder() {
     return () => {
       ignore = true;
     };
-  }, [positions]);
+  }, [positions, league]);
 
   const activeCol = columns.find((c) => c.key === sort.key);
   const getSortValue = useMemo(() => {
@@ -230,9 +255,24 @@ function PlayerRosterBuilder() {
     <div className="roster-builder">
       <h2 className="roster-builder-title">Player Pick&rsquo;em Roster</h2>
       <p className="roster-builder-sub">
-        Week {WEEK} &middot; {SEASON_YEAR} &middot; NCAAFB (FBS) &mdash; admin
-        preview, selections are local-only
+        Week {WEEK} &middot; {SEASON_YEAR} &middot;{' '}
+        {LEAGUES.find((l) => l.id === league)?.label} &mdash; admin preview,
+        selections are local-only
       </p>
+
+      <div className="roster-leagues" role="group" aria-label="League">
+        {LEAGUES.map((l) => (
+          <button
+            key={l.id}
+            type="button"
+            className={`roster-league-btn${l.id === league ? ' roster-league-btn--active' : ''}`}
+            aria-pressed={l.id === league}
+            onClick={() => setLeague(l.id)}
+          >
+            {l.label}
+          </button>
+        ))}
+      </div>
 
       {/* Button group, not tabs: there's no tabpanel relationship here and
           the remove buttons live between the slot controls, so tablist
@@ -393,7 +433,7 @@ function PlayerRosterBuilder() {
                       </span>
                       <Link
                         className="roster-grid-team"
-                        to={`/sport/football/ncaa/team/${a.teamSlug}`}
+                        to={`/sport/football/${league}/team/${a.teamSlug}`}
                       >
                         {a.teamName}
                       </Link>
@@ -406,7 +446,7 @@ function PlayerRosterBuilder() {
                     <td>
                       {a.opponentName ? (
                         a.opponentSlug ? (
-                          <Link to={`/sport/football/ncaa/team/${a.opponentSlug}`}>
+                          <Link to={`/sport/football/${league}/team/${a.opponentSlug}`}>
                             {a.opponentName}
                           </Link>
                         ) : (

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
@@ -34,6 +34,18 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
             .Returns(new DateTime(2026, 8, 26, 0, 0, 0, DateTimeKind.Utc));
         Mocker.Use<IValidator<GetAthleteMatchupSummariesQuery>>(
             new GetAthleteMatchupSummariesQueryValidator(dateTimeProvider.Object));
+
+        // Default the app mode to NCAAFB; the NFL test overrides it. An
+        // unset mock would report Sport 0 and silently skip the FBS filter
+        // the NCAAFB tests exercise.
+        SetAppMode(Sport.FootballNcaa);
+    }
+
+    private void SetAppMode(Sport sport)
+    {
+        Mocker.GetMock<SportsData.Core.DependencyInjection.IAppMode>()
+            .Setup(x => x.CurrentSport)
+            .Returns(sport);
     }
 
     private void SeedPositionAndStatus()
@@ -524,6 +536,26 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
         row.OpponentName.Should().BeNull();
         row.OpponentSlug.Should().BeNull();
         row.OpponentDefPerGame.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task NflMode_ReturnsAthletes_WithoutRequiringGroupSeasonMap()
+    {
+        // NFL FranchiseSeasons carry an EMPTY GroupSeasonMap — there is no
+        // classification concept — so the FBS filter must be NCAAFB-only.
+        SetAppMode(Sport.FootballNfl);
+        SeedPositionAndStatus();
+        var texans = SeedFranchiseSeason(2026, "houston-texans", "Houston Texans", groupSeasonMap: string.Empty);
+        SeedAthleteSeason(Guid.NewGuid(), texans, "C.J.", "Stroud");
+
+        await FootballDataContext.SaveChangesAsync();
+
+        var handler = Mocker.CreateInstance<GetAthleteMatchupSummariesQueryHandler>();
+        var result = await handler.ExecuteAsync(new GetAthleteMatchupSummariesQuery("QB", 2026, 1));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Athletes.Should().ContainSingle()
+            .Which.LastName.Should().Be("Stroud");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Enables NFL in the Player Pick'em roster builder for closed-testing coverage. NCAAFB remains the product; NFL rides along (and who knows).

The API route always carried the sport — `/api/{sport}/{league}/athletes/pickem` resolves through `ModeMapper` and the athlete client factory to the per-sport Producer instance. Two layers below it were NCAAFB-hardcoded:

## Producer: mode-aware classification filter

The handler unconditionally required `GroupSeasonMap` to contain `fbs`. NFL FranchiseSeasons carry an **empty** `GroupSeasonMap` — there is no classification concept — so an NFL request returned zero athletes. The filter is now conditional via `IAppMode`: NCAAFB requires the fbs node; other sports skip it.

Everything else already worked for NFL unchanged, verified against the local NFL database:
- Identical position abbreviations (QB 121 / RB 203 / WR 397 / TE 206 / PK 41)
- `SeasonWeek.Number` week resolution (272 regular-season 2026 contests, all with `SeasonWeekId`)
- Opponent allowance aggregation and the prior-season fallback
- The regular-season phase filter (from #675's review) also keeps NFL **preseason** (TypeCode 1, 49 contests) out of the week lookup — consistent with the preseason-is-never-signal rule

## UI: league toggle on both surfaces

- NCAAFB (FBS) / NFL toggle above the slot row; switching refetches and resets slot/sort/filters/page
- The local roster draft is keyed **per league**, with a write guard so a league switch cannot save the old league's lineup over the new league's stored draft mid-transition
- Web team/opponent links are league-aware (`/sport/football/nfl/team/…`)

## Validation

- Producer matchup tests 13/13 (adds the NFL no-GroupSeasonMap case); full suite 605 green
- Web 26 vitest + ESLint clean, production build compiles; mobile tsc + 9 jest
- Operator E2E'd **both leagues** against local production-copy data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added league selection for Player Pick’em, supporting separate NCAAFB and NFL rosters.
  * League-specific rosters, athlete data, team links, and displayed metadata now update when switching leagues.
  * Added accessible league controls with active-state styling.

* **Bug Fixes**
  * NFL athlete selections no longer require an FBS classification.
  * Prevented stale data from being applied when switching leagues.
  * Filters, sorting, and pagination now reset appropriately when changing leagues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->