### PR TITLE
Phase-aware league weeks + unified league picks route

### DIFF
--- a/docs/features/phase-aware-league-weeks.md
+++ b/docs/features/phase-aware-league-weeks.md
@@ -44,15 +44,17 @@ The fix is not a URL scheme; it is threading phase through all three.
 - `MatchupScheduleProcessor` fetches by `command.SeasonWeekId` instead
   of (year, number). This alone restores preseason syncs for the test
   league and makes every future postseason sync correct by construction.
-- `PickemGroupWeek` + `PickemGroupMatchup` gain `SeasonPhaseTypeCode`
-  (int, migration) stamped from the Matchup DTO on sync.
+- `PickemGroupWeek` gains `SeasonPhaseTypeCode` (int, migration)
+  stamped from the Matchup DTO on sync. (Matchups reach every consumer
+  through their GroupWeek — no per-matchup copy.)
 - Backfill: one-time UPDATE joining existing rows to canonical
   SeasonWeek data (ops step, local + prod).
 - League DTOs (GetMe membership + league summary): ADDITIVE
   `seasonWeekDetails: [{ seasonWeekId, week, phase }]` alongside the
   existing `seasonWeeks` int list (mobile keeps working untouched;
   mobile adopts later). `phase` is a slug: `preseason` | `regular` |
-  `postseason` (TypeCode 1/2/3).
+  `postseason` | `offseason` (TypeCode 1/2/3/4 — offseason surfaced in
+  real data during backfill and is labeled honestly).
 
 ### Web
 

--- a/docs/features/phase-aware-league-weeks.md
+++ b/docs/features/phase-aware-league-weeks.md
@@ -1,0 +1,107 @@
+# Phase-Aware League Weeks
+
+Status: IMPLEMENTED 2026-08-26 (authorized same day; see Deviations)
+Date: 2026-08-26
+
+## The defect chain
+
+Week numbers repeat across `SeasonPhase`s within one season year (NFL
+2026: Preseason 1-4, Regular 1-18, Postseason 1-5). Three layers
+currently erase the phase:
+
+1. **Fetch**: `MatchupScheduleProcessor` calls
+   `GetMatchupsForSeasonWeek(year, weekNumber)` — even though its
+   command ALREADY carries the phase-precise `SeasonWeekId`. The
+   number-based call is where ambiguity enters. (Now regular-scoped by
+   default, which also means the NFL preseason test league can never
+   sync a preseason slate again — an unintended regression of intent.)
+2. **Storage/display model**: `PickemGroupWeek`/`PickemGroupMatchup`
+   store `SeasonWeekId` but not phase, and the league DTO exposes
+   `seasonWeeks` as a bare int list. A league spanning preseason +
+   regular season has TWO "week 4"s the UI cannot distinguish.
+3. **URL**: `/picks/weeks/4` (and every earlier variant) cannot say
+   which week 4. This bites NCAAFB and NFL both at postseason.
+
+The fix is not a URL scheme; it is threading phase through all three.
+
+## Design
+
+### Producer
+
+- `GetMatchupsForSeasonWeek.sql`: SELECT adds
+  `sp."TypeCode" AS "SeasonPhaseTypeCode"` (join already exists).
+- NEW query variant: matchups **by SeasonWeekId**
+  (`WHERE c."SeasonWeekId" = @SeasonWeekId`) — endpoint
+  `contests/matchups/by-season-week-id/{seasonWeekId}` + client method.
+  Precise identity, no phase/number ambiguity, works for ANY phase.
+- `Matchup` DTO gains `SeasonPhaseTypeCode` (int) — additive.
+- The number-based endpoint keeps its TypeCode filter (default 2) for
+  callers that genuinely mean "regular-season week N" (map page,
+  player-lineup anchoring).
+
+### API
+
+- `MatchupScheduleProcessor` fetches by `command.SeasonWeekId` instead
+  of (year, number). This alone restores preseason syncs for the test
+  league and makes every future postseason sync correct by construction.
+- `PickemGroupWeek` + `PickemGroupMatchup` gain `SeasonPhaseTypeCode`
+  (int, migration) stamped from the Matchup DTO on sync.
+- Backfill: one-time UPDATE joining existing rows to canonical
+  SeasonWeek data (ops step, local + prod).
+- League DTOs (GetMe membership + league summary): ADDITIVE
+  `seasonWeekDetails: [{ seasonWeekId, week, phase }]` alongside the
+  existing `seasonWeeks` int list (mobile keeps working untouched;
+  mobile adopts later). `phase` is a slug: `preseason` | `regular` |
+  `postseason` (TypeCode 1/2/3).
+
+### Web
+
+- Canonical URL (always, both games):
+  `/app/league/{leagueId}/picks/phase/{phase}/weeks/{week}` — the
+  user-approved shape. `leaguePicksPath(leagueId, week, phase)` emits it;
+  phase-less forms redirect to canonical once the week's phase resolves.
+- PicksPage week model becomes phase-aware: the week list renders from
+  `seasonWeekDetails` (falling back to `seasonWeeks` as regular during
+  rollout), the route (phase, week) pair selects the entry, and
+  navigations emit both segments. `LeagueWeekSelector` labels
+  non-regular weeks (e.g. "Pre W4", "Post W1").
+- Roster builder stays pinned (regular, week 1) → canonical
+  `/picks/phase/regular/weeks/1` until its week selector lands.
+
+## Sequencing
+
+1. Producer vertical (SQL, by-id query + endpoint + client, DTO field).
+2. API vertical (processor by-id fetch, migration + stamp, DTO
+   additive, backfill script).
+3. Web vertical (paths + PicksPage week model + selector labels).
+
+Each step is independently shippable; step 1+2 fix the preseason-sync
+regression even before the web work lands.
+
+## Deviations from the proposal (as implemented)
+
+- Phase is stamped on `PickemGroupWeek` only, NOT on
+  `PickemGroupMatchup` — the matchup's week context reaches every
+  consumer through its GroupWeek, and a second copy had no reader.
+- `CurrentSeasonWeek` selection (GetMe) now orders phase-then-week —
+  chronological by construction — instead of bare week number, which
+  mis-picked regular Week 1 over a pending preseason Week 4.
+  `CurrentSeasonWeekId` disambiguates it fully.
+- The backfill surfaced 5 OFF-SEASON league weeks (TypeCode 4); the
+  slug set gained "offseason" to label them honestly.
+- Data fetches (picks, matchups) remain NUMBER-based `(league, week)`.
+  A league holding BOTH phases of the same week number would fetch
+  ambiguously — acceptable today (no such league exists; the test
+  league is preseason-only), and the tracked prerequisite for real
+  postseason pick'em is moving those endpoints to SeasonWeekId.
+- Phase-less `/weeks/N` URLs are accepted and redirect to the canonical
+  phase-qualified URL by adopting the first matching entry's phase.
+
+## Out of scope
+
+- Mobile adoption of `seasonWeekDetails` (additive; batch with next EAS
+  round).
+- Player Pick'em week selector (separate tracked alpha-blocker; will
+  consume the same phase-aware model).
+- Postseason league mechanics (CFP bracket pass, playoff pick'em) —
+  this design only guarantees their week identity won't collide.

--- a/sql/pgsql/backfill_pickemgroupweek_phase.sql
+++ b/sql/pgsql/backfill_pickemgroupweek_phase.sql
@@ -1,3 +1,11 @@
+-- ============================================================================
+-- MANUAL RELEASE STEP — NOT DIRECTLY EXECUTABLE.
+-- This file is a cross-database RUNBOOK: the mapping is exported from each
+-- Producer DB and applied to the API DB, so `psql -f` on this file alone
+-- performs no work by design. Run the numbered steps below verbatim.
+-- Required BEFORE repair_phantom_league_weeks.sql.
+-- ============================================================================
+--
 -- One-time backfill: PickemGroupWeek.SeasonPhaseTypeCode (added 2026-08-26,
 -- migration PickemGroupWeekSeasonPhase; default 2 = regular season).
 -- Week numbers repeat across SeasonPhases within a season year, so week

--- a/sql/pgsql/backfill_pickemgroupweek_phase.sql
+++ b/sql/pgsql/backfill_pickemgroupweek_phase.sql
@@ -1,0 +1,22 @@
+-- One-time backfill: PickemGroupWeek.SeasonPhaseTypeCode (added 2026-08-26,
+-- migration PickemGroupWeekSeasonPhase; default 2 = regular season).
+-- Week numbers repeat across SeasonPhases within a season year, so week
+-- identity needs the phase; rows created before the migration carry the
+-- default and must be corrected from canonical SeasonWeek data.
+--
+-- Cross-database: the API DB (sdApi.All) has no SeasonWeek table — phase
+-- truth lives in each Producer DB. Run per sport:
+--
+--   1. Against sdProducer.<Sport>, export the mapping:
+--        \copy (SELECT sw."Id", sp."TypeCode" FROM public."SeasonWeek" sw JOIN public."SeasonPhase" sp ON sp."Id" = sw."SeasonPhaseId") TO '/tmp/sw_phase.csv' CSV
+--   2. Against sdApi.All, load and apply:
+--        CREATE TEMP TABLE sw_phase ("SeasonWeekId" uuid, "TypeCode" int);
+--        \copy sw_phase FROM '/tmp/sw_phase.csv' CSV
+--        UPDATE public."PickemGroupWeek" w
+--        SET    "SeasonPhaseTypeCode" = p."TypeCode"
+--        FROM   sw_phase p
+--        WHERE  p."SeasonWeekId" = w."SeasonWeekId"
+--          AND  w."SeasonPhaseTypeCode" IS DISTINCT FROM p."TypeCode";
+--
+-- Idempotent (the DISTINCT FROM guard); safe to re-run. Verify with:
+--   SELECT "SeasonPhaseTypeCode", count(*) FROM public."PickemGroupWeek" GROUP BY 1;

--- a/sql/pgsql/repair_phantom_league_weeks.sql
+++ b/sql/pgsql/repair_phantom_league_weeks.sql
@@ -1,0 +1,62 @@
+-- One-time repair: phantom NCAA league weeks keyed to contest-less
+-- SeasonWeeks (2026-08-27, follows backfill_pickemgroupweek_phase.sql).
+--
+-- Root cause: NCAA's "Preseason Week 1" SeasonWeek spans Feb-Aug (an
+-- ESPN calendar artifact with ZERO contests ever), so every full-season
+-- NCAA league's date window overlapped it and bootstrap created a
+-- PickemGroupWeek keyed to it; the old number-based matchup fetch then
+-- stored REGULAR-SEASON week-1 games under that preseason-keyed row.
+-- Off-season rows (also contest-less) produced empty duplicates the
+-- same way. Fixed forward in Producer (week resolution now requires a
+-- week to HAVE contests); this repairs existing rows.
+--
+-- Scope: NCAA leagues only (Sport = 2). NFL preseason league weeks
+-- (Sport = 3, phase 1) are CORRECT — real preseason games — untouched.
+-- Safe for picks: PickemGroupUserPick keys on ContestId, not week.
+-- Idempotent: re-running matches nothing once repaired.
+--
+-- Run against sdApi.All:
+
+BEGIN;
+
+-- 1. Move matchups from each phantom preseason-keyed week to its
+--    regular-season twin (same group, same week number).
+UPDATE public."PickemGroupMatchup" m
+SET    "SeasonWeekId" = reg."SeasonWeekId"
+FROM   public."PickemGroupWeek" ph
+JOIN   public."PickemGroup" g   ON g."Id" = ph."GroupId" AND g."Sport" = 2
+JOIN   public."PickemGroupWeek" reg
+       ON  reg."GroupId" = ph."GroupId"
+       AND reg."SeasonWeek" = ph."SeasonWeek"
+       AND reg."SeasonPhaseTypeCode" = 2
+WHERE  ph."SeasonPhaseTypeCode" = 1
+  AND  m."GroupId" = ph."GroupId"
+  AND  m."SeasonWeekId" = ph."SeasonWeekId";
+
+-- 2. The twin now owns the matchups; carry the generated flag.
+UPDATE public."PickemGroupWeek" reg
+SET    "AreMatchupsGenerated" = true
+FROM   public."PickemGroupWeek" ph
+JOIN   public."PickemGroup" g ON g."Id" = ph."GroupId" AND g."Sport" = 2
+WHERE  ph."SeasonPhaseTypeCode" = 1
+  AND  ph."AreMatchupsGenerated"
+  AND  reg."GroupId" = ph."GroupId"
+  AND  reg."SeasonWeek" = ph."SeasonWeek"
+  AND  reg."SeasonPhaseTypeCode" = 2;
+
+-- 3. Drop the phantoms: NCAA preseason- and offseason-keyed week rows.
+--    (Any matchups they held were moved in step 1; offseason rows never
+--    held any.)
+DELETE FROM public."PickemGroupWeek" ph
+USING  public."PickemGroup" g
+WHERE  g."Id" = ph."GroupId"
+  AND  g."Sport" = 2
+  AND  ph."SeasonPhaseTypeCode" IN (1, 4);
+
+COMMIT;
+
+-- Verify: expect zero rows.
+SELECT g."Name", w."SeasonWeek", w."SeasonPhaseTypeCode"
+FROM   public."PickemGroupWeek" w
+JOIN   public."PickemGroup" g ON g."Id" = w."GroupId"
+WHERE  g."Sport" = 2 AND w."SeasonPhaseTypeCode" IN (1, 4);

--- a/sql/pgsql/repair_phantom_league_weeks.sql
+++ b/sql/pgsql/repair_phantom_league_weeks.sql
@@ -17,10 +17,16 @@
 --
 -- Run against sdApi.All:
 
+-- Duplicate-safety note: PickemGroupMatchup carries a UNIQUE
+-- (GroupId, ContestId) index, so a contest cannot exist under two weeks
+-- of one group — the move in step 1 can never collide with a row
+-- already on the twin.
+
 BEGIN;
 
 -- 1. Move matchups from each phantom preseason-keyed week to its
---    regular-season twin (same group, same week number).
+--    regular-season twin (same group, same week number). Phantom rows
+--    WITHOUT a twin are deliberately not touched — see step 3.
 UPDATE public."PickemGroupMatchup" m
 SET    "SeasonWeekId" = reg."SeasonWeekId"
 FROM   public."PickemGroupWeek" ph
@@ -44,19 +50,31 @@ WHERE  ph."SeasonPhaseTypeCode" = 1
   AND  reg."SeasonWeek" = ph."SeasonWeek"
   AND  reg."SeasonPhaseTypeCode" = 2;
 
--- 3. Drop the phantoms: NCAA preseason- and offseason-keyed week rows.
---    (Any matchups they held were moved in step 1; offseason rows never
---    held any.)
+-- 3. Drop phantoms ONLY when they hold no matchups. The FK from
+--    PickemGroupMatchup to PickemGroupWeek cascades, so an unguarded
+--    delete of a phantom that still holds matchups (no regular twin to
+--    receive them in step 1) would destroy those matchups. Such rows
+--    survive this script and surface in the verify query below for
+--    manual repair.
 DELETE FROM public."PickemGroupWeek" ph
 USING  public."PickemGroup" g
 WHERE  g."Id" = ph."GroupId"
   AND  g."Sport" = 2
-  AND  ph."SeasonPhaseTypeCode" IN (1, 4);
+  AND  ph."SeasonPhaseTypeCode" IN (1, 4)
+  AND  NOT EXISTS (
+         SELECT 1 FROM public."PickemGroupMatchup" m
+         WHERE  m."GroupId" = ph."GroupId"
+           AND  m."SeasonWeekId" = ph."SeasonWeekId");
 
 COMMIT;
 
--- Verify: expect zero rows.
-SELECT g."Name", w."SeasonWeek", w."SeasonPhaseTypeCode"
+-- Verify: expect zero rows. Any survivor is a phantom still holding
+-- matchups with no regular-season twin — create the twin (or decide the
+-- matchups' fate) manually before re-running.
+SELECT g."Name", w."SeasonWeek", w."SeasonPhaseTypeCode", count(m."GroupId") AS matchups
 FROM   public."PickemGroupWeek" w
 JOIN   public."PickemGroup" g ON g."Id" = w."GroupId"
-WHERE  g."Sport" = 2 AND w."SeasonPhaseTypeCode" IN (1, 4);
+LEFT JOIN public."PickemGroupMatchup" m
+       ON m."GroupId" = w."GroupId" AND m."SeasonWeekId" = w."SeasonWeekId"
+WHERE  g."Sport" = 2 AND w."SeasonPhaseTypeCode" IN (1, 4)
+GROUP BY 1, 2, 3;

--- a/src/SportsData.Api/Application/Athletes/AthletesController.cs
+++ b/src/SportsData.Api/Application/Athletes/AthletesController.cs
@@ -25,11 +25,12 @@ public class AthletesController : ApiControllerBase
         [FromQuery] string position,
         [FromQuery] int seasonYear,
         [FromQuery] int week,
+        [FromQuery] string? phase,
         [FromServices] IGetPickemAthletesQueryHandler handler,
         CancellationToken cancellationToken)
     {
         var result = await handler.ExecuteAsync(
-            new GetPickemAthletesQuery(sport, league, position, seasonYear, week),
+            new GetPickemAthletesQuery(sport, league, position, seasonYear, week, phase ?? "regular"),
             cancellationToken);
         return result.ToActionResult();
     }

--- a/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQuery.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQuery.cs
@@ -1,8 +1,10 @@
 namespace SportsData.Api.Application.Athletes.Queries.GetPickemAthletes;
 
+/// <param name="Phase">Week-number phase slug — "preseason" | "regular" | "postseason". Week numbers restart per phase.</param>
 public record GetPickemAthletesQuery(
     string Sport,
     string League,
     string Position,
     int SeasonYear,
-    int Week);
+    int Week,
+    string Phase = "regular");

--- a/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryHandler.cs
@@ -70,8 +70,14 @@ public class GetPickemAthletesQueryHandler : IGetPickemAthletesQueryHandler
         try
         {
             var client = _athleteClientFactory.Resolve(mode);
+            var phaseTypeCode = query.Phase switch
+            {
+                "preseason" => 1,
+                "postseason" => 3,
+                _ => 2,
+            };
             return await client.GetAthleteMatchupSummaries(
-                query.Position, query.SeasonYear, query.Week, cancellationToken);
+                query.Position, query.SeasonYear, query.Week, phaseTypeCode, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryValidator.cs
+++ b/src/SportsData.Api/Application/Athletes/Queries/GetPickemAthletes/GetPickemAthletesQueryValidator.cs
@@ -30,5 +30,9 @@ public class GetPickemAthletesQueryValidator : AbstractValidator<GetPickemAthlet
         RuleFor(x => x.Week)
             .InclusiveBetween(1, 30)
             .WithMessage("Week must be between 1 and 30");
+
+        RuleFor(x => x.Phase)
+            .Must(p => p is "preseason" or "regular" or "postseason")
+            .WithMessage("Phase must be 'preseason', 'regular', or 'postseason'");
     }
 }

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -109,16 +109,30 @@ namespace SportsData.Api.Application.Processors
             // 2. are there conferences to always be included?
             var conferenceSlugs = group.Conferences.Select(x => x.ConferenceSlug).ToList();
 
+            // Fetch by SeasonWeekId — the PRECISE week identity the command
+            // already carries. Number-based lookups are phase-ambiguous
+            // (NFL 2026 has a week 4 in preseason, regular season, AND
+            // postseason) and the number endpoint is regular-scoped by
+            // default, which would silently break preseason/postseason
+            // league weeks. The id form syncs any phase correctly.
             var matchupsResult = await _contestClientFactory
                 .Resolve(group.Sport)
-                .GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek);
+                .GetMatchupsBySeasonWeekId(command.SeasonWeekId);
 
             if (!matchupsResult.IsSuccess)
             {
-                _logger.LogWarning("Failed to retrieve matchups for season {Year} week {Week}. Skipping.", command.SeasonYear, command.SeasonWeek);
+                _logger.LogWarning("Failed to retrieve matchups for season {Year} week {Week} (SeasonWeekId={SeasonWeekId}). Skipping.", command.SeasonYear, command.SeasonWeek, command.SeasonWeekId);
                 return;
             }
             var allMatchups = matchupsResult.Value;
+
+            // Stamp the week's phase from the canonical matchup data — all
+            // matchups of one SeasonWeekId share a phase by construction.
+            var phaseTypeCode = allMatchups.FirstOrDefault()?.SeasonPhaseTypeCode;
+            if (phaseTypeCode is > 0 && groupWeek.SeasonPhaseTypeCode != phaseTypeCode)
+            {
+                groupWeek.SeasonPhaseTypeCode = phaseTypeCode.Value;
+            }
 
             // League window filter — excludes contests whose kickoff falls outside
             // [StartsOn, EndsOn]. Null bounds mean "no constraint" (full-season league),

--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueSummaryDto.cs
@@ -51,6 +51,14 @@
         public List<int> SeasonWeeks { get; set; } = [];
 
         /// <summary>
+        /// Phase-qualified week identities, ordered phase-then-week. Week
+        /// numbers repeat across season phases, so <see cref="SeasonWeeks"/>
+        /// under-identifies a week; the UI routes and renders from this
+        /// list. ADDITIVE — existing consumers of SeasonWeeks unaffected.
+        /// </summary>
+        public List<Application.User.Dtos.LeagueSeasonWeekDetailDto> SeasonWeekDetails { get; set; } = [];
+
+        /// <summary>
         /// Set once the group's season has passed. Non-null means the league is
         /// read-only: it cannot be cloned (the clone handler rejects it) and the
         /// UI hides its Duplicate action. Only populated when the caller opts in

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetUserLeagues/GetUserLeaguesQueryHandler.cs
@@ -28,6 +28,11 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
     {
         var leagues = await _dbContext.PickemGroupMembers
             .AsNoTracking()
+            // Two collection projections (SeasonWeeks + SeasonWeekDetails)
+            // trip the context's throw-on-MultipleCollectionIncludeWarning
+            // under Npgsql (InMemory tests are blind to it) — split, same
+            // as GetMe.
+            .AsSplitQuery()
             .Where(m => m.UserId == query.UserId)
             // Hide deactivated leagues unless the caller opts in — matches the
             // filter on /user/me. Opting in is how the My Leagues page powers its
@@ -55,6 +60,21 @@ public class GetUserLeaguesQueryHandler : IGetUserLeaguesQueryHandler
                     .Select(w => w.SeasonWeek)
                     .Distinct()
                     .OrderBy(w => w)
+                    .ToList(),
+                // Collision-free week identities (numbers repeat across
+                // phases) — mirrors the projection on /user/me.
+                SeasonWeekDetails = m.Group.Weeks
+                    .OrderBy(w => w.SeasonPhaseTypeCode)
+                    .ThenBy(w => w.SeasonWeek)
+                    .Select(w => new Application.User.Dtos.LeagueSeasonWeekDetailDto
+                    {
+                        SeasonWeekId = w.SeasonWeekId,
+                        Week = w.SeasonWeek,
+                        Phase = w.SeasonPhaseTypeCode == 1 ? "preseason"
+                            : w.SeasonPhaseTypeCode == 3 ? "postseason"
+                            : w.SeasonPhaseTypeCode == 4 ? "offseason"
+                            : "regular",
+                    })
                     .ToList(),
                 DeactivatedUtc = m.Group.DeactivatedUtc,
                 CreatedUtc = m.Group.CreatedUtc

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/ClearLineupSlot/ClearLineupSlotCommandHandler.cs
@@ -93,9 +93,10 @@ public class ClearLineupSlotCommandHandler : IClearLineupSlotCommandHandler
         WeekMatchupMap weekMap;
         try
         {
-            var matchups = await _contestClientFactory
-                .Resolve(gate.Group!.Sport)
-                .GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek, cancellationToken);
+            var matchups = await LeagueWeekMatchupResolver.ResolveAsync(
+                _dataContext,
+                _contestClientFactory.Resolve(gate.Group!.Sport),
+                command.LeagueId, command.SeasonYear, command.SeasonWeek, cancellationToken);
 
             if (!matchups.IsSuccess)
             {

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Commands/UpsertLineupSlot/UpsertLineupSlotCommandHandler.cs
@@ -96,9 +96,10 @@ public class UpsertLineupSlotCommandHandler : IUpsertLineupSlotCommandHandler
         WeekMatchupMap weekMap;
         try
         {
-            var matchups = await _contestClientFactory
-                .Resolve(gate.Group!.Sport)
-                .GetMatchupsForSeasonWeek(command.SeasonYear, command.SeasonWeek, cancellationToken);
+            var matchups = await LeagueWeekMatchupResolver.ResolveAsync(
+                _dataContext,
+                _contestClientFactory.Resolve(gate.Group!.Sport),
+                command.LeagueId, command.SeasonYear, command.SeasonWeek, cancellationToken);
 
             if (!matchups.IsSuccess)
             {

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
@@ -122,9 +122,10 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
         WeekMatchupMap weekMap;
         try
         {
-            var matchups = await _contestClientFactory
-                .Resolve(group.Sport)
-                .GetMatchupsForSeasonWeek(query.SeasonYear, query.SeasonWeek, cancellationToken);
+            var matchups = await LeagueWeekMatchupResolver.ResolveAsync(
+                _dataContext,
+                _contestClientFactory.Resolve(group.Sport),
+                query.LeagueId, query.SeasonYear, query.SeasonWeek, cancellationToken);
 
             if (!matchups.IsSuccess)
             {

--- a/src/SportsData.Api/Application/UI/PlayerLineups/WeekMatchups.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/WeekMatchups.cs
@@ -1,6 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Infrastructure.Clients.Contest;
 
 namespace SportsData.Api.Application.UI.PlayerLineups;
+
+/// <summary>
+/// Resolves the week's matchups for a LEAGUE week. Prefers the league's
+/// own PickemGroupWeek row: its SeasonWeekId is the precise (phase-
+/// qualified) identity, so a preseason-only league anchors to preseason
+/// games — a bare (year, number) lookup is regular-scoped and would
+/// anchor to the wrong phase. Falls back to the number query for weeks
+/// the league hasn't materialized (Player Pick'em leagues may play
+/// weeks with no team-pick slate).
+/// </summary>
+internal static class LeagueWeekMatchupResolver
+{
+    internal static async Task<Result<List<Matchup>>> ResolveAsync(
+        AppDataContext dataContext,
+        IProvideContests contestClient,
+        Guid leagueId,
+        int seasonYear,
+        int seasonWeek,
+        CancellationToken cancellationToken)
+    {
+        var seasonWeekId = await dataContext.PickemGroupWeeks
+            .AsNoTracking()
+            .Where(w => w.GroupId == leagueId &&
+                        w.SeasonYear == seasonYear &&
+                        w.SeasonWeek == seasonWeek)
+            .OrderBy(w => w.SeasonPhaseTypeCode)
+            .Select(w => (Guid?)w.SeasonWeekId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return seasonWeekId is not null
+            ? await contestClient.GetMatchupsBySeasonWeekId(seasonWeekId.Value, cancellationToken)
+            : await contestClient.GetMatchupsForSeasonWeek(seasonYear, seasonWeek, cancellationToken);
+    }
+}
 
 /// <summary>
 /// Team-slug → (ContestId, StartUtc) lookup for one season-week, built

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -75,5 +75,38 @@ public class UserDto
         /// the league has no weeks at all.
         /// </summary>
         public int? CurrentSeasonWeek { get; set; }
+
+        /// <summary>
+        /// Phase-qualified week identities, ordered phase-then-week. Week
+        /// NUMBERS repeat across season phases (an NFL league can hold a
+        /// preseason Week 4 AND a regular-season Week 4), so
+        /// <see cref="SeasonWeeks"/> alone under-identifies a week; this
+        /// list is the full identity the UI routes and renders from
+        /// (/picks/phase/{phase}/weeks/{week}). ADDITIVE alongside
+        /// SeasonWeeks — mobile keeps consuming the int list untouched.
+        /// </summary>
+        public IList<LeagueSeasonWeekDetailDto> SeasonWeekDetails { get; set; } = [];
+
+        /// <summary>
+        /// SeasonWeekId of the <see cref="CurrentSeasonWeek"/> entry —
+        /// disambiguates which phase's week the user should be picking
+        /// when numbers collide across phases.
+        /// </summary>
+        public Guid? CurrentSeasonWeekId { get; set; }
     }
+}
+
+/// <summary>
+/// One phase-qualified league week. <see cref="Phase"/> is a slug —
+/// "preseason" | "regular" | "postseason" (SeasonPhase.TypeCode 1/2/3) —
+/// chosen over the int for URL and payload readability. Shared by the
+/// GetMe membership payload and the league summary payload.
+/// </summary>
+public class LeagueSeasonWeekDetailDto
+{
+    public Guid SeasonWeekId { get; set; }
+
+    public int Week { get; set; }
+
+    public string Phase { get; set; } = null!;
 }

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -92,21 +92,53 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                             .Distinct()
                             .OrderBy(w => w)
                             .ToList(),
-                        // "Current week" = smallest SeasonWeek that still has an unstarted
-                        // matchup. Picks-page UX intent: when the user opens the page mid-
-                        // season, drop them on the week they should be picking, not the
-                        // last week of the season. Coalesces to MAX(SeasonWeek) once every
-                        // matchup has kicked off so a season-over visit lands on the most
-                        // recent week instead of nothing.
+                        // "Current week" = first week IN PHASE ORDER (preseason →
+                        // regular → postseason, then week number — chronological
+                        // by construction) that still has an unstarted matchup.
+                        // Picks-page UX intent: when the user opens the page mid-
+                        // season, drop them on the week they should be picking,
+                        // not the last week of the season. Coalesces to the LAST
+                        // week once every matchup has kicked off so a season-over
+                        // visit lands on the most recent week instead of nothing.
                         CurrentSeasonWeek = m.Group.Weeks
                             .Where(w => w.Matchups.Any(mm => mm.StartDateUtc > nowUtc))
-                            .OrderBy(w => w.SeasonWeek)
+                            .OrderBy(w => w.SeasonPhaseTypeCode)
+                            .ThenBy(w => w.SeasonWeek)
                             .Select(w => (int?)w.SeasonWeek)
                             .FirstOrDefault()
                             ?? m.Group.Weeks
-                                .OrderByDescending(w => w.SeasonWeek)
+                                .OrderByDescending(w => w.SeasonPhaseTypeCode)
+                                .ThenByDescending(w => w.SeasonWeek)
                                 .Select(w => (int?)w.SeasonWeek)
-                                .FirstOrDefault()
+                                .FirstOrDefault(),
+                        CurrentSeasonWeekId = m.Group.Weeks
+                            .Where(w => w.Matchups.Any(mm => mm.StartDateUtc > nowUtc))
+                            .OrderBy(w => w.SeasonPhaseTypeCode)
+                            .ThenBy(w => w.SeasonWeek)
+                            .Select(w => (Guid?)w.SeasonWeekId)
+                            .FirstOrDefault()
+                            ?? m.Group.Weeks
+                                .OrderByDescending(w => w.SeasonPhaseTypeCode)
+                                .ThenByDescending(w => w.SeasonWeek)
+                                .Select(w => (Guid?)w.SeasonWeekId)
+                                .FirstOrDefault(),
+                        // Full phase-qualified week identities — what the UI
+                        // routes and renders from. SeasonWeeks (above) keeps
+                        // its dedup because numbers collide across phases;
+                        // this list is the collision-free replacement.
+                        SeasonWeekDetails = m.Group.Weeks
+                            .OrderBy(w => w.SeasonPhaseTypeCode)
+                            .ThenBy(w => w.SeasonWeek)
+                            .Select(w => new LeagueSeasonWeekDetailDto
+                            {
+                                SeasonWeekId = w.SeasonWeekId,
+                                Week = w.SeasonWeek,
+                                Phase = w.SeasonPhaseTypeCode == 1 ? "preseason"
+                                    : w.SeasonPhaseTypeCode == 3 ? "postseason"
+                                    : w.SeasonPhaseTypeCode == 4 ? "offseason"
+                                    : "regular",
+                            })
+                            .ToList()
                     })
                     .ToList()
             })

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroupWeek.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PickemGroupWeek.cs
@@ -16,6 +16,18 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public required Guid SeasonWeekId { get; set; }
 
+        /// <summary>
+        /// SeasonPhase.TypeCode of this week: 1 Preseason, 2 Regular
+        /// Season, 3 Postseason. Week NUMBERS repeat across phases within
+        /// a season year (an NFL league can hold a preseason Week 4 AND a
+        /// regular-season Week 4), so week identity shown to users — and
+        /// in URLs — needs the phase. Stamped by MatchupScheduleProcessor
+        /// from canonical matchup data; default 2 covers pre-existing
+        /// rows, corrected by the one-time backfill
+        /// (sql/pgsql/backfill_pickemgroupweek_phase.sql).
+        /// </summary>
+        public int SeasonPhaseTypeCode { get; set; } = 2;
+
         public bool IsNonStandardWeek { get; set; }
 
         public bool AreMatchupsGenerated { get; set; }
@@ -33,6 +45,7 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.Property(x => x.SeasonYear).IsRequired();
                 builder.Property(x => x.SeasonWeek).IsRequired();
                 builder.Property(x => x.SeasonWeekId).IsRequired();
+                builder.Property(x => x.SeasonPhaseTypeCode).IsRequired().HasDefaultValue(2);
                 builder.Property(x => x.IsNonStandardWeek).IsRequired();
 
                 builder.Property(x => x.AreMatchupsGenerated).IsRequired();

--- a/src/SportsData.Api/Migrations/20260826220804_PickemGroupWeekSeasonPhase.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260826220804_PickemGroupWeekSeasonPhase.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260826220804_PickemGroupWeekSeasonPhase")]
+    partial class PickemGroupWeekSeasonPhase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260826220804_PickemGroupWeekSeasonPhase.cs
+++ b/src/SportsData.Api/Migrations/20260826220804_PickemGroupWeekSeasonPhase.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PickemGroupWeekSeasonPhase : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SeasonPhaseTypeCode",
+                table: "PickemGroupWeek",
+                type: "integer",
+                nullable: false,
+                defaultValue: 2);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SeasonPhaseTypeCode",
+                table: "PickemGroupWeek");
+        }
+    }
+}

--- a/src/SportsData.Core/Dtos/Canonical/Matchup.cs
+++ b/src/SportsData.Core/Dtos/Canonical/Matchup.cs
@@ -9,6 +9,14 @@ using System;
 
         public int SeasonWeek { get; set; }
 
+        /// <summary>
+        /// SeasonPhase.TypeCode of this matchup's week: 1 Preseason,
+        /// 2 Regular Season, 3 Postseason. Week NUMBERS repeat across
+        /// phases within a season year, so consumers that persist or
+        /// display week identity need this alongside SeasonWeek.
+        /// </summary>
+        public int SeasonPhaseTypeCode { get; set; }
+
         public Guid ContestId { get; set; }
 
         public string? Headline { get; set; }

--- a/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClient.cs
@@ -17,7 +17,7 @@ public interface IProvideAthletes : IProvideHealthChecks
     Task<Result<AthleteDetailDto>> GetAthleteDetails(Guid athleteId, CancellationToken cancellationToken = default);
 
     /// <summary>Athletes at a position with their week opponent, the opponent's defensive allowance per game, and current/previous season stat blocks.</summary>
-    Task<Result<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(string position, int seasonYear, int week, CancellationToken cancellationToken = default);
+    Task<Result<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(string position, int seasonYear, int week, int seasonPhaseTypeCode = 2, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -52,10 +52,11 @@ public class AthleteClient : ClientBase, IProvideAthletes
         string position,
         int seasonYear,
         int week,
+        int seasonPhaseTypeCode = 2,
         CancellationToken cancellationToken = default)
     {
         return await GetAsync(
-            $"athletes/matchup-summaries?position={Uri.EscapeDataString(position)}&seasonYear={seasonYear}&week={week}",
+            $"athletes/matchup-summaries?position={Uri.EscapeDataString(position)}&seasonYear={seasonYear}&week={week}&phaseTypeCode={seasonPhaseTypeCode}",
             new AthleteMatchupSummariesDto(),
             entityName: "AthleteMatchupSummaries",
             cancellationToken: cancellationToken);

--- a/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Contest/ContestClient.cs
@@ -88,6 +88,15 @@ public interface IProvideContests : IProvideHealthChecks
     Task<Result<List<Matchup>>> GetMatchupsForSeasonWeek(int year, int week, CancellationToken ct = default);
 
     /// <summary>
+    /// Matchups by SeasonWeek GUID — the precise week identity. Week
+    /// NUMBERS repeat across season phases (NFL: preseason/regular/
+    /// postseason each count from 1); the id form has no such ambiguity
+    /// and works for any phase. Preferred whenever the caller holds a
+    /// SeasonWeekId (the league schedule sync does, end-to-end).
+    /// </summary>
+    Task<Result<List<Matchup>>> GetMatchupsBySeasonWeekId(Guid seasonWeekId, CancellationToken ct = default);
+
+    /// <summary>
     /// Distinct calendar dates (US Eastern) that have at least one scheduled game
     /// in the [from, to] window. Either bound may be null for an open-ended
     /// range. Backs the create-league blackout-date picker and the create-time
@@ -368,6 +377,13 @@ public class ContestClient : ClientBase, IProvideContests
         return await GetAsync<List<Matchup>>(
             $"contests/matchups/by-season-week?year={year}&week={week}",
             new List<Matchup>(), "Matchups for season week", ResultStatus.NotFound, ct);
+    }
+
+    public async Task<Result<List<Matchup>>> GetMatchupsBySeasonWeekId(Guid seasonWeekId, CancellationToken ct = default)
+    {
+        return await GetAsync<List<Matchup>>(
+            $"contests/matchups/by-season-week-id/{seasonWeekId}",
+            new List<Matchup>(), "Matchups for season week id", ResultStatus.NotFound, ct);
     }
 
     public async Task<Result<List<DateOnly>>> GetGameDates(DateTime? from, DateTime? to, CancellationToken ct = default)

--- a/src/SportsData.Producer/Application/Athletes/AthleteController.cs
+++ b/src/SportsData.Producer/Application/Athletes/AthleteController.cs
@@ -51,11 +51,13 @@ public class AthleteController : ControllerBase
         [FromQuery] string position,
         [FromQuery] int seasonYear,
         [FromQuery] int week,
+        // Nullable so an omitted param cannot bind to 0 and match no phase.
+        [FromQuery] int? phaseTypeCode,
         [FromServices] IGetAthleteMatchupSummariesQueryHandler handler,
         CancellationToken cancellationToken)
     {
         var result = await handler.ExecuteAsync(
-            new GetAthleteMatchupSummariesQuery(position, seasonYear, week),
+            new GetAthleteMatchupSummariesQuery(position, seasonYear, week, phaseTypeCode ?? 2),
             cancellationToken);
         return result.ToActionResult();
     }

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQuery.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQuery.cs
@@ -6,4 +6,5 @@ namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteMatchupSumm
 /// <param name="Position">Position abbreviation: QB, RB, WR, TE, or K.</param>
 /// <param name="SeasonYear">The season being played (current-season blocks and opponent lookup).</param>
 /// <param name="Week">The week whose opponent/matchup context is attached.</param>
-public record GetAthleteMatchupSummariesQuery(string Position, int SeasonYear, int Week);
+/// <param name="SeasonPhaseTypeCode">Phase the week number belongs to (1 Preseason, 2 Regular Season, 3 Postseason) — numbers restart per phase.</param>
+public record GetAthleteMatchupSummariesQuery(string Position, int SeasonYear, int Week, int SeasonPhaseTypeCode = 2);

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryHandler.cs
@@ -267,10 +267,11 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
         // hydrates it (all 1,527 local 2026 contests were null), while
         // SeasonWeekId is populated on every one of them.
         //
-        // Scoped to the REGULAR SEASON phase (TypeCode 2): week numbers
-        // restart per phase, so an unscoped Number match would let a
-        // postseason "week 1" overwrite the real week-1 opponent.
-        const int regularSeasonTypeCode = 2;
+        // Scoped to the REQUESTED phase (default 2, regular season): week
+        // numbers restart per phase, so an unscoped Number match would let
+        // a postseason "week 1" overwrite the real week-1 opponent. A
+        // preseason league passes 1 and gets preseason opponents.
+        var phaseTypeCode = query.SeasonPhaseTypeCode;
         var weekContests = await (
                 from c in _dataContext.Contests.AsNoTracking()
                 join sw in _dataContext.SeasonWeeks.AsNoTracking()
@@ -279,7 +280,7 @@ public class GetAthleteMatchupSummariesQueryHandler : IGetAthleteMatchupSummarie
                     on sw.SeasonPhaseId equals sp.Id
                 where c.SeasonYear == query.SeasonYear &&
                       sw.Number == query.Week &&
-                      sp.TypeCode == regularSeasonTypeCode &&
+                      sp.TypeCode == phaseTypeCode &&
                       c.CancelledUtc == null &&
                       (teamFsIds.Contains(c.HomeTeamFranchiseSeasonId) ||
                        teamFsIds.Contains(c.AwayTeamFranchiseSeasonId))

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteMatchupSummaries/GetAthleteMatchupSummariesQueryValidator.cs
@@ -29,5 +29,9 @@ public class GetAthleteMatchupSummariesQueryValidator
         RuleFor(x => x.Week)
             .InclusiveBetween(1, 30)
             .WithMessage("Week must be between 1 and 30");
+
+        RuleFor(x => x.SeasonPhaseTypeCode)
+            .InclusiveBetween(1, 3)
+            .WithMessage("Season phase type code must be 1 (Preseason), 2 (Regular Season), or 3 (Postseason)");
     }
 }

--- a/src/SportsData.Producer/Application/Contests/ContestController.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestController.cs
@@ -450,6 +450,21 @@ namespace SportsData.Producer.Application.Contests
         }
 
         /// <summary>
+        /// Matchups by SeasonWeek GUID — the precise week identity (no
+        /// phase/number ambiguity). Used by the API's league schedule
+        /// sync, whose commands carry SeasonWeekId end-to-end.
+        /// </summary>
+        [HttpGet("matchups/by-season-week-id/{seasonWeekId:guid}")]
+        public async Task<ActionResult<List<Dtos.Canonical.Matchup>>> GetMatchupsBySeasonWeekId(
+            [FromRoute] Guid seasonWeekId,
+            [FromServices] Queries.Matchups.GetMatchupsBySeasonWeekId.IGetMatchupsBySeasonWeekIdQueryHandler handler,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await handler.ExecuteAsync(new Queries.Matchups.GetMatchupsBySeasonWeekId.GetMatchupsBySeasonWeekIdQuery(seasonWeekId), cancellationToken);
+            return result.ToActionResult();
+        }
+
+        /// <summary>
         /// Distinct calendar dates (US Eastern) that have at least one scheduled
         /// game in the [from, to] window. Backs the create-league blackout-date
         /// picker and the create-time zero-game guard. Sport is implicit (this

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQuery.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQuery.cs
@@ -1,0 +1,10 @@
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId;
+
+/// <summary>
+/// Matchups by SeasonWeek GUID — the PRECISE week identity. Unlike
+/// number-based lookups there is no phase ambiguity: one SeasonWeek row
+/// belongs to exactly one SeasonPhase. This is the query the league
+/// schedule sync uses (its commands carry SeasonWeekId end-to-end), so
+/// preseason and postseason league weeks sync correctly by construction.
+/// </summary>
+public record GetMatchupsBySeasonWeekIdQuery(Guid SeasonWeekId);

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQueryHandler.cs
@@ -1,0 +1,63 @@
+using Dapper;
+
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Sql;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId;
+
+public interface IGetMatchupsBySeasonWeekIdQueryHandler
+{
+    Task<Result<List<Matchup>>> ExecuteAsync(
+        GetMatchupsBySeasonWeekIdQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+public class GetMatchupsBySeasonWeekIdQueryHandler : IGetMatchupsBySeasonWeekIdQueryHandler
+{
+    private readonly TeamSportDataContext _dbContext;
+    private readonly ProducerSqlQueryProvider _sqlProvider;
+    private readonly IValidator<GetMatchupsBySeasonWeekIdQuery> _validator;
+
+    public GetMatchupsBySeasonWeekIdQueryHandler(
+        TeamSportDataContext dbContext,
+        ProducerSqlQueryProvider sqlProvider,
+        IValidator<GetMatchupsBySeasonWeekIdQuery> validator)
+    {
+        _dbContext = dbContext;
+        _sqlProvider = sqlProvider;
+        _validator = validator;
+    }
+
+    public async Task<Result<List<Matchup>>> ExecuteAsync(
+        GetMatchupsBySeasonWeekIdQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<List<Matchup>>(
+                default!,
+                ResultStatus.Validation,
+                validation.Errors);
+        }
+
+        var sql = _sqlProvider.GetMatchupsBySeasonWeekId();
+
+        var connection = _dbContext.Database.GetDbConnection();
+        var result = await connection.QueryAsync<Matchup>(
+            new CommandDefinition(sql, new { query.SeasonWeekId }, cancellationToken: cancellationToken));
+
+        return new Success<List<Matchup>>(result.ToList());
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQueryHandler.cs
@@ -9,11 +9,6 @@ using SportsData.Core.Dtos.Canonical;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Sql;
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId;
 
 public interface IGetMatchupsBySeasonWeekIdQueryHandler

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsBySeasonWeekId/GetMatchupsBySeasonWeekIdQueryValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId;
+
+/// <summary>
+/// An empty GUID matches no SeasonWeek and would silently return an
+/// empty slate; reject it up front (same rationale as the number-based
+/// query's validator).
+/// </summary>
+public class GetMatchupsBySeasonWeekIdQueryValidator
+    : AbstractValidator<GetMatchupsBySeasonWeekIdQuery>
+{
+    public GetMatchupsBySeasonWeekIdQueryValidator()
+    {
+        RuleFor(x => x.SeasonWeekId)
+            .NotEmpty()
+            .WithMessage("SeasonWeekId is required");
+    }
+}

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetCurrentSeasonWeek/GetCurrentSeasonWeekQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetCurrentSeasonWeek/GetCurrentSeasonWeekQueryHandler.cs
@@ -38,6 +38,10 @@ public class GetCurrentSeasonWeekQueryHandler : IGetCurrentSeasonWeekQueryHandle
             .Include(sw => sw.Season)
             .Include(sw => sw.SeasonPhase)
             .Where(sw => sw.StartDate <= now && sw.EndDate > now)
+            // Contest-less calendar artifacts (NCAA "Preseason Week 1"
+            // spans Feb-Aug with zero games) must never be "current" —
+            // same discriminator as GetSeasonWeeksByDateRange.
+            .Where(sw => _dbContext.Contests.Any(c => c.SeasonWeekId == sw.Id))
             .OrderBy(sw => sw.StartDate)
             .Select(sw => new CanonicalSeasonWeekDto
             {

--- a/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandler.cs
@@ -24,6 +24,17 @@ public interface IGetSeasonWeeksByDateRangeQueryHandler
 /// <c>To</c> or ends exactly on <c>From</c> still overlaps.
 ///
 /// <para>
+/// Only weeks that HAVE at least one contest are returned. ESPN's
+/// calendar carries administrative weeks with huge date windows and no
+/// games — NCAA "Preseason Week 1" spans Feb-Aug — so a bare date
+/// overlap handed league bootstrap phantom weeks whose numbers collide
+/// with real ones (the Curbstomp preseason-keyed week-1 corruption).
+/// Contest existence is the phase-agnostic discriminator: NFL preseason
+/// weeks (real games) stay eligible, contest-less calendar artifacts
+/// drop out.
+/// </para>
+///
+/// <para>
 /// Empty result is a legitimate <see cref="Success{T}"/> (not a
 /// failure). The most common reason for an empty list is "no
 /// SeasonWeeks are sourced yet for the requested date range" — e.g.
@@ -64,6 +75,7 @@ public class GetSeasonWeeksByDateRangeQueryHandler : IGetSeasonWeeksByDateRangeQ
             .Include(sw => sw.Season)
             .Include(sw => sw.SeasonPhase)
             .Where(sw => sw.StartDate <= query.To && sw.EndDate >= query.From)
+            .Where(sw => _dbContext.Contests.Any(c => c.SeasonWeekId == sw.Id))
             .OrderBy(sw => sw.StartDate)
             .Select(sw => new CanonicalSeasonWeekDto
             {

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -379,6 +379,10 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IGetMatchupsForSeasonWeekQueryHandler, GetMatchupsForSeasonWeekQueryHandler>();
             services.AddScoped<IValidator<Application.Contests.Queries.Matchups.GetMatchupsForSeasonWeek.GetMatchupsForSeasonWeekQuery>,
                 Application.Contests.Queries.Matchups.GetMatchupsForSeasonWeek.GetMatchupsForSeasonWeekQueryValidator>();
+            services.AddScoped<Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId.IGetMatchupsBySeasonWeekIdQueryHandler,
+                Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId.GetMatchupsBySeasonWeekIdQueryHandler>();
+            services.AddScoped<IValidator<Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId.GetMatchupsBySeasonWeekIdQuery>,
+                Application.Contests.Queries.Matchups.GetMatchupsBySeasonWeekId.GetMatchupsBySeasonWeekIdQueryValidator>();
             services.AddScoped<IGetMatchupByContestIdQueryHandler, GetMatchupByContestIdQueryHandler>();
             services.AddScoped<
                 Application.Contests.Queries.GetGameDates.IGetGameDatesQueryHandler,

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsBySeasonWeekId.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsBySeasonWeekId.sql
@@ -77,4 +77,9 @@ LEFT JOIN LATERAL (
   -- this team's entry in it, or NULL = honestly unranked.
   SELECT public.poll_rank_asof(fsHome."Id", fsHome."SeasonYear", c."StartDateUtc") AS "Current"
 ) fsrdHome ON TRUE
-WHERE c."Id" = @ContestId
+-- SeasonWeekId is the PRECISE week identity — one row in SeasonWeek
+-- belongs to exactly one phase, so unlike number-based lookups there is
+-- no phase ambiguity to scope away. This is the query the league
+-- schedule sync uses (its commands carry SeasonWeekId end-to-end).
+WHERE sw."Id" = @SeasonWeekId
+ORDER BY c."StartDateUtc", fHome."Slug"

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsForCurrentWeek.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsForCurrentWeek.sql
@@ -1,6 +1,7 @@
 WITH current_week AS (
   SELECT sw."Id" AS "SeasonWeekId",
          sw."Number" AS "WeekNumber",
+         sp."TypeCode" AS "SeasonPhaseTypeCode",
          s."Id" AS "SeasonId",
          s."Year" AS "SeasonYear"
   FROM public."Season" s
@@ -14,6 +15,7 @@ SELECT
   cw."SeasonWeekId",
   cw."SeasonYear" AS "SeasonYear",
   cw."WeekNumber" AS "SeasonWeek",
+  cw."SeasonPhaseTypeCode",
   c."Id" AS "ContestId",
   cn."Headline" AS "Headline",
   c."StartDateUtc" AS "StartDateUtc",

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsForSeasonWeek.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsForSeasonWeek.sql
@@ -2,6 +2,7 @@ SELECT
   sw."Id" AS "SeasonWeekId",
   s."Year" AS "SeasonYear",
   sw."Number" AS "SeasonWeek",
+  sp."TypeCode" AS "SeasonPhaseTypeCode",
   c."Id" AS "ContestId",
   cn."Headline" AS "Headline",
   c."StartDateUtc" AS "StartDateUtc",

--- a/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
+++ b/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
@@ -15,6 +15,7 @@ public class ProducerSqlQueryProvider
         "GetMatchupForPreviewBatch.sql",
         "GetMatchupsForCurrentWeek.sql",
         "GetMatchupsForSeasonWeek.sql",
+        "GetMatchupsBySeasonWeekId.sql",
         "GetGameDates.sql",
         "GetMatchupByContestId.sql",
         "GetRankingsByPollByWeek.sql",
@@ -97,6 +98,8 @@ public class ProducerSqlQueryProvider
     public string GetMatchupsForCurrentWeek() => Get("GetMatchupsForCurrentWeek.sql");
 
     public string GetMatchupsForSeasonWeek() => Get("GetMatchupsForSeasonWeek.sql");
+
+    public string GetMatchupsBySeasonWeekId() => Get("GetMatchupsBySeasonWeekId.sql");
 
     public string GetGameDates() => Get("GetGameDates.sql");
 

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -10,14 +10,13 @@ import { setGlobalApiErrorHandler } from "api/apiClient";
 import { useContestUpdates } from "./contexts/ContestUpdatesContext";
 
 import ErrorPage from "components/common/ErrorPage";
-import PicksPage from "./components/picks/PicksPage.jsx";
 import LeaderboardPage from "./components/leaderboard/LeaderboardPage.jsx";
 import MessageBoardPage from "./components/messageboard/MessageboardPage.jsx";
 import HomePage from "./components/home/HomePage.jsx";
 import WarRoomPage from "./components/warRoom/WarRoomPage.jsx";
 import SettingsPage from "./components/settings/SettingsPage.jsx";
 import GameMap from "./components/map/GameMap.jsx";
-import PlayerRosterBuilder from "./components/pickem/players/PlayerRosterBuilder";
+import LeaguePicksRouter from "./routes/LeaguePicksRouter";
 import WelcomeDialog from "./components/welcome/WelcomeDialog";
 import TeamCard from "./components/teams/TeamCard";
 import AthleteCard from "./components/athletes/AthleteCard";
@@ -170,8 +169,22 @@ function MainApp() {
         ) : (
           <Routes>
             <Route index element={<HomePage />} />
-            <Route path="/picks/:leagueId?" element={<PicksPage />} />
-            <Route path="/picks/:leagueId/weeks/:week" element={<PicksPage />} />
+            {/* Canonical league-rooted picks routes — ONE family for both
+                games; LeaguePicksRouter branches on the league's GroupType.
+                Bare /picks is the league-less nav landing (redirects to the
+                remembered league's canonical URL). Canonical week URLs are
+                phase-less; the explicit /phase variant is reserved for a
+                future postseason pick'em (see routes/paths.js). */}
+            <Route path="/picks" element={<LeaguePicksRouter />} />
+            <Route path="/league/:leagueId/picks" element={<LeaguePicksRouter />} />
+            <Route
+              path="/league/:leagueId/picks/weeks/:week"
+              element={<LeaguePicksRouter />}
+            />
+            <Route
+              path="/league/:leagueId/picks/phase/:phase/weeks/:week"
+              element={<LeaguePicksRouter />}
+            />
             <Route path="/warroom" element={<WarRoomPage />} />
             <Route path="/leaderboard" element={<LeaderboardPage />} />
             {/* Admin-only until launch-ready — the nav link is hidden for
@@ -181,16 +194,6 @@ function MainApp() {
               element={
                 <AdminRoute>
                   <GameMap />
-                </AdminRoute>
-              }
-            />
-            {/* Player Pick'em roster builder — admin-only v1 exploration;
-                users see only the home-page teaser until launch. */}
-            <Route
-              path="/pickem/players/:leagueId?"
-              element={
-                <AdminRoute>
-                  <PlayerRosterBuilder />
                 </AdminRoute>
               }
             />

--- a/src/UI/sd-ui/src/api/playerPickemApi.js
+++ b/src/UI/sd-ui/src/api/playerPickemApi.js
@@ -29,9 +29,9 @@ import apiClient from './apiClient';
 const PlayerPickemApi = {
   // position: "QB" | "RB" | "WR" | "TE" | "K". FLEX is a UI concept —
   // the page requests each eligible position and merges.
-  getAthletesByPosition: (sport, league, position, seasonYear, week) =>
+  getAthletesByPosition: (sport, league, position, seasonYear, week, phase) =>
     apiClient.get(
-      `/api/${sport}/${league}/athletes/pickem?position=${encodeURIComponent(position)}&seasonYear=${seasonYear}&week=${week}`
+      `/api/${sport}/${league}/athletes/pickem?position=${encodeURIComponent(position)}&seasonYear=${seasonYear}&week=${week}${phase ? `&phase=${encodeURIComponent(phase)}` : ''}`
     ),
 
   // ── Roster persistence (server-side lineups, per-player derived locks).

--- a/src/UI/sd-ui/src/components/home/PendingInvitesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/PendingInvitesCard.jsx
@@ -4,6 +4,7 @@ import LeaguesApi from "api/leagues/leaguesApi";
 import { useUserDto } from "../../contexts/UserContext";
 import JoinClosesLabel from "../leagues/JoinClosesLabel";
 import JoinLeagueConfirmDialog from "../leagues/JoinLeagueConfirmDialog";
+import { leaguePicksPath } from "../../routes/paths";
 import "./PendingInvitesCard.css";
 
 const SPORT_LABEL = {
@@ -76,10 +77,9 @@ function PendingInvitesCard() {
         return;
       }
       removeRow(invite.invitationId);
-      // Land on picks for the newly joined league. PicksPage takes the league
-      // as a ROUTE param (/picks/:leagueId — see MainApp.jsx), not a query
-      // string; a query param is silently ignored.
-      navigate(`/app/picks/${leagueId}`);
+      // Land on the joined league's picks; LeaguePicksRouter renders
+      // whichever game the league plays.
+      navigate(leaguePicksPath(leagueId));
     } catch (err) {
       console.error("Failed to accept invitation:", err);
       setBusy((b) => ({ ...b, [invite.invitationId]: "error" }));

--- a/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { useUserDto } from "../../contexts/UserContext";
+import { leaguePicksPath } from "../../routes/paths";
 import "./YourLeaguesCard.css";
 
 // Default sport-icon glyphs. Stand-in until commissioner-uploaded league
@@ -15,8 +16,8 @@ const SPORT_ICON = {
  * Tier 2 — "Your Leagues" card. Web mirror of sd-mobile's YourLeaguesCard
  * (src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx).
  * Lists the user's active leagues below the Tier 1 primary slot. Each row
- * deep-links to the picks screen with that league preselected
- * (/app/picks/:leagueId — see MainApp route).
+ * deep-links to the league's picks surface (leaguePicksPath — the
+ * unified league-rooted route).
  *
  * Hidden when the user has zero leagues; HomePage already routes that
  * branch to PrimarySlotNewUser.
@@ -45,12 +46,9 @@ function YourLeaguesCard() {
       <ul className="your-leagues-card__list">
         {leagues.map((league) => {
           const icon = SPORT_ICON[league.sport];
-          // One game per league: PlayerPickem leagues open the roster
-          // builder, everything else opens the team picks page.
-          const destination =
-            league.groupType === 'PlayerPickem'
-              ? `/app/pickem/players/${league.id}`
-              : `/app/picks/${league.id}`;
+          // League-rooted canonical URL — LeaguePicksRouter renders
+          // whichever game this league plays, so no branching here.
+          const destination = leaguePicksPath(league.id);
           return (
             <li key={league.id} className="your-leagues-card__item">
               <Link

--- a/src/UI/sd-ui/src/components/layout/Navigation.jsx
+++ b/src/UI/sd-ui/src/components/layout/Navigation.jsx
@@ -1,5 +1,5 @@
 // ./layout/Navigation.jsx
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import {
   FaHome,
   FaClipboardCheck,
@@ -17,6 +17,14 @@ import { useUserDto } from '../../contexts/UserContext';
 import './Navigation.css';
 
 function Navigation({ isSideNav, onToggle, onSignOut }) {
+  // The Picks entry points at the league-less landing (/app/picks), but
+  // the canonical URLs it redirects to are league-rooted
+  // (/app/league/:id/picks...), which NavLink's own matching can't see —
+  // mark it active by path shape instead.
+  const location = useLocation();
+  const picksLinkClass = /\/picks(\/|$)/.test(location.pathname)
+    ? "nav-link active"
+    : "nav-link";
   // Game Map is admin-only until the feature is launch-ready — hidden from
   // regular users in BOTH nav variants (the /app/map route is AdminRoute-
   // gated too, so a typed URL bounces).
@@ -47,7 +55,7 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
               <FaRocket className="nav-icon" />
               <span>War Room</span>
             </NavLink>
-            <NavLink to="/app/picks" className="nav-link" onClick={handleNavLinkClick}>
+            <NavLink to="/app/picks" className={picksLinkClass} onClick={handleNavLinkClick}>
               <FaClipboardCheck className="nav-icon" />
               <span>Picks</span>
             </NavLink>
@@ -118,7 +126,7 @@ function Navigation({ isSideNav, onToggle, onSignOut }) {
                 </NavLink>
               </td>
               <td>
-                <NavLink to="/app/picks" className="nav-link">
+                <NavLink to="/app/picks" className={picksLinkClass}>
                   <FaClipboardCheck className="nav-icon" />
                   <span>Picks</span>
                 </NavLink>

--- a/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueDetail.jsx
@@ -5,6 +5,7 @@ import leaguesApi from "../../api/leagues/leaguesApi";
 import "./LeagueDetail.css";
 import LeagueInvitation from "./LeagueInvitation";
 import JoinClosesLabel from "./JoinClosesLabel";
+import { leaguePicksPath } from "../../routes/paths";
 
 // Render the league window as a human-readable date range, or "Full Season"
 // when both bounds are null (the league was created without a custom window).
@@ -120,7 +121,7 @@ const LeagueDetail = () => {
               reach this page from public-league discovery — their picks would
               403 at the API, so don't offer the affordance. */}
           {isMember && (
-            <Link to={`/app/picks/${league.id}`} className="make-picks-button">
+            <Link to={leaguePicksPath(league.id)} className="make-picks-button">
               {isPast ? "View Picks" : "Make Your Picks"}
             </Link>
           )}

--- a/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueOverviewCard.jsx
@@ -1,5 +1,6 @@
 // src/components/leagues/LeagueOverviewCard.jsx
 import { Link } from "react-router-dom";
+import { leaguePicksPath } from "../../routes/paths";
 import "./LeagueOverviewCard.css"; // Assuming you have styles for the card
 
 const LeagueOverviewCard = ({ league, onDuplicate }) => {
@@ -18,16 +19,9 @@ const LeagueOverviewCard = ({ league, onDuplicate }) => {
       )}
       <div className="league-card-header">
         <h2 className="league-card-title">
-          {/* One game per league: PlayerPickem leagues open the roster
-              builder, everything else opens the team picks page. */}
-          <Link
-            to={
-              league.groupType === 'PlayerPickem'
-                ? `/app/pickem/players/${league.id}`
-                : `/app/picks/${league.id}`
-            }
-            className="league-card-name-link"
-          >
+          {/* League-rooted canonical URL — LeaguePicksRouter renders
+              whichever game this league plays, so no branching here. */}
+          <Link to={leaguePicksPath(league.id)} className="league-card-name-link">
             {league.name}
           </Link>
           {isPast && <span className="past-league-badge">Past</span>}

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -26,9 +26,11 @@ const LEAGUES = [
 ];
 
 // Fixed to opening week for now; a week selector (and
-// deriving the current week server-side) is future work.
-const SEASON_YEAR = 2026;
-const WEEK = 1;
+// deriving the current week server-side) is future work. Exported so
+// LeaguePicksRouter can canonicalize the URL to the week this page
+// actually renders.
+export const SEASON_YEAR = 2026;
+export const WEEK = 1;
 
 // Full-depth FBS position lists run to ~2,000 rows (WR); the grid pages
 // client-side — the payload is already in the browser, so filtering and
@@ -86,8 +88,15 @@ function PlayerRosterBuilder() {
   // Optional league scope from the route (league cards pass their id) —
   // without it the page falls back to the first PlayerPickem league per
   // sport.
-  const { leagueId: routeLeagueId } = useParams();
+  const { leagueId: routeLeagueId, week: routeWeekParam, phase: routePhaseParam } = useParams();
   const [league, setLeague] = useState('ncaa');
+  // Week identity comes from the ROUTE, which LeaguePicksRouter has
+  // already canonicalized to the league's current phase-qualified week
+  // (a preseason-only league lives at its preseason week). The pinned
+  // constants remain only as a fallback for the league-less admin view.
+  const routeWeekNum = Number(routeWeekParam);
+  const seasonWeek = Number.isInteger(routeWeekNum) && routeWeekNum > 0 ? routeWeekNum : WEEK;
+  const seasonPhase = routePhaseParam ?? 'regular';
   const [roster, setRoster] = useState({});
   // The user's PlayerPickem-type leagues (null = still loading). The
   // SPORT isn't a free choice — it's a fact of these leagues: the page
@@ -160,7 +169,7 @@ function PlayerRosterBuilder() {
       return undefined;
     }
 
-    PlayerPickemApi.getMyLineup(target.id, SEASON_YEAR, WEEK)
+    PlayerPickemApi.getMyLineup(target.id, target.seasonYear ?? SEASON_YEAR, seasonWeek)
       .then((response) => {
         if (ignore) return;
         setRoster(rosterFromLineup(response.data));
@@ -175,7 +184,7 @@ function PlayerRosterBuilder() {
     return () => {
       ignore = true;
     };
-  }, [league, playerLeagues, routeLeagueId]);
+  }, [league, playerLeagues, routeLeagueId, seasonWeek]);
 
   const positions = useMemo(
     () => eligiblePositions(activeSlotId),
@@ -213,7 +222,10 @@ function PlayerRosterBuilder() {
 
     Promise.all(
       positions.map((pos) =>
-        PlayerPickemApi.getAthletesByPosition('football', league, pos, SEASON_YEAR, WEEK)
+        PlayerPickemApi.getAthletesByPosition(
+          'football', league, pos,
+          pickemLeague?.seasonYear ?? SEASON_YEAR, seasonWeek, seasonPhase
+        )
       )
     )
       .then((responses) => {
@@ -232,7 +244,7 @@ function PlayerRosterBuilder() {
     return () => {
       ignore = true;
     };
-  }, [positions, league]);
+  }, [positions, league, pickemLeague, seasonWeek, seasonPhase]);
 
   const activeCol = columns.find((c) => c.key === sort.key);
   const getSortValue = useMemo(() => {
@@ -287,7 +299,7 @@ function PlayerRosterBuilder() {
     setSaveError(null);
     try {
       const response = await PlayerPickemApi.upsertSlot(
-        pickemLeague.id, SEASON_YEAR, WEEK, activeSlotId, athlete
+        pickemLeague.id, pickemLeague.seasonYear ?? SEASON_YEAR, seasonWeek, activeSlotId, athlete
       );
       setRoster((prev) => ({ ...prev, [activeSlotId]: response.data }));
     } catch (err) {
@@ -299,7 +311,7 @@ function PlayerRosterBuilder() {
     if (!pickemLeague) return;
     setSaveError(null);
     try {
-      await PlayerPickemApi.clearSlot(pickemLeague.id, SEASON_YEAR, WEEK, slotId);
+      await PlayerPickemApi.clearSlot(pickemLeague.id, pickemLeague.seasonYear ?? SEASON_YEAR, seasonWeek, slotId);
       setRoster((prev) => {
         const next = { ...prev };
         delete next[slotId];
@@ -319,7 +331,7 @@ function PlayerRosterBuilder() {
     <div className="roster-builder">
       <h2 className="roster-builder-title">Player Pick&rsquo;em Roster</h2>
       <p className="roster-builder-sub">
-        Week {WEEK} &middot; {SEASON_YEAR} &middot;{' '}
+        {seasonPhase === 'preseason' ? 'Preseason ' : seasonPhase === 'postseason' ? 'Postseason ' : ''}Week {seasonWeek} &middot; {pickemLeague?.seasonYear ?? SEASON_YEAR} &middot;{' '}
         {LEAGUES.find((l) => l.id === league)?.label}
         {pickemLeague ? (
           <> &middot; <strong>{pickemLeague.name}</strong></>

--- a/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
+++ b/src/UI/sd-ui/src/components/picks/LeagueWeekSelector.jsx
@@ -1,23 +1,53 @@
 import "./LeagueWeekSelector.css";
 import LeagueSelector from "../shared/LeagueSelector";
 
+// Week numbers repeat across season phases, so a phase-qualified entry
+// labels non-regular weeks explicitly; regular season keeps the plain
+// "Week N" label users expect.
+const PHASE_LABEL = {
+  preseason: "Preseason",
+  postseason: "Postseason",
+  offseason: "Offseason",
+};
+
+const weekLabel = (week, phase) =>
+  PHASE_LABEL[phase] ? `${PHASE_LABEL[phase]} Week ${week}` : `Week ${week}`;
+
 function LeagueWeekSelector({
   leagues = [],
   selectedLeagueId,
   setSelectedLeagueId,
   selectedWeek,
+  selectedPhase, // only meaningful with weekDetails
   setSelectedWeek,
   seasonWeeks = [],
+  // Phase-qualified entries [{ week, phase }] — when provided they
+  // replace seasonWeeks as the option source and setSelectedWeek is
+  // called as (week, phase). Legacy callers (GameMap) keep passing the
+  // int list and are unaffected.
+  weekDetails = null,
   allowAll = false, // New prop to enable "All" option
 }) {
-  const hasWeeks = Array.isArray(seasonWeeks) && seasonWeeks.length > 0;
+  const phased = Array.isArray(weekDetails) && weekDetails.length > 0;
+  const hasWeeks = phased
+    ? true
+    : Array.isArray(seasonWeeks) && seasonWeeks.length > 0;
 
   // Custom-window leagues (e.g. a one-week pool) only ever have a single
   // entry — a dropdown there implies a selection to make when there isn't
   // one. Render the value as static text instead so it stays informational.
   // allowAll is the exception (admin view): even with one week, "All
   // Weeks" is a meaningful alternative, so keep the dropdown.
-  const isSingleWeek = !allowAll && hasWeeks && seasonWeeks.length === 1;
+  const optionCount = phased ? weekDetails.length : seasonWeeks.length;
+  const isSingleWeek = !allowAll && hasWeeks && optionCount === 1;
+
+  // Composite option value — "phase:week" — because the number alone
+  // under-identifies a week when phases collide.
+  const detailValue = (d) => `${d.phase}:${d.week}`;
+  const selectedDetailValue =
+    phased && selectedWeek != null
+      ? detailValue({ phase: selectedPhase ?? "regular", week: selectedWeek })
+      : "";
 
   return (
     <div className="league-week-selector">
@@ -39,23 +69,45 @@ function LeagueWeekSelector({
                 form control (input/select/textarea/etc.), not at a <span>.
                 Use a styled span for the visual "Week:" prefix instead. */}
             <span className="week-label">Week:</span>
-            <span className="week-static">{seasonWeeks[0]}</span>
+            <span className="week-static">
+              {phased
+                ? weekLabel(weekDetails[0].week, weekDetails[0].phase)
+                : seasonWeeks[0]}
+            </span>
           </>
         ) : (
           <>
             <label htmlFor="weekSelect">Week:</label>
             <select
               id="weekSelect"
-              value={selectedWeek ?? ""}
-              onChange={(e) => setSelectedWeek(e.target.value ? Number(e.target.value) : null)}
+              value={phased ? selectedDetailValue : selectedWeek ?? ""}
+              onChange={(e) => {
+                if (!e.target.value) {
+                  setSelectedWeek(null);
+                  return;
+                }
+                if (phased) {
+                  const [phase, week] = e.target.value.split(":");
+                  setSelectedWeek(Number(week), phase);
+                } else {
+                  setSelectedWeek(Number(e.target.value));
+                }
+              }}
               disabled={!hasWeeks}
             >
               {allowAll && <option value="">All Weeks</option>}
-              {hasWeeks && seasonWeeks.map((week) => (
-                <option key={week} value={week}>
-                  Week {week}
-                </option>
-              ))}
+              {phased
+                ? weekDetails.map((d) => (
+                    <option key={detailValue(d)} value={detailValue(d)}>
+                      {weekLabel(d.week, d.phase)}
+                    </option>
+                  ))
+                : hasWeeks &&
+                  seasonWeeks.map((week) => (
+                    <option key={week} value={week}>
+                      Week {week}
+                    </option>
+                  ))}
             </select>
           </>
         )}

--- a/src/UI/sd-ui/src/components/picks/PicksPage.jsx
+++ b/src/UI/sd-ui/src/components/picks/PicksPage.jsx
@@ -2,6 +2,7 @@ import "./PicksPage.css";
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { leaguePicksPath } from "../../routes/paths";
 import { useUserDto } from "../../contexts/UserContext";
 import { useLeagueContext } from "../../contexts/LeagueContext";
 import { useContestUpdates } from "../../contexts/ContestUpdatesContext";
@@ -23,7 +24,7 @@ function PicksPage() {
     setSelectedLeagueId: setGlobalLeagueId,
     initializeLeagueSelection,
   } = useLeagueContext();
-  const { leagueId: routeLeagueId, week: routeWeekParam } = useParams();
+  const { leagueId: routeLeagueId, week: routeWeekParam, phase: routePhaseParam } = useParams();
   const navigate = useNavigate();
 
   // Route param arrives as a string; parse once. Invalid values (negative,
@@ -34,6 +35,16 @@ function PicksPage() {
     const n = Number(routeWeekParam);
     return Number.isInteger(n) && n > 0 ? n : null;
   }, [routeWeekParam]);
+
+  // Phase slug from the URL. Week NUMBERS repeat across season phases
+  // (an NFL league can hold a preseason Week 4 AND a regular-season
+  // Week 4), so (phase, week) is the full week identity. Unknown or
+  // missing values become null and the week-snap effect redirects to
+  // the canonical URL.
+  const routePhase = useMemo(() => {
+    const known = ["preseason", "regular", "postseason", "offseason"];
+    return known.includes(routePhaseParam) ? routePhaseParam : null;
+  }, [routePhaseParam]);
 
   const [userPicks, setUserPicks] = useState({});
   const [isSubscribed] = useState(false);
@@ -171,17 +182,38 @@ function PicksPage() {
     () => selectedLeague?.seasonWeeks ?? [],
     [selectedLeague]
   );
+  // Phase-qualified week identities ({ seasonWeekId, week, phase }),
+  // ordered phase-then-week by the backend. Falls back to mapping the
+  // legacy int list as regular-season for payloads that predate
+  // seasonWeekDetails (stale cached /me during rollout).
+  const weekDetails = useMemo(() => {
+    const details = selectedLeague?.seasonWeekDetails;
+    if (details && details.length > 0) return details;
+    return seasonWeeks.map((w) => ({
+      seasonWeekId: null,
+      week: w,
+      phase: "regular",
+    }));
+  }, [selectedLeague, seasonWeeks]);
   // Default landing week — prefer the backend-computed current week (the
-  // earliest week with an unstarted matchup, falling back to the last
-  // week of the season). Custom-window leagues may only have a single
-  // entry.
-  const latestSeasonWeek =
-    seasonWeeks.length > 0 ? seasonWeeks[seasonWeeks.length - 1] : null;
-  const currentSeasonWeek = selectedLeague?.currentSeasonWeek ?? null;
-  const defaultLandingWeek =
-    currentSeasonWeek && seasonWeeks.includes(currentSeasonWeek)
-      ? currentSeasonWeek
-      : latestSeasonWeek;
+  // earliest week, in phase order, with an unstarted matchup, falling
+  // back to the last week of the season). Custom-window leagues may only
+  // have a single entry.
+  const currentDetail = useMemo(() => {
+    const byId = selectedLeague?.currentSeasonWeekId
+      ? weekDetails.find(
+          (d) => d.seasonWeekId === selectedLeague.currentSeasonWeekId
+        )
+      : null;
+    if (byId) return byId;
+    const byNumber = selectedLeague?.currentSeasonWeek
+      ? weekDetails.find((d) => d.week === selectedLeague.currentSeasonWeek)
+      : null;
+    return byNumber ?? null;
+  }, [selectedLeague, weekDetails]);
+  const defaultLandingDetail =
+    currentDetail ??
+    (weekDetails.length > 0 ? weekDetails[weekDetails.length - 1] : null);
 
   // Recovery for newly-created leagues. League creation publishes
   // PickemGroupCreated via the outbox; the consumer that populates
@@ -300,7 +332,7 @@ function PicksPage() {
   }, [matchups, getContestUpdate]);
 
   // One-shot init: ensure the URL carries a valid league. When the user
-  // lands on /app/picks with no param (or a stale id) redirect to the
+  // lands here with a stale league id, redirect to the
   // remembered league (LeagueContext, localStorage-backed) or the first
   // available. Once the URL has a valid league id, subsequent league
   // switches happen through `handleLeagueChange` (selector → navigate).
@@ -331,7 +363,7 @@ function PicksPage() {
         ? globalLeagueId
         : activeLeagues[0].id;
     setGlobalLeagueId(fallback);
-    navigate(`/app/picks/${fallback}`, { replace: true });
+    navigate(leaguePicksPath(fallback), { replace: true });
   }, [
     userLoading,
     activeLeagues,
@@ -739,7 +771,9 @@ function PicksPage() {
     (newLeagueId) => {
       if (!newLeagueId || newLeagueId === routeLeagueId) return;
       setGlobalLeagueId(newLeagueId);
-      navigate(`/app/picks/${newLeagueId}`, { replace: true });
+      // The unified router re-branches on the new league's GroupType, so
+      // switching into a Player Pick'em league lands on the roster builder.
+      navigate(leaguePicksPath(newLeagueId), { replace: true });
     },
     [routeLeagueId, navigate, setGlobalLeagueId]
   );
@@ -748,35 +782,45 @@ function PicksPage() {
   // back button returns to wherever the user came from rather than
   // cycling through every week they clicked through.
   const handleWeekChange = useCallback(
-    (newWeek) => {
+    (newWeek, newPhase) => {
       if (!routeLeagueId || newWeek == null) return;
-      if (newWeek === routeWeek) return;
-      navigate(`/app/picks/${routeLeagueId}/weeks/${newWeek}`, {
+      const phase = newPhase ?? "regular";
+      if (newWeek === routeWeek && phase === routePhase) return;
+      navigate(leaguePicksPath(routeLeagueId, newWeek, phase), {
         replace: true,
       });
     },
-    [routeLeagueId, routeWeek, navigate]
+    [routeLeagueId, routeWeek, routePhase, navigate]
   );
 
-  // Redirect to the canonical URL when the route is missing the week
-  // segment or carries one that's not in the league's week list.
-  // Replaces the prior `setSelectedWeek(latestSeasonWeek)` snap which
-  // only updated local state — that's the refresh-loses-selection bug:
-  // every remount re-defaulted to the latest week regardless of what
-  // the user had picked.
+  // Redirect to the canonical URL when the route is missing the week or
+  // phase segment, or carries a (phase, week) pair that's not in the
+  // league's week list. A phase-less /weeks/N URL adopts the phase of
+  // the first matching entry (phase order — chronological), so shared
+  // legacy links keep working. Replaces the prior
+  // `setSelectedWeek(latestSeasonWeek)` snap which only updated local
+  // state — that's the refresh-loses-selection bug: every remount
+  // re-defaulted to the latest week regardless of what the user picked.
   useEffect(() => {
     if (!routeLeagueId) return;
-    if (seasonWeeks.length === 0) return; // user-dto still hydrating
+    if (weekDetails.length === 0) return; // user-dto still hydrating
 
-    const weekIsValid =
-      routeWeek != null && seasonWeeks.includes(routeWeek);
-    if (weekIsValid) return;
+    const exact =
+      routeWeek != null &&
+      routePhase != null &&
+      weekDetails.some((d) => d.week === routeWeek && d.phase === routePhase);
+    if (exact) return;
 
-    if (defaultLandingWeek == null) return;
-    navigate(`/app/picks/${routeLeagueId}/weeks/${defaultLandingWeek}`, {
+    // Week matches but phase is missing/wrong → canonicalize to that
+    // week's real phase rather than bouncing to the default week.
+    const byWeek =
+      routeWeek != null ? weekDetails.find((d) => d.week === routeWeek) : null;
+    const target = byWeek ?? defaultLandingDetail;
+    if (target == null) return;
+    navigate(leaguePicksPath(routeLeagueId, target.week, target.phase), {
       replace: true,
     });
-  }, [routeLeagueId, routeWeek, seasonWeeks, defaultLandingWeek, navigate]);
+  }, [routeLeagueId, routeWeek, routePhase, weekDetails, defaultLandingDetail, navigate]);
 
   if (userLoading) return <div>Loading user info...</div>;
 
@@ -838,8 +882,10 @@ function PicksPage() {
             selectedLeagueId={routeLeagueId}
             setSelectedLeagueId={handleLeagueChange}
             selectedWeek={selectedWeek}
+            selectedPhase={routePhase}
             setSelectedWeek={handleWeekChange}
             seasonWeeks={seasonWeeks}
+            weekDetails={weekDetails}
           />
           <div className="pick-status-toggle-row">
             {isReadOnly && (

--- a/src/UI/sd-ui/src/routes/LeaguePicksRouter.jsx
+++ b/src/UI/sd-ui/src/routes/LeaguePicksRouter.jsx
@@ -1,0 +1,81 @@
+import { Navigate, useParams } from "react-router-dom";
+import { useUserDto } from "../contexts/UserContext";
+import { useLeagueContext } from "../contexts/LeagueContext";
+import PicksPage from "../components/picks/PicksPage.jsx";
+import PlayerRosterBuilder, {
+  WEEK as PICKEM_WEEK,
+} from "../components/pickem/players/PlayerRosterBuilder";
+import AdminRoute from "./AdminRoute";
+import { leaguePicksPath } from "./paths";
+
+/**
+ * One route family, both games. /app/league/:leagueId/picks[/phase/:phase
+ * /weeks/:week] renders whichever surface the league's GroupType calls
+ * for — team pick'em (PicksPage) or Player Pick'em (roster builder). One
+ * league plays one game (the GroupType enum), so the URL never encodes
+ * the game type and link builders never branch on it.
+ *
+ * The bare /app/picks nav landing also routes here (no :leagueId): the
+ * remembered league (LeagueContext, localStorage-backed) or the first
+ * active league wins, redirecting to its canonical URL. No leagues at
+ * all → PicksPage renders its own empty state.
+ *
+ * A leagueId that isn't in the active set falls through to PicksPage,
+ * which owns the past-league (deactivated) read-only view and the
+ * bad-id fallback redirect.
+ */
+function LeaguePicksRouter() {
+  const { leagueId, phase, week } = useParams();
+  const { userDto, loading } = useUserDto();
+  const { selectedLeagueId } = useLeagueContext();
+
+  if (loading) {
+    return <div className="route-loading">Loading...</div>;
+  }
+
+  // BE may return leagues as an array or an id-keyed object — match the
+  // defensive shape handling used elsewhere (YourLeaguesCard).
+  const leagues = Array.isArray(userDto?.leagues)
+    ? userDto.leagues
+    : Object.values(userDto?.leagues || {});
+
+  if (!leagueId) {
+    const remembered = leagues.find((l) => l.id === selectedLeagueId);
+    const target = remembered ?? leagues[0];
+    if (target) {
+      return <Navigate to={leaguePicksPath(target.id)} replace />;
+    }
+    // No leagues: PicksPage renders the join-a-league empty state.
+    return <PicksPage />;
+  }
+
+  const league = leagues.find((l) => l.id === leagueId);
+
+  if (league?.groupType === "PlayerPickem") {
+    // Canonicalize to the LEAGUE'S current week (phase-qualified, from
+    // /user/me) — a preseason-only league lives at its preseason week,
+    // not at a pinned default. Fallback covers rollout payloads that
+    // predate seasonWeekDetails.
+    const details = league.seasonWeekDetails ?? [];
+    const current =
+      details.find((d) => d.seasonWeekId === league.currentSeasonWeekId) ??
+      details[details.length - 1] ??
+      { week: PICKEM_WEEK, phase: "regular" };
+    if (Number(week) !== current.week || phase !== current.phase) {
+      return (
+        <Navigate to={leaguePicksPath(leagueId, current.week, current.phase)} replace />
+      );
+    }
+    // Admin-only until Player Pick'em launches (week 3-4 alpha) — same
+    // gate the old /pickem/players route carried.
+    return (
+      <AdminRoute>
+        <PlayerRosterBuilder />
+      </AdminRoute>
+    );
+  }
+
+  return <PicksPage />;
+}
+
+export default LeaguePicksRouter;

--- a/src/UI/sd-ui/src/routes/paths.js
+++ b/src/UI/sd-ui/src/routes/paths.js
@@ -1,0 +1,20 @@
+// Canonical league-rooted picks URLs. ONE route family serves both games
+// (team pick'em and Player Pick'em) — the league's GroupType decides what
+// renders (LeaguePicksRouter), so no link-builder ever needs to know what
+// game a league plays.
+//
+// Phase is part of every canonical week URL because week NUMBERS repeat
+// across season phases (NFL: preseason/regular/postseason each count
+// from 1) — "/weeks/4" alone is ambiguous. Phases are slugs sourced from
+// the league's seasonWeekDetails payload: "preseason" | "regular" |
+// "postseason" | "offseason". Phase-less URLs are accepted and redirect
+// to canonical once the week's phase resolves (PicksPage week-snap).
+
+export const leaguePicksPath = (leagueId, week, phase = "regular") =>
+  week == null
+    ? `/app/league/${leagueId}/picks`
+    : `/app/league/${leagueId}/picks/phase/${phase}/weeks/${week}`;
+
+// League-less nav landing: LeaguePicksRouter resolves the remembered (or
+// first) league and redirects to leaguePicksPath.
+export const picksLandingPath = "/app/picks";

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetPickemAthletesQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Athletes/GetPickemAthletesQueryHandlerTests.cs
@@ -41,7 +41,7 @@ public class GetPickemAthletesQueryHandlerTests : UnitTestBase<GetPickemAthletes
     {
         var payload = new AthleteMatchupSummariesDto();
         _athleteClientMock
-            .Setup(x => x.GetAthleteMatchupSummaries("QB", 2026, 1, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetAthleteMatchupSummaries("QB", 2026, 1, 2, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Success<AthleteMatchupSummariesDto>(payload));
 
         var handler = Mocker.CreateInstance<GetPickemAthletesQueryHandler>();
@@ -67,7 +67,7 @@ public class GetPickemAthletesQueryHandlerTests : UnitTestBase<GetPickemAthletes
         result.Status.Should().Be(ResultStatus.Validation);
         _athleteClientMock.Verify(
             x => x.GetAthleteMatchupSummaries(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -61,7 +61,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
 
             // Assert
             _contestClientMock
-                .Verify(x => x.GetMatchupsForSeasonWeek(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+                .Verify(x => x.GetMatchupsBySeasonWeekId(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
 
             // Assert
             _contestClientMock
-                .Verify(x => x.GetMatchupsForSeasonWeek(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+                .Verify(x => x.GetMatchupsBySeasonWeekId(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -255,7 +255,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 16, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -320,7 +320,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 16, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -386,7 +386,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 17, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -435,7 +435,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             await DataContext.SaveChangesAsync();
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 5, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(new List<Matchup>()));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -493,7 +493,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 .Create();
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 3, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(new List<Matchup> { activeMatchup }));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -557,7 +557,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 .Create();
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 8, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(new List<Matchup> { sourceMatchup }));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -653,7 +653,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -738,7 +738,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -833,7 +833,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -916,7 +916,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
             };
 
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -1036,7 +1036,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 },
             };
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -1134,7 +1134,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 },
             };
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var command = new ScheduleGroupWeekMatchupsCommand(
@@ -1235,7 +1235,7 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
                 },
             };
             _contestClientMock
-                .Setup(x => x.GetMatchupsForSeasonWeek(2024, 1, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Success<List<Matchup>>(allMatchups));
 
             var eventBus = Mocker.GetMock<IEventBus>();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Seasons/Queries/GetSeasonWeeksByDateRange/GetSeasonWeeksByDateRangeQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using SportsData.Core.Common;
 using SportsData.Producer.Application.Seasons.Queries.GetSeasonWeeksByDateRange;
 using SportsData.Producer.Infrastructure.Data.Entities;
+using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 using Xunit;
 
@@ -225,9 +226,16 @@ public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSe
         await FootballDataContext.SaveChangesAsync();
     }
 
-    private async Task SeedWeekAsync(int weekNumber, DateTime startDate, DateTime endDate)
+    /// <summary>
+    /// Seeds a week WITH one contest by default — the handler only returns
+    /// weeks that have contests (ESPN's calendar carries contest-less
+    /// administrative weeks with huge windows, e.g. NCAA "Preseason Week
+    /// 1" spanning Feb-Aug, which poisoned league bootstrap).
+    /// </summary>
+    private async Task SeedWeekAsync(
+        int weekNumber, DateTime startDate, DateTime endDate, bool withContest = true)
     {
-        await FootballDataContext.SeasonWeeks.AddAsync(new SeasonWeek
+        var week = new SeasonWeek
         {
             Id = Guid.NewGuid(),
             SeasonId = SeasonId,
@@ -237,7 +245,46 @@ public class GetSeasonWeeksByDateRangeQueryHandlerTests : ProducerTestBase<GetSe
             EndDate = endDate,
             CreatedUtc = Mocker.Get<IDateTimeProvider>().UtcNow(),
             CreatedBy = Guid.NewGuid()
-        });
+        };
+        await FootballDataContext.SeasonWeeks.AddAsync(week);
+        if (withContest)
+        {
+            await FootballDataContext.Contests.AddAsync(new FootballContest
+            {
+                Id = Guid.NewGuid(),
+                Name = $"game wk{weekNumber}",
+                ShortName = "game",
+                Sport = Sport.FootballNcaa,
+                SeasonYear = 2026,
+                SeasonWeekId = week.Id,
+                SeasonPhaseId = SeasonPhaseId,
+                StartDateUtc = startDate,
+                HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+                AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            });
+        }
         await FootballDataContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task ContestlessWeek_IsExcluded()
+    {
+        // NCAA "Preseason Week 1" spans Feb-Aug with zero games — a bare
+        // date overlap used to hand bootstrap this phantom week, whose
+        // number collides with the real regular-season week 1.
+        await SeedSeasonScaffoldingAsync();
+        await SeedWeekAsync(1, new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 8, 22, 0, 0, 0, DateTimeKind.Utc), withContest: false);
+        await SeedWeekAsync(1, new DateTime(2026, 8, 22, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 9, 8, 0, 0, 0, DateTimeKind.Utc));
+        var handler = Mocker.CreateInstance<GetSeasonWeeksByDateRangeQueryHandler>();
+
+        var result = await handler.ExecuteAsync(new GetSeasonWeeksByDateRangeQuery(
+            new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 12, 1, 0, 0, 0, DateTimeKind.Utc)));
+
+        result.IsSuccess.Should().BeTrue();
+        // Only the contest-bearing week survives; both share Number 1, so
+        // a single result IS the assertion that the phantom was dropped.
+        result.Value.Should().ContainSingle()
+            .Which.WeekNumber.Should().Be(1);
     }
 }


### PR DESCRIPTION
## Problem

Week numbers repeat across SeasonPhases within one season year (NFL 2026 has a week 4 in Preseason, Regular Season, AND Postseason), and three layers erased the phase:

1. **Sync**: `MatchupScheduleProcessor` fetched matchups by `(year, number)` even though its command carries the phase-precise `SeasonWeekId`. ESPN's calendar also holds contest-less administrative weeks with huge date windows (NCAA "Preseason Week 1" spans Feb–Aug), which league bootstrap overlapped — creating phantom preseason-keyed week rows that held regular-season matchups (Curbstomp, Hogg v Hoverstock).
2. **Payloads**: league weeks were bare int lists — a preseason Week 4 and a regular Week 4 were indistinguishable to any client.
3. **URLs**: `/app/picks/{id}` vs `/app/pickem/players/{id}` encoded the *game type*, and neither could say which phase's week it showed.

Design doc: `docs/features/phase-aware-league-weeks.md` (includes as-implemented deviations).

## Changes

**Web** — one route family for both games: `/app/league/{id}/picks/phase/{phase}/weeks/{n}`. `LeaguePicksRouter` branches on the league's `GroupType`; PlayerPickem leagues canonicalize to the league's current phase-qualified week (a preseason-only league lives at `phase/preseason/weeks/4`). `leaguePicksPath()` is the single URL builder; PicksPage's week model runs on `seasonWeekDetails` with phase-labeled selector options ("Preseason Week 4"); the roster builder derives year/week/phase from route + league. Old routes removed — clean break (no user base; testers are on mobile).

**API** — `PickemGroupWeek.SeasonPhaseTypeCode` (migration, default 2) stamped on sync; sync fetches by `SeasonWeekId`; GetMe + league summaries gain additive `seasonWeekDetails` + `currentSeasonWeekId` (mobile untouched); current-week selection orders phase-then-week (bare-number ordering mis-picked regular W1 over a pending preseason W4); `GetUserLeagues` gains `AsSplitQuery` (AppDataContext throws on `MultipleCollectionIncludeWarning`; the second collection projection 500'd live — InMemory is blind to it); player-lineup lock anchoring resolves via the league's own week id (`LeagueWeekMatchupResolver`); athlete feed carries a phase slug.

**Producer** — new `GetMatchupsBySeasonWeekId` (precise identity, any phase); `SeasonPhaseTypeCode` on all Matchup queries; athlete matchup summaries accept a phase type code; `GetSeasonWeeksByDateRange`/`GetCurrentSeasonWeek` now require a week to have contests (kills the phantom-week source without breaking NFL preseason leagues, whose weeks hold real games).

## Deploy checklist (prod, after images land — in order)

1. `sql/pgsql/backfill_pickemgroupweek_phase.sql` — stamp real phases on existing `PickemGroupWeek` rows
2. `sql/pgsql/repair_phantom_league_weeks.sql` — rekey NCAA matchups off phantom preseason/offseason weeks (pick-safe: picks key on ContestId)

Both idempotent; already run and verified on local `sdApi.All`.

## Validation

- API suite 735/735 · Producer 625 passed / 18 skipped (new phantom-week exclusion test) · web 83/83 · eslint clean · prod build compiles
- Local E2E: regular NCAAFB league (`phase/regular` URLs, matchups + picks intact post-repair), NFL preseason leagues (`phase/preseason` URLs), Player Pick'em league (preseason week-4 athletes, opponents, and lock anchors; header "Preseason Week 4 · 2026 · NFL")
- By-ID SQL verified against local NFL data (preseason week 4 → its 16 games, phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added phase-aware Pick’em navigation for preseason, regular season, postseason, and offseason weeks.
  - League pages now display clearly labeled phase and week options.
  - Added canonical league picks URLs and unified picks routing.
  - Athlete selection now supports phase-specific matchup data.
  - League summaries expose detailed season week information.

- **Bug Fixes**
  - Improved matchup resolution when week numbers overlap across phases.
  - Excluded contest-free calendar weeks from active schedules.
  - Repaired incorrect or phantom league week records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->