### PR TITLE
feat(api,producer,core,web): Player Pick'em roster persistence — one game per league

### DIFF
--- a/docs/features/player-pickem/roster-persistence.md
+++ b/docs/features/player-pickem/roster-persistence.md
@@ -116,6 +116,13 @@ validation error the pre-check produces. An xmin token adds an
 untestable-under-InMemory failure path for negligible remaining gain;
 revisit with the scoring integrity pass.
 
+Week numbers are PHASE-SCOPED: within one season year the NFL counts
+weeks 1-4 in preseason, 1-18 in the regular season, and 1-5 in the
+postseason. Matchup resolution (GetMatchupsForSeasonWeek) filters on
+SeasonPhase.TypeCode — default 2, regular season — so a bare week
+number can never anchor a slot to a preseason or playoff game. A future
+playoff/CFP pick'em passes TypeCode 3 explicitly.
+
 **Alpha-blocking, tracked**: SEASON_YEAR/WEEK are pinned to 2026 week 1
 in the UI. A server-resolved current week (or a week selector) must land
 before the week-3/4 alpha — a user cannot reach later weeks without it.

--- a/docs/features/player-pickem/roster-persistence.md
+++ b/docs/features/player-pickem/roster-persistence.md
@@ -16,7 +16,7 @@ draft shipped with the admin-preview roster builder (#674–#676).
 
 ## Entities (API database, beside the pick tables)
 
-```
+```text
 PlayerLineup
   Id               Guid PK
   PickemGroupId    Guid
@@ -42,7 +42,7 @@ PlayerLineupSlot
   OpponentName     string?
   Created/Modified audit fields
   UNIQUE (PlayerLineupId, SlotId)
-```
+```text
 
 The v1 lineup shape (1 QB / 2 RB / 2 WR / 1 TE / 1 FLEX / 1 K) is fixed and
 enforced server-side; `DEF` is reserved until the team-defense picker exists.
@@ -93,6 +93,30 @@ modules — kept pure from day one for exactly this move.
 - Admin preview targets the first `PlayerPickem`-type league the user
   belongs to; a proper league picker comes with launch shape.
 - Locked slots render disabled with a lock affordance; bye slots badge.
+
+## Trust boundary (alpha)
+
+The upsert accepts the athlete identity + display snapshot from the
+client; the server authoritatively resolves the CONTEST ANCHOR from the
+athlete's claimed TeamSlug. A malicious member could therefore submit a
+locked athlete under an unlocked team's slug and slip a mid-game player
+into their own lineup. Accepted for the alpha (founder + friends): the
+blast radius is the cheater's own roster, and the planned scoring-side
+audit closes it retroactively — scoring resolves each athlete's REAL
+game server-side and invalidates slots whose stored anchor mismatches.
+Full server-side athlete verification per save would mean re-fetching
+the position feed on every write; deliberately deferred.
+
+Concurrency: lineup writes carry no concurrency token. The only writer
+of a lineup is its owner; the worst same-user race (two simultaneous
+saves of the same athlete into different slots) yields a duplicate
+athlete in one's OWN roster, which the UI and scoring tolerate. An xmin
+token adds an untestable-under-InMemory failure path for negligible
+gain; revisit with the scoring integrity pass.
+
+**Alpha-blocking, tracked**: SEASON_YEAR/WEEK are pinned to 2026 week 1
+in the UI. A server-resolved current week (or a week selector) must land
+before the week-3/4 alpha — a user cannot reach later weeks without it.
 
 ## Future (explicitly out of scope here)
 

--- a/docs/features/player-pickem/roster-persistence.md
+++ b/docs/features/player-pickem/roster-persistence.md
@@ -1,0 +1,105 @@
+# Player Pick'em — Roster Persistence
+
+**Status:** Approved 2026-08-26 (operator). Supersedes the localStorage-only
+draft shipped with the admin-preview roster builder (#674–#676).
+
+## Decisions (operator-ratified)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Lock granularity | **Per-player**, at that player's kickoff | Doc open question #2. A Thursday player locks Thursday; Saturday slots stay editable. Weekly lock makes Thursday slots dead weight. |
+| Lock rule | **Kickoff − 5 minutes**, via the shared `IsStartLocked` | Team picks lock 5 minutes before kickoff; rosters are no different. One lock rule in the product. |
+| Lock storage | **Derived, never stored** | Schedule moves self-heal (`ContestStartTimeUpdated` exists because games move). Also makes the future commissioner option (weekly-lock mode) a group setting with zero schema change: evaluate every slot against the week's earliest kickoff instead of its own. |
+| League game model | **`PickemGroup.GroupType` enum (`TeamPickem` = 0 / `PlayerPickem`) — one game per league** | Operator decision 2026-08-26, superseding an earlier companion-mode draft: Player Pick'em is a DIFFERENT GAME and lives in a DIFFERENT league — two scoring systems in one group is asking for trouble; invite the same friends to a second league instead. An enum rather than capability flags because the games are mutually exclusive: flags would make the invalid both-enabled state representable and force every consumer to police it, where the enum makes it unrepresentable. `TeamPickem = 0` so every existing row is correct by default. NOT a `PickType` value — `PickType` answers "how is a TEAM pick scored?" within a TeamPickem group and is referenced in ~85 files. Creation-flow support for PlayerPickem groups (the standalone-league vertical: game-type choice at creation; player leagues skip matchup filters/PickType/confidence, keep week structure, skip matchup slates and team-pick scoring) is the NEXT vertical; until then, `UPDATE "PickemGroup" SET "GroupType" = 1` is the admin substitute for E2E. |
+| Carry-over | **Lazy clone on read** | On GET for week N+1: no lineup + week N exists → clone, re-resolving each athlete's new-week contest. Same user experience as the doc's "rollover job" without a fleet-wide Sunday job; clones only for users who show up. |
+| Bye/departed athletes | **Carry and badge, never auto-drop** | Doc open question #4. A bye slot (`ContestId` null) never locks and never scores; the UI badges it loudly. |
+
+## Entities (API database, beside the pick tables)
+
+```
+PlayerLineup
+  Id               Guid PK
+  PickemGroupId    Guid
+  UserId           Guid
+  SeasonYear       int
+  SeasonWeek       int
+  Created/Modified audit fields
+  UNIQUE (PickemGroupId, UserId, SeasonYear, SeasonWeek)
+
+PlayerLineupSlot
+  Id               Guid PK
+  PlayerLineupId   Guid FK → PlayerLineup (cascade delete)
+  SlotId           string(8)    'QB','RB1','RB2','WR1','WR2','TE','FLEX','K' ('DEF' reserved)
+  -- athlete: soft canonical refs + render snapshot (the pick-table pattern)
+  AthleteId        Guid         stable across seasons (stats-audit lesson:
+                                never trust a roster-row's year)
+  AthleteSeasonId  Guid         season row at save time; the scoring join
+  Position         string(4)    FLEX-eligibility validation + badge
+  FirstName, LastName, TeamName, TeamSlug
+  -- the week's game: lock + scoring anchor
+  ContestId        Guid?        null = bye at save time
+  ContestStartUtc  DateTime?    denormalized start; lock derives from it
+  OpponentName     string?
+  Created/Modified audit fields
+  UNIQUE (PlayerLineupId, SlotId)
+```
+
+The v1 lineup shape (1 QB / 2 RB / 2 WR / 1 TE / 1 FLEX / 1 K) is fixed and
+enforced server-side; `DEF` is reserved until the team-defense picker exists.
+
+## Locking
+
+A slot is locked ⟺ `IsStartLocked(slot.ContestStartUtc, now)` — the same
+extension the team-pick submit path uses (locked when start ≤ now + 5 min).
+
+Write validation on assign/replace/remove:
+- slot id exists in the fixed shape
+- position eligible for the slot (FLEX = RB/WR/TE)
+- no duplicate athlete across the lineup's slots
+- **target slot not locked** (can't swap out a player whose game started)
+- **incoming athlete's game not locked** (can't add a player mid-game)
+- bye athletes (no contest this week) are assignable and never lock
+
+Staleness note: `ContestStartUtc` is denormalized, exactly like
+`PickemGroupMatchup.StartDateUtc`. The slot updater should eventually join
+the `ContestStartTimeUpdated` consumer family; v1 accepts the same staleness
+the pick tables do. Flagged, not forgotten.
+
+## Feed contract addition
+
+`AthleteMatchupSummaryDto` gains `ContestId` + `ContestStartUtc` (already
+joined in the Producer query, just not projected). The UI passes them on
+save; the API **revalidates the lock from its own clock** — the client's
+values are a convenience, never the authority.
+
+## Endpoints (API, UI namespace; all gated on `GroupType == PlayerPickem`)
+
+- `GET  /ui/leagues/{leagueId}/player-lineups/{seasonYear}/{week}/mine`
+  → lineup + slots, each with derived `isLocked`; triggers the lazy clone
+- `PUT  /ui/leagues/{leagueId}/player-lineups/{seasonYear}/{week}/mine/slots/{slotId}`
+  → assign/replace (validations above)
+- `DELETE …/mine/slots/{slotId}` → clear an unlocked slot
+
+Requests against a TeamPickem league → 403 (one game per league). Membership
+in the league is required (existing league authorization).
+
+The slot rules are a server-side port of the UI's pure `rosterLogic`
+modules — kept pure from day one for exactly this move.
+
+## UI changes
+
+- Roster builder swaps localStorage for the API (localStorage dies; the
+  per-league draft keys were a stand-in for exactly this).
+- Admin preview targets the first `PlayerPickem`-type league the user
+  belongs to; a proper league picker comes with launch shape.
+- Locked slots render disabled with a lock affordance; bye slots badge.
+
+## Future (explicitly out of scope here)
+
+- Scoring engine (doc open question #3) — joins slots
+  (`AthleteSeasonId`, `ContestId`) to `AthleteCompetitionStatistic`.
+- Commissioner options: weekly-lock mode, roster shape config — live next
+  to `GroupType`.
+- `DEF` slot (team-defense picker), depth-chart-driven roster slimming
+  (ESPN `/depthcharts` — the game-roster feed's `starter` is empty for
+  college).

--- a/docs/features/player-pickem/roster-persistence.md
+++ b/docs/features/player-pickem/roster-persistence.md
@@ -107,12 +107,14 @@ game server-side and invalidates slots whose stored anchor mismatches.
 Full server-side athlete verification per save would mean re-fetching
 the position feed on every write; deliberately deferred.
 
-Concurrency: lineup writes carry no concurrency token. The only writer
-of a lineup is its owner; the worst same-user race (two simultaneous
-saves of the same athlete into different slots) yields a duplicate
-athlete in one's OWN roster, which the UI and scoring tolerate. An xmin
-token adds an untestable-under-InMemory failure path for negligible
-gain; revisit with the scoring integrity pass.
+Concurrency: lineup writes carry no concurrency token — the only
+writer of a lineup is its owner. The no-duplicate-athlete rule is
+enforced by a unique (PlayerLineupId, AthleteId) index, so the one
+meaningful same-user race (simultaneous saves of the same athlete into
+different slots) is rejected by the database and surfaced as the same
+validation error the pre-check produces. An xmin token adds an
+untestable-under-InMemory failure path for negligible remaining gain;
+revisit with the scoring integrity pass.
 
 **Alpha-blocking, tracked**: SEASON_YEAR/WEEK are pinned to 2026 week 1
 in the UI. A server-resolved current week (or a week selector) must land

--- a/src/SportsData.Api/Application/Common/Enums/GroupType.cs
+++ b/src/SportsData.Api/Application/Common/Enums/GroupType.cs
@@ -1,0 +1,19 @@
+namespace SportsData.Api.Application.Common.Enums;
+
+/// <summary>
+/// Which game a PickemGroup plays. PRODUCT RULE (operator, 2026-08-26):
+/// a league is exactly ONE game — a roster league is a different league,
+/// not a companion mode on a team-pick league (two scoring systems in
+/// one group is asking for trouble; invite the same friends to a second
+/// league instead). An enum rather than capability flags because the
+/// games are mutually exclusive — flags would make the invalid
+/// both-enabled state representable and force every consumer to police
+/// it. TeamPickem is deliberately 0 so every existing row is correct by
+/// default. Distinct from PickType, which answers "how is a TEAM pick
+/// scored?" within a TeamPickem group.
+/// </summary>
+public enum GroupType
+{
+    TeamPickem = 0,
+    PlayerPickem = 1,
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
@@ -22,6 +22,14 @@
 
         public string LeagueType { get; set; } = null!;
 
+        /// <summary>
+        /// Which game this league plays ("TeamPickem" / "PlayerPickem") —
+        /// one game per league. Drives the roster builder's league
+        /// resolution. Naming wart acknowledged: the pre-existing
+        /// LeagueType above carries PickType, not this.
+        /// </summary>
+        public string GroupType { get; set; } = null!;
+
         public bool UseConfidencePoints { get; set; } = false;
 
         public int MemberCount { get; set; }

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
@@ -43,6 +43,7 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
                 Sport = m.Group.Sport.ToString(),
                 League = m.Group.League.ToString(),
                 LeagueType = m.Group.PickType.ToString(),
+                GroupType = m.Group.GroupType.ToString(),
                 UseConfidencePoints = m.Group.UseConfidencePoints,
                 MemberCount = m.Group.Members.Count,
                 SeasonYear = m.Group.SeasonYear,

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommand.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommand.cs
@@ -1,0 +1,8 @@
+namespace SportsData.Api.Application.UI.PlayerLineups.Commands.ClearLineupSlot;
+
+public record ClearLineupSlotCommand(
+    Guid LeagueId,
+    Guid UserId,
+    int SeasonYear,
+    int SeasonWeek,
+    string SlotId);

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandHandler.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
@@ -30,30 +31,47 @@ public class ClearLineupSlotCommandHandler : IClearLineupSlotCommandHandler
     private readonly ILeagueMembershipGuard _membershipGuard;
     private readonly IContestClientFactory _contestClientFactory;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IValidator<ClearLineupSlotCommand> _validator;
 
     public ClearLineupSlotCommandHandler(
         ILogger<ClearLineupSlotCommandHandler> logger,
         AppDataContext dataContext,
         ILeagueMembershipGuard membershipGuard,
         IContestClientFactory contestClientFactory,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        IValidator<ClearLineupSlotCommand> validator)
     {
         _logger = logger;
         _dataContext = dataContext;
         _membershipGuard = membershipGuard;
         _contestClientFactory = contestClientFactory;
         _dateTimeProvider = dateTimeProvider;
+        _validator = validator;
     }
 
     public async Task<Result<bool>> ExecuteAsync(
         ClearLineupSlotCommand command,
         CancellationToken cancellationToken = default)
     {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<bool>(default!, ResultStatus.Validation, validation.Errors);
+        }
+
+        // Canonical slot id — same casing rule as the upsert.
+        var slotId = LineupSlots.Normalize(command.SlotId);
+        if (slotId is null)
+        {
+            return new Failure<bool>(default!, ResultStatus.NotFound,
+                [new ValidationFailure(nameof(command.SlotId), "No athlete in that slot.")]);
+        }
+
         var gate = await PlayerLineupGate.CheckAsync(
             _dataContext, _membershipGuard, command.LeagueId, command.UserId, cancellationToken);
         if (gate.Failure is not null)
         {
-            return new Failure<bool>(default, gate.Failure.Value.Status, gate.Failure.Value.Errors);
+            return new Failure<bool>(default!, gate.Failure.Value.Status, gate.Failure.Value.Errors);
         }
 
         var lineup = await _dataContext.PlayerLineups
@@ -65,10 +83,10 @@ public class ClearLineupSlotCommandHandler : IClearLineupSlotCommandHandler
                     l.SeasonWeek == command.SeasonWeek,
                 cancellationToken);
 
-        var slot = lineup?.Slots.FirstOrDefault(s => s.SlotId == command.SlotId);
+        var slot = lineup?.Slots.FirstOrDefault(s => s.SlotId == slotId);
         if (lineup is null || slot is null)
         {
-            return new Failure<bool>(default, ResultStatus.NotFound,
+            return new Failure<bool>(default!, ResultStatus.NotFound,
                 [new ValidationFailure(nameof(command.SlotId), "No athlete in that slot.")]);
         }
 
@@ -84,7 +102,7 @@ public class ClearLineupSlotCommandHandler : IClearLineupSlotCommandHandler
                 _logger.LogError(
                     "Slot clear rejected: matchup resolution failed. LeagueId={LeagueId} Week={Week} Status={Status}",
                     command.LeagueId, command.SeasonWeek, matchups.Status);
-                return new Failure<bool>(default, ResultStatus.Error,
+                return new Failure<bool>(default!, ResultStatus.Error,
                     [new ValidationFailure(nameof(command.SlotId), "Unable to verify game locks right now. Please try again.")]);
             }
 
@@ -99,16 +117,16 @@ public class ClearLineupSlotCommandHandler : IClearLineupSlotCommandHandler
             _logger.LogError(ex,
                 "Slot clear rejected: matchup resolution threw. LeagueId={LeagueId} Week={Week}",
                 command.LeagueId, command.SeasonWeek);
-            return new Failure<bool>(default, ResultStatus.Error,
+            return new Failure<bool>(default!, ResultStatus.Error,
                 [new ValidationFailure(nameof(command.SlotId), "Unable to verify game locks right now. Please try again.")]);
         }
 
         var now = _dateTimeProvider.UtcNow();
         if (UpsertLineupSlotCommandHandler.IsSlotLocked(slot, weekMap, now))
         {
-            return new Failure<bool>(default, ResultStatus.Validation,
+            return new Failure<bool>(default!, ResultStatus.Validation,
                 [new ValidationFailure(nameof(command.SlotId),
-                    $"Slot '{command.SlotId}' is locked — {slot.LastName}'s game has started or starts within 5 minutes.")]);
+                    $"Slot '{slotId}' is locked — {slot.LastName}'s game has started or starts within 5 minutes.")]);
         }
 
         _dataContext.PlayerLineupSlots.Remove(slot);

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandHandler.cs
@@ -1,0 +1,121 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.UI.Leagues.Authorization;
+using SportsData.Api.Application.UI.PlayerLineups.Commands.UpsertLineupSlot;
+using SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.UI.PlayerLineups.Commands.ClearLineupSlot;
+
+public interface IClearLineupSlotCommandHandler
+{
+    Task<Result<bool>> ExecuteAsync(
+        ClearLineupSlotCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Clear an unlocked slot. Same lock evaluation as the upsert (stored
+/// anchor OR current resolution of the occupant's team), and the same
+/// fail-closed posture when matchup resolution is unavailable.
+/// </summary>
+public class ClearLineupSlotCommandHandler : IClearLineupSlotCommandHandler
+{
+    private readonly ILogger<ClearLineupSlotCommandHandler> _logger;
+    private readonly AppDataContext _dataContext;
+    private readonly ILeagueMembershipGuard _membershipGuard;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public ClearLineupSlotCommandHandler(
+        ILogger<ClearLineupSlotCommandHandler> logger,
+        AppDataContext dataContext,
+        ILeagueMembershipGuard membershipGuard,
+        IContestClientFactory contestClientFactory,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _membershipGuard = membershipGuard;
+        _contestClientFactory = contestClientFactory;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<bool>> ExecuteAsync(
+        ClearLineupSlotCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var gate = await PlayerLineupGate.CheckAsync(
+            _dataContext, _membershipGuard, command.LeagueId, command.UserId, cancellationToken);
+        if (gate.Failure is not null)
+        {
+            return new Failure<bool>(default, gate.Failure.Value.Status, gate.Failure.Value.Errors);
+        }
+
+        var lineup = await _dataContext.PlayerLineups
+            .Include(l => l.Slots)
+            .FirstOrDefaultAsync(l =>
+                    l.PickemGroupId == command.LeagueId &&
+                    l.UserId == command.UserId &&
+                    l.SeasonYear == command.SeasonYear &&
+                    l.SeasonWeek == command.SeasonWeek,
+                cancellationToken);
+
+        var slot = lineup?.Slots.FirstOrDefault(s => s.SlotId == command.SlotId);
+        if (lineup is null || slot is null)
+        {
+            return new Failure<bool>(default, ResultStatus.NotFound,
+                [new ValidationFailure(nameof(command.SlotId), "No athlete in that slot.")]);
+        }
+
+        WeekMatchupMap weekMap;
+        try
+        {
+            var matchups = await _contestClientFactory
+                .Resolve(gate.Group!.Sport)
+                .GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek, cancellationToken);
+
+            if (!matchups.IsSuccess)
+            {
+                _logger.LogError(
+                    "Slot clear rejected: matchup resolution failed. LeagueId={LeagueId} Week={Week} Status={Status}",
+                    command.LeagueId, command.SeasonWeek, matchups.Status);
+                return new Failure<bool>(default, ResultStatus.Error,
+                    [new ValidationFailure(nameof(command.SlotId), "Unable to verify game locks right now. Please try again.")]);
+            }
+
+            weekMap = new WeekMatchupMap(matchups.Value);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Slot clear rejected: matchup resolution threw. LeagueId={LeagueId} Week={Week}",
+                command.LeagueId, command.SeasonWeek);
+            return new Failure<bool>(default, ResultStatus.Error,
+                [new ValidationFailure(nameof(command.SlotId), "Unable to verify game locks right now. Please try again.")]);
+        }
+
+        var now = _dateTimeProvider.UtcNow();
+        if (UpsertLineupSlotCommandHandler.IsSlotLocked(slot, weekMap, now))
+        {
+            return new Failure<bool>(default, ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.SlotId),
+                    $"Slot '{command.SlotId}' is locked — {slot.LastName}'s game has started or starts within 5 minutes.")]);
+        }
+
+        _dataContext.PlayerLineupSlots.Remove(slot);
+        lineup.ModifiedUtc = now;
+        lineup.ModifiedBy = command.UserId;
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        return new Success<bool>(true);
+    }
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.UI.PlayerLineups.Commands.ClearLineupSlot;
+
+public class ClearLineupSlotCommandValidator : AbstractValidator<ClearLineupSlotCommand>
+{
+    public ClearLineupSlotCommandValidator()
+    {
+        RuleFor(x => x.SeasonYear).InclusiveBetween(2000, 2100);
+        RuleFor(x => x.SeasonWeek).InclusiveBetween(1, 30);
+        RuleFor(x => x.SlotId).NotEmpty().MaximumLength(8);
+    }
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommand.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommand.cs
@@ -1,0 +1,25 @@
+namespace SportsData.Api.Application.UI.PlayerLineups.Commands.UpsertLineupSlot;
+
+/// <summary>
+/// Assign or replace one slot. Contest anchoring (ContestId/StartUtc) is
+/// deliberately ABSENT here: the server resolves it from its own matchup
+/// data — client-provided contest fields are never trusted for locking.
+/// OpponentName is display-only and accepted from the client.
+/// </summary>
+public class UpsertLineupSlotCommand
+{
+    public Guid LeagueId { get; set; }
+    public Guid UserId { get; set; }
+    public int SeasonYear { get; set; }
+    public int SeasonWeek { get; set; }
+    public string SlotId { get; set; } = null!;
+
+    public Guid AthleteId { get; set; }
+    public Guid AthleteSeasonId { get; set; }
+    public string Position { get; set; } = null!;
+    public string FirstName { get; set; } = null!;
+    public string LastName { get; set; } = null!;
+    public string TeamName { get; set; } = null!;
+    public string TeamSlug { get; set; } = null!;
+    public string? OpponentName { get; set; }
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
@@ -38,25 +39,34 @@ public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
     private readonly ILeagueMembershipGuard _membershipGuard;
     private readonly IContestClientFactory _contestClientFactory;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IValidator<UpsertLineupSlotCommand> _validator;
 
     public UpsertLineupSlotCommandHandler(
         ILogger<UpsertLineupSlotCommandHandler> logger,
         AppDataContext dataContext,
         ILeagueMembershipGuard membershipGuard,
         IContestClientFactory contestClientFactory,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        IValidator<UpsertLineupSlotCommand> validator)
     {
         _logger = logger;
         _dataContext = dataContext;
         _membershipGuard = membershipGuard;
         _contestClientFactory = contestClientFactory;
         _dateTimeProvider = dateTimeProvider;
+        _validator = validator;
     }
 
     public async Task<Result<PlayerLineupSlotDto>> ExecuteAsync(
         UpsertLineupSlotCommand command,
         CancellationToken cancellationToken = default)
     {
+        var validation = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<PlayerLineupSlotDto>(default!, ResultStatus.Validation, validation.Errors);
+        }
+
         var gate = await PlayerLineupGate.CheckAsync(
             _dataContext, _membershipGuard, command.LeagueId, command.UserId, cancellationToken);
         if (gate.Failure is not null)
@@ -64,16 +74,20 @@ public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
             return new Failure<PlayerLineupSlotDto>(default!, gate.Failure.Value.Status, gate.Failure.Value.Errors);
         }
 
-        if (!LineupSlots.IsValidSlot(command.SlotId))
+        // Canonical slot id from here on — persisting the caller's casing
+        // would let "qb" and "QB" become two distinct QB slots under the
+        // case-sensitive unique index.
+        var slotId = LineupSlots.Normalize(command.SlotId);
+        if (slotId is null)
         {
             return Fail(ResultStatus.Validation, nameof(command.SlotId),
                 $"Unknown slot '{command.SlotId}'.");
         }
 
-        if (!LineupSlots.IsEligible(command.SlotId, command.Position))
+        if (!LineupSlots.IsEligible(slotId, command.Position))
         {
             return Fail(ResultStatus.Validation, nameof(command.Position),
-                $"Position '{command.Position}' is not eligible for slot '{command.SlotId}'.");
+                $"Position '{command.Position}' is not eligible for slot '{slotId}'.");
         }
 
         // ── Server-side matchup resolution (the lock authority) ───────────
@@ -121,7 +135,7 @@ public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
 
         // ── Duplicate athlete across slots ────────────────────────────────
         if (lineup is not null && lineup.Slots.Any(s =>
-                s.SlotId != command.SlotId && s.AthleteId == command.AthleteId))
+                s.SlotId != slotId && s.AthleteId == command.AthleteId))
         {
             return Fail(ResultStatus.Validation, nameof(command.AthleteId),
                 "That athlete is already rostered in another slot.");
@@ -130,11 +144,11 @@ public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
         // ── Target slot lock (both the stored anchor AND the current
         //    resolution of the OCCUPANT's team — a cloned slot can carry a
         //    null anchor, and null must never mean unlocked-forever) ───────
-        var existing = lineup?.Slots.FirstOrDefault(s => s.SlotId == command.SlotId);
+        var existing = lineup?.Slots.FirstOrDefault(s => s.SlotId == slotId);
         if (existing is not null && IsSlotLocked(existing, weekMap, now))
         {
             return Fail(ResultStatus.Validation, nameof(command.SlotId),
-                $"Slot '{command.SlotId}' is locked — {existing.LastName}'s game has started or starts within 5 minutes.");
+                $"Slot '{slotId}' is locked — {existing.LastName}'s game has started or starts within 5 minutes.");
         }
 
         // ── Incoming athlete's game lock ──────────────────────────────────
@@ -168,7 +182,7 @@ public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
             {
                 Id = Guid.NewGuid(),
                 PlayerLineupId = lineup.Id,
-                SlotId = command.SlotId,
+                SlotId = slotId,
                 CreatedUtc = now,
                 CreatedBy = command.UserId,
             };

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
@@ -1,0 +1,228 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.UI.Leagues.Authorization;
+using SportsData.Api.Application.UI.PlayerLineups.Dtos;
+using SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
+using SportsData.Api.Extensions;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.UI.PlayerLineups.Commands.UpsertLineupSlot;
+
+public interface IUpsertLineupSlotCommandHandler
+{
+    Task<Result<PlayerLineupSlotDto>> ExecuteAsync(
+        UpsertLineupSlotCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Assign or replace one lineup slot. The write-side rules from the
+/// design doc, in order: slot exists in the fixed shape; position
+/// eligible; no duplicate athlete across slots; TARGET slot not locked;
+/// INCOMING athlete's game not locked. Lock evaluation is fully
+/// server-side: one GetMatchupsForSeasonWeek call resolves every team's
+/// contest and kickoff, and the stored anchor is what this handler
+/// resolved — never what the client sent. Matchup resolution failure
+/// FAILS CLOSED (unlike the read-side clone): we will not accept a write
+/// we cannot lock-check.
+/// </summary>
+public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
+{
+    private readonly ILogger<UpsertLineupSlotCommandHandler> _logger;
+    private readonly AppDataContext _dataContext;
+    private readonly ILeagueMembershipGuard _membershipGuard;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public UpsertLineupSlotCommandHandler(
+        ILogger<UpsertLineupSlotCommandHandler> logger,
+        AppDataContext dataContext,
+        ILeagueMembershipGuard membershipGuard,
+        IContestClientFactory contestClientFactory,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _membershipGuard = membershipGuard;
+        _contestClientFactory = contestClientFactory;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<PlayerLineupSlotDto>> ExecuteAsync(
+        UpsertLineupSlotCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var gate = await PlayerLineupGate.CheckAsync(
+            _dataContext, _membershipGuard, command.LeagueId, command.UserId, cancellationToken);
+        if (gate.Failure is not null)
+        {
+            return new Failure<PlayerLineupSlotDto>(default!, gate.Failure.Value.Status, gate.Failure.Value.Errors);
+        }
+
+        if (!LineupSlots.IsValidSlot(command.SlotId))
+        {
+            return Fail(ResultStatus.Validation, nameof(command.SlotId),
+                $"Unknown slot '{command.SlotId}'.");
+        }
+
+        if (!LineupSlots.IsEligible(command.SlotId, command.Position))
+        {
+            return Fail(ResultStatus.Validation, nameof(command.Position),
+                $"Position '{command.Position}' is not eligible for slot '{command.SlotId}'.");
+        }
+
+        // ── Server-side matchup resolution (the lock authority) ───────────
+        WeekMatchupMap weekMap;
+        try
+        {
+            var matchups = await _contestClientFactory
+                .Resolve(gate.Group!.Sport)
+                .GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek, cancellationToken);
+
+            if (!matchups.IsSuccess)
+            {
+                _logger.LogError(
+                    "Slot upsert rejected: matchup resolution failed. LeagueId={LeagueId} Week={Week} Status={Status}",
+                    command.LeagueId, command.SeasonWeek, matchups.Status);
+                return Fail(ResultStatus.Error, nameof(command.SlotId),
+                    "Unable to verify game locks right now. Please try again.");
+            }
+
+            weekMap = new WeekMatchupMap(matchups.Value);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Slot upsert rejected: matchup resolution threw. LeagueId={LeagueId} Week={Week}",
+                command.LeagueId, command.SeasonWeek);
+            return Fail(ResultStatus.Error, nameof(command.SlotId),
+                "Unable to verify game locks right now. Please try again.");
+        }
+
+        var now = _dateTimeProvider.UtcNow();
+
+        var lineup = await _dataContext.PlayerLineups
+            .Include(l => l.Slots)
+            .FirstOrDefaultAsync(l =>
+                    l.PickemGroupId == command.LeagueId &&
+                    l.UserId == command.UserId &&
+                    l.SeasonYear == command.SeasonYear &&
+                    l.SeasonWeek == command.SeasonWeek,
+                cancellationToken);
+
+        // ── Duplicate athlete across slots ────────────────────────────────
+        if (lineup is not null && lineup.Slots.Any(s =>
+                s.SlotId != command.SlotId && s.AthleteId == command.AthleteId))
+        {
+            return Fail(ResultStatus.Validation, nameof(command.AthleteId),
+                "That athlete is already rostered in another slot.");
+        }
+
+        // ── Target slot lock (both the stored anchor AND the current
+        //    resolution of the OCCUPANT's team — a cloned slot can carry a
+        //    null anchor, and null must never mean unlocked-forever) ───────
+        var existing = lineup?.Slots.FirstOrDefault(s => s.SlotId == command.SlotId);
+        if (existing is not null && IsSlotLocked(existing, weekMap, now))
+        {
+            return Fail(ResultStatus.Validation, nameof(command.SlotId),
+                $"Slot '{command.SlotId}' is locked — {existing.LastName}'s game has started or starts within 5 minutes.");
+        }
+
+        // ── Incoming athlete's game lock ──────────────────────────────────
+        var incoming = weekMap.Resolve(command.TeamSlug);
+        if (incoming is not null &&
+            PickemGroupMatchupExtensions.IsStartLocked(incoming.Value.StartUtc, now))
+        {
+            return Fail(ResultStatus.Validation, nameof(command.AthleteId),
+                "That athlete's game has started or starts within 5 minutes.");
+        }
+
+        // ── Upsert ────────────────────────────────────────────────────────
+        if (lineup is null)
+        {
+            lineup = new PlayerLineup
+            {
+                Id = Guid.NewGuid(),
+                PickemGroupId = command.LeagueId,
+                UserId = command.UserId,
+                SeasonYear = command.SeasonYear,
+                SeasonWeek = command.SeasonWeek,
+                CreatedUtc = now,
+                CreatedBy = command.UserId,
+            };
+            await _dataContext.PlayerLineups.AddAsync(lineup, cancellationToken);
+        }
+
+        if (existing is null)
+        {
+            existing = new PlayerLineupSlot
+            {
+                Id = Guid.NewGuid(),
+                PlayerLineupId = lineup.Id,
+                SlotId = command.SlotId,
+                CreatedUtc = now,
+                CreatedBy = command.UserId,
+            };
+            // Explicit DbSet.Add, NOT just lineup.Slots.Add: when the
+            // lineup is ALREADY TRACKED, an entity discovered through
+            // navigation fixup with a client-set Guid key is marked
+            // Modified (EF can't tell new from pre-existing), producing
+            // UPDATE ... WHERE Id = <fresh guid> → 0 rows →
+            // DbUpdateConcurrencyException. DbSet.Add pins Added. (The
+            // new-lineup path never hit this — everything reachable from
+            // an explicitly Add()ed root is Added.)
+            _dataContext.PlayerLineupSlots.Add(existing);
+            lineup.Slots.Add(existing);
+        }
+
+        existing.AthleteId = command.AthleteId;
+        existing.AthleteSeasonId = command.AthleteSeasonId;
+        existing.Position = command.Position;
+        existing.FirstName = command.FirstName;
+        existing.LastName = command.LastName;
+        existing.TeamName = command.TeamName;
+        existing.TeamSlug = command.TeamSlug;
+        existing.ContestId = incoming?.ContestId;         // server-resolved
+        existing.ContestStartUtc = incoming?.StartUtc;    // server-resolved
+        existing.OpponentName = command.OpponentName;     // display-only
+        existing.ModifiedUtc = now;
+        existing.ModifiedBy = command.UserId;
+        lineup.ModifiedUtc = now;
+        lineup.ModifiedBy = command.UserId;
+
+        await _dataContext.SaveChangesAsync(cancellationToken);
+
+        return new Success<PlayerLineupSlotDto>(existing.ToDto(now));
+    }
+
+    /// <summary>
+    /// A slot is locked when EITHER its stored anchor says so or the
+    /// occupant's team resolves to a locked game this week. The second
+    /// check closes the carry-over hole: cloned slots can hold a null
+    /// anchor, and without it a user could swap out a player mid-game.
+    /// </summary>
+    internal static bool IsSlotLocked(PlayerLineupSlot slot, WeekMatchupMap weekMap, DateTime nowUtc)
+    {
+        if (slot.ContestStartUtc.HasValue &&
+            PickemGroupMatchupExtensions.IsStartLocked(slot.ContestStartUtc.Value, nowUtc))
+        {
+            return true;
+        }
+
+        var current = weekMap.Resolve(slot.TeamSlug);
+        return current is not null &&
+               PickemGroupMatchupExtensions.IsStartLocked(current.Value.StartUtc, nowUtc);
+    }
+
+    private static Failure<PlayerLineupSlotDto> Fail(ResultStatus status, string property, string message) =>
+        new(default!, status, [new ValidationFailure(property, message)]);
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
@@ -3,6 +3,8 @@ using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
 
+using Npgsql;
+
 using SportsData.Api.Application.UI.Leagues.Authorization;
 using SportsData.Api.Application.UI.PlayerLineups.Dtos;
 using SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
@@ -213,7 +215,19 @@ public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
         lineup.ModifiedUtc = now;
         lineup.ModifiedBy = command.UserId;
 
-        await _dataContext.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _dataContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+        {
+            // The duplicate-athlete pre-check above raced a concurrent save
+            // into another slot; the unique (PlayerLineupId, AthleteId)
+            // index is the authority. Same user, same intent — reject like
+            // the pre-check would have.
+            return Fail(ResultStatus.Validation, nameof(command.AthleteId),
+                "That athlete is already in your lineup.");
+        }
 
         return new Success<PlayerLineupSlotDto>(existing.ToDto(now));
     }

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+
+namespace SportsData.Api.Application.UI.PlayerLineups.Commands.UpsertLineupSlot;
+
+/// <summary>
+/// Bounds + length gate in front of the upsert. Max lengths mirror the
+/// PlayerLineupSlot column configuration — without them an oversized
+/// client value reaches SaveChanges and surfaces as a persistence error
+/// instead of a 400. Slot membership and position eligibility stay in
+/// the handler beside the LineupSlots authority.
+/// </summary>
+public class UpsertLineupSlotCommandValidator : AbstractValidator<UpsertLineupSlotCommand>
+{
+    public UpsertLineupSlotCommandValidator()
+    {
+        RuleFor(x => x.SeasonYear).InclusiveBetween(2000, 2100);
+        RuleFor(x => x.SeasonWeek).InclusiveBetween(1, 30);
+        RuleFor(x => x.SlotId).NotEmpty().MaximumLength(8);
+        RuleFor(x => x.AthleteId).NotEmpty();
+        RuleFor(x => x.AthleteSeasonId).NotEmpty();
+        RuleFor(x => x.Position).NotEmpty().MaximumLength(4);
+        RuleFor(x => x.FirstName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.LastName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.TeamName).NotEmpty().MaximumLength(150);
+        RuleFor(x => x.TeamSlug).NotEmpty().MaximumLength(150);
+        RuleFor(x => x.OpponentName).MaximumLength(150);
+    }
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Dtos/PlayerLineupDto.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Dtos/PlayerLineupDto.cs
@@ -1,0 +1,28 @@
+namespace SportsData.Api.Application.UI.PlayerLineups.Dtos;
+
+public class PlayerLineupDto
+{
+    public Guid LeagueId { get; set; }
+    public int SeasonYear { get; set; }
+    public int SeasonWeek { get; set; }
+    /// <summary>Filled slots only — the client knows the fixed shape.</summary>
+    public List<PlayerLineupSlotDto> Slots { get; set; } = [];
+}
+
+public class PlayerLineupSlotDto
+{
+    public required string SlotId { get; set; }
+    public Guid AthleteId { get; set; }
+    public Guid AthleteSeasonId { get; set; }
+    public required string Position { get; set; }
+    public required string FirstName { get; set; }
+    public required string LastName { get; set; }
+    public required string TeamName { get; set; }
+    public required string TeamSlug { get; set; }
+    /// <summary>Null = bye week (never locks, never scores, badge it).</summary>
+    public Guid? ContestId { get; set; }
+    public DateTime? ContestStartUtc { get; set; }
+    public string? OpponentName { get; set; }
+    /// <summary>Derived server-side at read time via the product-wide kickoff−5 rule.</summary>
+    public bool IsLocked { get; set; }
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/LineupSlots.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/LineupSlots.cs
@@ -28,4 +28,14 @@ public static class LineupSlots
     public static bool IsEligible(string slotId, string position) =>
         Eligibility.TryGetValue(slotId, out var positions) &&
         positions.Contains(position, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The CANONICAL slot id (fixed casing) for any accepted spelling, or
+    /// null. Persisting the caller's casing would let "qb" and "QB" slip
+    /// past the case-sensitive unique (PlayerLineupId, SlotId) index as
+    /// two distinct QB slots — always store what this returns.
+    /// </summary>
+    public static string? Normalize(string slotId) =>
+        Eligibility.Keys.FirstOrDefault(
+            k => string.Equals(k, slotId, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/SportsData.Api/Application/UI/PlayerLineups/LineupSlots.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/LineupSlots.cs
@@ -1,0 +1,31 @@
+namespace SportsData.Api.Application.UI.PlayerLineups;
+
+/// <summary>
+/// The fixed v1 Player Pick'em lineup shape and its eligibility rules —
+/// the server-side authority the UI's rosterLogic modules mirror.
+/// 'DEF' is reserved until the team-defense picker exists; a
+/// commissioner-configurable shape is a future option that lives beside
+/// PickemGroup.GroupType (one game per league).
+/// See docs/features/player-pickem/roster-persistence.md.
+/// </summary>
+public static class LineupSlots
+{
+    public static readonly IReadOnlyDictionary<string, string[]> Eligibility =
+        new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["QB"] = ["QB"],
+            ["RB1"] = ["RB"],
+            ["RB2"] = ["RB"],
+            ["WR1"] = ["WR"],
+            ["WR2"] = ["WR"],
+            ["TE"] = ["TE"],
+            ["FLEX"] = ["RB", "WR", "TE"],
+            ["K"] = ["K"],
+        };
+
+    public static bool IsValidSlot(string slotId) => Eligibility.ContainsKey(slotId);
+
+    public static bool IsEligible(string slotId, string position) =>
+        Eligibility.TryGetValue(slotId, out var positions) &&
+        positions.Contains(position, StringComparer.OrdinalIgnoreCase);
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/PlayerLineupsController.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/PlayerLineupsController.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Api.Application.UI.PlayerLineups.Commands.ClearLineupSlot;
+using SportsData.Api.Application.UI.PlayerLineups.Commands.UpsertLineupSlot;
+using SportsData.Api.Application.UI.PlayerLineups.Dtos;
+using SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
+using SportsData.Api.Extensions;
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+
+namespace SportsData.Api.Application.UI.PlayerLineups;
+
+/// <summary>
+/// Player Pick'em roster persistence — one lineup per user per
+/// league-week, per-player derived locking (kickoff−5, the product-wide
+/// rule). All routes gate on GroupType == PlayerPickem + league
+/// membership inside the handlers.
+/// See docs/features/player-pickem/roster-persistence.md.
+/// </summary>
+[ApiController]
+[Route("ui/leagues/{leagueId:guid}/player-lineups")]
+public class PlayerLineupsController : ApiControllerBase
+{
+    /// <summary>
+    /// The caller's lineup for the week, slots carrying derived isLocked.
+    /// First read of a new week performs the lazy carry-over clone from
+    /// the most recent populated week.
+    /// </summary>
+    [Authorize]
+    [HttpGet("{seasonYear:int}/{seasonWeek:int}/mine")]
+    public async Task<ActionResult<PlayerLineupDto>> GetMine(
+        [FromRoute] Guid leagueId,
+        [FromRoute] int seasonYear,
+        [FromRoute] int seasonWeek,
+        [FromServices] IGetMyPlayerLineupQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await handler.ExecuteAsync(
+            new GetMyPlayerLineupQuery(leagueId, userId, seasonYear, seasonWeek),
+            cancellationToken);
+        return result.ToActionResult();
+    }
+
+    public class UpsertSlotRequest
+    {
+        public Guid AthleteId { get; set; }
+        public Guid AthleteSeasonId { get; set; }
+        public string Position { get; set; } = null!;
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public string TeamName { get; set; } = null!;
+        public string TeamSlug { get; set; } = null!;
+        public string? OpponentName { get; set; }
+    }
+
+    [Authorize]
+    [HttpPut("{seasonYear:int}/{seasonWeek:int}/mine/slots/{slotId}")]
+    public async Task<ActionResult<PlayerLineupSlotDto>> UpsertSlot(
+        [FromRoute] Guid leagueId,
+        [FromRoute] int seasonYear,
+        [FromRoute] int seasonWeek,
+        [FromRoute] string slotId,
+        [FromBody] UpsertSlotRequest request,
+        [FromServices] IUpsertLineupSlotCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new UpsertLineupSlotCommand
+        {
+            LeagueId = leagueId,
+            UserId = HttpContext.GetCurrentUserId(),
+            SeasonYear = seasonYear,
+            SeasonWeek = seasonWeek,
+            SlotId = slotId,
+            AthleteId = request.AthleteId,
+            AthleteSeasonId = request.AthleteSeasonId,
+            Position = request.Position,
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            TeamName = request.TeamName,
+            TeamSlug = request.TeamSlug,
+            OpponentName = request.OpponentName,
+        };
+
+        var result = await handler.ExecuteAsync(command, cancellationToken);
+        return result.ToActionResult();
+    }
+
+    [Authorize]
+    [HttpDelete("{seasonYear:int}/{seasonWeek:int}/mine/slots/{slotId}")]
+    public async Task<ActionResult<bool>> ClearSlot(
+        [FromRoute] Guid leagueId,
+        [FromRoute] int seasonYear,
+        [FromRoute] int seasonWeek,
+        [FromRoute] string slotId,
+        [FromServices] IClearLineupSlotCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(
+            new ClearLineupSlotCommand(leagueId, HttpContext.GetCurrentUserId(), seasonYear, seasonWeek, slotId),
+            cancellationToken);
+        return result.ToActionResult();
+    }
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQuery.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQuery.cs
@@ -1,0 +1,7 @@
+namespace SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
+
+public record GetMyPlayerLineupQuery(
+    Guid LeagueId,
+    Guid UserId,
+    int SeasonYear,
+    int SeasonWeek);

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
@@ -62,7 +62,11 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
             return new Failure<PlayerLineupDto>(default!, gate.Failure.Value.Status, gate.Failure.Value.Errors);
         }
 
+        // Pure read — the result is only projected to the DTO (the clone
+        // path constructs and Adds fresh entities), so nothing needs
+        // tracking.
         var lineup = await _dataContext.PlayerLineups
+            .AsNoTracking()
             .Include(l => l.Slots)
             .FirstOrDefaultAsync(l =>
                     l.PickemGroupId == query.LeagueId &&
@@ -135,6 +139,12 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
 
             weekMap = new WeekMatchupMap(matchups.Value);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller went away — surface the cancellation instead of
+            // serving a fabricated empty week.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(
@@ -200,6 +210,7 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
             }
 
             lineup = await _dataContext.PlayerLineups
+                .AsNoTracking()
                 .Include(l => l.Slots)
                 .FirstOrDefaultAsync(l =>
                         l.PickemGroupId == query.LeagueId &&

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
@@ -1,0 +1,281 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.UI.Leagues.Authorization;
+using SportsData.Api.Application.UI.PlayerLineups.Dtos;
+using SportsData.Api.Extensions;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
+
+public interface IGetMyPlayerLineupQueryHandler
+{
+    Task<Result<PlayerLineupDto>> ExecuteAsync(
+        GetMyPlayerLineupQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// The user's roster for a league-week, with per-slot locking DERIVED via
+/// the product-wide kickoff−5 rule. This read is also where the LAZY
+/// CARRY-OVER happens: no lineup for the requested week + a populated
+/// earlier week exists → clone the most recent one, re-resolving every
+/// athlete's contest for the NEW week (bye → null, badged). Lazy beats a
+/// fleet-wide rollover job: clones only for users who show up, no Sunday
+/// thundering herd, same experience.
+/// See docs/features/player-pickem/roster-persistence.md.
+/// </summary>
+public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
+{
+    private readonly ILogger<GetMyPlayerLineupQueryHandler> _logger;
+    private readonly AppDataContext _dataContext;
+    private readonly ILeagueMembershipGuard _membershipGuard;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public GetMyPlayerLineupQueryHandler(
+        ILogger<GetMyPlayerLineupQueryHandler> logger,
+        AppDataContext dataContext,
+        ILeagueMembershipGuard membershipGuard,
+        IContestClientFactory contestClientFactory,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _dataContext = dataContext;
+        _membershipGuard = membershipGuard;
+        _contestClientFactory = contestClientFactory;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<PlayerLineupDto>> ExecuteAsync(
+        GetMyPlayerLineupQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var gate = await PlayerLineupGate.CheckAsync(
+            _dataContext, _membershipGuard, query.LeagueId, query.UserId, cancellationToken);
+        if (gate.Failure is not null)
+        {
+            return new Failure<PlayerLineupDto>(default!, gate.Failure.Value.Status, gate.Failure.Value.Errors);
+        }
+
+        var lineup = await _dataContext.PlayerLineups
+            .Include(l => l.Slots)
+            .FirstOrDefaultAsync(l =>
+                    l.PickemGroupId == query.LeagueId &&
+                    l.UserId == query.UserId &&
+                    l.SeasonYear == query.SeasonYear &&
+                    l.SeasonWeek == query.SeasonWeek,
+                cancellationToken);
+
+        if (lineup is null)
+        {
+            lineup = await TryCloneFromPriorWeekAsync(query, gate.Group!, cancellationToken);
+        }
+
+        var now = _dateTimeProvider.UtcNow();
+        var dto = new PlayerLineupDto
+        {
+            LeagueId = query.LeagueId,
+            SeasonYear = query.SeasonYear,
+            SeasonWeek = query.SeasonWeek,
+            Slots = lineup?.Slots
+                .OrderBy(s => s.SlotId)
+                .Select(s => s.ToDto(now))
+                .ToList() ?? [],
+        };
+
+        return new Success<PlayerLineupDto>(dto);
+    }
+
+    private async Task<PlayerLineup?> TryCloneFromPriorWeekAsync(
+        GetMyPlayerLineupQuery query,
+        PickemGroup group,
+        CancellationToken cancellationToken)
+    {
+        var prior = await _dataContext.PlayerLineups
+            .AsNoTracking()
+            .Include(l => l.Slots)
+            .Where(l =>
+                l.PickemGroupId == query.LeagueId &&
+                l.UserId == query.UserId &&
+                l.SeasonYear == query.SeasonYear &&
+                l.SeasonWeek < query.SeasonWeek)
+            .OrderByDescending(l => l.SeasonWeek)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (prior is null || prior.Slots.Count == 0)
+        {
+            return null;
+        }
+
+        // Contest anchors are re-resolved for the NEW week from the server's
+        // own matchup data — never carried from the prior week (a stale
+        // anchor would lock the slot to last week's kickoff).
+        WeekMatchupMap weekMap;
+        try
+        {
+            var matchups = await _contestClientFactory
+                .Resolve(group.Sport)
+                .GetMatchupsForSeasonWeek(query.SeasonYear, query.SeasonWeek, cancellationToken);
+
+            if (!matchups.IsSuccess)
+            {
+                // Fail open on the CLONE only: serve the empty week now and
+                // let the next read retry — cloning is a convenience, not
+                // correctness. (Writes fail closed; see the upsert handler.)
+                _logger.LogWarning(
+                    "Carry-over clone skipped: matchup resolution failed. LeagueId={LeagueId} Week={Week} Status={Status}",
+                    query.LeagueId, query.SeasonWeek, matchups.Status);
+                return null;
+            }
+
+            weekMap = new WeekMatchupMap(matchups.Value);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Carry-over clone skipped: matchup resolution threw. LeagueId={LeagueId} Week={Week}",
+                query.LeagueId, query.SeasonWeek);
+            return null;
+        }
+
+        var now = _dateTimeProvider.UtcNow();
+        var lineup = new PlayerLineup
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = query.LeagueId,
+            UserId = query.UserId,
+            SeasonYear = query.SeasonYear,
+            SeasonWeek = query.SeasonWeek,
+            CreatedUtc = now,
+            CreatedBy = query.UserId,
+        };
+
+        foreach (var s in prior.Slots)
+        {
+            var matchup = weekMap.Resolve(s.TeamSlug);
+            lineup.Slots.Add(new PlayerLineupSlot
+            {
+                Id = Guid.NewGuid(),
+                PlayerLineupId = lineup.Id,
+                SlotId = s.SlotId,
+                AthleteId = s.AthleteId,
+                AthleteSeasonId = s.AthleteSeasonId,
+                Position = s.Position,
+                FirstName = s.FirstName,
+                LastName = s.LastName,
+                TeamName = s.TeamName,
+                TeamSlug = s.TeamSlug,
+                ContestId = matchup?.ContestId,
+                ContestStartUtc = matchup?.StartUtc,
+                // Opponent display is unknown until the UI enriches or the
+                // user re-saves; the anchor fields above are what matter.
+                OpponentName = null,
+                CreatedUtc = now,
+                CreatedBy = query.UserId,
+            });
+        }
+
+        await _dataContext.PlayerLineups.AddAsync(lineup, cancellationToken);
+        try
+        {
+            await _dataContext.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation(
+                "Carried lineup over. LeagueId={LeagueId} UserId={UserId} FromWeek={FromWeek} ToWeek={ToWeek} Slots={Slots}",
+                query.LeagueId, query.UserId, prior.SeasonWeek, query.SeasonWeek, lineup.Slots.Count);
+        }
+        catch (DbUpdateException)
+        {
+            // Two concurrent first-reads raced the unique index; the winner's
+            // clone is canonical. Detach ours and reload.
+            _dataContext.Entry(lineup).State = EntityState.Detached;
+            foreach (var slot in lineup.Slots)
+            {
+                _dataContext.Entry(slot).State = EntityState.Detached;
+            }
+
+            lineup = await _dataContext.PlayerLineups
+                .Include(l => l.Slots)
+                .FirstOrDefaultAsync(l =>
+                        l.PickemGroupId == query.LeagueId &&
+                        l.UserId == query.UserId &&
+                        l.SeasonYear == query.SeasonYear &&
+                        l.SeasonWeek == query.SeasonWeek,
+                    cancellationToken);
+        }
+
+        return lineup;
+    }
+}
+
+/// <summary>
+/// Shared gate for every player-lineup operation: the league exists, IS a
+/// PlayerPickem group (one game per league — see GroupType), and the
+/// caller is a member. A TeamPickem league is Forbid, not NotFound, so
+/// the client can distinguish "no such league" from "this league plays a
+/// different game".
+/// </summary>
+internal static class PlayerLineupGate
+{
+    internal readonly record struct GateResult(
+        PickemGroup? Group,
+        (ResultStatus Status, List<ValidationFailure> Errors)? Failure);
+
+    internal static async Task<GateResult> CheckAsync(
+        AppDataContext dataContext,
+        ILeagueMembershipGuard membershipGuard,
+        Guid leagueId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var group = await dataContext.PickemGroups
+            .AsNoTracking()
+            .FirstOrDefaultAsync(g => g.Id == leagueId, cancellationToken);
+
+        if (group is null)
+        {
+            return new GateResult(null, (ResultStatus.NotFound,
+                [new ValidationFailure(nameof(leagueId), "League not found.")]));
+        }
+
+        if (group.GroupType != Application.Common.Enums.GroupType.PlayerPickem)
+        {
+            return new GateResult(null, (ResultStatus.Forbid,
+                [new ValidationFailure(nameof(leagueId), "This league does not play Player Pick'em.")]));
+        }
+
+        if (!await membershipGuard.IsMemberAsync(leagueId, userId, cancellationToken))
+        {
+            return new GateResult(null, (ResultStatus.Forbid,
+                [new ValidationFailure(nameof(userId), "You are not a member of this league.")]));
+        }
+
+        return new GateResult(group, null);
+    }
+}
+
+internal static class PlayerLineupSlotExtensions
+{
+    /// <summary>Locking derives from the same kickoff−5 rule team picks use.</summary>
+    internal static PlayerLineupSlotDto ToDto(this PlayerLineupSlot s, DateTime nowUtc) => new()
+    {
+        SlotId = s.SlotId,
+        AthleteId = s.AthleteId,
+        AthleteSeasonId = s.AthleteSeasonId,
+        Position = s.Position,
+        FirstName = s.FirstName,
+        LastName = s.LastName,
+        TeamName = s.TeamName,
+        TeamSlug = s.TeamSlug,
+        ContestId = s.ContestId,
+        ContestStartUtc = s.ContestStartUtc,
+        OpponentName = s.OpponentName,
+        IsLocked = s.ContestStartUtc.HasValue &&
+                   PickemGroupMatchupExtensions.IsStartLocked(s.ContestStartUtc.Value, nowUtc),
+    };
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/WeekMatchups.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/WeekMatchups.cs
@@ -1,0 +1,35 @@
+using SportsData.Core.Dtos.Canonical;
+
+namespace SportsData.Api.Application.UI.PlayerLineups;
+
+/// <summary>
+/// Team-slug → (ContestId, StartUtc) lookup for one season-week, built
+/// from ONE ContestClient.GetMatchupsForSeasonWeek call. This is the
+/// server-side authority for slot locking and contest anchoring — client
+/// -provided contest fields are never trusted. A team absent from the map
+/// is on a bye.
+/// </summary>
+public sealed class WeekMatchupMap
+{
+    private readonly Dictionary<string, (Guid ContestId, DateTime StartUtc)> _bySlug;
+
+    public WeekMatchupMap(IEnumerable<Matchup> matchups)
+    {
+        _bySlug = new Dictionary<string, (Guid, DateTime)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var m in matchups)
+        {
+            // StartDateUtc arrives over the wire with DateTimeKind.Unspecified
+            // (JSON round-trip strips the kind), and Npgsql refuses to write
+            // an Unspecified DateTime to a timestamptz column — the write
+            // path stores this value on PlayerLineupSlot.ContestStartUtc.
+            // The value is semantically UTC; stamp it so every consumer
+            // (persist + IsStartLocked comparisons) agrees.
+            var startUtc = DateTime.SpecifyKind(m.StartDateUtc, DateTimeKind.Utc);
+            _bySlug[m.HomeSlug] = (m.ContestId, startUtc);
+            _bySlug[m.AwaySlug] = (m.ContestId, startUtc);
+        }
+    }
+
+    public (Guid ContestId, DateTime StartUtc)? Resolve(string teamSlug) =>
+        _bySlug.TryGetValue(teamSlug, out var hit) ? hit : null;
+}

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -49,6 +49,14 @@ public class UserDto
         public Sport Sport { get; set; }
 
         /// <summary>
+        /// Which game this league plays ("TeamPickem" / "PlayerPickem") —
+        /// one game per league. Routes the home-page league card: team
+        /// leagues open the picks page, player leagues open the roster
+        /// builder.
+        /// </summary>
+        public string GroupType { get; set; } = null!;
+
+        /// <summary>
         /// Week numbers that exist for this league, ascending with duplicates removed.
         /// </summary>
         /// <remarks>

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -82,6 +82,7 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                         Name = m.Group.Name,
                         Description = m.Group.Description,
                         Sport = m.Group.Sport,
+                        GroupType = m.Group.GroupType.ToString(),
                         // Dedupe: some leagues have multiple PickemGroupWeek rows with
                         // the same SeasonWeek number (e.g. a preseason Week 1 alongside a
                         // regular-season Week 1, or rows carried over across SeasonYears).

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -331,6 +331,8 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetMyPlayerLineupQueryHandler, GetMyPlayerLineupQueryHandler>();
             services.AddScoped<IUpsertLineupSlotCommandHandler, UpsertLineupSlotCommandHandler>();
             services.AddScoped<IClearLineupSlotCommandHandler, ClearLineupSlotCommandHandler>();
+            services.AddScoped<FluentValidation.IValidator<UpsertLineupSlotCommand>, UpsertLineupSlotCommandValidator>();
+            services.AddScoped<FluentValidation.IValidator<ClearLineupSlotCommand>, ClearLineupSlotCommandValidator>();
 
             // TeamCard Queries
             services.AddScoped<IGetTeamCardQueryHandler, GetTeamCardQueryHandler>();

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -5,6 +5,9 @@ using FluentValidation;
 using SportsData.Api.Application.Admin.Commands.BackfillLeagueScores;
 using SportsData.Api.Application.Athletes.Queries.GetAthleteDetails;
 using SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
+using SportsData.Api.Application.UI.PlayerLineups.Commands.ClearLineupSlot;
+using SportsData.Api.Application.UI.PlayerLineups.Commands.UpsertLineupSlot;
+using SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
 using SportsData.Api.Application.Admin.Commands.GenerateLoadTest;
 using SportsData.Api.Application.Admin.Commands.RefreshAiExistence;
 using SportsData.Api.Application.Admin.Commands.SendTestPushNotification;
@@ -323,6 +326,11 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetAthleteDetailsQueryHandler, GetAthleteDetailsQueryHandler>();
             services.AddScoped<IGetPickemAthletesQueryHandler, GetPickemAthletesQueryHandler>();
             services.AddScoped<FluentValidation.IValidator<GetPickemAthletesQuery>, GetPickemAthletesQueryValidator>();
+
+            // Player Lineups (Player Pick'em roster persistence)
+            services.AddScoped<IGetMyPlayerLineupQueryHandler, GetMyPlayerLineupQueryHandler>();
+            services.AddScoped<IUpsertLineupSlotCommandHandler, UpsertLineupSlotCommandHandler>();
+            services.AddScoped<IClearLineupSlotCommandHandler, ClearLineupSlotCommandHandler>();
 
             // TeamCard Queries
             services.AddScoped<IGetTeamCardQueryHandler, GetTeamCardQueryHandler>();

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -26,6 +26,10 @@ public class AppDataContext : DbContext
 
     public DbSet<PickemGroupMatchup> PickemGroupMatchups { get; set; }
 
+    public DbSet<PlayerLineup> PlayerLineups { get; set; }
+
+    public DbSet<PlayerLineupSlot> PlayerLineupSlots { get; set; }
+
     public DbSet<PickemGroupMember> PickemGroupMembers { get; set; }
 
     public DbSet<PickemGroupInvitation> PickemGroupInvitations { get; set; }

--- a/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupsForSeasonWeek.sql
+++ b/src/SportsData.Api/Infrastructure/Data/Canonical/Sql/GetMatchupsForSeasonWeek.sql
@@ -41,6 +41,10 @@ SELECT
   co."OverOdds"       as "OverOdds",
   co."UnderOdds"      as "UnderOdds"
 FROM public."SeasonWeek" sw
+-- Week numbers repeat across phases within one season year (NFL:
+-- preseason/regular/postseason each count from 1). Scope to the regular
+-- season so a bare number is unambiguous.
+INNER JOIN public."SeasonPhase" sp on sp."Id" = sw."SeasonPhaseId" and sp."TypeCode" = 2
 INNER JOIN public."Season" s on s."Id" = sw."SeasonId"
 inner join public."Contest" c ON c."SeasonWeekId" = sw."Id"
 inner join public."Competition" comp on comp."ContestId" = c."Id"

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroup.cs
@@ -32,6 +32,16 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public bool UseConfidencePoints { get; set; }
 
+        /// <summary>
+        /// Which game this league plays — see <see cref="Enums.GroupType"/>
+        /// for the one-game-per-league product rule and why this is an
+        /// enum, not capability flags. PickType below remains meaningful
+        /// only for TeamPickem groups. Creation-flow support for
+        /// PlayerPickem groups ships with the standalone-league vertical.
+        /// See docs/features/player-pickem/roster-persistence.md.
+        /// </summary>
+        public GroupType GroupType { get; set; } = GroupType.TeamPickem;
+
         public bool IsPublic { get; set; }
 
         /// <summary>

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PlayerLineup.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PlayerLineup.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// One user's Player Pick'em roster for one league-week. Slots carry
+    /// the athletes; locking is DERIVED per slot from the athlete's game
+    /// start (see PlayerLineupSlot) — a lineup itself never locks. Created
+    /// either by the first slot write of the week or by the lazy carry-over
+    /// clone when the user first reads a week that follows a populated one.
+    /// See docs/features/player-pickem/roster-persistence.md.
+    /// </summary>
+    public class PlayerLineup : CanonicalEntityBase<Guid>
+    {
+        public Guid PickemGroupId { get; set; }
+
+        public PickemGroup Group { get; set; } = null!;
+
+        public Guid UserId { get; set; }
+
+        public int SeasonYear { get; set; }
+
+        public int SeasonWeek { get; set; }
+
+        public ICollection<PlayerLineupSlot> Slots { get; set; } = [];
+
+        public class EntityConfiguration : IEntityTypeConfiguration<PlayerLineup>
+        {
+            public void Configure(EntityTypeBuilder<PlayerLineup> builder)
+            {
+                builder.ToTable(nameof(PlayerLineup));
+                builder.HasKey(x => x.Id);
+
+                // One lineup per user per league-week.
+                builder.HasIndex(x => new { x.PickemGroupId, x.UserId, x.SeasonYear, x.SeasonWeek })
+                    .IsUnique();
+
+                builder.HasOne(x => x.Group)
+                    .WithMany()
+                    .HasForeignKey(x => x.PickemGroupId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                builder.HasMany(x => x.Slots)
+                    .WithOne(x => x.Lineup)
+                    .HasForeignKey(x => x.PlayerLineupId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PlayerLineupSlot.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PlayerLineupSlot.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// One filled slot in a Player Pick'em lineup. Carries soft canonical
+    /// refs plus a render snapshot (the pick-table pattern: the API never
+    /// joins Producer's database to draw a lineup).
+    ///
+    /// LOCKING IS DERIVED, NEVER STORED: a slot is locked iff
+    /// IsStartLocked(ContestStartUtc) — the same kickoff-minus-5-minutes
+    /// rule team picks use. Derived locking self-heals schedule moves and
+    /// keeps the future commissioner weekly-lock option a pure read-side
+    /// change. Because locked slots reject writes, the persisted state IS
+    /// the locked state — scoring reads this table as-is.
+    /// </summary>
+    public class PlayerLineupSlot : CanonicalEntityBase<Guid>
+    {
+        public Guid PlayerLineupId { get; set; }
+
+        public PlayerLineup Lineup { get; set; } = null!;
+
+        /// <summary>'QB','RB1','RB2','WR1','WR2','TE','FLEX','K' — the fixed v1 shape ('DEF' reserved).</summary>
+        public string SlotId { get; set; } = null!;
+
+        /// <summary>Canonical Athlete id — stable across seasons (the stats-audit lesson: never trust a roster-row's year).</summary>
+        public Guid AthleteId { get; set; }
+
+        /// <summary>The AthleteSeason used at save time; the scoring join to AthleteCompetitionStatistic.</summary>
+        public Guid AthleteSeasonId { get; set; }
+
+        /// <summary>'QB'/'RB'/'WR'/'TE'/'K' — FLEX-eligibility validation and the position badge.</summary>
+        public string Position { get; set; } = null!;
+
+        public string FirstName { get; set; } = null!;
+
+        public string LastName { get; set; } = null!;
+
+        public string TeamName { get; set; } = null!;
+
+        public string TeamSlug { get; set; } = null!;
+
+        /// <summary>The athlete's contest for this lineup's week. Null = bye at save time (never locks, never scores, badged in the UI).</summary>
+        public Guid? ContestId { get; set; }
+
+        /// <summary>
+        /// Denormalized kickoff; the lock derives from it. Same staleness
+        /// contract as PickemGroupMatchup.StartDateUtc — the
+        /// ContestStartTimeUpdated consumer family is the eventual updater.
+        /// </summary>
+        public DateTime? ContestStartUtc { get; set; }
+
+        public string? OpponentName { get; set; }
+
+        public class EntityConfiguration : IEntityTypeConfiguration<PlayerLineupSlot>
+        {
+            public void Configure(EntityTypeBuilder<PlayerLineupSlot> builder)
+            {
+                builder.ToTable(nameof(PlayerLineupSlot));
+                builder.HasKey(x => x.Id);
+
+                builder.HasIndex(x => new { x.PlayerLineupId, x.SlotId })
+                    .IsUnique();
+
+                builder.Property(x => x.SlotId).HasMaxLength(8);
+                builder.Property(x => x.Position).HasMaxLength(4);
+                builder.Property(x => x.FirstName).HasMaxLength(100);
+                builder.Property(x => x.LastName).HasMaxLength(100);
+                builder.Property(x => x.TeamName).HasMaxLength(150);
+                builder.Property(x => x.TeamSlug).HasMaxLength(150);
+                builder.Property(x => x.OpponentName).HasMaxLength(150);
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PlayerLineupSlot.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PlayerLineupSlot.cs
@@ -65,6 +65,12 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.HasIndex(x => new { x.PlayerLineupId, x.SlotId })
                     .IsUnique();
 
+                // The no-duplicate-athlete rule the handler pre-checks,
+                // enforced at the database so concurrent saves into
+                // different slots cannot slip the same athlete in twice.
+                builder.HasIndex(x => new { x.PlayerLineupId, x.AthleteId })
+                    .IsUnique();
+
                 builder.Property(x => x.SlotId).HasMaxLength(8);
                 builder.Property(x => x.Position).HasMaxLength(4);
                 builder.Property(x => x.FirstName).HasMaxLength(100);

--- a/src/SportsData.Api/Migrations/20260826123121_PlayerLineupPersistence.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260826123121_PlayerLineupPersistence.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260826123121_PlayerLineupPersistence")]
+    partial class PlayerLineupPersistence
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260826123121_PlayerLineupPersistence.cs
+++ b/src/SportsData.Api/Migrations/20260826123121_PlayerLineupPersistence.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerLineupPersistence : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GroupType",
+                table: "PickemGroup",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "PlayerLineup",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PickemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SeasonYear = table.Column<int>(type: "integer", nullable: false),
+                    SeasonWeek = table.Column<int>(type: "integer", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerLineup", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PlayerLineup_PickemGroup_PickemGroupId",
+                        column: x => x.PickemGroupId,
+                        principalTable: "PickemGroup",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PlayerLineupSlot",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlayerLineupId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SlotId = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    AthleteId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AthleteSeasonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Position = table.Column<string>(type: "character varying(4)", maxLength: 4, nullable: false),
+                    FirstName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    LastName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    TeamName = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
+                    TeamSlug = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
+                    ContestId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ContestStartUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    OpponentName = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerLineupSlot", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PlayerLineupSlot_PlayerLineup_PlayerLineupId",
+                        column: x => x.PlayerLineupId,
+                        principalTable: "PlayerLineup",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerLineup_PickemGroupId_UserId_SeasonYear_SeasonWeek",
+                table: "PlayerLineup",
+                columns: new[] { "PickemGroupId", "UserId", "SeasonYear", "SeasonWeek" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerLineupSlot_PlayerLineupId_SlotId",
+                table: "PlayerLineupSlot",
+                columns: new[] { "PlayerLineupId", "SlotId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerLineupSlot");
+
+            migrationBuilder.DropTable(
+                name: "PlayerLineup");
+
+            migrationBuilder.DropColumn(
+                name: "GroupType",
+                table: "PickemGroup");
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260826182034_PlayerLineupSlotAthleteUnique.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260826182034_PlayerLineupSlotAthleteUnique.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260826182034_PlayerLineupSlotAthleteUnique")]
+    partial class PlayerLineupSlotAthleteUnique
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260826182034_PlayerLineupSlotAthleteUnique.cs
+++ b/src/SportsData.Api/Migrations/20260826182034_PlayerLineupSlotAthleteUnique.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerLineupSlotAthleteUnique : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerLineupSlot_PlayerLineupId_AthleteId",
+                table: "PlayerLineupSlot",
+                columns: new[] { "PlayerLineupId", "AthleteId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PlayerLineupSlot_PlayerLineupId_AthleteId",
+                table: "PlayerLineupSlot");
+        }
+    }
+}

--- a/src/SportsData.Core/Dtos/Canonical/AthleteMatchupSummaryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/AthleteMatchupSummaryDto.cs
@@ -15,6 +15,9 @@ namespace SportsData.Core.Dtos.Canonical
     public class AthleteMatchupSummaryDto
     {
         public Guid AthleteId { get; set; }
+
+        /// <summary>The season roster row behind this summary — the lineup-slot scoring join.</summary>
+        public Guid AthleteSeasonId { get; set; }
         public required string FirstName { get; set; }
         public required string LastName { get; set; }
         public required string TeamName { get; set; }
@@ -25,6 +28,17 @@ namespace SportsData.Core.Dtos.Canonical
         /// <summary>Null on a bye week.</summary>
         public string? OpponentName { get; set; }
         public string? OpponentSlug { get; set; }
+
+        /// <summary>The athlete's team's contest for the requested week; null on a bye.</summary>
+        public Guid? ContestId { get; set; }
+
+        /// <summary>
+        /// The contest's kickoff. Consumers derive slot locking from this
+        /// (kickoff − 5 minutes, the product-wide IsStartLocked rule) — the
+        /// API revalidates from its own data on save, so this is a display/
+        /// convenience value, never the authority.
+        /// </summary>
+        public DateTime? ContestStartUtc { get; set; }
 
         /// <summary>
         /// The week opponent's relevant defensive allowance per game,

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
@@ -283,20 +283,20 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
                       c.CancelledUtc == null &&
                       (teamFsIds.Contains(c.HomeTeamFranchiseSeasonId) ||
                        teamFsIds.Contains(c.AwayTeamFranchiseSeasonId))
-                select new { c.HomeTeamFranchiseSeasonId, c.AwayTeamFranchiseSeasonId })
+                select new { ContestId = c.Id, c.StartDateUtc, c.HomeTeamFranchiseSeasonId, c.AwayTeamFranchiseSeasonId })
             .ToListAsync(cancellationToken);
 
-        var opponentByTeam = new Dictionary<Guid, Guid>();
+        var opponentByTeam = new Dictionary<Guid, (Guid OpponentFsId, Guid ContestId, DateTime StartUtc)>();
         foreach (var c in weekContests)
         {
             // Both sides may be FBS; register each direction we care about.
             if (teamFsIds.Contains(c.HomeTeamFranchiseSeasonId))
-                opponentByTeam[c.HomeTeamFranchiseSeasonId] = c.AwayTeamFranchiseSeasonId;
+                opponentByTeam[c.HomeTeamFranchiseSeasonId] = (c.AwayTeamFranchiseSeasonId, c.ContestId, c.StartDateUtc);
             if (teamFsIds.Contains(c.AwayTeamFranchiseSeasonId))
-                opponentByTeam[c.AwayTeamFranchiseSeasonId] = c.HomeTeamFranchiseSeasonId;
+                opponentByTeam[c.AwayTeamFranchiseSeasonId] = (c.HomeTeamFranchiseSeasonId, c.ContestId, c.StartDateUtc);
         }
 
-        var opponentFsIds = opponentByTeam.Values.Distinct().ToList();
+        var opponentFsIds = opponentByTeam.Values.Select(v => v.OpponentFsId).Distinct().ToList();
 
         var opponentInfo = await _dataContext.FranchiseSeasons
             .AsNoTracking()
@@ -358,12 +358,14 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
         var dto = new AthleteMatchupSummariesDto();
         foreach (var a in athletes.OrderBy(x => x.LastName ?? string.Empty).ThenBy(x => x.FirstName ?? string.Empty))
         {
-            Guid? oppId = opponentByTeam.TryGetValue(a.FranchiseSeasonId, out var o) ? o : null;
+            var hasMatchup = opponentByTeam.TryGetValue(a.FranchiseSeasonId, out var matchup);
+            Guid? oppId = hasMatchup ? matchup.OpponentFsId : null;
             var opp = oppId.HasValue && opponentById.TryGetValue(oppId.Value, out var info) ? info : null;
 
             dto.Athletes.Add(new AthleteMatchupSummaryDto
             {
                 AthleteId = a.AthleteId,
+                AthleteSeasonId = a.AthleteSeasonId,
                 FirstName = a.FirstName ?? string.Empty,
                 LastName = a.LastName ?? string.Empty,
                 TeamName = a.TeamName ?? a.TeamSlug ?? string.Empty,
@@ -371,6 +373,8 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
                 Position = position,
                 OpponentName = opp?.Name,
                 OpponentSlug = opp?.Slug,
+                ContestId = hasMatchup ? matchup.ContestId : null,
+                ContestStartUtc = hasMatchup ? matchup.StartUtc : null,
                 OpponentDefPerGame = oppId.HasValue && allowedByOpponent.TryGetValue(oppId.Value, out var allowed)
                     ? allowed
                     : null,

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -437,10 +437,15 @@ namespace SportsData.Producer.Application.Contests
         public async Task<ActionResult<List<Dtos.Canonical.Matchup>>> GetMatchupsForSeasonWeek(
             [FromQuery] int year,
             [FromQuery] int week,
+            // Week numbers repeat across phases within a season year (NFL:
+            // preseason/regular/postseason each count from 1). Omitted = 2
+            // (regular season); a future playoff pick'em passes 3. Nullable
+            // so an omitted param cannot bind to 0 and match no phase.
+            [FromQuery] int? phaseTypeCode,
             [FromServices] Queries.Matchups.GetMatchupsForSeasonWeek.IGetMatchupsForSeasonWeekQueryHandler handler,
             CancellationToken cancellationToken = default)
         {
-            var result = await handler.ExecuteAsync(new Queries.Matchups.GetMatchupsForSeasonWeek.GetMatchupsForSeasonWeekQuery(year, week), cancellationToken);
+            var result = await handler.ExecuteAsync(new Queries.Matchups.GetMatchupsForSeasonWeek.GetMatchupsForSeasonWeekQuery(year, week, phaseTypeCode ?? 2), cancellationToken);
             return result.ToActionResult();
         }
 

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQuery.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQuery.cs
@@ -1,3 +1,9 @@
 namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsForSeasonWeek;
 
-public record GetMatchupsForSeasonWeekQuery(int SeasonYear, int SeasonWeekNumber);
+/// <summary>
+/// Week numbers repeat across phases within one season year (NFL 2026:
+/// Preseason 1-4, Regular Season 1-18, Postseason 1-5). The phase type
+/// code disambiguates; 2 = regular season, the default every pick'em
+/// surface wants. A future playoff/CFP mode passes 3.
+/// </summary>
+public record GetMatchupsForSeasonWeekQuery(int SeasonYear, int SeasonWeekNumber, int SeasonPhaseTypeCode = 2);

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQueryHandler.cs
@@ -1,5 +1,7 @@
 using Dapper;
 
+using FluentValidation;
+
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
@@ -26,19 +28,31 @@ public class GetMatchupsForSeasonWeekQueryHandler : IGetMatchupsForSeasonWeekQue
 {
     private readonly TeamSportDataContext _dbContext;
     private readonly ProducerSqlQueryProvider _sqlProvider;
+    private readonly IValidator<GetMatchupsForSeasonWeekQuery> _validator;
 
     public GetMatchupsForSeasonWeekQueryHandler(
         TeamSportDataContext dbContext,
-        ProducerSqlQueryProvider sqlProvider)
+        ProducerSqlQueryProvider sqlProvider,
+        IValidator<GetMatchupsForSeasonWeekQuery> validator)
     {
         _dbContext = dbContext;
         _sqlProvider = sqlProvider;
+        _validator = validator;
     }
 
     public async Task<Result<List<Matchup>>> ExecuteAsync(
         GetMatchupsForSeasonWeekQuery query,
         CancellationToken cancellationToken = default)
     {
+        var validation = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<List<Matchup>>(
+                default!,
+                ResultStatus.Validation,
+                validation.Errors);
+        }
+
         var sql = _sqlProvider.GetMatchupsForSeasonWeek();
 
         var connection = _dbContext.Database.GetDbConnection();

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQueryHandler.cs
@@ -43,7 +43,7 @@ public class GetMatchupsForSeasonWeekQueryHandler : IGetMatchupsForSeasonWeekQue
 
         var connection = _dbContext.Database.GetDbConnection();
         var result = await connection.QueryAsync<Matchup>(
-            new CommandDefinition(sql, new { query.SeasonYear, query.SeasonWeekNumber }, cancellationToken: cancellationToken));
+            new CommandDefinition(sql, new { query.SeasonYear, query.SeasonWeekNumber, query.SeasonPhaseTypeCode }, cancellationToken: cancellationToken));
 
         return new Success<List<Matchup>>(result.ToList());
     }

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsForSeasonWeek/GetMatchupsForSeasonWeekQueryValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsForSeasonWeek;
+
+/// <summary>
+/// An out-of-range value here doesn't error — it silently matches no
+/// SeasonWeek rows and returns an empty slate, which reads as "bye week
+/// everywhere" to callers. Reject nonsense up front instead.
+/// </summary>
+public class GetMatchupsForSeasonWeekQueryValidator
+    : AbstractValidator<GetMatchupsForSeasonWeekQuery>
+{
+    /// <summary>ESPN SeasonPhase type codes: 1 Preseason, 2 Regular Season, 3 Postseason, 4 Off Season.</summary>
+    private static readonly int[] KnownPhaseTypeCodes = [1, 2, 3, 4];
+
+    public GetMatchupsForSeasonWeekQueryValidator(IDateTimeProvider dateTimeProvider)
+    {
+        RuleFor(x => x.SeasonYear)
+            .GreaterThanOrEqualTo(2000)
+            .WithMessage("Season year must be 2000 or later")
+            .Must(year => year <= dateTimeProvider.UtcNow().Year + 1)
+            .WithMessage("Season year cannot be more than one year in the future");
+
+        RuleFor(x => x.SeasonWeekNumber)
+            .InclusiveBetween(1, 30)
+            .WithMessage("Week must be between 1 and 30");
+
+        RuleFor(x => x.SeasonPhaseTypeCode)
+            .Must(code => KnownPhaseTypeCodes.Contains(code))
+            .WithMessage("Season phase type code must be 1 (Preseason), 2 (Regular Season), 3 (Postseason), or 4 (Off Season)");
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -377,6 +377,8 @@ namespace SportsData.Producer.DependencyInjection
             // Contest Matchup Queries
             services.AddScoped<IGetMatchupsForCurrentWeekQueryHandler, GetMatchupsForCurrentWeekQueryHandler>();
             services.AddScoped<IGetMatchupsForSeasonWeekQueryHandler, GetMatchupsForSeasonWeekQueryHandler>();
+            services.AddScoped<IValidator<Application.Contests.Queries.Matchups.GetMatchupsForSeasonWeek.GetMatchupsForSeasonWeekQuery>,
+                Application.Contests.Queries.Matchups.GetMatchupsForSeasonWeek.GetMatchupsForSeasonWeekQueryValidator>();
             services.AddScoped<IGetMatchupByContestIdQueryHandler, GetMatchupByContestIdQueryHandler>();
             services.AddScoped<
                 Application.Contests.Queries.GetGameDates.IGetGameDatesQueryHandler,

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsForSeasonWeek.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsForSeasonWeek.sql
@@ -62,6 +62,7 @@ INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchise
 INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
 INNER JOIN public."GroupSeason" gsHome ON gsHome."Id" = fsHome."GroupSeasonId"
 INNER JOIN public."SeasonWeek" sw ON sw."Id" = c."SeasonWeekId"
+INNER JOIN public."SeasonPhase" sp ON sp."Id" = sw."SeasonPhaseId"
 INNER JOIN public."Season" s ON s."Id" = sw."SeasonId"
 LEFT JOIN LATERAL (
   -- Rank via poll_rank_asof — the single poll-rank definition (see the
@@ -75,5 +76,12 @@ LEFT JOIN LATERAL (
   -- this team's entry in it, or NULL = honestly unranked.
   SELECT public.poll_rank_asof(fsHome."Id", fsHome."SeasonYear", c."StartDateUtc") AS "Current"
 ) fsrdHome ON TRUE
-WHERE s."Year" = @SeasonYear AND sw."Number" = @SeasonWeekNumber
+-- Phase scope is REQUIRED: week numbers repeat across phases within one
+-- season year (NFL 2026 has a week 4 in Preseason, Regular Season, AND
+-- Postseason). An unscoped number query mixes phases and hands callers
+-- whichever game sorts last. Callers default to TypeCode 2 (regular
+-- season); a future playoff/CFP pick'em passes TypeCode 3.
+WHERE s."Year" = @SeasonYear
+  AND sw."Number" = @SeasonWeekNumber
+  AND sp."TypeCode" = @SeasonPhaseTypeCode
 ORDER BY c."StartDateUtc", fHome."Slug"

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -187,7 +187,7 @@ function MainApp() {
             {/* Player Pick'em roster builder — admin-only v1 exploration;
                 users see only the home-page teaser until launch. */}
             <Route
-              path="/pickem/players"
+              path="/pickem/players/:leagueId?"
               element={
                 <AdminRoute>
                   <PlayerRosterBuilder />

--- a/src/UI/sd-ui/src/api/playerPickemApi.js
+++ b/src/UI/sd-ui/src/api/playerPickemApi.js
@@ -33,6 +33,33 @@ const PlayerPickemApi = {
     apiClient.get(
       `/api/${sport}/${league}/athletes/pickem?position=${encodeURIComponent(position)}&seasonYear=${seasonYear}&week=${week}`
     ),
+
+  // ── Roster persistence (server-side lineups, per-player derived locks).
+  // The server resolves contest anchors and enforces the kickoff−5 lock
+  // rule itself — athlete payloads here are identity + display snapshot.
+
+  getMyLineup: (leagueId, seasonYear, week) =>
+    apiClient.get(`/ui/leagues/${leagueId}/player-lineups/${seasonYear}/${week}/mine`),
+
+  upsertSlot: (leagueId, seasonYear, week, slotId, athlete) =>
+    apiClient.put(
+      `/ui/leagues/${leagueId}/player-lineups/${seasonYear}/${week}/mine/slots/${encodeURIComponent(slotId)}`,
+      {
+        athleteId: athlete.athleteId,
+        athleteSeasonId: athlete.athleteSeasonId,
+        position: athlete.position,
+        firstName: athlete.firstName,
+        lastName: athlete.lastName,
+        teamName: athlete.teamName,
+        teamSlug: athlete.teamSlug,
+        opponentName: athlete.opponentName ?? null,
+      }
+    ),
+
+  clearSlot: (leagueId, seasonYear, week, slotId) =>
+    apiClient.delete(
+      `/ui/leagues/${leagueId}/player-lineups/${seasonYear}/${week}/mine/slots/${encodeURIComponent(slotId)}`
+    ),
 };
 
 export default PlayerPickemApi;

--- a/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
@@ -45,10 +45,16 @@ function YourLeaguesCard() {
       <ul className="your-leagues-card__list">
         {leagues.map((league) => {
           const icon = SPORT_ICON[league.sport];
+          // One game per league: PlayerPickem leagues open the roster
+          // builder, everything else opens the team picks page.
+          const destination =
+            league.groupType === 'PlayerPickem'
+              ? '/app/pickem/players'
+              : `/app/picks/${league.id}`;
           return (
             <li key={league.id} className="your-leagues-card__item">
               <Link
-                to={`/app/picks/${league.id}`}
+                to={destination}
                 className="your-leagues-card__row"
                 aria-label={`Open ${league.name}`}
               >

--- a/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
@@ -49,7 +49,7 @@ function YourLeaguesCard() {
           // builder, everything else opens the team picks page.
           const destination =
             league.groupType === 'PlayerPickem'
-              ? '/app/pickem/players'
+              ? `/app/pickem/players/${league.id}`
               : `/app/picks/${league.id}`;
           return (
             <li key={league.id} className="your-leagues-card__item">

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
@@ -23,7 +23,7 @@ const LeagueOverviewCard = ({ league, onDuplicate }) => {
           <Link
             to={
               league.groupType === 'PlayerPickem'
-                ? '/app/pickem/players'
+                ? `/app/pickem/players/${league.id}`
                 : `/app/picks/${league.id}`
             }
             className="league-card-name-link"

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
@@ -18,7 +18,16 @@ const LeagueOverviewCard = ({ league, onDuplicate }) => {
       )}
       <div className="league-card-header">
         <h2 className="league-card-title">
-          <Link to={`/app/picks/${league.id}`} className="league-card-name-link">
+          {/* One game per league: PlayerPickem leagues open the roster
+              builder, everything else opens the team picks page. */}
+          <Link
+            to={
+              league.groupType === 'PlayerPickem'
+                ? '/app/pickem/players'
+                : `/app/picks/${league.id}`
+            }
+            className="league-card-name-link"
+          >
             {league.name}
           </Link>
           {isPast && <span className="past-league-badge">Past</span>}

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import PlayerPickemApi from '../../../api/playerPickemApi';
 import LeaguesApi from '../../../api/leagues/leaguesApi';
 import {
@@ -83,6 +83,10 @@ function errorMessage(err, fallback) {
  * exists for closed-testing coverage.
  */
 function PlayerRosterBuilder() {
+  // Optional league scope from the route (league cards pass their id) —
+  // without it the page falls back to the first PlayerPickem league per
+  // sport.
+  const { leagueId: routeLeagueId } = useParams();
   const [league, setLeague] = useState('ncaa');
   const [roster, setRoster] = useState({});
   // The user's PlayerPickem-type leagues (null = still loading). The
@@ -112,10 +116,15 @@ function PlayerRosterBuilder() {
         if (ignore) return;
         const mine = (leagues ?? []).filter((l) => l.groupType === 'PlayerPickem');
         setPlayerLeagues(mine);
-        const firstAvailable = LEAGUES.find((opt) =>
-          mine.some((l) => l.sport === opt.sport)
-        );
-        if (firstAvailable) setLeague(firstAvailable.id);
+        // Route-scoped league wins; its sport drives the page. Fallback:
+        // first sport that has a player league.
+        const routed = routeLeagueId
+          ? mine.find((l) => l.id === routeLeagueId)
+          : null;
+        const target = routed
+          ? LEAGUES.find((opt) => opt.sport === routed.sport)
+          : LEAGUES.find((opt) => mine.some((l) => l.sport === opt.sport));
+        if (target) setLeague(target.id);
       })
       .catch(() => {
         if (!ignore) {
@@ -126,7 +135,7 @@ function PlayerRosterBuilder() {
     return () => {
       ignore = true;
     };
-  }, []);
+  }, [routeLeagueId]);
 
   // Resolve the target league for the selected sport, then load the
   // server lineup (whose first read of a new week performs the lazy
@@ -140,7 +149,10 @@ function PlayerRosterBuilder() {
     setRoster({});
 
     const sport = LEAGUES.find((l) => l.id === league)?.sport;
-    const target = playerLeagues.find((l) => l.sport === sport) ?? null;
+    const routed = routeLeagueId
+      ? playerLeagues.find((l) => l.id === routeLeagueId && l.sport === sport)
+      : null;
+    const target = routed ?? playerLeagues.find((l) => l.sport === sport) ?? null;
     setPickemLeague(target);
 
     if (!target) {
@@ -163,7 +175,7 @@ function PlayerRosterBuilder() {
     return () => {
       ignore = true;
     };
-  }, [league, playerLeagues]);
+  }, [league, playerLeagues, routeLeagueId]);
 
   const positions = useMemo(
     () => eligiblePositions(activeSlotId),

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -1,12 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PlayerPickemApi from '../../../api/playerPickemApi';
+import LeaguesApi from '../../../api/leagues/leaguesApi';
 import {
   SLOT_DEFS,
-  slotById,
   eligiblePositions,
-  assign,
-  remove,
+  canAssign,
   isRostered,
 } from './rosterLogic';
 import {
@@ -18,27 +17,25 @@ import {
 import { columnsFor, cellText } from './gridColumns';
 import './PlayerRosterBuilder.css';
 
-// Selections survive reloads — rudimentary stand-in for the carry-over
-// behavior until PlayerLineup entities exist server-side. Keyed per
-// league so an NCAAFB draft never bleeds into the NFL view.
-const rosterKey = (league) => `playerPickemRosterDraft.${league}`;
-
 // NCAAFB is the product; NFL rides along for closed-testing coverage
-// (and who knows).
+// (and who knows). `sport` matches LeagueSummaryDto.Sport for resolving
+// which of the user's Player-Pick'em-enabled leagues this toggle targets.
 const LEAGUES = [
-  { id: 'ncaa', label: 'NCAAFB (FBS)' },
-  { id: 'nfl', label: 'NFL' },
+  { id: 'ncaa', label: 'NCAAFB (FBS)', sport: 'FootballNcaa' },
+  { id: 'nfl', label: 'NFL', sport: 'FootballNfl' },
 ];
 
-// Fixed to opening week for the admin preview; a week selector (and
+// Fixed to opening week for now; a week selector (and
 // deriving the current week server-side) is future work.
 const SEASON_YEAR = 2026;
 const WEEK = 1;
 
 // Full-depth FBS position lists run to ~2,000 rows (WR); the grid pages
 // client-side — the payload is already in the browser, so filtering and
-// paging never refetch.
-const PAGE_SIZE = 25;
+// paging never refetch. 10 keeps the page scannable (each athlete is a
+// two-line row pair, so 10 athletes ≈ 20 visual rows); operator may tune
+// toward 15.
+const PAGE_SIZE = 10;
 
 // Meaning of opponentDefPerGame varies by the position being browsed.
 // FLEX merges positions, so it gets the generic label and the per-row
@@ -57,39 +54,18 @@ const OPP_DEF_LABEL = {
 // previous fallback in sortAthletes never distinguishes for it).
 const OPP_DEF_SORT_KEY = 'oppDef';
 
-/**
- * A stored draft is untrusted input: JSON.parse happily returns null,
- * arrays, or strings (all valid JSON). Accept only a plain object whose
- * keys are real slot ids and whose values look like athletes; anything
- * else degrades to the slot-by-slot best effort or an empty roster.
- * Mirrors the mobile screen's sanitizer.
- */
-function sanitizeRoster(raw) {
-  try {
-    const parsed = JSON.parse(raw);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      return {};
-    }
-    const next = {};
-    for (const [slotId, val] of Object.entries(parsed)) {
-      if (
-        slotById(slotId) &&
-        val !== null &&
-        typeof val === 'object' &&
-        !Array.isArray(val) &&
-        typeof val.athleteId === 'string' &&
-        // The slot chip renders firstName.charAt(0) + lastName — an entry
-        // missing either would crash on first paint.
-        typeof val.firstName === 'string' &&
-        typeof val.lastName === 'string'
-      ) {
-        next[slotId] = val;
-      }
-    }
-    return next;
-  } catch {
-    return {};
+/** Server lineup → the {slotId: slot} shape the slot row renders. */
+function rosterFromLineup(lineup) {
+  return Object.fromEntries((lineup?.slots ?? []).map((s) => [s.slotId, s]));
+}
+
+/** First useful message out of an API validation failure, else a fallback. */
+function errorMessage(err, fallback) {
+  const errors = err?.response?.data?.errors;
+  if (Array.isArray(errors) && errors.length > 0 && errors[0]?.errorMessage) {
+    return errors[0].errorMessage;
   }
+  return fallback;
 }
 
 /**
@@ -101,20 +77,23 @@ function sanitizeRoster(raw) {
  * current season on the primary row, previous season directly beneath in
  * the same columns for vertical comparison. Sorting orders the pairs by
  * the current-season value, falling back to previous-season when no row
- * has current data (week 1). Roster is local-only (localStorage), keyed
- * per league. NCAAFB is the product; the NFL toggle exists for
- * closed-testing coverage.
+ * has current data (week 1). The roster persists server-side to the
+ * user's PlayerPickem-type league for the toggled sport, with per-player
+ * derived locking (kickoff−5). NCAAFB is the product; the NFL toggle
+ * exists for closed-testing coverage.
  */
 function PlayerRosterBuilder() {
   const [league, setLeague] = useState('ncaa');
-  const [roster, setRoster] = useState(() =>
-    sanitizeRoster(localStorage.getItem(rosterKey('ncaa')) ?? 'null')
-  );
-  // Which league the current roster state belongs to. Guards the save
-  // effect during a league switch — without it, the old league's roster
-  // would be written over the new league's stored draft before the load
-  // effect has swapped it in.
-  const rosterLeagueRef = useRef('ncaa');
+  const [roster, setRoster] = useState({});
+  // The user's PlayerPickem-type leagues (null = still loading). The
+  // SPORT isn't a free choice — it's a fact of these leagues: the page
+  // auto-selects the first sport with a player league, and the toggle
+  // only renders when leagues span more than one sport.
+  const [playerLeagues, setPlayerLeagues] = useState(null);
+  // The PickemGroup this roster persists to for the selected sport.
+  const [pickemLeague, setPickemLeague] = useState(null);
+  const [rosterLoading, setRosterLoading] = useState(true);
+  const [saveError, setSaveError] = useState(null);
   const [activeSlotId, setActiveSlotId] = useState('QB');
   const [athletes, setAthletes] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -124,22 +103,67 @@ function PlayerRosterBuilder() {
   const [opponentText, setOpponentText] = useState('');
   const [page, setPage] = useState(0);
 
-  // Load the new league's draft on switch.
+  // Load the user's PlayerPickem leagues once; auto-select the first
+  // sport that actually has one.
   useEffect(() => {
-    if (rosterLeagueRef.current === league) return;
-    setRoster(sanitizeRoster(localStorage.getItem(rosterKey(league)) ?? 'null'));
-    rosterLeagueRef.current = league;
-  }, [league]);
+    let ignore = false;
+    LeaguesApi.getUserLeagues()
+      .then((leagues) => {
+        if (ignore) return;
+        const mine = (leagues ?? []).filter((l) => l.groupType === 'PlayerPickem');
+        setPlayerLeagues(mine);
+        const firstAvailable = LEAGUES.find((opt) =>
+          mine.some((l) => l.sport === opt.sport)
+        );
+        if (firstAvailable) setLeague(firstAvailable.id);
+      })
+      .catch(() => {
+        if (!ignore) {
+          setPlayerLeagues([]);
+          setSaveError('Could not load your leagues.');
+        }
+      });
+    return () => {
+      ignore = true;
+    };
+  }, []);
 
-  // Save under the league the roster BELONGS to (the ref), never the
-  // currently selected league. During a switch the two disagree for one
-  // render while state is still the old league's lineup; keying the
-  // write by the ref makes effect ordering irrelevant — the switch pass
-  // doesn't run this effect at all (roster hasn't changed), and once the
-  // loaded roster commits, ref and league agree again.
+  // Resolve the target league for the selected sport, then load the
+  // server lineup (whose first read of a new week performs the lazy
+  // carry-over clone server-side).
   useEffect(() => {
-    localStorage.setItem(rosterKey(rosterLeagueRef.current), JSON.stringify(roster));
-  }, [roster]);
+    if (playerLeagues === null) return undefined; // leagues still loading
+
+    let ignore = false;
+    setRosterLoading(true);
+    setSaveError(null);
+    setRoster({});
+
+    const sport = LEAGUES.find((l) => l.id === league)?.sport;
+    const target = playerLeagues.find((l) => l.sport === sport) ?? null;
+    setPickemLeague(target);
+
+    if (!target) {
+      setRosterLoading(false);
+      return undefined;
+    }
+
+    PlayerPickemApi.getMyLineup(target.id, SEASON_YEAR, WEEK)
+      .then((response) => {
+        if (ignore) return;
+        setRoster(rosterFromLineup(response.data));
+      })
+      .catch(() => {
+        if (!ignore) setSaveError('Could not load your roster.');
+      })
+      .finally(() => {
+        if (!ignore) setRosterLoading(false);
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [league, playerLeagues]);
 
   const positions = useMemo(
     () => eligiblePositions(activeSlotId),
@@ -243,15 +267,39 @@ function PlayerRosterBuilder() {
         : 'descending'
       : undefined;
 
-  const handleAssign = (athlete) => {
-    setRoster((prev) => assign(prev, activeSlotId, athlete));
+  const handleAssign = async (athlete) => {
+    // Client-side pre-checks (eligibility, duplicates) fail fast; the
+    // server re-validates everything INCLUDING locks, which only it can
+    // judge authoritatively.
+    if (!pickemLeague || !canAssign(roster, activeSlotId, athlete)) return;
+    setSaveError(null);
+    try {
+      const response = await PlayerPickemApi.upsertSlot(
+        pickemLeague.id, SEASON_YEAR, WEEK, activeSlotId, athlete
+      );
+      setRoster((prev) => ({ ...prev, [activeSlotId]: response.data }));
+    } catch (err) {
+      setSaveError(errorMessage(err, 'Could not save that pick.'));
+    }
   };
 
-  const handleRemove = (slotId) => {
-    setRoster((prev) => remove(prev, slotId));
+  const handleRemove = async (slotId) => {
+    if (!pickemLeague) return;
+    setSaveError(null);
+    try {
+      await PlayerPickemApi.clearSlot(pickemLeague.id, SEASON_YEAR, WEEK, slotId);
+      setRoster((prev) => {
+        const next = { ...prev };
+        delete next[slotId];
+        return next;
+      });
+    } catch (err) {
+      setSaveError(errorMessage(err, 'Could not clear that slot.'));
+    }
   };
 
   const activeSlot = SLOT_DEFS.find((s) => s.id === activeSlotId);
+  const activeOccupantLocked = roster[activeSlotId]?.isLocked === true;
   const oppDefLabel =
     OPP_DEF_LABEL[activeSlot?.id === 'FLEX' ? 'FLEX' : positions[0]];
 
@@ -260,23 +308,49 @@ function PlayerRosterBuilder() {
       <h2 className="roster-builder-title">Player Pick&rsquo;em Roster</h2>
       <p className="roster-builder-sub">
         Week {WEEK} &middot; {SEASON_YEAR} &middot;{' '}
-        {LEAGUES.find((l) => l.id === league)?.label} &mdash; admin preview,
-        selections are local-only
+        {LEAGUES.find((l) => l.id === league)?.label}
+        {pickemLeague ? (
+          <> &middot; <strong>{pickemLeague.name}</strong></>
+        ) : null}
       </p>
 
-      <div className="roster-leagues" role="group" aria-label="League">
-        {LEAGUES.map((l) => (
-          <button
-            key={l.id}
-            type="button"
-            className={`roster-league-btn${l.id === league ? ' roster-league-btn--active' : ''}`}
-            aria-pressed={l.id === league}
-            onClick={() => setLeague(l.id)}
-          >
-            {l.label}
-          </button>
-        ))}
-      </div>
+      {/* The sport is a fact of the user's player leagues, not a free
+          choice — the toggle only exists when their leagues span more
+          than one sport. */}
+      {(() => {
+        const available = LEAGUES.filter((opt) =>
+          (playerLeagues ?? []).some((l) => l.sport === opt.sport)
+        );
+        return available.length > 1 ? (
+          <div className="roster-leagues" role="group" aria-label="League">
+            {available.map((l) => (
+              <button
+                key={l.id}
+                type="button"
+                className={`roster-league-btn${l.id === league ? ' roster-league-btn--active' : ''}`}
+                aria-pressed={l.id === league}
+                onClick={() => setLeague(l.id)}
+              >
+                {l.label}
+              </button>
+            ))}
+          </div>
+        ) : null;
+      })()}
+
+      {rosterLoading ? (
+        <div className="roster-grid-status">Loading your roster&hellip;</div>
+      ) : playerLeagues !== null && playerLeagues.length === 0 ? (
+        <div className="roster-grid-status roster-grid-status--error">
+          You&rsquo;re not in a Player Pick&rsquo;em league yet &mdash; the
+          grid is browsable, but picks can&rsquo;t be saved.
+        </div>
+      ) : null}
+      {saveError ? (
+        <div className="roster-grid-status roster-grid-status--error" role="alert">
+          {saveError}
+        </div>
+      ) : null}
 
       {/* Button group, not tabs: there's no tabpanel relationship here and
           the remove buttons live between the slot controls, so tablist
@@ -308,13 +382,15 @@ function PlayerRosterBuilder() {
                 <span className="roster-slot-label">{slot.label}</span>
                 <span className="roster-slot-player">
                   {filled
-                    ? `${filled.firstName.charAt(0)}. ${filled.lastName}`
+                    ? `${filled.isLocked ? '🔒 ' : ''}${filled.firstName.charAt(0)}. ${filled.lastName}`
                     : slot.disabled
                       ? 'Soon'
                       : '—'}
                 </span>
               </button>
-              {filled ? (
+              {/* Locked slots hide the remove affordance — the server
+                  would reject it anyway; don't offer a dead button. */}
+              {filled && !filled.isLocked ? (
                 <button
                   type="button"
                   className="roster-slot-remove"
@@ -467,10 +543,21 @@ function PlayerRosterBuilder() {
                       <button
                         type="button"
                         className="roster-grid-add"
-                        disabled={rostered}
+                        disabled={rostered || !pickemLeague || activeOccupantLocked}
+                        title={
+                          activeOccupantLocked
+                            ? 'This slot is locked — its game has started.'
+                            : !pickemLeague
+                              ? 'No Player Pick’em league to save to.'
+                              : undefined
+                        }
                         onClick={() => handleAssign(a)}
                       >
-                        {rostered ? 'Rostered' : addLabel}
+                        {rostered
+                          ? 'Rostered'
+                          : activeOccupantLocked
+                            ? 'Locked'
+                            : addLabel}
                       </button>
                     </td>
                   </tr>,

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerLineupHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerLineupHandlerTests.cs
@@ -34,6 +34,10 @@ public class PlayerLineupHandlerTests : ApiTestBase<UpsertLineupSlotCommandHandl
     public PlayerLineupHandlerTests()
     {
         Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+        // Real validators — auto-mocked IValidator returns a null
+        // ValidationResult and NREs before the code under test runs.
+        Mocker.Use<FluentValidation.IValidator<UpsertLineupSlotCommand>>(new UpsertLineupSlotCommandValidator());
+        Mocker.Use<FluentValidation.IValidator<ClearLineupSlotCommand>>(new ClearLineupSlotCommandValidator());
         Mocker.GetMock<IContestClientFactory>()
             .Setup(x => x.Resolve(It.IsAny<Sport>()))
             .Returns(_contestClient.Object);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerLineupHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerLineupHandlerTests.cs
@@ -1,0 +1,382 @@
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.UI.PlayerLineups.Commands.ClearLineupSlot;
+using SportsData.Api.Application.UI.PlayerLineups.Commands.UpsertLineupSlot;
+using SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.PlayerLineups;
+
+/// <summary>
+/// Roster persistence: derived per-player locking (kickoff−5, the
+/// product-wide rule), server-authoritative contest anchoring, the lazy
+/// carry-over clone, and the enablement gate. Lock scenarios pivot on a
+/// fixed clock; the week's matchups come from a mocked ContestClient.
+/// </summary>
+public class PlayerLineupHandlerTests : ApiTestBase<UpsertLineupSlotCommandHandler>
+{
+    private static readonly DateTime Now = new(2026, 9, 5, 16, 0, 0, DateTimeKind.Utc);
+    private static readonly Guid LeagueId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    private readonly Mock<IProvideContests> _contestClient = new();
+
+    public PlayerLineupHandlerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>().Setup(x => x.UtcNow()).Returns(Now);
+        Mocker.GetMock<IContestClientFactory>()
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(_contestClient.Object);
+        SetWeekMatchups([]);
+    }
+
+    private void SetWeekMatchups(List<Matchup> matchups) =>
+        _contestClient
+            .Setup(x => x.GetMatchupsForSeasonWeek(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<Matchup>>(matchups));
+
+    private static Matchup MakeMatchup(string homeSlug, string awaySlug, DateTime startUtc) => new()
+    {
+        ContestId = Guid.NewGuid(),
+        SeasonYear = 2026,
+        SeasonWeek = 2,
+        SeasonWeekId = Guid.NewGuid(),
+        StartDateUtc = startUtc,
+        Status = "STATUS_SCHEDULED",
+        StatusDescription = "Scheduled",
+        HomeSlug = homeSlug,
+        AwaySlug = awaySlug,
+    };
+
+    private async Task SeedLeagueAsync(GroupType groupType = GroupType.PlayerPickem)
+    {
+        DataContext.PickemGroups.Add(new PickemGroup
+        {
+            Id = LeagueId,
+            Name = "Test League",
+            Sport = Sport.FootballNcaa,
+            League = League.NCAAF,
+            CommissionerUserId = Guid.NewGuid(),
+            SeasonYear = 2026,
+            GroupType = groupType,
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    private static UpsertLineupSlotCommand QbCommand(string slotId = "QB") => new()
+    {
+        LeagueId = LeagueId,
+        UserId = UserId,
+        SeasonYear = 2026,
+        SeasonWeek = 2,
+        SlotId = slotId,
+        AthleteId = Guid.NewGuid(),
+        AthleteSeasonId = Guid.NewGuid(),
+        Position = "QB",
+        FirstName = "Arch",
+        LastName = "Manning",
+        TeamName = "Texas Longhorns",
+        TeamSlug = "texas-longhorns",
+        OpponentName = "Oklahoma Sooners",
+    };
+
+    // ── Gate ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TeamPickemLeague_IsForbidden()
+    {
+        // One game per league: a TeamPickem group does not play this game.
+        await SeedLeagueAsync(GroupType.TeamPickem);
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var result = await handler.ExecuteAsync(QbCommand());
+
+        result.Status.Should().Be(ResultStatus.Forbid);
+    }
+
+    [Fact]
+    public async Task NonMember_IsForbidden()
+    {
+        await SeedLeagueAsync();
+        DenyLeagueMembership();
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var result = await handler.ExecuteAsync(QbCommand());
+
+        result.Status.Should().Be(ResultStatus.Forbid);
+    }
+
+    // ── Upsert rules ──────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("BENCH", "QB")]  // unknown slot
+    [InlineData("QB", "RB")]     // ineligible position
+    [InlineData("FLEX", "QB")]   // QB is not FLEX-eligible
+    public async Task ShapeViolations_FailValidation(string slotId, string position)
+    {
+        await SeedLeagueAsync();
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var command = QbCommand(slotId);
+        command.Position = position;
+        var result = await handler.ExecuteAsync(command);
+
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task HappyPath_CreatesLineup_AndStoresServerResolvedAnchor()
+    {
+        await SeedLeagueAsync();
+        var kickoff = Now.AddHours(3);
+        var matchup = MakeMatchup("texas-longhorns", "oklahoma-sooners", kickoff);
+        SetWeekMatchups([matchup]);
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var result = await handler.ExecuteAsync(QbCommand());
+
+        result.IsSuccess.Should().BeTrue();
+        var slot = await DataContext.PlayerLineupSlots.SingleAsync();
+        // The anchor is what the SERVER resolved — the command carries none.
+        slot.ContestId.Should().Be(matchup.ContestId);
+        slot.ContestStartUtc.Should().Be(kickoff);
+        result.Value.IsLocked.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ByeAthlete_SavesWithNullAnchor()
+    {
+        await SeedLeagueAsync();
+        SetWeekMatchups([]); // team not on the slate
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var result = await handler.ExecuteAsync(QbCommand());
+
+        result.IsSuccess.Should().BeTrue();
+        var slot = await DataContext.PlayerLineupSlots.SingleAsync();
+        slot.ContestId.Should().BeNull();
+        slot.ContestStartUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DuplicateAthleteAcrossSlots_FailsValidation()
+    {
+        await SeedLeagueAsync();
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+        var first = QbCommand("RB1");
+        first.Position = "RB";
+        (await handler.ExecuteAsync(first)).IsSuccess.Should().BeTrue();
+
+        var second = QbCommand("RB2");
+        second.Position = "RB";
+        second.AthleteId = first.AthleteId; // same athlete, different slot
+        var result = await handler.ExecuteAsync(second);
+
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task IncomingAthleteWithLockedGame_FailsValidation()
+    {
+        await SeedLeagueAsync();
+        // Kickoff 3 minutes out — inside the 5-minute lock window.
+        SetWeekMatchups([MakeMatchup("texas-longhorns", "oklahoma-sooners", Now.AddMinutes(3))]);
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var result = await handler.ExecuteAsync(QbCommand());
+
+        result.Status.Should().Be(ResultStatus.Validation);
+        (await DataContext.PlayerLineupSlots.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TargetSlotWithLockedOccupant_RejectsReplacement()
+    {
+        await SeedLeagueAsync();
+        // Occupant's game is comfortably future at first save…
+        SetWeekMatchups([MakeMatchup("texas-longhorns", "oklahoma-sooners", Now.AddMinutes(4))]);
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+        var occupant = QbCommand();
+        // …seed the occupant directly with an already-locked anchor.
+        await SeedLeagueLineupWithSlotAsync(occupant, contestStartUtc: Now.AddMinutes(-30));
+
+        var replacement = QbCommand();
+        var result = await handler.ExecuteAsync(replacement);
+
+        result.Status.Should().Be(ResultStatus.Validation);
+        (await DataContext.PlayerLineupSlots.SingleAsync()).AthleteId.Should().Be(occupant.AthleteId);
+    }
+
+    [Fact]
+    public async Task ClonedNullAnchorOccupant_WhoseGameIsLive_RejectsReplacement()
+    {
+        // The carry-over hole: a cloned slot can hold a NULL anchor. The
+        // occupant's team currently resolves to a locked game, so the swap
+        // must be rejected even though the stored anchor says nothing.
+        await SeedLeagueAsync();
+        var occupant = QbCommand();
+        await SeedLeagueLineupWithSlotAsync(occupant, contestStartUtc: null);
+        SetWeekMatchups([MakeMatchup(occupant.TeamSlug, "oklahoma-sooners", Now.AddMinutes(-10))]);
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var replacement = QbCommand();
+        replacement.TeamSlug = "lsu-tigers"; // incoming athlete not on the locked team
+        var result = await handler.ExecuteAsync(replacement);
+
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task MatchupResolutionFailure_FailsClosed_AndPersistsNothing()
+    {
+        await SeedLeagueAsync();
+        _contestClient
+            .Setup(x => x.GetMatchupsForSeasonWeek(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<List<Matchup>>(default!, ResultStatus.Error, []));
+        var handler = Mocker.CreateInstance<UpsertLineupSlotCommandHandler>();
+
+        var result = await handler.ExecuteAsync(QbCommand());
+
+        result.Status.Should().Be(ResultStatus.Error);
+        (await DataContext.PlayerLineups.AnyAsync()).Should().BeFalse();
+    }
+
+    // ── Clear ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Clear_LockedSlot_FailsValidation_UnlockedSlot_Removes()
+    {
+        await SeedLeagueAsync();
+        var locked = QbCommand("QB");
+        await SeedLeagueLineupWithSlotAsync(locked, contestStartUtc: Now.AddMinutes(-30));
+        var handler = Mocker.CreateInstance<ClearLineupSlotCommandHandler>();
+
+        var lockedResult = await handler.ExecuteAsync(
+            new ClearLineupSlotCommand(LeagueId, UserId, 2026, 2, "QB"));
+        lockedResult.Status.Should().Be(ResultStatus.Validation);
+
+        // Unlock by moving the anchor to the future, then clear succeeds.
+        var slot = await DataContext.PlayerLineupSlots.SingleAsync();
+        slot.ContestStartUtc = Now.AddHours(5);
+        await DataContext.SaveChangesAsync();
+
+        var clearedResult = await handler.ExecuteAsync(
+            new ClearLineupSlotCommand(LeagueId, UserId, 2026, 2, "QB"));
+        clearedResult.IsSuccess.Should().BeTrue();
+        (await DataContext.PlayerLineupSlots.AnyAsync()).Should().BeFalse();
+    }
+
+    // ── Read + lazy clone ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_NoLineupNoPrior_ReturnsEmptySlots_AndCreatesNothing()
+    {
+        await SeedLeagueAsync();
+        var handler = Mocker.CreateInstance<GetMyPlayerLineupQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetMyPlayerLineupQuery(LeagueId, UserId, 2026, 2));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Slots.Should().BeEmpty();
+        (await DataContext.PlayerLineups.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Get_ClonesPriorWeek_ReresolvingContests()
+    {
+        await SeedLeagueAsync();
+        var occupant = QbCommand();
+        await SeedLeagueLineupWithSlotAsync(occupant, contestStartUtc: Now.AddDays(-6), seasonWeek: 1);
+
+        // Week 2: the occupant's team plays a NEW game.
+        var week2 = MakeMatchup(occupant.TeamSlug, "georgia-bulldogs", Now.AddDays(1));
+        SetWeekMatchups([week2]);
+        var handler = Mocker.CreateInstance<GetMyPlayerLineupQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetMyPlayerLineupQuery(LeagueId, UserId, 2026, 2));
+
+        result.IsSuccess.Should().BeTrue();
+        var slot = result.Value.Slots.Should().ContainSingle().Subject;
+        slot.AthleteId.Should().Be(occupant.AthleteId);
+        slot.ContestId.Should().Be(week2.ContestId);          // re-resolved, not carried
+        slot.ContestStartUtc.Should().Be(week2.StartDateUtc);
+        slot.IsLocked.Should().BeFalse();
+
+        (await DataContext.PlayerLineups.CountAsync()).Should().Be(2); // week 1 + cloned week 2
+    }
+
+    [Fact]
+    public async Task Get_CloneSkipsWhenMatchupResolutionFails_ServesEmpty()
+    {
+        await SeedLeagueAsync();
+        await SeedLeagueLineupWithSlotAsync(QbCommand(), contestStartUtc: Now.AddDays(-6), seasonWeek: 1);
+        _contestClient
+            .Setup(x => x.GetMatchupsForSeasonWeek(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<List<Matchup>>(default!, ResultStatus.Error, []));
+        var handler = Mocker.CreateInstance<GetMyPlayerLineupQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetMyPlayerLineupQuery(LeagueId, UserId, 2026, 2));
+
+        // Fail open on the read: empty week now, retry next read.
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Slots.Should().BeEmpty();
+        (await DataContext.PlayerLineups.CountAsync()).Should().Be(1); // week 1 only
+    }
+
+    [Fact]
+    public async Task Get_DerivesIsLocked_FromTheSharedRule()
+    {
+        await SeedLeagueAsync();
+        // Kickoff 3 minutes out — locked under kickoff−5.
+        await SeedLeagueLineupWithSlotAsync(QbCommand(), contestStartUtc: Now.AddMinutes(3), seasonWeek: 2);
+        var handler = Mocker.CreateInstance<GetMyPlayerLineupQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetMyPlayerLineupQuery(LeagueId, UserId, 2026, 2));
+
+        result.Value.Slots.Single().IsLocked.Should().BeTrue();
+    }
+
+    // ── Seed helper ───────────────────────────────────────────────────────
+
+    private async Task SeedLeagueLineupWithSlotAsync(
+        UpsertLineupSlotCommand source,
+        DateTime? contestStartUtc,
+        int seasonWeek = 2)
+    {
+        var lineup = new PlayerLineup
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = LeagueId,
+            UserId = UserId,
+            SeasonYear = 2026,
+            SeasonWeek = seasonWeek,
+        };
+        lineup.Slots.Add(new PlayerLineupSlot
+        {
+            Id = Guid.NewGuid(),
+            PlayerLineupId = lineup.Id,
+            SlotId = source.SlotId,
+            AthleteId = source.AthleteId,
+            AthleteSeasonId = source.AthleteSeasonId,
+            Position = source.Position,
+            FirstName = source.FirstName,
+            LastName = source.LastName,
+            TeamName = source.TeamName,
+            TeamSlug = source.TeamSlug,
+            ContestId = contestStartUtc.HasValue ? Guid.NewGuid() : null,
+            ContestStartUtc = contestStartUtc,
+        });
+        DataContext.PlayerLineups.Add(lineup);
+        await DataContext.SaveChangesAsync();
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Athletes/GetAthleteMatchupSummariesQueryHandlerTests.cs
@@ -453,9 +453,13 @@ public class GetAthleteMatchupSummariesQueryHandlerTests : ProducerTestBase<GetA
         var row = result.Value.Athletes.Should().ContainSingle().Subject;
         row.LastName.Should().Be("Manning");
         row.TeamSlug.Should().Be("texas-longhorns");
+        row.AthleteSeasonId.Should().Be(season2026.Id); // the lineup-slot scoring join
         row.OpponentName.Should().Be("Oklahoma Sooners");
         row.OpponentSlug.Should().Be("oklahoma-sooners");
         row.OpponentDefPerGame.Should().Be(250.0m);
+        // Contest anchor for slot locking (kickoff−5 derives from it).
+        row.ContestId.Should().NotBeNull();
+        row.ContestStartUtc.Should().Be(new DateTime(2026, 9, 6, 0, 0, 0, DateTimeKind.Utc));
 
         row.CurrentSeason.Should().NotBeNull();
         row.CurrentSeason!.SeasonYear.Should().Be(2026);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsForSeasonWeekQueryValidatorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsForSeasonWeekQueryValidatorTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsForSeasonWeek;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests.Queries;
+
+/// <summary>
+/// The validator is the only guard between a bad week/phase value and a
+/// silent empty slate (out-of-range values match no SeasonWeek rows —
+/// they don't error). The handler itself is a thin Dapper pass-through
+/// and is not unit-tested; the validator carries the behavior worth
+/// pinning.
+/// </summary>
+public class GetMatchupsForSeasonWeekQueryValidatorTests
+{
+    private readonly GetMatchupsForSeasonWeekQueryValidator _validator;
+
+    public GetMatchupsForSeasonWeekQueryValidatorTests()
+    {
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.Setup(x => x.UtcNow())
+            .Returns(new DateTime(2026, 8, 26, 0, 0, 0, DateTimeKind.Utc));
+        _validator = new GetMatchupsForSeasonWeekQueryValidator(dateTimeProvider.Object);
+    }
+
+    [Theory]
+    [InlineData(1)]  // Preseason
+    [InlineData(2)]  // Regular Season
+    [InlineData(3)]  // Postseason
+    [InlineData(4)]  // Off Season
+    public void KnownPhaseTypeCodes_AreValid(int typeCode)
+    {
+        var result = _validator.Validate(new GetMatchupsForSeasonWeekQuery(2026, 4, typeCode));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    [InlineData(999)]
+    [InlineData(-1)]
+    public void UnknownPhaseTypeCodes_AreRejected(int typeCode)
+    {
+        var result = _validator.Validate(new GetMatchupsForSeasonWeekQuery(2026, 4, typeCode));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e =>
+            e.PropertyName == nameof(GetMatchupsForSeasonWeekQuery.SeasonPhaseTypeCode));
+    }
+
+    [Fact]
+    public void OmittedPhase_DefaultsToRegularSeason_AndIsValid()
+    {
+        var query = new GetMatchupsForSeasonWeekQuery(2026, 4);
+
+        query.SeasonPhaseTypeCode.Should().Be(2);
+        _validator.Validate(query).IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(1999, 4)]   // year too early
+    [InlineData(2028, 4)]   // more than one year out (clock fixed at 2026)
+    [InlineData(2026, 0)]   // week below range
+    [InlineData(2026, 31)]  // week above range
+    public void OutOfRangeYearOrWeek_IsRejected(int year, int week)
+    {
+        var result = _validator.Validate(new GetMatchupsForSeasonWeekQuery(year, week));
+
+        result.IsValid.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Player Pick'em roster **persistence** — localStorage dies, real server-side lineups arrive, with per-player derived locking and the one-game-per-league model. Design doc: `docs/features/player-pickem/roster-persistence.md`. Alpha targeting week 3–4 of the 2026 season.

## League model: `GroupType` enum, one game per league

`PickemGroup.GroupType` (`TeamPickem = 0` / `PlayerPickem`) — operator-ratified, refined twice during design:
- A roster league is a **different league**, not a companion mode on a team-pick group — two scoring systems in one group is asking for trouble; invite the same friends to a second league.
- An **enum, not capability flags**: the games are mutually exclusive, and the enum makes the invalid both-enabled state unrepresentable where flags would force every consumer to police it.
- `TeamPickem = 0` keeps every existing row correct by default. Creation-flow support for PlayerPickem leagues is the **next vertical**; until then `UPDATE "PickemGroup" SET "GroupType" = 1` is the documented admin substitute.

## Entities + locking

`PlayerLineup` (unique per group/user/year/week) + `PlayerLineupSlot` (fixed v1 shape, `DEF` reserved; soft canonical refs + render snapshot — the pick-table pattern).

**Locking is derived, never stored** — the same kickoff−5 `IsStartLocked` rule team picks use, so schedule moves self-heal and the future commissioner weekly-lock option becomes a read-side change. Lock evaluation is **fully server-authoritative**: one `GetMatchupsForSeasonWeek` call resolves every team's contest + kickoff; the stored anchor is what the *server* resolved (the command carries no contest fields); and a slot with a null anchor (carry-over clone) still lock-checks against the current resolution — closing the swap-out-mid-game hole. Writes **fail closed** when matchup resolution is unavailable; the read-side lazy clone fails open.

**Carry-over = lazy clone** on first read of a new week, re-resolving every athlete's new-week contest. No fleet-wide rollover job.

## Routing + UI

- `UserDto` memberships + `LeagueSummaryDto` carry `groupType`; home-page and league-overview cards route PlayerPickem leagues to the roster builder.
- The builder resolves the user's PlayerPickem league per sport — **the sport is a fact of the leagues, not a free choice**; the toggle renders only when leagues span sports.
- Locked slots badge 🔒 and hide dead affordances; server validation messages surface verbatim; grid pages at 10 (each athlete is a two-line row pair).
- Feed contract: `AthleteMatchupSummaryDto` gains `AthleteSeasonId` (the scoring join), `ContestId`, `ContestStartUtc`.

## Two bugs found by operator E2E, fixed here

1. **EF navigation-discovery state bug**: a slot added to an *already-tracked* lineup via `lineup.Slots.Add(...)` was marked `Modified` (client-set Guid key → EF can't tell new from pre-existing), producing `UPDATE … WHERE Id = <fresh guid>` → 0 rows → `DbUpdateConcurrencyException`. Explicit `DbSet.Add` pins `Added`. The InMemory test provider doesn't throw on missing-row updates — why 17 green tests missed it.
2. `WeekMatchupMap` stamps `DateTimeKind.Utc` on wire-deserialized kickoffs (defensive; Npgsql `timestamptz`).

## Validation

- 17 lineup handler tests: gates (incl. TeamPickem-league Forbid), shape violations, server-resolved anchors, byes, duplicates, both lock paths (incl. the clone-hole case), fail-closed, lazy clone + re-resolution, derived `isLocked`
- Api 735; Producer matchup 13 (contract assertions on the new feed fields); web 26 vitest + ESLint + prod build; migration applied + verified locally
- Operator E2E: `GroupType` routing, league auto-resolution, full 8-slot roster persisted (incl. reproducing + confirming the concurrency fix), real server-resolved contest anchors

## Deferred (recorded in the design doc)

Standalone PlayerPickem league **creation flow** + team-pick UI gating for player leagues · **DEF slot** wiring · mobile swap off AsyncStorage · `ContestStartTimeUpdated` slot updater · small-sample disclosure on opponent allowances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-backed Player Pick’em roster persistence across devices.
  * Players can load, assign, replace, and remove eligible roster slots.
  * Roster slots lock at kickoff, with locked controls clearly displayed.
  * Added automatic week-to-week roster carry-over, including bye and departed-player handling.
  * Added Player Pick’em league identification and dedicated navigation.
* **Bug Fixes**
  * Improved validation for duplicate athletes, invalid positions, locked slots, and league access.
  * Improved matchup accuracy across preseason, regular season, and postseason weeks.
* **Documentation**
  * Added Player Pick’em roster-persistence design documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->