### PR TITLE
Player Pick'em league creation + boot-path request diet

### DIFF
--- a/sql/pgsql/backfill_pickemgroupweek_phase.sql
+++ b/sql/pgsql/backfill_pickemgroupweek_phase.sql
@@ -6,6 +6,16 @@
 -- Required BEFORE repair_phantom_league_weeks.sql.
 -- ============================================================================
 --
+-- ============================================================================
+-- MANUAL RELEASE STEP -- NOT DIRECTLY EXECUTABLE.
+-- This file is a cross-database RUNBOOK: the mapping is exported from each
+-- Producer DB and applied to the API DB, so `psql -f` on this file alone
+-- performs no work by design. Run the numbered steps below verbatim.
+-- Required BEFORE repair_phantom_league_weeks.sql.
+-- (Alternative used for the 2026-08-27 prod run: paste the exported rows
+-- into a generated inline-VALUES UPDATE when \copy is awkward.)
+-- ============================================================================
+--
 -- One-time backfill: PickemGroupWeek.SeasonPhaseTypeCode (added 2026-08-26,
 -- migration PickemGroupWeekSeasonPhase; default 2 = regular season).
 -- Week numbers repeat across SeasonPhases within a season year, so week

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -134,6 +134,20 @@ namespace SportsData.Api.Application.Processors
                 groupWeek.SeasonPhaseTypeCode = phaseTypeCode.Value;
             }
 
+            // PLAYER Pick'em leagues get the WEEK (identity + phase — it
+            // powers seasonWeekDetails and lineup lock anchoring) but no
+            // team-pick slate: no PickemGroupMatchup rows, no
+            // matchup-created notification fan-out. The roster is the game.
+            if (group.GroupType == Application.Common.Enums.GroupType.PlayerPickem)
+            {
+                groupWeek.AreMatchupsGenerated = true;
+                await _dataContext.SaveChangesAsync();
+                _logger.LogInformation(
+                    "PlayerPickem group {GroupId}: week {Week} (phase {Phase}) materialized without a matchup slate.",
+                    group.Id, command.SeasonWeek, groupWeek.SeasonPhaseTypeCode);
+                return;
+            }
+
             // League window filter — excludes contests whose kickoff falls outside
             // [StartsOn, EndsOn]. Null bounds mean "no constraint" (full-season league),
             // so this is a no-op when neither is set.

--- a/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
+++ b/src/SportsData.Api/Application/Processors/MatchupScheduleProcessor.cs
@@ -140,7 +140,21 @@ namespace SportsData.Api.Application.Processors
             // matchup-created notification fan-out. The roster is the game.
             if (group.GroupType == Application.Common.Enums.GroupType.PlayerPickem)
             {
-                groupWeek.AreMatchupsGenerated = true;
+                // Latch AreMatchupsGenerated ONLY once the phase is stamped
+                // (an empty canonical response — transient producer gap —
+                // leaves phaseTypeCode null). Latching early would let the
+                // generated-guard above skip every future pass and strand
+                // the week on the default phase forever.
+                if (phaseTypeCode is > 0)
+                {
+                    groupWeek.AreMatchupsGenerated = true;
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "PlayerPickem group {GroupId}: week {Week} (SeasonWeekId={SeasonWeekId}) had no canonical matchups; leaving week unlatched for the next scheduler pass.",
+                        group.Id, command.SeasonWeek, command.SeasonWeekId);
+                }
                 await _dataContext.SaveChangesAsync();
                 _logger.LogInformation(
                     "PlayerPickem group {GroupId}: week {Week} (phase {Phase}) materialized without a matchup slate.",

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommand.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommand.cs
@@ -8,7 +8,7 @@ namespace SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
 /// <see cref="Sport"/> rather than the per-sport endpoint trio, because
 /// nothing else differs per sport.
 /// </summary>
-public class CreatePlayerLeagueRequest
+public class CreatePlayerLeagueCommand
 {
     /// <summary>"FootballNcaa" | "FootballNfl".</summary>
     public required string Sport { get; set; }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommand.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommand.cs
@@ -37,10 +37,7 @@ public class CreatePlayerLeagueCommand
     /// to timestamptz; values are semantically UTC per project
     /// convention, so stamp the kind rather than converting.
     /// </summary>
-    public DateTime? EffectiveStartsOn =>
-        StartsOn is { Kind: DateTimeKind.Unspecified } startsOn
-            ? DateTime.SpecifyKind(startsOn, DateTimeKind.Utc)
-            : StartsOn;
+    public DateTime? EffectiveStartsOn => NormalizeToUtc(StartsOn);
 
     /// <summary>
     /// Midnight-normalized end (same contract as the team-league flow):
@@ -49,9 +46,24 @@ public class CreatePlayerLeagueCommand
     /// rejects Kind=Unspecified on timestamptz).
     /// </summary>
     public DateTime? EffectiveEndsOn =>
-        EndsOn is { TimeOfDay.Ticks: 0 } endsOn
-            ? DateTime.SpecifyKind(endsOn.Date.AddDays(1).AddTicks(-1), DateTimeKind.Utc)
-            : EndsOn is { Kind: DateTimeKind.Unspecified } raw
-                ? DateTime.SpecifyKind(raw, DateTimeKind.Utc)
-                : EndsOn;
+        EndsOn is { TimeOfDay.Ticks: 0 } endsOn && endsOn.Date < DateTime.MaxValue.Date
+            // End-of-day on the AUTHORED calendar day (before any timezone
+            // conversion), then normalized to UTC. The MaxValue guard keeps
+            // AddDays(1) from overflowing; the validator's range rule turns
+            // that boundary into a validation failure instead.
+            ? NormalizeToUtc(DateTime.SpecifyKind(
+                endsOn.Date.AddDays(1).AddTicks(-1), endsOn.Kind))
+            : NormalizeToUtc(EndsOn);
+
+    /// <summary>
+    /// Npgsql-safe UTC: Unspecified is STAMPED Utc (values are semantically
+    /// UTC per project convention), Local is CONVERTED — relabeling a local
+    /// wall-clock would shift the instant by the machine's offset.
+    /// </summary>
+    private static DateTime? NormalizeToUtc(DateTime? value) => value switch
+    {
+        { Kind: DateTimeKind.Unspecified } v => DateTime.SpecifyKind(v, DateTimeKind.Utc),
+        { Kind: DateTimeKind.Local } v => v.ToUniversalTime(),
+        _ => value,
+    };
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandHandler.cs
@@ -1,0 +1,179 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Common;
+using SportsData.Core.Eventing;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
+
+public interface ICreatePlayerLeagueCommandHandler
+{
+    Task<Result<Guid>> ExecuteAsync(
+        CreatePlayerLeagueRequest request,
+        Guid currentUserId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Creates a PLAYER Pick'em league. Deliberately standalone from
+/// <see cref="CreateLeagueCommandHandlerBase{TRequest}"/>: player leagues
+/// carry none of the team-pick configuration (pick type, tiebreakers,
+/// confidence, ranking/conference filters), and creation is ADMIN-ONLY
+/// while the game is in alpha (week 3-4 go-live) — the standing
+/// availability gate models per-sport open dates, not per-game rollout.
+///
+/// The same PickemGroupCreated outbox event fans out to bootstrap, which
+/// creates the league's PickemGroupWeek rows; MatchupScheduleProcessor
+/// stamps their phase and SKIPS matchup generation for PlayerPickem
+/// groups — the roster is the game, so a team-pick slate would only add
+/// dead rows and notification fan-out.
+/// </summary>
+public class CreatePlayerLeagueCommandHandler : ICreatePlayerLeagueCommandHandler
+{
+    private const int DefaultMaxUsers = int.MaxValue;
+
+    private readonly ILogger<CreatePlayerLeagueCommandHandler> _logger;
+    private readonly AppDataContext _dbContext;
+    private readonly IEventBus _eventBus;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly IValidator<CreatePlayerLeagueRequest> _validator;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public CreatePlayerLeagueCommandHandler(
+        ILogger<CreatePlayerLeagueCommandHandler> logger,
+        AppDataContext dbContext,
+        IEventBus eventBus,
+        IContestClientFactory contestClientFactory,
+        IValidator<CreatePlayerLeagueRequest> validator,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+        _eventBus = eventBus;
+        _contestClientFactory = contestClientFactory;
+        _validator = validator;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<Guid>> ExecuteAsync(
+        CreatePlayerLeagueRequest request,
+        Guid currentUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validation.IsValid)
+            return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
+
+        // Alpha gate: Player Pick'em leagues are operator-created until the
+        // game launches. Fresh read, never the cached middleware identity —
+        // enforcement decisions don't ride caches (same rule as the
+        // availability-gate bypass in the team-league base handler).
+        var isAdmin = await _dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.Id == currentUserId)
+            .Select(u => u.IsAdmin)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (!isAdmin)
+        {
+            _logger.LogWarning(
+                "Rejecting create-player-league: user {UserId} is not an admin.",
+                currentUserId);
+            return new Failure<Guid>(default!, ResultStatus.Forbid,
+                [new ValidationFailure(nameof(currentUserId), "Player Pick'em league creation is not open yet.")]);
+        }
+
+        var sport = Enum.Parse<Sport>(request.Sport, ignoreCase: true);
+        var league = sport == Sport.FootballNfl ? League.NFL : League.NCAAF;
+
+        // Blackout guard, same contract as team leagues: a windowed league
+        // whose range holds no games bootstraps to zero weeks. Fail OPEN on
+        // dependency errors; reject only a confirmed-empty window.
+        if (request.StartsOn.HasValue || request.EndsOn.HasValue)
+        {
+            var gameDates = await _contestClientFactory
+                .Resolve(sport)
+                .GetGameDates(request.EffectiveStartsOn, request.EffectiveEndsOn, cancellationToken);
+
+            if (gameDates.IsSuccess && gameDates.Value.Count == 0)
+            {
+                return new Failure<Guid>(default!, ResultStatus.Validation,
+                    [new ValidationFailure(nameof(request.StartsOn),
+                        "No games are scheduled in the selected date range. " +
+                        "Choose a range that includes at least one game day.")]);
+            }
+        }
+
+        var joinPolicy = request.JoinPolicy is null
+            ? JoinPolicy.Open
+            : Enum.Parse<JoinPolicy>(request.JoinPolicy, ignoreCase: true);
+
+        var seasonYear = request.SeasonYear ?? _dateTimeProvider.UtcNow().Year;
+
+        var group = new PickemGroup
+        {
+            Id = Guid.NewGuid(),
+            CommissionerUserId = currentUserId,
+            CreatedBy = currentUserId,
+            Name = request.Name.Trim(),
+            Description = request.Description?.Trim(),
+            Sport = sport,
+            League = league,
+            GroupType = GroupType.PlayerPickem,
+            IsPublic = request.IsPublic,
+            JoinPolicy = joinPolicy,
+            SeasonYear = seasonYear,
+            MaxUsers = DefaultMaxUsers,
+            LeagueWindow = request.StartsOn is null && request.EffectiveEndsOn is null
+                ? LeagueWindow.FullSeason
+                : LeagueWindow.DateRange,
+            StartsOn = request.EffectiveStartsOn,
+            EndsOn = request.EffectiveEndsOn,
+            // Team-pick configuration is inert for this game; set the
+            // benign defaults rather than nulls so nothing downstream
+            // null-checks a column that was always non-null.
+            PickType = PickType.StraightUp,
+            TiebreakerType = TiebreakerType.None,
+            TiebreakerTiePolicy = TiebreakerTiePolicy.EarliestSubmission,
+            UseConfidencePoints = false,
+        };
+
+        group.Members.Add(new PickemGroupMember
+        {
+            CreatedBy = currentUserId,
+            PickemGroupId = group.Id,
+            Role = LeagueRole.Commissioner,
+            UserId = currentUserId,
+        });
+
+        await _dbContext.PickemGroups.AddAsync(group, cancellationToken);
+
+        // Outbox: publish BEFORE SaveChanges so the event commits atomically
+        // with the aggregate (same contract as the team-league base).
+        await _eventBus.Publish(new PickemGroupCreated(
+            group.Id,
+            group.Name,
+            group.CommissionerUserId,
+            group.PickType.ToString(),
+            null,
+            group.Sport,
+            seasonYear,
+            Guid.NewGuid(),
+            Guid.NewGuid()), cancellationToken);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Created PlayerPickem league {LeagueId} ({Sport}) named {LeagueName} by admin {UserId}",
+            group.Id, sport, group.Name, currentUserId);
+
+        return new Success<Guid>(group.Id);
+    }
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandHandler.cs
@@ -16,7 +16,7 @@ namespace SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
 public interface ICreatePlayerLeagueCommandHandler
 {
     Task<Result<Guid>> ExecuteAsync(
-        CreatePlayerLeagueRequest request,
+        CreatePlayerLeagueCommand request,
         Guid currentUserId,
         CancellationToken cancellationToken = default);
 }
@@ -43,7 +43,7 @@ public class CreatePlayerLeagueCommandHandler : ICreatePlayerLeagueCommandHandle
     private readonly AppDataContext _dbContext;
     private readonly IEventBus _eventBus;
     private readonly IContestClientFactory _contestClientFactory;
-    private readonly IValidator<CreatePlayerLeagueRequest> _validator;
+    private readonly IValidator<CreatePlayerLeagueCommand> _validator;
     private readonly IDateTimeProvider _dateTimeProvider;
 
     public CreatePlayerLeagueCommandHandler(
@@ -51,7 +51,7 @@ public class CreatePlayerLeagueCommandHandler : ICreatePlayerLeagueCommandHandle
         AppDataContext dbContext,
         IEventBus eventBus,
         IContestClientFactory contestClientFactory,
-        IValidator<CreatePlayerLeagueRequest> validator,
+        IValidator<CreatePlayerLeagueCommand> validator,
         IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
@@ -63,7 +63,7 @@ public class CreatePlayerLeagueCommandHandler : ICreatePlayerLeagueCommandHandle
     }
 
     public async Task<Result<Guid>> ExecuteAsync(
-        CreatePlayerLeagueRequest request,
+        CreatePlayerLeagueCommand request,
         Guid currentUserId,
         CancellationToken cancellationToken = default)
     {
@@ -170,9 +170,11 @@ public class CreatePlayerLeagueCommandHandler : ICreatePlayerLeagueCommandHandle
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 
+        // League name deliberately not logged — user-provided values in
+        // log entries trip CodeQL (log injection); the id is the join key.
         _logger.LogInformation(
-            "Created PlayerPickem league {LeagueId} ({Sport}) named {LeagueName} by admin {UserId}",
-            group.Id, sport, group.Name, currentUserId);
+            "Created PlayerPickem league {LeagueId} ({Sport}) by admin {UserId}",
+            group.Id, sport, currentUserId);
 
         return new Success<Guid>(group.Id);
     }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandValidator.cs
@@ -33,9 +33,15 @@ public class CreatePlayerLeagueCommandValidator : AbstractValidator<CreatePlayer
             .InclusiveBetween(2000, 2100)
             .When(x => x.SeasonYear.HasValue);
 
+        RuleFor(x => x.EndsOn)
+            .LessThan(new DateTime(2100, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .When(x => x.EndsOn.HasValue)
+            .WithMessage("EndsOn must be before year 2100");
+
         RuleFor(x => x.StartsOn)
             .LessThanOrEqualTo(x => x.EffectiveEndsOn!.Value)
-            .When(x => x.StartsOn.HasValue && x.EndsOn.HasValue)
+            .When(x => x.StartsOn.HasValue && x.EndsOn.HasValue &&
+                       x.EndsOn.Value < new DateTime(2100, 1, 1, 0, 0, 0, DateTimeKind.Utc))
             .WithMessage("StartsOn must be on or before EndsOn");
     }
 }

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandValidator.cs
@@ -4,11 +4,11 @@ using SportsData.Api.Application.Common.Enums;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
 
-public class CreatePlayerLeagueRequestValidator : AbstractValidator<CreatePlayerLeagueRequest>
+public class CreatePlayerLeagueCommandValidator : AbstractValidator<CreatePlayerLeagueCommand>
 {
     private static readonly string[] SupportedSports = ["FootballNcaa", "FootballNfl"];
 
-    public CreatePlayerLeagueRequestValidator()
+    public CreatePlayerLeagueCommandValidator()
     {
         RuleFor(x => x.Sport)
             .Must(s => SupportedSports.Contains(s, StringComparer.OrdinalIgnoreCase))
@@ -19,10 +19,14 @@ public class CreatePlayerLeagueRequestValidator : AbstractValidator<CreatePlayer
             .MaximumLength(100);
 
         RuleFor(x => x.Description)
-            .MaximumLength(500);
+            .MaximumLength(100); // PickemGroup.Description column limit
 
         RuleFor(x => x.JoinPolicy)
-            .Must(p => p is null || Enum.TryParse<JoinPolicy>(p, ignoreCase: true, out _))
+            // IsDefined too: TryParse happily accepts numeric strings like
+            // "999" that no downstream logic handles.
+            .Must(p => p is null ||
+                       (Enum.TryParse<JoinPolicy>(p, ignoreCase: true, out var parsed) &&
+                        Enum.IsDefined(parsed)))
             .WithMessage("Unknown join policy");
 
         RuleFor(x => x.SeasonYear)

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueCommandValidator.cs
@@ -38,7 +38,10 @@ public class CreatePlayerLeagueCommandValidator : AbstractValidator<CreatePlayer
             .When(x => x.EndsOn.HasValue)
             .WithMessage("EndsOn must be before year 2100");
 
-        RuleFor(x => x.StartsOn)
+        // Compare NORMALIZED start against normalized end — DateTime
+        // comparison ignores Kind, so raw-Local vs effective-UTC would
+        // pass or fail by the server's offset.
+        RuleFor(x => x.EffectiveStartsOn)
             .LessThanOrEqualTo(x => x.EffectiveEndsOn!.Value)
             .When(x => x.StartsOn.HasValue && x.EndsOn.HasValue &&
                        x.EndsOn.Value < new DateTime(2100, 1, 1, 0, 0, 0, DateTimeKind.Utc))

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueRequest.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueRequest.cs
@@ -1,0 +1,57 @@
+namespace SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
+
+/// <summary>
+/// Create-request for a PLAYER Pick'em league. Deliberately not a
+/// <see cref="CreateLeagueRequestBase"/> descendant: player leagues have
+/// no pick type, tiebreakers, confidence points, or grouping filters —
+/// the roster IS the game. One request covers both football sports via
+/// <see cref="Sport"/> rather than the per-sport endpoint trio, because
+/// nothing else differs per sport.
+/// </summary>
+public class CreatePlayerLeagueRequest
+{
+    /// <summary>"FootballNcaa" | "FootballNfl".</summary>
+    public required string Sport { get; set; }
+
+    public required string Name { get; set; }
+
+    public string? Description { get; set; }
+
+    public bool IsPublic { get; set; }
+
+    /// <summary>JoinPolicy enum name; absent = Open (matches team-league default).</summary>
+    public string? JoinPolicy { get; set; }
+
+    /// <summary>Defaults to the current year.</summary>
+    public int? SeasonYear { get; set; }
+
+    /// <summary>Inclusive window start; null = from the start of the season.</summary>
+    public DateTime? StartsOn { get; set; }
+
+    /// <summary>Inclusive window end; null = through the end of the season.</summary>
+    public DateTime? EndsOn { get; set; }
+
+    /// <summary>
+    /// UTC-kind-stamped start. JSON date-only values ("2026-08-27")
+    /// deserialize with Kind=Unspecified, which Npgsql refuses to write
+    /// to timestamptz; values are semantically UTC per project
+    /// convention, so stamp the kind rather than converting.
+    /// </summary>
+    public DateTime? EffectiveStartsOn =>
+        StartsOn is { Kind: DateTimeKind.Unspecified } startsOn
+            ? DateTime.SpecifyKind(startsOn, DateTimeKind.Utc)
+            : StartsOn;
+
+    /// <summary>
+    /// Midnight-normalized end (same contract as the team-league flow):
+    /// a date-only value becomes end-of-day UTC so "inclusive" holds.
+    /// Non-midnight values still get their kind stamped UTC (Npgsql
+    /// rejects Kind=Unspecified on timestamptz).
+    /// </summary>
+    public DateTime? EffectiveEndsOn =>
+        EndsOn is { TimeOfDay.Ticks: 0 } endsOn
+            ? DateTime.SpecifyKind(endsOn.Date.AddDays(1).AddTicks(-1), DateTimeKind.Utc)
+            : EndsOn is { Kind: DateTimeKind.Unspecified } raw
+                ? DateTime.SpecifyKind(raw, DateTimeKind.Utc)
+                : EndsOn;
+}

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueRequestValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreatePlayerLeague/CreatePlayerLeagueRequestValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+
+using SportsData.Api.Application.Common.Enums;
+
+namespace SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
+
+public class CreatePlayerLeagueRequestValidator : AbstractValidator<CreatePlayerLeagueRequest>
+{
+    private static readonly string[] SupportedSports = ["FootballNcaa", "FootballNfl"];
+
+    public CreatePlayerLeagueRequestValidator()
+    {
+        RuleFor(x => x.Sport)
+            .Must(s => SupportedSports.Contains(s, StringComparer.OrdinalIgnoreCase))
+            .WithMessage("Sport must be 'FootballNcaa' or 'FootballNfl'");
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(100);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(500);
+
+        RuleFor(x => x.JoinPolicy)
+            .Must(p => p is null || Enum.TryParse<JoinPolicy>(p, ignoreCase: true, out _))
+            .WithMessage("Unknown join policy");
+
+        RuleFor(x => x.SeasonYear)
+            .InclusiveBetween(2000, 2100)
+            .When(x => x.SeasonYear.HasValue);
+
+        RuleFor(x => x.StartsOn)
+            .LessThanOrEqualTo(x => x.EffectiveEndsOn!.Value)
+            .When(x => x.StartsOn.HasValue && x.EndsOn.HasValue)
+            .WithMessage("StartsOn must be on or before EndsOn");
+    }
+}

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -13,6 +13,7 @@ using SportsData.Api.Application.UI.Leagues.Commands.CreateBaseballMlbLeague.Dto
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNcaaLeague.Dtos;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague;
+using SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
 using SportsData.Api.Application.UI.Leagues.Commands.CreateFootballNflLeague.Dtos;
 using SportsData.Api.Application.UI.Leagues.Commands.DeclineLeagueInvitation;
 using SportsData.Api.Application.UI.Leagues.Commands.DeleteLeague;
@@ -71,6 +72,28 @@ public class LeagueController : ApiControllerBase
     public async Task<ActionResult<Guid>> CreateFootballNflLeague(
         [FromBody] CreateFootballNflLeagueRequest request,
         [FromServices] ICreateFootballNflLeagueCommandHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+
+        var result = await handler.ExecuteAsync(request, userId, cancellationToken);
+
+        if (result.IsSuccess)
+            return CreatedAtAction(nameof(GetById), new { id = result.Value }, new { id = result.Value });
+
+        return result.ToActionResult();
+    }
+
+    /// <summary>
+    /// Player Pick'em league — one endpoint for both football sports (the
+    /// request carries Sport; nothing else differs). Admin-only during the
+    /// alpha, enforced in the handler.
+    /// </summary>
+    [HttpPost("players")]
+    [Authorize]
+    public async Task<ActionResult<Guid>> CreatePlayerLeague(
+        [FromBody] CreatePlayerLeagueRequest request,
+        [FromServices] ICreatePlayerLeagueCommandHandler handler,
         CancellationToken cancellationToken)
     {
         var userId = HttpContext.GetCurrentUserId();

--- a/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/LeagueController.cs
@@ -92,7 +92,7 @@ public class LeagueController : ApiControllerBase
     [HttpPost("players")]
     [Authorize]
     public async Task<ActionResult<Guid>> CreatePlayerLeague(
-        [FromBody] CreatePlayerLeagueRequest request,
+        [FromBody] CreatePlayerLeagueCommand request,
         [FromServices] ICreatePlayerLeagueCommandHandler handler,
         CancellationToken cancellationToken)
     {

--- a/src/SportsData.Api/Application/User/Dtos/UserDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserDto.cs
@@ -29,6 +29,13 @@ public class UserDto
 
     public bool IsReadOnly { get; set; }
 
+    /// <summary>
+    /// The user's option set, embedded so clients need no second
+    /// round-trip to /user/me/options (that endpoint remains for
+    /// mobile). Never null — defaults apply when no rows exist.
+    /// </summary>
+    public UserOptionsDto Options { get; set; } = new();
+
     public class UserLeagueMembership
     {
         public Guid Id { get; set; }

--- a/src/SportsData.Api/Application/User/Dtos/UserOptionsDto.cs
+++ b/src/SportsData.Api/Application/User/Dtos/UserOptionsDto.cs
@@ -13,4 +13,28 @@ public record UserOptionsDto
     /// in. Per-user only — never a league setting.
     /// </summary>
     public bool ShowGamblingContent { get; init; }
+
+    /// <summary>
+    /// Single projection from raw UserOption key/value rows — shared by
+    /// GetMe (which embeds options on the user DTO so clients need no
+    /// second round-trip) and the standalone options endpoint (kept for
+    /// mobile). Unknown keys ignored; absent/unparsable values take each
+    /// option's default.
+    /// </summary>
+    public static UserOptionsDto FromRows(IEnumerable<KeyValuePair<string, string>> rows)
+    {
+        var byKey = new Dictionary<string, string>(rows, StringComparer.Ordinal);
+        return new UserOptionsDto
+        {
+            ShowGamblingContent = ParseBool(byKey, UserOptionKeys.ShowGamblingContent, defaultValue: false),
+        };
+    }
+
+    private static bool ParseBool(
+        IReadOnlyDictionary<string, string> byKey,
+        string key,
+        bool defaultValue)
+        => byKey.TryGetValue(key, out var raw) && bool.TryParse(raw, out var parsed)
+            ? parsed
+            : defaultValue;
 }

--- a/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetMe/GetMeQueryHandler.cs
@@ -164,6 +164,17 @@ public class GetMeQueryHandler : IGetMeQueryHandler
                 $"SeasonWeeks for league {league.Id} is not ascending+distinct.");
         }
 
+        // Options ride the same payload — clients needed a second GET to
+        // /user/me/options for a handful of booleans, which is a wasted
+        // round-trip on every initial load. One extra indexed read here;
+        // the standalone endpoint remains for mobile.
+        var optionRows = await _db.UserOptions
+            .AsNoTracking()
+            .Where(o => o.UserId == query.UserId)
+            .Select(o => new KeyValuePair<string, string>(o.Key, o.Value))
+            .ToListAsync(cancellationToken);
+        userDto.Options = UserOptionsDto.FromRows(optionRows);
+
         _logger.LogDebug("User retrieved successfully. UserId={UserId}", query.UserId);
 
         return new Success<UserDto>(userDto);

--- a/src/SportsData.Api/Application/User/Queries/GetUserOptions/GetUserOptionsQueryHandler.cs
+++ b/src/SportsData.Api/Application/User/Queries/GetUserOptions/GetUserOptionsQueryHandler.cs
@@ -44,19 +44,7 @@ public class GetUserOptionsQueryHandler : IGetUserOptionsQueryHandler
             .Select(o => new { o.Key, o.Value })
             .ToListAsync(cancellationToken);
 
-        var byKey = rows.ToDictionary(r => r.Key, r => r.Value, StringComparer.Ordinal);
-
-        return new Success<UserOptionsDto>(new UserOptionsDto
-        {
-            ShowGamblingContent = ParseBool(byKey, UserOptionKeys.ShowGamblingContent, defaultValue: false)
-        });
+        return new Success<UserOptionsDto>(
+            UserOptionsDto.FromRows(rows.Select(r => new KeyValuePair<string, string>(r.Key, r.Value))));
     }
-
-    private static bool ParseBool(
-        IReadOnlyDictionary<string, string> byKey,
-        string key,
-        bool defaultValue)
-        => byKey.TryGetValue(key, out var raw) && bool.TryParse(raw, out var parsed)
-            ? parsed
-            : defaultValue;
 }

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -124,6 +124,10 @@ namespace SportsData.Api.DependencyInjection
                 Application.UI.Leagues.Commands.CloneLeague.CloneLeagueCommandHandler>();
             services.AddScoped<ICreateFootballNcaaLeagueCommandHandler, CreateFootballNcaaLeagueCommandHandler>();
             services.AddScoped<ICreateFootballNflLeagueCommandHandler, CreateFootballNflLeagueCommandHandler>();
+            services.AddScoped<Application.UI.Leagues.Commands.CreatePlayerLeague.ICreatePlayerLeagueCommandHandler,
+                Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueCommandHandler>();
+            services.AddScoped<FluentValidation.IValidator<Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueRequest>,
+                Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueRequestValidator>();
             services.AddScoped<ICreateBaseballMlbLeagueCommandHandler, CreateBaseballMlbLeagueCommandHandler>();
             services.AddScoped<IDeleteLeagueCommandHandler, DeleteLeagueCommandHandler>();
             services.AddScoped<IGenerateLeagueWeekPreviewsCommandHandler, GenerateLeagueWeekPreviewsCommandHandler>();

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -126,8 +126,8 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<ICreateFootballNflLeagueCommandHandler, CreateFootballNflLeagueCommandHandler>();
             services.AddScoped<Application.UI.Leagues.Commands.CreatePlayerLeague.ICreatePlayerLeagueCommandHandler,
                 Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueCommandHandler>();
-            services.AddScoped<FluentValidation.IValidator<Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueRequest>,
-                Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueRequestValidator>();
+            services.AddScoped<FluentValidation.IValidator<Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueCommand>,
+                Application.UI.Leagues.Commands.CreatePlayerLeague.CreatePlayerLeagueCommandValidator>();
             services.AddScoped<ICreateBaseballMlbLeagueCommandHandler, CreateBaseballMlbLeagueCommandHandler>();
             services.AddScoped<IDeleteLeagueCommandHandler, DeleteLeagueCommandHandler>();
             services.AddScoped<IGenerateLeagueWeekPreviewsCommandHandler, GenerateLeagueWeekPreviewsCommandHandler>();

--- a/src/UI/sd-mobile/__tests__/components/features/home/RankingsCard.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/home/RankingsCard.test.tsx
@@ -12,6 +12,9 @@ jest.mock('@/src/services/api/seasonApi', () => ({
   seasonApi: {
     getCurrentSeason: jest.fn(),
   },
+  currentSeasonKeys: {
+    current: (sport: string, league: string) => ['season', 'current', sport, league],
+  },
 }));
 
 jest.mock('@/src/services/api/rankingsApi', () => {

--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -21,7 +21,7 @@ import { getTheme } from '@/constants/Colors';
 import { auth } from '@/src/lib/firebase';
 import { useAuthStore } from '@/src/stores/authStore';
 import { useCurrentUser, standingsKeys } from '@/src/hooks/useStandings';
-import { useUserOptions, userOptionsKeys } from '@/src/hooks/useUserOptions';
+import { useUserOptions, getUserOptionsCache, setUserOptionsCache } from '@/src/hooks/useUserOptions';
 import type { UserOptions } from '@/src/types/models';
 import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
 import { usersApi } from '@/src/services/api/usersApi';
@@ -130,13 +130,14 @@ export default function ProfileScreen() {
   const optionsMutation = useMutation<unknown, unknown, UserOptions, { previous?: UserOptions }>({
     mutationFn: (next) => usersApi.updateUserOptions(next),
     onMutate: (next) => {
-      const previous = queryClient.getQueryData<UserOptions>(userOptionsKeys.me);
-      queryClient.setQueryData(userOptionsKeys.me, next);
+      // Options live inside the cached /user/me payload now — patch it.
+      const previous = getUserOptionsCache(queryClient);
+      setUserOptionsCache(queryClient, next);
       setOptionsMessage('');
       return { previous };
     },
     onError: (_err, _next, context) => {
-      if (context?.previous) queryClient.setQueryData(userOptionsKeys.me, context.previous);
+      if (context?.previous) setUserOptionsCache(queryClient, context.previous);
       setOptionsMessage('Could not save. Please try again.');
     },
   });

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -10,6 +10,7 @@ import {
   seasonApi,
   REGULAR_SEASON_TYPE_CODE,
   type CurrentSeason,
+  currentSeasonKeys,
 } from '@/src/services/api/seasonApi';
 import {
   useLeagueCreationGates,
@@ -78,7 +79,7 @@ export function PrimarySlotOffSeasonCountdown() {
 
   const results = useQueries({
     queries: SPORTS.map((s) => ({
-      queryKey: ['season', 'current', s.sport, s.league],
+      queryKey: currentSeasonKeys.current(s.sport, s.league),
       queryFn: () => seasonApi.getCurrentSeason(s.sport, s.league).then((r) => r.data),
       staleTime: 1000 * 60 * 60, // kickoff dates barely move; refetch hourly at most
       // A sport with no sourced season is a valid "coming soon" state — don't

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -11,6 +11,7 @@ import {
   REGULAR_SEASON_TYPE_CODE,
   type CurrentSeason,
   currentSeasonKeys,
+  currentSeasonRetry,
 } from '@/src/services/api/seasonApi';
 import {
   useLeagueCreationGates,
@@ -82,9 +83,8 @@ export function PrimarySlotOffSeasonCountdown() {
       queryKey: currentSeasonKeys.current(s.sport, s.league),
       queryFn: () => seasonApi.getCurrentSeason(s.sport, s.league).then((r) => r.data),
       staleTime: 1000 * 60 * 60, // kickoff dates barely move; refetch hourly at most
-      // A sport with no sourced season is a valid "coming soon" state — don't
-      // retry it as though it were a transient error.
-      retry: false,
+      // 404 = valid "coming soon"; transient failures get a bounded retry.
+      retry: currentSeasonRetry,
     })),
   });
 

--- a/src/UI/sd-mobile/src/hooks/useCurrentSeasonYear.ts
+++ b/src/UI/sd-mobile/src/hooks/useCurrentSeasonYear.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { currentSeasonKeys, seasonApi } from '@/src/services/api/seasonApi';
+import { currentSeasonKeys, currentSeasonRetry, seasonApi } from '@/src/services/api/seasonApi';
 
 /**
  * Resolves the current (or upcoming) season year for a sport from
@@ -18,9 +18,7 @@ export function useCurrentSeasonYear(sport = 'football', league = 'ncaa') {
     queryKey: currentSeasonKeys.current(sport, league),
     queryFn: async () => (await seasonApi.getCurrentSeason(sport, league)).data,
     staleTime: 60 * 60 * 1000,
-    // No sourced season is a valid "coming soon" state, not a transient
-    // error — matches the countdown's observer options on the same key.
-    retry: false,
+    retry: currentSeasonRetry,
   });
 
   return { seasonYear: data?.seasonYear ?? null, loading: isLoading };

--- a/src/UI/sd-mobile/src/hooks/useCurrentSeasonYear.ts
+++ b/src/UI/sd-mobile/src/hooks/useCurrentSeasonYear.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { seasonApi } from '@/src/services/api/seasonApi';
+import { currentSeasonKeys, seasonApi } from '@/src/services/api/seasonApi';
 
 /**
  * Resolves the current (or upcoming) season year for a sport from
@@ -13,9 +13,14 @@ import { seasonApi } from '@/src/services/api/seasonApi';
  */
 export function useCurrentSeasonYear(sport = 'football', league = 'ncaa') {
   const { data, isLoading } = useQuery({
-    queryKey: ['currentSeason', sport, league],
+    // Shared key (currentSeasonKeys) so this and the off-season countdown
+    // dedupe to ONE fetch per sport per staleTime window.
+    queryKey: currentSeasonKeys.current(sport, league),
     queryFn: async () => (await seasonApi.getCurrentSeason(sport, league)).data,
     staleTime: 60 * 60 * 1000,
+    // No sourced season is a valid "coming soon" state, not a transient
+    // error — matches the countdown's observer options on the same key.
+    retry: false,
   });
 
   return { seasonYear: data?.seasonYear ?? null, loading: isLoading };

--- a/src/UI/sd-mobile/src/hooks/useUserOptions.ts
+++ b/src/UI/sd-mobile/src/hooks/useUserOptions.ts
@@ -1,26 +1,40 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type QueryClient } from '@tanstack/react-query';
 
 import { usersApi } from '@/src/services/api/usersApi';
-import type { UserOptions } from '@/src/types/models';
+import type { UserDto, UserOptions } from '@/src/types/models';
 import { useAuthStore } from '@/src/stores/authStore';
-
-export const userOptionsKeys = {
-  me: ['user', 'me', 'options'] as const,
-};
+import { standingsKeys } from '@/src/hooks/useStandings';
 
 /**
- * The signed-in user's typed options (UserOptionsDto). Consumers treat
- * `undefined` (loading / fetch failure) as all-defaults via
- * {@link shouldShowGambling}-style predicates, so a failed fetch degrades to
- * the safe defaults rather than blocking render. Long staleTime: options only
- * change from the Profile toggle, which writes the cache directly.
+ * The signed-in user's typed options (UserOptionsDto), DERIVED from the
+ * /user/me payload — options ride the same response, so this shares the
+ * me query's cache instead of making a second round-trip (the old
+ * /user/me/options GET). Consumers treat `undefined` (loading / fetch
+ * failure / pre-rollout payloads without the field) as all-defaults via
+ * {@link shouldShowGambling}-style predicates.
  */
 export function useUserOptions() {
   const { user, isInitialized } = useAuthStore();
-  return useQuery<UserOptions>({
-    queryKey: userOptionsKeys.me,
-    queryFn: () => usersApi.getUserOptions().then((r) => r.data),
+  return useQuery<UserDto, Error, UserOptions | undefined>({
+    queryKey: standingsKeys.me,
+    queryFn: () => usersApi.getMe().then((r) => r.data),
+    select: (me) => me.options,
     enabled: isInitialized && !!user,
-    staleTime: 1000 * 60 * 60,
+    staleTime: 1000 * 60 * 5,
   });
+}
+
+/**
+ * Cache helpers for the Profile toggle's optimistic write: options live
+ * INSIDE the cached /user/me payload now, so the mutation must patch
+ * that entry rather than a standalone options key.
+ */
+export function getUserOptionsCache(queryClient: QueryClient): UserOptions | undefined {
+  return queryClient.getQueryData<UserDto>(standingsKeys.me)?.options;
+}
+
+export function setUserOptionsCache(queryClient: QueryClient, next: UserOptions | undefined): void {
+  queryClient.setQueryData<UserDto>(standingsKeys.me, (me) =>
+    me ? { ...me, options: next } : me
+  );
 }

--- a/src/UI/sd-mobile/src/services/api/client.ts
+++ b/src/UI/sd-mobile/src/services/api/client.ts
@@ -1,5 +1,5 @@
 import axios, { type AxiosInstance } from 'axios';
-import { getAuth } from 'firebase/auth';
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
 
 const BASE_URL =
   process.env.EXPO_PUBLIC_API_BASE_URL ?? 'https://api.sportdeets.com';
@@ -10,8 +10,29 @@ export const apiClient: AxiosInstance = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
+// Resolves once Firebase has determined the initial auth state (persisted
+// session restored or confirmed absent). Requests fired during app boot
+// used to race this: `getAuth().currentUser` is null until the first
+// onAuthStateChanged emission, so early queries went out with NO bearer
+// and 401'd (creation-availability, invitations, discover, rankings),
+// then refetched after auth landed. Gating on INITIALIZATION — not on
+// being signed in — keeps anonymous endpoints working for logged-out
+// users while eliminating the race for everyone else. Lazy so module
+// import order can't touch Firebase before the app initializes it.
+let authInitialized: Promise<void> | null = null;
+const waitForAuthInit = (): Promise<void> => {
+  authInitialized ??= new Promise((resolve) => {
+    const unsubscribe = onAuthStateChanged(getAuth(), () => {
+      unsubscribe();
+      resolve();
+    });
+  });
+  return authInitialized;
+};
+
 // Attach Firebase JWT on every request
 apiClient.interceptors.request.use(async (config) => {
+  await waitForAuthInit();
   const user = getAuth().currentUser;
   if (user) {
     const token = await user.getIdToken();

--- a/src/UI/sd-mobile/src/services/api/seasonApi.ts
+++ b/src/UI/sd-mobile/src/services/api/seasonApi.ts
@@ -31,6 +31,20 @@ export const currentSeasonKeys = {
     ['season', 'current', sport, league] as const,
 };
 
+/**
+ * Retry policy for current-season observers (use on EVERY observer of a
+ * currentSeasonKeys query — mixed policies on one key are confusing).
+ * 404 is the VALID "no season sourced" state — never retry it. Anything
+ * else (timeouts, connection failures, 5xx) gets the bounded retry a
+ * blank seasonYear deserves, since a resolved failure disables
+ * dependent queries (rankings) until the next mount.
+ */
+export const currentSeasonRetry = (failureCount: number, error: unknown): boolean => {
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  if (status === 404) return false;
+  return failureCount < 2;
+};
+
 export const seasonApi = {
   // GET /api/{sport}/{league}/seasons/current — current-or-upcoming season with
   // its phases. Raw phase data; the caller interprets it (e.g. the off-season

--- a/src/UI/sd-mobile/src/services/api/seasonApi.ts
+++ b/src/UI/sd-mobile/src/services/api/seasonApi.ts
@@ -20,6 +20,17 @@ export interface CurrentSeason {
 
 export const REGULAR_SEASON_TYPE_CODE = 2;
 
+/**
+ * Canonical react-query keys for current-season lookups. Every consumer
+ * MUST use these — the off-season countdown and useCurrentSeasonYear
+ * once used different ad-hoc keys for the same endpoint, so react-query
+ * couldn't dedupe and the home screen fetched NCAA's season twice.
+ */
+export const currentSeasonKeys = {
+  current: (sport: string, league: string) =>
+    ['season', 'current', sport, league] as const,
+};
+
 export const seasonApi = {
   // GET /api/{sport}/{league}/seasons/current — current-or-upcoming season with
   // its phases. Raw phase data; the caller interprets it (e.g. the off-season

--- a/src/UI/sd-mobile/src/services/api/usersApi.ts
+++ b/src/UI/sd-mobile/src/services/api/usersApi.ts
@@ -41,7 +41,6 @@ export const usersApi = {
   // never changed anything). PATCH is a full replacement of KNOWN options —
   // unknown/newer options are never touched server-side.
   // See docs/features/user-options.md.
-  getUserOptions: () => apiClient.get<UserOptions>('/user/me/options'),
   updateUserOptions: (options: UserOptions) =>
     apiClient.patch('/user/me/options', options),
 };

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -441,6 +441,12 @@ export interface UserDto {
   leagues: League[];
   isAdmin?: boolean;
   isReadOnly?: boolean;
+  /**
+   * Embedded option set — rides /user/me so no second round-trip is
+   * needed. Optional for pre-rollout API compat; consumers fall back to
+   * safe defaults when absent.
+   */
+  options?: UserOptions;
 }
 
 /**

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -25,6 +25,7 @@ import VenuePage from "components/venues/VenuePage";
 import VenuesPage from "components/venues/VenuesPage";
 import apiWrapper from "./api/apiWrapper";
 import LeagueCreatePage from "./components/leagues/LeagueCreatePage";
+import PlayerLeagueCreatePage from "./components/leagues/PlayerLeagueCreatePage";
 import LandingFooter from "./components/landing/LandingFooter";
 import LeagueDetail from "./components/leagues/LeagueDetail";
 import Leagues from "./components/leagues/Leagues";
@@ -239,6 +240,15 @@ function MainApp() {
             />
             <Route path="/league/discover" element={<LeagueDiscoverPage />} />
             <Route path="/league/create" element={<LeagueCreatePage />} />
+            {/* Player Pick'em league creation — admin-only during alpha. */}
+            <Route
+              path="/league/create/players"
+              element={
+                <AdminRoute>
+                  <PlayerLeagueCreatePage />
+                </AdminRoute>
+              }
+            />
             <Route path="/league/:id" element={<LeagueDetail />} />
             <Route path="/league" element={<Leagues />} />
             {/* Alias: honor the plural /leagues too. */}

--- a/src/UI/sd-ui/src/api/leagues/leaguesApi.js
+++ b/src/UI/sd-ui/src/api/leagues/leaguesApi.js
@@ -23,6 +23,16 @@ const createFootballNflLeague = async (request) => {
 };
 
 /**
+ * Creates a new PLAYER Pick'em league (admin-gated during alpha). One
+ * endpoint for both football sports — the request carries sport.
+ * @returns {Promise<{ id: string }>} Created league ID
+ */
+const createPlayerLeague = async (request) => {
+  const response = await apiClient.post(`${BASE_PATH}/players`, request);
+  return response.data;
+};
+
+/**
  * Creates a new MLB pick'em league (admin-gated).
  * @returns {Promise<{ id: string }>} Created league ID
  */
@@ -215,6 +225,7 @@ const LeaguesApi = {
   createFootballNcaaLeague,
   createFootballNflLeague,
   createBaseballMlbLeague,
+  createPlayerLeague,
   cloneLeague,
   getLeagueById,
   getUserLeagues,

--- a/src/UI/sd-ui/src/api/seasonApi.js
+++ b/src/UI/sd-ui/src/api/seasonApi.js
@@ -8,6 +8,10 @@ import apiClient from "./apiClient";
 // also dedupes concurrent first-load calls. A failed request is evicted
 // so the next caller retries instead of caching an error forever.
 const currentSeasonCache = new Map();
+// Fresh for an hour (matches mobile's staleTime): long enough to kill
+// the duplicate-call problem, short enough that a tab left open across
+// a season rollover picks up the new season without a reload.
+const CURRENT_SEASON_TTL_MS = 60 * 60 * 1000;
 
 const SeasonApi = {
   getSeasonOverview: (seasonYear) =>
@@ -19,16 +23,18 @@ const SeasonApi = {
   // startDate. `sport`/`league` are the route segments, e.g. ("football","ncaa").
   getCurrentSeason: (sport, league) => {
     const key = `${sport}/${league}`;
-    if (!currentSeasonCache.has(key)) {
-      const request = apiClient
-        .get(`/api/${sport}/${league}/seasons/current`)
-        .catch((err) => {
-          currentSeasonCache.delete(key);
-          throw err;
-        });
-      currentSeasonCache.set(key, request);
+    const cached = currentSeasonCache.get(key);
+    if (cached && Date.now() - cached.at < CURRENT_SEASON_TTL_MS) {
+      return cached.request;
     }
-    return currentSeasonCache.get(key);
+    const request = apiClient
+      .get(`/api/${sport}/${league}/seasons/current`)
+      .catch((err) => {
+        currentSeasonCache.delete(key);
+        throw err;
+      });
+    currentSeasonCache.set(key, { request, at: Date.now() });
+    return request;
   },
 };
 

--- a/src/UI/sd-ui/src/api/seasonApi.js
+++ b/src/UI/sd-ui/src/api/seasonApi.js
@@ -27,14 +27,19 @@ const SeasonApi = {
     if (cached && Date.now() - cached.at < CURRENT_SEASON_TTL_MS) {
       return cached.request;
     }
-    const request = apiClient
+    const entry = { request: null, at: Date.now() };
+    entry.request = apiClient
       .get(`/api/${sport}/${league}/seasons/current`)
       .catch((err) => {
-        currentSeasonCache.delete(key);
+        // Evict only OUR entry — a TTL-expired request rejecting late must
+        // not delete a newer in-flight replacement.
+        if (currentSeasonCache.get(key) === entry) {
+          currentSeasonCache.delete(key);
+        }
         throw err;
       });
-    currentSeasonCache.set(key, { request, at: Date.now() });
-    return request;
+    currentSeasonCache.set(key, entry);
+    return entry.request;
   },
 };
 

--- a/src/UI/sd-ui/src/api/seasonApi.js
+++ b/src/UI/sd-ui/src/api/seasonApi.js
@@ -1,5 +1,14 @@
 import apiClient from "./apiClient";
 
+// Session-lifetime promise cache for the current-season lookup. The
+// answer changes roughly once a YEAR, yet multiple independent surfaces
+// need it (off-season countdown fetches both sports, rankings resolve
+// their season year) — without a cache the home page fired the same
+// NCAA request twice per load. Caching the PROMISE (not the result)
+// also dedupes concurrent first-load calls. A failed request is evicted
+// so the next caller retries instead of caching an error forever.
+const currentSeasonCache = new Map();
+
 const SeasonApi = {
   getSeasonOverview: (seasonYear) =>
     apiClient.get(`/ui/season/${seasonYear}/overview`),
@@ -8,8 +17,19 @@ const SeasonApi = {
   // returning raw phase data (TypeCode + dates); the caller interprets it —
   // e.g. the off-season countdown reads the Regular Season (TypeCode 2) phase's
   // startDate. `sport`/`league` are the route segments, e.g. ("football","ncaa").
-  getCurrentSeason: (sport, league) =>
-    apiClient.get(`/api/${sport}/${league}/seasons/current`),
+  getCurrentSeason: (sport, league) => {
+    const key = `${sport}/${league}`;
+    if (!currentSeasonCache.has(key)) {
+      const request = apiClient
+        .get(`/api/${sport}/${league}/seasons/current`)
+        .catch((err) => {
+          currentSeasonCache.delete(key);
+          throw err;
+        });
+      currentSeasonCache.set(key, request);
+    }
+    return currentSeasonCache.get(key);
+  },
 };
 
 export default SeasonApi;

--- a/src/UI/sd-ui/src/api/usersApi.js
+++ b/src/UI/sd-ui/src/api/usersApi.js
@@ -15,7 +15,6 @@ const UsersApi = {
   // user has never changed anything; PATCH is a full replacement of KNOWN
   // options (unknown/newer options are never touched server-side).
   // See docs/features/user-options.md.
-  getUserOptions: () => apiClient.get("/user/me/options"),
   updateUserOptions: (options) => apiClient.patch("/user/me/options", options),
   // DELETE /user/me — server anonymizes the record and removes the Firebase
   // login; caller signs out afterward. Mirrors the mobile app's deleteAccount.

--- a/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
+++ b/src/UI/sd-ui/src/components/home/YourLeaguesCard.jsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { GiAmericanFootballHelmet } from "react-icons/gi";
 import { useUserDto } from "../../contexts/UserContext";
 import { leaguePicksPath } from "../../routes/paths";
 import "./YourLeaguesCard.css";
@@ -33,6 +34,16 @@ function YourLeaguesCard() {
 
   if (leagues.length === 0) return null;
 
+  // Player Pick'em is a different game — its rows get a helmet (no
+  // Unicode football-helmet emoji exists, so this one comes from
+  // react-icons' Game Icons set) instead of the sport-ball glyph.
+  const leagueIcon = (league) =>
+    league.groupType === "PlayerPickem" ? (
+      <GiAmericanFootballHelmet />
+    ) : (
+      SPORT_ICON[league.sport]
+    );
+
   return (
     <div className="your-leagues-card">
       <div className="your-leagues-card__header">
@@ -45,7 +56,7 @@ function YourLeaguesCard() {
       </div>
       <ul className="your-leagues-card__list">
         {leagues.map((league) => {
-          const icon = SPORT_ICON[league.sport];
+          const icon = leagueIcon(league);
           // League-rooted canonical URL — LeaguePicksRouter renders
           // whichever game this league plays, so no branching here.
           const destination = leaguePicksPath(league.id);

--- a/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/LeagueCreatePage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import toast from "react-hot-toast";
 import apiWrapper from "../../api/apiWrapper.js";
 import { useUserDto } from "../../contexts/UserContext";
@@ -542,6 +542,16 @@ const LeagueCreatePage = () => {
         Let’s set up your custom league so you can compete with friends - or
         publish it for others to join!
       </p>
+      {/* Player Pick'em is a different game with its own (much smaller)
+          create flow — admin-only during alpha, so the link hides for
+          everyone else. */}
+      {userDto?.isAdmin === true && (
+        <p>
+          <Link to="/app/league/create/players">
+            Creating a Player Pick’em league instead? →
+          </Link>
+        </p>
+      )}
 
       <div className="card">
         <div

--- a/src/UI/sd-ui/src/components/leagues/PlayerLeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/PlayerLeagueCreatePage.jsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import LeaguesApi from "api/leagues/leaguesApi";
+import { useUserDto } from "../../contexts/UserContext";
+import { leaguePicksPath } from "../../routes/paths";
+import "./LeagueCreatePage.css";
+
+/**
+ * Player Pick'em league creation — the companion to the team-league
+ * create page. Deliberately minimal: player leagues carry none of the
+ * team-pick configuration (pick type, tiebreakers, confidence,
+ * ranking/conference filters) — the roster is the game. Admin-only
+ * during the alpha (route is AdminRoute-wrapped; the API enforces it
+ * server-side too).
+ *
+ * Optional date window mirrors team leagues: bounds scope which weeks
+ * bootstrap materializes (a preseason-only test league sets both dates
+ * inside preseason). Blank = full season.
+ */
+function PlayerLeagueCreatePage() {
+  const navigate = useNavigate();
+  const { refreshUserDto } = useUserDto();
+  const [sport, setSport] = useState("FootballNfl");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isPublic, setIsPublic] = useState(false);
+  const [startsOn, setStartsOn] = useState("");
+  const [endsOn, setEndsOn] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const canSubmit = name.trim().length > 0 && !submitting;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const { id } = await LeaguesApi.createPlayerLeague({
+        sport,
+        name: name.trim(),
+        description: description.trim() || null,
+        isPublic,
+        // Z-suffixed like the team create form: date-only strings
+        // deserialize as Kind=Unspecified server-side, which Npgsql
+        // rejects for timestamptz.
+        startsOn: startsOn ? `${startsOn}T00:00:00Z` : null,
+        endsOn: endsOn ? `${endsOn}T23:59:59Z` : null,
+      });
+      // Refresh /user/me BEFORE navigating: LeaguePicksRouter resolves
+      // the league from userDto, and a stale DTO can't find the new
+      // league — PicksPage's bad-id fallback would then bounce to the
+      // remembered league instead. (Same contract as the team create
+      // page and invite-accept.)
+      await refreshUserDto();
+      // Straight to the roster builder — the router canonicalizes to the
+      // league's current week once bootstrap materializes its weeks.
+      navigate(leaguePicksPath(id));
+    } catch (err) {
+      const first = err?.response?.data?.errors;
+      setError(
+        (Array.isArray(first) && first[0]?.errorMessage) ||
+          "Could not create the league. Please try again."
+      );
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="league-create-container">
+      <h1>Create a Player Pick&rsquo;em League</h1>
+      <p>
+        Weekly fantasy-style rosters &mdash; no team picks, no spreads.
+        Admin-only while the game is in alpha.
+      </p>
+
+      <form className="card" onSubmit={handleSubmit}>
+        <div
+          className="segmented-control sport-selector"
+          role="tablist"
+          aria-label="Sport"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={sport === "FootballNfl"}
+            className={`segmented-tab${sport === "FootballNfl" ? " active" : ""}`}
+            onClick={() => setSport("FootballNfl")}
+          >
+            NFL
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={sport === "FootballNcaa"}
+            className={`segmented-tab${sport === "FootballNcaa" ? " active" : ""}`}
+            onClick={() => setSport("FootballNcaa")}
+          >
+            NCAAFB
+          </button>
+        </div>
+
+        <label htmlFor="pl-name">League Name</label>
+        <input
+          id="pl-name"
+          type="text"
+          maxLength={100}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Friday Night Rosters"
+        />
+
+        <label htmlFor="pl-description">Description (optional)</label>
+        <input
+          id="pl-description"
+          type="text"
+          maxLength={500}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+
+        <label className="checkbox-label" htmlFor="pl-public">
+          <input
+            id="pl-public"
+            type="checkbox"
+            checked={isPublic}
+            onChange={(e) => setIsPublic(e.target.checked)}
+          />
+          Public league (discoverable by anyone)
+        </label>
+
+        <fieldset className="date-window">
+          <legend>Date window (optional &mdash; blank = full season)</legend>
+          <label htmlFor="pl-starts">Starts on</label>
+          <input
+            id="pl-starts"
+            type="date"
+            value={startsOn}
+            onChange={(e) => setStartsOn(e.target.value)}
+          />
+          <label htmlFor="pl-ends">Ends on</label>
+          <input
+            id="pl-ends"
+            type="date"
+            value={endsOn}
+            onChange={(e) => setEndsOn(e.target.value)}
+          />
+        </fieldset>
+
+        {error && (
+          <div className="form-error" role="alert">
+            {error}
+          </div>
+        )}
+
+        <button type="submit" className="submit-button" disabled={!canSubmit}>
+          {submitting ? "Creating…" : "Create League"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default PlayerLeagueCreatePage;

--- a/src/UI/sd-ui/src/components/leagues/PlayerLeagueCreatePage.jsx
+++ b/src/UI/sd-ui/src/components/leagues/PlayerLeagueCreatePage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import LeaguesApi from "api/leagues/leaguesApi";
 import { useUserDto } from "../../contexts/UserContext";
@@ -20,6 +20,11 @@ import "./LeagueCreatePage.css";
 function PlayerLeagueCreatePage() {
   const navigate = useNavigate();
   const { refreshUserDto } = useUserDto();
+  // Once the POST succeeds the league EXISTS — a later failure (the
+  // userDto refresh) must not funnel back into another POST, or a retry
+  // click creates a duplicate league. Holds the created id so retries
+  // resume at the refresh/navigate step.
+  const createdIdRef = useRef(null);
   const [sport, setSport] = useState("FootballNfl");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -36,35 +41,48 @@ function PlayerLeagueCreatePage() {
     if (!canSubmit) return;
     setSubmitting(true);
     setError(null);
-    try {
-      const { id } = await LeaguesApi.createPlayerLeague({
-        sport,
-        name: name.trim(),
-        description: description.trim() || null,
-        isPublic,
-        // Z-suffixed like the team create form: date-only strings
-        // deserialize as Kind=Unspecified server-side, which Npgsql
-        // rejects for timestamptz.
-        startsOn: startsOn ? `${startsOn}T00:00:00Z` : null,
-        endsOn: endsOn ? `${endsOn}T23:59:59Z` : null,
-      });
-      // Refresh /user/me BEFORE navigating: LeaguePicksRouter resolves
-      // the league from userDto, and a stale DTO can't find the new
-      // league — PicksPage's bad-id fallback would then bounce to the
-      // remembered league instead. (Same contract as the team create
-      // page and invite-accept.)
-      await refreshUserDto();
-      // Straight to the roster builder — the router canonicalizes to the
-      // league's current week once bootstrap materializes its weeks.
-      navigate(leaguePicksPath(id));
-    } catch (err) {
-      const first = err?.response?.data?.errors;
+
+    if (createdIdRef.current === null) {
+      try {
+        const { id } = await LeaguesApi.createPlayerLeague({
+          sport,
+          name: name.trim(),
+          description: description.trim() || null,
+          isPublic,
+          // Z-suffixed like the team create form: date-only strings
+          // deserialize as Kind=Unspecified server-side, which Npgsql
+          // rejects for timestamptz.
+          startsOn: startsOn ? `${startsOn}T00:00:00Z` : null,
+          endsOn: endsOn ? `${endsOn}T23:59:59Z` : null,
+        });
+        createdIdRef.current = id;
+      } catch (err) {
+        const first = err?.response?.data?.errors;
+        setError(
+          (Array.isArray(first) && first[0]?.errorMessage) ||
+            "Could not create the league. Please try again."
+        );
+        setSubmitting(false);
+        return;
+      }
+    }
+
+    // Refresh /user/me BEFORE navigating: LeaguePicksRouter resolves the
+    // league from userDto, and a stale DTO can't find the new league —
+    // PicksPage's bad-id fallback would then bounce to the remembered
+    // league instead. A refresh failure is NOT a creation failure: the
+    // league exists, so the retry path re-runs only this step.
+    const refreshed = await refreshUserDto();
+    if (!refreshed) {
       setError(
-        (Array.isArray(first) && first[0]?.errorMessage) ||
-          "Could not create the league. Please try again."
+        "League created, but loading it failed. Retry to open it."
       );
       setSubmitting(false);
+      return;
     }
+    // Straight to the roster builder — the router canonicalizes to the
+    // league's current week once bootstrap materializes its weeks.
+    navigate(leaguePicksPath(createdIdRef.current));
   };
 
   return (
@@ -115,7 +133,7 @@ function PlayerLeagueCreatePage() {
         <input
           id="pl-description"
           type="text"
-          maxLength={500}
+          maxLength={100}
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />

--- a/src/UI/sd-ui/src/contexts/UserContext.jsx
+++ b/src/UI/sd-ui/src/contexts/UserContext.jsx
@@ -24,21 +24,16 @@ export const UserProvider = ({ children }) => {
     try {
       const response = await UsersApi.getCurrentUser();
       setUserDto(response.data);
+      // Options ride the /user/me payload — no second round-trip. The
+      // ?? null keeps pre-rollout cached responses (no options field)
+      // on the safe-defaults path.
+      setUserOptions(response.data?.options ?? null);
     } catch (err) {
       console.error('Failed to load user DTO:', err);
       setUserDto(null);
+      setUserOptions(null);
     } finally {
       setLoading(false);
-    }
-
-    // Off the critical path: options only refine display (safe defaults
-    // apply until they arrive), so they must not delay first render.
-    try {
-      const options = await UsersApi.getUserOptions();
-      setUserOptions(options.data);
-    } catch (err) {
-      console.error('Failed to load user options:', err);
-      setUserOptions(null);
     }
   }, [user]);
 
@@ -51,6 +46,7 @@ export const UserProvider = ({ children }) => {
     try {
       const response = await UsersApi.getCurrentUser();
       setUserDto(response.data);
+      setUserOptions(response.data?.options ?? null);
       return true;
     } catch (err) {
       console.error('Failed to refresh user DTO:', err);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -519,6 +519,42 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
         }
 
         /// <summary>
+        /// A successful-but-EMPTY canonical response carries no phase; the
+        /// week must stay unlatched so the next scheduler pass can stamp it
+        /// (latching would strand it on the default phase forever).
+        /// </summary>
+        [Fact]
+        public async Task Process_PlayerPickemGroup_EmptyCanonicalResponse_LeavesWeekUnlatched()
+        {
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+
+            var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
+                .With(x => x.Id, groupId)
+                .With(x => x.GroupType, SportsData.Api.Application.Common.Enums.GroupType.PlayerPickem)
+                .With(x => x.Conferences, new List<PickemGroupConference>())
+                .Create();
+
+            await DataContext.PickemGroups.AddAsync(group);
+            await DataContext.SaveChangesAsync();
+
+            _contestClientMock
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(new List<Matchup>()));
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+            await sut.Process(new ScheduleGroupWeekMatchupsCommand(
+                groupId, seasonWeekId, 2026, 4, false, Guid.NewGuid()));
+
+            var savedGroupWeek = DataContext.PickemGroupWeeks
+                .FirstOrDefault(x => x.SeasonWeekId == seasonWeekId && x.GroupId == groupId);
+            savedGroupWeek.Should().NotBeNull();
+            savedGroupWeek!.AreMatchupsGenerated.Should().BeFalse();
+        }
+
+        /// <summary>
         /// Validates that upon successful matchup generation, the processor publishes
         /// a PickemGroupWeekMatchupsGenerated event with the correct GroupId, SeasonYear,
         /// and CorrelationId for downstream consumers to react to.

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Processors/MatchupScheduleProcessorTests.cs
@@ -462,6 +462,63 @@ namespace SportsData.Api.Tests.Unit.Application.Processors
         }
 
         /// <summary>
+        /// PLAYER Pick'em leagues get the week (identity + phase stamp) but
+        /// no team-pick slate: no PickemGroupMatchup rows are inserted even
+        /// when canonical matchups exist for the week. The roster is the
+        /// game — a slate would only add dead rows and notification fan-out.
+        /// </summary>
+        [Fact]
+        public async Task Process_PlayerPickemGroup_MaterializesWeekWithoutMatchups()
+        {
+            // Arrange
+            var groupId = Guid.NewGuid();
+            var seasonWeekId = Guid.NewGuid();
+
+            var group = Fixture.Build<PickemGroup>()
+                .Without(x => x.StartsOn)
+                .Without(x => x.EndsOn)
+                .With(x => x.Id, groupId)
+                .With(x => x.GroupType, SportsData.Api.Application.Common.Enums.GroupType.PlayerPickem)
+                .With(x => x.Conferences, new List<PickemGroupConference>())
+                .Create();
+
+            await DataContext.PickemGroups.AddAsync(group);
+            await DataContext.SaveChangesAsync();
+
+            _contestClientMock
+                .Setup(x => x.GetMatchupsBySeasonWeekId(seasonWeekId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<List<Matchup>>(new List<Matchup>
+                {
+                    Fixture.Build<Matchup>().With(x => x.SeasonPhaseTypeCode, 1).Create(),
+                }));
+
+            var command = new ScheduleGroupWeekMatchupsCommand(
+                groupId,
+                seasonWeekId,
+                2026,
+                4,
+                false,
+                Guid.NewGuid());
+
+            var sut = Mocker.CreateInstance<MatchupScheduleProcessor>();
+
+            // Act
+            await sut.Process(command);
+
+            // Assert — week exists, phase stamped, flag set, ZERO matchups
+            // for THIS week (AutoFixture seeds unrelated weeks with matchup
+            // graphs on the group; scope the count to the processed week).
+            var savedGroupWeek = DataContext.PickemGroupWeeks
+                .FirstOrDefault(x => x.SeasonWeekId == seasonWeekId && x.GroupId == groupId);
+            savedGroupWeek.Should().NotBeNull();
+            savedGroupWeek!.SeasonPhaseTypeCode.Should().Be(1);
+            savedGroupWeek.AreMatchupsGenerated.Should().BeTrue();
+            DataContext.PickemGroupMatchups
+                .Count(m => m.GroupId == groupId && m.SeasonWeekId == seasonWeekId)
+                .Should().Be(0);
+        }
+
+        /// <summary>
         /// Validates that upon successful matchup generation, the processor publishes
         /// a PickemGroupWeekMatchupsGenerated event with the correct GroupId, SeasonYear,
         /// and CorrelationId for downstream consumers to react to.

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
@@ -155,20 +155,39 @@ public class CreatePlayerLeagueCommandHandlerTests : ApiTestBase<CreatePlayerLea
     }
 
     [Fact]
-    public async Task LocalStart_SameDayAsDateOnlyEnd_PassesRangeValidation()
+    public async Task LocalStart_WithNextDayDateOnlyEnd_PassesUnderAnyOffset()
     {
         // The range rule compares NORMALIZED bounds. A local mid-day start
-        // with a same-day date-only end must validate regardless of the
-        // machine's offset: effective start (local noon -> UTC, at most
-        // +/-14h) always precedes the effective end (next-day end-of-day
-        // expansion of the date-only value). A raw-vs-effective comparison
-        // could flip this by server timezone.
+        // with a NEXT-day date-only end must validate on any machine:
+        // effective start (local noon -> UTC, at most +/-14h) always
+        // precedes the next day's end-of-day expansion. A deterministic
+        // raw-fails/effective-passes discriminator is not portably
+        // testable — the divergence depends on the process timezone, which
+        // xunit cannot pin.
         var userId = await SeedUserAsync(isAdmin: true);
         var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
 
         var request = ValidRequest();
         request.StartsOn = new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Local);
         request.EndsOn = new DateTime(2026, 8, 28, 0, 0, 0, DateTimeKind.Unspecified);
+        var result = await handler.ExecuteAsync(request, userId);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SameDayStartAndDateOnlyEnd_PassesRangeValidation()
+    {
+        // True same-calendar-day case: a mid-day start with a SAME-day
+        // date-only end validates only because the end expands to
+        // end-of-day (raw midnight end < noon start would fail). Kinds are
+        // Unspecified so the assertion is deterministic on any machine.
+        var userId = await SeedUserAsync(isAdmin: true);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var request = ValidRequest();
+        request.StartsOn = new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Unspecified);
+        request.EndsOn = new DateTime(2026, 8, 27, 0, 0, 0, DateTimeKind.Unspecified);
         var result = await handler.ExecuteAsync(request, userId);
 
         result.IsSuccess.Should().BeTrue();

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
@@ -28,7 +28,7 @@ public class CreatePlayerLeagueCommandHandlerTests : ApiTestBase<CreatePlayerLea
     {
         // Real validator — an auto-mocked IValidator returns a null
         // ValidationResult and NREs before the code under test runs.
-        Mocker.Use<IValidator<CreatePlayerLeagueRequest>>(new CreatePlayerLeagueRequestValidator());
+        Mocker.Use<IValidator<CreatePlayerLeagueCommand>>(new CreatePlayerLeagueCommandValidator());
 
         // Blackout guard dependency: windowed requests check game dates.
         // The auto-mocked client would return a NULL Result and NRE.
@@ -58,7 +58,7 @@ public class CreatePlayerLeagueCommandHandlerTests : ApiTestBase<CreatePlayerLea
         return userId;
     }
 
-    private static CreatePlayerLeagueRequest ValidRequest() => new()
+    private static CreatePlayerLeagueCommand ValidRequest() => new()
     {
         Sport = "FootballNfl",
         Name = "NFL Rosters",

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
@@ -155,6 +155,26 @@ public class CreatePlayerLeagueCommandHandlerTests : ApiTestBase<CreatePlayerLea
     }
 
     [Fact]
+    public async Task LocalStart_SameDayAsDateOnlyEnd_PassesRangeValidation()
+    {
+        // The range rule compares NORMALIZED bounds. A local mid-day start
+        // with a same-day date-only end must validate regardless of the
+        // machine's offset: effective start (local noon -> UTC, at most
+        // +/-14h) always precedes the effective end (next-day end-of-day
+        // expansion of the date-only value). A raw-vs-effective comparison
+        // could flip this by server timezone.
+        var userId = await SeedUserAsync(isAdmin: true);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var request = ValidRequest();
+        request.StartsOn = new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Local);
+        request.EndsOn = new DateTime(2026, 8, 28, 0, 0, 0, DateTimeKind.Unspecified);
+        var result = await handler.ExecuteAsync(request, userId);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task MaxValueEndsOn_FailsValidation_InsteadOfThrowing()
     {
         // DateTime.MaxValue.Date is midnight — without the guard the

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
@@ -132,4 +132,40 @@ public class CreatePlayerLeagueCommandHandlerTests : ApiTestBase<CreatePlayerLea
         // Inclusive end: midnight input becomes end-of-day.
         group.EndsOn.Value.Hour.Should().Be(23);
     }
+
+    [Fact]
+    public async Task LocalKindBounds_AreConvertedToUtc_NotRelabeled()
+    {
+        // A Local wall-clock relabeled as UTC would silently shift the
+        // instant by the machine's offset — Local must be CONVERTED.
+        var userId = await SeedUserAsync(isAdmin: true);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var localStart = new DateTime(2026, 8, 27, 9, 30, 0, DateTimeKind.Local);
+        var request = ValidRequest();
+        request.StartsOn = localStart;
+        request.EndsOn = new DateTime(2026, 8, 28, 18, 0, 0, DateTimeKind.Local);
+        var result = await handler.ExecuteAsync(request, userId);
+
+        result.IsSuccess.Should().BeTrue();
+        var group = await DataContext.PickemGroups.SingleAsync(g => g.Id == result.Value);
+        group.StartsOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        group.StartsOn.Value.Should().Be(localStart.ToUniversalTime());
+        group.EndsOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task MaxValueEndsOn_FailsValidation_InsteadOfThrowing()
+    {
+        // DateTime.MaxValue.Date is midnight — without the guard the
+        // end-of-day AddDays(1) would overflow inside the validator.
+        var userId = await SeedUserAsync(isAdmin: true);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var request = ValidRequest();
+        request.EndsOn = DateTime.MaxValue.Date;
+        var result = await handler.ExecuteAsync(request, userId);
+
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
 }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/CreatePlayerLeagueCommandHandlerTests.cs
@@ -1,0 +1,135 @@
+using FluentAssertions;
+
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Common.Enums;
+using Moq;
+
+using SportsData.Api.Application.UI.Leagues.Commands.CreatePlayerLeague;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+using Xunit;
+
+using UserEntity = SportsData.Api.Infrastructure.Data.Entities.User;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues;
+
+/// <summary>
+/// Player Pick'em league creation: the alpha admin gate, the GroupType
+/// stamp, and validation. The weeks-without-matchups behavior lives in
+/// MatchupScheduleProcessor and is covered by its tests.
+/// </summary>
+public class CreatePlayerLeagueCommandHandlerTests : ApiTestBase<CreatePlayerLeagueCommandHandler>
+{
+    public CreatePlayerLeagueCommandHandlerTests()
+    {
+        // Real validator — an auto-mocked IValidator returns a null
+        // ValidationResult and NREs before the code under test runs.
+        Mocker.Use<IValidator<CreatePlayerLeagueRequest>>(new CreatePlayerLeagueRequestValidator());
+
+        // Blackout guard dependency: windowed requests check game dates.
+        // The auto-mocked client would return a NULL Result and NRE.
+        var contestClient = new Mock<IProvideContests>();
+        contestClient
+            .Setup(x => x.GetGameDates(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<DateOnly>>([new DateOnly(2026, 8, 27)]));
+        Mocker.GetMock<IContestClientFactory>()
+            .Setup(x => x.Resolve(It.IsAny<Sport>()))
+            .Returns(contestClient.Object);
+    }
+
+    private async Task<Guid> SeedUserAsync(bool isAdmin)
+    {
+        var userId = Guid.NewGuid();
+        DataContext.Users.Add(new UserEntity
+        {
+            Id = userId,
+            FirebaseUid = $"fb-{userId:N}",
+            Email = "op@sportdeets.com",
+            SignInProvider = "password",
+            DisplayName = "Operator",
+            Username = $"op{userId:N}"[..12],
+            IsAdmin = isAdmin,
+        });
+        await DataContext.SaveChangesAsync();
+        return userId;
+    }
+
+    private static CreatePlayerLeagueRequest ValidRequest() => new()
+    {
+        Sport = "FootballNfl",
+        Name = "NFL Rosters",
+        IsPublic = true,
+    };
+
+    [Fact]
+    public async Task NonAdmin_IsForbidden()
+    {
+        var userId = await SeedUserAsync(isAdmin: false);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var result = await handler.ExecuteAsync(ValidRequest(), userId);
+
+        result.Status.Should().Be(ResultStatus.Forbid);
+        (await DataContext.PickemGroups.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Admin_CreatesPlayerPickemLeague_WithCommissionerMembership()
+    {
+        var userId = await SeedUserAsync(isAdmin: true);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var result = await handler.ExecuteAsync(ValidRequest(), userId);
+
+        result.IsSuccess.Should().BeTrue();
+        var group = await DataContext.PickemGroups
+            .Include(g => g.Members)
+            .SingleAsync(g => g.Id == result.Value);
+        group.GroupType.Should().Be(GroupType.PlayerPickem);
+        group.Sport.Should().Be(Sport.FootballNfl);
+        group.League.Should().Be(League.NFL);
+        group.CommissionerUserId.Should().Be(userId);
+        group.Members.Should().ContainSingle(m => m.UserId == userId && m.Role == LeagueRole.Commissioner);
+    }
+
+    [Theory]
+    [InlineData("BaseballMlb")] // player pick'em is football-only
+    [InlineData("")]
+    public async Task UnsupportedSport_FailsValidation(string sport)
+    {
+        var userId = await SeedUserAsync(isAdmin: true);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var request = ValidRequest();
+        request.Sport = sport;
+        var result = await handler.ExecuteAsync(request, userId);
+
+        result.Status.Should().Be(ResultStatus.Validation);
+    }
+
+    [Fact]
+    public async Task DateOnlyBounds_PersistAsUtc()
+    {
+        // JSON date-only values deserialize Kind=Unspecified — Npgsql
+        // rejects those on timestamptz (the E2E 500). The request's
+        // Effective* properties stamp UTC; assert the entity carries it.
+        var userId = await SeedUserAsync(isAdmin: true);
+        var handler = Mocker.CreateInstance<CreatePlayerLeagueCommandHandler>();
+
+        var request = ValidRequest();
+        request.StartsOn = new DateTime(2026, 8, 27, 0, 0, 0, DateTimeKind.Unspecified);
+        request.EndsOn = new DateTime(2026, 8, 27, 0, 0, 0, DateTimeKind.Unspecified);
+        var result = await handler.ExecuteAsync(request, userId);
+
+        result.IsSuccess.Should().BeTrue();
+        var group = await DataContext.PickemGroups.SingleAsync(g => g.Id == result.Value);
+        group.StartsOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        group.EndsOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        // Inclusive end: midnight input becomes end-of-day.
+        group.EndsOn.Value.Hour.Should().Be(23);
+    }
+}


### PR DESCRIPTION
## Player Pick'em league creation (alpha-blocker)

Creating a player league previously meant creating a team league, then manually flipping `GroupType` in the database — which also generated a full team-pick slate (matchups + notification fan-out).

- **API**: `POST /ui/leagues/players` — one endpoint for both football sports (request carries `Sport`). Standalone `CreatePlayerLeagueCommandHandler`: admin-only during alpha (fresh-read enforcement), `GroupType` stamped at creation, blackout guard + outbox contract borrowed from the team-league base, benign defaults for the inert team-pick columns. Date-only JSON bounds are UTC-kind-stamped (`EffectiveStartsOn/EndsOn`) — Npgsql rejects `Kind=Unspecified` on timestamptz (found in E2E).
- **Processor**: `MatchupScheduleProcessor` branches on `GroupType` — PlayerPickem leagues materialize their `PickemGroupWeek` rows (identity + phase stamp, powering `seasonWeekDetails` and lineup lock anchoring) but skip matchup insertion and the matchup-created notification fan-out. The roster is the game.
- **Web**: `/app/league/create/players` (AdminRoute) — minimal form (sport toggle, name, description, public, optional date window), refreshes `/user/me` before navigating so the router resolves the new league, lands on the roster builder. Admin-only link from the team create page. PlayerPickem home rows get a helmet icon (react-icons Game Icons — no Unicode football-helmet emoji exists).

## Boot-path request diet (web + mobile)

Mobile boot went from ~10 API calls (4 of them doomed 401s) to 5:

- **Options ride `/user/me`**: `UserDto` embeds `UserOptionsDto` via a shared `FromRows` projector; the standalone GET endpoint remains for older mobile builds. Web `UserContext` and mobile `useUserOptions` (now a `select` over the me query) drop the second GET; mobile's Profile toggle patches options inside the cached me payload (optimistic + revert preserved).
- **Current-season dedup**: web `seasonApi` gains a session promise cache; mobile's countdown and `useCurrentSeasonYear` used *different* react-query keys for the same endpoint (defeating dedup) — both now use canonical `currentSeasonKeys`.
- **Pre-auth 401s killed at the source**: mobile's axios interceptor awaits the first `onAuthStateChanged` emission before sending anything. Gated on *initialization*, not sign-in, so anonymous endpoints keep working logged-out. One fix covers the whole class — no per-hook `enabled` guards to remember.

## Sequencing

The mobile options change requires this PR's embedded `options` field — **no EAS build before this deploys**.

## Validation

- API 741/741 (new: 4 create-handler tests incl. the UTC-kind regression, processor weeks-without-matchups test)
- Web 83/83 vitest + eslint + prod build; mobile 175/175 jest + tsc clean
- Local E2E: create → roster builder for a windowed NFL league; weeks materialized with phases, zero matchup rows; dev console clean (no 401s, no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can create Player Pick’em leagues for NFL and college football with configurable details, visibility, dates, and join policies.
  * Added a dedicated Player Pick’em creation experience and improved league navigation and icons.
  * User preferences are now included in main profile data.

* **Bug Fixes**
  * Improved authentication initialization before API requests.
  * Player Pick’em weeks retry when matchup data is unavailable.
  * Current-season requests use consistent caching and retry behavior.

* **Documentation**
  * Expanded the production runbook with an alternative data-update procedure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->