### PR TITLE
feat(producer): live in-game athlete statistics refresh — play-driven with debounce

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionPlayDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionPlayDocumentProcessorBase.cs
@@ -125,6 +125,17 @@ public abstract class EventCompetitionPlayDocumentProcessorBase<TDataContext, TD
                 _logger.LogInformation(
                     "Persisted CompetitionPlay. CompetitionId={CompId}, PlayId={PlayId}, Sequence={Sequence}",
                     competition.Id, play.Id, play.SequenceNumber);
+
+                if (inProgress.Value)
+                {
+                    // Live-stats freshness: let the sport-specific processor
+                    // fan out cumulative athlete-statistics requests for the
+                    // play's participants. AFTER the play persists so a retry
+                    // of a failed save can't have already stamped debounce
+                    // watermarks; skipped on the duplicate-race path below
+                    // because the winning worker performs the same fan-out.
+                    await RequestParticipantStatisticsAsync(command, externalDto, competitionIdValue);
+                }
             }
             catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
             {
@@ -170,8 +181,29 @@ public abstract class EventCompetitionPlayDocumentProcessorBase<TDataContext, TD
             await _dataContext.SaveChangesAsync();
 
             _logger.LogInformation("Persisted CompetitionPlay update. PlayId={PlayId}", entity.Id);
+
+            if (inProgress.Value)
+            {
+                // A re-processed live play (stat correction) refreshes its
+                // participants' cumulative stats too.
+                await RequestParticipantStatisticsAsync(command, externalDto, competitionIdValue);
+            }
         }
     }
+
+    /// <summary>
+    /// Live-stats freshness hook, called after a play persists while its
+    /// competition is IN PROGRESS — never for backfills, replays of
+    /// completed games, or post-final corrections, which keeps historical
+    /// play sweeps from fanning out millions of ESPN fetches. Default is a
+    /// no-op; sport processors override to request the play participants'
+    /// cumulative EventCompetitionAthleteStatistics documents (debounced —
+    /// see the football implementation).
+    /// </summary>
+    protected virtual Task RequestParticipantStatisticsAsync(
+        ProcessDocumentCommand command,
+        TDto dto,
+        Guid competitionId) => Task.CompletedTask;
 
     /// <summary>
     /// Returns true when the competition's status indicates it is mid-game,

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -23,14 +23,93 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
     : EventCompetitionPlayDocumentProcessorBase<TDataContext, EspnFootballEventCompetitionPlayDto>
     where TDataContext : FootballDataContext
 {
+    // Live in-game athlete-stats refresh: minimum minutes between requests
+    // for one athlete's cumulative statistics doc within one competition.
+    // 3 minutes ≈ drive granularity — plays cluster inside drives, so each
+    // involved athlete refreshes about once per drive instead of once per
+    // play (a QB would otherwise fan out ~40 ESPN fetches a game against an
+    // IP-based rate limiter). Scoring plays bypass the debounce.
+    private const int StatsRequestDebounceMinutes = 3;
+
+    private readonly IDateTimeProvider _dateTimeProvider;
+
     public FootballEventCompetitionPlayDocumentProcessor(
         ILogger<FootballEventCompetitionPlayDocumentProcessor<TDataContext>> logger,
         TDataContext dataContext,
         IEventBus publishEndpoint,
         IGenerateExternalRefIdentities externalRefIdentityGenerator,
-        IGenerateResourceRefs refs)
+        IGenerateResourceRefs refs,
+        IDateTimeProvider dateTimeProvider)
         : base(logger, dataContext, publishEndpoint, externalRefIdentityGenerator, refs)
     {
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    /// <summary>
+    /// Fan out cumulative athlete-statistics requests for the play's
+    /// participants. The base calls this only while the competition is IN
+    /// PROGRESS, and Provider auto-bypasses its cache for current-season
+    /// requests, so each request that survives the debounce is a fresh
+    /// ESPN fetch; Provider's content-hash dedupe suppresses the
+    /// downstream publish when nothing changed. The debounce watermark
+    /// lives on the AthleteCompetition roster row — DB-backed, so it holds
+    /// across the 30-worker fleet (two workers racing the same check cost
+    /// at most one duplicate fetch, which is not worth locking over).
+    /// </summary>
+    protected override async Task RequestParticipantStatisticsAsync(
+        ProcessDocumentCommand command,
+        EspnFootballEventCompetitionPlayDto dto,
+        Guid competitionId)
+    {
+        if (dto.Participants is null || dto.Participants.Count == 0) return;
+
+        var now = _dateTimeProvider.UtcNow();
+        var stampedAny = false;
+
+        foreach (var participant in dto.Participants
+                     .Where(p => p.Athlete?.Ref is not null && p.Statistics?.Ref is not null)
+                     .DistinctBy(p => p.Athlete!.Ref))
+        {
+            var athleteSeasonId = await _dataContext.ResolveIdAsync<AthleteSeason, AthleteSeasonExternalId>(
+                participant.Athlete!,
+                command.SourceDataProvider,
+                () => _dataContext.AthleteSeasons,
+                externalIdsNav: "ExternalIds",
+                key: a => a.Id);
+
+            // Participants were dependency-resolved when the play was
+            // built; a miss here means the play itself threw for retry
+            // before we were called. Defensive skip regardless.
+            if (athleteSeasonId is null) continue;
+
+            var rosterRow = await _dataContext.AthleteCompetitions
+                .FirstOrDefaultAsync(ac =>
+                    ac.CompetitionId == competitionId &&
+                    ac.AthleteSeasonId == athleteSeasonId.Value);
+
+            // Roster doc not sourced yet (pre-game cascade still running).
+            // A later play retries; no watermark to stamp without a row.
+            if (rosterRow is null) continue;
+
+            var due = dto.ScoringPlay
+                      || rosterRow.StatsRequestedUtc is null
+                      || (now - rosterRow.StatsRequestedUtc.Value).TotalMinutes >= StatsRequestDebounceMinutes;
+            if (!due) continue;
+
+            rosterRow.StatsRequestedUtc = now;
+            stampedAny = true;
+
+            await PublishChildDocumentRequest(
+                command,
+                participant.Statistics,
+                rosterRow.Id,
+                DocumentType.EventCompetitionAthleteStatistics);
+        }
+
+        if (stampedAny)
+        {
+            await _dataContext.SaveChangesAsync();
+        }
     }
 
     /// <summary>

--- a/src/SportsData.Producer/Infrastructure/Data/Entities/AthleteCompetition.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Entities/AthleteCompetition.cs
@@ -57,6 +57,16 @@ public class AthleteCompetition : CanonicalEntityBase<Guid>
     /// </summary>
     public bool Active { get; set; }
 
+    /// <summary>
+    /// Debounce watermark for live in-game statistics refresh: the last time
+    /// the play processor requested this athlete's cumulative
+    /// EventCompetitionAthleteStatistics document for this competition.
+    /// Bounds ESPN fetch volume — a QB appears on ~40 plays a game and must
+    /// not trigger a fetch per play. Null = never requested via the live
+    /// play-driven path (pre-game roster cascade requests don't stamp it).
+    /// </summary>
+    public DateTime? StatsRequestedUtc { get; set; }
+
     public class EntityConfiguration : IEntityTypeConfiguration<AthleteCompetition>
     {
         public void Configure(EntityTypeBuilder<AthleteCompetition> builder)

--- a/src/SportsData.Producer/Migrations/Baseball/20260825205952_AthleteStatsRequestWatermark.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260825205952_AthleteStatsRequestWatermark.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Football
+namespace SportsData.Producer.Migrations.Baseball
 {
-    [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(BaseballDataContext))]
+    [Migration("20260825205952_AthleteStatsRequestWatermark")]
+    partial class AthleteStatsRequestWatermark
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,6 +415,269 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("ConfigurationId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("Season")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SeasonType")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SplitTypeId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
+
+                    b.ToTable("AthleteSeasonHotZone", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("AtBats")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("AthleteSeasonHotZoneId")
+                        .HasColumnType("uuid");
+
+                    b.Property<double?>("BattingAvg")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("BattingAvgScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("Hits")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<double?>("Slugging")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("SluggingScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("ZoneId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonHotZoneId");
+
+                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituationNote", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("SituationId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Text")
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<string>("Type")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SituationId");
+
+                    b.ToTable("BaseballCompetitionSituationNote", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("AthleteRef")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("CompetitionStatusId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasColumnType("text");
+
+                    b.Property<string>("TeamRef")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionStatusId");
+
+                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionCompetitorId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("EspnPlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId");
+
+                    b.HasIndex("CompetitionCompetitorId", "Name")
+                        .IsUnique();
+
+                    b.ToTable("CompetitionCompetitorProbable", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3051,206 +3317,6 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("CompetitionCompetitorStatisticCategoryId");
 
                     b.ToTable("CompetitionCompetitorStatisticStats");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Description")
-                        .IsRequired()
-                        .HasMaxLength(250)
-                        .HasColumnType("character varying(250)");
-
-                    b.Property<string>("DisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("EndClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("EndClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("EndDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("EndPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("EndShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("EndText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("EndYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsScore")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("OffensivePlays")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Result")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SequenceNumber")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("ShortDisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SourceDescription")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("SourceId")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("StartClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("StartClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("StartDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("StartFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("StartPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("StartShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StartText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("StartYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("TimeElapsedDisplay")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("TimeElapsedValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("Yards")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionId");
-
-                    b.ToTable("CompetitionDrive", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("DriveId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Provider")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SourceUrl")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("SourceUrlHash")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Value")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DriveId");
-
-                    b.ToTable("CompetitionDriveExternalId", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -8082,9 +8148,17 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -8092,188 +8166,293 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid?>("FranchiseSeasonId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("HandAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("HandDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("HandType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("ThrowsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("ThrowsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("FootballAthlete");
+                    b.HasDiscriminator().HasValue("BaseballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
+                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetition");
+                    b.Property<int?>("CurrentSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("CurrentSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("CurrentSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CurrentSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("CurrentSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Duration")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EspnSeriesId")
+                        .HasColumnType("text");
+
+                    b.Property<bool?>("Necessary")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("SeasonSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("SeasonSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("SeasonSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SeasonSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("SeasonSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeOfDay")
+                        .HasColumnType("text");
+
+                    b.Property<bool?>("WasSuspended")
+                        .HasColumnType("boolean");
+
+                    b.HasIndex("EspnSeriesId");
+
+                    b.HasDiscriminator().HasValue("BaseballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.Property<int?>("CuratedRankCurrent")
-                        .HasColumnType("integer");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<string>("ClockDisplayValue")
+                    b.Property<Guid?>("AtBatAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("AtBatId")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<double>("ClockValue")
+                    b.Property<int?>("AtBatPitchNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayHits")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("BatOrder")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("HalfInning")
+                        .HasMaxLength(8)
+                        .HasColumnType("character varying(8)");
+
+                    b.Property<double?>("HitCoordinateX")
+                        .HasPrecision(7, 2)
                         .HasColumnType("double precision");
 
-                    b.Property<Guid?>("DriveId")
-                        .HasColumnType("uuid");
+                    b.Property<double?>("HitCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
 
-                    b.Property<int?>("EndDistance")
+                    b.Property<int>("HomeErrors")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndDown")
+                    b.Property<int>("HomeHits")
                         .HasColumnType("integer");
 
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
+                    b.Property<bool>("IsDoublePlay")
+                        .HasColumnType("boolean");
 
-                    b.Property<int?>("EndYardLine")
+                    b.Property<bool>("IsTriplePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsValid")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("Outs")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndYardsToEndzone")
+                    b.Property<double?>("PitchCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("PitchCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("PitchCountBalls")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PointAfterAttemptAbbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<int?>("PointAfterAttemptId")
+                    b.Property<int?>("PitchCountStrikes")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PointAfterAttemptText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                    b.Property<string>("PitchTypeAbbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
-                    b.Property<int?>("PointAfterAttemptValue")
-                        .HasColumnType("integer");
+                    b.Property<string>("PitchTypeId")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
-                    b.Property<string>("ScoringTypeAbbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("ScoringTypeDisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("ScoringTypeName")
+                    b.Property<string>("PitchTypeText")
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
-                    b.Property<int?>("StartDistance")
+                    b.Property<int?>("PitchVelocity")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartDown")
+                    b.Property<string>("PitchesAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("PitchesType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<Guid?>("PitchingAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("RbiCount")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartYardLine")
+                    b.Property<int?>("ResultCountBalls")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartYardsToEndzone")
+                    b.Property<int?>("ResultCountStrikes")
                         .HasColumnType("integer");
 
-                    b.Property<int>("StatYardage")
-                        .HasColumnType("integer");
+                    b.Property<string>("StrikeType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("SummaryType")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("Trajectory")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
 
                     b.Property<DateTime?>("Wallclock")
                         .HasColumnType("timestamp with time zone");
 
-                    b.HasIndex("DriveId");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionPlayParticipant");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlayParticipant");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionSituation", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionSituationBase");
 
-                    b.Property<int>("AwayTimeouts")
+                    b.Property<int>("Balls")
                         .HasColumnType("integer");
 
-                    b.Property<int>("Distance")
+                    b.Property<Guid?>("OnFirstAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("OnSecondAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("OnThirdAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("Outs")
                         .HasColumnType("integer");
 
-                    b.Property<int>("Down")
+                    b.Property<int>("Strikes")
                         .HasColumnType("integer");
 
-                    b.Property<int>("HomeTimeouts")
-                        .HasColumnType("integer");
+                    b.HasIndex("OnFirstAthleteSeasonId");
 
-                    b.Property<bool>("IsRedZone")
-                        .HasColumnType("boolean");
+                    b.HasIndex("OnSecondAthleteSeasonId");
 
-                    b.Property<int>("YardLine")
-                        .HasColumnType("integer");
+                    b.HasIndex("OnThirdAthleteSeasonId");
 
-                    b.ToTable(t =>
-                        {
-                            t.HasCheckConstraint("CK_CompetitionSituation_AwayTimeouts", "\"AwayTimeouts\" >= 0");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_Distance", "\"Distance\" >= -110");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_Down", "\"Down\" BETWEEN -1 AND 4");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_HomeTimeouts", "\"HomeTimeouts\" >= 0");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_YardLine", "\"YardLine\" BETWEEN 0 AND 100");
-                        });
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionSituation");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionSituation");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+
+                    b.Property<int?>("HalfInning")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PeriodPrefix")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("FootballContest");
+                    b.HasDiscriminator().HasValue("BaseballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8306,6 +8485,58 @@ namespace SportsData.Producer.Migrations.Football
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
+                        .WithMany("Entries")
+                        .HasForeignKey("AthleteSeasonHotZoneId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("HotZone");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituationNote", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", "Situation")
+                        .WithMany("Notes")
+                        .HasForeignKey("SituationId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Situation");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
+                        .WithMany("FeaturedAthletes")
+                        .HasForeignKey("CompetitionStatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionStatus");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "AthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("AthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", "CompetitionCompetitor")
+                        .WithMany("Probables")
+                        .HasForeignKey("CompetitionCompetitorId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("AthleteSeason");
+
+                    b.Navigation("CompetitionCompetitor");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8890,34 +9121,6 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
-                        .WithMany()
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
-                        .WithMany("Drives")
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Competition");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("ExternalIds")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9852,7 +10055,7 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9861,34 +10064,27 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("Plays")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade);
-
-                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", "CompetitionPlay")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", "CompetitionPlay")
                         .WithMany("Participants")
                         .HasForeignKey("CompetitionPlayId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -9897,11 +10093,35 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("CompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnFirstAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnFirstAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnSecondAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnSecondAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnThirdAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnThirdAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("OnFirstAthleteSeason");
+
+                    b.Navigation("OnSecondAthleteSeason");
+
+                    b.Navigation("OnThirdAthleteSeason");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9913,6 +10133,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -10066,13 +10291,6 @@ namespace SportsData.Producer.Migrations.Football
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Navigation("ExternalIds");
-
-                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10265,21 +10483,34 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.Navigation("Drives");
-
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+                {
+                    b.Navigation("Probables");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
                     b.Navigation("Participants");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
+                {
+                    b.Navigation("Notes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.Navigation("FeaturedAthletes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Baseball/20260825205952_AthleteStatsRequestWatermark.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260825205952_AthleteStatsRequestWatermark.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class AthleteStatsRequestWatermark : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "StatsRequestedUtc",
+                table: "AthleteCompetition",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StatsRequestedUtc",
+                table: "AthleteCompetition");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
@@ -1080,6 +1080,9 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.Property<bool>("Starter")
                         .HasColumnType("boolean");
 
+                    b.Property<DateTime?>("StatsRequestedUtc")
+                        .HasColumnType("timestamp with time zone");
+
                     b.HasKey("Id");
 
                     b.HasIndex("AthleteSeasonId");

--- a/src/SportsData.Producer/Migrations/Football/20260825205945_AthleteStatsRequestWatermark.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260825205945_AthleteStatsRequestWatermark.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260825205945_AthleteStatsRequestWatermark")]
+    partial class AthleteStatsRequestWatermark
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260825205945_AthleteStatsRequestWatermark.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260825205945_AthleteStatsRequestWatermark.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class AthleteStatsRequestWatermark : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "StatsRequestedUtc",
+                table: "AthleteCompetition",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StatsRequestedUtc",
+                table: "AthleteCompetition");
+        }
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
@@ -903,4 +903,221 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
         // act & assert
         await Assert.ThrowsAsync<InvalidOperationException>(() => sut.ProcessAsync(command));
     }
+
+    // ── Live athlete-stats refresh (participants fan-out + debounce) ──────
+
+    /// <summary>
+    /// Full arrange for the stats-refresh tests: competition + status +
+    /// both teams + participant deps from the KickoffReturnOffense fixture,
+    /// plus AthleteCompetition roster rows carrying the debounce watermark.
+    /// Returns the two roster rows (kicker, returner).
+    /// </summary>
+    private async Task<(Guid CompetitionId, AthleteCompetition Kicker, AthleteCompetition Returner)>
+        ArrangeKickoffStatsScenarioAsync(
+            ExternalRefIdentityGenerator generator,
+            bool inProgress = true,
+            DateTime? statsRequestedUtc = null,
+            bool seedRosterRows = true)
+    {
+        var competitionId = Guid.NewGuid();
+        await FootballDataContext.Competitions.AddAsync(new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = Guid.NewGuid(),
+            Date = UtcNow(),
+            CreatedUtc = UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        });
+        await FootballDataContext.Set<FootballCompetitionStatus>().AddAsync(new FootballCompetitionStatus
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = competitionId,
+            IsCompleted = !inProgress,
+            CreatedUtc = UtcNow(),
+            CreatedBy = Guid.NewGuid()
+        });
+
+        foreach (var (teamUrl, abbr) in new[]
+                 {
+                     ("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/teams/99", "T99"),
+                     ("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/teams/30", "T30"),
+                 })
+        {
+            var teamId = Guid.NewGuid();
+            await FootballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+            {
+                Id = teamId,
+                FranchiseId = Guid.NewGuid(),
+                SeasonYear = 2024,
+                Abbreviation = abbr,
+                DisplayName = abbr,
+                DisplayNameShort = abbr,
+                Location = abbr,
+                Name = abbr,
+                Slug = abbr.ToLowerInvariant(),
+                ColorCodeHex = "#FFFFFF",
+                CreatedUtc = UtcNow(),
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds =
+                [
+                    new FranchiseSeasonExternalId
+                    {
+                        Id = Guid.NewGuid(),
+                        FranchiseSeasonId = teamId,
+                        Provider = SourceDataProvider.Espn,
+                        Value = generator.Generate(teamUrl).UrlHash,
+                        SourceUrl = teamUrl,
+                        SourceUrlHash = generator.Generate(teamUrl).UrlHash,
+                        CreatedBy = Guid.NewGuid()
+                    }
+                ]
+            });
+        }
+        await FootballDataContext.SaveChangesAsync();
+
+        var (kickerSeasonId, returnerSeasonId) = await SeedKickoffReturnParticipantDepsAsync(generator);
+
+        AthleteCompetition SeedRoster(Guid athleteSeasonId)
+        {
+            var row = new AthleteCompetition
+            {
+                Id = Guid.NewGuid(),
+                CompetitionId = competitionId,
+                CompetitionCompetitorId = Guid.NewGuid(),
+                AthleteSeasonId = athleteSeasonId,
+                StatsRequestedUtc = statsRequestedUtc,
+                CreatedUtc = UtcNow(),
+                CreatedBy = Guid.NewGuid()
+            };
+            FootballDataContext.AthleteCompetitions.Add(row);
+            return row;
+        }
+
+        AthleteCompetition kicker = null!, returner = null!;
+        if (seedRosterRows)
+        {
+            kicker = SeedRoster(kickerSeasonId);
+            returner = SeedRoster(returnerSeasonId);
+            await FootballDataContext.SaveChangesAsync();
+        }
+
+        return (competitionId, kicker, returner);
+    }
+
+    private void VerifyStatsRequests(Times times)
+    {
+        Mocker.GetMock<IEventBus>().Verify(
+            x => x.Publish(
+                It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.EventCompetitionAthleteStatistics),
+                It.IsAny<CancellationToken>()),
+            times);
+    }
+
+    [Fact]
+    public async Task LivePlay_RequestsParticipantStatistics_AndStampsWatermark()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var (competitionId, kicker, returner) = await ArrangeKickoffStatsScenarioAsync(generator);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
+
+        // One cumulative-stats request per participant (kicker + returner).
+        VerifyStatsRequests(Times.Exactly(2));
+        kicker.StatsRequestedUtc.Should().Be(FixedUtcNow);
+        returner.StatsRequestedUtc.Should().Be(FixedUtcNow);
+    }
+
+    [Fact]
+    public async Task LivePlay_WithinDebounceWindow_DoesNotRequest()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var recent = FixedUtcNow.AddMinutes(-1); // < 3-minute debounce
+        var (competitionId, kicker, _) = await ArrangeKickoffStatsScenarioAsync(
+            generator, statsRequestedUtc: recent);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
+
+        VerifyStatsRequests(Times.Never());
+        kicker.StatsRequestedUtc.Should().Be(recent); // watermark untouched
+    }
+
+    [Fact]
+    public async Task LivePlay_AfterDebounceWindow_RequestsAgain()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var stale = FixedUtcNow.AddMinutes(-4); // > 3-minute debounce
+        var (competitionId, kicker, _) = await ArrangeKickoffStatsScenarioAsync(
+            generator, statsRequestedUtc: stale);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
+
+        VerifyStatsRequests(Times.Exactly(2));
+        kicker.StatsRequestedUtc.Should().Be(FixedUtcNow);
+    }
+
+    [Fact]
+    public async Task ScoringPlay_BypassesDebounce()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var recent = FixedUtcNow.AddMinutes(-1); // inside the window
+        var (competitionId, _, _) = await ArrangeKickoffStatsScenarioAsync(
+            generator, statsRequestedUtc: recent);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+        json = json.Replace("\"scoringPlay\": false", "\"scoringPlay\": true");
+
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
+
+        // A TD must show up NOW — the debounce does not apply.
+        VerifyStatsRequests(Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task CompletedCompetition_DoesNotRequestStatistics()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var (competitionId, _, _) = await ArrangeKickoffStatsScenarioAsync(
+            generator, inProgress: false);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
+
+        // Backfills and post-final corrections must never fan out fetches.
+        VerifyStatsRequests(Times.Never());
+    }
+
+    [Fact]
+    public async Task MissingRosterRows_SkipsQuietly_AndStillPersistsThePlay()
+    {
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+        var (competitionId, _, _) = await ArrangeKickoffStatsScenarioAsync(
+            generator, seedRosterRows: false);
+
+        var sut = Mocker.CreateInstance<FootballEventCompetitionPlayDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionPlay_KickoffReturnOffense.json");
+
+        await sut.ProcessAsync(CreateCommand(json, competitionId.ToString()));
+
+        VerifyStatsRequests(Times.Never());
+        (await FootballDataContext.CompetitionPlays.AnyAsync(p => p.CompetitionId == competitionId))
+            .Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary

Keeps athlete in-game totals fresh while a game is live. Box scores previously refreshed only via the competitor-roster cascade (pre-game / enrichment) — the live-update cascade deliberately excludes per-athlete stats, so in-game totals froze at kickoff. **Final** scoring never needed this (finalization delivers the last word); this is the live-view layer for Player Pick'em's "am I winning?" surface.

## Mechanism

Every play document lists participants with a `$ref` to the athlete's **cumulative** in-game statistics doc (`…/competitors/{id}/roster/{athleteId}/statistics/0`). The play processor now fans out requests for those docs — cumulative, not the inline per-play deltas, so re-processing and stat corrections are idempotent (ESPN's running total is the authority; the deltas are already persisted as play participants).

Freshness comes free downstream: Provider **auto-bypasses its Mongo cache for current-season requests**, and its content-hash dedupe suppresses the publish when nothing changed. Requests land in the existing `EventCompetitionAthleteStatistics` processor — zero new document types.

## Bounding ESPN fetch volume (the 403 rate limiter is real)

- **Per-athlete-per-game debounce** via a new watermark column, `AthleteCompetition.StatsRequestedUtc`. 3 minutes ≈ drive granularity — plays cluster inside drives, so a QB refreshes ~once per drive instead of once per snap. ~250–350 fetches/game vs ~700 naive. DB-backed, so it holds across the 30-worker fleet; a cross-worker race costs one duplicate fetch, not worth locking.
- **Scoring plays bypass the debounce** — a TD shows up immediately.
- **The hook fires only while the competition is IN PROGRESS** — the load-bearing safety keeping historical play backfills (1.4M archived plays) and post-final corrections from fanning out millions of fetches. The duplicate-insert race path skips it (the winning worker fans out). Baseball inherits the no-op.

## Implementation notes

- Base play processor: virtual `RequestParticipantStatisticsAsync` no-op hook, called after persist on both create and update paths.
- Football override: distinct participants → roster-row debounce check → stamp + child `DocumentRequested`. Missing roster row (pre-game cascade still running) skips quietly; a later play retries.
- The football processor gains an `IDateTimeProvider` ctor parameter (`ActivatorUtilities` resolves it) so the debounce clock is testable.
- Migrations for both Football and Baseball contexts, applied and verified against local databases.

## Validation

- 6 new tests on the real `KickoffReturnOffense` fixture: fan-out + watermark stamp, within-window suppression, after-window re-request, scoring-play bypass, completed-competition skip, missing-roster tolerance
- Play-processor suite 16 green; full Producer suite 611 green
- Operator-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live football plays now trigger athlete statistics refresh requests.
  * Statistics requests are automatically limited to once every three minutes per athlete.
  * Scoring plays receive immediate statistics refreshes.
  * Completed competitions and athletes without roster data are handled without unnecessary requests.

* **Bug Fixes**
  * Live play processing continues successfully when roster records are unavailable.

* **Tests**
  * Added coverage for refresh timing, scoring plays, completed competitions, and missing roster data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->